### PR TITLE
Enable `clippy::option_as_ref_deref`

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7123,7 +7123,7 @@ impl Project {
                             .set_local_settings(
                                 worktree_id.as_u64() as usize,
                                 directory.clone(),
-                                file_content.as_ref().map(String::as_str),
+                                file_content.as_deref(),
                                 cx,
                             )
                             .log_err();
@@ -7424,7 +7424,7 @@ impl Project {
                         .set_local_settings(
                             worktree.entity_id().as_u64() as usize,
                             PathBuf::from(&envelope.payload.path).into(),
-                            envelope.payload.content.as_ref().map(String::as_str),
+                            envelope.payload.content.as_deref(),
                             cx,
                         )
                         .log_err();

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -109,7 +109,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::non_canonical_clone_impl",
         "clippy::non_canonical_partial_ord_impl",
         "clippy::nonminimal_bool",
-        "clippy::option_as_ref_deref",
         "clippy::option_map_unit_fn",
         "clippy::redundant_closure_call",
         "clippy::redundant_guards",


### PR DESCRIPTION
This PR enables the [`clippy::option_as_ref_deref`](https://rust-lang.github.io/rust-clippy/master/index.html#/option_as_ref_deref) rule and fixes the outstanding violations.

Release Notes:

- N/A
