### PR TITLE
Deny Clippy warnings in CI for fixed crates

### DIFF
--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -126,16 +126,15 @@ pub struct SettingsJsonSchemaParams<'a> {
     pub font_names: &'a [String],
 }
 
+type TabSizeCallback = Box<dyn Fn(&dyn Any) -> Option<usize> + Send + Sync + 'static>;
+
 /// A set of strongly-typed setting values defined via multiple JSON files.
 pub struct SettingsStore {
     setting_values: HashMap<TypeId, Box<dyn AnySettingValue>>,
     raw_default_settings: serde_json::Value,
     raw_user_settings: serde_json::Value,
     raw_local_settings: BTreeMap<(usize, Arc<Path>), serde_json::Value>,
-    tab_size_callback: Option<(
-        TypeId,
-        Box<dyn Fn(&dyn Any) -> Option<usize> + Send + Sync + 'static>,
-    )>,
+    tab_size_callback: Option<(TypeId, TabSizeCallback)>,
 }
 
 impl Global for SettingsStore {}

--- a/script/clippy
+++ b/script/clippy
@@ -12,10 +12,8 @@ cargo clippy --release --workspace --all-features --all-targets -- --allow clipp
 #
 # Once all packages have no more Clippy warnings we can promote `--deny warnings` to
 # the entire workspace.
-
-# TODO: `fs` doesn't build on Windows.
-# cargo clippy --package fs --no-deps -- --deny warnings
-cargo clippy --package fuzzy --no-deps -- --deny warnings
-cargo clippy --package gpui --no-deps -- --deny warnings
-cargo clippy --package settings --no-deps -- --deny warnings
-cargo clippy --package theme --no-deps -- --deny warnings
+cargo clippy --release --package fs --no-deps -- --deny warnings
+cargo clippy --release --package fuzzy --no-deps -- --deny warnings
+cargo clippy --release --package gpui --no-deps -- --deny warnings
+cargo clippy --release --package settings --no-deps -- --deny warnings
+cargo clippy --release --package theme --no-deps -- --deny warnings

--- a/script/clippy
+++ b/script/clippy
@@ -12,7 +12,9 @@ cargo clippy --release --workspace --all-features --all-targets -- --allow clipp
 #
 # Once all packages have no more Clippy warnings we can promote `--deny warnings` to
 # the entire workspace.
-cargo clippy --package fs --no-deps -- --deny warnings
+
+# TODO: `fs` doesn't build on Windows.
+# cargo clippy --package fs --no-deps -- --deny warnings
 cargo clippy --package fuzzy --no-deps -- --deny warnings
 cargo clippy --package gpui --no-deps -- --deny warnings
 cargo clippy --package settings --no-deps -- --deny warnings

--- a/script/clippy
+++ b/script/clippy
@@ -12,8 +12,8 @@ cargo clippy --release --workspace --all-features --all-targets -- --allow clipp
 #
 # Once all packages have no more Clippy warnings we can promote `--deny warnings` to
 # the entire workspace.
-cargo clippy --package fs -- --deny warnings --no-deps
-cargo clippy --package fuzzy -- --deny warnings --no-deps
-cargo clippy --package gpui -- --deny warnings --no-deps
-cargo clippy --package settings -- --deny warnings --no-deps
-cargo clippy --package theme -- --deny warnings --no-deps
+cargo clippy --package fs --no-deps -- --deny warnings
+cargo clippy --package fuzzy --no-deps -- --deny warnings
+cargo clippy --package gpui --no-deps -- --deny warnings
+cargo clippy --package settings --no-deps -- --deny warnings
+cargo clippy --package theme --no-deps -- --deny warnings

--- a/script/clippy
+++ b/script/clippy
@@ -6,4 +6,14 @@ set -euxo pipefail
 # so specify those here, and disable the rest until Zed's workspace
 # will have more fixes & suppression for the standard lint set
 cargo clippy --release --workspace --all-features --all-targets -- --allow clippy::all --deny clippy::dbg_macro --deny clippy::todo
-cargo clippy --package gpui -- --deny warnings
+
+# Deny warnings in individual packages that we've passed over, to prevent warnings
+# from slipping back in.
+#
+# Once all packages have no more Clippy warnings we can promote `--deny warnings` to
+# the entire workspace.
+cargo clippy --package fs -- --deny warnings --no-deps
+cargo clippy --package fuzzy -- --deny warnings --no-deps
+cargo clippy --package gpui -- --deny warnings --no-deps
+cargo clippy --package settings -- --deny warnings --no-deps
+cargo clippy --package theme -- --deny warnings --no-deps


### PR DESCRIPTION
This PR updates CI to deny Clippy warnings in crates that have already had their Clippy warnings addressed.

This will help us ratchet down the warnings until we're able to pass `--deny warnings` for the entire workspace.

Release Notes:

- N/A
