### PR TITLE
Add option to sign in to copilot from welcome screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11937,6 +11937,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "client",
+ "copilot_ui",
  "db",
  "editor",
  "fuzzy",

--- a/crates/copilot_ui/src/copilot_button.rs
+++ b/crates/copilot_ui/src/copilot_button.rs
@@ -332,7 +332,7 @@ fn hide_copilot(fs: Arc<dyn Fs>, cx: &mut AppContext) {
     });
 }
 
-fn initiate_sign_in(cx: &mut WindowContext) {
+pub fn initiate_sign_in(cx: &mut WindowContext) {
     let Some(copilot) = Copilot::global(cx) else {
         return;
     };

--- a/crates/copilot_ui/src/copilot_ui.rs
+++ b/crates/copilot_ui/src/copilot_ui.rs
@@ -1,4 +1,4 @@
-mod copilot_button;
+pub mod copilot_button;
 mod sign_in;
 
 pub use copilot_button::*;

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -14,6 +14,7 @@ test-support = []
 [dependencies]
 anyhow.workspace = true
 client.workspace = true
+copilot_ui.workspace = true
 db.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -2,6 +2,7 @@ mod base_keymap_picker;
 mod base_keymap_setting;
 
 use client::{telemetry::Telemetry, TelemetrySettings};
+use copilot_ui;
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
     svg, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
@@ -133,6 +134,16 @@ impl Render for WelcomePage {
                                                 install_cli::install_cli(&cx).await
                                             })
                                             .detach_and_log_err(cx);
+                                    })),
+                            )
+                            .child(
+                                Button::new("sign-in-to-copilot", "Sign in to GitHub Copilot")
+                                    .full_width()
+                                    .on_click(cx.listener(|this, _, cx| {
+                                        this.telemetry.report_app_event(
+                                            "welcome page: sign in to copilot".to_string(),
+                                        );
+                                        copilot_ui::initiate_sign_in(cx);
                                     })),
                             ),
                     )


### PR DESCRIPTION
Fixes: https://github.com/zed-industries/zed/issues/8851

https://github.com/zed-industries/zed/assets/19867440/5d391289-34e8-4abc-9337-b7e253f4e513

Release Notes:

- Added GitHub Copilot sign in on welcome screen ([#8851](https://github.com/zed-industries/zed/issues/8851)).