### PR TITLE
Allow to handle autoclosed characters differently

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -97,7 +97,7 @@
   // happen only for auto-inserted characters.
   // Otherwise(when `true`), the closing characters are always skipped over and auto-removed
   // no matter how they were inserted.
-  "always_handle_autoclosed_character": false,
+  "always_treat_brackets_as_autoclosed": false,
   // Controls whether copilot provides suggestion immediately
   // or waits for a `copilot::Toggle`
   "show_copilot_suggestions": true,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -95,7 +95,7 @@
   // Controls how the editor handles the autoclosed characters.
   // When set to `false`(default), skipping over and auto-removing of the closing characters
   // happen only for auto-inserted characters.
-  // Otherwise(when `true`), the closing charcaters are always skipped over and auto-removed
+  // Otherwise(when `true`), the closing characters are always skipped over and auto-removed
   // no matter how they were inserted.
   "always_handle_autoclosed_character": false,
   // Controls whether copilot provides suggestion immediately

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -92,6 +92,12 @@
   // Whether to automatically type closing characters for you. For example,
   // when you type (, Zed will automatically add a closing ) at the correct position.
   "use_autoclose": true,
+  // Controls how the editor handles the autoclosed characters.
+  // When set to `false`(default), skipping over and auto-removing of the closing characters
+  // happen only for auto-inserted characters.
+  // Otherwise(when `true`), the closing charcaters are always skipped over and auto-removed
+  // no matter how they were inserted.
+  "always_handle_autoclosed_character": false,
   // Controls whether copilot provides suggestion immediately
   // or waits for a `copilot::Toggle`
   "show_copilot_suggestions": true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -430,7 +430,7 @@ pub struct Editor {
     editor_actions: Vec<Box<dyn Fn(&mut ViewContext<Self>)>>,
     show_copilot_suggestions: bool,
     use_autoclose: bool,
-    always_handle_autoclosed_character: bool,
+    always_treat_brackets_as_autoclosed: bool,
     auto_replace_emoji_shortcode: bool,
     custom_context_menu: Option<
         Box<
@@ -1558,7 +1558,7 @@ impl Editor {
             use_modal_editing: mode == EditorMode::Full,
             read_only: false,
             use_autoclose: true,
-            always_handle_autoclosed_character: false,
+            always_treat_brackets_as_autoclosed: false,
             auto_replace_emoji_shortcode: false,
             leader_peer_id: None,
             remote_id: None,
@@ -1851,11 +1851,11 @@ impl Editor {
         self.use_autoclose = autoclose;
     }
 
-    pub fn set_always_handle_autoclosed_character(
+    pub fn set_always_treat_brackets_as_autoclosed(
         &mut self,
-        always_handle_autoclosed_character: bool,
+        always_treat_brackets_as_autoclosed: bool,
     ) {
-        self.always_handle_autoclosed_character = always_handle_autoclosed_character;
+        self.always_treat_brackets_as_autoclosed = always_treat_brackets_as_autoclosed;
     }
 
     pub fn set_auto_replace_emoji_shortcode(&mut self, auto_replace: bool) {
@@ -2521,16 +2521,16 @@ impl Editor {
                             }
                         }
 
-                        let always_handle_autoclosed_character = self
-                            .always_handle_autoclosed_character
+                        let always_treat_brackets_as_autoclosed = self
+                            .always_treat_brackets_as_autoclosed
                             && snapshot
                                 .settings_at(selection.start, cx)
-                                .always_handle_autoclosed_character;
-                        if always_handle_autoclosed_character
+                                .always_treat_brackets_as_autoclosed;
+                        if always_treat_brackets_as_autoclosed
                             && is_bracket_pair_end
                             && snapshot.contains_str_at(selection.end, text.as_ref())
                         {
-                            // Otherwise, when `always_handle_autoclosed_character` is set to `true
+                            // Otherwise, when `always_treat_brackets_as_autoclosed` is set to `true
                             // and the inserted text is a closing bracket and the selection is followed
                             // by the closing bracket then move the selection past the closing bracket.
                             let anchor = snapshot.anchor_after(selection.end);
@@ -3082,12 +3082,12 @@ impl Editor {
                     }
                 }
 
-                let always_handle_autoclosed_character = self.always_handle_autoclosed_character
+                let always_treat_brackets_as_autoclosed = self.always_treat_brackets_as_autoclosed
                     && buffer
                         .settings_at(selection.start, cx)
-                        .always_handle_autoclosed_character;
+                        .always_treat_brackets_as_autoclosed;
 
-                if !always_handle_autoclosed_character {
+                if !always_treat_brackets_as_autoclosed {
                     return selection;
                 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3055,18 +3055,16 @@ impl Editor {
 
                 if let Some(region) = region {
                     let mut range = region.range.to_offset(&buffer);
-                    if selection.start == range.start {
-                        if range.start >= region.pair.start.len() {
-                            range.start -= region.pair.start.len();
-                            if buffer.contains_str_at(range.start, &region.pair.start) {
-                                if buffer.contains_str_at(range.end, &region.pair.end) {
-                                    range.end += region.pair.end.len();
-                                    selection.start = range.start;
-                                    selection.end = range.end;
+                    if selection.start == range.start && range.start >= region.pair.start.len() {
+                        range.start -= region.pair.start.len();
+                        if buffer.contains_str_at(range.start, &region.pair.start)
+                            && buffer.contains_str_at(range.end, &region.pair.end)
+                        {
+                            range.end += region.pair.end.len();
+                            selection.start = range.start;
+                            selection.end = range.end;
 
-                                    return selection;
-                                }
-                            }
+                            return selection;
                         }
                     }
                 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -430,7 +430,6 @@ pub struct Editor {
     editor_actions: Vec<Box<dyn Fn(&mut ViewContext<Self>)>>,
     show_copilot_suggestions: bool,
     use_autoclose: bool,
-    always_treat_brackets_as_autoclosed: bool,
     auto_replace_emoji_shortcode: bool,
     custom_context_menu: Option<
         Box<
@@ -1558,7 +1557,6 @@ impl Editor {
             use_modal_editing: mode == EditorMode::Full,
             read_only: false,
             use_autoclose: true,
-            always_treat_brackets_as_autoclosed: false,
             auto_replace_emoji_shortcode: false,
             leader_peer_id: None,
             remote_id: None,
@@ -1849,13 +1847,6 @@ impl Editor {
 
     pub fn set_use_autoclose(&mut self, autoclose: bool) {
         self.use_autoclose = autoclose;
-    }
-
-    pub fn set_always_treat_brackets_as_autoclosed(
-        &mut self,
-        always_treat_brackets_as_autoclosed: bool,
-    ) {
-        self.always_treat_brackets_as_autoclosed = always_treat_brackets_as_autoclosed;
     }
 
     pub fn set_auto_replace_emoji_shortcode(&mut self, auto_replace: bool) {
@@ -2521,11 +2512,9 @@ impl Editor {
                             }
                         }
 
-                        let always_treat_brackets_as_autoclosed = self
-                            .always_treat_brackets_as_autoclosed
-                            && snapshot
-                                .settings_at(selection.start, cx)
-                                .always_treat_brackets_as_autoclosed;
+                        let always_treat_brackets_as_autoclosed = snapshot
+                            .settings_at(selection.start, cx)
+                            .always_treat_brackets_as_autoclosed;
                         if always_treat_brackets_as_autoclosed
                             && is_bracket_pair_end
                             && snapshot.contains_str_at(selection.end, text.as_ref())
@@ -3082,10 +3071,9 @@ impl Editor {
                     }
                 }
 
-                let always_treat_brackets_as_autoclosed = self.always_treat_brackets_as_autoclosed
-                    && buffer
-                        .settings_at(selection.start, cx)
-                        .always_treat_brackets_as_autoclosed;
+                let always_treat_brackets_as_autoclosed = buffer
+                    .settings_at(selection.start, cx)
+                    .always_treat_brackets_as_autoclosed;
 
                 if !always_treat_brackets_as_autoclosed {
                     return selection;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4573,7 +4573,6 @@ async fn test_always_treat_brackets_as_autoclosed_skip_over(cx: &mut gpui::TestA
     });
 
     let mut cx = EditorTestContext::new(cx).await;
-    cx.update_editor(|view, _cx| view.set_always_treat_brackets_as_autoclosed(true));
 
     let language = Arc::new(Language::new(
         LanguageConfig {
@@ -4606,10 +4605,8 @@ async fn test_always_treat_brackets_as_autoclosed_skip_over(cx: &mut gpui::TestA
         Some(tree_sitter_rust::language()),
     ));
 
-    let registry = Arc::new(LanguageRegistry::test());
-    registry.add(language.clone());
+    cx.language_registry().add(language.clone());
     cx.update_buffer(|buffer, cx| {
-        buffer.set_language_registry(registry);
         buffer.set_language(Some(language), cx);
     });
 
@@ -5272,7 +5269,6 @@ async fn test_always_treat_brackets_as_autoclosed_delete(cx: &mut gpui::TestAppC
     });
 
     let mut cx = EditorTestContext::new(cx).await;
-    cx.update_editor(|view, _cx| view.set_always_treat_brackets_as_autoclosed(true));
 
     let language = Arc::new(Language::new(
         LanguageConfig {
@@ -5305,10 +5301,8 @@ async fn test_always_treat_brackets_as_autoclosed_delete(cx: &mut gpui::TestAppC
         Some(tree_sitter_rust::language()),
     ));
 
-    let registry = Arc::new(LanguageRegistry::test());
-    registry.add(language.clone());
+    cx.language_registry().add(language.clone());
     cx.update_buffer(|buffer, cx| {
-        buffer.set_language_registry(registry);
         buffer.set_language(Some(language), cx);
     });
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4567,6 +4567,120 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_always_handle_autoclosed_character_skip_over(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.always_handle_autoclosed_character = Some(true);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_editor(|view, _cx| view.set_always_handle_autoclosed_character(true));
+
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            brackets: BracketPairConfig {
+                pairs: vec![
+                    BracketPair {
+                        start: "{".to_string(),
+                        end: "}".to_string(),
+                        close: true,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "(".to_string(),
+                        end: ")".to_string(),
+                        close: true,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "/*".to_string(),
+                        end: " */".to_string(),
+                        close: true,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "[".to_string(),
+                        end: "]".to_string(),
+                        close: false,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "\"".to_string(),
+                        end: "\"".to_string(),
+                        close: true,
+                        newline: false,
+                    },
+                ],
+                ..Default::default()
+            },
+            autoclose_before: "})]".to_string(),
+            ..Default::default()
+        },
+        Some(tree_sitter_rust::language()),
+    ));
+
+    let registry = Arc::new(LanguageRegistry::test());
+    registry.add(language.clone());
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language_registry(registry);
+        buffer.set_language(Some(language), cx);
+    });
+
+    cx.set_state(
+        &"
+            ˇ
+            ˇ
+            ˇ
+        "
+        .unindent(),
+    );
+
+    // ensure only matching closing brackets are skipped over
+    cx.update_editor(|view, cx| {
+        view.handle_input("}", cx);
+        view.move_left(&MoveLeft, cx);
+        view.handle_input(")", cx);
+        view.move_left(&MoveLeft, cx);
+    });
+    cx.assert_editor_state(
+        &"
+            ˇ)}
+            ˇ)}
+            ˇ)}
+        "
+        .unindent(),
+    );
+
+    // skip-over closing brackets at multiple cursors
+    cx.update_editor(|view, cx| {
+        view.handle_input(")", cx);
+        view.handle_input("}", cx);
+    });
+    cx.assert_editor_state(
+        &"
+            )}ˇ
+            )}ˇ
+            )}ˇ
+        "
+        .unindent(),
+    );
+
+    // ignore non-close brackets
+    cx.update_editor(|view, cx| {
+        view.handle_input("]", cx);
+        view.move_left(&MoveLeft, cx);
+        view.handle_input("]", cx);
+    });
+    cx.assert_editor_state(
+        &"
+            )}]ˇ]
+            )}]ˇ]
+            )}]ˇ]
+        "
+        .unindent(),
+    );
+}
+
+#[gpui::test]
 async fn test_autoclose_with_embedded_language(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
@@ -5161,6 +5275,121 @@ async fn test_delete_autoclose_pair(cx: &mut gpui::TestAppContext) {
             ]
         );
     });
