### PR TITLE
Enable `clippy::option_map_unit_fn`

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -631,14 +631,12 @@ impl ChatPanel {
                     "Copy message text",
                     None,
                     cx.handler_for(&this, move |this, cx| {
-                        this.active_chat().map(|active_chat| {
-                            if let Some(message) =
-                                active_chat.read(cx).find_loaded_message(message_id)
-                            {
-                                let text = message.body.clone();
-                                cx.write_to_clipboard(ClipboardItem::new(text))
-                            }
-                        });
+                        if let Some(message) = this.active_chat().and_then(|active_chat| {
+                            active_chat.read(cx).find_loaded_message(message_id)
+                        }) {
+                            let text = message.body.clone();
+                            cx.write_to_clipboard(ClipboardItem::new(text))
+                        }
                     }),
                 )
                 .when(can_delete_message, move |menu| {

--- a/crates/copilot_ui/src/copilot_button.rs
+++ b/crates/copilot_ui/src/copilot_button.rs
@@ -119,7 +119,9 @@ impl Render for CopilotButton {
 
 impl CopilotButton {
     pub fn new(fs: Arc<dyn Fs>, cx: &mut ViewContext<Self>) -> Self {
-        Copilot::global(cx).map(|copilot| cx.observe(&copilot, |_, _, cx| cx.notify()).detach());
+        if let Some(copilot) = Copilot::global(cx) {
+            cx.observe(&copilot, |_, _, cx| cx.notify()).detach()
+        }
 
         cx.observe_global::<SettingsStore>(move |_, cx| cx.notify())
             .detach();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -957,14 +957,14 @@ impl CompletionsMenu {
                                 .selected(item_ix == selected_item)
                                 .on_click(cx.listener(move |editor, _event, cx| {
                                     cx.stop_propagation();
-                                    editor
-                                        .confirm_completion(
-                                            &ConfirmCompletion {
-                                                item_ix: Some(item_ix),
-                                            },
-                                            cx,
-                                        )
-                                        .map(|task| task.detach_and_log_err(cx));
+                                    if let Some(task) = editor.confirm_completion(
+                                        &ConfirmCompletion {
+                                            item_ix: Some(item_ix),
+                                        },
+                                        cx,
+                                    ) {
+                                        task.detach_and_log_err(cx)
+                                    }
                                 }))
                                 .child(h_flex().overflow_hidden().child(completion_label))
                                 .end_slot::<Div>(documentation_label),
@@ -1175,14 +1175,14 @@ impl CodeActionsMenu {
                                 MouseButton::Left,
                                 cx.listener(move |editor, _, cx| {
                                     cx.stop_propagation();
-                                    editor
-                                        .confirm_code_action(
-                                            &ConfirmCodeAction {
-                                                item_ix: Some(item_ix),
-                                            },
-                                            cx,
-                                        )
-                                        .map(|task| task.detach_and_log_err(cx));
+                                    if let Some(task) = editor.confirm_code_action(
+                                        &ConfirmCodeAction {
+                                            item_ix: Some(item_ix),
+                                        },
+                                        cx,
+                                    ) {
+                                        task.detach_and_log_err(cx)
+                                    }
                                 }),
                             )
                             // TASK: It would be good to make lsp_action.title a SharedString to avoid allocating here.

--- a/crates/gpui/src/test.rs
+++ b/crates/gpui/src/test.rs
@@ -72,7 +72,9 @@ pub fn run_test(
                         if is_randomized {
                             eprintln!("failing seed: {}", seed);
                         }
-                        on_fail_fn.map(|f| f());
+                        if let Some(f) = on_fail_fn {
+                            f()
+                        }
                         panic::resume_unwind(error);
                     }
                 }

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -657,9 +657,9 @@ impl SemanticIndex {
                 if register.await.log_err().is_none() {
                     // Stop tracking this worktree if the registration failed.
                     this.update(&mut cx, |this, _| {
-                        this.projects.get_mut(&project).map(|project_state| {
+                        if let Some(project_state) = this.projects.get_mut(&project) {
                             project_state.worktrees.remove(&worktree_id);
-                        });
+                        }
                     })
                     .ok();
                 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1433,16 +1433,20 @@ impl Pane {
                             "Close Clean",
                             Some(Box::new(CloseCleanItems)),
                             cx.handler_for(&pane, move |pane, cx| {
-                                pane.close_clean_items(&CloseCleanItems, cx)
-                                    .map(|task| task.detach_and_log_err(cx));
+                                if let Some(task) = pane.close_clean_items(&CloseCleanItems, cx) {
+                                    task.detach_and_log_err(cx)
+                                }
                             }),
                         )
                         .entry(
                             "Close All",
                             Some(Box::new(CloseAllItems { save_intent: None })),
                             cx.handler_for(&pane, |pane, cx| {
-                                pane.close_all_items(&CloseAllItems { save_intent: None }, cx)
-                                    .map(|task| task.detach_and_log_err(cx));
+                                if let Some(task) =
+                                    pane.close_all_items(&CloseAllItems { save_intent: None }, cx)
+                                {
+                                    task.detach_and_log_err(cx)
+                                }
                             }),
                         );
 
@@ -1783,42 +1787,49 @@ impl Render for Pane {
             }))
             .on_action(
                 cx.listener(|pane: &mut Self, action: &CloseActiveItem, cx| {
-                    pane.close_active_item(action, cx)
-                        .map(|task| task.detach_and_log_err(cx));
+                    if let Some(task) = pane.close_active_item(action, cx) {
+                        task.detach_and_log_err(cx)
+                    }
                 }),
             )
             .on_action(
                 cx.listener(|pane: &mut Self, action: &CloseInactiveItems, cx| {
-                    pane.close_inactive_items(action, cx)
-                        .map(|task| task.detach_and_log_err(cx));
+                    if let Some(task) = pane.close_inactive_items(action, cx) {
+                        task.detach_and_log_err(cx)
+                    }
                 }),
             )
             .on_action(
                 cx.listener(|pane: &mut Self, action: &CloseCleanItems, cx| {
-                    pane.close_clean_items(action, cx)
-                        .map(|task| task.detach_and_log_err(cx));
+                    if let Some(task) = pane.close_clean_items(action, cx) {
+                        task.detach_and_log_err(cx)
+                    }
                 }),
             )
             .on_action(
                 cx.listener(|pane: &mut Self, action: &CloseItemsToTheLeft, cx| {
-                    pane.close_items_to_the_left(action, cx)
-                        .map(|task| task.detach_and_log_err(cx));
+                    if let Some(task) = pane.close_items_to_the_left(action, cx) {
+                        task.detach_and_log_err(cx)
+                    }
                 }),
             )
             .on_action(
                 cx.listener(|pane: &mut Self, action: &CloseItemsToTheRight, cx| {
-                    pane.close_items_to_the_right(action, cx)
-                        .map(|task| task.detach_and_log_err(cx));
+                    if let Some(task) = pane.close_items_to_the_right(action, cx) {
+                        task.detach_and_log_err(cx)
+                    }
                 }),
             )
             .on_action(cx.listener(|pane: &mut Self, action: &CloseAllItems, cx| {
-                pane.close_all_items(action, cx)
-                    .map(|task| task.detach_and_log_err(cx));
+                if let Some(task) = pane.close_all_items(action, cx) {
+                    task.detach_and_log_err(cx)
+                }
             }))
             .on_action(
                 cx.listener(|pane: &mut Self, action: &CloseActiveItem, cx| {
-                    pane.close_active_item(action, cx)
-                        .map(|task| task.detach_and_log_err(cx));
+                    if let Some(task) = pane.close_active_item(action, cx) {
+                        task.detach_and_log_err(cx)
+                    }
                 }),
             )
             .on_action(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1628,8 +1628,11 @@ impl Workspace {
         action: &CloseInactiveTabsAndPanes,
         cx: &mut ViewContext<Self>,
     ) {
-        self.close_all_internal(true, action.save_intent.unwrap_or(SaveIntent::Close), cx)
-            .map(|task| task.detach_and_log_err(cx));
+        if let Some(task) =
+            self.close_all_internal(true, action.save_intent.unwrap_or(SaveIntent::Close), cx)
+        {
+            task.detach_and_log_err(cx)
+        }
     }
 
     pub fn close_all_items_and_panes(
@@ -1637,8 +1640,11 @@ impl Workspace {
         action: &CloseAllItemsAndPanes,
         cx: &mut ViewContext<Self>,
     ) {
-        self.close_all_internal(false, action.save_intent.unwrap_or(SaveIntent::Close), cx)
-            .map(|task| task.detach_and_log_err(cx));
+        if let Some(task) =
+            self.close_all_internal(false, action.save_intent.unwrap_or(SaveIntent::Close), cx)
+        {
+            task.detach_and_log_err(cx)
+        }
     }
 
     fn close_all_internal(
@@ -2600,8 +2606,9 @@ impl Workspace {
         if Some(leader_id) == self.unfollow(&pane, cx) {
             return;
         }
-        self.start_following(leader_id, cx)
-            .map(|task| task.detach_and_log_err(cx));
+        if let Some(task) = self.start_following(leader_id, cx) {
+            task.detach_and_log_err(cx)
+        }
     }
 
     pub fn follow(&mut self, leader_id: PeerId, cx: &mut ViewContext<Self>) {
@@ -2643,8 +2650,9 @@ impl Workspace {
         }
 
         // Otherwise, follow.
-        self.start_following(leader_id, cx)
-            .map(|task| task.detach_and_log_err(cx));
+        if let Some(task) = self.start_following(leader_id, cx) {
+            task.detach_and_log_err(cx)
+        }
     }
 
     pub fn unfollow(&mut self, pane: &View<Pane>, cx: &mut ViewContext<Self>) -> Option<PeerId> {

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -108,7 +108,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::non_canonical_clone_impl",
         "clippy::non_canonical_partial_ord_impl",
         "clippy::nonminimal_bool",
-        "clippy::option_map_unit_fn",
         "clippy::redundant_closure_call",
         "clippy::redundant_guards",
         "clippy::redundant_locals",


### PR DESCRIPTION
This PR enables the [`clippy::option_map_unit_fn`](https://rust-lang.github.io/rust-clippy/master/index.html#/option_map_unit_fn) rule and fixes the outstanding violations.

Release Notes:

- N/A
