### PR TITLE
Enable `clippy::filter_map_identity`

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7002,7 +7002,7 @@ impl Project {
                 .spawn(async move {
                     future_buffers
                         .into_iter()
-                        .filter_map(|e| e)
+                        .flatten()
                         .chain(current_buffers)
                         .filter_map(|(buffer, path)| {
                             let (work_directory, repo) =

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -325,10 +325,7 @@ impl PickerDelegate for RecentProjectsDelegate {
             .unzip();
 
         let highlighted_match = HighlightedMatchWithPaths {
-            match_label: HighlightedText::join(
-                match_labels.into_iter().filter_map(|name| name),
-                ", ",
-            ),
+            match_label: HighlightedText::join(match_labels.into_iter().flatten(), ", "),
             paths: if self.render_paths { paths } else { Vec::new() },
         };
         Some(

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -95,7 +95,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::explicit_auto_deref",
         "clippy::explicit_counter_loop",
         "clippy::extra_unused_lifetimes",
-        "clippy::filter_map_identity",
         "clippy::identity_op",
         "clippy::implied_bounds_in_impls",
         "clippy::iter_kv_map",


### PR DESCRIPTION
This PR enables the [`clippy::filter_map_identity`](https://rust-lang.github.io/rust-clippy/master/index.html#/filter_map_identity) rule and fixes the outstanding violations.

Release Notes:

- N/A
