### PR TITLE
Enable `clippy::extra_unused_lifetimes`

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1629,7 +1629,7 @@ impl CollabPanel {
         self.toggle_channel_collapsed(id, cx)
     }
 
-    fn toggle_channel_collapsed<'a>(&mut self, channel_id: ChannelId, cx: &mut ViewContext<Self>) {
+    fn toggle_channel_collapsed(&mut self, channel_id: ChannelId, cx: &mut ViewContext<Self>) {
         match self.collapsed_channels.binary_search(&channel_id) {
             Ok(ix) => {
                 self.collapsed_channels.remove(ix);

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -575,7 +575,7 @@ pub struct VisualTestContext {
     window: AnyWindowHandle,
 }
 
-impl<'a> VisualTestContext {
+impl VisualTestContext {
     /// Get the underlying window handle underlying this context.
     pub fn handle(&self) -> AnyWindowHandle {
         self.window

--- a/crates/project_core/src/worktree.rs
+++ b/crates/project_core/src/worktree.rs
@@ -220,7 +220,7 @@ impl Deref for WorkDirectoryEntry {
     }
 }
 
-impl<'a> From<ProjectEntryId> for WorkDirectoryEntry {
+impl From<ProjectEntryId> for WorkDirectoryEntry {
     fn from(value: ProjectEntryId) -> Self {
         WorkDirectoryEntry(value)
     }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -93,7 +93,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::expect_fun_call",
         "clippy::explicit_auto_deref",
         "clippy::explicit_counter_loop",
-        "clippy::extra_unused_lifetimes",
         "clippy::identity_op",
         "clippy::implied_bounds_in_impls",
         "clippy::iter_kv_map",


### PR DESCRIPTION
This PR enables the [`clippy::extra_unused_lifetimes`](https://rust-lang.github.io/rust-clippy/master/index.html#/extra_unused_lifetimes) rule and fixes the outstanding violations.

Release Notes:

- N/A
