### PR TITLE
Add ZED_SELECTED_TEXT variable to tasks

### DIFF
--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -113,9 +113,12 @@ fn task_context(
                         .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
                 });
 
+                let selected_text = buffer.read(cx).chars_for_range(selection_range).collect();
+
                 let mut env = HashMap::from_iter([
                     ("ZED_ROW".into(), row.to_string()),
                     ("ZED_COLUMN".into(), column.to_string()),
+                    ("ZED_SELECTED_TEXT".into(), selected_text),
                 ]);
                 if let Some(path) = current_file {
                     env.insert("ZED_FILE".into(), path);

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -323,6 +323,7 @@ mod tests {
                         ("ZED_WORKTREE_ROOT".into(), "/dir".into()),
                         ("ZED_ROW".into(), "1".into()),
                         ("ZED_COLUMN".into(), "1".into()),
+                        ("ZED_SELECTED_TEXT".into(), "".into())
                     ])
                 }
             );
@@ -340,6 +341,7 @@ mod tests {
                         ("ZED_SYMBOL".into(), "this_is_a_rust_file".into()),
                         ("ZED_ROW".into(), "1".into()),
                         ("ZED_COLUMN".into(), "15".into()),
+                        ("ZED_SELECTED_TEXT".into(), "is_i".into()),
                     ])
                 }
             );
@@ -356,6 +358,7 @@ mod tests {
                         ("ZED_SYMBOL".into(), "this_is_a_test".into()),
                         ("ZED_ROW".into(), "1".into()),
                         ("ZED_COLUMN".into(), "1".into()),
+                        ("ZED_SELECTED_TEXT".into(), "".into()),
                     ])
                 }
             );


### PR DESCRIPTION
Tasks are able to access a users selected text using the environment variable "ZED_SELECTED_TEXT". 

Release notes:

- Added ZED_SELECTED_TEXT task variable which contains contents of selection
