### PR TITLE
Move windows up to workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,17 @@ wasmtime-wasi = "18.0"
 which = "6.0.0"
 sys-locale = "0.3.1"
 
+[workspace.dependencies.windows]
+version = "0.53.0"
+features = [
+    "Win32_Graphics_Gdi",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Security",
+    "Win32_System_Threading",
+]
+
+
+
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "e4a23971ec3071a09c1e84816954c98f96e98e52" }
 # Workaround for a broken nightly build of gpui: See #7644 and revisit once 0.5.3 is released.

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -114,14 +114,8 @@ as-raw-xcb-connection = "1"
 calloop = "0.12.4"
 calloop-wayland-source = "0.2.0"
 
-[target.'cfg(windows)'.dependencies.windows]
-version = "0.53.0"
-features = [
-    "Win32_Graphics_Gdi",
-    "Win32_UI_WindowsAndMessaging",
-    "Win32_Security",
-    "Win32_System_Threading",
-]
+[target.'cfg(windows)'.dependencies]
+windows.workspace = true
 
 [[example]]
 name = "hello_world"

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -30,11 +30,8 @@ theme.workspace = true
 thiserror.workspace = true
 util.workspace = true
 
-[target.'cfg(windows)'.dependencies.windows]
-version = "0.53.0"
-features = [
-    "Win32_System_Threading",
-]
+[target.'cfg(windows)'.dependencies]
+windows.workspace = true
 
 [dev-dependencies]
 rand.workspace = true


### PR DESCRIPTION
This way we can keep track of what we're using.

Release Notes:

- N/A