### PR TITLE
Update `mio`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5968,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -6233,7 +6233,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio 0.8.8",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -10170,7 +10170,7 @@ dependencies = [
  "backtrace",
  "bytes 1.5.0",
  "libc",
- "mio 0.8.8",
+ "mio 0.8.11",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",


### PR DESCRIPTION
### Description
This is a part of #8809 

Update mio from 0.8.8 to 0.8.11.

When using named pipes on Windows, mio will under some circumstances return invalid tokens that correspond to named pipes that have already been deregistered from the mio registry. The impact of this vulnerability depends on how mio is used. For some applications, invalid tokens may be ignored or cause a warning or a crash. On the other hand, for applications that store pointers in the tokens, this vulnerability may result in a use-after-free.

### Connections

[named-pipes: fix receiving IOCP events after deregister #1760](https://github.com/tokio-rs/mio/pull/1760)

[Windows Named pipes invalid memory access #6369](https://github.com/tokio-rs/tokio/issues/6369)


Release Notes:

- N/A
