### PR TITLE
Fix all Picker Item cursor to use `Pointer`.

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -325,6 +325,7 @@ impl<D: PickerDelegate> Picker<D> {
     fn render_element(&self, cx: &mut ViewContext<Self>, ix: usize) -> impl IntoElement {
         div()
             .id(("item", ix))
+            .cursor_pointer()
             .on_click(cx.listener(move |this, event: &ClickEvent, cx| {
                 this.handle_click(ix, event.down.modifiers.command, cx)
             }))

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -133,7 +133,6 @@ impl Render for RecentProjects {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_flex()
             .w(rems(self.rem_width))
-            .cursor_pointer()
             .child(self.picker.clone())
             .on_mouse_down_out(cx.listener(|this, _, cx| {
                 this.picker.update(cx, |this, cx| {

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -67,7 +67,6 @@ impl Render for BranchList {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         v_flex()
             .w(rems(self.rem_width))
-            .cursor_pointer()
             .child(self.picker.clone())
             .on_mouse_down_out(cx.listener(|this, _, cx| {
                 this.picker.update(cx, |this, cx| {


### PR DESCRIPTION

Release Notes:

- Fixed Picker Item cursor style to use `Pointer`.


## Before

https://github.com/zed-industries/zed/assets/5518/84874858-7847-4fa4-b7a3-41ecc65a2f7d

## After

https://github.com/zed-industries/zed/assets/5518/d395ea96-aa26-4de1-8bfc-73cc43ee75cf


Hi @SomeoneToIgnore I have make changed for cursor style for Recent Projects and VCS Menu before in #8595, but I missed some cases. So I try to fix it again.

It looks like just need to update the Picker Item (There have a click action), Then the all Picker fixed.

I also did this in #8798 before, but you not accept it, maybe I was changed a wrong place. But now, I think this it right way, please check it again.