### PR TITLE
Add Java language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5282,6 +5282,7 @@ dependencies = [
  "tree-sitter-hcl",
  "tree-sitter-heex",
  "tree-sitter-html",
+ "tree-sitter-java",
  "tree-sitter-jsdoc",
  "tree-sitter-json 0.20.0",
  "tree-sitter-lua",
@@ -10303,6 +10304,16 @@ name = "tree-sitter-html"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "184e6b77953a354303dc87bf5fe36558c83569ce92606e7b382a0dc1b7443443"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adc5696bf5abf761081d7457d2bb82d0e3b28964f4214f63fd7e720ef462653"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,7 @@ tree-sitter-hcl = { git = "https://github.com/MichaHoffmann/tree-sitter-hcl", re
 rustc-demangle = "0.1.23"
 tree-sitter-heex = { git = "https://github.com/phoenixframework/tree-sitter-heex", rev = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a" }
 tree-sitter-html = "0.19.0"
+tree-sitter-java = "0.20.2"
 tree-sitter-jsdoc = { git = "https://github.com/tree-sitter/tree-sitter-jsdoc", ref = "6a6cf9e7341af32d8e2b2e24a37fbfebefc3dc55" }
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json", rev = "40a81c01a40ac48744e0c8ccabbaba1920441199" }
 tree-sitter-lua = "0.0.14"

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -58,6 +58,7 @@ tree-sitter-haskell.workspace = true
 tree-sitter-hcl.workspace = true
 tree-sitter-heex.workspace = true
 tree-sitter-html.workspace = true
+tree-sitter-java.workspace = true
 tree-sitter-jsdoc.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-lua.workspace = true

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -35,12 +35,11 @@ impl LspAdapter for JavaLspAdapter {
             .iter()
             .find(|asset| asset.name == asset_name)
             .ok_or_else(|| anyhow!("no asset found matching {:?}", asset_name))?;
-        let version = GitHubLspBinaryVersion {
+
+        Ok(Box::new(GitHubLspBinaryVersion {
             name: release.tag_name,
             url: asset.browser_download_url.clone(),
-        };
-
-        Ok(Box::new(version) as Box<_>)
+        }))
     }
 
     async fn fetch_server_binary(

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -37,6 +37,7 @@ impl LspAdapter for JavaLspAdapter {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "jdtls".into(),
+            env: None,
             arguments: vec![
                 "-configuration".into(),
                 HOME.join(".cache/jdtls").into(),
@@ -58,6 +59,7 @@ impl LspAdapter for JavaLspAdapter {
     ) -> Option<LanguageServerBinary> {
         Some(LanguageServerBinary {
             path: "jdtls".into(),
+            env: None,
             arguments: vec!["--help".into()],
             env: None,
         })

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -1,8 +1,9 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 pub use language::*;
+use log::warn;
 use lsp::LanguageServerBinary;
-use std::{any::Any, path::PathBuf};
+use std::{any::Any, path::PathBuf, sync::Arc};
 use util::paths::HOME;
 
 pub struct JavaLspAdapter;
@@ -64,5 +65,62 @@ impl LspAdapter for JavaLspAdapter {
 
     fn disk_based_diagnostic_sources(&self) -> Vec<String> {
         vec!["java".into()]
+    }
+
+    async fn label_for_completion(
+        &self,
+        completion: &lsp::CompletionItem,
+        language: &Arc<Language>,
+    ) -> Option<CodeLabel> {
+        match completion.kind {
+            Some(
+                lsp::CompletionItemKind::VARIABLE
+                | lsp::CompletionItemKind::CONSTANT
+                | lsp::CompletionItemKind::FIELD,
+            ) => {
+                if let Some((name, detail)) = completion.label.split_once(" : ") {
+                    let text = format!("{detail} {name}");
+                    let source = Rope::from(format!("{} = null;", text).as_str());
+                    let runs = language.highlight_text(&source, 0..text.len());
+
+                    return Some(CodeLabel {
+                        text,
+                        runs,
+                        filter_range: detail.len() + 1..detail.len() + 1 + name.len(),
+                    });
+                }
+            }
+            Some(lsp::CompletionItemKind::METHOD) => {
+                if let Some((name, detail)) = completion.label.split_once(" : ") {
+                    let text = format!("{detail} {name}");
+                    let source = Rope::from(format!("{} {{}}", text).as_str());
+                    let runs = language.highlight_text(&source, 0..text.len());
+
+                    return Some(CodeLabel {
+                        text,
+                        runs,
+                        filter_range: detail.len() + 1..detail.len() + 1 + name.rfind('(').unwrap(),
+                    });
+                }
+            }
+            Some(lsp::CompletionItemKind::CLASS) => {
+                if let Some((name, _detail)) = completion.label.split_once(" - ") {
+                    let source = Rope::from(format!("class {} {{}}", name).as_str());
+                    let runs = language.highlight_text(&source, 6..6 + name.len());
+
+                    return Some(CodeLabel {
+                        text: name.into(),
+                        runs,
+                        filter_range: 0..name.len(),
+                    });
+                }
+            }
+            Some(kind) if kind != lsp::CompletionItemKind::SNIPPET => {
+                warn!("Unimplemented completion: {completion:#?}")
+            }
+            _ => (),
+        }
+
+        None
     }
 }

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -103,16 +103,18 @@ impl LspAdapter for JavaLspAdapter {
                     });
                 }
             }
-            Some(lsp::CompletionItemKind::CLASS) => {
-                if let Some((name, _detail)) = completion.label.split_once(" - ") {
-                    let source = Rope::from(format!("class {} {{}}", name).as_str());
-                    let runs = language.highlight_text(&source, 6..6 + name.len());
+            Some(
+                lsp::CompletionItemKind::CLASS
+                | lsp::CompletionItemKind::INTERFACE
+                | lsp::CompletionItemKind::ENUM,
+            ) => {
+                if let Some((name, detail)) = completion.label.split_once(" - ") {
+                    let highlight_id = language.grammar()?.highlight_id_for_name("type")?;
+                    let mut label = CodeLabel::plain(format!("{name} (import {detail})"), None);
 
-                    return Some(CodeLabel {
-                        text: name.into(),
-                        runs,
-                        filter_range: 0..name.len(),
-                    });
+                    label.runs.push((0..name.len(), highlight_id));
+
+                    return Some(label);
                 }
             }
             Some(lsp::CompletionItemKind::KEYWORD) => {

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -98,17 +98,6 @@ impl LspAdapter for JavaLspAdapter {
         }
     }
 
-    // TODO: code actions don't work
-    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
-        Some(vec![
-            CodeActionKind::EMPTY,
-            CodeActionKind::QUICKFIX,
-            CodeActionKind::REFACTOR,
-            CodeActionKind::REFACTOR_EXTRACT,
-            CodeActionKind::SOURCE,
-        ])
-    }
-
     async fn installation_test_binary(
         &self,
         container_dir: PathBuf,
@@ -119,10 +108,6 @@ impl LspAdapter for JavaLspAdapter {
                 binary.arguments = vec!["--help".into()];
                 binary
             })
-    }
-
-    fn disk_based_diagnostic_sources(&self) -> Vec<String> {
-        vec!["java".into()]
     }
 
     async fn label_for_completion(
@@ -210,6 +195,21 @@ impl LspAdapter for JavaLspAdapter {
         }
 
         None
+    }
+
+    // TODO: code actions don't work
+    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
+        Some(vec![
+            CodeActionKind::EMPTY,
+            CodeActionKind::QUICKFIX,
+            CodeActionKind::REFACTOR,
+            CodeActionKind::REFACTOR_EXTRACT,
+            CodeActionKind::SOURCE,
+        ])
+    }
+
+    fn disk_based_diagnostic_sources(&self) -> Vec<String> {
+        vec!["java".into()]
     }
 }
 

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -1,0 +1,68 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+pub use language::*;
+use lsp::LanguageServerBinary;
+use std::{any::Any, path::PathBuf};
+use util::paths::HOME;
+
+pub struct JavaLspAdapter;
+
+#[async_trait]
+impl LspAdapter for JavaLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        LanguageServerName("eclipse.jdt.ls".into())
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _delegate: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        Ok(Box::new(()))
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        _version: Box<dyn 'static + Send + Any>,
+        _container_dir: PathBuf,
+        _delegate: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        Err(anyhow!("eclipse.jdt.ls must be installed manually"))
+    }
+
+    async fn cached_server_binary(
+        &self,
+        _container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "jdtls".into(),
+            arguments: vec![
+                "-configuration".into(),
+                HOME.join(".cache/jdtls").into(),
+                // Should work but... doesn't
+                // "-data".into(),
+                // ".".into(),
+            ],
+            env: None,
+        })
+    }
+
+    fn can_be_reinstalled(&self) -> bool {
+        false
+    }
+
+    async fn installation_test_binary(
+        &self,
+        _container_dir: PathBuf,
+    ) -> Option<LanguageServerBinary> {
+        Some(LanguageServerBinary {
+            path: "jdtls".into(),
+            arguments: vec!["--help".into()],
+            env: None,
+        })
+    }
+
+    fn disk_based_diagnostic_sources(&self) -> Vec<String> {
+        vec!["java".into()]
+    }
+}

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -103,6 +103,30 @@ impl LspAdapter for JavaLspAdapter {
                     });
                 }
             }
