### PR TITLE
Restore signature of `build_permalink`

### DIFF
--- a/crates/editor/src/git/permalink.rs
+++ b/crates/editor/src/git/permalink.rs
@@ -8,7 +8,6 @@ enum GitHostingProvider {
     Github,
     Gitlab,
     Gitee,
-    BitbucketCloud,
 }
 
 impl GitHostingProvider {
@@ -17,7 +16,6 @@ impl GitHostingProvider {
             Self::Github => "https://github.com",
             Self::Gitlab => "https://gitlab.com",
             Self::Gitee => "https://gitee.com",
-            Self::BitbucketCloud => "https://bitbucket.org",
         };
 
         Url::parse(&base_url).unwrap()
@@ -31,7 +29,6 @@ impl GitHostingProvider {
 
             match self {
                 Self::Github | Self::Gitlab | Self::Gitee => format!("L{}", line),
-                Self::BitbucketCloud => format!("lines-{}", line),
             }
         } else {
             let start_line = selection.start.row + 1;
@@ -39,19 +36,28 @@ impl GitHostingProvider {
 
             match self {
                 Self::Github => format!("L{}-L{}", start_line, end_line),
-                Self::Gitlab | Self::Gitee => format!("L{}-{}", start_line, end_line),
-                Self::BitbucketCloud => format!("lines-{}:{}", start_line, end_line),
+                Self::Gitlab => format!("L{}-{}", start_line, end_line),
+                Self::Gitee => format!("L{}-{}", start_line, end_line),
             }
         }
     }
 }
 
-pub fn build_permalink(
-    remote_url: &str,
-    sha: &str,
-    path: &str,
-    selection: Option<Range<Point>>,
-) -> Result<Url> {
+pub struct BuildPermalinkParams<'a> {
+    pub remote_url: &'a str,
+    pub sha: &'a str,
+    pub path: &'a str,
+    pub selection: Option<Range<Point>>,
+}
+
+pub fn build_permalink(params: BuildPermalinkParams) -> Result<Url> {
+    let BuildPermalinkParams {
+        remote_url,
+        sha,
+        path,
+        selection,
+    } = params;
+
     let ParsedGitRemote {
         provider,
         owner,
@@ -63,7 +69,6 @@ pub fn build_permalink(
         GitHostingProvider::Github => format!("{owner}/{repo}/blob/{sha}/{path}"),
         GitHostingProvider::Gitlab => format!("{owner}/{repo}/-/blob/{sha}/{path}"),
         GitHostingProvider::Gitee => format!("{owner}/{repo}/blob/{sha}/{path}"),
-        GitHostingProvider::BitbucketCloud => format!("{owner}/{repo}/src/{sha}/{path}"),
     };
     let line_fragment = selection.map(|selection| provider.line_fragment(&selection));
 
@@ -125,20 +130,6 @@ fn parse_git_remote_url(url: &str) -> Option<ParsedGitRemote> {
         });
     }
 
-    if url.contains("bitbucket.org") {
-        let (_, repo_with_owner) = url.trim_end_matches(".git").split_once("bitbucket.org")?;
-        let (owner, repo) = repo_with_owner
-            .trim_start_matches("/")
-            .trim_start_matches(":")
-            .split_once("/")?;
-
-        return Some(ParsedGitRemote {
-            provider: GitHostingProvider::BitbucketCloud,
-            owner,
-            repo,
-        });
-    }
-
     None
 }
 
