### PR TITLE
Enable `clippy::manual_flatten`

### DIFF
--- a/crates/project_core/src/worktree.rs
+++ b/crates/project_core/src/worktree.rs
@@ -3918,16 +3918,14 @@ impl BackgroundScanner {
         let repository =
             dotgit_path.and_then(|path| state.build_git_repository(path, self.fs.as_ref()));
 
-        for new_job in new_jobs {
-            if let Some(mut new_job) = new_job {
-                if let Some(containing_repository) = &repository {
-                    new_job.containing_repository = Some(containing_repository.clone());
-                }
-
-                job.scan_queue
-                    .try_send(new_job)
-                    .expect("channel is unbounded");
+        for mut new_job in new_jobs.into_iter().flatten() {
+            if let Some(containing_repository) = &repository {
+                new_job.containing_repository = Some(containing_repository.clone());
             }
+
+            job.scan_queue
+                .try_send(new_job)
+                .expect("channel is unbounded");
         }
 
         Ok(())

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3713,7 +3713,7 @@ fn open_items(
             project_paths_to_open
                 .into_iter()
                 .enumerate()
-                .map(|(i, (abs_path, project_path))| {
+                .map(|(ix, (abs_path, project_path))| {
                     let workspace = workspace.clone();
                     cx.spawn(|mut cx| {
                         let fs = app_state.fs.clone();
@@ -3721,7 +3721,7 @@ fn open_items(
                             let file_project_path = project_path?;
                             if fs.is_file(&abs_path).await {
                                 Some((
-                                    i,
+                                    ix,
                                     workspace
                                         .update(&mut cx, |workspace, cx| {
                                             workspace.open_path(file_project_path, None, true, cx)
@@ -3739,10 +3739,8 @@ fn open_items(
         let tasks = tasks.collect::<Vec<_>>();
 
         let tasks = futures::future::join_all(tasks.into_iter());
-        for maybe_opened_path in tasks.await.into_iter() {
-            if let Some((i, path_open_result)) = maybe_opened_path {
-                opened_items[i] = Some(path_open_result);
-            }
+        for (ix, path_open_result) in tasks.await.into_iter().flatten() {
+            opened_items[ix] = Some(path_open_result);
         }
 
         Ok(opened_items)

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -296,9 +296,9 @@ fn main() {
             let task = workspace::open_paths(&paths, &app_state, None, cx);
             cx.spawn(|_| async move {
                 if let Some((_window, results)) = task.await.log_err() {
-                    for result in results {
-                        if let Some(Err(e)) = result {
-                            log::error!("Error opening path: {}", e);
+                    for result in results.into_iter().flatten() {
+                        if let Err(err) = result {
+                            log::error!("Error opening path: {err}",);
                         }
                     }
                 }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -101,7 +101,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::iter_kv_map",
         "clippy::iter_overeager_cloned",
         "clippy::let_underscore_future",
-        "clippy::manual_flatten",
         "clippy::map_entry",
         "clippy::needless_arbitrary_self_type",
         "clippy::needless_borrowed_reference",


### PR DESCRIPTION
This PR enables the [`clippy::manual_flatten`](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_flatten) rule and fixes the outstanding violations.

Release Notes:

- N/A
