### PR TITLE
Enable `clippy::explicit_auto_deref`

### DIFF
--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -53,8 +53,8 @@ impl Database {
             let mut membership = None;
 
             if let Some(parent_channel_id) = parent_channel_id {
-                let parent_channel = self.get_channel_internal(parent_channel_id, &*tx).await?;
-                self.check_user_is_channel_admin(&parent_channel, admin_id, &*tx)
+                let parent_channel = self.get_channel_internal(parent_channel_id, &tx).await?;
+                self.check_user_is_channel_admin(&parent_channel, admin_id, &tx)
                     .await?;
                 parent = Some(parent_channel);
             }
@@ -105,14 +105,14 @@ impl Database {
         connection: ConnectionId,
     ) -> Result<(JoinRoom, Option<MembershipUpdated>, ChannelRole)> {
         self.transaction(move |tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            let mut role = self.channel_role_for_user(&channel, user_id, &*tx).await?;
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            let mut role = self.channel_role_for_user(&channel, user_id, &tx).await?;
 
             let mut accept_invite_result = None;
 
             if role.is_none() {
                 if let Some(invitation) = self
-                    .pending_invite_for_channel(&channel, user_id, &*tx)
+                    .pending_invite_for_channel(&channel, user_id, &tx)
                     .await?
                 {
                     // note, this may be a parent channel
@@ -125,12 +125,12 @@ impl Database {
                     .await?;
 
                     accept_invite_result = Some(
-                        self.calculate_membership_updated(&channel, user_id, &*tx)
+                        self.calculate_membership_updated(&channel, user_id, &tx)
                             .await?,
                     );
 
                     debug_assert!(
-                        self.channel_role_for_user(&channel, user_id, &*tx).await? == role
+                        self.channel_role_for_user(&channel, user_id, &tx).await? == role
                     );
                 } else if channel.visibility == ChannelVisibility::Public {
                     role = Some(ChannelRole::Guest);
@@ -145,12 +145,12 @@ impl Database {
                     .await?;
 
                     accept_invite_result = Some(
-                        self.calculate_membership_updated(&channel, user_id, &*tx)
+                        self.calculate_membership_updated(&channel, user_id, &tx)
                             .await?,
                     );
 
                     debug_assert!(
-                        self.channel_role_for_user(&channel, user_id, &*tx).await? == role
+                        self.channel_role_for_user(&channel, user_id, &tx).await? == role
                     );
                 }
             }
@@ -162,10 +162,10 @@ impl Database {
 
             let live_kit_room = format!("channel-{}", nanoid::nanoid!(30));
             let room_id = self
-                .get_or_create_channel_room(channel_id, &live_kit_room, &*tx)
+                .get_or_create_channel_room(channel_id, &live_kit_room, &tx)
                 .await?;
 
-            self.join_channel_room_internal(room_id, user_id, connection, role, &*tx)
+            self.join_channel_room_internal(room_id, user_id, connection, role, &tx)
                 .await
                 .map(|jr| (jr, accept_invite_result, role))
         })
@@ -180,13 +180,13 @@ impl Database {
         admin_id: UserId,
     ) -> Result<(Channel, Vec<channel_member::Model>)> {
         self.transaction(move |tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_admin(&channel, admin_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_admin(&channel, admin_id, &tx)
                 .await?;
 
             if visibility == ChannelVisibility::Public {
                 if let Some(parent_id) = channel.parent_id() {
-                    let parent = self.get_channel_internal(parent_id, &*tx).await?;
+                    let parent = self.get_channel_internal(parent_id, &tx).await?;
 
                     if parent.visibility != ChannelVisibility::Public {
                         Err(ErrorCode::BadPublicNesting
@@ -196,7 +196,7 @@ impl Database {
                 }
             } else if visibility == ChannelVisibility::Members {
                 if self
-                    .get_channel_descendants_excluding_self([&channel], &*tx)
+                    .get_channel_descendants_excluding_self([&channel], &tx)
                     .await?
                     .into_iter()
                     .any(|channel| channel.visibility == ChannelVisibility::Public)
@@ -228,7 +228,7 @@ impl Database {
         requires_zed_cla: bool,
     ) -> Result<()> {
         self.transaction(move |tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
             let mut model = channel.into_active_model();
             model.requires_zed_cla = ActiveValue::Set(requires_zed_cla);
             model.update(&*tx).await?;
@@ -244,8 +244,8 @@ impl Database {
         user_id: UserId,
     ) -> Result<(Vec<ChannelId>, Vec<UserId>)> {
         self.transaction(move |tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_admin(&channel, user_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_admin(&channel, user_id, &tx)
                 .await?;
 
             let members_to_notify: Vec<UserId> = channel_member::Entity::find()
@@ -258,7 +258,7 @@ impl Database {
                 .await?;
 
             let channels_to_remove = self
-                .get_channel_descendants_excluding_self([&channel], &*tx)
+                .get_channel_descendants_excluding_self([&channel], &tx)
                 .await?
                 .into_iter()
                 .map(|channel| channel.id)
@@ -284,8 +284,8 @@ impl Database {
         role: ChannelRole,
     ) -> Result<InviteMemberResult> {
         self.transaction(move |tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_admin(&channel, inviter_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_admin(&channel, inviter_id, &tx)
                 .await?;
             if !channel.is_root() {
                 Err(ErrorCode::NotARootChannel.anyhow())?
@@ -312,7 +312,7 @@ impl Database {
                         inviter_id: inviter_id.to_proto(),
                     },
                     true,
-                    &*tx,
+                    &tx,
                 )
                 .await?
                 .into_iter()
@@ -344,8 +344,8 @@ impl Database {
         self.transaction(move |tx| async move {
             let new_name = Self::sanitize_channel_name(new_name)?.to_string();
 
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_admin(&channel, admin_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_admin(&channel, admin_id, &tx)
                 .await?;
 
             let mut model = channel.into_active_model();
@@ -370,7 +370,7 @@ impl Database {
         accept: bool,
     ) -> Result<RespondToChannelInvite> {
         self.transaction(move |tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
 
             let membership_update = if accept {
                 let rows_affected = channel_member::Entity::update_many()
@@ -393,7 +393,7 @@ impl Database {
                 }
 
                 Some(
-                    self.calculate_membership_updated(&channel, user_id, &*tx)
+                    self.calculate_membership_updated(&channel, user_id, &tx)
                         .await?,
                 )
             } else {
@@ -425,7 +425,7 @@ impl Database {
                             inviter_id: Default::default(),
                         },
                         accept,
-                        &*tx,
+                        &tx,
                     )
                     .await?
                     .into_iter()
@@ -466,10 +466,10 @@ impl Database {
         admin_id: UserId,
     ) -> Result<RemoveChannelMemberResult> {
         self.transaction(|tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
 
             if member_id != admin_id {
-                self.check_user_is_channel_admin(&channel, admin_id, &*tx)
+                self.check_user_is_channel_admin(&channel, admin_id, &tx)
                     .await?;
             }
 
@@ -488,7 +488,7 @@ impl Database {
 
             Ok(RemoveChannelMemberResult {
                 membership_update: self
-                    .calculate_membership_updated(&channel, member_id, &*tx)
+                    .calculate_membership_updated(&channel, member_id, &tx)
                     .await?,
                 notification_id: self
                     .remove_notification(
@@ -498,7 +498,7 @@ impl Database {
                             channel_name: Default::default(),
                             inviter_id: Default::default(),
                         },
-                        &*tx,
+                        &tx,
                     )
                     .await?,
             })
@@ -674,8 +674,8 @@ impl Database {
         role: ChannelRole,
     ) -> Result<SetMemberRoleResult> {
         self.transaction(|tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_admin(&channel, admin_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_admin(&channel, admin_id, &tx)
                 .await?;
 
             let membership = channel_member::Entity::find()
@@ -697,7 +697,7 @@ impl Database {
 
             if updated.accepted {
                 Ok(SetMemberRoleResult::MembershipUpdated(
-                    self.calculate_membership_updated(&channel, for_user, &*tx)
+                    self.calculate_membership_updated(&channel, for_user, &tx)
                         .await?,
                 ))
             } else {
@@ -717,13 +717,13 @@ impl Database {
     ) -> Result<Vec<proto::ChannelMember>> {
         let (role, members) = self
             .transaction(move |tx| async move {
-                let channel = self.get_channel_internal(channel_id, &*tx).await?;
+                let channel = self.get_channel_internal(channel_id, &tx).await?;
                 let role = self
-                    .check_user_is_channel_participant(&channel, user_id, &*tx)
+                    .check_user_is_channel_participant(&channel, user_id, &tx)
                     .await?;
                 Ok((
                     role,
-                    self.get_channel_participant_details_internal(&channel, &*tx)
+                    self.get_channel_participant_details_internal(&channel, &tx)
                         .await?,
                 ))
             })
@@ -915,8 +915,8 @@ impl Database {
     /// Returns the channel with the given ID.
     pub async fn get_channel(&self, channel_id: ChannelId, user_id: UserId) -> Result<Channel> {
         self.transaction(|tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_participant(&channel, user_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_participant(&channel, user_id, &tx)
                 .await?;
 
             Ok(Channel::from_model(channel))
@@ -971,10 +971,10 @@ impl Database {
         admin_id: UserId,
     ) -> Result<(Vec<Channel>, Vec<channel_member::Model>)> {
         self.transaction(|tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_admin(&channel, admin_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_admin(&channel, admin_id, &tx)
                 .await?;
-            let new_parent = self.get_channel_internal(new_parent_id, &*tx).await?;
+            let new_parent = self.get_channel_internal(new_parent_id, &tx).await?;
 
             if new_parent.root_id() != channel.root_id() {
                 Err(anyhow!(ErrorCode::WrongMoveTarget))?;

--- a/crates/collab/src/db/queries/contacts.rs
+++ b/crates/collab/src/db/queries/contacts.rs
@@ -177,7 +177,7 @@ impl Database {
                         sender_id: sender_id.to_proto(),
                     },
                     true,
-                    &*tx,
+                    &tx,
                 )
                 .await?
                 .into_iter()
@@ -227,7 +227,7 @@ impl Database {
                         rpc::Notification::ContactRequest {
                             sender_id: requester_id.to_proto(),
                         },
-                        &*tx,
+                        &tx,
                     )
                     .await?;
             }
@@ -335,7 +335,7 @@ impl Database {
                         sender_id: requester_id.to_proto(),
                     },
                     accept,
-                    &*tx,
+                    &tx,
                 )
                 .await?,
             );
@@ -348,7 +348,7 @@ impl Database {
                             responder_id: responder_id.to_proto(),
                         },
                         true,
-                        &*tx,
+                        &tx,
                     )
                     .await?,
                 );

--- a/crates/collab/src/db/queries/contributors.rs
+++ b/crates/collab/src/db/queries/contributors.rs
@@ -72,7 +72,7 @@ impl Database {
                     github_login,
                     github_user_id,
                     github_email,
-                    &*tx,
+                    &tx,
                 )
                 .await?;
 

--- a/crates/collab/src/db/queries/messages.rs
+++ b/crates/collab/src/db/queries/messages.rs
@@ -12,8 +12,8 @@ impl Database {
         user_id: UserId,
     ) -> Result<()> {
         self.transaction(|tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_participant(&channel, user_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_participant(&channel, user_id, &tx)
                 .await?;
             channel_chat_participant::ActiveModel {
                 id: ActiveValue::NotSet,
@@ -87,8 +87,8 @@ impl Database {
         before_message_id: Option<MessageId>,
     ) -> Result<Vec<proto::ChannelMessage>> {
         self.transaction(|tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_participant(&channel, user_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_participant(&channel, user_id, &tx)
                 .await?;
 
             let mut condition =
@@ -105,7 +105,7 @@ impl Database {
                 .all(&*tx)
                 .await?;
 
-            self.load_channel_messages(rows, &*tx).await
+            self.load_channel_messages(rows, &tx).await
         })
         .await
     }
@@ -127,16 +127,16 @@ impl Database {
             for row in &rows {
                 channels.insert(
                     row.channel_id,
-                    self.get_channel_internal(row.channel_id, &*tx).await?,
+                    self.get_channel_internal(row.channel_id, &tx).await?,
                 );
             }
 
             for (_, channel) in channels {
-                self.check_user_is_channel_participant(&channel, user_id, &*tx)
+                self.check_user_is_channel_participant(&channel, user_id, &tx)
                     .await?;
             }
 
-            let messages = self.load_channel_messages(rows, &*tx).await?;
+            let messages = self.load_channel_messages(rows, &tx).await?;
             Ok(messages)
         })
         .await
@@ -212,8 +212,8 @@ impl Database {
         reply_to_message_id: Option<MessageId>,
     ) -> Result<CreatedChannelMessage> {
         self.transaction(|tx| async move {
-            let channel = self.get_channel_internal(channel_id, &*tx).await?;
-            self.check_user_is_channel_participant(&channel, user_id, &*tx)
+            let channel = self.get_channel_internal(channel_id, &tx).await?;
+            self.check_user_is_channel_participant(&channel, user_id, &tx)
                 .await?;
 
             let mut rows = channel_chat_participant::Entity::find()
@@ -303,13 +303,13 @@ impl Database {
                                     channel_id: channel_id.to_proto(),
                                 },
                                 false,
-                                &*tx,
+                                &tx,
                             )
                             .await?,
                         );
                     }
 
-                    self.observe_channel_message_internal(channel_id, user_id, message_id, &*tx)
+                    self.observe_channel_message_internal(channel_id, user_id, message_id, &tx)
                         .await?;
                 }
                 _ => {
@@ -322,7 +322,7 @@ impl Database {
                 }
             }
 
-            let mut channel_members = self.get_channel_participants(&channel, &*tx).await?;
+            let mut channel_members = self.get_channel_participants(&channel, &tx).await?;
             channel_members.retain(|member| !participant_user_ids.contains(member));
 
             Ok(CreatedChannelMessage {
@@ -342,7 +342,7 @@ impl Database {
         message_id: MessageId,
     ) -> Result<NotificationBatch> {
         self.transaction(|tx| async move {
-            self.observe_channel_message_internal(channel_id, user_id, message_id, &*tx)
+            self.observe_channel_message_internal(channel_id, user_id, message_id, &tx)
                 .await?;
             let mut batch = NotificationBatch::default();
             batch.extend(
@@ -353,7 +353,7 @@ impl Database {
                         sender_id: Default::default(),
                         channel_id: Default::default(),
                     },
-                    &*tx,
+                    &tx,
                 )
                 .await?,
             );
@@ -501,9 +501,9 @@ impl Database {
                 .await?;
 
             if result.rows_affected == 0 {
-                let channel = self.get_channel_internal(channel_id, &*tx).await?;
+                let channel = self.get_channel_internal(channel_id, &tx).await?;
                 if self
-                    .check_user_is_channel_admin(&channel, user_id, &*tx)
+                    .check_user_is_channel_admin(&channel, user_id, &tx)
                     .await
                     .is_ok()
                 {

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -1061,7 +1061,7 @@ impl Database {
             .insert(&*tx)
             .await?;
 
-            let room = self.get_room(room_id, &*tx).await?;
+            let room = self.get_room(room_id, &tx).await?;
             Ok(room)
         })
         .await
@@ -1095,7 +1095,7 @@ impl Database {
                 .exec(&*tx)
                 .await?;
 
-            let room = self.get_room(room_id, &*tx).await?;
+            let room = self.get_room(room_id, &tx).await?;
             Ok(room)
         })
         .await

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -321,7 +321,7 @@ impl Database {
             }
 
             let participant_index = self
-                .get_next_participant_index_internal(room_id, &*tx)
+                .get_next_participant_index_internal(room_id, &tx)
                 .await?;
 
             let result = room_participant::Entity::update_many()
@@ -1010,7 +1010,7 @@ impl Database {
                 .ok_or_else(|| anyhow!("only admins can set participant role"))?;
 
             if role.requires_cla() {
-                self.check_user_has_signed_cla(user_id, room_id, &*tx)
+                self.check_user_has_signed_cla(user_id, room_id, &tx)
                     .await?;
             }
 
@@ -1076,10 +1076,10 @@ impl Database {
 
     pub async fn connection_lost(&self, connection: ConnectionId) -> Result<()> {
         self.transaction(|tx| async move {
-            self.room_connection_lost(connection, &*tx).await?;
-            self.channel_buffer_connection_lost(connection, &*tx)
+            self.room_connection_lost(connection, &tx).await?;
+            self.channel_buffer_connection_lost(connection, &tx)
                 .await?;
-            self.channel_chat_connection_lost(connection, &*tx).await?;
+            self.channel_chat_connection_lost(connection, &tx).await?;
             Ok(())
         })
         .await

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -1077,8 +1077,7 @@ impl Database {
     pub async fn connection_lost(&self, connection: ConnectionId) -> Result<()> {
         self.transaction(|tx| async move {
             self.room_connection_lost(connection, &tx).await?;
-            self.channel_buffer_connection_lost(connection, &tx)
-                .await?;
+            self.channel_buffer_connection_lost(connection, &tx).await?;
             self.channel_chat_connection_lost(connection, &tx).await?;
             Ok(())
         })

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -80,7 +80,7 @@ impl Database {
                 github_login,
                 github_user_id,
                 github_email,
-                &*tx,
+                &tx,
             )
             .await
         })

--- a/crates/collab/src/db/tests/buffer_tests.rs
+++ b/crates/collab/src/db/tests/buffer_tests.rs
@@ -222,7 +222,7 @@ async fn test_channel_buffers_last_operations(db: &Database) {
             .unwrap();
 
         buffers.push(
-            db.transaction(|tx| async move { db.get_channel_buffer(channel, &*tx).await })
+            db.transaction(|tx| async move { db.get_channel_buffer(channel, &tx).await })
                 .await
                 .unwrap(),
         );
@@ -238,7 +238,7 @@ async fn test_channel_buffers_last_operations(db: &Database) {
         .transaction(|tx| {
             let buffers = &buffers;
             async move {
-                db.get_latest_operations_for_buffers([buffers[0].id, buffers[2].id], &*tx)
+                db.get_latest_operations_for_buffers([buffers[0].id, buffers[2].id], &tx)
                     .await
             }
         })
@@ -302,7 +302,7 @@ async fn test_channel_buffers_last_operations(db: &Database) {
         .transaction(|tx| {
             let buffers = &buffers;
             async move {
-                db.get_latest_operations_for_buffers([buffers[1].id, buffers[2].id], &*tx)
+                db.get_latest_operations_for_buffers([buffers[1].id, buffers[2].id], &tx)
                     .await
             }
         })
@@ -320,7 +320,7 @@ async fn test_channel_buffers_last_operations(db: &Database) {
         .transaction(|tx| {
             let buffers = &buffers;
             async move {
-                db.get_latest_operations_for_buffers([buffers[0].id, buffers[1].id], &*tx)
+                db.get_latest_operations_for_buffers([buffers[0].id, buffers[1].id], &tx)
                     .await
             }
         })
@@ -342,7 +342,7 @@ async fn test_channel_buffers_last_operations(db: &Database) {
             hash.insert(buffers[1].id, buffers[1].channel_id);
             hash.insert(buffers[2].id, buffers[2].channel_id);
 
-            async move { db.latest_channel_buffer_changes(&hash, &*tx).await }
+            async move { db.latest_channel_buffer_changes(&hash, &tx).await }
         })
         .await
         .unwrap();

--- a/crates/collab/src/db/tests/channel_tests.rs
+++ b/crates/collab/src/db/tests/channel_tests.rs
@@ -42,8 +42,8 @@ async fn test_channels(db: &Arc<Database>) {
 
     let mut members = db
         .transaction(|tx| async move {
-            let channel = db.get_channel_internal(replace_id, &*tx).await?;
-            Ok(db.get_channel_participants(&channel, &*tx).await?)
+            let channel = db.get_channel_internal(replace_id, &tx).await?;
+            Ok(db.get_channel_participants(&channel, &tx).await?)
         })
         .await
         .unwrap();
@@ -464,9 +464,9 @@ async fn test_user_is_channel_participant(db: &Arc<Database>) {
 
     db.transaction(|tx| async move {
         db.check_user_is_channel_participant(
-            &db.get_channel_internal(public_channel_id, &*tx).await?,
+            &db.get_channel_internal(public_channel_id, &tx).await?,
             admin,
-            &*tx,
+            &tx,
         )
         .await
     })
@@ -474,9 +474,9 @@ async fn test_user_is_channel_participant(db: &Arc<Database>) {
     .unwrap();
     db.transaction(|tx| async move {
         db.check_user_is_channel_participant(
-            &db.get_channel_internal(public_channel_id, &*tx).await?,
+            &db.get_channel_internal(public_channel_id, &tx).await?,
             member,
-            &*tx,
+            &tx,
         )
         .await
     })
@@ -517,9 +517,9 @@ async fn test_user_is_channel_participant(db: &Arc<Database>) {
 
     db.transaction(|tx| async move {
         db.check_user_is_channel_participant(
-            &db.get_channel_internal(public_channel_id, &*tx).await?,
+            &db.get_channel_internal(public_channel_id, &tx).await?,
             guest,
-            &*tx,
+            &tx,
         )
         .await
     })
@@ -547,11 +547,11 @@ async fn test_user_is_channel_participant(db: &Arc<Database>) {
     assert!(db
         .transaction(|tx| async move {
             db.check_user_is_channel_participant(
-                &db.get_channel_internal(public_channel_id, &*tx)
+                &db.get_channel_internal(public_channel_id, &tx)
                     .await
                     .unwrap(),
                 guest,
-                &*tx,
+                &tx,
             )
             .await
         })
@@ -629,9 +629,9 @@ async fn test_user_is_channel_participant(db: &Arc<Database>) {
 
     db.transaction(|tx| async move {
         db.check_user_is_channel_participant(
-            &db.get_channel_internal(zed_channel, &*tx).await.unwrap(),
+            &db.get_channel_internal(zed_channel, &tx).await.unwrap(),
             guest,
-            &*tx,
+            &tx,
         )
         .await
     })
@@ -640,11 +640,11 @@ async fn test_user_is_channel_participant(db: &Arc<Database>) {
     assert!(db
         .transaction(|tx| async move {
             db.check_user_is_channel_participant(
-                &db.get_channel_internal(internal_channel_id, &*tx)
+                &db.get_channel_internal(internal_channel_id, &tx)
                     .await
                     .unwrap(),
                 guest,
-                &*tx,
+                &tx,
             )
             .await
         })
@@ -653,11 +653,11 @@ async fn test_user_is_channel_participant(db: &Arc<Database>) {
 
     db.transaction(|tx| async move {
         db.check_user_is_channel_participant(
-            &db.get_channel_internal(public_channel_id, &*tx)
+            &db.get_channel_internal(public_channel_id, &tx)
                 .await
                 .unwrap(),
             guest,
-            &*tx,
+            &tx,
         )
         .await
     })

--- a/crates/collab/src/db/tests/message_tests.rs
+++ b/crates/collab/src/db/tests/message_tests.rs
@@ -297,7 +297,7 @@ async fn test_unseen_channel_messages(db: &Arc<Database>) {
     // Check that observer has new messages
     let latest_messages = db
         .transaction(|tx| async move {
-            db.latest_channel_messages(&[channel_1, channel_2], &*tx)
+            db.latest_channel_messages(&[channel_1, channel_2], &tx)
                 .await
         })
         .await

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -353,7 +353,7 @@ impl Server {
                                     &refreshed_room.room,
                                     &refreshed_room.channel_members,
                                     &peer,
-                                    &*pool.lock(),
+                                    &pool.lock(),
                                 );
                             }
                             contacts_to_update
@@ -754,13 +754,13 @@ impl<'a> Deref for ConnectionPoolGuard<'a> {
     type Target = ConnectionPool;
 
     fn deref(&self) -> &Self::Target {
-        &*self.guard
+        &self.guard
     }
 }
 
 impl<'a> DerefMut for ConnectionPoolGuard<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.guard
+        &mut self.guard
     }
 }
 
@@ -2226,7 +2226,7 @@ async fn request_contact(
         session.peer.send(connection_id, update.clone())?;
     }
 
-    send_notifications(&*connection_pool, &session.peer, notifications);
+    send_notifications(&connection_pool, &session.peer, notifications);
 
     response.send(proto::Ack {})?;
     Ok(())
@@ -2283,7 +2283,7 @@ async fn respond_to_contact_request(
             session.peer.send(connection_id, update.clone())?;
         }
 
-        send_notifications(&*pool, &session.peer, notifications);
+        send_notifications(&pool, &session.peer, notifications);
     }
 
     response.send(proto::Ack {})?;
@@ -2451,7 +2451,7 @@ async fn invite_channel_member(
         session.peer.send(connection_id, update.clone())?;
     }
 
-    send_notifications(&*connection_pool, &session.peer, notifications);
+    send_notifications(&connection_pool, &session.peer, notifications);
 
     response.send(proto::Ack {})?;
     Ok(())
@@ -2713,7 +2713,7 @@ async fn respond_to_channel_invite(
         }
     };
 
-    send_notifications(&*connection_pool, &session.peer, notifications);
+    send_notifications(&connection_pool, &session.peer, notifications);
 
     response.send(proto::Ack {})?;
 

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -466,7 +466,7 @@ impl TestServer {
         let active_call_a = cx_a.read(ActiveCall::global);
 
         for (client_b, cx_b) in right {
-            let user_id_b = client_b.current_user_id(*cx_b).to_proto();
+            let user_id_b = client_b.current_user_id(cx_b).to_proto();
             active_call_a
                 .update(*cx_a, |call, cx| call.invite(user_id_b, None, cx))
                 .await

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10052,7 +10052,7 @@ impl ViewInputHandler for Editor {
                     .disjoint_anchors()
                     .iter()
                     .map(|selection| {
-                        selection.start.bias_left(&*snapshot)..selection.end.bias_right(&*snapshot)
+                        selection.start.bias_left(&snapshot)..selection.end.bias_right(&snapshot)
                     })
                     .collect::<Vec<_>>()
             };

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6774,7 +6774,7 @@ async fn test_following(cx: &mut gpui::TestAppContext) {
                 move |_, leader, event, cx| {
                     leader
                         .read(cx)
-                        .add_event_to_update_proto(event, &mut *update.borrow_mut(), cx);
+                        .add_event_to_update_proto(event, &mut update.borrow_mut(), cx);
                 },
             )
             .detach();
@@ -6943,7 +6943,7 @@ async fn test_following_with_multiple_excerpts(cx: &mut gpui::TestAppContext) {
             cx.subscribe(&leader, move |_, leader, event, cx| {
                 leader
                     .read(cx)
-                    .add_event_to_update_proto(event, &mut *update.borrow_mut(), cx);
+                    .add_event_to_update_proto(event, &mut update.borrow_mut(), cx);
             })
             .detach();
         }

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -160,7 +160,7 @@ impl TestAppContext {
     /// Gives you an `&AppContext` for the duration of the closure
     pub fn read<R>(&self, f: impl FnOnce(&AppContext) -> R) -> R {
         let cx = self.app.borrow();
-        f(&*cx)
+        f(&cx)
     }
 
     /// Adds a new window. The Window will always be backed by a `TestWindow` which

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1859,7 +1859,7 @@ impl MultiBuffer {
                     .cloned()
                     .collect::<Vec<_>>();
                 let snapshot = self.snapshot.borrow();
-                excerpts_to_remove.sort_unstable_by(|a, b| a.cmp(b, &*snapshot));
+                excerpts_to_remove.sort_unstable_by(|a, b| a.cmp(b, &snapshot));
                 drop(snapshot);
                 log::info!("Removing excerpts {:?}", excerpts_to_remove);
                 self.remove_excerpts(excerpts_to_remove, cx);
@@ -1920,7 +1920,7 @@ impl MultiBuffer {
 
         for (ix, entry) in excerpt_ids.iter().enumerate() {
             if ix == 0 {
-                if entry.id.cmp(&ExcerptId::min(), &*snapshot).is_le() {
+                if entry.id.cmp(&ExcerptId::min(), &snapshot).is_le() {
                     panic!("invalid first excerpt id {:?}", entry.id);
                 }
             } else {

--- a/crates/ui/src/components/stories/keybinding.rs
+++ b/crates/ui/src/components/stories/keybinding.rs
@@ -42,7 +42,7 @@ impl Render for KeybindingStory {
                                 .gap_4()
                                 .py_3()
                                 .children(chunk.map(|permutation| {
-                                    KeyBinding::new(binding(&*(permutation.join("-") + "-x")))
+                                    KeyBinding::new(binding(&(permutation.join("-") + "-x")))
                                 }))
                         }),
                 ),

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -451,7 +451,7 @@ impl<T: Item> ItemHandle for View<T> {
                         if item.focus_handle(cx).contains_focused(cx)
                             && item.add_event_to_update_proto(
                                 event,
-                                &mut *pending_update.borrow_mut(),
+                                &mut pending_update.borrow_mut(),
                                 cx,
                             )
                             && !pending_update_scheduled.load(Ordering::SeqCst)

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -91,7 +91,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
         "clippy::expect_fun_call",
-        "clippy::explicit_auto_deref",
         "clippy::explicit_counter_loop",
         "clippy::extra_unused_lifetimes",
         "clippy::identity_op",


### PR DESCRIPTION
This PR enables the [`clippy::explicit_auto_deref`](https://rust-lang.github.io/rust-clippy/master/index.html#/explicit_auto_deref) rule and fixes the outstanding violations.

Release Notes:

- N/A
