### PR TITLE
Remove workspace border, avoid the main window having double borders

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3819,8 +3819,6 @@ impl Render for Workspace {
             .items_start()
             .text_color(colors.text)
             .bg(colors.background)
-            .border()
-            .border_color(colors.border)
             .children(self.titlebar_item.clone())
             .child(
                 div()


### PR DESCRIPTION
Release Notes:

- Fixed main window border, avoid double borders.



## Diff (Left is Before, Right is After)

![SCR-20240306-g2v](https://github.com/zed-industries/zed/assets/5518/b13bab55-9d74-4181-ae43-e338bb6f7112)
![SCR-20240306-g0x](https://github.com/zed-industries/zed/assets/5518/af9d4190-a974-4c26-8466-dce1c78c3f31)




Reference to Safari:
![SCR-20240306-ejo](https://github.com/zed-industries/zed/assets/5518/14c41898-8218-4bec-8574-8915a7186926)


## More Theme tests
![SCR-20240306-g0d](https://github.com/zed-industries/zed/assets/5518/8938671e-bc7c-4a6a-8c06-0992beb92bb1)
![SCR-20240306-g0j](https://github.com/zed-industries/zed/assets/5518/73a68663-70f5-4f83-aea0-2079236079e7)
![SCR-20240306-g0q](https://github.com/zed-industries/zed/assets/5518/0a2b4905-3dd1-4081-b538-a78728470004)


![SCR-20240306-fu9](https://github.com/zed-industries/zed/assets/5518/dd3a9e2c-ea28-46c6-a993-047dae8b2d8f)


