### PR TITLE
Enable `clippy::needless_question_mark`

### DIFF
--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -179,8 +179,7 @@ async fn add_contributor(
     Json(params): Json<AuthenticatedUserParams>,
     Extension(app): Extension<Arc<AppState>>,
 ) -> Result<()> {
-    app
-        .db
+    app.db
         .add_contributor(
             &params.github_login,
             params.github_user_id,

--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -179,14 +179,14 @@ async fn add_contributor(
     Json(params): Json<AuthenticatedUserParams>,
     Extension(app): Extension<Arc<AppState>>,
 ) -> Result<()> {
-    Ok(app
+    app
         .db
         .add_contributor(
             &params.github_login,
             params.github_user_id,
             params.github_email.as_deref(),
         )
-        .await?)
+        .await
 }
 
 #[derive(Deserialize)]

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -1030,7 +1030,7 @@ impl Database {
             if result.rows_affected != 1 {
                 Err(anyhow!("could not update room participant role"))?;
             }
-            Ok(self.get_room(room_id, &tx).await?)
+            self.get_room(room_id, &tx).await
         })
         .await
     }

--- a/crates/collab/src/db/tests/channel_tests.rs
+++ b/crates/collab/src/db/tests/channel_tests.rs
@@ -43,7 +43,7 @@ async fn test_channels(db: &Arc<Database>) {
     let mut members = db
         .transaction(|tx| async move {
             let channel = db.get_channel_internal(replace_id, &tx).await?;
-            Ok(db.get_channel_participants(&channel, &tx).await?)
+            db.get_channel_participants(&channel, &tx).await
         })
         .await
         .unwrap();

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -952,14 +952,14 @@ impl Item for Editor {
                     let buffer = project_item
                         .downcast::<Buffer>()
                         .map_err(|_| anyhow!("Project item at stored path was not a buffer"))?;
-                    Ok(pane.update(&mut cx, |_, cx| {
+                    pane.update(&mut cx, |_, cx| {
                         cx.new_view(|cx| {
                             let mut editor = Editor::for_buffer(buffer, Some(project), cx);
 
                             editor.read_scroll_position_from_db(item_id, workspace_id, cx);
                             editor
                         })
-                    })?)
+                    })
                 })
             })
             .unwrap_or_else(|error| Task::ready(Err(error)))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5424,11 +5424,11 @@ impl Project {
                         return Err(err);
                     }
 
-                    return Ok(this.update(&mut cx, |this, _| {
+                    return this.update(&mut cx, |this, _| {
                         this.last_workspace_edits_by_language_server
                             .remove(&lang_server.server_id())
                             .unwrap_or_default()
-                    })?);
+                    });
                 }
 
                 Ok(ProjectTransaction::default())
