### PR TITLE
Return "open in new window" as default in recent projects

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -381,7 +381,6 @@ impl<D: PickerDelegate> Render for Picker<D> {
         div()
             .key_context("Picker")
             .size_full()
-            .cursor_pointer()
             .when_some(self.width, |el, width| el.w(width))
             .overflow_hidden()
             // This is a bit of a hack to remove the modal styling when we're rendering the `Picker`

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -381,6 +381,7 @@ impl<D: PickerDelegate> Render for Picker<D> {
         div()
             .key_context("Picker")
             .size_full()
+            .cursor_pointer()
             .when_some(self.width, |el, width| el.w(width))
             .overflow_hidden()
             // This is a bit of a hack to remove the modal styling when we're rendering the `Picker`

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -16,8 +16,12 @@ use workspace::{ModalView, Workspace, WorkspaceId, WorkspaceLocation, WORKSPACE_
 
 #[derive(PartialEq, Clone, Deserialize, Default)]
 pub struct OpenRecent {
-    #[serde(default)]
+    #[serde(default = "default_create_new_window")]
     pub create_new_window: bool,
+}
+
+fn default_create_new_window() -> bool {
+    true
 }
 
 gpui::impl_actions!(projects, [OpenRecent]);
@@ -284,7 +288,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                                     workspace
                                         .update(&mut cx, |workspace, cx| {
                                             workspace.open_workspace_for_paths(
-                                                replace_current_window,
+                                                true,
                                                 candidate_paths,
                                                 cx,
                                             )
@@ -295,11 +299,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 }
                             })
                         } else {
-                            workspace.open_workspace_for_paths(
-                                replace_current_window,
-                                candidate_paths,
-                                cx,
-                            )
+                            workspace.open_workspace_for_paths(false, candidate_paths, cx)
                         }
                     } else {
                         Task::ready(Ok(()))

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -10,7 +10,7 @@ use picker::{
 };
 use serde::Deserialize;
 use std::{path::Path, sync::Arc};
-use ui::{prelude::*, tooltip_container, ListItem, ListItemSpacing, Tooltip};
+use ui::{prelude::*, tooltip_container, Divider, ListItem, ListItemSpacing, Tooltip};
 use util::paths::PathExt;
 use workspace::{ModalView, Workspace, WorkspaceId, WorkspaceLocation, WORKSPACE_DB};
 
@@ -96,7 +96,7 @@ impl RecentProjects {
                 let weak_workspace = cx.view().downgrade();
                 workspace.toggle_modal(cx, |cx| {
                     let delegate =
-                        RecentProjectsDelegate::new(weak_workspace, create_new_window, true);
+                        RecentProjectsDelegate::new(weak_workspace, create_new_window, true, false);
 
                     let modal = Self::new(delegate, 34., cx);
                     modal
@@ -109,7 +109,7 @@ impl RecentProjects {
     pub fn open_popover(workspace: WeakView<Workspace>, cx: &mut WindowContext<'_>) -> View<Self> {
         cx.new_view(|cx| {
             Self::new(
-                RecentProjectsDelegate::new(workspace, false, false),
+                RecentProjectsDelegate::new(workspace, false, false, true),
                 20.,
                 cx,
             )
@@ -145,13 +145,19 @@ pub struct RecentProjectsDelegate {
     selected_match_index: usize,
     matches: Vec<StringMatch>,
     render_paths: bool,
+    popover: bool,
     create_new_window: bool,
     // Flag to reset index when there is a new query vs not reset index when user delete an item
     reset_selected_match_index: bool,
 }
 
 impl RecentProjectsDelegate {
-    fn new(workspace: WeakView<Workspace>, create_new_window: bool, render_paths: bool) -> Self {
+    fn new(
+        workspace: WeakView<Workspace>,
+        create_new_window: bool,
+        render_paths: bool,
+        popover: bool,
+    ) -> Self {
         Self {
             workspace,
             workspaces: vec![],
@@ -160,14 +166,11 @@ impl RecentProjectsDelegate {
             create_new_window,
             render_paths,
             reset_selected_match_index: true,
+            popover,
         }
     }
-}
-impl EventEmitter<DismissEvent> for RecentProjectsDelegate {}
-impl PickerDelegate for RecentProjectsDelegate {
-    type ListItem = ListItem;
 
-    fn placeholder_text(&self, cx: &mut WindowContext) -> Arc<str> {
+    fn help_text(&self, cx: &mut WindowContext) -> Arc<str> {
         let (create_window, reuse_window) = if self.create_new_window {
             (
                 cx.keystroke_text_for(&menu::Confirm),
@@ -182,6 +185,18 @@ impl PickerDelegate for RecentProjectsDelegate {
         Arc::from(format!(
             "{reuse_window} reuses the window, {create_window} opens a new one",
         ))
+    }
+}
+impl EventEmitter<DismissEvent> for RecentProjectsDelegate {}
+impl PickerDelegate for RecentProjectsDelegate {
+    type ListItem = ListItem;
+
+    fn placeholder_text(&self, cx: &mut WindowContext) -> Arc<str> {
+        if !self.popover {
+            return Arc::from("Search recent project...");
+        }
+
+        self.help_text(cx)
     }
 
     fn match_count(&self) -> usize {
@@ -363,6 +378,23 @@ impl PickerDelegate for RecentProjectsDelegate {
                     .into()
                 }),
         )
+    }
+
+    fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<AnyElement> {
+        if self.popover {
+            return None;
+        }
+
+        let text = self.help_text(cx).to_string();
+        let view = v_flex().child(Divider::horizontal()).child(
+            div()
+                .py_1()
+                .px_4()
+                .text_color(cx.theme().colors().text_muted)
+                .child(text),
+        );
+
+        Some(view.into_any_element())
     }
 }
 

--- a/crates/zed/src/app_menus.rs
+++ b/crates/zed/src/app_menus.rs
@@ -40,7 +40,7 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 MenuItem::action(
                     "Open Recent...",
                     recent_projects::OpenRecent {
-                        create_new_window: false,
+                        create_new_window: true,
                     },
                 ),
                 MenuItem::separator(),


### PR DESCRIPTION
Release Notes:

- Improved Recent Projects default open behavior for:
  - **File Menu / cmd+alt+o**: To open in new window. 
  - **Collab Popover Menu**: To open in same window (Like branch switch).

### Screenshot


https://github.com/zed-industries/zed/assets/5518/8bbd13a7-9144-48b0-9bc8-6651725476f8





