### PR TITLE
Add max_file_size restriction

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -333,6 +333,9 @@
     "**/.classpath",
     "**/.settings"
   ],
+  // The maximum size in kilobytes of a file that Zed will open. Files larger than this will not be opened.
+  // The default is 10MB, some users may want to increase this, but be aware that large files can slow down or crash Zed.
+  "max_file_size": 10240,
   // Git gutter behavior configuration.
   "git": {
     // Control whether the git gutter is shown. May take 2 values:

--- a/crates/project_core/src/project_settings.rs
+++ b/crates/project_core/src/project_settings.rs
@@ -39,6 +39,9 @@ pub struct ProjectSettings {
     /// Treat the files matching these globs as `.env` files.
     /// Default: [ "**/.env*" ]
     pub private_files: Option<Vec<String>>,
+
+    /// Maximum file size in bytes to open in the editor.
+    pub max_file_size: usize,
 }
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/project_core/src/project_settings.rs
+++ b/crates/project_core/src/project_settings.rs
@@ -40,7 +40,7 @@ pub struct ProjectSettings {
     /// Default: [ "**/.env*" ]
     pub private_files: Option<Vec<String>>,
 
-    /// Maximum file size in bytes to open in the editor.
+    /// Maximum file size in kilobytes to open in the editor.
     pub max_file_size: usize,
 }
 

--- a/crates/project_core/src/project_settings.rs
+++ b/crates/project_core/src/project_settings.rs
@@ -41,6 +41,10 @@ pub struct ProjectSettings {
     pub private_files: Option<Vec<String>>,
 
     /// Maximum file size in kilobytes to open in the editor.
+    /// Files larger than this will not be opened and a warning will be shown.
+    /// Keep in mind that large files can slow down or even crash the editor.
+    ///
+    /// Default: 10240 (10MB)
     pub max_file_size: usize,
 }
 


### PR DESCRIPTION
Release Notes:

Added a max file size restriction to prevent performance issues or crashes when opening large files in Zed. If a user attempts to open a file exceeding the max_file_size setting (default limit: 10MB), a modal will display the message: "File size of X MB exceeds maximum allowed size: Y MB". This setting can be adjusted in bytes within the project settings.

**Background:**

In my experience with Zed, opening large files inadvertently has led to significant slowdowns and, in some cases, crashes, resulting in lost work.

**Additional Notes:**

Ideally, large files would be opened in read-only mode to mitigate memory consumption issues. However, given Zed's current architecture where files are fully loaded into memory, implementing this feature would require substantial changes. Therefore, introducing a file size restriction serves as an essential safeguard to prevent data loss and enhance user experience.


https://github.com/zed-industries/zed/assets/13990333/64090193-5317-41b6-bc2f-0f9cd82a9d1a

