### PR TITLE
Improve VCS Menu header top margin.

### DIFF
--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -9,7 +9,7 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 use std::{ops::Not, sync::Arc};
 use ui::{
-    h_flex, v_flex, Button, ButtonCommon, Clickable, HighlightedLabel, Label, LabelCommon,
+    h_flex, v_flex, Button, ButtonCommon, Clickable, Color, HighlightedLabel, Label, LabelCommon,
     LabelSize, ListItem, ListItemSpacing, Selectable,
 };
 use util::ResultExt;
@@ -293,11 +293,13 @@ impl PickerDelegate for BranchListDelegate {
         let label = if self.last_query.is_empty() {
             h_flex()
                 .ml_3()
-                .child(Label::new("Recent branches").size(LabelSize::Small))
+                .child(Label::new("Recent Branches").size(LabelSize::Small))
         } else {
             let match_label = self.matches.is_empty().not().then(|| {
                 let suffix = if self.matches.len() == 1 { "" } else { "es" };
-                Label::new(format!("{} match{}", self.matches.len(), suffix)).size(LabelSize::Small)
+                Label::new(format!("{} match{}", self.matches.len(), suffix))
+                    .color(Color::Muted)
+                    .size(LabelSize::Small)
             });
             h_flex()
                 .px_3()
@@ -306,7 +308,7 @@ impl PickerDelegate for BranchListDelegate {
                 .child(Label::new("Branches").size(LabelSize::Small))
                 .children(match_label)
         };
-        Some(label.into_any())
+        Some(label.mt_1().into_any())
     }
     fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<AnyElement> {
         if self.last_query.is_empty() {


### PR DESCRIPTION

Release Notes:

- Improve VCS Menu header top margin, and use `TextMuted` color for matched count label.

## Before
![SCR-20240305-nga](https://github.com/zed-industries/zed/assets/5518/e814d770-a5b1-4289-acc4-808bf7d96690)
![SCR-20240305-nge](https://github.com/zed-industries/zed/assets/5518/abba4f7c-7e6c-447f-8e4f-fbecdf802f62)

## After
![SCR-20240305-nfp](https://github.com/zed-industries/zed/assets/5518/5539b15c-c67d-466b-9c46-44e488788b04)
![SCR-20240305-nfu](https://github.com/zed-industries/zed/assets/5518/5cfdf861-b55c-4f1e-a41f-dcd42a449488)
