### PR TITLE
Fix tracing subscriber after introducing Tokio-console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,6 @@ dependencies = [
  "tower",
  "tower-http 0.4.4",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "unindent",
  "util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,13 +1224,13 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core 0.2.9",
- "base64 0.13.1",
+ "axum-core",
+ "base64 0.21.4",
  "bitflags 1.3.2",
  "bytes 1.5.0",
  "futures-util",
@@ -1239,64 +1239,21 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit 0.5.0",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sha-1 0.10.1",
- "sync_wrapper",
- "tokio",
- "tokio-tungstenite",
- "tower",
- "tower-http 0.3.5",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes 1.5.0",
- "futures-util",
- "http 0.2.9",
- "http-body",
- "hyper",
- "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
  "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
-dependencies = [
- "async-trait",
- "bytes 1.5.0",
- "futures-util",
- "http 0.2.9",
- "http-body",
- "mime",
  "tower-layer",
  "tower-service",
 ]
@@ -1320,11 +1277,11 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.3.7"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69034b3b0fd97923eee2ce8a47540edb21e07f48f87f67d44bb4271cec622bdb"
+checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
 dependencies = [
- "axum 0.5.17",
+ "axum",
  "bytes 1.5.0",
  "futures-util",
  "http 0.2.9",
@@ -2264,7 +2221,7 @@ dependencies = [
  "audio",
  "aws-config",
  "aws-sdk-s3",
- "axum 0.5.17",
+ "axum",
  "axum-extra",
  "call",
  "channel",
@@ -2286,7 +2243,6 @@ dependencies = [
  "git",
  "gpui",
  "hex",
- "hyper",
  "indoc",
  "language",
  "lazy_static",
@@ -3059,6 +3015,12 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "data-url"
@@ -5804,12 +5766,6 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
@@ -8854,6 +8810,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8922,17 +8888,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -10292,14 +10247,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.17.3",
+ "tungstenite 0.20.1",
 ]
 
 [[package]]
@@ -10390,7 +10345,7 @@ checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.21.4",
  "bytes 1.5.0",
  "h2",
@@ -10443,7 +10398,6 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -11044,7 +10998,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
  "thiserror",
  "url",
  "utf-8",
@@ -11052,18 +11006,18 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes 1.5.0",
+ "data-encoding",
  "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.10.1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -58,8 +58,7 @@ toml.workspace = true
 tower = "0.4"
 tower-http = { workspace = true, features = ["trace"] }
 tracing = "0.1.34"
-tracing-log = "0.1.3"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json", "registry", "tracing-log"] }
 util.workspace = true
 uuid.workspace = true
 

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -22,8 +22,8 @@ anyhow.workspace = true
 async-tungstenite = "0.16"
 aws-config = { version = "1.1.5" }
 aws-sdk-s3 = { version = "1.15.0" }
-axum = { version = "0.5", features = ["json", "headers", "ws"] }
-axum-extra = { version = "0.3", features = ["erased-json"] }
+axum = { version = "0.6", features = ["json", "headers", "ws"] }
+axum-extra = { version = "0.4", features = ["erased-json"] }
 chrono.workspace = true
 clock.workspace = true
 clickhouse.workspace = true
@@ -32,7 +32,6 @@ dashmap = "5.4"
 envy = "0.4.2"
 futures.workspace = true
 hex.workspace = true
-hyper = "0.14"
 live_kit_server.workspace = true
 log.workspace = true
 nanoid = "0.4"

--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -63,6 +63,8 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+            - containerPort: 6669
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz

--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -11,7 +11,7 @@ use crate::{
 use anyhow::anyhow;
 use axum::{
     body::Body,
-    extract::{Path, Query},
+    extract::{self, Path, Query},
     http::{self, Request, StatusCode},
     middleware::{self, Next},
     response::IntoResponse,
@@ -26,7 +26,7 @@ use tower::ServiceBuilder;
 
 pub use extensions::fetch_extensions_from_blob_store_periodically;
 
-pub fn routes(rpc_server: Option<Arc<rpc::Server>>, state: Arc<AppState>) -> Router<Body> {
+pub fn routes(rpc_server: Option<Arc<rpc::Server>>, state: Arc<AppState>) -> Router<(), Body> {
     Router::new()
         .route("/user", get(get_authenticated_user))
         .route("/users/:id/access_tokens", post(create_access_token))
@@ -176,8 +176,8 @@ async fn check_is_contributor(
 }
 
 async fn add_contributor(
-    Json(params): Json<AuthenticatedUserParams>,
     Extension(app): Extension<Arc<AppState>>,
+    extract::Json(params): extract::Json<AuthenticatedUserParams>,
 ) -> Result<()> {
     app.db
         .add_contributor(

--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -3,9 +3,12 @@ use std::sync::{Arc, OnceLock};
 use anyhow::{anyhow, Context};
 use aws_sdk_s3::primitives::ByteStream;
 use axum::{
-    body::Bytes, headers::Header, http::HeaderName, routing::post, Extension, Router, TypedHeader,
+    body::Bytes,
+    headers::Header,
+    http::{HeaderMap, HeaderName, StatusCode},
+    routing::post,
+    Extension, Router, TypedHeader,
 };
-use hyper::{HeaderMap, StatusCode};
 use serde::{Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use telemetry_events::{
@@ -81,8 +84,8 @@ impl Header for CloudflareIpCountryHeader {
 
 pub async fn post_crash(
     Extension(app): Extension<Arc<AppState>>,
-    body: Bytes,
     headers: HeaderMap,
+    body: Bytes,
 ) -> Result<()> {
     static CRASH_REPORTS_BUCKET: &str = "zed-crash-reports";
 

--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -7,12 +7,12 @@ use anyhow::{anyhow, Context as _};
 use aws_sdk_s3::presigning::PresigningConfig;
 use axum::{
     extract::{Path, Query},
+    http::StatusCode,
     response::Redirect,
     routing::get,
     Extension, Json, Router,
 };
 use collections::HashMap;
-use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Duration};
 use time::PrimitiveDateTime;

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -43,8 +43,9 @@ impl From<axum::Error> for Error {
     }
 }
 
-impl From<hyper::Error> for Error {
-    fn from(error: hyper::Error) -> Self {
+
+impl From<axum::http::Error> for Error {
+    fn from(error: axum::http::Error) -> Self {
         Self::Internal(error.into())
     }
 }

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -43,7 +43,6 @@ impl From<axum::Error> for Error {
     }
 }
 
-
 impl From<axum::http::Error> for Error {
     fn from(error: axum::http::Error) -> Self {
         Self::Internal(error.into())

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -25,7 +25,6 @@ const REVISION: Option<&'static str> = option_env!("GITHUB_SHA");
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    console_subscriber::init();
     if let Err(error) = env::load_dotenv() {
         eprintln!(
             "error loading .env.toml (this is expected in production): {}",
@@ -184,6 +183,7 @@ pub fn init_tracing(config: &Config) -> Option<()> {
     LogTracer::init().log_err()?;
 
     let subscriber = tracing_subscriber::Registry::default()
+        .with(console_subscriber::spawn())
         .with(if config.log_json.unwrap_or(false) {
             Box::new(
                 tracing_subscriber::fmt::layer()

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -844,7 +844,7 @@ impl Header for AppVersionHeader {
     }
 }
 
-pub fn routes(server: Arc<Server>) -> Router<Body> {
+pub fn routes(server: Arc<Server>) -> Router<(), Body> {
     Router::new()
         .route("/rpc", get(handle_websocket_request))
         .layer(

--- a/script/run-local-minio
+++ b/script/run-local-minio
@@ -6,4 +6,4 @@ mkdir -p .blob_store/zed-crash-reports
 
 export MINIO_ROOT_USER=the-blob-store-access-key
 export MINIO_ROOT_PASSWORD=the-blob-store-secret-key
-minio server --quiet .blob_store
+exec minio server --quiet .blob_store


### PR DESCRIPTION
We've also upgraded `Axum` in order to avoid having two versions of that library in Collab (one due to Tokio-console).

Release Notes:

- N/A