### PR TITLE
Add UnwrapSyntaxNode action

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -327,6 +327,7 @@
       "alt-shift-down": "editor::DuplicateLine",
       "ctrl-shift-right": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-left": "editor::SelectSmallerSyntaxNode",
+      "ctrl-cmd-shift-right": "editor::UnwrapSyntaxNode",
       "cmd-d": [
         "editor::SelectNext",
         {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -252,6 +252,7 @@ gpui::actions!(
         UndoSelection,
         UnfoldLines,
         UniqueLinesCaseSensitive,
-        UniqueLinesCaseInsensitive
+        UniqueLinesCaseInsensitive,
+        UnwrapSyntaxNode
     ]
 );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4335,6 +4335,38 @@ async fn test_select_larger_smaller_syntax_node(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_unwrap_syntax_node(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let language = Arc::new(Language::new(
+        LanguageConfig::default(),
+        Some(tree_sitter_rust::language()),
+    ));
+
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(Some(language), cx);
+    });
+
+    cx.set_state(
+        &r#"
+            use mod1::mod2::{«mod3ˇ», mod4};
+        "#
+        .unindent(),
+    );
+    cx.update_editor(|view, cx| {
+        view.unwrap_syntax_node(&UnwrapSyntaxNode, cx);
+    });
+    cx.assert_editor_state(
+        &r#"
+            use mod1::mod2::«mod3ˇ»;
+        "#
+        .unindent(),
+    );
+}
+
+#[gpui::test]
 async fn test_autoindent_selections(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -251,6 +251,7 @@ impl EditorElement {
         register_action(view, cx, Editor::toggle_comments);
         register_action(view, cx, Editor::select_larger_syntax_node);
         register_action(view, cx, Editor::select_smaller_syntax_node);
+        register_action(view, cx, Editor::unwrap_syntax_node);
         register_action(view, cx, Editor::move_to_enclosing_bracket);
         register_action(view, cx, Editor::undo_selection);
         register_action(view, cx, Editor::redo_selection);


### PR DESCRIPTION
Hey there,

I have started relying on this action, that I've also put into VSCode as [an extension](https://github.com/Gregoor/soy). On some level I don't know how people code (cope?) without it:

Release Notes:

- Added UnwrapSyntaxNode action

https://github.com/zed-industries/zed/assets/4051932/d74c98c0-96d8-4075-9b63-cea55bea42f6


---

Since I had to put it into Zed anyway to make it my daily driver, I thought I'd also check here if there's an interest in shipping it by default (that would ofc also personally make my life better, not having to maintain my personal fork and all).

If there is interest, I'd be happy to make any changes to make this more mergeable. Two TODOs on my mind are:
- unwrap multiple into single (e.g. `fn(≤a≥, b)` to `fn(≤a≥)`)
- multi-cursor 
- syntax awareness, i.e. only unwrap if it does not break syntax (I added [a coarse version of that for my VSC extension](https://github.com/Gregoor/soy/blob/main/src/actions/unwrap.ts#L29))


Somewhat off-topic: I was happy to see that you're [also](https://github.com/Gregoor/soy/blob/main/src/actions/unwrap.test.ts) using rare special chars in test code to denote cursor positions.