### PR TITLE
Enable `clippy::bool_comparison`

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -487,21 +487,21 @@ impl TerminalBuilder {
                         }
                     }
 
-                    if events.is_empty() && wakeup == false {
+                    if events.is_empty() && !wakeup {
                         smol::future::yield_now().await;
                         break 'outer;
-                    } else {
-                        terminal.update(&mut cx, |this, cx| {
-                            if wakeup {
-                                this.process_event(&AlacTermEvent::Wakeup, cx);
-                            }
-
-                            for event in events {
-                                this.process_event(&event, cx);
-                            }
-                        })?;
-                        smol::future::yield_now().await;
                     }
+
+                    terminal.update(&mut cx, |this, cx| {
+                        if wakeup {
+                            this.process_event(&AlacTermEvent::Wakeup, cx);
+                        }
+
+                        for event in events {
+                            this.process_event(&event, cx);
+                        }
+                    })?;
+                    smol::future::yield_now().await;
                 }
             }
 

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -80,7 +80,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::almost_complete_range",
         "clippy::arc_with_non_send_sync",
         "clippy::await_holding_lock",
-        "clippy::bool_comparison",
         "clippy::borrow_deref_ref",
         "clippy::borrowed_box",
         "clippy::cast_abs_to_unsigned",


### PR DESCRIPTION
This PR enables the [`clippy::bool_comparison`](https://rust-lang.github.io/rust-clippy/master/index.html#/bool_comparison) rule and fixes the outstanding violations.

Release Notes:

- N/A