@@ -148,12 +139,12 @@ mod tests {
 
     #[test]
     fn test_build_github_permalink_from_ssh_url() {
-        let permalink = build_permalink(
-            "git@github.com:zed-industries/zed.git",
-            "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
-            "crates/editor/src/git/permalink.rs",
-            None,
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@github.com:zed-industries/zed.git",
+            sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: None,
+        })
         .unwrap();
 
         let expected_url = "https://github.com/zed-industries/zed/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs";
@@ -162,12 +153,12 @@ mod tests {
 
     #[test]
     fn test_build_github_permalink_from_ssh_url_single_line_selection() {
-        let permalink = build_permalink(
-            "git@github.com:zed-industries/zed.git",
-            "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
-            "crates/editor/src/git/permalink.rs",
-            Some(Point::new(6, 1)..Point::new(6, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@github.com:zed-industries/zed.git",
+            sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://github.com/zed-industries/zed/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs#L7";
@@ -176,12 +167,12 @@ mod tests {
 
     #[test]
     fn test_build_github_permalink_from_ssh_url_multi_line_selection() {
-        let permalink = build_permalink(
-            "git@github.com:zed-industries/zed.git",
-            "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
-            "crates/editor/src/git/permalink.rs",
-            Some(Point::new(23, 1)..Point::new(47, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@github.com:zed-industries/zed.git",
+            sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://github.com/zed-industries/zed/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs#L24-L48";
@@ -190,12 +181,12 @@ mod tests {
 
     #[test]
     fn test_build_github_permalink_from_https_url() {
-        let permalink = build_permalink(
-            "https://github.com/zed-industries/zed.git",
-            "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-            "crates/zed/src/main.rs",
-            None,
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://github.com/zed-industries/zed.git",
+            sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
+            path: "crates/zed/src/main.rs",
+            selection: None,
+        })
         .unwrap();
 
         let expected_url = "https://github.com/zed-industries/zed/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs";
@@ -204,12 +195,12 @@ mod tests {
 
     #[test]
     fn test_build_github_permalink_from_https_url_single_line_selection() {
-        let permalink = build_permalink(
-            "https://github.com/zed-industries/zed.git",
-            "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-            "crates/zed/src/main.rs",
-            Some(Point::new(6, 1)..Point::new(6, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://github.com/zed-industries/zed.git",
+            sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://github.com/zed-industries/zed/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L7";
@@ -218,12 +209,12 @@ mod tests {
 
     #[test]
     fn test_build_github_permalink_from_https_url_multi_line_selection() {
-        let permalink = build_permalink(
-            "https://github.com/zed-industries/zed.git",
-            "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-            "crates/zed/src/main.rs",
-            Some(Point::new(23, 1)..Point::new(47, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://github.com/zed-industries/zed.git",
+            sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://github.com/zed-industries/zed/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L24-L48";
@@ -232,12 +223,12 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_ssh_url() {
-        let permalink = build_permalink(
-            "git@gitlab.com:zed-industries/zed.git",
-            "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
-            "crates/editor/src/git/permalink.rs",
-            None,
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitlab.com:zed-industries/zed.git",
+            sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: None,
+        })
         .unwrap();
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs";
@@ -246,12 +237,12 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_ssh_url_single_line_selection() {
-        let permalink = build_permalink(
-            "git@gitlab.com:zed-industries/zed.git",
-            "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
-            "crates/editor/src/git/permalink.rs",
-            Some(Point::new(6, 1)..Point::new(6, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitlab.com:zed-industries/zed.git",
+            sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs#L7";
@@ -260,12 +251,12 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_ssh_url_multi_line_selection() {
-        let permalink = build_permalink(
-            "git@gitlab.com:zed-industries/zed.git",
-            "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
-            "crates/editor/src/git/permalink.rs",
-            Some(Point::new(23, 1)..Point::new(47, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitlab.com:zed-industries/zed.git",
+            sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs#L24-48";
@@ -274,12 +265,12 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_https_url() {
-        let permalink = build_permalink(
-            "https://gitlab.com/zed-industries/zed.git",
-            "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-            "crates/zed/src/main.rs",
-            None,
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitlab.com/zed-industries/zed.git",
+            sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
+            path: "crates/zed/src/main.rs",
+            selection: None,
+        })
         .unwrap();
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs";
@@ -288,12 +279,12 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_https_url_single_line_selection() {
-        let permalink = build_permalink(
-            "https://gitlab.com/zed-industries/zed.git",
-            "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-            "crates/zed/src/main.rs",
-            Some(Point::new(6, 1)..Point::new(6, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitlab.com/zed-industries/zed.git",
+            sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L7";
@@ -302,12 +293,12 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_https_url_multi_line_selection() {
-        let permalink = build_permalink(
-            "https://gitlab.com/zed-industries/zed.git",
-            "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-            "crates/zed/src/main.rs",
-            Some(Point::new(23, 1)..Point::new(47, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitlab.com/zed-industries/zed.git",
+            sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L24-48";
@@ -316,12 +307,12 @@ mod tests {
 
     #[test]
     fn test_build_gitee_permalink_from_ssh_url() {
-        let permalink = build_permalink(
-            "git@gitee.com:libkitten/zed.git",
-            "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-            "crates/editor/src/git/permalink.rs",
-            None,
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitee.com:libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: None,
+        })
         .unwrap();
 
         let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs";
@@ -330,12 +321,12 @@ mod tests {
 
     #[test]
     fn test_build_gitee_permalink_from_ssh_url_single_line_selection() {
-        let permalink = build_permalink(
-            "git@gitee.com:libkitten/zed.git",
-            "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-            "crates/editor/src/git/permalink.rs",
-            Some(Point::new(6, 1)..Point::new(6, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitee.com:libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L7";
@@ -344,12 +335,12 @@ mod tests {
 
     #[test]
     fn test_build_gitee_permalink_from_ssh_url_multi_line_selection() {
-        let permalink = build_permalink(
-            "git@gitee.com:libkitten/zed.git",
-            "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-            "crates/editor/src/git/permalink.rs",
-            Some(Point::new(23, 1)..Point::new(47, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@gitee.com:libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L24-48";
@@ -358,12 +349,12 @@ mod tests {
 
     #[test]
     fn test_build_gitee_permalink_from_https_url() {
-        let permalink = build_permalink(
-            "https://gitee.com/libkitten/zed.git",
-            "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-            "crates/zed/src/main.rs",
-            None,
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitee.com/libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/zed/src/main.rs",
+            selection: None,
+        })
         .unwrap();
 
         let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs";
@@ -372,12 +363,12 @@ mod tests {
 
     #[test]
     fn test_build_gitee_permalink_from_https_url_single_line_selection() {
-        let permalink = build_permalink(
-            "https://gitee.com/libkitten/zed.git",
-            "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-            "crates/zed/src/main.rs",
-            Some(Point::new(6, 1)..Point::new(6, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitee.com/libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
         .unwrap();
 
         let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs#L7";
@@ -386,94 +377,14 @@ mod tests {
 
     #[test]
     fn test_build_gitee_permalink_from_https_url_multi_line_selection() {
-        let permalink = build_permalink(
-            "https://gitee.com/libkitten/zed.git",
-            "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-            "crates/zed/src/main.rs",
-            Some(Point::new(23, 1)..Point::new(47, 10)),
-        )
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://gitee.com/libkitten/zed.git",
+            sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
         .unwrap();
         let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs#L24-48";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_parse_git_remote_url_bitbucket_https_with_username() {
-        let url = "https://thorstenballzed@bitbucket.org/thorstenzed/testingrepo.git";
-        let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(
-            parsed.provider,
-            GitHostingProvider::BitbucketCloud
-        ));
-        assert_eq!(parsed.owner, "thorstenzed");
-        assert_eq!(parsed.repo, "testingrepo");
-    }
-
-    #[test]
-    fn test_parse_git_remote_url_bitbucket_https_without_username() {
-        let url = "https://bitbucket.org/thorstenzed/testingrepo.git";
-        let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(
-            parsed.provider,
-            GitHostingProvider::BitbucketCloud
-        ));
-        assert_eq!(parsed.owner, "thorstenzed");
-        assert_eq!(parsed.repo, "testingrepo");
-    }
-
-    #[test]
-    fn test_parse_git_remote_url_bitbucket_git() {
-        let url = "git@bitbucket.org:thorstenzed/testingrepo.git";
-        let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(
-            parsed.provider,
-            GitHostingProvider::BitbucketCloud
-        ));
-        assert_eq!(parsed.owner, "thorstenzed");
-        assert_eq!(parsed.repo, "testingrepo");
-    }
-
-    #[test]
-    fn test_build_bitbucket_permalink_from_ssh_url() {
-        let permalink = build_permalink(
-            "git@bitbucket.org:thorstenzed/testingrepo.git",
-            "f00b4r",
-            "main.rs",
-            None,
-        )
-        .unwrap();
-
-        let expected_url = "https://bitbucket.org/thorstenzed/testingrepo/src/f00b4r/main.rs";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_bitbucket_permalink_from_ssh_url_single_line_selection() {
-        let permalink = build_permalink(
-            "git@bitbucket.org:thorstenzed/testingrepo.git",
-            "f00b4r",
-            "main.rs",
-            Some(Point::new(6, 1)..Point::new(6, 10)),
-        )
-        .unwrap();
-
-        let expected_url =
-            "https://bitbucket.org/thorstenzed/testingrepo/src/f00b4r/main.rs#lines-7";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_bitbucket_permalink_from_ssh_url_multi_line_selection() {
-        let permalink = build_permalink(
-            "git@bitbucket.org:thorstenzed/testingrepo.git",
-            "f00b4r",
-            "main.rs",
-            Some(Point::new(23, 1)..Point::new(47, 10)),
-        )
-        .unwrap();
-
-        let expected_url =
-            "https://bitbucket.org/thorstenzed/testingrepo/src/f00b4r/main.rs#lines-24:48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }


### PR DESCRIPTION
This PR restores the original signature of `build_permalink`, which intentionally uses a params struct to avoid mixing up the various `&str` params that could otherwise be accidentally provided in the wrong order without being caught by the compiler.

Release Notes:

- N/A
