### PR TITLE
Enable `clippy::useless_conversion`

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -979,7 +979,7 @@ impl AssistantPanel {
             font_size: rems(0.875).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.3).into(),
+            line_height: relative(1.3),
             background_color: None,
             underline: None,
             strikethrough: None,
@@ -1633,7 +1633,6 @@ impl Conversation {
     fn count_remaining_tokens(&mut self, cx: &mut ModelContext<Self>) {
         let messages = self
             .messages(cx)
-            .into_iter()
             .map(|message| tiktoken_rs::ChatCompletionRequestMessage {
                 role: match message.role {
                     Role::User => "user".into(),
@@ -3199,7 +3198,7 @@ impl InlineAssistant {
             font_size: rems(0.875).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.3).into(),
+            line_height: relative(1.3),
             background_color: None,
             underline: None,
             strikethrough: None,

--- a/crates/collab/src/api/ips_file.rs
+++ b/crates/collab/src/api/ips_file.rs
@@ -45,7 +45,7 @@ impl IpsFile {
     pub fn description(&self, panic: Option<&str>) -> String {
         let mut desc = if self.body.termination.indicator == "Abort trap: 6" {
             match panic {
-                Some(panic_message) => format!("Panic `{}`", panic_message).into(),
+                Some(panic_message) => format!("Panic `{}`", panic_message),
                 None => "Crash `Abort trap: 6` (possible panic)".into(),
             }
         } else if let Some(msg) = &self.body.exception.message {

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -1021,7 +1021,7 @@ impl Database {
                         .add(room_participant::Column::UserId.eq(user_id)),
                 )
                 .set(room_participant::ActiveModel {
-                    role: ActiveValue::set(Some(ChannelRole::from(role))),
+                    role: ActiveValue::set(Some(role)),
                     ..Default::default()
                 })
                 .exec(&*tx)

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -2883,7 +2883,7 @@ async fn update_channel_buffer(
             .flat_map(|user_id| pool.user_connection_ids(*user_id)),
         |peer_id| {
             session.peer.send(
-                peer_id.into(),
+                peer_id,
                 proto::UpdateChannels {
                     latest_channel_buffer_versions: vec![proto::ChannelBufferVersion {
                         channel_id: channel_id.to_proto(),
@@ -2968,8 +2968,8 @@ fn channel_buffer_updated<T: EnvelopedMessage>(
     message: &T,
     peer: &Peer,
 ) {
-    broadcast(Some(sender_id), collaborators.into_iter(), |peer_id| {
-        peer.send(peer_id.into(), message.clone())
+    broadcast(Some(sender_id), collaborators, |peer_id| {
+        peer.send(peer_id, message.clone())
     });
 }
 
@@ -3074,7 +3074,7 @@ async fn send_channel_message(
             .flat_map(|user_id| pool.user_connection_ids(*user_id)),
         |peer_id| {
             session.peer.send(
-                peer_id.into(),
+                peer_id,
                 proto::UpdateChannels {
                     latest_channel_message_ids: vec![proto::ChannelMessageId {
                         channel_id: channel_id.to_proto(),
@@ -3447,7 +3447,7 @@ fn room_updated(room: &proto::Room, peer: &Peer) {
             .filter_map(|participant| Some(participant.peer_id?.into())),
         |peer_id| {
             peer.send(
-                peer_id.into(),
+                peer_id,
                 proto::RoomUpdated {
                     room: Some(room.clone()),
                 },
@@ -3476,7 +3476,7 @@ fn channel_updated(
             .flat_map(|user_id| pool.user_connection_ids(*user_id)),
         |peer_id| {
             peer.send(
-                peer_id.into(),
+                peer_id,
                 proto::UpdateChannels {
                     channel_participants: vec![proto::ChannelParticipants {
                         channel_id: channel_id.to_proto(),

--- a/crates/collab/src/tests/channel_tests.rs
+++ b/crates/collab/src/tests/channel_tests.rs
@@ -1431,7 +1431,7 @@ fn assert_channels(
                 .ordered_channels()
                 .map(|(depth, channel)| ExpectedChannel {
                     depth,
-                    name: channel.name.clone().into(),
+                    name: channel.name.clone(),
                     id: channel.id,
                 })
                 .collect::<Vec<_>>()

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -833,7 +833,7 @@ async fn test_language_server_statuses(cx_a: &mut TestAppContext, cx_b: &mut Tes
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp_adapter(
         "Rust",
         FakeLspAdapter {
-            name: "the-language-server".into(),
+            name: "the-language-server",
             ..Default::default()
         },
     );

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -357,7 +357,7 @@ impl Render for MessageEditor {
             font_size: UiTextSize::Small.rems().into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.3).into(),
+            line_height: relative(1.3),
             background_color: None,
             underline: None,
             strikethrough: None,

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2171,7 +2171,7 @@ impl CollabPanel {
             font_size: rems(0.875).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.3).into(),
+            line_height: relative(1.3),
             background_color: None,
             underline: None,
             strikethrough: None,

--- a/crates/copilot_ui/src/copilot_button.rs
+++ b/crates/copilot_ui/src/copilot_button.rs
@@ -311,7 +311,7 @@ async fn configure_disabled_globs(
 fn toggle_copilot_globally(fs: Arc<dyn Fs>, cx: &mut AppContext) {
     let show_copilot_suggestions = all_language_settings(None, cx).copilot_enabled(None, None);
     update_settings_file::<AllLanguageSettings>(fs, cx, move |file| {
-        file.defaults.show_copilot_suggestions = Some((!show_copilot_suggestions).into())
+        file.defaults.show_copilot_suggestions = Some(!show_copilot_suggestions)
     });
 }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -797,7 +797,7 @@ impl Item for ProjectDiagnosticsEditor {
 
 fn diagnostic_header_renderer(diagnostic: Diagnostic) -> RenderBlock {
     let (message, code_ranges) = highlight_diagnostic_message(&diagnostic);
-    let message: SharedString = message.into();
+    let message: SharedString = message;
     Arc::new(move |cx| {
         let highlight_style: HighlightStyle = cx.theme().colors().text_accent.into();
         h_flex()

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -502,7 +502,7 @@ impl DisplaySnapshot {
 
     /// Returns text chunks starting at the end of the given display row in reverse until the start of the file
     pub fn reverse_text_chunks(&self, display_row: u32) -> impl Iterator<Item = &str> {
-        (0..=display_row).into_iter().rev().flat_map(|row| {
+        (0..=display_row).rev().flat_map(|row| {
             self.block_snapshot
                 .chunks(row..row + 1, false, Highlights::default())
                 .map(|h| h.text)
@@ -1456,8 +1456,8 @@ pub mod tests {
         .unindent();
 
         let theme = SyntaxTheme::new_test(vec![
-            ("mod.body", Hsla::red().into()),
-            ("fn.name", Hsla::blue().into()),
+            ("mod.body", Hsla::red()),
+            ("fn.name", Hsla::blue()),
         ]);
         let language = Arc::new(
             Language::new(
@@ -1546,8 +1546,8 @@ pub mod tests {
         .unindent();
 
         let theme = SyntaxTheme::new_test(vec![
-            ("mod.body", Hsla::red().into()),
-            ("fn.name", Hsla::blue().into()),
+            ("mod.body", Hsla::red()),
+            ("fn.name", Hsla::blue()),
         ]);
         let language = Arc::new(
             Language::new(
@@ -1617,8 +1617,8 @@ pub mod tests {
         cx.update(|cx| init_test(cx, |_| {}));
 
         let theme = SyntaxTheme::new_test(vec![
-            ("operator", Hsla::red().into()),
-            ("string", Hsla::green().into()),
+            ("operator", Hsla::red()),
+            ("string", Hsla::green()),
         ]);
         let language = Arc::new(
             Language::new(

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1455,10 +1455,8 @@ pub mod tests {
             }"#
         .unindent();
 
-        let theme = SyntaxTheme::new_test(vec![
-            ("mod.body", Hsla::red()),
-            ("fn.name", Hsla::blue()),
-        ]);
+        let theme =
+            SyntaxTheme::new_test(vec![("mod.body", Hsla::red()), ("fn.name", Hsla::blue())]);
         let language = Arc::new(
             Language::new(
                 LanguageConfig {
@@ -1545,10 +1543,8 @@ pub mod tests {
             }"#
         .unindent();
 
-        let theme = SyntaxTheme::new_test(vec![
-            ("mod.body", Hsla::red()),
-            ("fn.name", Hsla::blue()),
-        ]);
+        let theme =
+            SyntaxTheme::new_test(vec![("mod.body", Hsla::red()), ("fn.name", Hsla::blue())]);
         let language = Arc::new(
             Language::new(
                 LanguageConfig {
@@ -1616,10 +1612,8 @@ pub mod tests {
     async fn test_chunks_with_text_highlights(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| init_test(cx, |_| {}));
 
-        let theme = SyntaxTheme::new_test(vec![
-            ("operator", Hsla::red()),
-            ("string", Hsla::green()),
-        ]);
+        let theme =
+            SyntaxTheme::new_test(vec![("operator", Hsla::red()), ("string", Hsla::green())]);
         let language = Arc::new(
             Language::new(
                 LanguageConfig {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2004,7 +2004,7 @@ impl EditorElement {
             let text_width = bounds.size.width - gutter_dimensions.width;
             let overscroll = size(em_width, px(0.));
             let _snapshot = {
-                editor.set_visible_line_count((bounds.size.height / line_height).into(), cx);
+                editor.set_visible_line_count(bounds.size.height / line_height, cx);
 
                 let editor_width = text_width - gutter_dimensions.margin - overscroll.width - em_width;
                 let wrap_width = match editor.soft_wrap_mode(cx) {
@@ -2037,7 +2037,7 @@ impl EditorElement {
             // The scroll position is a fractional point, the whole number of which represents
             // the top of the window in terms of display rows.
             let start_row = scroll_position.y as u32;
-            let height_in_lines = f32::from(bounds.size.height / line_height);
+            let height_in_lines = bounds.size.height / line_height;
             let max_row = snapshot.max_point().row();
 
             // Add 1 to ensure selections bleed off screen
@@ -2262,7 +2262,7 @@ impl EditorElement {
             });
 
             let scroll_max = point(
-                f32::from((scroll_width - text_size.width) / em_width).max(0.0),
+                ((scroll_width - text_size.width) / em_width).max(0.0),
                 max_row as f32,
             );
 
@@ -2722,11 +2722,9 @@ impl EditorElement {
                         };
 
                         let scroll_position = position_map.snapshot.scroll_position();
-                        let x = f32::from(
-                            (scroll_position.x * max_glyph_width - delta.x) / max_glyph_width,
-                        );
+                        let x = (scroll_position.x * max_glyph_width - delta.x) / max_glyph_width;
                         let y =
-                            f32::from((scroll_position.y * line_height - delta.y) / line_height);
+                            (scroll_position.y * line_height - delta.y) / line_height;
                         let scroll_position =
                             point(x, y).clamp(&point(0., 0.), &position_map.scroll_max);
                         editor.scroll(scroll_position, axis, cx);
@@ -3268,7 +3266,7 @@ impl PositionMap {
         let position = position - text_bounds.origin;
         let y = position.y.max(px(0.)).min(self.size.height);
         let x = position.x + (scroll_position.x * self.em_width);
-        let row = (f32::from(y / self.line_height) + scroll_position.y) as u32;
+        let row = ((y / self.line_height) + scroll_position.y) as u32;
 
         let (column, x_overshoot_after_line_end) = if let Some(line) = self
             .line_layouts

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2723,8 +2723,7 @@ impl EditorElement {
 
                         let scroll_position = position_map.snapshot.scroll_position();
                         let x = (scroll_position.x * max_glyph_width - delta.x) / max_glyph_width;
-                        let y =
-                            (scroll_position.y * line_height - delta.y) / line_height;
+                        let y = (scroll_position.y * line_height - delta.y) / line_height;
                         let scroll_position =
                             point(x, y).clamp(&point(0., 0.), &position_map.scroll_max);
                         editor.scroll(scroll_position, axis, cx);

--- a/crates/editor/src/rust_analyzer_ext.rs
+++ b/crates/editor/src/rust_analyzer_ext.rs
@@ -62,7 +62,6 @@ pub fn expand_macro_recursively(
             project
                 .read(cx)
                 .language_servers_for_buffer(buffer.read(cx), cx)
-                .into_iter()
                 .find_map(|(adapter, server)| {
                     if adapter.name.0.as_ref() == "rust-analyzer" {
                         Some((

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -244,8 +244,7 @@ impl Editor {
             self.scroll_manager.anchor.offset.x = target_left / max_glyph_width;
             true
         } else if target_right > scroll_right {
-            self.scroll_manager.anchor.offset.x =
-                (target_right - viewport_width) / max_glyph_width;
+            self.scroll_manager.anchor.offset.x = (target_right - viewport_width) / max_glyph_width;
             true
         } else {
             false

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -62,7 +62,7 @@ impl Editor {
         line_height: Pixels,
         cx: &mut ViewContext<Editor>,
     ) -> bool {
-        let visible_lines = f32::from(viewport_height / line_height);
+        let visible_lines = viewport_height / line_height;
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let mut scroll_position = self.scroll_manager.scroll_position(&display_map);
         let max_scroll_top = if matches!(self.mode, EditorMode::AutoHeight { .. }) {
@@ -241,11 +241,11 @@ impl Editor {
         let scroll_right = scroll_left + viewport_width;
 
         if target_left < scroll_left {
-            self.scroll_manager.anchor.offset.x = (target_left / max_glyph_width).into();
+            self.scroll_manager.anchor.offset.x = target_left / max_glyph_width;
             true
         } else if target_right > scroll_right {
             self.scroll_manager.anchor.offset.x =
-                ((target_right - viewport_width) / max_glyph_width).into();
+                (target_right - viewport_width) / max_glyph_width;
             true
         } else {
             false

--- a/crates/extension/src/extension_lsp_adapter.rs
+++ b/crates/extension/src/extension_lsp_adapter.rs
@@ -52,7 +52,7 @@ impl LspAdapter for ExtensionLspAdapter {
                 .map_err(|e| anyhow!("{}", e))?;
 
             Ok(LanguageServerBinary {
-                path: self.work_dir.join(&command.command).into(),
+                path: self.work_dir.join(&command.command),
                 arguments: command.args.into_iter().map(|arg| arg.into()).collect(),
                 env: Some(command.env.into_iter().collect()),
             })

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -368,7 +368,7 @@ impl ExtensionsPage {
             font_size: rems(0.875).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.3).into(),
+            line_height: relative(1.3),
             background_color: None,
             underline: None,
             strikethrough: None,

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -335,7 +335,7 @@ impl TestAppContext {
             .map(Keystroke::parse)
             .map(Result::unwrap)
         {
-            self.dispatch_keystroke(window, keystroke.into());
+            self.dispatch_keystroke(window, keystroke);
         }
 
         self.background_executor.run_until_parked()
@@ -347,7 +347,7 @@ impl TestAppContext {
     /// This will also run the background executor until it's parked.
     pub fn simulate_input(&mut self, window: AnyWindowHandle, input: &str) {
         for keystroke in input.split("").map(Keystroke::parse).map(Result::unwrap) {
-            self.dispatch_keystroke(window, keystroke.into());
+            self.dispatch_keystroke(window, keystroke);
         }
 
         self.background_executor.run_until_parked()

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -766,7 +766,7 @@ impl SyntaxSnapshot {
         SyntaxMapCaptures::new(
             range.clone(),
             buffer.as_rope(),
-            self.layers_for_range(range, buffer).into_iter(),
+            self.layers_for_range(range, buffer),
             query,
         )
     }
@@ -780,7 +780,7 @@ impl SyntaxSnapshot {
         SyntaxMapMatches::new(
             range.clone(),
             buffer.as_rope(),
-            self.layers_for_range(range, buffer).into_iter(),
+            self.layers_for_range(range, buffer),
             query,
         )
     }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -132,7 +132,7 @@ impl MarkdownPreviewView {
                 workspace,
                 contents,
                 list_state,
-                tab_description: tab_description.into(),
+                tab_description: tab_description,
             }
         })
     }

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -279,7 +279,7 @@ impl PickerDelegate for OutlineViewDelegate {
             font_size: settings.buffer_font_size(cx).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.).into(),
+            line_height: relative(1.),
             background_color: None,
             underline: None,
             strikethrough: None,

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -536,7 +536,7 @@ mod tests {
             !cx.has_pending_prompt(),
             "Should have no pending prompt on dirty project before opening the new recent project"
         );
-        cx.dispatch_action((*workspace).into(), menu::Confirm);
+        cx.dispatch_action((*workspace), menu::Confirm);
         workspace
             .update(cx, |workspace, cx| {
                 assert!(

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -536,7 +536,7 @@ mod tests {
             !cx.has_pending_prompt(),
             "Should have no pending prompt on dirty project before opening the new recent project"
         );
-        cx.dispatch_action((*workspace), menu::Confirm);
+        cx.dispatch_action(*workspace, menu::Confirm);
         workspace
             .update(cx, |workspace, cx| {
                 assert!(

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -98,7 +98,7 @@ impl BufferSearchBar {
             font_size: rems(0.875).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.3).into(),
+            line_height: relative(1.3),
             background_color: None,
             underline: None,
             strikethrough: None,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1631,7 +1631,7 @@ impl ProjectSearchBar {
             font_size: rems(0.875).into(),
             font_weight: FontWeight::NORMAL,
             font_style: FontStyle::Normal,
-            line_height: relative(1.3).into(),
+            line_height: relative(1.3),
             background_color: None,
             underline: None,
             strikethrough: None,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -158,11 +158,11 @@ impl TerminalSize {
     }
 
     pub fn num_lines(&self) -> usize {
-        f32::from((self.size.height / self.line_height).floor()) as usize
+        (self.size.height / self.line_height).floor() as usize
     }
 
     pub fn num_columns(&self) -> usize {
-        f32::from((self.size.width / self.cell_width).floor()) as usize
+        (self.size.width / self.cell_width).floor() as usize
     }
 
     pub fn height(&self) -> Pixels {
@@ -1663,9 +1663,9 @@ mod tests {
     fn get_cells(size: TerminalSize, rng: &mut ThreadRng) -> Vec<Vec<char>> {
         let mut cells = Vec::new();
 
-        for _ in 0..(f32::from(size.height() / size.line_height()) as usize) {
+        for _ in 0..((size.height() / size.line_height()) as usize) {
             let mut row_vec = Vec::new();
-            for _ in 0..(f32::from(size.width() / size.cell_width()) as usize) {
+            for _ in 0..((size.width() / size.cell_width()) as usize) {
                 let cell_char = rng.sample(Alphanumeric) as char;
                 row_vec.push(cell_char)
             }

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -358,7 +358,7 @@ pub fn command_interceptor(mut query: &str, cx: &AppContext) -> Option<CommandIn
 
 fn generate_positions(string: &str, query: &str) -> Vec<usize> {
     let mut positions = Vec::new();
-    let mut chars = query.chars().into_iter();
+    let mut chars = query.chars();
 
     let Some(mut current) = chars.next() else {
         return positions;

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -221,7 +221,7 @@ impl Dock {
                     return;
                 };
                 if panel.is_zoomed(cx) {
-                    workspace.zoomed = Some(panel.to_any().downgrade().into());
+                    workspace.zoomed = Some(panel.to_any().downgrade());
                     workspace.zoomed_position = Some(position);
                 } else {
                     workspace.zoomed = None;

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -899,7 +899,7 @@ impl Pane {
             if not_shown_files == 1 {
                 file_names.push(".. 1 file not shown".into());
             } else {
-                file_names.push(format!(".. {} files not shown", not_shown_files).into());
+                file_names.push(format!(".. {} files not shown", not_shown_files));
             }
         }
         (

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2961,7 +2961,7 @@ impl Workspace {
         })?;
 
         let Some(id) = view.id.clone() else {
-            return Err(anyhow!("no id for view")).into();
+            return Err(anyhow!("no id for view"));
         };
         let id = ViewId::from_proto(id)?;
 
@@ -3744,7 +3744,7 @@ fn open_items(
 
         let tasks = tasks.collect::<Vec<_>>();
 
-        let tasks = futures::future::join_all(tasks.into_iter());
+        let tasks = futures::future::join_all(tasks);
         for (ix, path_open_result) in tasks.await.into_iter().flatten() {
             opened_items[ix] = Some(path_open_result);
         }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -662,7 +662,7 @@ fn init_panic_hook(app: &App, installation_id: Option<String>, session_id: Strin
 
         let panic_data = Panic {
             thread: thread_name.into(),
-            payload: payload,
+            payload,
             location_data: info.location().map(|location| LocationData {
                 file: location.file().into(),
                 line: location.line(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -662,7 +662,7 @@ fn init_panic_hook(app: &App, installation_id: Option<String>, session_id: Strin
 
         let panic_data = Panic {
             thread: thread_name.into(),
-            payload: payload.into(),
+            payload: payload,
             location_data: info.location().map(|location| LocationData {
                 file: location.file().into(),
                 line: location.line(),

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -111,7 +111,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",
         "clippy::unnecessary_to_owned",
-        "clippy::useless_conversion",
         "clippy::vec_init_then_push",
     ];
 


### PR DESCRIPTION
This PR enables the [`clippy::useless_conversion`](https://rust-lang.github.io/rust-clippy/master/index.html#/useless_conversion) rule and fixes the outstanding violations.

Release Notes:

- N/A
