### PR TITLE
Add Elixir symbols in outline view

### DIFF
--- a/crates/languages/src/elixir/outline.scm
+++ b/crates/languages/src/elixir/outline.scm
@@ -3,6 +3,26 @@
   (arguments (alias) @name)
   (#match? @context "^(defmodule|defprotocol)$")) @item
 
+(unary_operator
+  operator: "@" @name
+  operand: (call
+  target: (identifier) @context
+    (arguments
+      [
+        (binary_operator
+          left: (identifier) @name)
+        (binary_operator
+          left: (call
+          target: (identifier) @name
+          (arguments
+            "(" @context.extra
+            _* @context.extra
+            ")" @context.extra)))
+      ]
+    )
+)
+(#match? @context "^(callback|type|typep)$")) @item
+
 (call
   target: (identifier) @context
   (arguments


### PR DESCRIPTION

Release Notes:

- Improved: Add `@callback`, `@type` and `@typep` Elixir symbols in outline view


https://github.com/zed-industries/zed/assets/14976415/208d3def-f49e-41e0-a306-fb8e00317e6b

