### PR TITLE
Enable `clippy::needless_borrowed_reference`

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3273,7 +3273,7 @@ impl PositionMap {
         let (column, x_overshoot_after_line_end) = if let Some(line) = self
             .line_layouts
             .get(row as usize - scroll_position.y as usize)
-            .map(|&LineWithInvisibles { ref line, .. }| line)
+            .map(|LineWithInvisibles { line, .. }| line)
         {
             if let Some(ix) = line.index_for_x(x) {
                 (ix as u32, px(0.))

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -101,7 +101,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::iter_overeager_cloned",
         "clippy::let_underscore_future",
         "clippy::map_entry",
-        "clippy::needless_borrowed_reference",
         "clippy::needless_lifetimes",
         "clippy::needless_option_as_deref",
         "clippy::needless_question_mark",


### PR DESCRIPTION
This PR enables the [`clippy::needless_borrowed_reference`](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrowed_reference) rule and fixes the outstanding violations.

Release Notes:

- N/A
