### PR TITLE
Show channel indicator for new messages

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2614,15 +2614,17 @@ impl CollabPanel {
                                 .size(IconSize::Small)
                                 .color(Color::Muted),
                             )
-                            .children(has_notes_notification.then(|| {
-                                div()
-                                    .w_1p5()
-                                    .z_index(1)
-                                    .absolute()
-                                    .right(px(-1.))
-                                    .top(px(-1.))
-                                    .child(Indicator::dot().color(Color::Info))
-                            })),
+                            .children((has_notes_notification || has_messages_notification).then(
+                                || {
+                                    div()
+                                        .w_1p5()
+                                        .z_index(1)
+                                        .absolute()
+                                        .right(px(-1.))
+                                        .top(px(-1.))
+                                        .child(Indicator::dot().color(Color::Info))
+                                },
+                            )),
                     )
                     .child(
                         h_flex()

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2685,6 +2685,7 @@ impl CollabPanel {
                         channel_store: channel_store.clone(),
                         channel_id,
                         has_notes_notification,
+                        has_messages_notification,
                     })
                     .into()
                 }
@@ -2976,6 +2977,7 @@ struct JoinChannelTooltip {
     channel_store: Model<ChannelStore>,
     channel_id: ChannelId,
     has_notes_notification: bool,
+    has_messages_notification: bool,
 }
 
 impl Render for JoinChannelTooltip {
@@ -2988,12 +2990,27 @@ impl Render for JoinChannelTooltip {
 
             container
                 .child(Label::new("Join channel"))
-                .children(self.has_notes_notification.then(|| {
-                    h_flex()
-                        .gap_2()
-                        .child(Indicator::dot().color(Color::Info))
-                        .child(Label::new("Unread notes"))
-                }))
+                .when(
+                    self.has_notes_notification || self.has_messages_notification,
+                    |div| {
+                        div.child(
+                            h_flex()
+                                .gap_2()
+                                .child(Indicator::dot().color(Color::Info))
+                                .child(
+                                    v_flex()
+                                        .children(
+                                            self.has_notes_notification
+                                                .then(|| Label::new("Unread notes")),
+                                        )
+                                        .children(
+                                            self.has_messages_notification
+                                                .then(|| Label::new("Unread messages")),
+                                        ),
+                                ),
+                        )
+                    },
+                )
                 .children(participants.iter().map(|participant| {
                     h_flex()
                         .gap_2()


### PR DESCRIPTION
@evrsen noticed that there is no indicator on the channel itself, when there are new chat messages (although one is shown when the channel notes were changed)

https://github.com/zed-industries/zed/assets/53836821/d5eab2ef-b3e3-4003-a10f-6daf780b813c


Release Notes:

- Show indicator when channel chat contains unseen messages