### PR TITLE
Add Ruby language injections

### DIFF
--- a/crates/languages/src/ruby/injections.scm
+++ b/crates/languages/src/ruby/injections.scm
@@ -1,0 +1,2 @@
+(heredoc_body
+  (heredoc_end) @language) @content


### PR DESCRIPTION
This adds support for Ruby heredoc's syntax highlighting. The injection was directly taken from the tree-sitter [documentation](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection).

It is quite simple, but has the drawback of only showing highlighting once the heredoc is fully written and next line is started. This is due to the fact that we use the last line of the heredoc to determine the language. As using the first one would require some cleaning up that we cannot do trivially. (I might have not fully understood the behaviour of the `#match?` predicate, which could help us)

Fixes #4473



Release Notes:

- Added Ruby language injections ([#4473](https://github.com/zed-industries/zed/issues/4473)).
  - @JosephTLyons Note: Ruby support was moved to an extension in #11360, so we can omit this line from the release notes.

<img width="359" alt="image" src="https://github.com/zed-industries/zed/assets/11378424/5115b875-a32d-4f28-b21f-471495169266">

