### PR TITLE
Remove release channel from Zed URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,7 +2390,6 @@ dependencies = [
  "picker",
  "postage",
  "project",
- "release_channel",
  "serde",
  "serde_json",
  "settings",

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -3,7 +3,7 @@ mod channel_index;
 use crate::{channel_buffer::ChannelBuffer, channel_chat::ChannelChat, ChannelMessage};
 use anyhow::{anyhow, Result};
 use channel_index::ChannelIndex;
-use client::{ChannelId, Client, Subscription, User, UserId, UserStore};
+use client::{ChannelId, Client, ClientSettings, Subscription, User, UserId, UserStore};
 use collections::{hash_map, HashMap, HashSet};
 use futures::{channel::mpsc, future::Shared, Future, FutureExt, StreamExt};
 use gpui::{
@@ -11,11 +11,11 @@ use gpui::{
     Task, WeakModel,
 };
 use language::Capability;
-use release_channel::RELEASE_CHANNEL;
 use rpc::{
     proto::{self, ChannelRole, ChannelVisibility},
     TypedEnvelope,
 };
+use settings::Settings;
 use std::{mem, sync::Arc, time::Duration};
 use util::{async_maybe, maybe, ResultExt};
 
@@ -93,16 +93,17 @@ pub struct ChannelState {
 }
 
 impl Channel {
-    pub fn link(&self) -> String {
-        RELEASE_CHANNEL.link_prefix().to_owned()
-            + "channel/"
-            + &Self::slug(&self.name)
-            + "-"
-            + &self.id.to_string()
+    pub fn link(&self, cx: &AppContext) -> String {
+        format!(
+            "{}/channel/{}-{}",
+            ClientSettings::get_global(cx).server_url,
+            Self::slug(&self.name),
+            self.id
+        )
     }
 
-    pub fn notes_link(&self, heading: Option<String>) -> String {
-        self.link()
+    pub fn notes_link(&self, heading: Option<String>, cx: &AppContext) -> String {
+        self.link(cx)
             + "/notes"
             + &heading
                 .map(|h| format!("#{}", Self::slug(&h)))

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1448,7 +1448,7 @@ pub fn parse_zed_link<'a>(link: &'a str, cx: &AppContext) -> Option<&'a str> {
     let server_url = &ClientSettings::get_global(cx).server_url;
     if let Some(stripped) = link
         .strip_prefix(server_url)
-        .and_then(|result| result.strip_prefix("/"))
+        .and_then(|result| result.strip_prefix('/'))
     {
         return Some(stripped);
     }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1437,21 +1437,29 @@ async fn delete_credentials_from_keychain(cx: &AsyncAppContext) -> Result<()> {
         .await
 }
 
-const WORKTREE_URL_PREFIX: &str = "zed://worktrees/";
+/// prefix for the zed:// url scheme
+pub static ZED_URL_SCHEME: &str = "zed";
 
-pub fn encode_worktree_url(id: u64, access_token: &str) -> String {
-    format!("{}{}/{}", WORKTREE_URL_PREFIX, id, access_token)
-}
-
-pub fn decode_worktree_url(url: &str) -> Option<(u64, String)> {
-    let path = url.trim().strip_prefix(WORKTREE_URL_PREFIX)?;
-    let mut parts = path.split('/');
-    let id = parts.next()?.parse::<u64>().ok()?;
-    let access_token = parts.next()?;
-    if access_token.is_empty() {
-        return None;
+/// Parses the given link into a Zed link.
+///
+/// Returns a [`Some`] containing the unprefixed link if the link is a Zed link.
+/// Returns [`None`] otherwise.
+pub fn parse_zed_link<'a>(link: &'a str, cx: &AppContext) -> Option<&'a str> {
+    let server_url = &ClientSettings::get_global(cx).server_url;
+    if let Some(stripped) = link
+        .strip_prefix(server_url)
+        .and_then(|result| result.strip_prefix("/"))
+    {
+        return Some(stripped);
     }
-    Some((id, access_token.to_string()))
+    if let Some(stripped) = link
+        .strip_prefix(ZED_URL_SCHEME)
+        .and_then(|result| result.strip_prefix("://"))
+    {
+        return Some(stripped);
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -1627,17 +1635,6 @@ mod tests {
         executor.run_until_parked();
         assert_eq!(*auth_count.lock(), 2);
         assert_eq!(*dropped_auth_count.lock(), 1);
-    }
-
-    #[test]
-    fn test_encode_and_decode_worktree_url() {
-        let url = encode_worktree_url(5, "deadbeef");
-        assert_eq!(decode_worktree_url(&url), Some((5, "deadbeef".to_string())));
-        assert_eq!(
-            decode_worktree_url(&format!("\n {}\t", url)),
-            Some((5, "deadbeef".to_string()))
-        );
-        assert_eq!(decode_worktree_url("not://the-right-format"), None);
     }
 
     #[gpui::test]

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -265,7 +265,7 @@ impl ChannelView {
             return;
         };
 
-        let link = channel.notes_link(closest_heading.map(|heading| heading.text));
+        let link = channel.notes_link(closest_heading.map(|heading| heading.text), cx);
         cx.write_to_clipboard(ClipboardItem::new(link));
         self.workspace
             .update(cx, |workspace, cx| {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2023,7 +2023,7 @@ impl CollabPanel {
         let Some(channel) = channel_store.channel_for_id(channel_id) else {
             return;
         };
-        let item = ClipboardItem::new(channel.link());
+        let item = ClipboardItem::new(channel.link(cx));
         cx.write_to_clipboard(item)
     }
 
@@ -2206,7 +2206,7 @@ impl CollabPanel {
 
                     let channel = self.channel_store.read(cx).channel_for_id(channel_id)?;
 
-                    channel_link = Some(channel.link());
+                    channel_link = Some(channel.link(cx));
                     (channel_icon, channel_tooltip_text) = match channel.visibility {
                         proto::ChannelVisibility::Public => {
                             (Some("icons/public.svg"), Some("Copy public channel link."))

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -197,7 +197,7 @@ impl Render for ChannelModal {
                                                 .read(cx)
                                                 .channel_for_id(channel_id)
                                             {
-                                                let item = ClipboardItem::new(channel.link());
+                                                let item = ClipboardItem::new(channel.link(cx));
                                                 cx.write_to_clipboard(item);
                                             }
                                         })),

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -18,7 +18,6 @@ gpui.workspace = true
 picker.workspace = true
 postage.workspace = true
 project.workspace = true
-release_channel.workspace = true
 serde.workspace = true
 settings.workspace = true
 theme.workspace = true

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -25,6 +25,7 @@ use zed_actions::OpenZedUrl;
 actions!(command_palette, [Toggle]);
 
 pub fn init(cx: &mut AppContext) {
+    client::init_settings(cx);
     cx.set_global(HitCounts::default());
     cx.set_global(CommandPaletteFilter::default());
     cx.observe_new_views(CommandPalette::register).detach();

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use client::telemetry::Telemetry;
+use client::{parse_zed_link, telemetry::Telemetry};
 use collections::HashMap;
 use command_palette_hooks::{
     CommandInterceptResult, CommandPaletteFilter, CommandPaletteInterceptor,
@@ -17,7 +17,6 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 
 use postage::{sink::Sink, stream::Stream};
-use release_channel::parse_zed_link;
 use ui::{h_flex, prelude::*, v_flex, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing};
 use util::ResultExt;
 use workspace::{ModalView, Workspace};
@@ -192,7 +191,7 @@ impl CommandPaletteDelegate {
                 None
             };
 
-        if parse_zed_link(&query).is_some() {
+        if parse_zed_link(&query, cx).is_some() {
             intercept_result = Some(CommandInterceptResult {
                 action: OpenZedUrl { url: query.clone() }.boxed_clone(),
                 string: query.clone(),

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -566,6 +566,14 @@ impl AppContext {
         self.platform.open_url(url);
     }
 
+    /// register_url_scheme requests that the given scheme (e.g. `zed` for `zed://` urls)
+    /// is opened by the current app.
+    /// On some platforms (e.g. macOS) you may be able to register URL schemes as part of app
+    /// distribution, but this method exists to let you register schemes at runtime.
+    pub fn register_url_scheme(&self, scheme: &str) -> Task<Result<()>> {
+        self.platform.register_url_scheme(scheme)
+    }
+
     /// Returns the full pathname of the current app bundle.
     /// If the app is not being run from a bundle, returns an error.
     pub fn app_path(&self) -> Result<PathBuf> {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -101,6 +101,8 @@ pub(crate) trait Platform: 'static {
 
     fn open_url(&self, url: &str);
     fn on_open_urls(&self, callback: Box<dyn FnMut(Vec<String>)>);
+    fn register_url_scheme(&self, url: &str) -> Task<Result<()>>;
+
     fn prompt_for_paths(
         &self,
         options: PathPromptOptions,

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -441,6 +441,10 @@ impl Platform for LinuxPlatform {
     fn window_appearance(&self) -> crate::WindowAppearance {
         crate::WindowAppearance::Light
     }
+
+    fn register_url_scheme(&self, _: &str) -> Task<anyhow::Result<()>> {
+        Task::ready(Err(anyhow!("register_url_scheme unimplemented")))
+    }
 }
 
 #[cfg(test)]

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -298,4 +298,8 @@ impl Platform for TestPlatform {
     fn double_click_interval(&self) -> std::time::Duration {
         Duration::from_millis(500)
     }
+
+    fn register_url_scheme(&self, _: &str) -> Task<anyhow::Result<()>> {
+        unimplemented!()
+    }
 }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -314,4 +314,8 @@ impl Platform for WindowsPlatform {
     fn delete_credentials(&self, url: &str) -> Task<Result<()>> {
         Task::Ready(Some(Err(anyhow!("not implemented yet."))))
     }
+
+    fn register_url_scheme(&self, _: &str) -> Task<anyhow::Result<()>> {
+        Task::ready(Err(anyhow!("register_url_scheme unimplemented")))
+    }
 }

--- a/crates/install_cli/src/install_cli.rs
+++ b/crates/install_cli/src/install_cli.rs
@@ -1,18 +1,18 @@
 use anyhow::{anyhow, Result};
 use gpui::{actions, AsyncAppContext};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use util::ResultExt;
 
-actions!(cli, [Install]);
+actions!(cli, [Install, RegisterZedScheme]);
 
-pub async fn install_cli(cx: &AsyncAppContext) -> Result<()> {
+pub async fn install_cli(cx: &AsyncAppContext) -> Result<PathBuf> {
     let cli_path = cx.update(|cx| cx.path_for_auxiliary_executable("cli"))??;
     let link_path = Path::new("/usr/local/bin/zed");
     let bin_dir_path = link_path.parent().unwrap();
 
     // Don't re-create symlink if it points to the same CLI binary.
     if smol::fs::read_link(link_path).await.ok().as_ref() == Some(&cli_path) {
-        return Ok(());
+        return Ok(link_path.into());
     }
 
     // If the symlink is not there or is outdated, first try replacing it
@@ -26,7 +26,7 @@ pub async fn install_cli(cx: &AsyncAppContext) -> Result<()> {
             .log_err()
             .is_some()
         {
-            return Ok(());
+            return Ok(link_path.into());
         }
     }
 
@@ -51,7 +51,7 @@ pub async fn install_cli(cx: &AsyncAppContext) -> Result<()> {
         .await?
         .status;
     if status.success() {
-        Ok(())
+        Ok(link_path.into())
     } else {
         Err(anyhow!("error running osascript"))
     }

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -139,26 +139,6 @@ impl ReleaseChannel {
         }
     }
 
-    /// Returns the URL scheme for this [`ReleaseChannel`].
-    pub fn url_scheme(&self) -> &'static str {
-        match self {
-            ReleaseChannel::Dev => "zed-dev://",
-            ReleaseChannel::Nightly => "zed-nightly://",
-            ReleaseChannel::Preview => "zed-preview://",
-            ReleaseChannel::Stable => "zed://",
-        }
-    }
-
-    /// Returns the link prefix for this [`ReleaseChannel`].
-    pub fn link_prefix(&self) -> &'static str {
-        match self {
-            ReleaseChannel::Dev => "https://zed.dev/dev/",
-            ReleaseChannel::Nightly => "https://zed.dev/nightly/",
-            ReleaseChannel::Preview => "https://zed.dev/preview/",
-            ReleaseChannel::Stable => "https://zed.dev/",
-        }
-    }
-
     /// Returns the query parameter for this [`ReleaseChannel`].
     pub fn release_query_param(&self) -> Option<&'static str> {
         match self {
@@ -168,25 +148,4 @@ impl ReleaseChannel {
             Self::Stable => None,
         }
     }
-}
-
-/// Parses the given link into a Zed link.
-///
-/// Returns a [`Some`] containing the unprefixed link if the link is a Zed link.
-/// Returns [`None`] otherwise.
-pub fn parse_zed_link(link: &str) -> Option<&str> {
-    for release in [
-        ReleaseChannel::Dev,
-        ReleaseChannel::Nightly,
-        ReleaseChannel::Preview,
-        ReleaseChannel::Stable,
-    ] {
-        if let Some(stripped) = link.strip_prefix(release.link_prefix()) {
-            return Some(stripped);
-        }
-        if let Some(stripped) = link.strip_prefix(release.url_scheme()) {
-            return Some(stripped);
-        }
-    }
-    None
 }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -107,7 +107,7 @@ identifier = "dev.zed.Zed-Dev"
 name = "Zed Dev"
 osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
-osx_url_schemes = ["zed-dev"]
+osx_url_schemes = ["zed"]
 
 [package.metadata.bundle-nightly]
 icon = ["resources/app-icon-nightly@2x.png", "resources/app-icon-nightly.png"]
@@ -115,7 +115,7 @@ identifier = "dev.zed.Zed-Nightly"
 name = "Zed Nightly"
 osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
-osx_url_schemes = ["zed-nightly"]
+osx_url_schemes = ["zed"]
 
 [package.metadata.bundle-preview]
 icon = ["resources/app-icon-preview@2x.png", "resources/app-icon-preview.png"]
@@ -123,7 +123,7 @@ identifier = "dev.zed.Zed-Preview"
 name = "Zed Preview"
 osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
-osx_url_schemes = ["zed-preview"]
+osx_url_schemes = ["zed"]
 
 [package.metadata.bundle-stable]
 icon = ["resources/app-icon@2x.png", "resources/app-icon.png"]

--- a/crates/zed/src/open_listener.rs
+++ b/crates/zed/src/open_listener.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use cli::{ipc, IpcHandshake};
 use cli::{ipc::IpcSender, CliRequest, CliResponse};
+use client::parse_zed_link;
 use collections::HashMap;
 use editor::scroll::Autoscroll;
 use editor::Editor;
@@ -10,7 +11,6 @@ use futures::{FutureExt, SinkExt, StreamExt};
 use gpui::{AppContext, AsyncAppContext, Global};
 use itertools::Itertools;
 use language::{Bias, Point};
-use release_channel::parse_zed_link;
 use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -66,13 +66,13 @@ impl OpenListener {
         )
     }
 
-    pub fn open_urls(&self, urls: &[String]) {
+    pub fn open_urls(&self, urls: &[String], cx: &AppContext) {
         self.triggered.store(true, Ordering::Release);
         let request = if let Some(server_name) =
             urls.first().and_then(|url| url.strip_prefix("zed-cli://"))
         {
             self.handle_cli_connection(server_name)
-        } else if let Some(request_path) = urls.first().and_then(|url| parse_zed_link(url)) {
+        } else if let Some(request_path) = urls.first().and_then(|url| parse_zed_link(url, cx)) {
             self.handle_zed_url_scheme(request_path)
         } else {
             self.handle_file_urls(urls)

--- a/script/bundle
+++ b/script/bundle
@@ -173,6 +173,7 @@ if [ "$local_arch" = false ]; then
     cp -R target/${local_target_triple}/${target_dir}/WebRTC.framework "${app_path}/Contents/Frameworks/"
 else
     cp -R target/${target_dir}/WebRTC.framework "${app_path}/Contents/Frameworks/"
+    cp -R target/${target_dir}/cli "${app_path}/Contents/MacOS/"
 fi
 
 # Note: The app identifier for our development builds is the same as the app identifier for nightly.


### PR DESCRIPTION
Also adds a new command `cli: Register Zed Scheme` that will cause URLs
to be opened in the current zed version, and we call this implicitly if
you install the CLI

Also add some status reporting to install cli

Fixes: #8857



Release Notes:

- Added success/error reporting to `cli: Install Cli` ([#8857](https://github.com/zed-industries/zed/issues/8857)).
- Removed `zed-{preview,nightly,dev}:` url schemes (used by channel links)
- Added `cli: Register Zed Scheme` to control which zed handles the `zed://` scheme (defaults to the most recently installed, or
the version that you last used `cli: Install Cli` with)
