### PR TITLE
Editor: Add shortcut to toggle line numbers

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -117,7 +117,8 @@
         {
           "stop_at_soft_wraps": true
         }
-      ]
+      ],
+      "cmd-;": "editor::ToggleLineNumbers"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -118,7 +118,7 @@
           "stop_at_soft_wraps": true
         }
       ],
-      "cmd-;": "editor::ToggleLineNumbers"
+      "ctrl-;": "editor::ToggleLineNumbers"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -152,7 +152,8 @@
           "center_cursor": true
         }
       ],
-      "ctrl-cmd-space": "editor::ShowCharacterPalette"
+      "ctrl-cmd-space": "editor::ShowCharacterPalette",
+      "cmd-;": "editor::ToggleLineNumbers"
     }
   },
   {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -239,6 +239,7 @@ gpui::actions!(
         TabPrev,
         ToggleInlayHints,
         ToggleSoftWrap,
+        ToggleLineNumbers,
         Transpose,
         Undo,
         UndoSelection,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8586,6 +8586,12 @@ impl Editor {
         cx.notify();
     }
 
+    pub fn toggle_line_numbers(&mut self, _: &ToggleLineNumbers, cx: &mut ViewContext<Self>) {
+        let mut editor_settings = EditorSettings::get_global(cx).clone();
+        editor_settings.gutter.line_numbers = !editor_settings.gutter.line_numbers;
+        EditorSettings::override_global(editor_settings, cx);
+    }
+
     pub fn set_show_gutter(&mut self, show_gutter: bool, cx: &mut ViewContext<Self>) {
         self.show_gutter = show_gutter;
         cx.notify();

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct EditorSettings {
     pub cursor_blink: bool,
     pub hover_popover_enabled: bool,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -275,6 +275,7 @@ impl EditorElement {
         register_action(view, cx, Editor::open_excerpts);
         register_action(view, cx, Editor::open_excerpts_in_split);
         register_action(view, cx, Editor::toggle_soft_wrap);
+        register_action(view, cx, Editor::toggle_line_numbers);
         register_action(view, cx, Editor::toggle_inlay_hints);
         register_action(view, cx, hover_popover::hover);
         register_action(view, cx, Editor::reveal_in_finder);


### PR DESCRIPTION
Following #7665, I've added a keymap to quickly hide and show gutter line numbers.

`ctrl-l` and `cmd-l` were taken, so I've bound it to `cmd-;`. 


https://github.com/zed-industries/zed/assets/138762/365d2a7c-b775-4486-8389-edafe59b2a87

Release notes:

- Added `editor: toggle line numbers` command and default keybindings (`cmd-;` on macOS).

