### PR TITLE
Windows: add .exe to binary path

### DIFF
--- a/crates/languages/src/csharp.rs
+++ b/crates/languages/src/csharp.rs
@@ -65,6 +65,8 @@ impl super::LspAdapter for OmniSharpAdapter {
     ) -> Result<LanguageServerBinary> {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
         let binary_path = container_dir.join("omnisharp");
+        #[cfg(windows)]
+        let binary_path = binary_path.with_extension("exe");
 
         if fs::metadata(&binary_path).await.is_err() {
             let mut response = delegate
@@ -77,7 +79,6 @@ impl super::LspAdapter for OmniSharpAdapter {
             archive.unpack(container_dir).await?;
         }
 
-        // todo("windows")
         #[cfg(not(windows))]
         {
             fs::set_permissions(

--- a/crates/languages/src/elixir.rs
+++ b/crates/languages/src/elixir.rs
@@ -333,6 +333,8 @@ impl LspAdapter for NextLspAdapter {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
 
         let binary_path = container_dir.join("next-ls");
+        #[cfg(windows)]
+        let binary_path = binary_path.with_extension("exe");
 
         if fs::metadata(&binary_path).await.is_err() {
             let mut response = delegate
@@ -350,7 +352,6 @@ impl LspAdapter for NextLspAdapter {
             }
             futures::io::copy(response.body_mut(), &mut file).await?;
 
-            // todo("windows")
             #[cfg(not(windows))]
             {
                 fs::set_permissions(

--- a/crates/languages/src/lua.rs
+++ b/crates/languages/src/lua.rs
@@ -67,6 +67,8 @@ impl super::LspAdapter for LuaLspAdapter {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
 
         let binary_path = container_dir.join("bin/lua-language-server");
+        #[cfg(windows)]
+        let binary_path = binary_path.with_extension("exe");
 
         if fs::metadata(&binary_path).await.is_err() {
             let mut response = delegate
@@ -79,7 +81,6 @@ impl super::LspAdapter for LuaLspAdapter {
             archive.unpack(container_dir).await?;
         }
 
-        // todo("windows")
         #[cfg(not(windows))]
         {
             fs::set_permissions(

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -60,6 +60,8 @@ impl LspAdapter for RustLspAdapter {
     ) -> Result<LanguageServerBinary> {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
         let destination_path = container_dir.join(format!("rust-analyzer-{}", version.name));
+        #[cfg(windows)]
+        let destination_path = destination_path.with_extension("exe");
 
         if fs::metadata(&destination_path).await.is_err() {
             let mut response = delegate
@@ -70,7 +72,6 @@ impl LspAdapter for RustLspAdapter {
             let decompressed_bytes = GzipDecoder::new(BufReader::new(response.body_mut()));
             let mut file = File::create(&destination_path).await?;
             futures::io::copy(decompressed_bytes, &mut file).await?;
-            // todo("windows")
             #[cfg(not(windows))]
             {
                 fs::set_permissions(

--- a/crates/languages/src/toml.rs
+++ b/crates/languages/src/toml.rs
@@ -55,6 +55,8 @@ impl LspAdapter for TaploLspAdapter {
     ) -> Result<LanguageServerBinary> {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
         let binary_path = container_dir.join("taplo");
+        #[cfg(windows)]
+        let binary_path = binary_path.with_extension("exe");
 
         if fs::metadata(&binary_path).await.is_err() {
             let mut response = delegate
@@ -68,7 +70,6 @@ impl LspAdapter for TaploLspAdapter {
 
             futures::io::copy(decompressed_bytes, &mut file).await?;
 
-            // todo("windows")
             #[cfg(not(windows))]
             {
                 fs::set_permissions(

--- a/crates/languages/src/zig.rs
+++ b/crates/languages/src/zig.rs
@@ -61,6 +61,8 @@ impl LspAdapter for ZlsAdapter {
     ) -> Result<LanguageServerBinary> {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
         let binary_path = container_dir.join("bin/zls");
+        #[cfg(windows)]
+        let binary_path = binary_path.with_extension("exe");
 
         if fs::metadata(&binary_path).await.is_err() {
             let mut response = delegate
@@ -73,7 +75,6 @@ impl LspAdapter for ZlsAdapter {
             archive.unpack(container_dir).await?;
         }
 
-        // todo("windows")
         #[cfg(not(windows))]
         {
             fs::set_permissions(


### PR DESCRIPTION
Waiting for #8791 to be merged as it is not confirmed to be working.

Release Notes:

- Windows: make binary language servers executable