@@ -7865,13 +7865,13 @@ impl Project {
 
         this.update(&mut cx, |this, cx| this.save_buffer(buffer.clone(), cx))?
             .await?;
-        Ok(buffer.update(&mut cx, |buffer, _| proto::BufferSaved {
+        buffer.update(&mut cx, |buffer, _| proto::BufferSaved {
             project_id,
             buffer_id: buffer_id.into(),
             version: serialize_version(buffer.saved_version()),
             mtime: Some(buffer.saved_mtime().into()),
             fingerprint: language::proto::serialize_fingerprint(buffer.saved_version_fingerprint()),
-        })?)
+        })
     }
 
     async fn handle_reload_buffers(
@@ -8206,7 +8206,7 @@ impl Project {
             .await
             .context("inlay hints fetch")?;
 
-        Ok(this.update(&mut cx, |project, cx| {
+        this.update(&mut cx, |project, cx| {
             InlayHints::response_to_proto(
                 buffer_hints,
                 project,
@@ -8214,7 +8214,7 @@ impl Project {
                 &buffer.read(cx).version(),
                 cx,
             )
-        })?)
+        })
     }
 
     async fn handle_resolve_inlay_hint(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1028,7 +1028,7 @@ impl ProjectPanel {
                 cx.foreground_executor().spawn(task).detach_and_log_err(cx);
             }
 
-            Some(project.worktree_id_for_entry(destination, cx)?)
+            project.worktree_id_for_entry(destination, cx)
         });
 
         if let Some(destination_worktree) = destination_worktree {

--- a/crates/semantic_index/src/db.rs
+++ b/crates/semantic_index/src/db.rs
@@ -125,7 +125,7 @@ impl VectorDatabase {
             // Delete existing tables, if SEMANTIC_INDEX_VERSION is bumped
             let version_query = db.prepare("SELECT version from semantic_index_config");
             let version = version_query
-                .and_then(|mut query| query.query_row([], |row| Ok(row.get::<_, i64>(0)?)));
+                .and_then(|mut query| query.query_row([], |row| row.get::<_, i64>(0)));
             if version.map_or(false, |version| version == SEMANTIC_INDEX_VERSION as i64) {
                 log::trace!("vector database schema up to date");
                 return Ok(());
@@ -276,7 +276,7 @@ impl VectorDatabase {
             let mut worktree_query =
                 db.prepare("SELECT id FROM worktrees WHERE absolute_path = ?1")?;
             let worktree_id = worktree_query
-                .query_row(params![worktree_root_path], |row| Ok(row.get::<_, i64>(0)?));
+                .query_row(params![worktree_root_path], |row| row.get::<_, i64>(0));
 
             Ok(worktree_id.is_ok())
         })
@@ -356,7 +356,7 @@ impl VectorDatabase {
                 db.prepare("SELECT id FROM worktrees WHERE absolute_path = ?1")?;
             let worktree_id = worktree_query
                 .query_row(params![worktree_root_path.to_string_lossy()], |row| {
-                    Ok(row.get::<_, i64>(0)?)
+                    row.get::<_, i64>(0)
                 });
 
             if worktree_id.is_ok() {

--- a/crates/semantic_index/src/db.rs
+++ b/crates/semantic_index/src/db.rs
@@ -275,8 +275,8 @@ impl VectorDatabase {
         self.transact(move |db| {
             let mut worktree_query =
                 db.prepare("SELECT id FROM worktrees WHERE absolute_path = ?1")?;
-            let worktree_id = worktree_query
-                .query_row(params![worktree_root_path], |row| row.get::<_, i64>(0));
+            let worktree_id =
+                worktree_query.query_row(params![worktree_root_path], |row| row.get::<_, i64>(0));
 
             Ok(worktree_id.is_ok())
         })

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -622,11 +622,11 @@ impl WorkspaceDb {
     }
 
     fn get_items(&self, pane_id: PaneId) -> Result<Vec<SerializedItem>> {
-        Ok(self.select_bound(sql!(
+        self.select_bound(sql!(
             SELECT kind, item_id, active FROM items
             WHERE pane_id = ?
                 ORDER BY position
-        ))?(pane_id)?)
+        ))?(pane_id)
     }
 
     fn save_items(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1243,11 +1243,11 @@ impl Workspace {
                 }
             }
 
-            Ok(this
+            this
                 .update(&mut cx, |this, cx| {
                     this.save_all_internal(SaveIntent::Close, cx)
                 })?
-                .await?)
+                .await
         })
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1243,11 +1243,10 @@ impl Workspace {
                 }
             }
 
-            this
-                .update(&mut cx, |this, cx| {
-                    this.save_all_internal(SaveIntent::Close, cx)
-                })?
-                .await
+            this.update(&mut cx, |this, cx| {
+                this.save_all_internal(SaveIntent::Close, cx)
+            })?
+            .await
         })
     }
 

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -100,7 +100,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::map_entry",
         "clippy::needless_lifetimes",
         "clippy::needless_option_as_deref",
-        "clippy::needless_question_mark",
         "clippy::needless_update",
         "clippy::never_loop",
         "clippy::non_canonical_clone_impl",


### PR DESCRIPTION
This PR enables the [`clippy::needless_question_mark`](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_question_mark) rule and fixes the outstanding violations.

Release Notes:

- N/A
