### PR TITLE
Enable `clippy::unnecessary_operation`

### DIFF
--- a/crates/collab/src/db/tests/contributor_tests.rs
+++ b/crates/collab/src/db/tests/contributor_tests.rs
@@ -18,8 +18,7 @@ async fn test_contributors(db: &Arc<Database>) {
         },
     )
     .await
-    .unwrap()
-    .user_id;
+    .unwrap();
 
     assert_eq!(db.get_contributors().await.unwrap(), Vec::<String>::new());
 

--- a/crates/collab/src/db/tests/db_tests.rs
+++ b/crates/collab/src/db/tests/db_tests.rs
@@ -87,8 +87,7 @@ async fn test_get_or_create_user_by_github_account(db: &Arc<Database>) {
         },
     )
     .await
-    .unwrap()
-    .user_id;
+    .unwrap();
     let user_id2 = db
         .create_user(
             "user2@example.com",

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -115,7 +115,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::single_range_in_vec_init",
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",
-        "clippy::unnecessary_operation",
         "clippy::unnecessary_to_owned",
         "clippy::unnecessary_unwrap",
         "clippy::useless_conversion",


### PR DESCRIPTION
This PR enables the [`clippy::unnecessary_operation`](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_operation) rule and fixes the outstanding violations.

Release Notes:

- N/A
