### PR TITLE
windows: properly compute size of current display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,6 +313,7 @@ sys-locale = "0.3.1"
 version = "0.53.0"
 features = [
     "Win32_Graphics_Gdi",
+    "Win32_UI_Controls_Dialogs",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_System_SystemServices",

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, Result};
 use uuid::Uuid;
+use windows::{
+    core::PCSTR,
+    Win32::Graphics::Gdi::{DEVMODEA, ENUM_CURRENT_SETTINGS, EnumDisplaySettingsA},
+};
 
 use crate::{Bounds, DisplayId, GlobalPixels, PlatformDisplay, Point, Size};
 
@@ -25,11 +29,20 @@ impl PlatformDisplay for WindowsDisplay {
 
     // todo!("windows")
     fn bounds(&self) -> Bounds<GlobalPixels> {
+        let mut dev = DEVMODEA {
+            dmSize: std::mem::size_of::<DEVMODEA>() as _,
+            ..unsafe { std::mem::zeroed() }
+        };
+        unsafe { EnumDisplaySettingsA(PCSTR::null(), ENUM_CURRENT_SETTINGS, &mut dev) };
+        let w = dev.dmPelsWidth;
+        let h = dev.dmPelsHeight;
+
+        log::debug!("Screen size: {w} {h}");
         Bounds::new(
             Point::new(0.0.into(), 0.0.into()),
             Size {
-                width: 1920.0.into(),
-                height: 1280.0.into(),
+                width: GlobalPixels(w as f32),
+                height: GlobalPixels(h as f32),
             },
         )
     }


### PR DESCRIPTION
The display management code is not complete, but at least the display is no longer hard-coding the display size.

Notice that the size returned is the one from the current display.

