### PR TITLE
Use xcb-xinput for pixel level scrolling under x11

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -96,7 +96,7 @@ objc = "0.2"
 flume = "0.11"
 open = "5.0.1"
 ashpd = "0.7.0"
-xcb = { version = "1.3", features = ["as-raw-xcb-connection", "randr", "xkb"] }
+xcb = { version = "1.3", features = ["as-raw-xcb-connection", "randr", "xinput", "xkb"] }
 wayland-client= { version = "0.31.2" }
 wayland-protocols = { version = "0.31.2", features = ["client", "staging", "unstable"] }
 wayland-backend = { version = "0.3.3", features = ["client_system"] }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -143,6 +143,7 @@ impl X11WindowState {
         x_main_screen_index: i32,
         x_window: x::Window,
         atoms: &XcbAtoms,
+        scroll_devices: &Vec<xcb::xinput::Device>,
     ) -> Self {
         let x_screen_index = options
             .display_id
@@ -169,8 +170,6 @@ impl X11WindowState {
                     | x::EventMask::BUTTON1_MOTION
                     | x::EventMask::BUTTON2_MOTION
                     | x::EventMask::BUTTON3_MOTION
-                    | x::EventMask::BUTTON4_MOTION
-                    | x::EventMask::BUTTON5_MOTION
                     | x::EventMask::BUTTON_MOTION,
             ),
         ];
@@ -199,6 +198,16 @@ impl X11WindowState {
             visual: screen.root_visual(),
             value_list: &xcb_values,
         });
+
+        for device in scroll_devices {
+            xcb_connection.send_request(&xcb::xinput::XiSelectEvents {
+                window: x_window,
+                masks: &[xcb::xinput::EventMaskBuf::new(
+                    *device,
+                    &[xcb::xinput::XiEventMask::MOTION],
+                )],
+            });
+        }
 
         if let Some(titlebar) = options.titlebar {
             if let Some(title) = titlebar.title {


### PR DESCRIPTION
This PR enables pixel level horizontal and vertical scrolling under X11 using the The X Input Extension 2.x. I've tested it with only a mouse, only a trackpad, and both together. It should also work with touchscreen, but I don't have the hardware to test it. Trackpad testing was done under xwayland, mouse testing under xorg.