### PR TITLE
Wire up Azure OpenAI completion provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "postage",
  "rand 0.8.5",
  "rusqlite",
+ "schemars",
  "serde",
  "serde_json",
  "tiktoken-rs",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -240,17 +240,16 @@
     // 3. "gpt-4-1106-preview"
     "default_open_ai_model": "gpt-4-1106-preview",
     "provider": {
-      "openai": {
-        // The default OpenAI API endpoint to use when starting new conversations.
-        "api_url": "https://api.openai.com/v1",
-        // The default OpenAI model to use when starting new conversations. This
-        // setting can take three values:
-        //
-        // 1. "gpt-3.5-turbo-0613""
-        // 2. "gpt-4-0613""
-        // 3. "gpt-4-1106-preview"
-        "default_model": "gpt-4-1106-preview"
-      }
+      "type": "openai",
+      // The default OpenAI API endpoint to use when starting new conversations.
+      "api_url": "https://api.openai.com/v1",
+      // The default OpenAI model to use when starting new conversations. This
+      // setting can take three values:
+      //
+      // 1. "gpt-3.5-turbo-0613""
+      // 2. "gpt-4-0613""
+      // 3. "gpt-4-1106-preview"
+      "default_model": "gpt-4-1106-preview"
     }
   },
   // Whether the screen sharing icon is shown in the os status bar.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -228,15 +228,30 @@
     "default_width": 640,
     // Default height when the assistant is docked to the bottom.
     "default_height": 320,
+    // Deprecated: Please use `provider.openai.api_url` instead.
     // The default OpenAI API endpoint to use when starting new conversations.
     "openai_api_url": "https://api.openai.com/v1",
+    // Deprecated: Please use `provider.openai.default_model` instead.
     // The default OpenAI model to use when starting new conversations. This
     // setting can take three values:
     //
     // 1. "gpt-3.5-turbo-0613""
     // 2. "gpt-4-0613""
     // 3. "gpt-4-1106-preview"
-    "default_open_ai_model": "gpt-4-1106-preview"
+    "default_open_ai_model": "gpt-4-1106-preview",
+    "provider": {
+      "openai": {
+        // The default OpenAI API endpoint to use when starting new conversations.
+        "api_url": "https://api.openai.com/v1",
+        // The default OpenAI model to use when starting new conversations. This
+        // setting can take three values:
+        //
+        // 1. "gpt-3.5-turbo-0613""
+        // 2. "gpt-4-0613""
+        // 3. "gpt-4-1106-preview"
+        "default_model": "gpt-4-1106-preview"
+      }
+    }
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -228,10 +228,10 @@
     "default_width": 640,
     // Default height when the assistant is docked to the bottom.
     "default_height": 320,
-    // Deprecated: Please use `provider.openai.api_url` instead.
+    // Deprecated: Please use `provider.api_url` instead.
     // The default OpenAI API endpoint to use when starting new conversations.
     "openai_api_url": "https://api.openai.com/v1",
-    // Deprecated: Please use `provider.openai.default_model` instead.
+    // Deprecated: Please use `provider.default_model` instead.
     // The default OpenAI model to use when starting new conversations. This
     // setting can take three values:
     //

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -29,6 +29,7 @@ parse_duration = "2.1.1"
 postage.workspace = true
 rand.workspace = true
 rusqlite = { version = "0.29.0", features = ["blob", "array", "modern_sqlite"] }
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tiktoken-rs.workspace = true

