### PR TITLE
Enable `clippy::unnecessary_unwrap`

### DIFF
--- a/crates/ai/src/embedding.rs
+++ b/crates/ai/src/embedding.rs
@@ -19,11 +19,9 @@ pub struct Embedding(pub Vec<f32>);
 impl FromSql for Embedding {
     fn column_result(value: ValueRef) -> FromSqlResult<Self> {
         let bytes = value.as_blob()?;
-        let embedding: Result<Vec<f32>, Box<bincode::ErrorKind>> = bincode::deserialize(bytes);
-        if embedding.is_err() {
-            return Err(rusqlite::types::FromSqlError::Other(embedding.unwrap_err()));
-        }
-        Ok(Embedding(embedding.unwrap()))
+        let embedding =
+            bincode::deserialize(bytes).map_err(|err| rusqlite::types::FromSqlError::Other(err))?;
+        Ok(Embedding(embedding))
     }
 }
 

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -51,8 +51,10 @@ impl<M: ManagedView> PopoverMenu<M> {
 
                             cx.subscribe(&new_menu, move |modal, _: &DismissEvent, cx| {
                                 if modal.focus_handle(cx).contains_focused(cx) {
-                                    if previous_focus_handle.is_some() {
-                                        cx.focus(previous_focus_handle.as_ref().unwrap())
+                                    if let Some(previous_focus_handle) =
+                                        previous_focus_handle.as_ref()
+                                    {
+                                        cx.focus(previous_focus_handle);
                                     }
                                 }
                                 *menu2.borrow_mut() = None;

--- a/crates/ui/src/components/right_click_menu.rs
+++ b/crates/ui/src/components/right_click_menu.rs
@@ -154,8 +154,8 @@ impl<M: ManagedView> Element for RightClickMenu<M> {
 
                 cx.subscribe(&new_menu, move |modal, _: &DismissEvent, cx| {
                     if modal.focus_handle(cx).contains_focused(cx) {
-                        if previous_focus_handle.is_some() {
-                            cx.focus(previous_focus_handle.as_ref().unwrap())
+                        if let Some(previous_focus_handle) = previous_focus_handle.as_ref() {
+                            cx.focus(previous_focus_handle);
                         }
                     }
                     *menu2.borrow_mut() = None;
@@ -165,11 +165,12 @@ impl<M: ManagedView> Element for RightClickMenu<M> {
                 cx.focus_view(&new_menu);
                 *menu.borrow_mut() = Some(new_menu);
 
-                *position.borrow_mut() = if attach.is_some() && child_layout_id.is_some() {
-                    attach.unwrap().corner(child_bounds)
-                } else {
-                    cx.mouse_position()
-                };
+                *position.borrow_mut() =
+                    if let Some(attach) = attach.filter(|_| child_layout_id.is_some()) {
+                        attach.corner(child_bounds)
+                    } else {
+                        cx.mouse_position()
+                    };
                 cx.refresh();
             }
         });

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -113,7 +113,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",
         "clippy::unnecessary_to_owned",
-        "clippy::unnecessary_unwrap",
         "clippy::useless_conversion",
         "clippy::useless_format",
         "clippy::vec_init_then_push",


### PR DESCRIPTION
This PR enables the [`clippy::unnecessary_unwrap`](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_unwrap) rule and fixes the outstanding violations.

Release Notes:

- N/A
