### PR TITLE
Enable `clippy::map_flatten`

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -343,8 +343,7 @@ impl AutoUpdater {
         ));
         cx.update(|cx| {
             if let Some(param) = ReleaseChannel::try_global(cx)
-                .map(|release_channel| release_channel.release_query_param())
-                .flatten()
+                .and_then(|release_channel| release_channel.release_query_param())
             {
                 url_string += "&";
                 url_string += param;

--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -94,21 +94,19 @@ impl ConnectionPool {
         self.connected_users
             .get(&user_id)
             .into_iter()
-            .map(|state| {
+            .flat_map(|state| {
                 state
                     .connection_ids
                     .iter()
                     .flat_map(|cid| self.connections.get(cid))
             })
-            .flatten()
     }
 
     pub fn user_connection_ids(&self, user_id: UserId) -> impl Iterator<Item = ConnectionId> + '_ {
         self.connected_users
             .get(&user_id)
             .into_iter()
-            .map(|state| &state.connection_ids)
-            .flatten()
+            .flat_map(|state| &state.connection_ids)
             .copied()
     }
 

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -444,8 +444,7 @@ impl ChatPanel {
 
         let reply_to_message = message
             .reply_to_message_id
-            .map(|id| active_chat.read(cx).find_loaded_message(id))
-            .flatten()
+            .and_then(|id| active_chat.read(cx).find_loaded_message(id))
             .cloned();
 
         let replied_to_you =
@@ -839,7 +838,7 @@ impl Render for ChatPanel {
             .when_some(reply_to_message_id, |el, reply_to_message_id| {
                 let reply_message = self
                     .active_chat()
-                    .map(|active_chat| {
+                    .and_then(|active_chat| {
                         active_chat.read(cx).messages().iter().find_map(|m| {
                             if m.id == ChannelMessageId::Saved(reply_to_message_id) {
                                 Some(m)
@@ -848,7 +847,6 @@ impl Render for ChatPanel {
                             }
                         })
                     })
-                    .flatten()
                     .cloned();
 
                 el.when_some(reply_message, |el, reply_message| {

--- a/crates/copilot_ui/src/copilot_button.rs
+++ b/crates/copilot_ui/src/copilot_button.rs
@@ -238,7 +238,7 @@ impl CopilotButton {
 
 impl StatusItemView for CopilotButton {
     fn set_active_pane_item(&mut self, item: Option<&dyn ItemHandle>, cx: &mut ViewContext<Self>) {
-        if let Some(editor) = item.map(|item| item.act_as::<Editor>(cx)).flatten() {
+        if let Some(editor) = item.and_then(|item| item.act_as::<Editor>(cx)) {
             self.editor_subscription = Some((
                 cx.observe(&editor, Self::update_enabled),
                 editor.entity_id().as_u64() as usize,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4083,8 +4083,7 @@ mod tests {
             .position_map
             .line_layouts
             .iter()
-            .map(|line_with_invisibles| &line_with_invisibles.invisibles)
-            .flatten()
+            .flat_map(|line_with_invisibles| &line_with_invisibles.invisibles)
             .cloned()
             .collect()
     }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -688,7 +688,7 @@ mod tests {
         // add all kinds of inlays between two word boundaries: we should be able to cross them all, when looking for another boundary
         let mut id = 0;
         let inlays = (0..buffer_snapshot.len())
-            .map(|offset| {
+            .flat_map(|offset| {
                 [
                     Inlay {
                         id: InlayId::Suggestion(post_inc(&mut id)),
@@ -712,7 +712,6 @@ mod tests {
                     },
                 ]
             })
-            .flatten()
             .collect();
         let snapshot = display_map.update(cx, |map, cx| {
             map.splice_inlays(Vec::new(), inlays, cx);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2775,7 +2775,7 @@ impl Project {
         let project_settings =
             ProjectSettings::get(Some((worktree_id.to_proto() as usize, Path::new(""))), cx);
         let lsp = project_settings.lsp.get(&adapter.name.0);
-        let override_options = lsp.map(|s| s.initialization_options.clone()).flatten();
+        let override_options = lsp.and_then(|s| s.initialization_options.clone());
 
         let server_id = pending_server.server_id;
         let container_dir = pending_server.container_dir.clone();

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -879,11 +879,9 @@ impl Item for TerminalView {
                 .or_else(|| {
                     cx.update(|cx| {
                         let strategy = TerminalSettings::get_global(cx).working_directory.clone();
-                        workspace
-                            .upgrade()
-                            .and_then(|workspace| {
-                                get_working_directory(workspace.read(cx), cx, strategy)
-                            })
+                        workspace.upgrade().and_then(|workspace| {
+                            get_working_directory(workspace.read(cx), cx, strategy)
+                        })
                     })
                     .ok()
                     .flatten()

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -881,10 +881,9 @@ impl Item for TerminalView {
                         let strategy = TerminalSettings::get_global(cx).working_directory.clone();
                         workspace
                             .upgrade()
-                            .map(|workspace| {
+                            .and_then(|workspace| {
                                 get_working_directory(workspace.read(cx), cx, strategy)
                             })
-                            .flatten()
                     })
                     .ok()
                     .flatten()

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -108,8 +108,7 @@ fn main() {
     let open_listener = listener.clone();
     app.on_open_urls(move |urls, _| open_listener.open_urls(&urls));
     app.on_reopen(move |cx| {
-        if let Some(app_state) = AppState::try_global(cx)
-            .and_then(|app_state| app_state.upgrade())
+        if let Some(app_state) = AppState::try_global(cx).and_then(|app_state| app_state.upgrade())
         {
             workspace::open_new(&app_state, cx, |workspace, cx| {
                 Editor::new_file(workspace, &Default::default(), cx)

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -109,8 +109,7 @@ fn main() {
     app.on_open_urls(move |urls, _| open_listener.open_urls(&urls));
     app.on_reopen(move |cx| {
         if let Some(app_state) = AppState::try_global(cx)
-            .map(|app_state| app_state.upgrade())
-            .flatten()
+            .and_then(|app_state| app_state.upgrade())
         {
             workspace::open_new(&app_state, cx, |workspace, cx| {
                 Editor::new_file(workspace, &Default::default(), cx)

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -104,7 +104,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::manual_find",
         "clippy::manual_flatten",
         "clippy::map_entry",
-        "clippy::map_flatten",
         "clippy::needless_arbitrary_self_type",
         "clippy::needless_borrowed_reference",
         "clippy::needless_lifetimes",


### PR DESCRIPTION
This PR enables the [`clippy::map_flatten`](https://rust-lang.github.io/rust-clippy/master/index.html#/map_flatten) rule and fixes the outstanding violations.

Release Notes:

- N/A