+            Some(lsp::CompletionItemKind::ENUM_MEMBER) => {
+                if let Some((name, detail)) = completion.label.split_once(" : ") {
+                    let property_highlight_id =
+                        language.grammar()?.highlight_id_for_name("property")?;
+                    let type_highlight_id = language.grammar()?.highlight_id_for_name("type")?;
+                    let mut label = CodeLabel::plain(format!("{detail}.{name}"), Some(name));
+                    let mut next_start = 0;
+
+                    for identifier in detail.split('.') {
+                        label
+                            .runs
+                            .push((next_start..next_start + identifier.len(), type_highlight_id));
+
+                        next_start += identifier.len() + 1;
+                    }
+
+                    label.runs.push((
+                        detail.len() + 1..detail.len() + 1 + name.len(),
+                        property_highlight_id,
+                    ));
+
+                    return Some(label);
+                }
+            }
             Some(
                 lsp::CompletionItemKind::CLASS
                 | lsp::CompletionItemKind::INTERFACE

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -34,7 +34,7 @@ impl LspAdapter for JavaLspAdapter {
             .assets
             .iter()
             .find(|asset| asset.name == asset_name)
-            .ok_or_else(|| anyhow!("no asset found matching {:?} \n", asset_name))?;
+            .ok_or_else(|| anyhow!("no asset found matching {:?}", asset_name))?;
         let version = GitHubLspBinaryVersion {
             name: release.tag_name,
             url: asset.browser_download_url.clone(),

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -125,23 +125,14 @@ impl LspAdapter for JavaLspAdapter {
     ) -> Option<CodeLabel> {
         match completion.kind {
             Some(
-                lsp::CompletionItemKind::VARIABLE
+                lsp::CompletionItemKind::METHOD
+                | lsp::CompletionItemKind::VARIABLE
                 | lsp::CompletionItemKind::CONSTANT
                 | lsp::CompletionItemKind::FIELD,
             ) => {
                 if let Some((name, detail)) = completion.label.split_once(" : ") {
-                    let highlight_id = language.grammar()?.highlight_id_for_name("constant")?;
-                    let mut label = CodeLabel::plain(format!("{name}: {detail}"), None);
-
-                    label.runs.push((0..name.len(), highlight_id));
-
-                    return Some(label);
-                }
-            }
-            Some(lsp::CompletionItemKind::METHOD) => {
-                if let Some((name, detail)) = completion.label.split_once(" : ") {
                     let text = format!("{detail} {name}");
-                    let source = Rope::from(format!("{text} {{}}").as_str());
+                    let source = Rope::from(text.as_str());
                     let runs = language.highlight_text(&source, 0..text.len());
 
                     return Some(CodeLabel {
@@ -199,7 +190,7 @@ impl LspAdapter for JavaLspAdapter {
             }
             Some(kind) if kind != lsp::CompletionItemKind::SNIPPET => {
                 // Run `RUST_LOG=warn cargo run` to run and show warnings!
-                warn!("Unimplemented Java completion: {completion:#?}")
+                warn!("Unimplemented Java completion: {completion:#?}");
             }
             _ => (),
         }

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -17,7 +17,7 @@ use util::{
 
 pub struct JavaLspAdapter;
 
-#[async_trait]
+#[async_trait(?Send)]
 impl LspAdapter for JavaLspAdapter {
     fn name(&self) -> LanguageServerName {
         LanguageServerName("eclipse.jdt.ls".into())

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use futures::{io::BufReader, StreamExt};
 pub use language::*;
 use log::warn;
-use lsp::{CodeActionKind, LanguageServerBinary};
+use lsp::LanguageServerBinary;
 use smol::fs::{self};
 use std::{any::Any, path::PathBuf, sync::Arc};
 use util::{
@@ -195,17 +195,6 @@ impl LspAdapter for JavaLspAdapter {
         }
 
         None
-    }
-
-    // TODO: code actions don't work
-    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
-        Some(vec![
-            CodeActionKind::EMPTY,
-            CodeActionKind::QUICKFIX,
-            CodeActionKind::REFACTOR,
-            CodeActionKind::REFACTOR_EXTRACT,
-            CodeActionKind::SOURCE,
-        ])
     }
 
     fn disk_based_diagnostic_sources(&self) -> Vec<String> {

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -4,10 +4,8 @@ use async_tar::Archive;
 use async_trait::async_trait;
 use futures::{io::BufReader, StreamExt};
 pub use language::*;
-use lazy_static::lazy_static;
 use log::warn;
 use lsp::{CodeActionKind, LanguageServerBinary};
-use regex::Regex;
 use smol::fs::{self};
 use std::{any::Any, path::PathBuf, sync::Arc};
 use util::{
@@ -125,10 +123,6 @@ impl LspAdapter for JavaLspAdapter {
 
     fn disk_based_diagnostic_sources(&self) -> Vec<String> {
         vec!["java".into()]
-    }
-
-    // TODO: filter diagnostics to get rid of annoying messages while typing
-    fn process_diagnostics(&self, params: &mut lsp::PublishDiagnosticsParams) {
     }
 
     async fn label_for_completion(

--- a/crates/languages/src/java.rs
+++ b/crates/languages/src/java.rs
@@ -99,7 +99,7 @@ impl LspAdapter for JavaLspAdapter {
                     return Some(CodeLabel {
                         text,
                         runs,
-                        filter_range: detail.len() + 1..detail.len() + 1 + name.rfind('(').unwrap(),
+                        filter_range: detail.len() + 1..detail.len() + 1 + name.rfind('(')?,
                     });
                 }
             }
@@ -114,6 +114,14 @@ impl LspAdapter for JavaLspAdapter {
                         filter_range: 0..name.len(),
                     });
                 }
+            }
+            Some(lsp::CompletionItemKind::KEYWORD) => {
+                let highlight_id = language.grammar()?.highlight_id_for_name("keyword")?;
+                let mut label = CodeLabel::plain(completion.label.clone(), None);
+
+                label.runs.push((0..label.text.len(), highlight_id));
+
+                return Some(label);
             }
             Some(kind) if kind != lsp::CompletionItemKind::SNIPPET => {
                 warn!("Unimplemented completion: {completion:#?}")

--- a/crates/languages/src/java/brackets.scm
+++ b/crates/languages/src/java/brackets.scm
@@ -1,0 +1,5 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)

--- a/crates/languages/src/java/config.toml
+++ b/crates/languages/src/java/config.toml
@@ -1,0 +1,22 @@
+name = "Java"
+grammar = "java"
+path_suffixes = ["java"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true, not_in = [
+        "string",
+        "comment",
+    ] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "string",
+    ] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = [
+        "string",
+        "comment",
+    ] },
+]
+collapsed_placeholder = " /* ... */ "

--- a/crates/languages/src/java/config.toml
+++ b/crates/languages/src/java/config.toml
@@ -2,6 +2,7 @@ name = "Java"
 grammar = "java"
 path_suffixes = ["java"]
 line_comments = ["// "]
+block_comment = ["/* ", " */"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/java/highlights.scm
+++ b/crates/languages/src/java/highlights.scm
@@ -1,0 +1,142 @@
+; Methods
+
+(method_declaration
+  name: (identifier) @function.method)
+(method_invocation
+  name: (identifier) @function.method)
+(super) @function.builtin
+
+; Annotations
+
+(annotation
+  name: (identifier) @attribute)
+(marker_annotation
+  name: (identifier) @attribute)
+
+"@" @operator
+
+; Types
+
+(type_identifier) @type
+
+(interface_declaration
+  name: (identifier) @type)
+(class_declaration
+  name: (identifier) @type)
+(enum_declaration
+  name: (identifier) @type)
+
+((field_access
+  object: (identifier) @type)
+ (#match? @type "^[A-Z]"))
+((scoped_identifier
+  scope: (identifier) @type)
+ (#match? @type "^[A-Z]"))
+((method_invocation
+  object: (identifier) @type)
+ (#match? @type "^[A-Z]"))
+((method_reference
+  . (identifier) @type)
+ (#match? @type "^[A-Z]"))
+
+(constructor_declaration
+  name: (identifier) @type)
+
+[
+  (boolean_type)
+  (integral_type)
+  (floating_point_type)
+  (floating_point_type)
+  (void_type)
+] @type.builtin
+
+; Variables
+
+((identifier) @constant
+ (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
+
+(identifier) @variable
+
+(this) @variable.builtin
+
+; Literals
+
+[
+  (hex_integer_literal)
+  (decimal_integer_literal)
+  (octal_integer_literal)
+  (decimal_floating_point_literal)
+  (hex_floating_point_literal)
+] @number
+
+[
+  (character_literal)
+  (string_literal)
+] @string
+(escape_sequence) @string.escape
+
+[
+  (true)
+  (false)
+  (null_literal)
+] @constant.builtin
+
+[
+  (line_comment)
+  (block_comment)
+] @comment
+
+; Keywords
+
+[
+  "abstract"
+  "assert"
+  "break"
+  "case"
+  "catch"
+  "class"
+  "continue"
+  "default"
+  "do"
+  "else"
+  "enum"
+  "exports"
+  "extends"
+  "final"
+  "finally"
+  "for"
+  "if"
+  "implements"
+  "import"
+  "instanceof"
+  "interface"
+  "module"
+  "native"
+  "new"
+  "non-sealed"
+  "open"
+  "opens"
+  "package"
+  "private"
+  "protected"
+  "provides"
+  "public"
+  "requires"
+  "record"
+  "return"
+  "sealed"
+  "static"
+  "strictfp"
+  "switch"
+  "synchronized"
+  "throw"
+  "throws"
+  "to"
+  "transient"
+  "transitive"
+  "try"
+  "uses"
+  "volatile"
+  "while"
+  "with"
+] @keyword

--- a/crates/languages/src/java/highlights.scm
+++ b/crates/languages/src/java/highlights.scm
@@ -55,9 +55,10 @@
 ((identifier) @constant
  (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
 
-(identifier) @variable
+(field_access
+  field: (identifier) @property)
 
-(this) @variable.builtin
+(this) @variable.special
 
 ; Literals
 

--- a/crates/languages/src/java/indents.scm
+++ b/crates/languages/src/java/indents.scm
@@ -1,0 +1,17 @@
+[
+    (assignment_expression)
+    (binary_expression)
+    (instanceof_expression)
+    (lambda_expression)
+    (ternary_expression)
+    (update_expression)
+    (primary_expression)
+    (unary_expression)
+    (cast_expression)
+    (switch_expression)
+] @indent
+
+(_ "[" "]" @end) @indent
+(_ "<" ">" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -1,0 +1,40 @@
+(module_declaration
+    "open"? @context
+    "module" @context
+    name: (_) @name) @item
+
+(package_declaration
+    "package" @context
+    (_) @name) @item
+
+(class_declaration
+    (modifiers)? @context
+    "class" @context
+    name: (_) @name
+    superclass: (_)? @name
+    interfaces: (_)? @name
+    permits: (_)? @name) @item
+
+(record_declaration
+    (modifiers)? @context
+    "record" @context
+    name: (_) @name
+    interfaces: (_)? @name) @item
+
+(interface_declaration
+    (modifiers)? @context
+    "interface" @context
+    name: (_) @name
+    (extends_interfaces)? @context
+    permits: (_)? @name) @item
+
+(annotation_type_declaration
+    (modifiers)? @context
+    "@interface" @context
+    name: (_) @name) @item
+
+(enum_declaration
+    (modifiers)? @context
+    "enum" @context
+    name: (_) @name
+    interfaces: (_)? @name) @item

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -24,39 +24,38 @@
 
 (constructor_declaration
     (modifiers
-            [
-                "private"
-                "protected"
-                "public"
-            ]+ @context)?
-        type: (_) @context
-        name: (_) @name
-        ; TODO: fix multiline parameters causing space between parenthesis
-        parameters: (formal_parameters
-            "(" @context
-            [
-                (receiver_parameter) @context
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
+    name: (_) @name
+    ; TODO: fix multiline parameters causing space between parenthesis
+    parameters: (formal_parameters
+        "(" @context
+        [
+            (receiver_parameter) @context
+            (
                 (
+                    (receiver_parameter) @context
+                    "," @context
+                )?
+                (
+                    [
+                        (formal_parameter) @context
+                        (spread_parameter) @context
+                    ]
                     (
-                        (receiver_parameter) @context
                         "," @context
-                    )?
-                    (
                         [
                             (formal_parameter) @context
                             (spread_parameter) @context
                         ]
-                        (
-                            "," @context
-                            [
-                                (formal_parameter) @context
-                                (spread_parameter) @context
-                            ]
-                        )*
-                    )?
-                )
-            ]
-            ")" @context)) @item
+                    )*
+                )?
+            )
+        ]
+        ")" @context)) @item
 
 ; TODO: definitely needs more testing in projects with methods that actually use
 ;       all of these rules

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -18,9 +18,15 @@
     name: (_) @name) @item
 
 (field_declaration
-    (modifiers)? @context
+    (modifiers
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
     type: (_) @context
-    declarator: (_) @context) @item
+    declarator: (variable_declarator
+        name: (_) @name)) @item
 
 (constructor_declaration
     (modifiers

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -63,8 +63,6 @@
         ]
         ")" @context)) @item
 
-; TODO: definitely needs more testing in projects with methods that actually use
-;       all of these rules
 (method_declaration
     (modifiers
         [

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -8,12 +8,14 @@
     (_) @name) @item
 
 (class_declaration
-    (modifiers)? @context
+    (modifiers
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
     "class" @context
-    name: (_) @name
-    superclass: (_)? @name
-    interfaces: (_)? @name
-    permits: (_)? @name) @item
+    name: (_) @name) @item
 
 (field_declaration
     (modifiers)? @context
@@ -21,96 +23,98 @@
     declarator: (_) @context) @item
 
 (constructor_declaration
-    (modifiers)? @context
-    type_parameters: (_)? @context
-    name: (_) @name
-    ; TODO: fix multiline parameters causing space between parenthesis
-    parameters: (formal_parameters
-      "(" @context
-      [
-        (receiver_parameter) @context
-        (
-          (
-            (receiver_parameter) @context
-            "," @context
-          )?
-          (
+    (modifiers
             [
-              (formal_parameter) @context
-              (spread_parameter) @context
+                "private"
+                "protected"
+                "public"
+            ]+ @context)?
+        type: (_) @context
+        name: (_) @name
+        ; TODO: fix multiline parameters causing space between parenthesis
+        parameters: (formal_parameters
+            "(" @context
+            [
+                (receiver_parameter) @context
+                (
+                    (
+                        (receiver_parameter) @context
+                        "," @context
+                    )?
+                    (
+                        [
+                            (formal_parameter) @context
+                            (spread_parameter) @context
+                        ]
+                        (
+                            "," @context
+                            [
+                                (formal_parameter) @context
+                                (spread_parameter) @context
+                            ]
+                        )*
+                    )?
+                )
             ]
-            (
-              "," @context
-              [
-                (formal_parameter) @context
-                (spread_parameter) @context
-              ]
-            )*
-          )?
-        )
-      ]
-      ")" @context)
-    (throws)? @context) @item
+            ")" @context)) @item
 
 ; TODO: definitely needs more testing in projects with methods that actually use
 ;       all of these rules
 (method_declaration
-    (modifiers _+ @context)?
-    (_
-      type_parameters: (_) @context
-      [
-        (marker_annotation) @context
-        (annotation) @context
-      ]*
-    )?
+    (modifiers
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
     type: (_) @context
     name: (_) @name
     ; TODO: fix multiline parameters causing space between parenthesis
     parameters: (formal_parameters
-      "(" @context
-      [
-        (receiver_parameter) @context
-        (
-          (
+        "(" @context
+        [
             (receiver_parameter) @context
-            "," @context
-          )?
-          (
-            [
-              (formal_parameter) @context
-              (spread_parameter) @context
-            ]
             (
-              "," @context
-              [
-                (formal_parameter) @context
-                (spread_parameter) @context
-              ]
-            )*
-          )?
-        )
-      ]
-      ")" @context)
-    dimensions: (dimensions
-      (
-        (_)* @context
-        "[" @context
-        "]" @context
-      )+)?
-    (throws)? @context) @item
+                (
+                    (receiver_parameter) @context
+                    "," @context
+                )?
+                (
+                    [
+                        (formal_parameter) @context
+                        (spread_parameter) @context
+                    ]
+                    (
+                        "," @context
+                        [
+                            (formal_parameter) @context
+                            (spread_parameter) @context
+                        ]
+                    )*
+                )?
+            )
+        ]
+        ")" @context)) @item
 
 (record_declaration
-    (modifiers)? @context
+    (modifiers
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
     "record" @context
-    name: (_) @name
-    interfaces: (_)? @name) @item
+    name: (_) @name) @item
 
 (interface_declaration
-    (modifiers)? @context
+    (modifiers
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
     "interface" @context
-    name: (_) @name
-    (extends_interfaces)? @context
-    permits: (_)? @name) @item
+    name: (_) @name) @item
 
 (annotation_type_declaration
     (modifiers)? @context
@@ -118,7 +122,11 @@
     name: (_) @name) @item
 
 (enum_declaration
-    (modifiers)? @context
+    (modifiers
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
     "enum" @context
-    name: (_) @name
-    interfaces: (_)? @name) @item
+    name: (_) @name) @item

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -15,6 +15,16 @@
     interfaces: (_)? @name
     permits: (_)? @name) @item
 
+(constructor_declaration
+    (modifiers)? @context
+    name: (_) @name
+    parameters: (formal_parameters) @context) @item
+
+(method_declaration
+    type: (type_identifier)? @type
+    name: (_) @name
+    parameters: (formal_parameters) @context) @item
+
 (record_declaration
     (modifiers)? @context
     "record" @context

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -25,10 +25,52 @@
     name: (_) @name
     parameters: (formal_parameters) @context) @item
 
+; TODO: definitely needs more testing in projects with methods that actually use
+;       all of these rules
 (method_declaration
-    type: (type_identifier)? @context
+    (modifiers _+ @context)?
+    (_
+      type_parameters: (_) @context
+      [
+        (marker_annotation) @context
+        (annotation) @context
+      ]*
+    )?
+    type: (_) @context
     name: (_) @name
-    parameters: (formal_parameters) @context) @item
+    ; TODO: fix multiline parameters causing space between parenthesis
+    parameters: (formal_parameters
+      "(" @context
+      [
+        (receiver_parameter) @context
+        (
+          (
+            (receiver_parameter) @context
+            "," @context
+          )?
+          (
+            [
+              (formal_parameter) @context
+              (spread_parameter) @context
+            ]
+            (
+              "," @context
+              [
+                (formal_parameter) @context
+                (spread_parameter) @context
+              ]
+            )*
+          )?
+        )
+      ]
+      ")" @context)
+    dimensions: (dimensions
+      (
+        (_)* @context
+        "[" @context
+        "]" @context
+      )+)?
+    (throws)? @context) @item
 
 (record_declaration
     (modifiers)? @context

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -15,13 +15,18 @@
     interfaces: (_)? @name
     permits: (_)? @name) @item
 
+(field_declaration
+    (modifiers)? @context
+    type: (_) @context
+    declarator: (_) @context) @item
+
 (constructor_declaration
     (modifiers)? @context
     name: (_) @name
     parameters: (formal_parameters) @context) @item
 
 (method_declaration
-    type: (type_identifier)? @type
+    type: (type_identifier)? @context
     name: (_) @name
     parameters: (formal_parameters) @context) @item
 

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -22,8 +22,35 @@
 
 (constructor_declaration
     (modifiers)? @context
+    type_parameters: (_)? @context
     name: (_) @name
-    parameters: (formal_parameters) @context) @item
+    ; TODO: fix multiline parameters causing space between parenthesis
+    parameters: (formal_parameters
+      "(" @context
+      [
+        (receiver_parameter) @context
+        (
+          (
+            (receiver_parameter) @context
+            "," @context
+          )?
+          (
+            [
+              (formal_parameter) @context
+              (spread_parameter) @context
+            ]
+            (
+              "," @context
+              [
+                (formal_parameter) @context
+                (spread_parameter) @context
+              ]
+            )*
+          )?
+        )
+      ]
+      ")" @context)
+    (throws)? @context) @item
 
 ; TODO: definitely needs more testing in projects with methods that actually use
 ;       all of these rules

--- a/crates/languages/src/java/outline.scm
+++ b/crates/languages/src/java/outline.scm
@@ -122,7 +122,12 @@
     name: (_) @name) @item
 
 (annotation_type_declaration
-    (modifiers)? @context
+    (modifiers
+        [
+            "private"
+            "protected"
+            "public"
+        ]+ @context)?
     "@interface" @context
     name: (_) @name) @item
 

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -26,6 +26,7 @@ mod gleam;
 mod go;
 mod haskell;
 mod html;
+mod java;
 mod json;
 mod lua;
 mod nu;
@@ -92,6 +93,7 @@ pub fn init(
         ("hcl", tree_sitter_hcl::language()),
         ("heex", tree_sitter_heex::language()),
         ("html", tree_sitter_html::language()),
+        ("java", tree_sitter_java::language()),
         ("jsdoc", tree_sitter_jsdoc::language()),
         ("json", tree_sitter_json::language()),
         ("lua", tree_sitter_lua::language()),
@@ -229,6 +231,7 @@ pub fn init(
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         ]
     );
+    language!("java", vec![Arc::new(java::JavaLspAdapter)]);
     language!(
         "json",
         vec![Arc::new(json::JsonLspAdapter::new(

--- a/docs/src/languages/java.md
+++ b/docs/src/languages/java.md
@@ -1,0 +1,8 @@
+# Java
+
+- Tree Sitter: [tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java)
+- Language Server: [eclipse.jdt.ls](https://github.com/eclipse-jdtls/eclipse.jdt.ls)
+
+### Setup
+
+Zed installs eclipse.jdt.ls automatically, however the language server cannot start without you first having Java installed and including the path to it in your `PATH` or `JAVA_HOME`.


### PR DESCRIPTION
Release Notes:

- Add Java language support [#5301 ](https://github.com/zed-industries/extensions/issues/500).

Added eclipse.jdtls lsp server with Lombok plugin for Java.
https://streamable.com/0cqa07


However, The Java support still has two main problems:
1. We are unable to navigate to the definition in the source code (basically .class files).
2. Quick actions do not work, likely due to unsupported types of code actions.

I would appreciate suggestions on how to solve these issues, as I have not found a way to do so.

PR is co-authored with @valentinegb 
