### PR TITLE
Add license to Gleam extension

### DIFF
--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -2,6 +2,8 @@
 name = "zed_gleam"
 version = "0.0.1"
 edition = "2021"
+publish = false
+license = "Apache-2.0"
 
 [dependencies]
 zed_extension_api = { path = "../../crates/extension_api" }

--- a/extensions/gleam/LICENSE-APACHE
+++ b/extensions/gleam/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE


### PR DESCRIPTION
This PR adds a license to the Gleam extension crate, since the bundling script was unhappy that it didn't have one.

Since extensions like this one may ultimately live outside of Zed itself, I went with the Apache 2.0 license.

Release Notes:

- N/A
