### PR TITLE
Optimize rustybuzz and ttf-parser in Dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,6 +337,8 @@ debug = "full"
 [profile.dev.package]
 taffy = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }
+rustybuzz = { opt-level = 3 }
+ttf-parser = { opt-level = 3 }
 wasmtime-cranelift = { opt-level = 3 }
 
 [profile.release]


### PR DESCRIPTION
This PR improves the `draw()` time from hundreds to about 30ms, so roughly 10x.
It makes Zed quite usable in Dev profile.

Release Notes:
- N/A
