### PR TITLE
Move Clippy configuration to the workspace level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "fsevent"
-version = "2.0.2"
+version = "0.1.0"
 dependencies = [
  "bitflags 2.4.2",
  "fsevent-sys 3.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,8 +318,6 @@ features = [
     "Win32_System_Threading",
 ]
 
-
-
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "e4a23971ec3071a09c1e84816954c98f96e98e52" }
 # Workaround for a broken nightly build of gpui: See #7644 and revisit once 0.5.3 is released.
@@ -343,6 +341,36 @@ wasmtime-cranelift = { opt-level = 3 }
 debug = "limited"
 lto = "thin"
 codegen-units = 1
+
+[workspace.lints.clippy]
+dbg_macro = "deny"
+todo = "deny"
+
+# There are a bunch of rules currently failing in the `style` group, so
+# allow all of those, for now.
+"style" = "allow"
+
+# Individual rules that have violations in the codebase:
+almost_complete_range = "allow"
+arc_with_non_send_sync = "allow"
+await_holding_lock = "allow"
+borrow_deref_ref = "allow"
+borrowed_box = "allow"
+cast_abs_to_unsigned = "allow"
+cmp_owned = "allow"
+derive_ord_xor_partial_ord = "allow"
+eq_op = "allow"
+implied_bounds_in_impls = "allow"
+let_underscore_future = "allow"
+map_entry = "allow"
+never_loop = "allow"
+non_canonical_clone_impl = "allow"
+non_canonical_partial_ord_impl = "allow"
+reversed_empty_ranges = "allow"
+single_range_in_vec_init = "allow"
+suspicious_to_owned = "allow"
+type_complexity = "allow"
+unnecessary_to_owned = "allow"
 
 [workspace.metadata.cargo-machete]
 ignored = ["bindgen", "cbindgen", "prost_build", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,6 +346,17 @@ codegen-units = 1
 dbg_macro = "deny"
 todo = "deny"
 
+# These are all of the rules that currently have violations in the Zed
+# codebase.
+#
+# We'll want to drive this list down by either:
+# 1. fixing violations of the rule and begin enforcing it
+# 2. deciding we want to allow the rule permanently, at which point
+#    we should codify that separately above.
+#
+# This list shouldn't be added to; it should only get shorter.
+# =============================================================================
+
 # There are a bunch of rules currently failing in the `style` group, so
 # allow all of those, for now.
 style = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,7 +348,7 @@ todo = "deny"
 
 # There are a bunch of rules currently failing in the `style` group, so
 # allow all of those, for now.
-"style" = "allow"
+style = "allow"
 
 # Individual rules that have violations in the codebase:
 almost_complete_range = "allow"

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/activity_indicator.rs"
 doctest = false

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/ai.rs"
 doctest = false

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 gpui.workspace = true

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/assistant.rs"
 doctest = false

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/audio.rs"
 doctest = false

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/auto_update.rs"
 doctest = false

--- a/crates/breadcrumbs/Cargo.toml
+++ b/crates/breadcrumbs/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/breadcrumbs.rs"
 doctest = false

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/call.rs"
 doctest = false

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/channel.rs"
 doctest = false

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/cli.rs"
 doctest = false

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/client.rs"
 doctest = false

--- a/crates/clock/Cargo.toml
+++ b/crates/clock/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/clock.rs"
 doctest = false

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -7,6 +7,9 @@ version = "0.44.0"
 publish = false
 license = "AGPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "collab"
 

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/collab_ui.rs"
 doctest = false

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/collections.rs"
 doctest = false

--- a/crates/color/Cargo.toml
+++ b/crates/color/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/command_palette.rs"
 doctest = false

--- a/crates/command_palette_hooks/Cargo.toml
+++ b/crates/command_palette_hooks/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/command_palette_hooks.rs"
 doctest = false

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/copilot.rs"
 doctest = false

--- a/crates/copilot_ui/Cargo.toml
+++ b/crates/copilot_ui/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/copilot_ui.rs"
 doctest = false

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/db.rs"
 doctest = false

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/diagnostics.rs"
 doctest = false

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/editor.rs"
 doctest = false

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/extension_store.rs"
 

--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/extension_api.rs"
 

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/extensions_ui.rs"
 

--- a/crates/feature_flags/Cargo.toml
+++ b/crates/feature_flags/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/feature_flags.rs"
 

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/feedback.rs"
 

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/file_finder.rs"
 doctest = false

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/fs.rs"
 

--- a/crates/fsevent/Cargo.toml
+++ b/crates/fsevent/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "fsevent"
-version = "2.0.2"
-license = "MIT"
+version = "0.1.0"
 edition = "2021"
 publish = false
+license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
 
 [lib]
 path = "src/fsevent.rs"

--- a/crates/fuzzy/Cargo.toml
+++ b/crates/fuzzy/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/fuzzy.rs"
 doctest = false

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/git.rs"
 

--- a/crates/go_to_line/Cargo.toml
+++ b/crates/go_to_line/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/go_to_line.rs"
 doctest = false

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -7,6 +7,9 @@ description = "Zed's GPU-accelerated UI framework"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [features]
 test-support = [
     "backtrace",

--- a/crates/gpui_macros/Cargo.toml
+++ b/crates/gpui_macros/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/gpui_macros.rs"
 proc-macro = true

--- a/crates/install_cli/Cargo.toml
+++ b/crates/install_cli/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/install_cli.rs"
 

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/journal.rs"
 doctest = false

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/language.rs"
 doctest = false

--- a/crates/language_selector/Cargo.toml
+++ b/crates/language_selector/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/language_selector.rs"
 doctest = false

--- a/crates/language_tools/Cargo.toml
+++ b/crates/language_tools/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/language_tools.rs"
 doctest = false

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-compression.workspace = true

--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -6,6 +6,9 @@ description = "Bindings to LiveKit Swift client SDK"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/live_kit_client.rs"
 doctest = false

--- a/crates/live_kit_server/Cargo.toml
+++ b/crates/live_kit_server/Cargo.toml
@@ -6,6 +6,9 @@ description = "SDK for the LiveKit server API"
 publish = false
 license = "AGPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/live_kit_server.rs"
 doctest = false

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lsp.rs"
 doctest = false

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/markdown_preview.rs"
 

--- a/crates/media/Cargo.toml
+++ b/crates/media/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/media.rs"
 doctest = false

--- a/crates/menu/Cargo.toml
+++ b/crates/menu/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/menu.rs"
 doctest = false

--- a/crates/multi_buffer/Cargo.toml
+++ b/crates/multi_buffer/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/multi_buffer.rs"
 doctest = false

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/node_runtime.rs"
 doctest = false

--- a/crates/notifications/Cargo.toml
+++ b/crates/notifications/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/notification_store.rs"
 doctest = false

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/outline.rs"
 doctest = false

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/picker.rs"
 doctest = false

--- a/crates/prettier/Cargo.toml
+++ b/crates/prettier/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/prettier.rs"
 doctest = false

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/project.rs"
 doctest = false

--- a/crates/project_core/Cargo.toml
+++ b/crates/project_core/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 test-support = [

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/project_panel.rs"
 doctest = false

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/project_symbols.rs"
 doctest = false

--- a/crates/quick_action_bar/Cargo.toml
+++ b/crates/quick_action_bar/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/quick_action_bar.rs"
 doctest = false

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/recent_projects.rs"
 doctest = false

--- a/crates/refineable/Cargo.toml
+++ b/crates/refineable/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/refineable.rs"
 doctest = false

--- a/crates/refineable/derive_refineable/Cargo.toml
+++ b/crates/refineable/derive_refineable/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/derive_refineable.rs"
 proc-macro = true

--- a/crates/release_channel/Cargo.toml
+++ b/crates/release_channel/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 gpui.workspace = true
 once_cell = "1.19.0"

--- a/crates/rich_text/Cargo.toml
+++ b/crates/rich_text/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/rich_text.rs"
 doctest = false

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/rope.rs"
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.1.0"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/rpc.rs"
 doctest = false

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/search.rs"
 doctest = false

--- a/crates/semantic_index/Cargo.toml
+++ b/crates/semantic_index/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/semantic_index.rs"
 doctest = false

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/settings.rs"
 doctest = false

--- a/crates/snippet/Cargo.toml
+++ b/crates/snippet/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/snippet.rs"
 doctest = false

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true

--- a/crates/sqlez_macros/Cargo.toml
+++ b/crates/sqlez_macros/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/sqlez_macros.rs"
 proc-macro = true

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 gpui.workspace = true
 itertools = { package = "itertools", version = "0.10" }

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "storybook"
 path = "src/storybook.rs"

--- a/crates/sum_tree/Cargo.toml
+++ b/crates/sum_tree/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/sum_tree.rs"
 doctest = false

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true

--- a/crates/tasks_ui/Cargo.toml
+++ b/crates/tasks_ui/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 editor.workspace = true

--- a/crates/telemetry_events/Cargo.toml
+++ b/crates/telemetry_events/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/telemetry_events.rs"
 

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/terminal.rs"
 doctest = false

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/terminal_view.rs"
 doctest = false

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/text.rs"
 doctest = false

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 stories = ["dep:story"]

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/theme_selector.rs"
 doctest = false

--- a/crates/time_format/Cargo.toml
+++ b/crates/time_format/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/time_format.rs"
 doctest = false

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 name = "ui"
 path = "src/ui.rs"

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/util.rs"
 doctest = true

--- a/crates/vcs_menu/Cargo.toml
+++ b/crates/vcs_menu/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 fs.workspace = true

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/vim.rs"
 doctest = false

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/welcome.rs"
 

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/workspace.rs"
 doctest = false

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.126.0"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 name = "zed"
 path = "src/zed.rs"

--- a/crates/zed_actions/Cargo.toml
+++ b/crates/zed_actions/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 gpui.workspace = true
 serde.workspace = true

--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 zed_extension_api = { path = "../../crates/extension_api" }
 

--- a/tooling/xtask/Cargo.toml
+++ b/tooling/xtask/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -63,57 +63,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
     #[cfg(not(target_os = "windows"))]
     clippy_command.args(["--deny", "warnings"]);
 
-    /// These are all of the rules that currently have violations in the Zed
-    /// codebase.
-    ///
-    /// We'll want to drive this list down by either:
-    /// 1. fixing violations of the rule and begin enforcing it
-    /// 2. deciding we want to allow the rule permanently, at which point
-    ///    we should codify that separately in this task.
-    ///
-    /// This list shouldn't be added to; it should only get shorter.
-    const MIGRATORY_RULES_TO_ALLOW: &[&str] = &[
-        // There are a bunch of rules currently failing in the `style` group, so
-        // allow all of those, for now.
-        "clippy::style",
-        // Individual rules that have violations in the codebase:
-        "clippy::almost_complete_range",
-        "clippy::arc_with_non_send_sync",
-        "clippy::await_holding_lock",
-        "clippy::borrow_deref_ref",
-        "clippy::borrowed_box",
-        "clippy::cast_abs_to_unsigned",
-        "clippy::cmp_owned",
-        "clippy::derive_ord_xor_partial_ord",
-        "clippy::eq_op",
-        "clippy::implied_bounds_in_impls",
-        "clippy::let_underscore_future",
-        "clippy::map_entry",
-        "clippy::never_loop",
-        "clippy::non_canonical_clone_impl",
-        "clippy::non_canonical_partial_ord_impl",
-        "clippy::reversed_empty_ranges",
-        "clippy::single_range_in_vec_init",
-        "clippy::suspicious_to_owned",
-        "clippy::type_complexity",
-        "clippy::unnecessary_to_owned",
-    ];
-
-    // When fixing violations automatically for a single package we don't care
-    // about the rules we're already violating, since it may be possible to
-    // have them fixed automatically.
-    let ignore_suppressed_rules = args.fix && args.package.is_some();
-    if !ignore_suppressed_rules {
-        for rule in MIGRATORY_RULES_TO_ALLOW {
-            clippy_command.args(["--allow", rule]);
-        }
-    }
-
-    // Deny `dbg!` and `todo!`s.
-    clippy_command
-        .args(["--deny", "clippy::dbg_macro"])
-        .args(["--deny", "clippy::todo"]);
-
     eprintln!(
         "running: {cargo} {}",
         clippy_command


### PR DESCRIPTION
This PR moves the Clippy configuration up to the workspace level.

We're using the [`lints` table](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table) to configure the Clippy ruleset in the workspace's `Cargo.toml`.

Each crate in the workspace now has the following in their own `Cargo.toml` to inherit the lints from the workspace:

```toml
[lints]
workspace = true
```

This allows for configuring rust-analyzer to show Clippy lints in the editor by using the following configuration in your Zed `settings.json`:

```json
{
  "lsp": {
    "rust-analyzer": {
      "initialization_options": {
        "check": {
          "command": "clippy"
        }
      }
    }
  }
```

Release Notes:

- N/A
