### PR TITLE
Wayland: Support integer scaling without wp_fractional_scale

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -55,10 +55,7 @@ pub(crate) struct WaylandClientStateInner {
     fractional_scale_manager: Option<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
     decoration_manager: Option<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1>,
     windows: Vec<(xdg_surface::XdgSurface, Rc<WaylandWindowState>)>,
-    outputs: Vec<(
-        wl_output::WlOutput,
-        Rc<RefCell<OutputState>>,
-    )>,
+    outputs: Vec<(wl_output::WlOutput, Rc<RefCell<OutputState>>)>,
     platform_inner: Rc<LinuxPlatformInner>,
     keymap_state: Option<xkb::State>,
     repeat: KeyRepeat,
@@ -132,7 +129,9 @@ impl WaylandClient {
         });
 
         let mut state_inner = Rc::new(RefCell::new(WaylandClientStateInner {
-            compositor: globals.bind(&qh, 1..=wl_surface::EVT_PREFERRED_BUFFER_SCALE_SINCE, ()).unwrap(),
+            compositor: globals
+                .bind(&qh, 1..=wl_surface::EVT_PREFERRED_BUFFER_SCALE_SINCE, ())
+                .unwrap(),
             wm_base: globals.bind(&qh, 1..=1, ()).unwrap(),
             shm: globals.bind(&qh, 1..=1, ()).unwrap(),
             outputs,
@@ -365,7 +364,9 @@ impl Dispatch<wl_surface::WlSurface, ()> for WaylandClientState {
 
         // We use `WpFractionalScale` instead to set the scale if it's available
         // or give up on scaling if `WlSurface::set_buffer_scale` isn't available
-        if state.fractional_scale_manager.is_some() || state.compositor.version() < wl_surface::REQ_SET_BUFFER_SCALE_SINCE {
+        if state.fractional_scale_manager.is_some()
+            || state.compositor.version() < wl_surface::REQ_SET_BUFFER_SCALE_SINCE
+        {
             return;
         }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::num::NonZeroU32;
 use std::rc::Rc;

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -10,6 +10,7 @@ use wayland_backend::client::ObjectId;
 use wayland_backend::protocol::WEnum;
 use wayland_client::globals::{registry_queue_init, GlobalListContents};
 use wayland_client::protocol::wl_callback::WlCallback;
+use wayland_client::protocol::wl_output;
 use wayland_client::protocol::wl_pointer::AxisRelativeDirection;
 use wayland_client::{
     delegate_noop,
@@ -294,7 +295,6 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for WaylandClientStat
 }
 
 delegate_noop!(WaylandClientState: ignore wl_compositor::WlCompositor);
-delegate_noop!(WaylandClientState: ignore wl_surface::WlSurface);
 delegate_noop!(WaylandClientState: ignore wl_shm::WlShm);
 delegate_noop!(WaylandClientState: ignore wl_shm_pool::WlShmPool);
 delegate_noop!(WaylandClientState: ignore wl_buffer::WlBuffer);
@@ -321,6 +321,57 @@ impl Dispatch<WlCallback, Arc<WlSurface>> for WaylandClientState {
                     window.1.surface.commit();
                 }
             }
+        }
+    }
+}
+
+impl Dispatch<wl_surface::WlSurface, ()> for WaylandClientState {
+    fn event(
+        state: &mut Self,
+        surface: &wl_surface::WlSurface,
+        event: <wl_surface::WlSurface as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let mut state = state.client_state_inner.borrow_mut();
+        dbg!(&event);
+        match event {
+            wl_surface::Event::Enter { output } => {
+                todo!()
+            },
+            wl_surface::Event::Leave { output } => {
+                todo!()
+            },
+            wl_surface::Event::PreferredBufferScale { factor } => {
+                for window in &state.windows {
+                    if &*window.1.surface == surface {
+                        window.1.rescale(factor as f32 / 120.0);
+                        surface.set_buffer_scale(factor);
+                        return;
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+impl Dispatch<wl_output::WlOutput, ()> for WaylandClientState {
+    fn event(
+        state: &mut Self,
+        proxy: &wl_output::WlOutput,
+        event: <wl_output::WlOutput as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let mut state = state.client_state_inner.borrow_mut();
+        dbg!(&event);
+        match event {
+            wl_output::Event::Scale { factor } => todo!(),
+            wl_output::Event::Done => todo!(),
+            _ => {},
         }
     }
 }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -116,7 +116,8 @@ impl WaylandClient {
             wm_base: globals.bind(&qh, 1..=1, ()).unwrap(),
             shm: globals.bind(&qh, 1..=1, ()).unwrap(),
             viewporter: globals.bind(&qh, 1..=1, ()).ok(),
-            fractional_scale_manager: globals.bind(&qh, 1..=1, ()).ok(),
+            // fractional_scale_manager: globals.bind(&qh, 1..=1, ()).ok(),
+            fractional_scale_manager: None,
             decoration_manager: globals.bind(&qh, 1..=1, ()).ok(),
             windows: Vec::new(),
             platform_inner: Rc::clone(&linux_platform_inner),
@@ -232,9 +233,9 @@ impl Client for WaylandClient {
             options,
         ));
 
-        if let Some(fractional_scale_manager) = state.fractional_scale_manager.as_ref() {
-            fractional_scale_manager.get_fractional_scale(&wl_surface, &self.qh, xdg_surface.id());
-        }
+        // if let Some(fractional_scale_manager) = state.fractional_scale_manager.as_ref() {
+        //     fractional_scale_manager.get_fractional_scale(&wl_surface, &self.qh, xdg_surface.id());
+        // }
 
         state.windows.push((xdg_surface, Rc::clone(&window_state)));
         Box::new(WaylandWindow(window_state))
@@ -297,7 +298,7 @@ delegate_noop!(WaylandClientState: ignore wl_surface::WlSurface);
 delegate_noop!(WaylandClientState: ignore wl_shm::WlShm);
 delegate_noop!(WaylandClientState: ignore wl_shm_pool::WlShmPool);
 delegate_noop!(WaylandClientState: ignore wl_buffer::WlBuffer);
-delegate_noop!(WaylandClientState: ignore wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
+// delegate_noop!(WaylandClientState: ignore wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
 delegate_noop!(WaylandClientState: ignore zxdg_decoration_manager_v1::ZxdgDecorationManagerV1);
 delegate_noop!(WaylandClientState: ignore wp_viewporter::WpViewporter);
 delegate_noop!(WaylandClientState: ignore wp_viewport::WpViewport);
@@ -765,26 +766,26 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientState {
     }
 }
 
-impl Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, ObjectId> for WaylandClientState {
-    fn event(
-        state: &mut Self,
-        _: &wp_fractional_scale_v1::WpFractionalScaleV1,
-        event: <wp_fractional_scale_v1::WpFractionalScaleV1 as Proxy>::Event,
-        id: &ObjectId,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-    ) {
-        let mut state = state.client_state_inner.borrow_mut();
-        if let wp_fractional_scale_v1::Event::PreferredScale { scale, .. } = event {
-            for window in &state.windows {
-                if window.0.id() == *id {
-                    window.1.rescale(scale as f32 / 120.0);
-                    return;
-                }
-            }
-        }
-    }
-}
+// impl Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, ObjectId> for WaylandClientState {
+//     fn event(
+//         state: &mut Self,
+//         _: &wp_fractional_scale_v1::WpFractionalScaleV1,
+//         event: <wp_fractional_scale_v1::WpFractionalScaleV1 as Proxy>::Event,
+//         id: &ObjectId,
+//         _: &Connection,
+//         _: &QueueHandle<Self>,
+//     ) {
+//         let mut state = state.client_state_inner.borrow_mut();
+//         if let wp_fractional_scale_v1::Event::PreferredScale { scale, .. } = event {
+//             for window in &state.windows {
+//                 if window.0.id() == *id {
+//                     window.1.rescale(scale as f32 / 120.0);
+//                     return;
+//                 }
+//             }
+//         }
+//     }
+// }
 
 impl Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, ObjectId>
     for WaylandClientState

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -6,10 +6,12 @@ use std::sync::Arc;
 
 use blade_graphics as gpu;
 use blade_rwh::{HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle};
+use collections::HashSet;
 use futures::channel::oneshot::Receiver;
 use raw_window_handle::{
     DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, WindowHandle,
 };
+use wayland_backend::client::ObjectId;
 use wayland_client::{protocol::wl_surface, Proxy};
 use wayland_protocols::wp::viewporter::client::wp_viewport;
 use wayland_protocols::xdg::shell::client::xdg_toplevel;
@@ -110,6 +112,7 @@ pub(crate) struct WaylandWindowState {
     pub(crate) callbacks: RefCell<Callbacks>,
     pub(crate) surface: Arc<wl_surface::WlSurface>,
     pub(crate) toplevel: Arc<xdg_toplevel::XdgToplevel>,
+    pub(crate) outputs: RefCell<HashSet<ObjectId>>,
     viewport: Option<wp_viewport::WpViewport>,
 }
 
@@ -141,6 +144,7 @@ impl WaylandWindowState {
             surface: Arc::clone(&wl_surf),
             inner: RefCell::new(WaylandWindowInner::new(&wl_surf, bounds)),
             callbacks: RefCell::new(Callbacks::default()),
+            outputs: RefCell::new(HashSet::default()),
             toplevel,
             viewport,
         }


### PR DESCRIPTION
Release Notes:
- N/A

`DoubleBuffered` is not currently very necessary because we only care about a single field `OutputState::scale` but I think it can be useful for other objects as it's a fairly common pattern in wayland.