### PR TITLE
Fix name of zstd package in Arch Linux repos

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -61,7 +61,7 @@ if [[ -n $pacman ]]; then
     wayland
     libxkbcommon-x11
     openssl
-    libzstd
+    zstd
   )
   $maysudo "$pacman" -S --needed --noconfirm "${deps[@]}"
   exit 0


### PR DESCRIPTION
Fixed name of [zstd](https://archlinux.org/packages/core/x86_64/zstd/) package in Arch Linux repos in script for installing deps, required for building Zed on linux

Release Notes:

- N/A