### PR TITLE
Enable `clippy::bind_instead_of_map`

### DIFF
--- a/crates/ai/src/prompts/base.rs
+++ b/crates/ai/src/prompts/base.rs
@@ -30,7 +30,7 @@ impl PromptArguments {
         if self
             .language_name
             .as_ref()
-            .and_then(|name| Some(!["Markdown", "Plain Text"].contains(&name.as_str())))
+            .map(|name| !["Markdown", "Plain Text"].contains(&name.as_str()))
             .unwrap_or(true)
         {
             PromptFileType::Code
@@ -51,8 +51,10 @@ pub trait PromptTemplate {
 #[repr(i8)]
 #[derive(PartialEq, Eq, Ord)]
 pub enum PromptPriority {
-    Mandatory,                // Ignores truncation
-    Ordered { order: usize }, // Truncates based on priority
+    /// Ignores truncation.
+    Mandatory,
+    /// Truncates based on priority.
+    Ordered { order: usize },
 }
 
 impl PartialOrd for PromptPriority {
@@ -86,7 +88,6 @@ impl PromptChain {
         let mut sorted_indices = (0..self.templates.len()).collect::<Vec<_>>();
         sorted_indices.sort_by_key(|&i| Reverse(&self.templates[i].0));
 
-        // If Truncate
         let mut tokens_outstanding = if truncate {
             Some(self.args.model.capacity()? - self.args.reserved_tokens)
         } else {

--- a/crates/ai/src/prompts/repository_context.rs
+++ b/crates/ai/src/prompts/repository_context.rs
@@ -24,11 +24,9 @@ impl PromptCodeSnippet {
 
             let language_name = buffer
                 .language()
-                .and_then(|language| Some(language.name().to_string().to_lowercase()));
+                .map(|language| language.name().to_string().to_lowercase());
 
-            let file_path = buffer
-                .file()
-                .and_then(|file| Some(file.path().to_path_buf()));
+            let file_path = buffer.file().map(|file| file.path().to_path_buf());
 
             (content, language_name, file_path)
         })?;
@@ -46,7 +44,7 @@ impl ToString for PromptCodeSnippet {
         let path = self
             .path
             .as_ref()
-            .and_then(|path| Some(path.to_string_lossy().to_string()))
+            .map(|path| path.to_string_lossy().to_string())
             .unwrap_or("".to_string());
         let language_name = self.language_name.clone().unwrap_or("".to_string());
         let content = self.content.clone();

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -756,8 +756,8 @@ impl Render for LspLogToolbarItemView {
             .trigger(Button::new(
                 "language_server_menu_header",
                 current_server
-                    .and_then(|row| {
-                        Some(Cow::Owned(format!(
+                    .map(|row| {
+                        Cow::Owned(format!(
                             "{} ({}) - {}",
                             row.server_name.0,
                             row.worktree_root_name,
@@ -766,7 +766,7 @@ impl Render for LspLogToolbarItemView {
                             } else {
                                 SERVER_LOGS
                             },
-                        )))
+                        ))
                     })
                     .unwrap_or_else(|| "No server selected".into()),
             ))

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3355,7 +3355,7 @@ impl Workspace {
             let left_visible = left_dock.is_open();
             let left_active_panel = left_dock
                 .visible_panel()
-                .and_then(|panel| Some(panel.persistent_name().to_string()));
+                .map(|panel| panel.persistent_name().to_string());
             let left_dock_zoom = left_dock
                 .visible_panel()
                 .map(|panel| panel.is_zoomed(cx))
@@ -3365,7 +3365,7 @@ impl Workspace {
             let right_visible = right_dock.is_open();
             let right_active_panel = right_dock
                 .visible_panel()
-                .and_then(|panel| Some(panel.persistent_name().to_string()));
+                .map(|panel| panel.persistent_name().to_string());
             let right_dock_zoom = right_dock
                 .visible_panel()
                 .map(|panel| panel.is_zoomed(cx))
@@ -3375,7 +3375,7 @@ impl Workspace {
             let bottom_visible = bottom_dock.is_open();
             let bottom_active_panel = bottom_dock
                 .visible_panel()
-                .and_then(|panel| Some(panel.persistent_name().to_string()));
+                .map(|panel| panel.persistent_name().to_string());
             let bottom_dock_zoom = bottom_dock
                 .visible_panel()
                 .map(|panel| panel.is_zoomed(cx))

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -78,7 +78,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::almost_complete_range",
         "clippy::arc_with_non_send_sync",
         "clippy::await_holding_lock",
-        "clippy::bind_instead_of_map",
         "clippy::bool_comparison",
         "clippy::borrow_deref_ref",
         "clippy::borrowed_box",


### PR DESCRIPTION
This PR enables the [`clippy::bind_instead_of_map`](https://rust-lang.github.io/rust-clippy/master/index.html#/bind_instead_of_map) rule and fixes the outstanding violations.

Release Notes:

- N/A
