### PR TITLE
project: still call codeAction/resolve if no range is found

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5423,6 +5423,10 @@ impl Project {
                     action.lsp_action = lang_server
                         .request::<lsp::request::CodeActionResolveRequest>(action.lsp_action)
                         .await?;
+                } else if action.lsp_action.data.is_some() {
+                    action.lsp_action = lang_server
+                        .request::<lsp::request::CodeActionResolveRequest>(action.lsp_action)
+                        .await?;
                 } else {
                     let actions = this
                         .update(&mut cx, |this, cx| {


### PR DESCRIPTION
Go (gopls) code action `Fill Struct` stopped working. It appears that the code action is coming back with range data buried within the `data` field. I'm no expert in LSP but it appears data can contain any language server specific data to be sent in a subsequent request to `codeAction/resolve`. So I added a new else condition to still apply the resolve if there's a data field. This fixed the case of gopls struct fill not being applied and I'd assume other LSP actions.