### PR TITLE
docs: Fix "it's" typos that should be "its"

### DIFF
--- a/crates/color/src/color.rs
+++ b/crates/color/src/color.rs
@@ -14,7 +14,7 @@
 //! Once we have a good idea of the needs of the theme system and color in gpui in general I see 3 paths:
 //! 1. Use `palette` (or another color library) directly in gpui and everywhere else, rather than rolling our own color system.
 //! 2. Keep this crate as a thin wrapper around `palette` and use it everywhere except gpui, and convert to gpui's color system when needed.
-//! 3. Build the needed functionality into gpui and keep using it's color system everywhere.
+//! 3. Build the needed functionality into gpui and keep using its color system everywhere.
 //!
 //! I'm leaning towards 2 in the short term and 1 in the long term, but we'll need to discuss it more.
 //!

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11,7 +11,7 @@
 //!
 //! All other submodules and structs are mostly concerned with holding editor data about the way it displays current buffer region(s).
 //!
-//! If you're looking to improve Vim mode, you should check out Vim crate that wraps Editor and overrides it's behaviour.
+//! If you're looking to improve Vim mode, you should check out Vim crate that wraps Editor and overrides its behaviour.
 pub mod actions;
 mod blink_manager;
 pub mod display_map;

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -480,7 +480,7 @@ impl Interactivity {
         self.tooltip_builder = Some(Rc::new(build_tooltip));
     }
 
