### PR TITLE
Enable `clippy::useless_format`

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -355,40 +355,68 @@ struct ToUpload {
 
 impl ToUpload {
     pub async fn upload(&self, clickhouse_client: &clickhouse::Client) -> anyhow::Result<()> {
-        Self::upload_to_table("editor_events", &self.editor_events, clickhouse_client)
+        const EDITOR_EVENTS_TABLE: &str = "editor_events";
+        Self::upload_to_table(EDITOR_EVENTS_TABLE, &self.editor_events, clickhouse_client)
             .await
-            .with_context(|| format!("failed to upload to table 'editor_events'"))?;
-        Self::upload_to_table("copilot_events", &self.copilot_events, clickhouse_client)
-            .await
-            .with_context(|| format!("failed to upload to table 'copilot_events'"))?;
+            .with_context(|| format!("failed to upload to table '{EDITOR_EVENTS_TABLE}'"))?;
+
+        const COPILOT_EVENTS_TABLE: &str = "copilot_events";
         Self::upload_to_table(
-            "assistant_events",
+            COPILOT_EVENTS_TABLE,
+            &self.copilot_events,
+            clickhouse_client,
+        )
+        .await
+        .with_context(|| format!("failed to upload to table '{COPILOT_EVENTS_TABLE}'"))?;
+
+        const ASSISTANT_EVENTS_TABLE: &str = "assistant_events";
+        Self::upload_to_table(
+            ASSISTANT_EVENTS_TABLE,
             &self.assistant_events,
             clickhouse_client,
         )
         .await
-        .with_context(|| format!("failed to upload to table 'assistant_events'"))?;
-        Self::upload_to_table("call_events", &self.call_events, clickhouse_client)
+        .with_context(|| format!("failed to upload to table '{ASSISTANT_EVENTS_TABLE}'"))?;
+
+        const CALL_EVENTS_TABLE: &str = "call_events";
+        Self::upload_to_table(CALL_EVENTS_TABLE, &self.call_events, clickhouse_client)
             .await
-            .with_context(|| format!("failed to upload to table 'call_events'"))?;
-        Self::upload_to_table("cpu_events", &self.cpu_events, clickhouse_client)
+            .with_context(|| format!("failed to upload to table '{CALL_EVENTS_TABLE}'"))?;
+
+        const CPU_EVENTS_TABLE: &str = "cpu_events";
+        Self::upload_to_table(CPU_EVENTS_TABLE, &self.cpu_events, clickhouse_client)
             .await
-            .with_context(|| format!("failed to upload to table 'cpu_events'"))?;
-        Self::upload_to_table("memory_events", &self.memory_events, clickhouse_client)
+            .with_context(|| format!("failed to upload to table '{CPU_EVENTS_TABLE}'"))?;
+
+        const MEMORY_EVENTS_TABLE: &str = "memory_events";
+        Self::upload_to_table(MEMORY_EVENTS_TABLE, &self.memory_events, clickhouse_client)
             .await
-            .with_context(|| format!("failed to upload to table 'memory_events'"))?;
-        Self::upload_to_table("app_events", &self.app_events, clickhouse_client)
+            .with_context(|| format!("failed to upload to table '{MEMORY_EVENTS_TABLE}'"))?;
+
+        const APP_EVENTS_TABLE: &str = "app_events";
+        Self::upload_to_table(APP_EVENTS_TABLE, &self.app_events, clickhouse_client)
             .await
-            .with_context(|| format!("failed to upload to table 'app_events'"))?;
-        Self::upload_to_table("setting_events", &self.setting_events, clickhouse_client)
+            .with_context(|| format!("failed to upload to table '{APP_EVENTS_TABLE}'"))?;
+
+        const SETTING_EVENTS_TABLE: &str = "setting_events";
+        Self::upload_to_table(
+            SETTING_EVENTS_TABLE,
+            &self.setting_events,
+            clickhouse_client,
+        )
+        .await
+        .with_context(|| format!("failed to upload to table '{SETTING_EVENTS_TABLE}'"))?;
+
+        const EDIT_EVENTS_TABLE: &str = "edit_events";
+        Self::upload_to_table(EDIT_EVENTS_TABLE, &self.edit_events, clickhouse_client)
             .await
-            .with_context(|| format!("failed to upload to table 'setting_events'"))?;
-        Self::upload_to_table("edit_events", &self.edit_events, clickhouse_client)
+            .with_context(|| format!("failed to upload to table '{EDIT_EVENTS_TABLE}'"))?;
+
+        const ACTION_EVENTS_TABLE: &str = "action_events";
+        Self::upload_to_table(ACTION_EVENTS_TABLE, &self.action_events, clickhouse_client)
             .await
-            .with_context(|| format!("failed to upload to table 'edit_events'"))?;
-        Self::upload_to_table("action_events", &self.action_events, clickhouse_client)
-            .await
-            .with_context(|| format!("failed to upload to table 'action_events'"))?;
+            .with_context(|| format!("failed to upload to table '{ACTION_EVENTS_TABLE}'"))?;
+
         Ok(())
     }
 

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -23,7 +23,7 @@ pub struct TestDb {
 
 impl TestDb {
     pub fn sqlite(background: BackgroundExecutor) -> Self {
-        let url = format!("sqlite::memory:");
+        let url = "sqlite::memory:";
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_io()
             .enable_time()

--- a/crates/collab/src/db/tests/contributor_tests.rs
+++ b/crates/collab/src/db/tests/contributor_tests.rs
@@ -10,10 +10,10 @@ test_both_dbs!(
 
 async fn test_contributors(db: &Arc<Database>) {
     db.create_user(
-        &format!("user1@example.com"),
+        "user1@example.com",
         false,
         NewUserParams {
-            github_login: format!("user1"),
+            github_login: "user1".to_string(),
             github_user_id: 1,
         },
     )

--- a/crates/collab/src/db/tests/db_tests.rs
+++ b/crates/collab/src/db/tests/db_tests.rs
@@ -494,7 +494,7 @@ async fn test_project_count(db: &Arc<Database>) {
 
     let user1 = db
         .create_user(
-            &format!("admin@example.com"),
+            "admin@example.com",
             true,
             NewUserParams {
                 github_login: "admin".into(),
@@ -505,7 +505,7 @@ async fn test_project_count(db: &Arc<Database>) {
         .unwrap();
     let user2 = db
         .create_user(
-            &format!("user@example.com"),
+            "user@example.com",
             false,
             NewUserParams {
                 github_login: "user".into(),

--- a/crates/collab/src/db/tests/feature_flag_tests.rs
+++ b/crates/collab/src/db/tests/feature_flag_tests.rs
@@ -13,10 +13,10 @@ test_both_dbs!(
 async fn test_get_user_flags(db: &Arc<Database>) {
     let user_1 = db
         .create_user(
-            &format!("user1@example.com"),
+            "user1@example.com",
             false,
             NewUserParams {
-                github_login: format!("user1"),
+                github_login: "user1".to_string(),
                 github_user_id: 1,
             },
         )
@@ -26,10 +26,10 @@ async fn test_get_user_flags(db: &Arc<Database>) {
 
     let user_2 = db
         .create_user(
-            &format!("user2@example.com"),
+            "user2@example.com",
             false,
             NewUserParams {
-                github_login: format!("user2"),
+                github_login: "user2".to_string(),
                 github_user_id: 2,
             },
         )

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -376,7 +376,7 @@ impl Item for ChannelView {
                 (_, false) => format!("#{} (disconnected)", channel.name),
             }
         } else {
-            format!("channel notes (disconnected)")
+            "channel notes (disconnected)".to_string()
         };
         Label::new(label)
             .color(if selected {

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -137,9 +137,9 @@ impl MessageEditor {
     ) {
         self.editor.update(cx, |editor, cx| {
             if let Some(channel_name) = channel_name {
-                editor.set_placeholder_text(format!("Message #{}", channel_name), cx);
+                editor.set_placeholder_text(format!("Message #{channel_name}"), cx);
             } else {
-                editor.set_placeholder_text(format!("Message Channel"), cx);
+                editor.set_placeholder_text("Message Channel", cx);
             }
         });
         self.channel_id = Some(channel_id);

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -952,7 +952,7 @@ impl CollabPanel {
                         })
                         .ok();
                 }))
-                .tooltip(move |cx| Tooltip::text(format!("Open shared screen"), cx))
+                .tooltip(move |cx| Tooltip::text("Open shared screen", cx))
             })
     }
 
@@ -2220,7 +2220,7 @@ impl CollabPanel {
                 });
 
                 if let Some(name) = channel_name {
-                    SharedString::from(format!("{}", name))
+                    SharedString::from(name.to_string())
                 } else {
                     SharedString::from("Current Call")
                 }

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -778,7 +778,7 @@ fn format_timestamp(
             "just now".to_string()
         }
     } else if date.next_day() == Some(today) {
-        format!("yesterday")
+        "yesterday".to_string()
     } else {
         format!("{:02}/{}/{}", date.month() as u32, date.day(), date.year())
     }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -693,22 +693,22 @@ mod tests {
                     Inlay {
                         id: InlayId::Suggestion(post_inc(&mut id)),
                         position: buffer_snapshot.anchor_at(offset, Bias::Left),
-                        text: format!("test").into(),
+                        text: "test".into(),
                     },
                     Inlay {
                         id: InlayId::Suggestion(post_inc(&mut id)),
                         position: buffer_snapshot.anchor_at(offset, Bias::Right),
-                        text: format!("test").into(),
+                        text: "test".into(),
                     },
                     Inlay {
                         id: InlayId::Hint(post_inc(&mut id)),
                         position: buffer_snapshot.anchor_at(offset, Bias::Left),
-                        text: format!("test").into(),
+                        text: "test".into(),
                     },
                     Inlay {
                         id: InlayId::Hint(post_inc(&mut id)),
                         position: buffer_snapshot.anchor_at(offset, Bias::Right),
-                        text: format!("test").into(),
+                        text: "test".into(),
                     },
                 ]
             })

--- a/crates/vim/src/test/neovim_connection.rs
+++ b/crates/vim/src/test/neovim_connection.rs
@@ -272,10 +272,7 @@ impl NeovimConnection {
 
     #[cfg(feature = "neovim")]
     pub async fn exec(&mut self, value: &str) {
-        self.nvim
-            .command_output(format!("{}", value).as_str())
-            .await
-            .unwrap();
+        self.nvim.command_output(value).await.unwrap();
 
         self.data.push_back(NeovimData::Exec {
             command: value.to_string(),

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -114,7 +114,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::unnecessary_to_owned",
         "clippy::unnecessary_unwrap",
         "clippy::useless_conversion",
-        "clippy::useless_format",
         "clippy::vec_init_then_push",
     ];
 


### PR DESCRIPTION
This PR enables the [`clippy::useless_format`](https://rust-lang.github.io/rust-clippy/master/index.html#/useless_format) rule and fixes the outstanding violations.

Release Notes:

- N/A
