### PR TITLE
Enable `clippy::search_is_some`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6445,7 +6445,8 @@ impl Editor {
                     {
                         // TODO: This is n^2, because we might check all the selections
                         if !selections
-                            .iter().any(|selection| selection.range().overlaps(&offset_range))
+                            .iter()
+                            .any(|selection| selection.range().overlaps(&offset_range))
                         {
                             next_selected_range = Some(offset_range);
                             break;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6444,10 +6444,8 @@ impl Editor {
                             && !movement::is_inside_word(&display_map, display_range.end))
                     {
                         // TODO: This is n^2, because we might check all the selections
-                        if selections
-                            .iter()
-                            .find(|selection| selection.range().overlaps(&offset_range))
-                            .is_none()
+                        if !selections
+                            .iter().any(|selection| selection.range().overlaps(&offset_range))
                         {
                             next_selected_range = Some(offset_range);
                             break;

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -8,7 +8,7 @@ struct FeatureFlags {
 
 impl FeatureFlags {
     fn has_flag(&self, flag: &str) -> bool {
-        self.staff || self.flags.iter().find(|f| f.as_str() == flag).is_some()
+        self.staff || self.flags.iter().any(|f| f.as_str() == flag)
     }
 }
 

--- a/crates/search/src/history.rs
+++ b/crates/search/src/history.rs
@@ -16,7 +16,7 @@ impl SearchHistory {
         }
 
         if let Some(previously_searched) = self.history.last_mut() {
-            if search_string.find(previously_searched.as_str()).is_some() {
+            if search_string.contains(previously_searched.as_str()) {
                 *previously_searched = search_string;
                 self.selected = Some(self.history.len() - 1);
                 return;

--- a/crates/sum_tree/src/tree_map.rs
+++ b/crates/sum_tree/src/tree_map.rs
@@ -357,8 +357,8 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(result.len(), 2);
-        assert!(result.iter().find(|(k, _)| k == &&"baa").is_some());
-        assert!(result.iter().find(|(k, _)| k == &&"baaab").is_some());
+        assert!(result.iter().any(|(k, _)| k == &&"baa"));
+        assert!(result.iter().any(|(k, _)| k == &&"baaab"));
 
         let result = map
             .iter_from(&"c")
@@ -366,7 +366,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(result.len(), 1);
-        assert!(result.iter().find(|(k, _)| k == &&"c").is_some());
+        assert!(result.iter().any(|(k, _)| k == &&"c"));
     }
 
     #[test]

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -114,7 +114,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::redundant_guards",
         "clippy::redundant_locals",
         "clippy::reversed_empty_ranges",
-        "clippy::search_is_some",
         "clippy::single_range_in_vec_init",
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",


### PR DESCRIPTION
This PR enables the [`clippy::search_is_some`](https://rust-lang.github.io/rust-clippy/master/index.html#/search_is_some) rule and fixes the outstanding violations.

Release Notes:

- N/A
