### PR TITLE
Enable `clippy::unnecessary_filter_map`

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1634,22 +1634,20 @@ impl Conversation {
         let messages = self
             .messages(cx)
             .into_iter()
-            .filter_map(|message| {
-                Some(tiktoken_rs::ChatCompletionRequestMessage {
-                    role: match message.role {
-                        Role::User => "user".into(),
-                        Role::Assistant => "assistant".into(),
-                        Role::System => "system".into(),
-                    },
-                    content: Some(
-                        self.buffer
-                            .read(cx)
-                            .text_for_range(message.offset_range)
-                            .collect(),
-                    ),
-                    name: None,
-                    function_call: None,
-                })
+            .map(|message| tiktoken_rs::ChatCompletionRequestMessage {
+                role: match message.role {
+                    Role::User => "user".into(),
+                    Role::Assistant => "assistant".into(),
+                    Role::System => "system".into(),
+                },
+                content: Some(
+                    self.buffer
+                        .read(cx)
+                        .text_for_range(message.offset_range)
+                        .collect(),
+                ),
+                name: None,
+                function_call: None,
             })
             .collect::<Vec<_>>();
         let model = self.model;

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -839,12 +839,10 @@ impl ChannelStore {
             Ok(users
                 .into_iter()
                 .zip(response.members)
-                .filter_map(|(user, member)| {
-                    Some(ChannelMembership {
-                        user,
-                        role: member.role(),
-                        kind: member.kind(),
-                    })
+                .map(|(user, member)| ChannelMembership {
+                    user,
+                    role: member.role(),
+                    kind: member.kind(),
                 })
                 .collect())
         })

--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -529,10 +529,7 @@ impl Database {
                 .all(&*tx)
                 .await?;
 
-            let channels = channels
-                .into_iter()
-                .filter_map(|channel| Some(Channel::from_model(channel)))
-                .collect();
+            let channels = channels.into_iter().map(Channel::from_model).collect();
 
             Ok(channels)
         })

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -441,17 +441,13 @@ impl CollabPanel {
                 // Populate remote participants.
                 self.match_candidates.clear();
                 self.match_candidates
-                    .extend(
-                        room.remote_participants()
-                            .iter()
-                            .filter_map(|(_, participant)| {
-                                Some(StringMatchCandidate {
-                                    id: participant.user.id as usize,
-                                    string: participant.user.github_login.clone(),
-                                    char_bag: participant.user.github_login.chars().collect(),
-                                })
-                            }),
-                    );
+                    .extend(room.remote_participants().values().map(|participant| {
+                        StringMatchCandidate {
+                            id: participant.user.id as usize,
+                            string: participant.user.github_login.clone(),
+                            char_bag: participant.user.github_login.chars().collect(),
+                        }
+                    }));
                 let mut matches = executor.block(match_strings(
                     &self.match_candidates,
                     &query,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3172,7 +3172,7 @@ impl MultiBufferSnapshot {
             let buffer_hunks = excerpt
                 .buffer
                 .git_diff_hunks_intersecting_range_rev(buffer_start..buffer_end)
-                .filter_map(move |hunk| {
+                .map(move |hunk| {
                     let start = multibuffer_start.row
                         + hunk
                             .buffer_range
@@ -3185,10 +3185,10 @@ impl MultiBufferSnapshot {
                             .min(excerpt_end_point.row + 1)
                             .saturating_sub(excerpt_start_point.row);
 
-                    Some(DiffHunk {
+                    DiffHunk {
                         buffer_range: start..end,
                         diff_base_byte_range: hunk.diff_base_byte_range.clone(),
-                    })
+                    }
                 });
 
             cursor.prev(&());
@@ -3234,7 +3234,7 @@ impl MultiBufferSnapshot {
             let buffer_hunks = excerpt
                 .buffer
                 .git_diff_hunks_intersecting_range(buffer_start..buffer_end)
-                .filter_map(move |hunk| {
+                .map(move |hunk| {
                     let start = multibuffer_start.row
                         + hunk
                             .buffer_range
@@ -3247,10 +3247,10 @@ impl MultiBufferSnapshot {
                             .min(excerpt_end_point.row + 1)
                             .saturating_sub(excerpt_start_point.row);
 
-                    Some(DiffHunk {
+                    DiffHunk {
                         buffer_range: start..end,
                         diff_base_byte_range: hunk.diff_base_byte_range.clone(),
-                    })
+                    }
                 });
 
             cursor.next(&());

--- a/crates/zed/src/open_listener.rs
+++ b/crates/zed/src/open_listener.rs
@@ -184,7 +184,7 @@ pub async fn handle_cli_connection(
                 } else {
                     paths
                         .into_iter()
-                        .filter_map(|path_with_position_string| {
+                        .map(|path_with_position_string| {
                             let path_with_position = PathLikeWithPosition::parse_str(
                                 &path_with_position_string,
                                 |path_str| {
@@ -203,7 +203,7 @@ pub async fn handle_cli_connection(
                                     caret_positions.insert(path.clone(), Point::new(row, col));
                                 }
                             }
-                            Some(path)
+                            path
                         })
                         .collect()
                 };

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -125,7 +125,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",
         "clippy::unit_arg",
-        "clippy::unnecessary_filter_map",
         "clippy::unnecessary_find_map",
         "clippy::unnecessary_operation",
         "clippy::unnecessary_to_owned",


### PR DESCRIPTION
This PR enables the [`clippy::unnecessary_filter_map`](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_filter_map) rule and fixes the outstanding violations.

Release Notes:

- N/A
