### PR TITLE
Enable `clippy::redundant_closure_call`

### DIFF
--- a/crates/languages/src/astro.rs
+++ b/crates/languages/src/astro.rs
@@ -12,7 +12,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use util::ResultExt;
+use util::{async_maybe, ResultExt};
 
 const SERVER_PATH: &str = "node_modules/@astrojs/language-server/bin/nodeServer.js";
 
@@ -105,7 +105,7 @@ async fn get_cached_server_binary(
     container_dir: PathBuf,
     node: &dyn NodeRuntime,
 ) -> Option<LanguageServerBinary> {
-    (|| async move {
+    async_maybe!({
         let mut last_version_dir = None;
         let mut entries = fs::read_dir(&container_dir).await?;
         while let Some(entry) = entries.next().await {
@@ -128,7 +128,7 @@ async fn get_cached_server_binary(
                 last_version_dir
             ))
         }
-    })()
+    })
     .await
     .log_err()
 }

--- a/crates/languages/src/elm.rs
+++ b/crates/languages/src/elm.rs
@@ -15,7 +15,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use util::ResultExt;
+use util::{async_maybe, ResultExt};
 
 const SERVER_NAME: &str = "elm-language-server";
 const SERVER_PATH: &str = "node_modules/@elm-tooling/elm-language-server/out/node/index.js";
@@ -117,7 +117,7 @@ async fn get_cached_server_binary(
     container_dir: PathBuf,
     node: &dyn NodeRuntime,
 ) -> Option<LanguageServerBinary> {
-    (|| async move {
+    async_maybe!({
         let mut last_version_dir = None;
         let mut entries = fs::read_dir(&container_dir).await?;
         while let Some(entry) = entries.next().await {
@@ -140,7 +140,7 @@ async fn get_cached_server_binary(
                 last_version_dir
             ))
         }
-    })()
+    })
     .await
     .log_err()
 }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -93,7 +93,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::never_loop",
         "clippy::non_canonical_clone_impl",
         "clippy::non_canonical_partial_ord_impl",
-        "clippy::redundant_closure_call",
         "clippy::reversed_empty_ranges",
         "clippy::single_range_in_vec_init",
         "clippy::suspicious_to_owned",


### PR DESCRIPTION
This PR enables the [`clippy::redundant_closure_call`](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_closure_call) rule and fixes the outstanding violations.

Release Notes:

- N/A
