### PR TITLE
Fix to avoid back layer hover style when the popover menu opened

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1957,9 +1957,7 @@ impl Interactivity {
                         if let Some(group_bounds) =
                             GroupBounds::get(&group_hover.group, cx.deref_mut())
                         {
-                            if group_bounds.contains(&mouse_position)
-                                && cx.was_top_layer(&mouse_position, cx.stacking_order())
-                            {
+                            if group_bounds.contains(&mouse_position) {
                                 style.refine(&group_hover.style);
                             }
                         }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1957,7 +1957,9 @@ impl Interactivity {
                         if let Some(group_bounds) =
                             GroupBounds::get(&group_hover.group, cx.deref_mut())
                         {
-                            if group_bounds.contains(&mouse_position) {
+                            if group_bounds.contains(&mouse_position)
+                                && cx.was_top_layer(&mouse_position, cx.stacking_order())
+                            {
                                 style.refine(&group_hover.style);
                             }
                         }
@@ -1967,6 +1969,7 @@ impl Interactivity {
                         if bounds
                             .intersect(&cx.content_mask().bounds)
                             .contains(&mouse_position)
+                            && cx.was_top_layer(&mouse_position, cx.stacking_order())
                         {
                             style.refine(hover_style);
                         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1801,7 +1801,7 @@ impl VisualContext for WindowContext<'_> {
 
     fn focus_view<V: crate::FocusableView>(&mut self, view: &View<V>) -> Self::Result<()> {
         self.update_view(view, |view, cx| {
-            view.focus_handle(cx).clone().focus(cx);
+            view.focus_handle(cx).focus(cx);
         })
     }
 


### PR DESCRIPTION
Release Notes:

- Fixed to avoid back layer hover event when the popover menu opened. #8276



## Before
![before](https://github.com/zed-industries/zed/assets/5518/7db4dea7-367c-4f87-8335-4722043fcdcd)

## After

By my test, this changes can fix for the Popover Menus, but the Modals is not affected. 

I have read a lot of logic about the view layer that related to `cx.was_top_layer`, it's looks same behavior between of the Popover Menu and Modal. I don't why modals are not work.

![after](https://github.com/zed-industries/zed/assets/5518/ff209859-a7a8-47ee-935b-d46b20a64af9)

