### PR TITLE
linux/wayland: prevent possible panic

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -558,11 +558,12 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                                         return TimeoutAction::Drop;
                                     }
 
-                                    state_
-                                        .keyboard_focused_window
-                                        .as_ref()
-                                        .unwrap()
-                                        .handle_input(input.clone());
+                                    let focused_window =
+                                        state_.keyboard_focused_window.as_ref().unwrap().clone();
+
+                                    drop(state_);
+
+                                    focused_window.handle_input(input.clone());
 
                                     TimeoutAction::ToDuration(Duration::from_secs(1) / rate)
                                 })


### PR DESCRIPTION
Prevent a panic from arising from this case: https://github.com/zed-industries/zed/pull/8632#discussion_r1510015928

It's not really safe to dispatch any action before dropping the state borrow, because it may need to be modified.
