### PR TITLE
Make collab quieter on startup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 collab: RUST_LOG=${RUST_LOG:-warn,tower_http=info,collab=info} cargo run --package=collab serve
 livekit: livekit-server --dev
-blob_store: MINIO_ROOT_USER=the-blob-store-access-key MINIO_ROOT_PASSWORD=the-blob-store-secret-key minio server .blob_store
+blob_store: ./script/run-local-minio

--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -147,9 +147,7 @@ async fn fetch_extensions_from_blob_store(
         .send()
         .await?;
 
-    let objects = list
-        .contents
-        .ok_or_else(|| anyhow!("missing bucket contents"))?;
+    let objects = list.contents.unwrap_or_default();
 
     let mut published_versions = HashMap::<&str, Vec<&str>>::default();
     for object in &objects {

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -175,7 +175,7 @@ impl AppState {
             db: Arc::new(db),
             live_kit_client,
             blob_store_client: build_blob_store_client(&config).await.log_err(),
-            clickhouse_client: build_clickhouse_client(&config).log_err(),
+            clickhouse_client: build_clickhouse_client(&config),
             config,
         };
         Ok(Arc::new(this))
@@ -217,30 +217,30 @@ async fn build_blob_store_client(config: &Config) -> anyhow::Result<aws_sdk_s3::
     Ok(aws_sdk_s3::Client::new(&s3_config))
 }
 
-fn build_clickhouse_client(config: &Config) -> anyhow::Result<clickhouse::Client> {
-    Ok(clickhouse::Client::default()
-        .with_url(
-            config
-                .clickhouse_url
-                .as_ref()
-                .ok_or_else(|| anyhow!("missing clickhouse_url"))?,
-        )
-        .with_user(
-            config
-                .clickhouse_user
-                .as_ref()
-                .ok_or_else(|| anyhow!("missing clickhouse_user"))?,
-        )
-        .with_password(
-            config
-                .clickhouse_password
-                .as_ref()
-                .ok_or_else(|| anyhow!("missing clickhouse_password"))?,
-        )
-        .with_database(
-            config
-                .clickhouse_database
-                .as_ref()
-                .ok_or_else(|| anyhow!("missing clickhouse_database"))?,
-        ))
+fn build_clickhouse_client(config: &Config) -> Option<clickhouse::Client> {
+    let Some(url) = config.clickhouse_url.as_ref() else {
+        return None;
+    };
+    Some(
+        clickhouse::Client::default()
+            .with_url(url)
+            .with_user(
+                config
+                    .clickhouse_user
+                    .as_ref()
+                    .expect("missing clickhouse_user"),
+            )
+            .with_password(
+                config
+                    .clickhouse_password
+                    .as_ref()
+                    .expect("missing clickhouse_password"),
+            )
+            .with_database(
+                config
+                    .clickhouse_database
+                    .as_ref()
+                    .expect("missing clickhouse_database"),
+            ),
+    )
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,10 +3,6 @@
 echo "installing foreman..."
 which foreman > /dev/null || brew install foreman
 
-echo "installing minio..."
-which minio > /dev/null || brew install minio/stable/minio
-mkdir -p .blob_store/the-extensions-bucket
-
 echo "creating database..."
 script/sqlx database create
 

--- a/script/run-local-minio
+++ b/script/run-local-minio
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+which minio > /dev/null || (echo "installing minio..."; brew install minio/stable/minio)
+mkdir -p .blob_store/the-extensions-bucket
+mkdir -p .blob_store/zed-crash-reports
+
+export MINIO_ROOT_USER=the-blob-store-access-key
+export MINIO_ROOT_PASSWORD=the-blob-store-secret-key
+minio server --quiet .blob_store


### PR DESCRIPTION
Fix initialization of minio to happen on service start instead of bootstrap,
don't log errors if extensions are empty or if clickhouse is disabled

Release Notes:

- N/A
