### PR TITLE
New keybindings for VSCode

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -336,8 +336,10 @@
           "advance_downwards": false
         }
       ],
-      "alt-up": "editor::SelectLargerSyntaxNode",
-      "alt-down": "editor::SelectSmallerSyntaxNode",
+      "alt-up": "editor::MoveLineUp",
+      "alt-down": "editor::MoveLineDown",
+      "alt-shift-down": "editor::DuplicateLine",
+      "alt-shift-up": ["workspace::SendKeystrokes", "alt-shift-down up"],
       "cmd-u": "editor::UndoSelection",
       "cmd-shift-u": "editor::RedoSelection",
       "f8": "editor::GoToDiagnostic",


### PR DESCRIPTION
Release Notes:

- Changed `Alt+Up/Down` from selecting larger/smaller syntax nodes to **moving line up/down**. This is the default behavior from VSCode, which is what the JSON section is labeled as.
- Added `Alt+Shift+Up/Down` as **duplicating lines up/down**, as this is also the default VSCode behavior. These key bindings were also unused previously, so this is simply an addition.