### PR TITLE
Enable `clippy::iter_overeager_cloned`

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -614,9 +614,9 @@ impl SyntaxSnapshot {
                             Some(old_tree.clone()),
                         );
                         changed_ranges = join_ranges(
-                            invalidated_ranges.iter().cloned().filter(|range| {
+                            invalidated_ranges.iter().filter(|&range| {
                                 range.start <= step_end_byte && range.end >= step_start_byte
-                            }),
+                            }).cloned(),
                             old_tree.changed_ranges(&tree).map(|r| {
                                 step_start_byte + r.start_byte..step_start_byte + r.end_byte
                             }),

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -614,9 +614,12 @@ impl SyntaxSnapshot {
                             Some(old_tree.clone()),
                         );
                         changed_ranges = join_ranges(
-                            invalidated_ranges.iter().filter(|&range| {
-                                range.start <= step_end_byte && range.end >= step_start_byte
-                            }).cloned(),
+                            invalidated_ranges
+                                .iter()
+                                .filter(|&range| {
+                                    range.start <= step_end_byte && range.end >= step_start_byte
+                                })
+                                .cloned(),
                             old_tree.changed_ranges(&tree).map(|r| {
                                 step_start_byte + r.start_byte..step_start_byte + r.end_byte
                             }),

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -88,7 +88,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
         "clippy::implied_bounds_in_impls",
-        "clippy::iter_overeager_cloned",
         "clippy::let_underscore_future",
         "clippy::map_entry",
         "clippy::never_loop",


### PR DESCRIPTION
This PR enables the [`clippy::iter_overeager_cloned`](https://rust-lang.github.io/rust-clippy/master/index.html#/iter_overeager_cloned) rule and fixes the outstanding violations.

Release Notes:

- N/A