--- a/crates/ai/src/providers/open_ai/completion.rs
+++ b/crates/ai/src/providers/open_ai/completion.rs
@@ -1,3 +1,10 @@
+use std::{
+    env,
+    fmt::{self, Display},
+    io,
+    sync::Arc,
+};
+
 use anyhow::{anyhow, Result};
 use futures::{
     future::BoxFuture, io::BufReader, stream::BoxStream, AsyncBufReadExt, AsyncReadExt, FutureExt,
@@ -6,22 +13,16 @@ use futures::{
 use gpui::{AppContext, BackgroundExecutor};
 use isahc::{http::StatusCode, Request, RequestExt};
 use parking_lot::RwLock;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{
-    env,
-    fmt::{self, Display},
-    io,
-    sync::Arc,
-};
 use util::ResultExt;
 
+use crate::providers::open_ai::{OpenAiLanguageModel, OPEN_AI_API_URL};
 use crate::{
     auth::{CredentialProvider, ProviderCredential},
     completion::{CompletionProvider, CompletionRequest},
     models::LanguageModel,
 };
-
-use crate::providers::open_ai::{OpenAiLanguageModel, OPEN_AI_API_URL};
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -196,12 +197,59 @@ async fn stream_completion(
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+pub enum AzureOpenAiApiVersion {
+    #[serde(rename = "2022-12-01")]
+    V2022_12_01,
+    /// Retiring April 2, 2024.
+    #[serde(rename = "2023-03-15-preview")]
+    V2023_03_15Preview,
+    #[serde(rename = "2023-05-15")]
+    V2023_05_15,
+    /// Retiring April 2, 2024.
+    #[serde(rename = "2023-06-01-preview")]
+    V2023_06_01Preview,
+    /// Retiring April 2, 2024.
+    #[serde(rename = "2023-07-01-preview")]
+    V2023_07_01Preview,
+    /// Retiring April 2, 2024.
+    #[serde(rename = "2023-08-01-preview")]
+    V2023_08_01Preview,
+    /// Retiring April 2, 2024.
+    #[serde(rename = "2023-09-01-preview")]
+    V2023_09_01Preview,
+    #[serde(rename = "2023-12-01-preview")]
+    V2023_12_01Preview,
+    #[serde(rename = "2024-02-15-preview")]
+    V2024_02_15Preview,
+}
+
+impl fmt::Display for AzureOpenAiApiVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::V2022_12_01 => "2022-12-01",
+                Self::V2023_03_15Preview => "2023-03-15-preview",
+                Self::V2023_05_15 => "2023-05-15",
+                Self::V2023_06_01Preview => "2023-06-01-preview",
+                Self::V2023_07_01Preview => "2023-07-01-preview",
+                Self::V2023_08_01Preview => "2023-08-01-preview",
+                Self::V2023_09_01Preview => "2023-09-01-preview",
+                Self::V2023_12_01Preview => "2023-12-01-preview",
+                Self::V2024_02_15Preview => "2024-02-15-preview",
+            }
+        )
+    }
+}
+
 #[derive(Clone)]
 pub enum OpenAiCompletionProviderKind {
     OpenAi,
     AzureOpenAi {
         deployment_id: String,
-        api_version: String,
+        api_version: AzureOpenAiApiVersion,
     },
 }
 

--- a/crates/ai/src/providers/open_ai/completion.rs
+++ b/crates/ai/src/providers/open_ai/completion.rs
@@ -265,8 +265,8 @@ impl OpenAiCompletionProviderKind {
                 deployment_id,
                 api_version,
             } => {
-                // https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions
-                format!("{api_url}/openai/deployments/{deployment_id}/completions?api-version={api_version}")
+                // https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions
+                format!("{api_url}/openai/deployments/{deployment_id}/chat/completions?api-version={api_version}")
             }
         }
     }

