### PR TITLE
windows: get current display size

### DIFF
--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -27,7 +27,7 @@ impl PlatformDisplay for WindowsDisplay {
         Err(anyhow!("not implemented yet."))
     }
 
-    // todo!("windows")
+
     fn bounds(&self) -> Bounds<GlobalPixels> {
         let mut dev = DEVMODEA {
             dmSize: std::mem::size_of::<DEVMODEA>() as _,

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use uuid::Uuid;
 use windows::{
     core::PCSTR,
-    Win32::Graphics::Gdi::{DEVMODEA, ENUM_CURRENT_SETTINGS, EnumDisplaySettingsA},
+    Win32::Graphics::Gdi::{EnumDisplaySettingsA, DEVMODEA, ENUM_CURRENT_SETTINGS},
 };
 
 use crate::{Bounds, DisplayId, GlobalPixels, PlatformDisplay, Point, Size};
@@ -26,7 +26,6 @@ impl PlatformDisplay for WindowsDisplay {
     fn uuid(&self) -> Result<Uuid> {
         Err(anyhow!("not implemented yet."))
     }
-
 
     fn bounds(&self) -> Bounds<GlobalPixels> {
         let mut dev = DEVMODEA {

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, Result};
 use uuid::Uuid;
+use windows::{
+    core::PCSTR,
+    Win32::Graphics::Gdi::{DEVMODEA, ENUM_CURRENT_SETTINGS, EnumDisplaySettingsA},
+};
 
 use crate::{Bounds, DisplayId, GlobalPixels, PlatformDisplay, Point, Size};
 
@@ -25,11 +29,20 @@ impl PlatformDisplay for WindowsDisplay {
 
     // todo!("windows")
     fn bounds(&self) -> Bounds<GlobalPixels> {
+        let mut dev = DEVMODEA {
+            dmSize: std::mem::size_of::<DEVMODEA>() as _,
+            ..unsafe { std::mem::zeroed() }
+        };
+        unsafe { EnumDisplaySettingsA(PCSTR::null(), ENUM_CURRENT_SETTINGS, &mut dev) };
+        let w = dev.dmPelsWidth;
+        let h = dev.dmPelsHeight;
+
+        log::debug!("Screen size: {w} {h}");
         Bounds::new(
             Point::new(0.0.into(), 0.0.into()),
             Size {
-                width: 1920.0.into(),
-                height: 1280.0.into(),
+                width: GlobalPixels(w as f32),
+                height: GlobalPixels(h as f32),
             },
         )
     }


### PR DESCRIPTION
For the moment the windows port has a single display with hard-coded values.

This first PR is just to at least fetch the **actual size of the current display**. The idea
is using this code as a first template to start getting familar with the code base
and prepare the work for enumerating all displays.