### PR TITLE
Enable `clippy::unnecessary_to_owned`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,6 @@ reversed_empty_ranges = "allow"
 single_range_in_vec_init = "allow"
 suspicious_to_owned = "allow"
 type_complexity = "allow"
-unnecessary_to_owned = "allow"
 
 [workspace.metadata.cargo-machete]
 ignored = ["bindgen", "cbindgen", "prost_build", "serde"]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8720,7 +8720,7 @@ impl Editor {
 
         match permalink {
             Ok(permalink) => {
-                cx.open_url(&permalink.to_string());
+                cx.open_url(permalink.as_ref());
             }
             Err(err) => {
                 let message = format!("Failed to open permalink: {err}");


### PR DESCRIPTION
lint for `unnecessary_to_owned` and fix the sole violation in the codebase
