### PR TITLE
Enable `clippy::explicit_counter_loop`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2731,9 +2731,8 @@ impl Editor {
 
         let mut edits = Vec::new();
         let mut rows = Vec::new();
-        let mut rows_inserted = 0;
 
-        for selection in self.selections.all_adjusted(cx) {
+        for (rows_inserted, selection) in self.selections.all_adjusted(cx).into_iter().enumerate() {
             let cursor = selection.head();
             let row = cursor.row;
 
@@ -2742,8 +2741,7 @@ impl Editor {
             let newline = "\n".to_string();
             edits.push((start_of_line..start_of_line, newline));
 
-            rows.push(row + rows_inserted);
-            rows_inserted += 1;
+            rows.push(row + rows_inserted as u32);
         }
 
         self.transact(cx, |editor, cx| {

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -89,7 +89,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::derivable_impls",
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
-        "clippy::explicit_counter_loop",
         "clippy::implied_bounds_in_impls",
         "clippy::iter_kv_map",
         "clippy::iter_overeager_cloned",


### PR DESCRIPTION
This PR enables the [`clippy::explicit_counter_loop`](https://rust-lang.github.io/rust-clippy/master/index.html#/explicit_counter_loop) rule and fixes the outstanding violations.

Release Notes:

- N/A