--- a/crates/ai/src/providers/open_ai/completion.rs
+++ b/crates/ai/src/providers/open_ai/completion.rs
@@ -199,8 +199,6 @@ async fn stream_completion(
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 pub enum AzureOpenAiApiVersion {
-    #[serde(rename = "2022-12-01")]
-    V2022_12_01,
     /// Retiring April 2, 2024.
     #[serde(rename = "2023-03-15-preview")]
     V2023_03_15Preview,
@@ -230,7 +228,6 @@ impl fmt::Display for AzureOpenAiApiVersion {
             f,
             "{}",
             match self {
-                Self::V2022_12_01 => "2022-12-01",
                 Self::V2023_03_15Preview => "2023-03-15-preview",
                 Self::V2023_05_15 => "2023-05-15",
                 Self::V2023_06_01Preview => "2023-06-01-preview",

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -75,10 +75,8 @@ pub struct AssistantSettings {
 impl AssistantSettings {
     pub fn provider_kind(&self) -> anyhow::Result<OpenAiCompletionProviderKind> {
         match &self.provider {
-            crate::assistant_settings::AiProviderSettings::OpenAi(_) => {
-                Ok(OpenAiCompletionProviderKind::OpenAi)
-            }
-            crate::assistant_settings::AiProviderSettings::AzureOpenAi(settings) => {
+            AiProviderSettings::OpenAi(_) => Ok(OpenAiCompletionProviderKind::OpenAi),
+            AiProviderSettings::AzureOpenAi(settings) => {
                 let deployment_id = settings
                     .deployment_id
                     .clone()

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -166,11 +166,13 @@ pub struct AssistantSettingsContent {
     ///
     /// Default: 320
     pub default_height: Option<f32>,
+    /// Deprecated: Please use `provider.default_model` instead.
     /// The default OpenAI model to use when starting new conversations.
     ///
     /// Default: gpt-4-1106-preview
     #[deprecated = "Please use `provider.default_model` instead."]
     pub default_open_ai_model: Option<OpenAiModel>,
+    /// Deprecated: Please use `provider.api_url` instead.
     /// OpenAI API base URL to use when starting new conversations.
     ///
     /// Default: https://api.openai.com/v1

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -118,20 +118,32 @@ pub struct AssistantSettingsContent {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct AiProviderSettings {
-    pub openai: OpenAiProviderSettings,
-    pub azure_openai: AzureOpenAiProviderSettings,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AiProviderSettings {
+    /// The settings for the OpenAI provider.
+    #[serde(rename = "openai")]
+    OpenAi(OpenAiProviderSettings),
+    /// The settings for the Azure OpenAI provider.
+    #[serde(rename = "azure_openai")]
+    AzureOpenAi(AzureOpenAiProviderSettings),
 }
 
 /// The settings for the AI provider used by the Zed Assistant.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct AiProviderSettingsContent {
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AiProviderSettingsContent {
     /// The settings for the OpenAI provider.
-    #[serde(default)]
-    pub openai: OpenAiProviderSettingsContent,
+    #[serde(rename = "openai")]
+    OpenAi(OpenAiProviderSettingsContent),
     /// The settings for the Azure OpenAI provider.
-    #[serde(default)]
-    pub azure_openai: AzureOpenAiProviderSettingsContent,
+    #[serde(rename = "azure_openai")]
+    AzureOpenAi(AzureOpenAiProviderSettingsContent),
+}
+
+impl Default for AiProviderSettingsContent {
+    fn default() -> Self {
+        Self::OpenAi(OpenAiProviderSettingsContent::default())
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use settings::Settings;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum OpenAiModel {
     #[serde(rename = "gpt-3.5-turbo-0613")]
     ThreePointFiveTurbo,
@@ -17,25 +18,25 @@ pub enum OpenAiModel {
 impl OpenAiModel {
     pub fn full_name(&self) -> &'static str {
         match self {
-            OpenAiModel::ThreePointFiveTurbo => "gpt-3.5-turbo-0613",
-            OpenAiModel::Four => "gpt-4-0613",
-            OpenAiModel::FourTurbo => "gpt-4-1106-preview",
+            Self::ThreePointFiveTurbo => "gpt-3.5-turbo-0613",
+            Self::Four => "gpt-4-0613",
+            Self::FourTurbo => "gpt-4-1106-preview",
         }
     }
 
     pub fn short_name(&self) -> &'static str {
         match self {
-            OpenAiModel::ThreePointFiveTurbo => "gpt-3.5-turbo",
-            OpenAiModel::Four => "gpt-4",
-            OpenAiModel::FourTurbo => "gpt-4-turbo",
+            Self::ThreePointFiveTurbo => "gpt-3.5-turbo",
+            Self::Four => "gpt-4",
+            Self::FourTurbo => "gpt-4-turbo",
         }
     }
 
     pub fn cycle(&self) -> Self {
         match self {
-            OpenAiModel::ThreePointFiveTurbo => OpenAiModel::Four,
-            OpenAiModel::Four => OpenAiModel::FourTurbo,
-            OpenAiModel::FourTurbo => OpenAiModel::ThreePointFiveTurbo,
+            Self::ThreePointFiveTurbo => Self::Four,
+            Self::Four => Self::FourTurbo,
+            Self::FourTurbo => Self::ThreePointFiveTurbo,
         }
     }
 }
@@ -48,14 +49,38 @@ pub enum AssistantDockPosition {
     Bottom,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize)]
 pub struct AssistantSettings {
+    /// Whether to show the assistant panel button in the status bar.
     pub button: bool,
+    /// Where to dock the assistant.
     pub dock: AssistantDockPosition,
+    /// Default width in pixels when the assistant is docked to the left or right.
     pub default_width: Pixels,
+    /// Default height in pixels when the assistant is docked to the bottom.
     pub default_height: Pixels,
+    /// The default OpenAI model to use when starting new conversations.
+    #[deprecated = "Please use `provider.openai.default_model` instead."]
     pub default_open_ai_model: OpenAiModel,
+    /// OpenAI API base URL to use when starting new conversations.
+    #[deprecated = "Please use `provider.openai.api_url` instead."]
     pub openai_api_url: String,
+    /// The settings for the AI provider.
+    pub provider: AiProviderSettings,
+}
+
+impl Settings for AssistantSettings {
+    const KEY: Option<&'static str> = Some("assistant");
+
+    type FileContent = AssistantSettingsContent;
+
+    fn load(
+        default_value: &Self::FileContent,
+        user_values: &[&Self::FileContent],
+        _: &mut gpui::AppContext,
+    ) -> anyhow::Result<Self> {
+        Self::load_via_json_merge(default_value, user_values)
+    }
 }
 
 /// Assistant panel settings
@@ -80,23 +105,71 @@ pub struct AssistantSettingsContent {
     /// The default OpenAI model to use when starting new conversations.
     ///
     /// Default: gpt-4-1106-preview
+    #[deprecated = "Please use `provider.openai.default_model` instead."]
     pub default_open_ai_model: Option<OpenAiModel>,
     /// OpenAI API base URL to use when starting new conversations.
     ///
     /// Default: https://api.openai.com/v1
+    #[deprecated = "Please use `provider.openai.api_url` instead."]
     pub openai_api_url: Option<String>,
+    /// The settings for the AI provider.
+    #[serde(default)]
+    pub provider: AiProviderSettingsContent,
 }
 
-impl Settings for AssistantSettings {
-    const KEY: Option<&'static str> = Some("assistant");
+#[derive(Debug, Deserialize)]
+pub struct AiProviderSettings {
+    pub openai: OpenAiProviderSettings,
+    pub azure_openai: AzureOpenAiProviderSettings,
+}
 
-    type FileContent = AssistantSettingsContent;
+/// The settings for the AI provider used by the Zed Assistant.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AiProviderSettingsContent {
+    /// The settings for the OpenAI provider.
+    #[serde(default)]
+    pub openai: OpenAiProviderSettingsContent,
+    /// The settings for the Azure OpenAI provider.
+    #[serde(default)]
+    pub azure_openai: AzureOpenAiProviderSettingsContent,
+}
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut gpui::AppContext,
-    ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
-    }
+#[derive(Debug, Deserialize)]
+pub struct OpenAiProviderSettings {
+    /// The OpenAI API base URL to use when starting new conversations.
+    pub api_url: Option<String>,
+    /// The default OpenAI model to use when starting new conversations.
+    pub default_model: Option<OpenAiModel>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OpenAiProviderSettingsContent {
+    /// The OpenAI API base URL to use when starting new conversations.
+    ///
+    /// Default: https://api.openai.com/v1
+    pub api_url: Option<String>,
+    /// The default OpenAI model to use when starting new conversations.
+    ///
+    /// Default: gpt-4-1106-preview
+    pub default_model: Option<OpenAiModel>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AzureOpenAiProviderSettings {
+    /// The Azure OpenAI API base URL to use when starting new conversations.
+    pub api_url: Option<String>,
+    /// The Azure OpenAI API version.
+    pub api_version: Option<String>,
+    /// The Azure OpenAI API deployment ID.
+    pub deployment_id: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AzureOpenAiProviderSettingsContent {
+    /// The Azure OpenAI API base URL to use when starting new conversations.
+    pub api_url: Option<String>,
+    /// The Azure OpenAI API version.
+    pub api_version: Option<String>,
+    /// The Azure OpenAI deployment ID.
+    pub deployment_id: Option<String>,
 }

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -66,10 +66,10 @@ pub struct AssistantSettings {
     /// Default height in pixels when the assistant is docked to the bottom.
     pub default_height: Pixels,
     /// The default OpenAI model to use when starting new conversations.
-    #[deprecated = "Please use `provider.openai.default_model` instead."]
+    #[deprecated = "Please use `provider.default_model` instead."]
     pub default_open_ai_model: OpenAiModel,
     /// OpenAI API base URL to use when starting new conversations.
-    #[deprecated = "Please use `provider.openai.api_url` instead."]
+    #[deprecated = "Please use `provider.api_url` instead."]
     pub openai_api_url: String,
     /// The settings for the AI provider.
     pub provider: AiProviderSettings,

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -149,12 +149,12 @@ pub struct AssistantSettingsContent {
     /// The default OpenAI model to use when starting new conversations.
     ///
     /// Default: gpt-4-1106-preview
-    #[deprecated = "Please use `provider.openai.default_model` instead."]
+    #[deprecated = "Please use `provider.default_model` instead."]
     pub default_open_ai_model: Option<OpenAiModel>,
     /// OpenAI API base URL to use when starting new conversations.
     ///
     /// Default: https://api.openai.com/v1
-    #[deprecated = "Please use `provider.openai.api_url` instead."]
+    #[deprecated = "Please use `provider.api_url` instead."]
     pub openai_api_url: Option<String>,
     /// The settings for the AI provider.
     #[serde(default)]

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -1,4 +1,4 @@
-use ai::providers::open_ai::OPEN_AI_API_URL;
+use ai::providers::open_ai::{AzureOpenAiApiVersion, OPEN_AI_API_URL};
 use anyhow::anyhow;
 use gpui::Pixels;
 use schemars::JsonSchema;
@@ -215,7 +215,7 @@ pub struct AzureOpenAiProviderSettings {
     /// The Azure OpenAI API base URL to use when starting new conversations.
     pub api_url: Option<String>,
     /// The Azure OpenAI API version.
-    pub api_version: Option<String>,
+    pub api_version: Option<AzureOpenAiApiVersion>,
     /// The Azure OpenAI API deployment ID.
     pub deployment_id: Option<String>,
 }
@@ -225,7 +225,7 @@ pub struct AzureOpenAiProviderSettingsContent {
     /// The Azure OpenAI API base URL to use when starting new conversations.
     pub api_url: Option<String>,
     /// The Azure OpenAI API version.
-    pub api_version: Option<String>,
+    pub api_version: Option<AzureOpenAiApiVersion>,
     /// The Azure OpenAI deployment ID.
     pub deployment_id: Option<String>,
 }

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -263,7 +263,7 @@ impl Telemetry {
         self: &Arc<Self>,
         conversation_id: Option<String>,
         kind: AssistantKind,
-        model: &'static str,
+        model: &str,
     ) {
         let event = Event::Assistant(AssistantEvent {
             conversation_id,


### PR DESCRIPTION
This PR wires up support for [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) as an alternative AI provider in the assistant panel.

This can be configured using the following in the settings file:

```json
{
  "assistant": {
    "provider": {
      "type": "azure_openai",
      "api_url": "https://{your-resource-name}.openai.azure.com",
      "deployment_id": "gpt-4",
      "api_version": "2023-05-15"
    }
  },
}
```

You will need to deploy a model within Azure and update the settings accordingly.

Release Notes:

- N/A
