### PR TITLE
Enable `clippy::vec_init_then_push`

### DIFF
--- a/crates/collab/src/db/tests/buffer_tests.rs
+++ b/crates/collab/src/db/tests/buffer_tests.rs
@@ -68,11 +68,12 @@ async fn test_channel_buffers(db: &Arc<Database>) {
         .unwrap();
 
     let mut buffer_a = Buffer::new(0, text::BufferId::new(1).unwrap(), "".to_string());
-    let mut operations = Vec::new();
-    operations.push(buffer_a.edit([(0..0, "hello world")]));
-    operations.push(buffer_a.edit([(5..5, ", cruel")]));
-    operations.push(buffer_a.edit([(0..5, "goodbye")]));
-    operations.push(buffer_a.undo().unwrap().1);
+    let operations = vec![
+        buffer_a.edit([(0..0, "hello world")]),
+        buffer_a.edit([(5..5, ", cruel")]),
+        buffer_a.edit([(0..5, "goodbye")]),
+        buffer_a.undo().unwrap().1,
+    ];
     assert_eq!(buffer_a.text(), "hello, cruel world");
 
     let operations = operations

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -679,8 +679,7 @@ impl Workspace {
         let mut active_call = None;
         if let Some(call) = ActiveCall::try_global(cx) {
             let call = call.clone();
-            let mut subscriptions = Vec::new();
-            subscriptions.push(cx.subscribe(&call, Self::on_active_call_event));
+            let subscriptions = vec![cx.subscribe(&call, Self::on_active_call_event)];
             active_call = Some((call, subscriptions));
         }
 

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -109,7 +109,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::suspicious_to_owned",
         "clippy::type_complexity",
         "clippy::unnecessary_to_owned",
-        "clippy::vec_init_then_push",
     ];
 
     // When fixing violations automatically for a single package we don't care


### PR DESCRIPTION
This PR enables the [`clippy::vec_init_then_push`](https://rust-lang.github.io/rust-clippy/master/index.html#/vec_init_then_push) rule and fixes the outstanding violations.

Release Notes:

- N/A
