### PR TITLE
Enable `clippy::needless_arbitrary_self_type`

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -847,7 +847,7 @@ impl DisplaySnapshot {
         self.block_snapshot.longest_row()
     }
 
-    pub fn fold_for_line(self: &Self, buffer_row: u32) -> Option<FoldStatus> {
+    pub fn fold_for_line(&self, buffer_row: u32) -> Option<FoldStatus> {
         if self.is_line_folded(buffer_row) {
             Some(FoldStatus::Folded)
         } else if self.is_foldable(buffer_row) {
@@ -857,7 +857,7 @@ impl DisplaySnapshot {
         }
     }
 
-    pub fn is_foldable(self: &Self, buffer_row: u32) -> bool {
+    pub fn is_foldable(&self, buffer_row: u32) -> bool {
         let max_row = self.buffer_snapshot.max_buffer_row();
         if buffer_row >= max_row {
             return false;
@@ -880,7 +880,7 @@ impl DisplaySnapshot {
         false
     }
 
-    pub fn foldable_range(self: &Self, buffer_row: u32) -> Option<Range<Point>> {
+    pub fn foldable_range(&self, buffer_row: u32) -> Option<Range<Point>> {
         let start = Point::new(buffer_row, self.buffer_snapshot.line_len(buffer_row));
         if self.is_foldable(start.row) && !self.is_line_folded(start.row) {
             let (start_indent, _) = self.line_indent_for_buffer_row(buffer_row);

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -101,7 +101,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::iter_overeager_cloned",
         "clippy::let_underscore_future",
         "clippy::map_entry",
-        "clippy::needless_arbitrary_self_type",
         "clippy::needless_borrowed_reference",
         "clippy::needless_lifetimes",
         "clippy::needless_option_as_deref",


### PR DESCRIPTION
This PR enables the [`clippy::needless_arbitrary_self_type`](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_arbitrary_self_type) rule and fixes the outstanding violations.

Release Notes:

- N/A
