### PR TITLE
Enable `clippy::clone_on_copy`

### DIFF
--- a/crates/ai/src/prompts/repository_context.rs
+++ b/crates/ai/src/prompts/repository_context.rs
@@ -65,7 +65,7 @@ impl PromptTemplate for RepositoryContext {
         let template = "You are working inside a large repository, here are a few code snippets that may be useful.";
         let mut prompt = String::new();
 
-        let mut remaining_tokens = max_token_length.clone();
+        let mut remaining_tokens = max_token_length;
         let separator_token_length = args.model.count_tokens("\n")?;
         for snippet in &args.snippets {
             let mut snippet_prompt = template.to_string();

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1483,7 +1483,7 @@ impl Conversation {
             max_token_count: tiktoken_rs::model::get_context_size(&model.full_name()),
             pending_token_count: Task::ready(None),
             api_url: Some(api_url),
-            model: model,
+            model,
             _subscriptions: vec![cx.subscribe(&buffer, Self::handle_buffer_event)],
             pending_save: Task::ready(Ok(())),
             path: None,

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1483,7 +1483,7 @@ impl Conversation {
             max_token_count: tiktoken_rs::model::get_context_size(&model.full_name()),
             pending_token_count: Task::ready(None),
             api_url: Some(api_url),
-            model: model.clone(),
+            model: model,
             _subscriptions: vec![cx.subscribe(&buffer, Self::handle_buffer_event)],
             pending_save: Task::ready(Ok(())),
             path: None,
@@ -1527,7 +1527,7 @@ impl Conversation {
                 .as_ref()
                 .map(|summary| summary.text.clone())
                 .unwrap_or_default(),
-            model: self.model.clone(),
+            model: self.model,
             api_url: self.api_url.clone(),
         }
     }
@@ -1652,7 +1652,7 @@ impl Conversation {
                 })
             })
             .collect::<Vec<_>>();
