### PR TITLE
Handle hover with multiple language servers (locally)

### DIFF
--- a/crates/project/src/lsp_ext_command.rs
+++ b/crates/project/src/lsp_ext_command.rs
@@ -48,22 +48,23 @@ impl LspCommand for ExpandMacro {
     type Response = ExpandedMacro;
     type LspRequest = LspExpandMacro;
     type ProtoRequest = proto::LspExtExpandMacro;
+    type RequestContainer = CommandRequest<Self>;
 
     fn to_lsp(
         &self,
         path: &Path,
         _: &Buffer,
-        _: &Arc<LanguageServer>,
+        _: &Project,
         _: &AppContext,
     ) -> CommandRequest<Self> {
         CommandRequest {
-            request_params: ExpandMacroParams {
+            params: ExpandMacroParams {
                 text_document: lsp::TextDocumentIdentifier {
                     uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
-            servers: vec![LanguageServerToQuery::Primary],
+            server: LanguageServerToQuery::Primary,
         }
     }
 

--- a/crates/project/src/lsp_ext_command.rs
+++ b/crates/project/src/lsp_ext_command.rs
@@ -9,7 +9,7 @@ use rpc::proto::{self, PeerId};
 use serde::{Deserialize, Serialize};
 use text::{BufferId, PointUtf16, ToPointUtf16};
 
-use crate::{lsp_command::LspCommand, Project};
+use crate::{lsp_command::LspCommand, CommandRequest, LanguageServerToQuery, Project};
 
 pub enum LspExpandMacro {}
 
@@ -55,12 +55,15 @@ impl LspCommand for ExpandMacro {
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &AppContext,
-    ) -> ExpandMacroParams {
-        ExpandMacroParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: lsp::Url::from_file_path(path).unwrap(),
+    ) -> CommandRequest<Self> {
+        CommandRequest {
+            request_params: ExpandMacroParams {
+                text_document: lsp::TextDocumentIdentifier {
+                    uri: lsp::Url::from_file_path(path).unwrap(),
+                },
+                position: point_to_lsp(self.position),
             },
-            position: point_to_lsp(self.position),
+            servers: vec![LanguageServerToQuery::Primary],
         }
     }
 


### PR DESCRIPTION
Enables tailwind class hover but only when local/host. It turns out that none of our multi-server stuff really handles being a client very well, always using the primary server. I've been thinking about how I want to fix this systematically but I haven't decided yet


Release Notes:

- Added Tailwind class hover.
