### PR TITLE
Enable `clippy::needless_option_as_deref`

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -326,7 +326,7 @@ impl DisplayMap {
             .read(cx)
             .as_singleton()
             .and_then(|buffer| buffer.read(cx).language());
-        language_settings(language.as_deref(), None, cx).tab_size
+        language_settings(language, None, cx).tab_size
     }
 
     #[cfg(test)]

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -97,7 +97,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::let_underscore_future",
         "clippy::map_entry",
         "clippy::needless_lifetimes",
-        "clippy::needless_option_as_deref",
         "clippy::needless_update",
         "clippy::never_loop",
         "clippy::non_canonical_clone_impl",


### PR DESCRIPTION
This PR enables the [`clippy::needless_option_as_deref`](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_option_as_deref) rule and fixes the outstanding violations.

Release Notes:

- N/A
