### PR TITLE
Enable `clippy::unnecessary_find_map`

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -839,12 +839,8 @@ impl Render for ChatPanel {
                 let reply_message = self
                     .active_chat()
                     .and_then(|active_chat| {
-                        active_chat.read(cx).messages().iter().find_map(|m| {
-                            if m.id == ChannelMessageId::Saved(reply_to_message_id) {
-                                Some(m)
-                            } else {
-                                None
-                            }
+                        active_chat.read(cx).messages().iter().find(|message| {
+                            message.id == ChannelMessageId::Saved(reply_to_message_id)
                         })
                     })
                     .cloned();

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -124,7 +124,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",
         "clippy::unit_arg",
-        "clippy::unnecessary_find_map",
         "clippy::unnecessary_operation",
         "clippy::unnecessary_to_owned",
         "clippy::unnecessary_unwrap",


### PR DESCRIPTION
This PR enables the [`clippy::unnecessary_find_map`](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_find_map) rule and fixes the outstanding violations.

Release Notes:

- N/A
