### PR TITLE
Ensure followed cursors are always visible

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2091,7 +2091,7 @@ impl EditorElement {
                         editor.cursor_shape,
                         &snapshot.display_snapshot,
                         is_newest,
-                        true,
+                        editor.leader_peer_id.is_none(),
                         None,
                     );
                     if is_newest {


### PR DESCRIPTION
Before this change they would disappear if you blurred the pane.

Release Notes:

- Fixed an issue where the followed users' cursor would disappear if you blurred the pane.

