### PR TITLE
Enable `clippy::default_constructed_unit_structs`

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3999,7 +3999,7 @@ async fn test_select_all_matches(cx: &mut gpui::TestAppContext) {
     let mut cx = EditorTestContext::new(cx).await;
     cx.set_state("abc\nˇabc abc\ndefabc\nabc");
 
-    cx.update_editor(|e, cx| e.select_all_matches(&SelectAllMatches::default(), cx))
+    cx.update_editor(|e, cx| e.select_all_matches(&SelectAllMatches, cx))
         .unwrap();
     cx.assert_editor_state("«abcˇ»\n«abcˇ» «abcˇ»\ndefabc\n«abcˇ»");
 }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -85,7 +85,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::cast_abs_to_unsigned",
         "clippy::cmp_owned",
         "clippy::crate_in_macro_def",
-        "clippy::default_constructed_unit_structs",
         "clippy::derivable_impls",
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",


### PR DESCRIPTION
This PR enables the [`clippy::default_constructed_unit_structs`](https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs) rule and fixes the outstanding violations.

Release Notes:

- N/A
