### PR TITLE
Fix a crash when opening Zed on Windows

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -872,7 +872,7 @@ impl Item for TerminalView {
     ) -> Task<anyhow::Result<View<Self>>> {
         let window = cx.window_handle();
         cx.spawn(|pane, mut cx| async move {
-            let cwd = TERMINAL_DB
+            let mut cwd = TERMINAL_DB
                 .get_working_directory(item_id, workspace_id)
                 .log_err()
                 .flatten()
@@ -887,6 +887,13 @@ impl Item for TerminalView {
                     .flatten()
                 });
 
+            // todo("windows")
+            // can we fix this from the source?
+            if let Some(ref cwd_path) = cwd {
+                if cwd_path.as_os_str().is_empty() {
+                    cwd = None;
+                }
+            }
             let terminal = project.update(&mut cx, |project, cx| {
                 project.create_terminal(cwd, None, window, cx)
             })??;


### PR DESCRIPTION
### Description

Fixed a crash: Opening Zed after it was closed with a project opened in the last session would cause a crash.

### Connections

This is a part of #8809 , will close #8825 

Release Notes:

- N/A
