### PR TITLE
Enable `clippy::nonminimal_bool`

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2506,7 +2506,7 @@ impl CollabPanel {
             .map(|channel| channel.visibility)
             == Some(proto::ChannelVisibility::Public);
         let disclosed =
-            has_children.then(|| !self.collapsed_channels.binary_search(&channel.id).is_ok());
+            has_children.then(|| self.collapsed_channels.binary_search(&channel.id).is_err());
 
         let has_messages_notification = channel_store.has_new_messages(channel_id);
         let has_notes_notification = channel_store.has_channel_buffer_changed(channel_id);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4283,6 +4283,7 @@ impl Project {
                             })
                             .collect();
 
+                        #[allow(clippy::nonminimal_bool)]
                         if !code_actions.is_empty()
                             && !(trigger == FormatTrigger::Save
                                 && settings.format_on_save == FormatOnSave::Off)

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -454,7 +454,7 @@ fn subscribe_for_terminal_events(
             Event::TitleChanged => {
                 cx.emit(ItemEvent::UpdateTab);
                 let terminal = this.terminal().read(cx);
-                if !terminal.task().is_some() {
+                if terminal.task().is_none() {
                     if let Some(foreground_info) = &terminal.foreground_process_info {
                         let cwd = foreground_info.cwd.clone();
 
@@ -897,7 +897,7 @@ impl Item for TerminalView {
     }
 
     fn added_to_workspace(&mut self, workspace: &mut Workspace, cx: &mut ViewContext<Self>) {
-        if !self.terminal().read(cx).task().is_some() {
+        if self.terminal().read(cx).task().is_none() {
             cx.background_executor()
                 .spawn(TERMINAL_DB.update_workspace_id(
                     workspace.database_id(),

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -458,7 +458,7 @@ fn argument(
             parent_covers_bracket_range = covers_bracket_range;
 
             // Unable to find a child node with a parent that covers the bracket range, so no argument to select
-            if !cursor.goto_first_child_for_byte(offset).is_some() {
+            if cursor.goto_first_child_for_byte(offset).is_none() {
                 return None;
             }
         }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -87,6 +87,7 @@ pub fn visual_motion(motion: Motion, times: Option<usize>, cx: &mut WindowContex
                         // If the file ends with a newline (which is common) we don't do this.
                         // so that if you go to the end of such a file you can use "up" to go
                         // to the previous line and have it work somewhat as expected.
+                        #[allow(clippy::nonminimal_bool)]
                         if !selection.reversed
                             && !selection.is_empty()
                             && !(selection.end.column() == 0 && selection.end == map.max_point())

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -106,7 +106,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::never_loop",
         "clippy::non_canonical_clone_impl",
         "clippy::non_canonical_partial_ord_impl",
-        "clippy::nonminimal_bool",
         "clippy::redundant_closure_call",
         "clippy::redundant_guards",
         "clippy::reversed_empty_ranges",


### PR DESCRIPTION
This PR enables the [`clippy::nonminimal_bool`](https://rust-lang.github.io/rust-clippy/master/index.html#/nonminimal_bool) rule and fixes the outstanding violations.

Release Notes:

- N/A