-    /// Block the mouse from interacting with this element or any of it's children
+    /// Block the mouse from interacting with this element or any of its children
     /// The imperative API equivalent to [`InteractiveElement::block_mouse`]
     pub fn block_mouse(&mut self) {
         self.block_mouse = true;
@@ -508,7 +508,7 @@ pub trait InteractiveElement: Sized {
 
     /// Track the focus state of the given focus handle on this element.
     /// If the focus handle is focused by the application, this element will
-    /// apply it's focused styles.
+    /// apply its focused styles.
     fn track_focus(mut self, focus_handle: &FocusHandle) -> Focusable<Self> {
         self.interactivity().focusable = true;
         self.interactivity().tracked_focus_handle = Some(focus_handle.clone());
@@ -834,7 +834,7 @@ pub trait InteractiveElement: Sized {
         self
     }
 
-    /// Block the mouse from interacting with this element or any of it's children
+    /// Block the mouse from interacting with this element or any of its children
     /// The fluent API equivalent to [`Interactivity::block_mouse`]
     fn block_mouse(mut self) -> Self {
         self.interactivity().block_mouse();

--- a/crates/gpui/src/keymap/binding.rs
+++ b/crates/gpui/src/keymap/binding.rs
@@ -2,7 +2,7 @@ use crate::{Action, KeyBindingContextPredicate, KeyMatch, Keystroke};
 use anyhow::Result;
 use smallvec::SmallVec;
 
-/// A keybinding and it's associated metadata, from the keymap.
+/// A keybinding and its associated metadata, from the keymap.
 pub struct KeyBinding {
     pub(crate) action: Box<dyn Action>,
     pub(crate) keystrokes: SmallVec<[Keystroke; 2]>,

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -122,7 +122,7 @@ pub struct Style {
     #[cfg(debug_assertions)]
     pub debug: bool,
 
-    /// Whether to draw a red debugging outline around this element and all of it's conforming children
+    /// Whether to draw a red debugging outline around this element and all of its conforming children
     #[cfg(debug_assertions)]
     pub debug_below: bool,
 }
@@ -148,7 +148,7 @@ pub enum Visibility {
 pub struct BoxShadow {
     /// What color should the shadow have?
     pub color: Hsla,
-    /// How should it be offset from it's element?
+    /// How should it be offset from its element?
     pub offset: Point<Pixels>,
     /// How much should the shadow be blurred?
     pub blur_radius: Pixels,
@@ -333,7 +333,7 @@ impl Style {
     }
 
     /// Get the content mask for this element style, based on the given bounds.
-    /// If the element does not hide it's overflow, this will return `None`.
+    /// If the element does not hide its overflow, this will return `None`.
     pub fn overflow_mask(
         &self,
         bounds: Bounds<Pixels>,

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -515,13 +515,13 @@ pub trait Styled: Sized {
         &mut style.text
     }
 
-    /// Set the text color of this element, this value cascades to it's child elements.
+    /// Set the text color of this element, this value cascades to its child elements.
     fn text_color(mut self, color: impl Into<Hsla>) -> Self {
         self.text_style().get_or_insert_with(Default::default).color = Some(color.into());
         self
     }
 
-    /// Set the font weight of this element, this value cascades to it's child elements.
+    /// Set the font weight of this element, this value cascades to its child elements.
     fn font_weight(mut self, weight: FontWeight) -> Self {
         self.text_style()
             .get_or_insert_with(Default::default)
@@ -529,7 +529,7 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Set the background color of this element, this value cascades to it's child elements.
+    /// Set the background color of this element, this value cascades to its child elements.
     fn text_bg(mut self, bg: impl Into<Hsla>) -> Self {
         self.text_style()
             .get_or_insert_with(Default::default)
@@ -537,7 +537,7 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Set the text size of this element, this value cascades to it's child elements.
+    /// Set the text size of this element, this value cascades to its child elements.
     fn text_size(mut self, size: impl Into<AbsoluteLength>) -> Self {
         self.text_style()
             .get_or_insert_with(Default::default)
@@ -563,7 +563,7 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Reset the text styling for this element and it's children.
+    /// Reset the text styling for this element and its children.
     fn text_base(mut self) -> Self {
         self.text_style()
             .get_or_insert_with(Default::default)
@@ -607,7 +607,7 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Remove the text decoration on this element, this value cascades to it's child elements.
+    /// Remove the text decoration on this element, this value cascades to its child elements.
     fn text_decoration_none(mut self) -> Self {
         self.text_style()
             .get_or_insert_with(Default::default)
@@ -679,7 +679,7 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Change the font on this element and it's children.
+    /// Change the font on this element and its children.
     fn font(mut self, family_name: impl Into<SharedString>) -> Self {
         self.text_style()
             .get_or_insert_with(Default::default)
@@ -687,7 +687,7 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Set the line height on this element and it's children.
+    /// Set the line height on this element and its children.
     fn line_height(mut self, line_height: impl Into<DefiniteLength>) -> Self {
         self.text_style()
             .get_or_insert_with(Default::default)

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -40,7 +40,7 @@ pub struct ShapedGlyph {
     /// The ID for this glyph, as determined by the text system.
     pub id: GlyphId,
 
-    /// The position of this glyph in it's containing line.
+    /// The position of this glyph in its containing line.
     pub position: Point<Pixels>,
 
     /// The index of this glyph in the original text.

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -5,7 +5,7 @@
 //! use Tree-sitter to provide syntax highlighting to the editor; note though that `language` doesn't perform the highlighting by itself. It only maps ranges in a buffer to colors. Treesitter is also used for buffer outlines (lists of symbols in a buffer)
 //! - Exposes [`LanguageConfig`] that describes how constructs (like brackets or line comments) should be handled by the editor for a source file of a particular language.
 //!
-//! Notably we do *not* assign a single language to a single file; in real world a single file can consist of multiple programming languages - HTML is a good example of that - and `language` crate tends to reflect that status quo in it's API.
+//! Notably we do *not* assign a single language to a single file; in real world a single file can consist of multiple programming languages - HTML is a good example of that - and `language` crate tends to reflect that status quo in its API.
 mod buffer;
 mod diagnostic_set;
 mod highlight_map;

--- a/crates/task/src/static_source.rs
+++ b/crates/task/src/static_source.rs
@@ -97,7 +97,7 @@ impl DefinitionProvider {
         serde_json_lenient::to_value(schema).unwrap()
     }
 }
-/// A Wrapper around deserializable T that keeps track of it's contents
+/// A Wrapper around deserializable T that keeps track of its contents
 /// via a provided channel. Once T value changes, the observers of [`TrackedFile`] are
 /// notified.
 struct TrackedFile<T> {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1478,7 +1478,7 @@ fn content_index_for_mouse(pos: Point<Pixels>, size: &TerminalSize) -> usize {
     clamped_row * size.columns() + clamped_col
 }
 
-/// Converts an 8 bit ANSI color to it's GPUI equivalent.
+/// Converts an 8 bit ANSI color to its GPUI equivalent.
 /// Accepts `usize` for compatibility with the `alacritty::Colors` interface,
 /// Other than that use case, should only be called with values in the [0,255] range
 pub fn get_color_at_index(index: usize, theme: &Theme) -> Hsla {
@@ -1504,7 +1504,7 @@ pub fn get_color_at_index(index: usize, theme: &Theme) -> Hsla {
         15 => colors.terminal_ansi_bright_white,
         // 16-231 are mapped to their RGB colors on a 0-5 range per channel
         16..=231 => {
-            let (r, g, b) = rgb_for_index(&(index as u8)); // Split the index into it's ANSI-RGB components
+            let (r, g, b) = rgb_for_index(&(index as u8)); // Split the index into its ANSI-RGB components
             let step = (u8::MAX as f32 / 5.).floor() as u8; // Split the RGB range into 5 chunks, with floor so no overflow
             rgba_color(r * step, g * step, b * step) // Map the ANSI-RGB components to an RGB color
         }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5489,7 +5489,7 @@ mod tests {
         workspace.update(cx, |workspace, cx| {
             // Since panel_2 was not visible on the right, we don't open the left dock.
             assert!(!workspace.left_dock().read(cx).is_open());
-            // And the right dock is unaffected in it's displaying of panel_1
+            // And the right dock is unaffected in its displaying of panel_1
             assert!(workspace.right_dock().read(cx).is_open());
             assert_eq!(
                 workspace


### PR DESCRIPTION
These all meant to use the possessive "its" rather than the contraction of "it is".