### PR TITLE
Enable `clippy::identity_op`

### DIFF
--- a/crates/languages/src/ocaml.rs
+++ b/crates/languages/src/ocaml.rs
@@ -140,7 +140,7 @@ impl LspAdapter for OCamlLspAdapter {
                 }
 
                 let mut label_highlight = vec![(
-                    0..0 + label.len(),
+                    0..label.len(),
                     language.grammar()?.highlight_id_for_name("property")?,
                 )];
 

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -90,7 +90,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
         "clippy::explicit_counter_loop",
-        "clippy::identity_op",
         "clippy::implied_bounds_in_impls",
         "clippy::iter_kv_map",
         "clippy::iter_overeager_cloned",


### PR DESCRIPTION
This PR enables the [`clippy::identity_op`](https://rust-lang.github.io/rust-clippy/master/index.html#/identity_op) rule and fixes the outstanding violations.

Release Notes:

- N/A
