### PR TITLE
Remove unneeded `'static` lifetimes on `&str`s in constants

### DIFF
--- a/crates/ai/src/providers/open_ai.rs
+++ b/crates/ai/src/providers/open_ai.rs
@@ -6,4 +6,4 @@ pub use completion::*;
 pub use embedding::*;
 pub use model::OpenAiLanguageModel;
 
-pub const OPEN_AI_API_URL: &'static str = "https://api.openai.com/v1";
+pub const OPEN_AI_API_URL: &str = "https://api.openai.com/v1";

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -375,7 +375,7 @@ impl Database {
 }
 
 fn is_serialization_error(error: &Error) -> bool {
-    const SERIALIZATION_FAILURE_CODE: &'static str = "40001";
+    const SERIALIZATION_FAILURE_CODE: &str = "40001";
     match error {
         Error::Database(
             DbErr::Exec(sea_orm::RuntimeErr::SqlxError(error))

--- a/crates/collab/src/db/tests/feature_flag_tests.rs
+++ b/crates/collab/src/db/tests/feature_flag_tests.rs
@@ -37,8 +37,8 @@ async fn test_get_user_flags(db: &Arc<Database>) {
         .unwrap()
         .user_id;
 
-    const CHANNELS_ALPHA: &'static str = "channels-alpha";
-    const NEW_SEARCH: &'static str = "new-search";
+    const CHANNELS_ALPHA: &str = "channels-alpha";
+    const NEW_SEARCH: &str = "new-search";
 
     let channels_flag = db.create_user_flag(CHANNELS_ALPHA).await.unwrap();
     let search_flag = db.create_user_flag(NEW_SEARCH).await.unwrap();

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -20,7 +20,7 @@ use tracing_log::LogTracer;
 use tracing_subscriber::{filter::EnvFilter, fmt::format::JsonFields, Layer};
 use util::ResultExt;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 const REVISION: Option<&'static str> = option_env!("GITHUB_SHA");
 
 #[tokio::main]

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -2821,8 +2821,8 @@ async fn test_git_status_sync(
         )
         .await;
 
-    const A_TXT: &'static str = "a.txt";
-    const B_TXT: &'static str = "b.txt";
+    const A_TXT: &str = "a.txt";
+    const B_TXT: &str = "b.txt";
 
     client_a.fs().set_status_for_repo_via_git_operation(
         Path::new("/dir/.git"),

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -34,7 +34,7 @@ use workspace::{
 mod message_editor;
 
 const MESSAGE_LOADING_THRESHOLD: usize = 50;
-const CHAT_PANEL_KEY: &'static str = "ChatPanel";
+const CHAT_PANEL_KEY: &str = "ChatPanel";
 
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(|workspace: &mut Workspace, _| {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -62,7 +62,7 @@ struct ChannelMoveClipboard {
     channel_id: ChannelId,
 }
 
-const COLLABORATION_PANEL_KEY: &'static str = "CollaborationPanel";
+const COLLABORATION_PANEL_KEY: &str = "CollaborationPanel";
 
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(|workspace: &mut Workspace, _| {

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -29,7 +29,7 @@ use workspace::{
 const LOADING_THRESHOLD: usize = 30;
 const MARK_AS_READ_DELAY: Duration = Duration::from_secs(1);
 const TOAST_DURATION: Duration = Duration::from_secs(5);
-const NOTIFICATION_PANEL_KEY: &'static str = "NotificationPanel";
+const NOTIFICATION_PANEL_KEY: &str = "NotificationPanel";
 
 pub struct NotificationPanel {
     client: Arc<Client>,

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -971,7 +971,7 @@ async fn clear_copilot_dir() {
 }
 
 async fn get_copilot_lsp(http: Arc<dyn HttpClient>) -> anyhow::Result<PathBuf> {
-    const SERVER_PATH: &'static str = "dist/agent.js";
+    const SERVER_PATH: &str = "dist/agent.js";
 
     ///Check for the latest copilot language server and download it if we haven't already
     async fn fetch_latest(http: Arc<dyn HttpClient>) -> anyhow::Result<PathBuf> {

--- a/crates/copilot_ui/src/sign_in.rs
+++ b/crates/copilot_ui/src/sign_in.rs
@@ -7,7 +7,7 @@ use gpui::{
 use ui::{prelude::*, Button, IconName, Label};
 use workspace::ModalView;
 
-const COPILOT_SIGN_UP_URL: &'static str = "https://github.com/features/copilot";
+const COPILOT_SIGN_UP_URL: &str = "https://github.com/features/copilot";
 
 pub struct CopilotCodeVerification {
     status: Status,

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -22,20 +22,20 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use util::{async_maybe, ResultExt};
 
-const CONNECTION_INITIALIZE_QUERY: &'static str = sql!(
+const CONNECTION_INITIALIZE_QUERY: &str = sql!(
     PRAGMA foreign_keys=TRUE;
 );
 
-const DB_INITIALIZE_QUERY: &'static str = sql!(
+const DB_INITIALIZE_QUERY: &str = sql!(
     PRAGMA journal_mode=WAL;
     PRAGMA busy_timeout=1;
     PRAGMA case_sensitive_like=TRUE;
     PRAGMA synchronous=NORMAL;
 );
 
-const FALLBACK_DB_NAME: &'static str = "FALLBACK_MEMORY_DB";
+const FALLBACK_DB_NAME: &str = "FALLBACK_MEMORY_DB";
 
-const DB_FILE_NAME: &'static str = "db.sqlite";
+const DB_FILE_NAME: &str = "db.sqlite";
 
 lazy_static::lazy_static! {
     pub static ref ZED_STATELESS: bool = std::env::var("ZED_STATELESS").map_or(false, |v| !v.is_empty());

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8644,7 +8644,7 @@ impl Editor {
         let mut cwd = worktree.read(cx).abs_path().to_path_buf();
         cwd.push(".git");
 
-        const REMOTE_NAME: &'static str = "origin";
+        const REMOTE_NAME: &str = "origin";
         let repo = project
             .fs()
             .open_repo(&cwd)

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -26,8 +26,7 @@ pub(crate) type PointF = crate::Point<f32>;
 #[cfg(not(feature = "runtime_shaders"))]
 const SHADERS_METALLIB: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shaders.metallib"));
 #[cfg(feature = "runtime_shaders")]
-const SHADERS_SOURCE_FILE: &'static str =
-    include_str!(concat!(env!("OUT_DIR"), "/stitched_shaders.metal"));
+const SHADERS_SOURCE_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/stitched_shaders.metal"));
 const INSTANCE_BUFFER_SIZE: usize = 2 * 1024 * 1024; // This is an arbitrary decision. There's probably a more optimal value (maybe even we could adjust dynamically...)
 
 pub type Context = Arc<Mutex<Vec<metal::Buffer>>>;

--- a/crates/languages/src/astro.rs
+++ b/crates/languages/src/astro.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use util::ResultExt;
 
-const SERVER_PATH: &'static str = "node_modules/@astrojs/language-server/bin/nodeServer.js";
+const SERVER_PATH: &str = "node_modules/@astrojs/language-server/bin/nodeServer.js";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/css.rs
+++ b/crates/languages/src/css.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str =
+const SERVER_PATH: &str =
     "node_modules/vscode-langservers-extracted/bin/vscode-css-language-server";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {

--- a/crates/languages/src/dockerfile.rs
+++ b/crates/languages/src/dockerfile.rs
@@ -13,8 +13,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str =
-    "node_modules/dockerfile-language-server-nodejs/bin/docker-langserver";
+const SERVER_PATH: &str = "node_modules/dockerfile-language-server-nodejs/bin/docker-langserver";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/elm.rs
+++ b/crates/languages/src/elm.rs
@@ -17,8 +17,8 @@ use std::{
 };
 use util::ResultExt;
 
-const SERVER_NAME: &'static str = "elm-language-server";
-const SERVER_PATH: &'static str = "node_modules/@elm-tooling/elm-language-server/out/node/index.js";
+const SERVER_NAME: &str = "elm-language-server";
+const SERVER_PATH: &str = "node_modules/@elm-tooling/elm-language-server/out/node/index.js";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/html.rs
+++ b/crates/languages/src/html.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str =
+const SERVER_PATH: &str =
     "node_modules/vscode-langservers-extracted/bin/vscode-html-language-server";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -18,8 +18,7 @@ use std::{
 };
 use util::{async_maybe, paths, ResultExt};
 
-const SERVER_PATH: &'static str =
-    "node_modules/vscode-json-languageserver/bin/vscode-json-languageserver";
+const SERVER_PATH: &str = "node_modules/vscode-json-languageserver/bin/vscode-json-languageserver";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/prisma.rs
+++ b/crates/languages/src/prisma.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str = "node_modules/.bin/prisma-language-server";
+const SERVER_PATH: &str = "node_modules/.bin/prisma-language-server";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/purescript.rs
+++ b/crates/languages/src/purescript.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str = "node_modules/.bin/purescript-language-server";
+const SERVER_PATH: &str = "node_modules/.bin/purescript-language-server";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use util::ResultExt;
 
-const SERVER_PATH: &'static str = "node_modules/pyright/langserver.index.js";
+const SERVER_PATH: &str = "node_modules/pyright/langserver.index.js";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/svelte.rs
+++ b/crates/languages/src/svelte.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str = "node_modules/svelte-language-server/bin/server.js";
+const SERVER_PATH: &str = "node_modules/svelte-language-server/bin/server.js";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -16,7 +16,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str = "node_modules/.bin/tailwindcss-language-server";
+const SERVER_PATH: &str = "node_modules/.bin/tailwindcss-language-server";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -17,7 +17,7 @@ use std::{
 };
 use util::{async_maybe, ResultExt};
 
-const SERVER_PATH: &'static str = "node_modules/yaml-language-server/bin/yaml-language-server";
+const SERVER_PATH: &str = "node_modules/yaml-language-server/bin/yaml-language-server";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/project_core/src/worktree_tests.rs
+++ b/crates/project_core/src/worktree_tests.rs
@@ -2102,7 +2102,7 @@ async fn test_git_repository_for_path(cx: &mut TestAppContext) {
 async fn test_git_status(cx: &mut TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();
-    const IGNORE_RULE: &'static str = "**/target";
+    const IGNORE_RULE: &str = "**/target";
 
     let root = temp_tree(json!({
         "project": {
@@ -2122,12 +2122,12 @@ async fn test_git_status(cx: &mut TestAppContext) {
 
     }));
 
-    const A_TXT: &'static str = "a.txt";
-    const B_TXT: &'static str = "b.txt";
-    const E_TXT: &'static str = "c/d/e.txt";
-    const F_TXT: &'static str = "f.txt";
-    const DOTGITIGNORE: &'static str = ".gitignore";
-    const BUILD_FILE: &'static str = "target/build_file";
+    const A_TXT: &str = "a.txt";
+    const B_TXT: &str = "b.txt";
+    const E_TXT: &str = "c/d/e.txt";
+    const F_TXT: &str = "f.txt";
+    const DOTGITIGNORE: &str = ".gitignore";
+    const BUILD_FILE: &str = "target/build_file";
     let project_path = Path::new("project");
 
     // Set up git repository before creating the worktree.
@@ -2243,7 +2243,7 @@ async fn test_git_status(cx: &mut TestAppContext) {
     cx.executor().run_until_parked();
 
     let mut renamed_dir_name = "first_directory/second_directory";
-    const RENAMED_FILE: &'static str = "rf.txt";
+    const RENAMED_FILE: &str = "rf.txt";
 
     std::fs::create_dir_all(work_dir.join(renamed_dir_name)).unwrap();
     std::fs::write(

--- a/crates/project_panel/src/file_associations.rs
+++ b/crates/project_panel/src/file_associations.rs
@@ -20,11 +20,11 @@ pub struct FileAssociations {
 
 impl Global for FileAssociations {}
 
-const COLLAPSED_DIRECTORY_TYPE: &'static str = "collapsed_folder";
-const EXPANDED_DIRECTORY_TYPE: &'static str = "expanded_folder";
-const COLLAPSED_CHEVRON_TYPE: &'static str = "collapsed_chevron";
-const EXPANDED_CHEVRON_TYPE: &'static str = "expanded_chevron";
-pub const FILE_TYPES_ASSET: &'static str = "icons/file_icons/file_types.json";
+const COLLAPSED_DIRECTORY_TYPE: &str = "collapsed_folder";
+const EXPANDED_DIRECTORY_TYPE: &str = "expanded_folder";
+const COLLAPSED_CHEVRON_TYPE: &str = "collapsed_chevron";
+const EXPANDED_CHEVRON_TYPE: &str = "expanded_chevron";
+pub const FILE_TYPES_ASSET: &str = "icons/file_icons/file_types.json";
 
 pub fn init(assets: impl AssetSource, cx: &mut AppContext) {
     cx.set_global(FileAssociations::new(assets))

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -34,7 +34,7 @@ use workspace::{
     Workspace,
 };
 
-const PROJECT_PANEL_KEY: &'static str = "ProjectPanel";
+const PROJECT_PANEL_KEY: &str = "ProjectPanel";
 const NEW_ENTRY_ID: ProjectEntryId = ProjectEntryId::MAX;
 
 pub struct ProjectPanel {

--- a/crates/rpc/src/notification.rs
+++ b/crates/rpc/src/notification.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{map, Value};
 use strum::{EnumVariantNames, VariantNames as _};
 
-const KIND: &'static str = "kind";
-const ENTITY_ID: &'static str = "entity_id";
+const KIND: &str = "kind";
+const ENTITY_ID: &str = "entity_id";
 
 /// A notification that can be stored, associated with a given recipient.
 ///

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -6,7 +6,7 @@ use gpui::{AppContext, BackgroundExecutor};
 use std::{io::ErrorKind, path::PathBuf, sync::Arc, time::Duration};
 use util::{paths, ResultExt};
 
-pub const EMPTY_THEME_NAME: &'static str = "empty-theme";
+pub const EMPTY_THEME_NAME: &str = "empty-theme";
 
 #[cfg(any(test, feature = "test-support"))]
 pub fn test_settings() -> String {

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -755,8 +755,8 @@ fn replace_value_in_json_text(
     tab_size: usize,
     new_value: &serde_json::Value,
 ) -> (Range<usize>, String) {
-    const LANGUAGE_OVERRIDES: &'static str = "language_overrides";
-    const LANGUAGES: &'static str = "languages";
+    const LANGUAGE_OVERRIDES: &str = "language_overrides";
+    const LANGUAGES: &str = "languages";
 
     lazy_static! {
         static ref PAIR_QUERY: tree_sitter::Query = tree_sitter::Query::new(

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -31,7 +31,7 @@ use workspace::{
 
 use anyhow::Result;
 
-const TERMINAL_PANEL_KEY: &'static str = "TerminalPanel";
+const TERMINAL_PANEL_KEY: &str = "TerminalPanel";
 
 actions!(terminal_panel, [ToggleFocus]);
 

--- a/crates/ui/src/components/stories/list_item.rs
+++ b/crates/ui/src/components/stories/list_item.rs
@@ -4,7 +4,7 @@ use story::Story;
 use crate::{prelude::*, Avatar};
 use crate::{IconName, ListItem};
 
-const OVERFLOWING_TEXT: &'static str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean mauris ligula, luctus vel dignissim eu, vestibulum sed libero. Sed at convallis velit.";
+const OVERFLOWING_TEXT: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean mauris ligula, luctus vel dignissim eu, vestibulum sed libero. Sed at convallis velit.";
 
 pub struct ListItemStory;
 

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -835,7 +835,7 @@ mod test {
         test::{ExemptionFeatures, NeovimBackedTestContext, VimTestContext},
     };
 
-    const WORD_LOCATIONS: &'static str = indoc! {"
+    const WORD_LOCATIONS: &str = indoc! {"
         The quick ˇbrowˇnˇ•••
         fox ˇjuˇmpsˇ over
         the lazy dogˇ••


### PR DESCRIPTION
This PR removes unneeded `'static` lifetimes on `&str`s stored in `const` declarations.

This addresses some Clippy lints about [`redundant_static_lifetimes`](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_static_lifetimes).

In item-level `const` declarations we can rely on lifetime elision and use the default `'static` lifetime.

Note that associated constants still require an explicit `'static` lifetime, as explained in https://github.com/rust-lang/rust/issues/115010.

Release Notes:

- N/A
