### PR TITLE
Enable `clippy::unit_arg`

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -497,7 +497,7 @@ impl Platform for MacPlatform {
         options: WindowOptions,
     ) -> Box<dyn PlatformWindow> {
         // Clippy thinks that this evaluates to `()`, for some reason.
-        #[allow(clippy::clone_on_copy)]
+        #[allow(clippy::unit_arg, clippy::clone_on_copy)]
         let renderer_context = self.0.lock().renderer_context.clone();
         Box::new(MacWindow::open(
             handle,

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -122,7 +122,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::single_range_in_vec_init",
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",
-        "clippy::unit_arg",
         "clippy::unnecessary_operation",
         "clippy::unnecessary_to_owned",
         "clippy::unnecessary_unwrap",


### PR DESCRIPTION
This PR enables the [`clippy::unit_arg`](https://rust-lang.github.io/rust-clippy/master/index.html#/unit_arg) rule and suppresses the false positive that it flags.

Release Notes:

- N/A
