### PR TITLE
Clean up and refactor X11 refresh loop (alternative)

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -96,8 +96,7 @@ objc = "0.2"
 flume = "0.11"
 open = "5.0.1"
 ashpd = "0.7.0"
-# todo(linux) - Technically do not use `randr`, but it doesn't compile otherwise
-xcb = { version = "1.3", features = ["as-raw-xcb-connection", "present", "randr", "xkb"] }
+xcb = { version = "1.3", features = ["as-raw-xcb-connection", "randr", "xkb"] }
 wayland-client= { version = "0.31.2" }
 wayland-protocols = { version = "0.31.2", features = ["client", "staging", "unstable"] }
 wayland-backend = { version = "0.3.3", features = ["client_system"] }

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -122,18 +122,15 @@ impl Platform for LinuxPlatform {
 
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {
         on_finish_launching();
+
         self.inner
             .event_loop
             .borrow_mut()
-            .run(None, &mut (), |data| {})
+            .run(None, &mut (), |&mut ()| {})
             .expect("Run loop failed");
 
-        let mut lock = self.inner.callbacks.borrow_mut();
-        if let Some(mut fun) = lock.quit.take() {
-            drop(lock);
+        if let Some(mut fun) = self.inner.callbacks.borrow_mut().quit.take() {
             fun();
-            let mut lock = self.inner.callbacks.borrow_mut();
-            lock.quit = Some(fun);
         }
     }
 


### PR DESCRIPTION
Associates every window with its own refresh event. Removes the use of X11 present.
Alternative to #8592.
Instead of doing the rendering on idle and then involving a hack for polling X11 events, this PR just tries to do the rendering inside the main loop. This guarantees that we continue to poll for events after the draw, and not get screwed by the driver talking to X11 via the same file descriptor.

Release Notes:
- N/A
