### PR TITLE
Ensure panel and pane sizes are integral

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -204,7 +204,7 @@ impl ChatPanel {
                 let panel = Self::new(workspace, cx);
                 if let Some(serialized_panel) = serialized_panel {
                     panel.update(cx, |panel, cx| {
-                        panel.width = serialized_panel.width;
+                        panel.width = serialized_panel.width.map(|r| r.round());
                         cx.notify();
                     });
                 }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -327,7 +327,7 @@ impl CollabPanel {
             let panel = CollabPanel::new(workspace, cx);
             if let Some(serialized_panel) = serialized_panel {
                 panel.update(cx, |panel, cx| {
-                    panel.width = serialized_panel.width;
+                    panel.width = serialized_panel.width.map(|w| w.round());
                     panel.collapsed_channels = serialized_panel
                         .collapsed_channels
                         .unwrap_or_else(|| Vec::new())

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -183,7 +183,7 @@ impl NotificationPanel {
                 let panel = Self::new(workspace, cx);
                 if let Some(serialized_panel) = serialized_panel {
                     panel.update(cx, |panel, cx| {
-                        panel.width = serialized_panel.width;
+                        panel.width = serialized_panel.width.map(|w| w.round());
                         cx.notify();
                     });
                 }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -338,7 +338,7 @@ impl ProjectPanel {
             let panel = ProjectPanel::new(workspace, cx);
             if let Some(serialized_panel) = serialized_panel {
                 panel.update(cx, |panel, cx| {
-                    panel.width = serialized_panel.width;
+                    panel.width = serialized_panel.width.map(|px| px.round());
                     cx.notify();
                 });
             }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -192,8 +192,8 @@ impl TerminalPanel {
             let items = if let Some(serialized_panel) = serialized_panel.as_ref() {
                 panel.update(cx, |panel, cx| {
                     cx.notify();
-                    panel.height = serialized_panel.height;
-                    panel.width = serialized_panel.width;
+                    panel.height = serialized_panel.height.map(|h| h.round());
+                    panel.width = serialized_panel.width.map(|w| w.round());
                     panel.pane.update(cx, |_, cx| {
                         serialized_panel
                             .items

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -522,7 +522,7 @@ impl Dock {
 
     pub fn resize_active_panel(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
         if let Some(entry) = self.panel_entries.get_mut(self.active_panel_index) {
-            let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE));
+            let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE).round());
             entry.panel.set_size(size, cx);
             cx.notify();
         }

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -883,7 +883,8 @@ mod element {
 
                 let child_size = bounds
                     .size
-                    .apply_along(self.axis, |_| space_per_flex * child_flex);
+                    .apply_along(self.axis, |_| space_per_flex * child_flex)
+                    .map(|d| d.round());
 
                 let child_bounds = Bounds {
                     origin,


### PR DESCRIPTION
Fixes: #8050

For some reason that we didn't investigate, if you have view caching enabled,
and you have non-integer sized bounds, and you are right aligning things, the
co-ordinates can differ by +/- 1px when using the cached view.

The easiest fix for now is to just not do that.

Co-Authored-By: Antonio <as-cii@zed.dev>

Release Notes:

- Fixed the pane icons flickering ([#8050](https://github.com/zed-industries/zed/issues/8050)).
