### PR TITLE
Update App Menus to add `...` for some modal action menu, and group menu items by type.

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -698,9 +698,9 @@ impl CollabTitlebarItem {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Extensions", extensions_ui::Extensions.boxed_clone())
-                            .action("Theme", theme_selector::Toggle.boxed_clone())
+                            .action("Theme...", theme_selector::Toggle.boxed_clone())
                             .separator()
-                            .action("Share Feedback", feedback::GiveFeedback.boxed_clone())
+                            .action("Share Feedback...", feedback::GiveFeedback.boxed_clone())
                             .action("Sign Out", client::SignOut.boxed_clone())
                     })
                     .into()
@@ -723,9 +723,9 @@ impl CollabTitlebarItem {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Theme", theme_selector::Toggle.boxed_clone())
-                            .action("Extensions", extensions_ui::Extensions.boxed_clone())
+                            .action("Extensions...", extensions_ui::Extensions.boxed_clone())
                             .separator()
-                            .action("Share Feedback", feedback::GiveFeedback.boxed_clone())
+                            .action("Share Feedback...", feedback::GiveFeedback.boxed_clone())
                     })
                     .into()
                 })

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -722,8 +722,8 @@ impl CollabTitlebarItem {
                 .menu(|cx| {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
-                            .action("Theme", theme_selector::Toggle.boxed_clone())
-                            .action("Extensions...", extensions_ui::Extensions.boxed_clone())
+                            .action("Theme...", theme_selector::Toggle.boxed_clone())
+                            .action("Extensions", extensions_ui::Extensions.boxed_clone())
                             .separator()
                             .action("Share Feedback...", feedback::GiveFeedback.boxed_clone())
                     })

--- a/crates/zed/src/app_menus.rs
+++ b/crates/zed/src/app_menus.rs
@@ -5,7 +5,7 @@ use terminal_view::terminal_panel;
 pub fn app_menus() -> Vec<Menu<'static>> {
     use zed_actions::Quit;
 
-    let vec = vec![
+    vec![
         Menu {
             name: "Zed",
             items: vec![
@@ -181,6 +181,5 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 ),
             ],
         },
-    ];
-    vec
+    ]
 }

--- a/crates/zed/src/app_menus.rs
+++ b/crates/zed/src/app_menus.rs
@@ -1,9 +1,11 @@
+use collab_ui::collab_panel;
 use gpui::{Menu, MenuItem, OsAction};
+use terminal_view::terminal_panel;
 
 pub fn app_menus() -> Vec<Menu<'static>> {
     use zed_actions::Quit;
 
-    vec![
+    let vec = vec![
         Menu {
             name: "Zed",
             items: vec![
@@ -18,7 +20,7 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                         MenuItem::action("Open Default Settings", super::OpenDefaultSettings),
                         MenuItem::action("Open Default Key Bindings", super::OpenDefaultKeymap),
                         MenuItem::action("Open Local Settings", super::OpenLocalSettings),
-                        MenuItem::action("Select Theme", theme_selector::Toggle),
+                        MenuItem::action("Select Theme...", theme_selector::Toggle),
                     ],
                 }),
                 MenuItem::action("Extensions", extensions_ui::Extensions),
@@ -122,7 +124,9 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 }),
                 MenuItem::separator(),
                 MenuItem::action("Project Panel", project_panel::ToggleFocus),
-                MenuItem::action("Command Palette", command_palette::Toggle),
+                MenuItem::action("Collab Panel", collab_panel::ToggleFocus),
+                MenuItem::action("Terminal Panel", terminal_panel::ToggleFocus),
+                MenuItem::separator(),
                 MenuItem::action("Diagnostics", diagnostics::Deploy),
                 MenuItem::separator(),
             ],
@@ -133,13 +137,16 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 MenuItem::action("Back", workspace::GoBack),
                 MenuItem::action("Forward", workspace::GoForward),
                 MenuItem::separator(),
-                MenuItem::action("Go to File", file_finder::Toggle),
+                MenuItem::action("Command Palette...", command_palette::Toggle),
+                MenuItem::separator(),
+                MenuItem::action("Go to File...", file_finder::Toggle),
                 // MenuItem::action("Go to Symbol in Project", project_symbols::Toggle),
-                MenuItem::action("Go to Symbol in Editor", outline::Toggle),
+                MenuItem::action("Go to Symbol in Editor...", outline::Toggle),
+                MenuItem::action("Go to Line/Column...", go_to_line::Toggle),
+                MenuItem::separator(),
                 MenuItem::action("Go to Definition", editor::actions::GoToDefinition),
                 MenuItem::action("Go to Type Definition", editor::actions::GoToTypeDefinition),
                 MenuItem::action("Find All References", editor::actions::FindAllReferences),
-                MenuItem::action("Go to Line/Column", go_to_line::Toggle),
                 MenuItem::separator(),
                 MenuItem::action("Next Problem", editor::actions::GoToDiagnostic),
                 MenuItem::action("Previous Problem", editor::actions::GoToPrevDiagnostic),
@@ -156,8 +163,6 @@ pub fn app_menus() -> Vec<Menu<'static>> {
         Menu {
             name: "Help",
             items: vec![
-                MenuItem::action("Command Palette", command_palette::Toggle),
-                MenuItem::separator(),
                 MenuItem::action("View Telemetry", crate::OpenTelemetryLog),
                 MenuItem::action("View Dependency Licenses", crate::OpenLicenses),
                 MenuItem::action("Show Welcome", workspace::Welcome),
@@ -176,5 +181,6 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 ),
             ],
         },
-    ]
+    ];
+    vec
 }


### PR DESCRIPTION
Release Notes:

- Improved App Menu, add `...` for modal action menu, and group menu items by type.

In macOS and Windows, the `...` suffix of menu item, is means that will open a dialog.