+}
+
+#[gpui::test]
+async fn test_always_handle_autoclosed_character_delete(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.always_handle_autoclosed_character = Some(true);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_editor(|view, _cx| view.set_always_handle_autoclosed_character(true));
+
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            brackets: BracketPairConfig {
+                pairs: vec![
+                    BracketPair {
+                        start: "{".to_string(),
+                        end: "}".to_string(),
+                        close: true,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "(".to_string(),
+                        end: ")".to_string(),
+                        close: true,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "/*".to_string(),
+                        end: " */".to_string(),
+                        close: true,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "[".to_string(),
+                        end: "]".to_string(),
+                        close: false,
+                        newline: true,
+                    },
+                    BracketPair {
+                        start: "\"".to_string(),
+                        end: "\"".to_string(),
+                        close: true,
+                        newline: false,
+                    },
+                ],
+                ..Default::default()
+            },
+            autoclose_before: "})]".to_string(),
+            ..Default::default()
+        },
+        Some(tree_sitter_rust::language()),
+    ));
+
+    let registry = Arc::new(LanguageRegistry::test());
+    registry.add(language.clone());
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language_registry(registry);
+        buffer.set_language(Some(language), cx);
+    });
+
+    cx.set_state(
+        &"
+            {(ˇ)}
+            [[ˇ]]
+            {(ˇ)}
+        "
+        .unindent(),
+    );
+
+    cx.update_editor(|view, cx| {
+        view.backspace(&Default::default(), cx);
+        view.backspace(&Default::default(), cx);
+    });
+
+    cx.assert_editor_state(
+        &"
+            ˇ
+            ˇ]]
+            ˇ
+        "
+        .unindent(),
+    );
+
+    cx.update_editor(|view, cx| {
+        view.handle_input("{", cx);
+        view.handle_input("{", cx);
+        view.move_right(&MoveRight, cx);
+        view.move_right(&MoveRight, cx);
+        view.move_left(&MoveLeft, cx);
+        view.move_left(&MoveLeft, cx);
+        view.backspace(&Default::default(), cx);
+    });
+
+    cx.assert_editor_state(
+        &"
+            {ˇ}
+            {ˇ}]]
+            {ˇ}
+        "
+        .unindent(),
+    );
+
+    cx.update_editor(|view, cx| {
+        view.backspace(&Default::default(), cx);
+    });
+
+    cx.assert_editor_state(
+        &"
+            ˇ
+            ˇ]]
+            ˇ
+        "
+        .unindent(),
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4592,22 +4592,10 @@ async fn test_always_treat_brackets_as_autoclosed_skip_over(cx: &mut gpui::TestA
                         newline: true,
                     },
                     BracketPair {
-                        start: "/*".to_string(),
-                        end: " */".to_string(),
-                        close: true,
-                        newline: true,
-                    },
-                    BracketPair {
                         start: "[".to_string(),
                         end: "]".to_string(),
                         close: false,
                         newline: true,
-                    },
-                    BracketPair {
-                        start: "\"".to_string(),
-                        end: "\"".to_string(),
-                        close: true,
-                        newline: false,
                     },
                 ],
                 ..Default::default()