-        let model = self.model.clone();
+        let model = self.model;
         self.pending_token_count = cx.spawn(|this, mut cx| {
             async move {
                 cx.background_executor()

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -302,7 +302,7 @@ impl ActiveCall {
             return Task::ready(Ok(()));
         }
 
-        let room_id = call.room_id.clone();
+        let room_id = call.room_id;
         let client = self.client.clone();
         let user_store = self.user_store.clone();
         let join = self

--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -1437,14 +1437,13 @@ async fn test_following_across_workspaces(cx_a: &mut TestAppContext, cx_b: &mut 
     });
 
     executor.run_until_parked();
-    let window_b_project_a = cx_b
+    let window_b_project_a = *cx_b
         .windows()
         .iter()
         .max_by_key(|window| window.window_id())
-        .unwrap()
-        .clone();
+        .unwrap();
 
-    let mut cx_b2 = VisualTestContext::from_window(window_b_project_a.clone(), cx_b);
+    let mut cx_b2 = VisualTestContext::from_window(window_b_project_a, cx_b);
 
     let workspace_b_project_a = window_b_project_a
         .downcast::<Workspace>()
@@ -1548,13 +1547,12 @@ async fn test_following_across_workspaces(cx_a: &mut TestAppContext, cx_b: &mut 
     executor.run_until_parked();
 
     assert_eq!(visible_push_notifications(cx_a).len(), 0);
-    let window_a_project_b = cx_a
+    let window_a_project_b = *cx_a
         .windows()
         .iter()
         .max_by_key(|window| window.window_id())
-        .unwrap()
-        .clone();
-    let cx_a2 = &mut VisualTestContext::from_window(window_a_project_b.clone(), cx_a);
+        .unwrap();
+    let cx_a2 = &mut VisualTestContext::from_window(window_a_project_b, cx_a);
     let workspace_a_project_b = window_a_project_b
         .downcast::<Workspace>()
         .unwrap()

--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -996,7 +996,7 @@ impl RandomizedTest for ProjectCollaborationTest {
 
                     let statuses = statuses
                         .iter()
-                        .map(|(path, val)| (path.as_path(), val.clone()))
+                        .map(|(path, val)| (path.as_path(), *val))
                         .collect::<Vec<_>>();
 
                     if client.fs().metadata(&dot_git_dir).await?.is_none() {

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -172,7 +172,7 @@ impl ChannelView {
                 Some(ui::ContextMenu::build(cx, move |menu, _| {
                     menu.entry("Copy link to section", None, move |cx| {
                         this.update(cx, |this, cx| {
-                            this.copy_link_for_position(position.clone(), cx)
+                            this.copy_link_for_position(position, cx)
                         })
                         .ok();
                     })

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -171,10 +171,8 @@ impl ChannelView {
                 let this = this.clone();
                 Some(ui::ContextMenu::build(cx, move |menu, _| {
                     menu.entry("Copy link to section", None, move |cx| {
-                        this.update(cx, |this, cx| {
-                            this.copy_link_for_position(position, cx)
-                        })
-                        .ok();
+                        this.update(cx, |this, cx| this.copy_link_for_position(position, cx))
+                            .ok();
                     })
                 }))
             });

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -403,7 +403,7 @@ impl CollabTitlebarItem {
                     )
                 })
                 .on_click({
-                    let host_peer_id = host.peer_id.clone();
+                    let host_peer_id = host.peer_id;
                     cx.listener(move |this, _, cx| {
                         this.workspace
                             .update(cx, |workspace, cx| {

--- a/crates/collab_ui/src/notifications/incoming_call_notification.rs
+++ b/crates/collab_ui/src/notifications/incoming_call_notification.rs
@@ -119,7 +119,7 @@ impl Render for IncomingCallNotification {
             let theme_settings = ThemeSettings::get_global(cx);
             (
                 theme_settings.ui_font.family.clone(),
-                theme_settings.ui_font_size.clone(),
+                theme_settings.ui_font_size,
             )
         };
 

--- a/crates/collab_ui/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui/src/notifications/project_shared_notification.rs
@@ -123,7 +123,7 @@ impl Render for ProjectSharedNotification {
             let theme_settings = ThemeSettings::get_global(cx);
             (
                 theme_settings.ui_font.family.clone(),
-                theme_settings.ui_font_size.clone(),
+                theme_settings.ui_font_size,
             )
         };
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -347,7 +347,7 @@ impl ProjectDiagnosticsEditor {
                 .diagnostic_groups
                 .last()
                 .unwrap();
-            prev_path_last_group.excerpts.last().unwrap().clone()
+            *prev_path_last_group.excerpts.last().unwrap()
         } else {
             ExcerptId::min()
         };
@@ -451,10 +451,10 @@ impl ProjectDiagnosticsEditor {
                                 .pop()
                                 .unwrap();
 
-                            prev_excerpt_id = excerpt_id.clone();
-                            first_excerpt_id.get_or_insert_with(|| prev_excerpt_id.clone());
-                            group_state.excerpts.push(excerpt_id.clone());
-                            let header_position = (excerpt_id.clone(), language::Anchor::MIN);
+                            prev_excerpt_id = excerpt_id;
+                            first_excerpt_id.get_or_insert_with(|| prev_excerpt_id);
+                            group_state.excerpts.push(excerpt_id);
+                            let header_position = (excerpt_id, language::Anchor::MIN);
 
                             if is_first_excerpt_for_group {
                                 is_first_excerpt_for_group = false;
@@ -483,7 +483,7 @@ impl ProjectDiagnosticsEditor {
                                 if !diagnostic.message.is_empty() {
                                     group_state.block_count += 1;
                                     blocks_to_add.push(BlockProperties {
-                                        position: (excerpt_id.clone(), entry.range.start),
+                                        position: (excerpt_id, entry.range.start),
                                         height: diagnostic.message.matches('\n').count() as u8 + 1,
                                         style: BlockStyle::Fixed,
                                         render: diagnostic_block_renderer(diagnostic, true),
@@ -506,8 +506,8 @@ impl ProjectDiagnosticsEditor {
                     group_ixs_to_remove.push(group_ix);
                     blocks_to_remove.extend(group_state.blocks.iter().copied());
                 } else if let Some((_, group)) = to_keep {
-                    prev_excerpt_id = group.excerpts.last().unwrap().clone();
-                    first_excerpt_id.get_or_insert_with(|| prev_excerpt_id.clone());
+                    prev_excerpt_id = *group.excerpts.last().unwrap();
+                    first_excerpt_id.get_or_insert_with(|| prev_excerpt_id);
                 }
             }
 
@@ -591,7 +591,7 @@ impl ProjectDiagnosticsEditor {
                     if let Some(group) = groups.get(group_ix) {
                         let offset = excerpts_snapshot
                             .anchor_in_excerpt(
-                                group.excerpts[group.primary_excerpt_ix].clone(),
+                                group.excerpts[group.primary_excerpt_ix],
                                 group.primary_diagnostic.range.start,
                             )
                             .to_offset(&excerpts_snapshot);

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1291,7 +1291,7 @@ pub mod tests {
 
         let mut cx = EditorTestContext::new(cx).await;
         let editor = cx.editor.clone();
-        let window = cx.window.clone();
+        let window = cx.window;
 
         _ = cx.update_window(window, |_, cx| {
             let text_layout_details =

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -884,10 +884,10 @@ impl sum_tree::Item for Fold {
 
     fn summary(&self) -> Self::Summary {
         FoldSummary {
-            start: self.range.start.clone(),
-            end: self.range.end.clone(),
-            min_start: self.range.start.clone(),
-            max_end: self.range.end.clone(),
+            start: self.range.start,
+            end: self.range.end,
+            min_start: self.range.start,
+            max_end: self.range.end,
             count: 1,
         }
     }
@@ -919,10 +919,10 @@ impl sum_tree::Summary for FoldSummary {
 
     fn add_summary(&mut self, other: &Self, buffer: &Self::Context) {
         if other.min_start.cmp(&self.min_start, buffer) == Ordering::Less {
-            self.min_start = other.min_start.clone();
+            self.min_start = other.min_start;
         }
         if other.max_end.cmp(&self.max_end, buffer) == Ordering::Greater {
-            self.max_end = other.max_end.clone();
+            self.max_end = other.max_end;
         }
 
         #[cfg(debug_assertions)]
@@ -934,16 +934,16 @@ impl sum_tree::Summary for FoldSummary {
             }
         }
 
-        self.start = other.start.clone();
-        self.end = other.end.clone();
+        self.start = other.start;
+        self.end = other.end;
         self.count += other.count;
     }
 }
 
 impl<'a> sum_tree::Dimension<'a, FoldSummary> for FoldRange {
     fn add_summary(&mut self, summary: &'a FoldSummary, _: &MultiBufferSnapshot) {
-        self.0.start = summary.start.clone();
-        self.0.end = summary.end.clone();
+        self.0.start = summary.start;
+        self.0.end = summary.end;
     }
 }
 

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -283,7 +283,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                 self.output_offset.0 += prefix.len();
                 let mut prefix = Chunk {
                     text: prefix,
-                    ..chunk.clone()
+                    ..*chunk
                 };
                 if !self.active_highlights.is_empty() {
                     let mut highlight_style = HighlightStyle::default();
@@ -322,7 +322,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         next_inlay_highlight_endpoint = range.end - offset_in_inlay.0;
                         highlight_style
                             .get_or_insert_with(|| Default::default())
-                            .highlight(style.clone());
+                            .highlight(*style);
                     }
                 } else {
                     next_inlay_highlight_endpoint = usize::MAX;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1892,8 +1892,7 @@ impl Editor {
 
             if let Some(completion_menu) = completion_menu {
                 let cursor_position = new_cursor_position.to_offset(buffer);
-                let (word_range, kind) =
-                    buffer.surrounding_word(completion_menu.initial_position);
+                let (word_range, kind) = buffer.surrounding_word(completion_menu.initial_position);
                 if kind == Some(CharKind::Word)
                     && word_range.to_inclusive().contains(&cursor_position)
                 {
@@ -3252,15 +3251,12 @@ impl Editor {
         };
 
         let position = self.selections.newest_anchor().head();
-        let (buffer, buffer_position) = if let Some(output) = self
-            .buffer
-            .read(cx)
-            .text_anchor_for_position(position, cx)
-        {
-            output
-        } else {
-            return;
-        };
+        let (buffer, buffer_position) =
+            if let Some(output) = self.buffer.read(cx).text_anchor_for_position(position, cx) {
+                output
+            } else {
+                return;
+            };
 
         let query = Self::completion_query(&self.buffer.read(cx).read(cx), position);
         let completions = provider.completions(&buffer, buffer_position, cx);
@@ -7447,10 +7443,8 @@ impl Editor {
 
     pub fn open_url(&mut self, _: &OpenUrl, cx: &mut ViewContext<Self>) {
         let position = self.selections.newest_anchor().head();
-        let Some((buffer, buffer_position)) = self
-            .buffer
-            .read(cx)
-            .text_anchor_for_position(position, cx)
+        let Some((buffer, buffer_position)) =
+            self.buffer.read(cx).text_anchor_for_position(position, cx)
         else {
             return;
         };

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1873,7 +1873,7 @@ impl Editor {
         let new_cursor_position = self.selections.newest_anchor().head();
 
         self.push_to_nav_history(
-            old_cursor_position.clone(),
+            *old_cursor_position,
             Some(new_cursor_position.to_point(buffer)),
             cx,
         );
@@ -1893,7 +1893,7 @@ impl Editor {
             if let Some(completion_menu) = completion_menu {
                 let cursor_position = new_cursor_position.to_offset(buffer);
                 let (word_range, kind) =
-                    buffer.surrounding_word(completion_menu.initial_position.clone());
+                    buffer.surrounding_word(completion_menu.initial_position);
                 if kind == Some(CharKind::Word)
                     && word_range.to_inclusive().contains(&cursor_position)
                 {
@@ -2114,7 +2114,7 @@ impl Editor {
         match click_count {
             1 => {
                 start = buffer.anchor_before(position.to_point(&display_map));
-                end = start.clone();
+                end = start;
                 mode = SelectMode::Character;
                 auto_scroll = true;
             }
@@ -2122,7 +2122,7 @@ impl Editor {
                 let range = movement::surrounding_word(&display_map, position);
                 start = buffer.anchor_before(range.start.to_point(&display_map));
                 end = buffer.anchor_before(range.end.to_point(&display_map));
-                mode = SelectMode::Word(start.clone()..end.clone());
+                mode = SelectMode::Word(start..end);
                 auto_scroll = true;
             }
             3 => {
@@ -2136,7 +2136,7 @@ impl Editor {
                 );
                 start = buffer.anchor_before(line_start);
                 end = buffer.anchor_before(next_line_start);
-                mode = SelectMode::Line(start.clone()..end.clone());
+                mode = SelectMode::Line(start..end);
                 auto_scroll = true;
             }
             _ => {
@@ -3208,7 +3208,7 @@ impl Editor {
         let (buffer, buffer_position) = self
             .buffer
             .read(cx)
-            .text_anchor_for_position(position.clone(), cx)?;
+            .text_anchor_for_position(position, cx)?;
 
         // OnTypeFormatting returns a list of edits, no need to pass them between Zed instances,
         // hence we do LSP request & edit on host side only — add formats to host's history.
@@ -3255,14 +3255,14 @@ impl Editor {
         let (buffer, buffer_position) = if let Some(output) = self
             .buffer
             .read(cx)
-            .text_anchor_for_position(position.clone(), cx)
+            .text_anchor_for_position(position, cx)
         {
             output
         } else {
             return;
         };
 
-        let query = Self::completion_query(&self.buffer.read(cx).read(cx), position.clone());
+        let query = Self::completion_query(&self.buffer.read(cx).read(cx), position);
         let completions = provider.completions(&buffer, buffer_position, cx);
 
         let id = post_inc(&mut self.next_completion_id);
@@ -3700,7 +3700,7 @@ impl Editor {
         let newest_selection = self.selections.newest_anchor().clone();
         let cursor_position = newest_selection.head();
         let (cursor_buffer, cursor_buffer_position) =
-            buffer.text_anchor_for_position(cursor_position.clone(), cx)?;
+            buffer.text_anchor_for_position(cursor_position, cx)?;
         let (tail_buffer, _) = buffer.text_anchor_for_position(newest_selection.tail(), cx)?;
         if cursor_buffer != tail_buffer {
             return None;
@@ -3758,7 +3758,7 @@ impl Editor {
 
                             let range = Anchor {
                                 buffer_id,
-                                excerpt_id: excerpt_id.clone(),
+                                excerpt_id: excerpt_id,
                                 text_anchor: start,
                             }..Anchor {
                                 buffer_id,
@@ -4741,7 +4741,7 @@ impl Editor {
                 row_range.end - 1,
                 snapshot.line_len(row_range.end - 1),
             ));
-            cursor_positions.push(anchor.clone()..anchor);
+            cursor_positions.push(anchor..anchor);
         }
 
         self.transact(cx, |this, cx| {
@@ -7450,7 +7450,7 @@ impl Editor {
         let Some((buffer, buffer_position)) = self
             .buffer
             .read(cx)
-            .text_anchor_for_position(position.clone(), cx)
+            .text_anchor_for_position(position, cx)
         else {
             return;
         };
@@ -7912,7 +7912,7 @@ impl Editor {
                     let block_id = this.insert_blocks(
                         [BlockProperties {
                             style: BlockStyle::Flex,
-                            position: range.start.clone(),
+                            position: range.start,
                             height: 1,
                             render: Arc::new({
                                 let rename_editor = rename_editor.clone();
@@ -7976,11 +7976,11 @@ impl Editor {
         let (start_buffer, start) = self
             .buffer
             .read(cx)
-            .text_anchor_for_position(rename.range.start.clone(), cx)?;
+            .text_anchor_for_position(rename.range.start, cx)?;
         let (end_buffer, end) = self
             .buffer
             .read(cx)
-            .text_anchor_for_position(rename.range.end.clone(), cx)?;
+            .text_anchor_for_position(rename.range.end, cx)?;
         if start_buffer != end_buffer {
             return None;
         }
@@ -8817,7 +8817,7 @@ impl Editor {
                     Ok(i) | Err(i) => i,
                 };
 
-                let right_position = right_position.clone();
+                let right_position = right_position;
                 ranges[start_ix..]
                     .iter()
                     .take_while(move |range| range.start.cmp(&right_position, buffer).is_le())

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -424,8 +424,7 @@ pub fn show_link_definition(
                 TriggerPoint::Text(_) => {
                     if let Some((url_range, url)) = find_url(&buffer, buffer_position, cx.clone()) {
                         this.update(&mut cx, |_, _| {
-                            let start =
-                                snapshot.anchor_in_excerpt(excerpt_id, url_range.start);
+                            let start = snapshot.anchor_in_excerpt(excerpt_id, url_range.start);
                             let end = snapshot.anchor_in_excerpt(excerpt_id, url_range.end);
                             (
                                 Some(RangeInEditor::Text(start..end)),
@@ -451,14 +450,10 @@ pub fn show_link_definition(
                                 (
                                     definition_result.iter().find_map(|link| {
                                         link.origin.as_ref().map(|origin| {
-                                            let start = snapshot.anchor_in_excerpt(
-                                                excerpt_id,
-                                                origin.range.start,
-                                            );
-                                            let end = snapshot.anchor_in_excerpt(
-                                                excerpt_id,
-                                                origin.range.end,
-                                            );
+                                            let start = snapshot
+                                                .anchor_in_excerpt(excerpt_id, origin.range.start);
+                                            let end = snapshot
+                                                .anchor_in_excerpt(excerpt_id, origin.range.end);
                                             RangeInEditor::Text(start..end)
                                         })
                                     }),

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -381,7 +381,7 @@ pub fn show_link_definition(
     let Some((buffer, buffer_position)) = editor
         .buffer
         .read(cx)
-        .text_anchor_for_position(trigger_anchor.clone(), cx)
+        .text_anchor_for_position(*trigger_anchor, cx)
     else {
         return;
     };
@@ -389,7 +389,7 @@ pub fn show_link_definition(
     let Some((excerpt_id, _, _)) = editor
         .buffer()
         .read(cx)
-        .excerpt_containing(trigger_anchor.clone(), cx)
+        .excerpt_containing(*trigger_anchor, cx)
     else {
         return;
     };
@@ -425,8 +425,8 @@ pub fn show_link_definition(
                     if let Some((url_range, url)) = find_url(&buffer, buffer_position, cx.clone()) {
                         this.update(&mut cx, |_, _| {
                             let start =
-                                snapshot.anchor_in_excerpt(excerpt_id.clone(), url_range.start);
-                            let end = snapshot.anchor_in_excerpt(excerpt_id.clone(), url_range.end);
+                                snapshot.anchor_in_excerpt(excerpt_id, url_range.start);
+                            let end = snapshot.anchor_in_excerpt(excerpt_id, url_range.end);
                             (
                                 Some(RangeInEditor::Text(start..end)),
                                 vec![HoverLink::Url(url)],
@@ -452,11 +452,11 @@ pub fn show_link_definition(
                                     definition_result.iter().find_map(|link| {
                                         link.origin.as_ref().map(|origin| {
                                             let start = snapshot.anchor_in_excerpt(
-                                                excerpt_id.clone(),
+                                                excerpt_id,
                                                 origin.range.start,
                                             );
                                             let end = snapshot.anchor_in_excerpt(
-                                                excerpt_id.clone(),
+                                                excerpt_id,
                                                 origin.range.end,
                                             );
                                             RangeInEditor::Text(start..end)

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -297,10 +297,10 @@ fn show_hover(
                     let range = if let Some(range) = hover_result.range {
                         let start = snapshot
                             .buffer_snapshot
-                            .anchor_in_excerpt(excerpt_id.clone(), range.start);
+                            .anchor_in_excerpt(excerpt_id, range.start);
                         let end = snapshot
                             .buffer_snapshot
-                            .anchor_in_excerpt(excerpt_id.clone(), range.end);
+                            .anchor_in_excerpt(excerpt_id, range.end);
 
                         start..end
                     } else {
@@ -597,7 +597,7 @@ impl DiagnosticPopover {
             .as_ref()
             .unwrap_or(&self.local_diagnostic);
 
-        (entry.diagnostic.group_id, entry.range.start.clone())
+        (entry.diagnostic.group_id, entry.range.start)
     }
 }
 

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -2197,7 +2197,7 @@ pub mod tests {
             "another change #3",
         ] {
             expected_changes.push(async_later_change);
-            let task_editor = editor.clone();
+            let task_editor = editor;
             edits.push(cx.spawn(|mut cx| async move {
                 task_editor
                     .update(&mut cx, |editor, cx| {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1147,8 +1147,8 @@ impl SearchableItem for Editor {
                                 let end = excerpt
                                     .buffer
                                     .anchor_before(excerpt_range.start + range.end);
-                                buffer.anchor_in_excerpt(excerpt.id.clone(), start)
-                                    ..buffer.anchor_in_excerpt(excerpt.id.clone(), end)
+                                buffer.anchor_in_excerpt(excerpt.id, start)
+                                    ..buffer.anchor_in_excerpt(excerpt.id, end)
                             }),
                     );
                 }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -863,7 +863,7 @@ mod tests {
 
         let mut cx = EditorTestContext::new(cx).await;
         let editor = cx.editor.clone();
-        let window = cx.window.clone();
+        let window = cx.window;
         _ = cx.update_window(window, |_, cx| {
             let text_layout_details =
                 editor.update(cx, |editor, cx| editor.text_layout_details(cx));

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -478,7 +478,7 @@ impl<'a> MutableSelectionsCollection<'a> {
 
         if !oldest.start.cmp(&oldest.end, &self.buffer()).is_eq() {
             let head = oldest.head();
-            oldest.start = head.clone();
+            oldest.start = head;
             oldest.end = head;
             self.collection.disjoint = Arc::from([oldest]);
             self.selections_changed = true;
@@ -794,8 +794,8 @@ impl<'a> MutableSelectionsCollection<'a> {
         let adjusted_disjoint: Vec<_> = anchors_with_status
             .chunks(2)
             .map(|selection_anchors| {
-                let (anchor_ix, start, kept_start) = selection_anchors[0].clone();
-                let (_, end, kept_end) = selection_anchors[1].clone();
+                let (anchor_ix, start, kept_start) = selection_anchors[0];
+                let (_, end, kept_end) = selection_anchors[1];
                 let selection = &self.disjoint[anchor_ix / 2];
                 let kept_head = if selection.reversed {
                     kept_start
@@ -826,8 +826,8 @@ impl<'a> MutableSelectionsCollection<'a> {
             let buffer = self.buffer();
             let anchors =
                 buffer.refresh_anchors([&pending.selection.start, &pending.selection.end]);
-            let (_, start, kept_start) = anchors[0].clone();
-            let (_, end, kept_end) = anchors[1].clone();
+            let (_, start, kept_start) = anchors[0];
+            let (_, end, kept_end) = anchors[1];
             let kept_head = if pending.selection.reversed {
                 kept_start
             } else {

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -496,11 +496,14 @@ impl Platform for MacPlatform {
         handle: AnyWindowHandle,
         options: WindowOptions,
     ) -> Box<dyn PlatformWindow> {
+        // Clippy thinks that this evaluates to `()`, for some reason.
+        #[allow(clippy::clone_on_copy)]
+        let renderer_context = self.0.lock().renderer_context.clone();
         Box::new(MacWindow::open(
             handle,
             options,
             self.foreground_executor(),
-            self.0.lock().renderer_context.clone(),
+            renderer_context,
         ))
     }
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -500,7 +500,7 @@ impl Platform for MacPlatform {
             handle,
             options,
             self.foreground_executor(),
-            self.0.lock().renderer_context,
+            self.0.lock().renderer_context.clone(),
         ))
     }
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -500,7 +500,7 @@ impl Platform for MacPlatform {
             handle,
             options,
             self.foreground_executor(),
-            self.0.lock().renderer_context.clone(),
+            self.0.lock().renderer_context,
         ))
     }
 

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1412,7 +1412,7 @@ fn insert_newlines_between_ranges(
             continue;
         }
 
-        let range_b = ranges[ix].clone();
+        let range_b = ranges[ix];
         let range_a = &mut ranges[ix - 1];
         if range_a.end_point.column == 0 {
             continue;

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -229,7 +229,7 @@ impl LanguageServer {
         let stdout = server.stdout.take().unwrap();
         let stderr = server.stderr.take().unwrap();
         let mut server = Self::new_internal(
-            server_id.clone(),
+            server_id,
             stdin,
             stdout,
             Some(stderr),

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -105,7 +105,7 @@ impl<'a> MarkdownParser<'a> {
                     classes: _,
                     attrs: _,
                 } => {
-                    let level = level.clone();
+                    let level = *level;
                     self.cursor += 1;
                     let heading = self.parse_heading(level);
                     Some(ParsedMarkdownElement::Heading(heading))
@@ -117,7 +117,7 @@ impl<'a> MarkdownParser<'a> {
                     Some(ParsedMarkdownElement::Table(table))
                 }
                 Tag::List(order) => {
-                    let order = order.clone();
+                    let order = *order;
                     self.cursor += 1;
                     let list = self.parse_list(1, order);
                     Some(ParsedMarkdownElement::List(list))
@@ -421,7 +421,7 @@ impl<'a> MarkdownParser<'a> {
             let (current, _source_range) = self.current().unwrap();
             match current {
                 Event::Start(Tag::List(order)) => {
-                    let order = order.clone();
+                    let order = *order;
                     self.cursor += 1;
 
                     let inner_list = self.parse_list(depth + 1, order);
@@ -467,7 +467,7 @@ impl<'a> MarkdownParser<'a> {
 
                     let item_type = if let Some(checked) = task_item {
                         ParsedMarkdownListItemType::Task(checked)
-                    } else if let Some(order) = order.clone() {
+                    } else if let Some(order) = order {
                         ParsedMarkdownListItemType::Ordered(order)
                     } else {
                         ParsedMarkdownListItemType::Unordered

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -55,12 +55,12 @@ impl Anchor {
             if let Some(excerpt) = snapshot.excerpt(self.excerpt_id) {
                 return Self {
                     buffer_id: self.buffer_id,
-                    excerpt_id: self.excerpt_id.clone(),
+                    excerpt_id: self.excerpt_id,
                     text_anchor: self.text_anchor.bias_left(&excerpt.buffer),
                 };
             }
         }
-        self.clone()
+        *self
     }
 
     pub fn bias_right(&self, snapshot: &MultiBufferSnapshot) -> Anchor {
@@ -68,12 +68,12 @@ impl Anchor {
             if let Some(excerpt) = snapshot.excerpt(self.excerpt_id) {
                 return Self {
                     buffer_id: self.buffer_id,
-                    excerpt_id: self.excerpt_id.clone(),
+                    excerpt_id: self.excerpt_id,
                     text_anchor: self.text_anchor.bias_right(&excerpt.buffer),
                 };
             }
         }
-        self.clone()
+        *self
     }
 
     pub fn summary<D>(&self, snapshot: &MultiBufferSnapshot) -> D

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -950,12 +950,12 @@ impl MultiBuffer {
                     for range in ranges.by_ref().take(range_count) {
                         let start = Anchor {
                             buffer_id: Some(buffer_id),
-                            excerpt_id: excerpt_id.clone(),
+                            excerpt_id: excerpt_id,
                             text_anchor: range.start,
                         };
                         let end = Anchor {
                             buffer_id: Some(buffer_id),
-                            excerpt_id: excerpt_id.clone(),
+                            excerpt_id: excerpt_id,
                             text_anchor: range.end,
                         };
                         if tx.send(start..end).await.is_err() {
@@ -1005,12 +1005,12 @@ impl MultiBuffer {
             anchor_ranges.extend(ranges.by_ref().take(range_count).map(|range| {
                 let start = Anchor {
                     buffer_id: Some(buffer_id),
-                    excerpt_id: excerpt_id.clone(),
+                    excerpt_id: excerpt_id,
                     text_anchor: buffer_snapshot.anchor_after(range.start),
                 };
                 let end = Anchor {
                     buffer_id: Some(buffer_id),
-                    excerpt_id: excerpt_id.clone(),
+                    excerpt_id: excerpt_id,
                     text_anchor: buffer_snapshot.anchor_after(range.end),
                 };
                 start..end
@@ -1206,7 +1206,7 @@ impl MultiBuffer {
             cursor.seek_forward(&Some(locator), Bias::Left, &());
             if let Some(excerpt) = cursor.item() {
                 if excerpt.locator == *locator {
-                    excerpts.push((excerpt.id.clone(), excerpt.range.clone()));
+                    excerpts.push((excerpt.id, excerpt.range.clone()));
                 }
             }
         }
@@ -1238,7 +1238,7 @@ impl MultiBuffer {
             .or_else(|| snapshot.excerpts.last())
             .map(|excerpt| {
                 (
-                    excerpt.id.clone(),
+                    excerpt.id,
                     self.buffers
                         .borrow()
                         .get(&excerpt.buffer_id)
@@ -2689,7 +2689,7 @@ impl MultiBufferSnapshot {
                 if !kept_position {
                     for excerpt in [next_excerpt, prev_excerpt].iter().filter_map(|e| *e) {
                         if excerpt.contains(&anchor) {
-                            anchor.excerpt_id = excerpt.id.clone();
+                            anchor.excerpt_id = excerpt.id;
                             kept_position = true;
                             break;
                         }
@@ -2713,7 +2713,7 @@ impl MultiBufferSnapshot {
                         }
                         Anchor {
                             buffer_id: Some(excerpt.buffer_id),
-                            excerpt_id: excerpt.id.clone(),
+                            excerpt_id: excerpt.id,
                             text_anchor,
                         }
                     } else if let Some(excerpt) = prev_excerpt {
@@ -2730,7 +2730,7 @@ impl MultiBufferSnapshot {
                         }
                         Anchor {
                             buffer_id: Some(excerpt.buffer_id),
-                            excerpt_id: excerpt.id.clone(),
+                            excerpt_id: excerpt.id,
                             text_anchor,
                         }
                     } else if anchor.text_anchor.bias == Bias::Left {
@@ -2760,7 +2760,7 @@ impl MultiBufferSnapshot {
         if let Some((excerpt_id, buffer_id, buffer)) = self.as_singleton() {
             return Anchor {
                 buffer_id: Some(buffer_id),
-                excerpt_id: excerpt_id.clone(),
+                excerpt_id: *excerpt_id,
                 text_anchor: buffer.anchor_at(offset, bias),
             };
         }
@@ -2782,7 +2782,7 @@ impl MultiBufferSnapshot {
                 excerpt.clip_anchor(excerpt.buffer.anchor_at(buffer_start + overshoot, bias));
             Anchor {
                 buffer_id: Some(excerpt.buffer_id),
-                excerpt_id: excerpt.id.clone(),
+                excerpt_id: excerpt.id,
                 text_anchor,
             }
         } else if offset == 0 && bias == Bias::Left {
@@ -2895,7 +2895,7 @@ impl MultiBufferSnapshot {
                 let excerpt = cursor.item()?;
                 let starts_new_buffer = Some(excerpt.buffer_id) != prev_buffer_id;
                 let boundary = ExcerptBoundary {
-                    id: excerpt.id.clone(),
+                    id: excerpt.id,
                     row: cursor.start().1.row,
                     buffer: excerpt.buffer.clone(),
                     range: excerpt.range.clone(),
@@ -3280,8 +3280,8 @@ impl MultiBufferSnapshot {
                 .into_iter()
                 .map(|item| OutlineItem {
                     depth: item.depth,
-                    range: self.anchor_in_excerpt(excerpt_id.clone(), item.range.start)
-                        ..self.anchor_in_excerpt(excerpt_id.clone(), item.range.end),
+                    range: self.anchor_in_excerpt(*excerpt_id, item.range.start)
+                        ..self.anchor_in_excerpt(*excerpt_id, item.range.end),
                     text: item.text,
                     highlight_ranges: item.highlight_ranges,
                     name_ranges: item.name_ranges,
@@ -3402,19 +3402,19 @@ impl MultiBufferSnapshot {
                         selections.map(move |selection| {
                             let mut start = Anchor {
                                 buffer_id: Some(excerpt.buffer_id),
-                                excerpt_id: excerpt.id.clone(),
+                                excerpt_id: excerpt.id,
                                 text_anchor: selection.start,
                             };
                             let mut end = Anchor {
                                 buffer_id: Some(excerpt.buffer_id),
-                                excerpt_id: excerpt.id.clone(),
+                                excerpt_id: excerpt.id,
                                 text_anchor: selection.end,
                             };
                             if range.start.cmp(&start, self).is_gt() {
-                                start = range.start.clone();
+                                start = range.start;
                             }
                             if range.end.cmp(&end, self).is_lt() {
-                                end = range.end.clone();
+                                end = range.end;
                             }
 
                             (

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1408,7 +1408,7 @@ impl LspCommand for GetHover {
         if let Some(range) = range.as_ref() {
             buffer
                 .update(&mut cx, |buffer, _| {
-                    buffer.wait_for_anchors([range.start.clone(), range.end.clone()])
+                    buffer.wait_for_anchors([range.start, range.end])
                 })?
                 .await?;
         }
@@ -1523,7 +1523,7 @@ impl LspCommand for GetCompletions {
                                 });
 
                             let range = if let Some(range) = default_edit_range {
-                                let range = range_from_lsp(range.clone());
+                                let range = range_from_lsp(*range);
                                 let start = snapshot.clip_point_utf16(range.start, Bias::Left);
                                 let end = snapshot.clip_point_utf16(range.end, Bias::Left);
                                 if start != range.start.0 || end != range.end.0 {

--- a/crates/project_core/src/worktree.rs
+++ b/crates/project_core/src/worktree.rs
@@ -991,7 +991,7 @@ impl LocalWorktree {
     pub fn scan_complete(&self) -> impl Future<Output = ()> {
         let mut is_scanning_rx = self.is_scanning.1.clone();
         async move {
-            let mut is_scanning = is_scanning_rx.borrow().clone();
+            let mut is_scanning = *is_scanning_rx.borrow();
             while is_scanning {
                 if let Some(value) = is_scanning_rx.recv().await {
                     is_scanning = value;

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -219,7 +219,7 @@ impl ProjectSearch {
             active_query: self.active_query.clone(),
             search_id: self.search_id,
             search_history: self.search_history.clone(),
-            no_results: self.no_results.clone(),
+            no_results: self.no_results,
         })
     }
 
@@ -1279,7 +1279,7 @@ impl ProjectSearchView {
     fn focus_results_editor(&mut self, cx: &mut ViewContext<Self>) {
         self.query_editor.update(cx, |query_editor, cx| {
             let cursor = query_editor.selections.newest_anchor().head();
-            query_editor.change_selections(None, cx, |s| s.select_ranges([cursor.clone()..cursor]));
+            query_editor.change_selections(None, cx, |s| s.select_ranges([cursor..cursor]));
         });
         self.query_editor_was_focused = false;
         let results_handle = self.results_editor.focus_handle(cx);
@@ -1299,7 +1299,6 @@ impl ProjectSearchView {
                 if is_new_search {
                     let range_to_select = match_ranges
                         .first()
-                        .clone()
                         .map(|range| editor.range_for_match(range));
                     editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                         s.select_ranges(range_to_select)
@@ -2245,7 +2244,7 @@ pub mod tests {
         .await;
         let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         let window = cx.add_window(|cx| Workspace::test_new(project, cx));
-        let workspace = window.clone();
+        let workspace = window;
         let search_bar = window.build_view(cx, |_| ProjectSearchBar::new());
 
         let active_item = cx.read(|cx| {
@@ -2475,7 +2474,7 @@ pub mod tests {
         .await;
         let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
         let window = cx.add_window(|cx| Workspace::test_new(project, cx));
-        let workspace = window.clone();
+        let workspace = window;
         let search_bar = window.build_view(cx, |_| ProjectSearchBar::new());
 
         let active_item = cx.read(|cx| {
@@ -3410,7 +3409,7 @@ pub mod tests {
         let search_view = cx.add_window(|cx| ProjectSearchView::new(search.clone(), cx, None));
 
         // First search
-        perform_search(search_view.clone(), "A", cx);
+        perform_search(search_view, "A", cx);
         search_view
             .update(cx, |search_view, cx| {
                 search_view.results_editor.update(cx, |results_editor, cx| {
@@ -3428,7 +3427,7 @@ pub mod tests {
             .expect("unable to update search view");
 
         // Second search
-        perform_search(search_view.clone(), "B", cx);
+        perform_search(search_view, "B", cx);
         search_view
             .update(cx, |search_view, cx| {
                 search_view.results_editor.update(cx, |results_editor, cx| {

--- a/crates/semantic_index/src/db.rs
+++ b/crates/semantic_index/src/db.rs
@@ -457,7 +457,7 @@ impl VectorDatabase {
                     let embeddings = std::mem::take(&mut batch_embeddings);
                     let ids = std::mem::take(&mut batch_ids);
                     let array =
-                        Array2::from_shape_vec((ids.len(), embedding_len.clone()), embeddings);
+                        Array2::from_shape_vec((ids.len(), embedding_len), embeddings);
                     match array {
                         Ok(array) => {
                             batches.push((ids, array));

--- a/crates/semantic_index/src/db.rs
+++ b/crates/semantic_index/src/db.rs
@@ -456,8 +456,7 @@ impl VectorDatabase {
                 if batch_ids.len() == batch_n {
                     let embeddings = std::mem::take(&mut batch_embeddings);
                     let ids = std::mem::take(&mut batch_ids);
-                    let array =
-                        Array2::from_shape_vec((ids.len(), embedding_len), embeddings);
+                    let array = Array2::from_shape_vec((ids.len(), embedding_len), embeddings);
                     match array {
                         Ok(array) => {
                             batches.push((ids, array));

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -329,7 +329,7 @@ impl SemanticIndex {
                 SemanticIndexStatus::Indexed
             } else {
                 SemanticIndexStatus::Indexing {
-                    remaining_files: project_state.pending_file_count_rx.borrow().clone(),
+                    remaining_files: *project_state.pending_file_count_rx.borrow(),
                     rate_limit_expiry: self.embedding_provider.rate_limit_expiration(),
                 }
             }
@@ -497,7 +497,7 @@ impl SemanticIndex {
         changes: Arc<[(Arc<Path>, ProjectEntryId, PathChange)]>,
         cx: &mut ModelContext<Self>,
     ) {
-        let Some(worktree) = project.read(cx).worktree_for_id(worktree_id.clone(), cx) else {
+        let Some(worktree) = project.read(cx).worktree_for_id(worktree_id, cx) else {
             return;
         };
         let project = project.downgrade();
@@ -840,7 +840,7 @@ impl SemanticIndex {
             let mut batch_results = Vec::new();
             for batch in file_ids.chunks(batch_size) {
                 let batch = batch.into_iter().map(|v| *v).collect::<Vec<i64>>();
-                let limit = limit.clone();
+                let limit = limit;
                 let fs = fs.clone();
                 let db_path = db_path.clone();
                 let query = query.clone();

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -42,7 +42,7 @@ fn main() {
     menu::init();
     let args = Args::parse();
 
-    let story_selector = args.story.clone().unwrap_or_else(|| {
+    let story_selector = args.story.unwrap_or_else(|| {
         let stories = ComponentStory::iter().collect::<Vec<_>>();
 
         ctrlc::set_handler(move || {}).unwrap();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -715,7 +715,7 @@ impl Terminal {
                 new_size.size.height = cmp::max(new_size.line_height, new_size.height());
                 new_size.size.width = cmp::max(new_size.cell_width, new_size.width());
 
-                self.last_content.size = new_size.clone();
+                self.last_content.size = new_size;
 
                 self.pty_tx.0.send(Msg::Resize(new_size.into())).ok();
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -406,11 +406,10 @@ impl TerminalElement {
 
         let font_features = terminal_settings
             .font_features
-            .clone()
-            .unwrap_or(settings.buffer_font.features.clone());
+            .unwrap_or(settings.buffer_font.features);
 
         let line_height = terminal_settings.line_height.value();
-        let font_size = terminal_settings.font_size.clone();
+        let font_size = terminal_settings.font_size;
 
         let font_size =
             font_size.map_or(buffer_font_size, |size| theme::adjusted_font_size(size, cx));
@@ -462,7 +461,7 @@ impl TerminalElement {
                 .width;
             gutter = cell_width;
 
-            let mut size = bounds.size.clone();
+            let mut size = bounds.size;
             size.width -= gutter;
 
             // https://github.com/zed-industries/zed/issues/2750
@@ -646,7 +645,7 @@ impl TerminalElement {
         });
 
         cx.on_mouse_event({
-            let bounds = bounds.clone();
+            let bounds = bounds;
             let focus = self.focus.clone();
             let terminal = self.terminal.clone();
             move |e: &MouseMoveEvent, phase, cx| {
@@ -828,7 +827,7 @@ impl Element for TerminalElement {
                                 start_y, //Need to change this
                                 line_height: layout.dimensions.line_height,
                                 lines: highlighted_range_lines,
-                                color: color.clone(),
+                                color: *color,
                                 //Copied from editor. TODO: move to theme or something
                                 corner_radius: 0.15 * layout.dimensions.line_height,
                             };

--- a/crates/ui/src/components/right_click_menu.rs
+++ b/crates/ui/src/components/right_click_menu.rs
@@ -132,8 +132,8 @@ impl<M: ManagedView> Element for RightClickMenu<M> {
         };
         let menu = element_state.menu.clone();
         let position = element_state.position.clone();
-        let attach = self.attach.clone();
-        let child_layout_id = element_state.child_layout_id.clone();
+        let attach = self.attach;
+        let child_layout_id = element_state.child_layout_id;
         let child_bounds = cx.layout_bounds(child_layout_id.unwrap());
 
         let interactive_bounds = InteractiveBounds {

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -294,7 +294,7 @@ mod test {
                     lsp::CompletionItem {
                         label: "first".to_string(),
                         text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
-                            range: lsp::Range::new(position.clone(), position.clone()),
+                            range: lsp::Range::new(position, position),
                             new_text: "first".to_string(),
                         })),
                         ..Default::default()
@@ -302,7 +302,7 @@ mod test {
                     lsp::CompletionItem {
                         label: "second".to_string(),
                         text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
-                            range: lsp::Range::new(position.clone(), position.clone()),
+                            range: lsp::Range::new(position, position),
                             new_text: "second".to_string(),
                         })),
                         ..Default::default()

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -90,7 +90,7 @@ impl VimTestContext {
         T: 'static,
         F: FnOnce(&mut T, &mut ViewContext<T>) -> R + 'static,
     {
-        let window = self.window.clone();
+        let window = self.window;
         self.update_window(window, move |_, cx| view.update(cx, update))
             .unwrap()
     }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -222,7 +222,7 @@ pub fn visual_block_motion(
                     start: start.to_point(map),
                     end: end.to_point(map),
                     reversed: is_reversed,
-                    goal: goal,
+                    goal,
                 };
 
                 selections.push(selection);

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -222,7 +222,7 @@ pub fn visual_block_motion(
                     start: start.to_point(map),
                     end: end.to_point(map),
                     reversed: is_reversed,
-                    goal: goal.clone(),
+                    goal: goal,
                 };
 
                 selections.push(selection);

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -367,7 +367,7 @@ impl WorkspaceDb {
 
                 conn.exec_bound(sql!(
                     DELETE FROM workspaces WHERE workspace_location = ? AND workspace_id != ?
-                ))?((&workspace.location, workspace.id.clone()))
+                ))?((&workspace.location, workspace.id))
                 .context("clearing out old locations")?;
 
                 // Upsert

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -871,7 +871,7 @@ impl Workspace {
 
                 cx.open_window(options, {
                     let app_state = app_state.clone();
-                    let workspace_id = workspace_id.clone();
+                    let workspace_id = workspace_id;
                     let project_handle = project_handle.clone();
                     move |cx| {
                         cx.new_view(|cx| {
@@ -3790,7 +3790,7 @@ impl Render for Workspace {
             let theme_settings = ThemeSettings::get_global(cx);
             (
                 theme_settings.ui_font.family.clone(),
-                theme_settings.ui_font_size.clone(),
+                theme_settings.ui_font_size,
             )
         };
 
@@ -4393,7 +4393,7 @@ pub fn open_paths(
     cx.spawn(move |mut cx| async move {
         if let Some(existing) = existing {
             Ok((
-                existing.clone(),
+                existing,
                 existing
                     .update(&mut cx, |workspace, cx| {
                         workspace.open_paths(abs_paths, OpenVisible::All, None, cx)

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -561,7 +561,7 @@ pub fn handle_keymap_file_changes(
         let new_base_keymap = *BaseKeymap::get_global(cx);
         let new_vim_enabled = VimModeSetting::get_global(cx).0;
         if new_base_keymap != old_base_keymap || new_vim_enabled != old_vim_enabled {
-            old_base_keymap = new_base_keymap.clone();
+            old_base_keymap = new_base_keymap;
             old_vim_enabled = new_vim_enabled;
             base_keymap_tx.unbounded_send(()).unwrap();
         }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -84,7 +84,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::borrow_deref_ref",
         "clippy::borrowed_box",
         "clippy::cast_abs_to_unsigned",
-        "clippy::clone_on_copy",
         "clippy::cmp_owned",
         "clippy::crate_in_macro_def",
         "clippy::default_constructed_unit_structs",


### PR DESCRIPTION
This PR enables the [`clippy::clone_on_copy`](https://rust-lang.github.io/rust-clippy/master/index.html#/clone_on_copy) rule and fixes the outstanding violations.

Release Notes:

- N/A
