### PR TITLE
Use long flags in `script/clippy` for readability

### DIFF
--- a/script/clippy
+++ b/script/clippy
@@ -5,5 +5,5 @@ set -euxo pipefail
 # clippy.toml is not currently supporting specifying allowed lints
 # so specify those here, and disable the rest until Zed's workspace
 # will have more fixes & suppression for the standard lint set
-cargo clippy --release --workspace --all-features --all-targets -- -A clippy::all -D clippy::dbg_macro -D clippy::todo
-cargo clippy -p gpui -- -D warnings
+cargo clippy --release --workspace --all-features --all-targets -- --allow clippy::all --deny clippy::dbg_macro --deny clippy::todo
+cargo clippy --package gpui -- --deny warnings


### PR DESCRIPTION
This PR modifies the `script/clippy` script to use long flags, as these are better for readability.

Release Notes:

- N/A
