### PR TITLE
Support Sourcehut & Codeberg in permalinks

### DIFF
--- a/crates/editor/src/git/permalink.rs
+++ b/crates/editor/src/git/permalink.rs
@@ -8,7 +8,7 @@ enum GitHostingProvider {
     Github,
     Gitlab,
     Gitee,
-    BitbucketCloud,
+    Bitbucket,
     Sourcehut,
     Codeberg,
 }
@@ -19,7 +19,7 @@ impl GitHostingProvider {
             Self::Github => "https://github.com",
             Self::Gitlab => "https://gitlab.com",
             Self::Gitee => "https://gitee.com",
-            Self::BitbucketCloud => "https://bitbucket.org",
+            Self::Bitbucket => "https://bitbucket.org",
             Self::Sourcehut => "https://git.sr.ht",
             Self::Codeberg => "https://codeberg.org",
         };
@@ -37,7 +37,7 @@ impl GitHostingProvider {
                 Self::Github | Self::Gitlab | Self::Gitee | Self::Sourcehut | Self::Codeberg => {
                     format!("L{}", line)
                 }
-                Self::BitbucketCloud => format!("lines-{}", line),
+                Self::Bitbucket => format!("lines-{}", line),
             }
         } else {
             let start_line = selection.start.row + 1;
@@ -48,7 +48,7 @@ impl GitHostingProvider {
                 Self::Gitlab | Self::Gitee | Self::Sourcehut => {
                     format!("L{}-{}", start_line, end_line)
                 }
-                Self::BitbucketCloud => format!("lines-{}:{}", start_line, end_line),
+                Self::Bitbucket => format!("lines-{}:{}", start_line, end_line),
             }
         }
     }
@@ -80,7 +80,7 @@ pub fn build_permalink(params: BuildPermalinkParams) -> Result<Url> {
         GitHostingProvider::Github => format!("{owner}/{repo}/blob/{sha}/{path}"),
         GitHostingProvider::Gitlab => format!("{owner}/{repo}/-/blob/{sha}/{path}"),
         GitHostingProvider::Gitee => format!("{owner}/{repo}/blob/{sha}/{path}"),
-        GitHostingProvider::BitbucketCloud => format!("{owner}/{repo}/src/{sha}/{path}"),
+        GitHostingProvider::Bitbucket => format!("{owner}/{repo}/src/{sha}/{path}"),
         GitHostingProvider::Sourcehut => format!("~{owner}/{repo}/tree/{sha}/item/{path}"),
         GitHostingProvider::Codeberg => format!("{owner}/{repo}/src/commit/{sha}/{path}"),
     };
