### PR TITLE
Enable `clippy::redundant_locals`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8811,7 +8811,6 @@ impl Editor {
                     Ok(i) | Err(i) => i,
                 };
 
-                let right_position = right_position;
                 ranges[start_ix..]
                     .iter()
                     .take_while(move |range| range.start.cmp(&right_position, buffer).is_le())

--- a/crates/rpc/src/conn.rs
+++ b/crates/rpc/src/conn.rs
@@ -84,7 +84,6 @@ impl Connection {
             });
 
             let rx = rx.then({
-                let killed = killed;
                 let executor = executor.clone();
                 move |msg| {
                     let killed = killed.clone();

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -840,7 +840,6 @@ impl SemanticIndex {
             let mut batch_results = Vec::new();
             for batch in file_ids.chunks(batch_size) {
                 let batch = batch.into_iter().map(|v| *v).collect::<Vec<i64>>();
-                let limit = limit;
                 let fs = fs.clone();
                 let db_path = db_path.clone();
                 let query = query.clone();

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -645,7 +645,6 @@ impl TerminalElement {
         });
 
         cx.on_mouse_event({
-            let bounds = bounds;
             let focus = self.focus.clone();
             let terminal = self.terminal.clone();
             move |e: &MouseMoveEvent, phase, cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -871,7 +871,6 @@ impl Workspace {
 
                 cx.open_window(options, {
                     let app_state = app_state.clone();
-                    let workspace_id = workspace_id;
                     let project_handle = project_handle.clone();
                     move |cx| {
                         cx.new_view(|cx| {

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -111,7 +111,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::option_map_unit_fn",
         "clippy::redundant_closure_call",
         "clippy::redundant_guards",
-        "clippy::redundant_locals",
         "clippy::reversed_empty_ranges",
         "clippy::search_is_some",
         "clippy::single_range_in_vec_init",


### PR DESCRIPTION
This PR enables the [`clippy::redundant_locals`](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_locals) rule and fixes the outstanding violations.

Release Notes:

- N/A
