### PR TITLE
Enable `clippy::redundant_guards`

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -9379,7 +9379,7 @@ fn relativize_path(base: &Path, path: &Path) -> PathBuf {
             }
             (None, _) => components.push(Component::ParentDir),
             (Some(a), Some(b)) if components.is_empty() && a == b => (),
-            (Some(a), Some(b)) if b == Component::CurDir => components.push(a),
+            (Some(a), Some(Component::CurDir)) => components.push(a),
             (Some(a), Some(_)) => {
                 components.push(Component::ParentDir);
                 for _ in base_components {

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -105,7 +105,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::non_canonical_clone_impl",
         "clippy::non_canonical_partial_ord_impl",
         "clippy::redundant_closure_call",
-        "clippy::redundant_guards",
         "clippy::reversed_empty_ranges",
         "clippy::single_range_in_vec_init",
         "clippy::suspicious_to_owned",


### PR DESCRIPTION
This PR enables the [`clippy::redundant_guards`](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_guards) rule and fixes the outstanding violations.

Release Notes:

- N/A
