### PR TITLE
Fix first/last item margin on scroll

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -396,6 +396,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                 .child(
                     h_flex()
                         .w_full()
+                        .py_px()
                         .justify_between()
                         .child(HighlightedLabel::new(
                             command.name.clone(),

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -880,6 +880,7 @@ impl PickerDelegate for FileFinderDelegate {
                 .child(
                     h_flex()
                         .gap_2()
+                        .py_px()
                         .child(HighlightedLabel::new(file_name, file_name_positions))
                         .child(
                             HighlightedLabel::new(full_path, full_path_positions)

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -241,7 +241,7 @@ impl ListState {
             let mut cursor = state.items.cursor::<ListItemSummary>();
             cursor.seek(&Count(ix + 1), Bias::Right, &());
             let bottom = cursor.start().height + padding.top;
-            let goal_top = px(0.).max(bottom - height);
+            let goal_top = px(0.).max(bottom - height + padding.bottom);
 
             cursor.seek(&Height(goal_top), Bias::Left, &());
             let start_ix = cursor.start().count;

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -221,10 +221,10 @@ impl Element for UniformList {
                         let item_top = item_height * ix + padding.top;
                         let item_bottom = item_top + item_height;
                         let scroll_top = -updated_scroll_offset.y;
-                        if item_top < scroll_top {
-                            updated_scroll_offset.y = -item_top;
-                        } else if item_bottom > scroll_top + list_height {
-                            updated_scroll_offset.y = -(item_bottom - list_height);
+                        if item_top < scroll_top + padding.top {
+                            updated_scroll_offset.y = -(item_top) + padding.top;
+                        } else if item_bottom > scroll_top + list_height - padding.bottom {
+                            updated_scroll_offset.y = -(item_bottom - list_height) - padding.bottom;
                         }
                         scroll_offset = *updated_scroll_offset;
                     }


### PR DESCRIPTION
Release Notes:

- Fixed first and last item margin when scroll view has padding.

## Before

https://github.com/zed-industries/zed/assets/5518/f7a4563a-504a-4a41-bfd4-21e9439cd02b

## After

https://github.com/zed-industries/zed/assets/5518/0ba41527-46fd-404f-8207-1b8c5cf37434


This change has modified the gpui basic element, so I don't know is there have side effect that out of my tests. By my tested cases, it is looks ok.

![output](https://github.com/zed-industries/zed/assets/5518/e39a3600-99c4-4d3c-baee-efd53a474f38)