@@ -5303,22 +5291,10 @@ async fn test_always_treat_brackets_as_autoclosed_delete(cx: &mut gpui::TestAppC
                         newline: true,
                     },
                     BracketPair {
-                        start: "/*".to_string(),
-                        end: " */".to_string(),
-                        close: true,
-                        newline: true,
-                    },
-                    BracketPair {
                         start: "[".to_string(),
                         end: "]".to_string(),
                         close: false,
                         newline: true,
-                    },
-                    BracketPair {
-                        start: "\"".to_string(),
-                        end: "\"".to_string(),
-                        close: true,
-                        newline: false,
                     },
                 ],
                 ..Default::default()

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4567,13 +4567,13 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_always_handle_autoclosed_character_skip_over(cx: &mut gpui::TestAppContext) {
+async fn test_always_treat_brackets_as_autoclosed_skip_over(cx: &mut gpui::TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.always_handle_autoclosed_character = Some(true);
+        settings.defaults.always_treat_brackets_as_autoclosed = Some(true);
     });
 
     let mut cx = EditorTestContext::new(cx).await;
-    cx.update_editor(|view, _cx| view.set_always_handle_autoclosed_character(true));
+    cx.update_editor(|view, _cx| view.set_always_treat_brackets_as_autoclosed(true));
 
     let language = Arc::new(Language::new(
         LanguageConfig {
@@ -5278,13 +5278,13 @@ async fn test_delete_autoclose_pair(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_always_handle_autoclosed_character_delete(cx: &mut gpui::TestAppContext) {
+async fn test_always_treat_brackets_as_autoclosed_delete(cx: &mut gpui::TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.always_handle_autoclosed_character = Some(true);
+        settings.defaults.always_treat_brackets_as_autoclosed = Some(true);
     });
 
     let mut cx = EditorTestContext::new(cx).await;
-    cx.update_editor(|view, _cx| view.set_always_handle_autoclosed_character(true));
+    cx.update_editor(|view, _cx| view.set_always_treat_brackets_as_autoclosed(true));
 
     let language = Arc::new(Language::new(
         LanguageConfig {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -241,7 +241,7 @@ pub struct LanguageSettingsContent {
     // Controls how the editor handles the autoclosed characters.
     // When set to `false`(default), skipping over and auto-removing of the closing characters
     // happen only for auto-inserted characters.
-    // Otherwise(when `true`), the closing charcaters are always skipped over and auto-removed
+    // Otherwise(when `true`), the closing characters are always skipped over and auto-removed
     // no matter how they were inserted.
     ///
     /// Default: false

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -103,10 +103,10 @@ pub struct LanguageSettings {
     pub inlay_hints: InlayHintSettings,
     /// Whether to automatically close brackets.
     pub use_autoclose: bool,
-    /// Which code actions to run on save
-    pub code_actions_on_format: HashMap<String, bool>,
     // Controls how the editor handles the autoclosed characters.
     pub always_treat_brackets_as_autoclosed: bool,
+    /// Which code actions to run on save
+    pub code_actions_on_format: HashMap<String, bool>,
 }
 
 /// The settings for [GitHub Copilot](https://github.com/features/copilot).
@@ -233,11 +233,6 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub use_autoclose: Option<bool>,
-
-    /// Which code actions to run on save
-    ///
-    /// Default: {} (or {"source.organizeImports": true} for Go).
-    pub code_actions_on_format: Option<HashMap<String, bool>>,
     // Controls how the editor handles the autoclosed characters.
     // When set to `false`(default), skipping over and auto-removing of the closing characters
     // happen only for auto-inserted characters.
@@ -246,6 +241,10 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: false
     pub always_treat_brackets_as_autoclosed: Option<bool>,
+    /// Which code actions to run on save
+    ///
+    /// Default: {} (or {"source.organizeImports": true} for Go).
+    pub code_actions_on_format: Option<HashMap<String, bool>>,
 }
 
 /// The contents of the GitHub Copilot settings.

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -106,7 +106,7 @@ pub struct LanguageSettings {
     /// Which code actions to run on save
     pub code_actions_on_format: HashMap<String, bool>,
     // Controls how the editor handles the autoclosed characters.
-    pub always_handle_autoclosed_character: bool,
+    pub always_treat_brackets_as_autoclosed: bool,
 }
 
 /// The settings for [GitHub Copilot](https://github.com/features/copilot).
@@ -245,7 +245,7 @@ pub struct LanguageSettingsContent {
     // no matter how they were inserted.
     ///
     /// Default: false
-    pub always_handle_autoclosed_character: Option<bool>,
+    pub always_treat_brackets_as_autoclosed: Option<bool>,
 }
 
 /// The contents of the GitHub Copilot settings.
@@ -613,8 +613,8 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
     merge(&mut settings.soft_wrap, src.soft_wrap);
     merge(&mut settings.use_autoclose, src.use_autoclose);
     merge(
-        &mut settings.always_handle_autoclosed_character,
-        src.always_handle_autoclosed_character,
+        &mut settings.always_treat_brackets_as_autoclosed,
+        src.always_treat_brackets_as_autoclosed,
     );
     merge(&mut settings.show_wrap_guides, src.show_wrap_guides);
     merge(&mut settings.wrap_guides, src.wrap_guides.clone());

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -105,6 +105,8 @@ pub struct LanguageSettings {
     pub use_autoclose: bool,
     /// Which code actions to run on save
     pub code_actions_on_format: HashMap<String, bool>,
+    // Controls how the editor handles the autoclosed characters.
+    pub always_handle_autoclosed_character: bool,
 }
 
 /// The settings for [GitHub Copilot](https://github.com/features/copilot).
@@ -236,6 +238,14 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: {} (or {"source.organizeImports": true} for Go).
     pub code_actions_on_format: Option<HashMap<String, bool>>,
+    // Controls how the editor handles the autoclosed characters.
+    // When set to `false`(default), skipping over and auto-removing of the closing characters
+    // happen only for auto-inserted characters.
+    // Otherwise(when `true`), the closing charcaters are always skipped over and auto-removed
+    // no matter how they were inserted.
+    ///
+    /// Default: false
+    pub always_handle_autoclosed_character: Option<bool>,
 }
 
 /// The contents of the GitHub Copilot settings.
@@ -602,6 +612,10 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
     merge(&mut settings.hard_tabs, src.hard_tabs);
     merge(&mut settings.soft_wrap, src.soft_wrap);
     merge(&mut settings.use_autoclose, src.use_autoclose);
+    merge(
+        &mut settings.always_handle_autoclosed_character,
+        src.always_handle_autoclosed_character,
+    );
     merge(&mut settings.show_wrap_guides, src.show_wrap_guides);
     merge(&mut settings.wrap_guides, src.wrap_guides.clone());
     merge(

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -390,6 +390,16 @@ To override settings for a language, add an entry for that language server's nam
 
 `boolean` values
 
+**Example**
+
+If the setting is set to `true`:
+
+1. Enter in the editor: `)))`
+2. Move the cursor to the start: `^)))`
+3. Enter again: `)))`
+
+The result is still `)))` and not `))))))`, which is what it would be by default.
+
 ## File Types
 
 - Setting: `file_types`

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -380,6 +380,16 @@ To override settings for a language, add an entry for that language server's nam
 
 `boolean` values
 
+## Always Treat Brackets As Autoclosed
+
+- Description: Controls how the editor handles the autoclosed characters.
+- Setting: `always_treat_brackets_as_autoclosed`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
 ## File Types
 
 - Setting: `file_types`
@@ -573,6 +583,8 @@ The following settings can be overridden for each specific language:
 - `show_whitespaces`
 - `soft_wrap`
 - `tab_size`
+- `use_autoclose`
+- `always_treat_brackets_as_autoclosed`
 
 These values take in the same options as the root-level settings with the same name.
 


### PR DESCRIPTION
Adds the `always_treat_brackets_as_autoclosed` setting to control how the autoclosed characters are handled.

The setting is off by default, meaning the behaviour stays the same (following how VSCode handles autoclosed characters).
When set to `true`, the autoclosed characters are always skipped over and auto-removed no matter how they were inserted (following how Sublime Text/Xcode handle this).

https://github.com/zed-industries/zed/assets/471335/304cd04a-59fe-450f-9c65-cc31b781b0db

https://github.com/zed-industries/zed/assets/471335/0f5b09c2-260f-48d4-8528-23f122dee45f

Release Notes:

- Added the setting `always_treat_brackets_as_autoclosed` (default: `false`) to always treat brackets as "auto-closed" brackets, i.e. deleting the pair when deleting start/end, etc. ([#7146](https://github.com/zed-industries/zed/issues/7146)).