### PR TITLE
Replace `lazy_static!` with `OnceLock` in `time_format` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9436,7 +9436,6 @@ dependencies = [
  "anyhow",
  "core-foundation",
  "core-foundation-sys 0.8.6",
- "lazy_static",
  "sys-locale",
  "time",
 ]

--- a/crates/time_format/Cargo.toml
+++ b/crates/time_format/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-lazy_static.workspace = true
 sys-locale.workspace = true
 time.workspace = true
 

--- a/crates/time_format/src/time_format.rs
+++ b/crates/time_format/src/time_format.rs
@@ -1,4 +1,5 @@
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
+
 use time::{OffsetDateTime, UtcOffset};
 
 /// Formats a timestamp, which respects the user's date and time preferences/custom format.
@@ -36,18 +37,18 @@ fn format_timestamp_fallback(
     timestamp: OffsetDateTime,
     timezone: UtcOffset,
 ) -> String {
-    lazy_static! {
-        static ref CURRENT_LOCALE: String =
-            sys_locale::get_locale().unwrap_or_else(|| String::from("en-US"));
-    }
-    let is_12_hour_time = is_12_hour_time_by_locale(CURRENT_LOCALE.as_str());
+    static CURRENT_LOCALE: OnceLock<String> = OnceLock::new();
+    let current_locale = CURRENT_LOCALE
+        .get_or_init(|| sys_locale::get_locale().unwrap_or_else(|| String::from("en-US")));
+
+    let is_12_hour_time = is_12_hour_time_by_locale(current_locale.as_str());
     format_timestamp_naive(reference, timestamp, timezone, is_12_hour_time)
 }
 
 /// Formats a timestamp, which is either in 12-hour or 24-hour time format.
 /// Note:
 /// This function does not respect the user's date and time preferences.
-/// This should only be used as a fallback mechanism when the os time formatting fails.
+/// This should only be used as a fallback mechanism when the OS time formatting fails.
 pub fn format_timestamp_naive(
     reference: OffsetDateTime,
     timestamp: OffsetDateTime,
@@ -109,7 +110,7 @@ pub fn format_timestamp_naive(
     }
 }
 
-/// Returns true if the locale is recognized as a 12-hour time locale.
+/// Returns `true` if the locale is recognized as a 12-hour time locale.
 fn is_12_hour_time_by_locale(locale: &str) -> bool {
     [
         "es-MX", "es-CO", "es-SV", "es-NI",


### PR DESCRIPTION
This PR replaces a `lazy_static!` usage in the `time_format` crate with `OnceLock` from the standard library.

This allows us to drop the `lazy_static` dependency from this crate.

Release Notes:

- N/A
