### PR TITLE
Enable `clippy::too_many_arguments`

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2835,6 +2835,7 @@ impl FocusableView for InlineAssistant {
 }
 
 impl InlineAssistant {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         id: usize,
         measurements: Rc<Cell<BlockMeasurements>>,

--- a/crates/collab/src/db/queries/messages.rs
+++ b/crates/collab/src/db/queries/messages.rs
@@ -200,6 +200,7 @@ impl Database {
     }
 
     /// Creates a new channel message.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_channel_message(
         &self,
         channel_id: ChannelId,

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -543,6 +543,7 @@ impl Server {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn handle_connection(
         self: &Arc<Self>,
         connection: Connection,

--- a/crates/collab/src/tests/randomized_test_helpers.rs
+++ b/crates/collab/src/tests/randomized_test_helpers.rs
@@ -464,6 +464,7 @@ impl<T: RandomizedTest> TestPlan<T> {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn apply_server_operation(
         plan: Arc<Mutex<Self>>,
         deterministic: BackgroundExecutor,

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -478,6 +478,7 @@ impl CollabTitlebarItem {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_collaborator(
         &self,
         user: &Arc<User>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2992,6 +2992,7 @@ impl LineWithInvisibles {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_invisibles(
         &self,
         selection_ranges: &[Range<DisplayPoint>],

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1180,6 +1180,7 @@ fn parse_text(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_injections(
     config: &InjectionConfig,
     text: &BufferSnapshot,

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -261,6 +261,7 @@ impl LanguageServer {
         Ok(server)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_internal<Stdin, Stdout, Stderr, F>(
         server_id: LanguageServerId,
         stdin: Stdin,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2909,6 +2909,7 @@ impl Project {
         }))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn setup_and_insert_language_server(
         this: WeakModel<Self>,
         worktree_path: &Path,
@@ -6182,6 +6183,7 @@ impl Project {
     }
 
     /// Pick paths that might potentially contain a match of a given search query.
+    #[allow(clippy::too_many_arguments)]
     async fn background_search(
         unnamed_buffers: Vec<Model<Buffer>>,
         opened_buffers: HashMap<Arc<Path>, (Model<Buffer>, BufferSnapshot)>,

--- a/crates/project_core/src/worktree.rs
+++ b/crates/project_core/src/worktree.rs
@@ -3299,6 +3299,7 @@ enum BackgroundScannerPhase {
 }
 
 impl BackgroundScanner {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         snapshot: LocalSnapshot,
         next_entry_id: Arc<AtomicUsize>,

--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -124,6 +124,7 @@ impl RichText {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_markdown_mut(
     block: &str,
     mut mentions: &[Mention],

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -303,6 +303,7 @@ pub struct TerminalBuilder {
 }
 
 impl TerminalBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         working_directory: Option<PathBuf>,
         task: Option<TaskState>,

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -88,6 +88,7 @@ impl PaneGroup {
         };
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn render(
         &self,
         project: &Model<Project>,
@@ -159,6 +160,7 @@ impl Member {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render(
         &self,
         project: &Model<Project>,
@@ -471,6 +473,7 @@ impl PaneAxis {
         None
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render(
         &self,
         project: &Model<Project>,
@@ -640,6 +643,7 @@ mod element {
             self
         }
 
+        #[allow(clippy::too_many_arguments)]
         fn compute_resize(
             flexes: &Arc<Mutex<Vec<f32>>>,
             e: &MouseMoveEvent,
@@ -728,6 +732,7 @@ mod element {
             cx.refresh();
         }
 
+        #[allow(clippy::too_many_arguments)]
         fn push_handle(
             flexes: Arc<Mutex<Vec<f32>>>,
             dragged_handle: Rc<RefCell<Option<usize>>>,

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -124,7 +124,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::search_is_some",
         "clippy::single_range_in_vec_init",
         "clippy::suspicious_to_owned",
-        "clippy::too_many_arguments",
         "clippy::type_complexity",
         "clippy::unit_arg",
         "clippy::unnecessary_filter_map",


### PR DESCRIPTION
This PR enables the [`clippy::too_many_arguments`](https://rust-lang.github.io/rust-clippy/master/index.html#/too_many_arguments) rule.

I opted to add `#[allow(clippy::too_many_arguments)]` on the individual violations, as reworking them to take fewer arguments is a more involved task.

Release Notes:

- N/A
