### PR TITLE
Enable `clippy::manual_find`

### DIFF
--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -245,7 +245,7 @@ impl Prettier {
                         );
                         let plugin_name_into_path = |plugin_name: &str| {
                             let prettier_plugin_dir = prettier_node_modules.join(plugin_name);
-                            for possible_plugin_path in [
+                            [
                                 prettier_plugin_dir.join("dist").join("index.mjs"),
                                 prettier_plugin_dir.join("dist").join("index.js"),
                                 prettier_plugin_dir.join("dist").join("plugin.js"),
@@ -255,12 +255,9 @@ impl Prettier {
                                 // this one is for @prettier/plugin-php
                                 prettier_plugin_dir.join("standalone.js"),
                                 prettier_plugin_dir,
-                            ] {
-                                if possible_plugin_path.is_file() {
-                                    return Some(possible_plugin_path);
-                                }
-                            }
-                            None
+                            ]
+                            .into_iter()
+                            .find(|possible_plugin_path| possible_plugin_path.is_file())
                         };
                         let (parser, located_plugins) = match parser_with_plugins {
                             Some((parser, plugins)) => {

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -101,7 +101,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::iter_kv_map",
         "clippy::iter_overeager_cloned",
         "clippy::let_underscore_future",
-        "clippy::manual_find",
         "clippy::manual_flatten",
         "clippy::map_entry",
         "clippy::needless_arbitrary_self_type",


### PR DESCRIPTION
This PR enables the [`clippy::manual_find`](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_find) rule and fixes the outstanding violations.

Release Notes:

- N/A
