### PR TITLE
Enable `clippy::derivable_impls`

### DIFF
--- a/crates/ai/src/test.rs
+++ b/crates/ai/src/test.rs
@@ -54,6 +54,7 @@ impl LanguageModel for FakeLanguageModel {
     }
 }
 
+#[derive(Default)]
 pub struct FakeEmbeddingProvider {
     pub embedding_count: AtomicUsize,
 }
@@ -62,14 +63,6 @@ impl Clone for FakeEmbeddingProvider {
     fn clone(&self) -> Self {
         FakeEmbeddingProvider {
             embedding_count: AtomicUsize::new(self.embedding_count.load(Ordering::SeqCst)),
-        }
-    }
-}
-
-impl Default for FakeEmbeddingProvider {
-    fn default() -> Self {
-        FakeEmbeddingProvider {
-            embedding_count: AtomicUsize::default(),
         }
     }
 }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -85,7 +85,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::cast_abs_to_unsigned",
         "clippy::cmp_owned",
         "clippy::crate_in_macro_def",
-        "clippy::derivable_impls",
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
         "clippy::implied_bounds_in_impls",


### PR DESCRIPTION
This PR enables the [`clippy::derivable_impls`](https://rust-lang.github.io/rust-clippy/master/index.html#/derivable_impls) rule and fixes the outstanding violations.

Release Notes:

- N/A
