### PR TITLE
windows: support opening a file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,6 +313,7 @@ sys-locale = "0.3.1"
 version = "0.53.0"
 features = [
     "Win32_Graphics_Gdi",
+    "Win32_UI_Controls_Dialogs",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_System_SystemServices",


### PR DESCRIPTION
Adding a prompt to open a file.

For the moment it is using old school open dialog. But it works and it give us the possibility to test other parts of the port. 
I am not familiar at all with Zed nor with the codebase, but I hope this approach using Win32 is Ok.
Still cannot open a "project".


- Added initial Windows implementation of method to promt for paths.
- Added dialog to open a file when clicking "Open a project" in the UI.

Screenshot:

![zed-open-file](https://github.com/zed-industries/zed/assets/3776819/622468a7-cc6d-40e6-a579-516076134309)
