### PR TITLE
Enable `clippy::expect_fun_call`

### DIFF
--- a/crates/collab/src/bin/seed.rs
+++ b/crates/collab/src/bin/seed.rs
@@ -88,9 +88,9 @@ async fn fetch_github<T: DeserializeOwned>(client: &reqwest::Client, url: &str) 
         .header("user-agent", "zed")
         .send()
         .await
-        .expect(&format!("failed to fetch '{}'", url));
+        .unwrap_or_else(|_| panic!("failed to fetch '{}'", url));
     response
         .json()
         .await
-        .expect(&format!("failed to deserialize github user from '{}'", url))
+        .unwrap_or_else(|_| panic!("failed to deserialize github user from '{}'", url))
 }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -90,7 +90,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::derivable_impls",
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
-        "clippy::expect_fun_call",
         "clippy::explicit_counter_loop",
         "clippy::identity_op",
         "clippy::implied_bounds_in_impls",


### PR DESCRIPTION
This PR enables the [`clippy::expect_fun_call`](https://rust-lang.github.io/rust-clippy/master/index.html#/expect_fun_call) rule and fixes the outstanding violations.

Release Notes:

- N/A
