### PR TITLE
Enable `clippy::crate_in_macro_def`

### DIFF
--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -109,13 +109,13 @@ macro_rules! test_both_dbs {
     ($test_name:ident, $postgres_test_name:ident, $sqlite_test_name:ident) => {
         #[gpui::test]
         async fn $postgres_test_name(cx: &mut gpui::TestAppContext) {
-            let test_db = crate::db::TestDb::postgres(cx.executor().clone());
+            let test_db = $crate::db::TestDb::postgres(cx.executor().clone());
             $test_name(test_db.db()).await;
         }
 
         #[gpui::test]
         async fn $sqlite_test_name(cx: &mut gpui::TestAppContext) {
-            let test_db = crate::db::TestDb::sqlite(cx.executor().clone());
+            let test_db = $crate::db::TestDb::sqlite(cx.executor().clone());
             $test_name(test_db.db()).await;
         }
     };

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -84,7 +84,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         "clippy::borrowed_box",
         "clippy::cast_abs_to_unsigned",
         "clippy::cmp_owned",
-        "clippy::crate_in_macro_def",
         "clippy::derive_ord_xor_partial_ord",
         "clippy::eq_op",
         "clippy::implied_bounds_in_impls",


### PR DESCRIPTION
This PR enables the [`clippy::crate_in_macro_def`](https://rust-lang.github.io/rust-clippy/master/index.html#/crate_in_macro_def) rule and fixes the outstanding violations.

Release Notes:

- N/A
