### PR TITLE
Enable `clippy::iter_kv_map`

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -798,8 +798,8 @@ impl ExtensionStore {
                 },
                 grammars: manifest_json
                     .grammars
-                    .into_iter()
-                    .map(|(grammar_name, _)| (grammar_name, Default::default()))
+                    .into_keys()
+                    .map(|grammar_name| (grammar_name, Default::default()))
                     .collect(),
                 language_servers: Default::default(),
             };

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -89,7 +89,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
         "clippy::implied_bounds_in_impls",
-        "clippy::iter_kv_map",
         "clippy::iter_overeager_cloned",
         "clippy::let_underscore_future",
         "clippy::map_entry",


### PR DESCRIPTION
This PR enables the [`clippy::iter_kv_map`](https://rust-lang.github.io/rust-clippy/master/index.html#/iter_kv_map) rule and fixes the outstanding violations.

Release Notes:

- N/A
