### PR TITLE
Always resolve code action if needed

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -570,7 +570,14 @@ impl LanguageServer {
                         }),
                         data_support: Some(true),
                         resolve_support: Some(CodeActionCapabilityResolveSupport {
-                            properties: vec!["edit".to_string(), "command".to_string()],
+                            properties: vec![
+                                "kind".to_string(),
+                                "diagnostics".to_string(),
+                                "isPreferred".to_string(),
+                                "disabled".to_string(),
+                                "edit".to_string(),
+                                "command".to_string(),
+                            ],
                         }),
                         ..Default::default()
                     }),

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1834,6 +1834,19 @@ impl LspCommand for GetCodeActions {
     }
 }
 
+impl GetCodeActions {
+    pub fn can_resolve_actions(capabilities: &ServerCapabilities) -> bool {
+        capabilities
+            .code_action_provider
+            .as_ref()
+            .and_then(|options| match options {
+                lsp::CodeActionProviderCapability::Simple(_is_supported) => None,
+                lsp::CodeActionProviderCapability::Options(options) => options.resolve_provider,
+            })
+            .unwrap_or(false)
+    }
+}
+
 #[async_trait(?Send)]
 impl LspCommand for OnTypeFormatting {
     type Response = Option<Transaction>;

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5423,6 +5423,10 @@ impl Project {
                     action.lsp_action = lang_server
                         .request::<lsp::request::CodeActionResolveRequest>(action.lsp_action)
                         .await?;
+                } else if action.lsp_action.data.is_some() {
+                    action.lsp_action = lang_server
+                        .request::<lsp::request::CodeActionResolveRequest>(action.lsp_action)
+                        .await?;
                 } else {
                     let actions = this
                         .update(&mut cx, |this, cx| {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -36,11 +36,11 @@ use language::{
         deserialize_anchor, deserialize_fingerprint, deserialize_line_ending, deserialize_version,
         serialize_anchor, serialize_version, split_operations,
     },
-    range_from_lsp, range_to_lsp, Bias, Buffer, BufferSnapshot, CachedLspAdapter, Capability,
-    CodeAction, CodeLabel, Completion, Diagnostic, DiagnosticEntry, DiagnosticSet, Diff,
-    Documentation, Event as BufferEvent, File as _, Language, LanguageRegistry, LanguageServerName,
-    LocalFile, LspAdapterDelegate, OffsetRangeExt, Operation, Patch, PendingLanguageServer,
-    PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction, Unclipped,
+    range_from_lsp, Bias, Buffer, BufferSnapshot, CachedLspAdapter, Capability, CodeAction,
+    CodeLabel, Completion, Diagnostic, DiagnosticEntry, DiagnosticSet, Diff, Documentation,
+    Event as BufferEvent, File as _, Language, LanguageRegistry, LanguageServerName, LocalFile,
+    LspAdapterDelegate, Operation, Patch, PendingLanguageServer, PointUtf16, TextBufferSnapshot,
+    ToOffset, ToPointUtf16, Transaction, Unclipped,
 };
 use log::error;
 use lsp::{
@@ -4347,7 +4347,10 @@ impl Project {
                                 })?
                                 .await?;
 
-                            for action in actions {
+                            for mut action in actions {
+                                Self::try_resolve_code_action(&language_server, &mut action)
+                                    .await
+                                    .context("resolving a formatting code action")?;
                                 if let Some(edit) = action.lsp_action.edit {
                                     if edit.changes.is_none() && edit.document_changes.is_none() {
                                         continue;
@@ -4367,6 +4370,7 @@ impl Project {
                                     project_transaction.0.extend(new.0);
                                 }
 
+                                // TODO kb here too:
                                 if let Some(command) = action.lsp_action.command {
                                     project.update(&mut cx, |this, _| {
                                         this.last_workspace_edits_by_language_server
@@ -5409,37 +5413,10 @@ impl Project {
             } else {
                 return Task::ready(Ok(Default::default()));
             };
-            let range = action.range.to_point_utf16(buffer);
-
             cx.spawn(move |this, mut cx| async move {
-                if let Some(lsp_range) = action
-                    .lsp_action
-                    .data
-                    .as_mut()
-                    .and_then(|d| d.get_mut("codeActionParams"))
-                    .and_then(|d| d.get_mut("range"))
-                {
-                    *lsp_range = serde_json::to_value(&range_to_lsp(range)).unwrap();
-                    action.lsp_action = lang_server
-                        .request::<lsp::request::CodeActionResolveRequest>(action.lsp_action)
-                        .await?;
-                } else if action.lsp_action.data.is_some() {
-                    action.lsp_action = lang_server
-                        .request::<lsp::request::CodeActionResolveRequest>(action.lsp_action)
-                        .await?;
-                } else {
-                    let actions = this
-                        .update(&mut cx, |this, cx| {
-                            this.code_actions(&buffer_handle, action.range, cx)
-                        })?
-                        .await?;
-                    action.lsp_action = actions
-                        .into_iter()
-                        .find(|a| a.lsp_action.title == action.lsp_action.title)
-                        .ok_or_else(|| anyhow!("code action is outdated"))?
-                        .lsp_action;
-                }
-
+                Self::try_resolve_code_action(&lang_server, &mut action)
+                    .await
+                    .context("resolving a code action")?;
                 if let Some(edit) = action.lsp_action.edit {
                     if edit.changes.is_some() || edit.document_changes.is_some() {
                         return Self::deserialize_workspace_edit(
@@ -8299,6 +8276,23 @@ impl Project {
         Ok(proto::ResolveInlayHintResponse {
             hint: Some(InlayHints::project_to_proto_hint(response_hint)),
         })
+    }
+
+    async fn try_resolve_code_action(
+        lang_server: &LanguageServer,
+        action: &mut CodeAction,
+    ) -> anyhow::Result<()> {
+        if GetCodeActions::can_resolve_actions(&lang_server.capabilities()) {
+            if action.lsp_action.data.is_some()
+                && (action.lsp_action.command.is_none() || action.lsp_action.edit.is_none())
+            {
+                action.lsp_action = lang_server
+                    .request::<lsp::request::CodeActionResolveRequest>(action.lsp_action.clone())
+                    .await?;
+            }
+        }
+
+        anyhow::Ok(())
     }
 
     async fn handle_refresh_inlay_hints(


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/8874 and https://github.com/zed-industries/zed/pull/7635
Closes https://github.com/zed-industries/zed/issues/7609

* mentions all `lsp::CodeActions` properties in the Zed client resolve capabilities to remove more json out of general actions request potentially
* removes odd `CodeActions.data` field checks, as that field is opaque and is intended to store data, needed by the langserver to resolve this code action
* if any `CodeAction` lacks either `command` or `edits` fields, tries to resolve the action

This all effectively causes Zed to always fire an action resolve request, since we update actions list (replacing the resolved actions with the new, unresolved ones) via `refresh_code_actions`
https://github.com/zed-industries/zed/blob/9e66d48ccd3bb87ee97aec4e63484dc8b78e45ac/crates/editor/src/editor.rs#L3650
that is being called on selections change and the actions menu open.

Yet, we do not query the resolve until the action is either applied (selected in the list), or called for formatting, so it seems to be fine to resolve them always, as it's not a frequent operation such as reacting to every keystroke.


Release Notes:

- Fixed certain code actions not being resolved properly