### PR TITLE
Enable `clippy::to_string_in_format_args`

### DIFF
--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -841,7 +841,7 @@ mod tests {
                 surrounding_word(&snapshot, display_points[1]),
                 display_points[0]..display_points[2],
                 "{}",
-                marked_text.to_string()
+                marked_text
             );
         }
 

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -236,7 +236,7 @@ impl EditorTestContext {
     pub fn set_state(&mut self, marked_text: &str) -> ContextHandle {
         let state_context = self.add_assertion_context(format!(
             "Initial Editor State: \"{}\"",
-            marked_text.escape_debug().to_string()
+            marked_text.escape_debug()
         ));
         let (unmarked_text, selection_ranges) = marked_text_ranges(marked_text, true);
         self.editor.update(&mut self.cx, |editor, cx| {
@@ -252,7 +252,7 @@ impl EditorTestContext {
     pub fn set_selections_state(&mut self, marked_text: &str) -> ContextHandle {
         let state_context = self.add_assertion_context(format!(
             "Initial Editor State: \"{}\"",
-            marked_text.escape_debug().to_string()
+            marked_text.escape_debug()
         ));
         let (unmarked_text, selection_ranges) = marked_text_ranges(marked_text, true);
         self.editor.update(&mut self.cx, |editor, cx| {

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -125,7 +125,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::search_is_some",
         "clippy::single_range_in_vec_init",
         "clippy::suspicious_to_owned",
-        "clippy::to_string_in_format_args",
         "clippy::too_many_arguments",
         "clippy::type_complexity",
         "clippy::unit_arg",


### PR DESCRIPTION
This PR enables the [`clippy::to_string_in_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#/to_string_in_format_args) rule and fixes the outstanding violations.

Release Notes:

- N/A