@@ -152,7 +152,7 @@ fn parse_git_remote_url(url: &str) -> Option<ParsedGitRemote> {
             .split_once("/")?;
 
         return Some(ParsedGitRemote {
-            provider: GitHostingProvider::BitbucketCloud,
+            provider: GitHostingProvider::Bitbucket,
             owner,
             repo,
         });
@@ -452,10 +452,7 @@ mod tests {
     fn test_parse_git_remote_url_bitbucket_https_with_username() {
         let url = "https://thorstenballzed@bitbucket.org/thorstenzed/testingrepo.git";
         let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(
-            parsed.provider,
-            GitHostingProvider::BitbucketCloud
-        ));
+        assert!(matches!(parsed.provider, GitHostingProvider::Bitbucket));
         assert_eq!(parsed.owner, "thorstenzed");
         assert_eq!(parsed.repo, "testingrepo");
     }
@@ -464,10 +461,7 @@ mod tests {
     fn test_parse_git_remote_url_bitbucket_https_without_username() {
         let url = "https://bitbucket.org/thorstenzed/testingrepo.git";
         let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(
-            parsed.provider,
-            GitHostingProvider::BitbucketCloud
-        ));
+        assert!(matches!(parsed.provider, GitHostingProvider::Bitbucket));
         assert_eq!(parsed.owner, "thorstenzed");
         assert_eq!(parsed.repo, "testingrepo");
     }
@@ -476,10 +470,7 @@ mod tests {
     fn test_parse_git_remote_url_bitbucket_git() {
         let url = "git@bitbucket.org:thorstenzed/testingrepo.git";
         let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(
-            parsed.provider,
-            GitHostingProvider::BitbucketCloud
-        ));
+        assert!(matches!(parsed.provider, GitHostingProvider::Bitbucket));
         assert_eq!(parsed.owner, "thorstenzed");
         assert_eq!(parsed.repo, "testingrepo");
     }

--- a/crates/editor/src/git/permalink.rs
+++ b/crates/editor/src/git/permalink.rs
@@ -617,8 +617,6 @@ mod tests {
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
-    // codeberg
-
     #[test]
     fn test_build_codeberg_permalink_from_ssh_url() {
         let permalink = build_permalink(BuildPermalinkParams {

--- a/crates/editor/src/git/permalink.rs
+++ b/crates/editor/src/git/permalink.rs
@@ -8,7 +8,9 @@ enum GitHostingProvider {
     Github,
     Gitlab,
     Gitee,
-    Bitbucket,
+    BitbucketCloud,
+    Sourcehut,
+    Codeberg,
 }
 
 impl GitHostingProvider {
@@ -17,7 +19,9 @@ impl GitHostingProvider {
             Self::Github => "https://github.com",
             Self::Gitlab => "https://gitlab.com",
             Self::Gitee => "https://gitee.com",
-            Self::Bitbucket => "https://bitbucket.org",
+            Self::BitbucketCloud => "https://bitbucket.org",
+            Self::Sourcehut => "https://git.sr.ht",
+            Self::Codeberg => "https://codeberg.org",
         };
 
         Url::parse(&base_url).unwrap()
@@ -30,17 +34,21 @@ impl GitHostingProvider {
             let line = selection.start.row + 1;
 
             match self {
-                Self::Github | Self::Gitlab | Self::Gitee => format!("L{}", line),
-                Self::Bitbucket => format!("lines-{}", line),
+                Self::Github | Self::Gitlab | Self::Gitee | Self::Sourcehut | Self::Codeberg => {
+                    format!("L{}", line)
+                }
+                Self::BitbucketCloud => format!("lines-{}", line),
             }
         } else {
             let start_line = selection.start.row + 1;
             let end_line = selection.end.row + 1;
 
             match self {
-                Self::Github => format!("L{}-L{}", start_line, end_line),
-                Self::Gitlab | Self::Gitee => format!("L{}-{}", start_line, end_line),
-                Self::Bitbucket => format!("lines-{}:{}", start_line, end_line),
+                Self::Github | Self::Codeberg => format!("L{}-L{}", start_line, end_line),
+                Self::Gitlab | Self::Gitee | Self::Sourcehut => {
+                    format!("L{}-{}", start_line, end_line)
+                }
+                Self::BitbucketCloud => format!("lines-{}:{}", start_line, end_line),
             }
         }
     }
@@ -72,7 +80,9 @@ pub fn build_permalink(params: BuildPermalinkParams) -> Result<Url> {
         GitHostingProvider::Github => format!("{owner}/{repo}/blob/{sha}/{path}"),
         GitHostingProvider::Gitlab => format!("{owner}/{repo}/-/blob/{sha}/{path}"),
         GitHostingProvider::Gitee => format!("{owner}/{repo}/blob/{sha}/{path}"),
-        GitHostingProvider::Bitbucket => format!("{owner}/{repo}/src/{sha}/{path}"),
+        GitHostingProvider::BitbucketCloud => format!("{owner}/{repo}/src/{sha}/{path}"),
+        GitHostingProvider::Sourcehut => format!("~{owner}/{repo}/tree/{sha}/item/{path}"),
+        GitHostingProvider::Codeberg => format!("{owner}/{repo}/src/commit/{sha}/{path}"),
     };
     let line_fragment = selection.map(|selection| provider.line_fragment(&selection));
 
@@ -142,7 +152,39 @@ fn parse_git_remote_url(url: &str) -> Option<ParsedGitRemote> {
             .split_once("/")?;
 
         return Some(ParsedGitRemote {
-            provider: GitHostingProvider::Bitbucket,
+            provider: GitHostingProvider::BitbucketCloud,
+            owner,
+            repo,
+        });
+    }
+
+    if url.starts_with("git@git.sr.ht:") || url.starts_with("https://git.sr.ht/") {
+        // sourcehut indicates a repo with '.git' suffix as a separate repo.
+        // For example, "git@git.sr.ht:~username/repo" and "git@git.sr.ht:~username/repo.git"
+        // are two distinct repositories.
+        let repo_with_owner = url
+            .trim_start_matches("git@git.sr.ht:~")
+            .trim_start_matches("https://git.sr.ht/~");
+
+        let (owner, repo) = repo_with_owner.split_once("/")?;
+
+        return Some(ParsedGitRemote {
+            provider: GitHostingProvider::Sourcehut,
+            owner,
+            repo,
+        });
+    }
+
+    if url.starts_with("git@codeberg.org:") || url.starts_with("https://codeberg.org/") {
+        let repo_with_owner = url
+            .trim_start_matches("git@codeberg.org:")
+            .trim_start_matches("https://codeberg.org/")
+            .trim_end_matches(".git");
+
+        let (owner, repo) = repo_with_owner.split_once("/")?;
+
+        return Some(ParsedGitRemote {
+            provider: GitHostingProvider::Codeberg,
             owner,
             repo,
         });
@@ -410,7 +452,10 @@ mod tests {
     fn test_parse_git_remote_url_bitbucket_https_with_username() {
         let url = "https://thorstenballzed@bitbucket.org/thorstenzed/testingrepo.git";
         let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(parsed.provider, GitHostingProvider::Bitbucket));
+        assert!(matches!(
+            parsed.provider,
+            GitHostingProvider::BitbucketCloud
+        ));
         assert_eq!(parsed.owner, "thorstenzed");
         assert_eq!(parsed.repo, "testingrepo");
     }
@@ -419,7 +464,10 @@ mod tests {
     fn test_parse_git_remote_url_bitbucket_https_without_username() {
         let url = "https://bitbucket.org/thorstenzed/testingrepo.git";
         let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(parsed.provider, GitHostingProvider::Bitbucket));
+        assert!(matches!(
+            parsed.provider,
+            GitHostingProvider::BitbucketCloud
+        ));
         assert_eq!(parsed.owner, "thorstenzed");
         assert_eq!(parsed.repo, "testingrepo");
     }
@@ -428,7 +476,10 @@ mod tests {
     fn test_parse_git_remote_url_bitbucket_git() {
         let url = "git@bitbucket.org:thorstenzed/testingrepo.git";
         let parsed = parse_git_remote_url(url).unwrap();
-        assert!(matches!(parsed.provider, GitHostingProvider::Bitbucket));
+        assert!(matches!(
+            parsed.provider,
+            GitHostingProvider::BitbucketCloud
+        ));
         assert_eq!(parsed.owner, "thorstenzed");
         assert_eq!(parsed.repo, "testingrepo");
     }
@@ -474,6 +525,190 @@ mod tests {
 
         let expected_url =
             "https://bitbucket.org/thorstenzed/testingrepo/src/f00b4r/main.rs#lines-24:48";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink_from_ssh_url() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@git.sr.ht:~rajveermalviya/zed",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: None,
+        })
+        .unwrap();
+
+        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink_from_ssh_url_with_git_prefix() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@git.sr.ht:~rajveermalviya/zed.git",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: None,
+        })
+        .unwrap();
+
+        let expected_url = "https://git.sr.ht/~rajveermalviya/zed.git/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink_from_ssh_url_single_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@git.sr.ht:~rajveermalviya/zed",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs#L7";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink_from_ssh_url_multi_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@git.sr.ht:~rajveermalviya/zed",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs#L24-48";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink_from_https_url() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://git.sr.ht/~rajveermalviya/zed",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/zed/src/main.rs",
+            selection: None,
+        })
+        .unwrap();
+
+        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/zed/src/main.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink_from_https_url_single_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://git.sr.ht/~rajveermalviya/zed",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/zed/src/main.rs#L7";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink_from_https_url_multi_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://git.sr.ht/~rajveermalviya/zed",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/zed/src/main.rs#L24-48";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    // codeberg
+
+    #[test]
+    fn test_build_codeberg_permalink_from_ssh_url() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@codeberg.org:rajveermalviya/zed.git",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: None,
+        })
+        .unwrap();
+
+        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_codeberg_permalink_from_ssh_url_single_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@codeberg.org:rajveermalviya/zed.git",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs#L7";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_codeberg_permalink_from_ssh_url_multi_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "git@codeberg.org:rajveermalviya/zed.git",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/editor/src/git/permalink.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs#L24-L48";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_codeberg_permalink_from_https_url() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://codeberg.org/rajveermalviya/zed.git",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/zed/src/main.rs",
+            selection: None,
+        })
+        .unwrap();
+
+        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/zed/src/main.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_codeberg_permalink_from_https_url_single_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://codeberg.org/rajveermalviya/zed.git",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(6, 1)..Point::new(6, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/zed/src/main.rs#L7";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_codeberg_permalink_from_https_url_multi_line_selection() {
+        let permalink = build_permalink(BuildPermalinkParams {
+            remote_url: "https://codeberg.org/rajveermalviya/zed.git",
+            sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
+            path: "crates/zed/src/main.rs",
+            selection: Some(Point::new(23, 1)..Point::new(47, 10)),
+        })
+        .unwrap();
+
+        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/zed/src/main.rs#L24-L48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }


### PR DESCRIPTION
Updates #5110 

Release Notes:

- Added support for repositories hosted on `git.sr.ht` (Sourcehut) and `codeberg.org` to the `editor: copy permalink to line` and `editor: open permalink to line` actions ([#5110](https://github.com/zed-industries/zed/issues/5110)).
