### PR TITLE
vim: Support keybinding `z.`

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -218,6 +218,7 @@
       // z commands
       "z t": "editor::ScrollCursorTop",
       "z z": "editor::ScrollCursorCenter",
+      "z .": ["workspace::SendKeystrokes", "z z ^"],
       "z b": "editor::ScrollCursorBottom",
       "z c": "editor::Fold",
       "z o": "editor::UnfoldLines",


### PR DESCRIPTION
`z.` is similar to zz but moves the cursor to the first non-blank character.

From the documentation:
```
z.   Redraw, line [count] at center of window (default cursor line). Put cursor at first non-blank in the line.
zz   Like "z.", but leave the cursor in the same column.
```

Release Notes:

- Support the `z.` vim keybinding: Center cursor in window and put cursor at first non-blank