### PR TITLE
Enable `clippy::map_identity`

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -340,7 +340,7 @@ impl LanguageServer {
             io_tasks: Mutex::new(Some((input_task, output_task))),
             output_done_rx: Mutex::new(Some(output_done_rx)),
             root_path: root_path.to_path_buf(),
-            server: Arc::new(Mutex::new(server.map(|server| server))),
+            server: Arc::new(Mutex::new(server)),
         }
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3665,7 +3665,7 @@ impl Project {
                                 proto::LspWorkStart {
                                     token,
                                     message: report.message,
-                                    percentage: report.percentage.map(|p| p),
+                                    percentage: report.percentage,
                                 },
                             ),
                         })
@@ -3691,7 +3691,7 @@ impl Project {
                                 proto::LspWorkProgress {
                                     token,
                                     message: report.message,
-                                    percentage: report.percentage.map(|p| p),
+                                    percentage: report.percentage,
                                 },
                             ),
                         })

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -105,7 +105,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::manual_flatten",
         "clippy::map_entry",
         "clippy::map_flatten",
-        "clippy::map_identity",
         "clippy::needless_arbitrary_self_type",
         "clippy::needless_borrowed_reference",
         "clippy::needless_lifetimes",


### PR DESCRIPTION
This PR enables the [`clippy::map_identity`](https://rust-lang.github.io/rust-clippy/master/index.html#/map_identity) rule and fixes the outstanding violations.

Release Notes:

- N/A
