### PR TITLE
Enable `clippy::needless_update`

### DIFF
--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -382,7 +382,6 @@ impl Database {
                 language_server_id: ActiveValue::set(summary.language_server_id as i64),
                 error_count: ActiveValue::set(summary.error_count as i32),
                 warning_count: ActiveValue::set(summary.warning_count as i32),
-                ..Default::default()
             })
             .on_conflict(
                 OnConflict::columns([
@@ -434,7 +433,6 @@ impl Database {
                 project_id: ActiveValue::set(project_id),
                 id: ActiveValue::set(server.id as i64),
                 name: ActiveValue::set(server.name.clone()),
-                ..Default::default()
             })
             .on_conflict(
                 OnConflict::columns([

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -3370,7 +3370,6 @@ fn build_update_user_channels(channels: &ChannelsForUser) -> proto::UpdateUserCh
             .collect(),
         observed_channel_buffer_version: channels.observed_buffer_versions.clone(),
         observed_channel_message_id: channels.observed_channel_messages.clone(),
-        ..Default::default()
     }
 }
 

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -3885,7 +3885,6 @@ async fn test_collaborating_with_diagnostics(
                 DiagnosticSummary {
                     error_count: 1,
                     warning_count: 0,
-                    ..Default::default()
                 },
             )]
         )
@@ -3922,7 +3921,6 @@ async fn test_collaborating_with_diagnostics(
             DiagnosticSummary {
                 error_count: 1,
                 warning_count: 0,
-                ..Default::default()
             },
         )]
     );

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -93,7 +93,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::iter_overeager_cloned",
         "clippy::let_underscore_future",
         "clippy::map_entry",
-        "clippy::needless_update",
         "clippy::never_loop",
         "clippy::non_canonical_clone_impl",
         "clippy::non_canonical_partial_ord_impl",


### PR DESCRIPTION
This PR enables the [`clippy::needless_update`](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_update) rule and fixes the outstanding violations.

Release Notes:

- N/A
