### PR TITLE
windows: get pid with win32 api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9462,6 +9462,7 @@ dependencies = [
  "theme",
  "thiserror",
  "util",
+ "windows 0.53.0",
 ]
 
 [[package]]

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -30,5 +30,11 @@ theme.workspace = true
 thiserror.workspace = true
 util.workspace = true
 
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.53.0"
+features = [
+    "Win32_System_Threading",
+]
+
 [dev-dependencies]
 rand.workspace = true

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -670,7 +670,7 @@ impl Terminal {
         let mut pid = unsafe { libc::tcgetpgrp(self.shell_fd as i32) };
         // todo("windows")
         #[cfg(windows)]
-        let mut pid = -1;
+        let mut pid = unsafe { windows::Win32::System::Threading::GetCurrentProcessId() } as i32;
         if pid < 0 {
             pid = self.shell_pid as i32;
         }


### PR DESCRIPTION
While trying to get mouse/keyboard support in for Windows I ran into a stack overflow issue related to the pid being `-1`. Getting the proper process ID seems to fix it.

Release Notes:

- Fixed stack overflow on Windows
