### PR TITLE
Enable `clippy::drain_collect`

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2883,7 +2883,7 @@ impl LineWithInvisibles {
                         .unwrap();
                     layouts.push(Self {
                         line: shaped_line,
-                        invisibles: invisibles.drain(..).collect(),
+                        invisibles: std::mem::take(&mut invisibles),
                     });
 
                     line.clear();

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -89,7 +89,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::default_constructed_unit_structs",
         "clippy::derivable_impls",
         "clippy::derive_ord_xor_partial_ord",
-        "clippy::drain_collect",
         "clippy::eq_op",
         "clippy::expect_fun_call",
         "clippy::explicit_auto_deref",


### PR DESCRIPTION
This PR enables the [`clippy::drain_collect`](https://rust-lang.github.io/rust-clippy/master/index.html#/drain_collect) rule and fixes the outstanding violations.

Release Notes:

- N/A
