### PR TITLE
Small fixes to task modal & long commands 

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use editor::Editor;
+use editor::{scroll::Autoscroll, Editor};
 use gpui::{
     div, list, prelude::*, uniform_list, AnyElement, AppContext, ClickEvent, DismissEvent,
     EventEmitter, FocusHandle, FocusableView, Length, ListState, Render, Task,
@@ -334,8 +334,13 @@ impl<D: PickerDelegate> Picker<D> {
     }
 
     pub fn set_query(&self, query: impl Into<Arc<str>>, cx: &mut ViewContext<Self>) {
-        self.editor
-            .update(cx, |editor, cx| editor.set_text(query, cx));
+        self.editor.update(cx, |editor, cx| {
+            editor.set_text(query, cx);
+            let editor_offset = editor.buffer().read(cx).len(cx);
+            editor.change_selections(Some(Autoscroll::Next), cx, |s| {
+                s.select_ranges(Some(editor_offset..editor_offset))
+            });
+        });
     }
 
     fn scroll_to_item_index(&mut self, ix: usize) {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1365,7 +1365,13 @@ impl Terminal {
     pub fn title(&self, truncate: bool) -> String {
         const MAX_CHARS: usize = 25;
         match &self.task {
-            Some(task_state) => truncate_and_trailoff(&task_state.label, MAX_CHARS),
+            Some(task_state) => {
+                if truncate {
+                    truncate_and_trailoff(&task_state.label, MAX_CHARS)
+                } else {
+                    task_state.label.clone()
+                }
+            }
             None => self
                 .foreground_process_info
                 .as_ref()


### PR DESCRIPTION
* Show the entire task tooltip on terminal tab hover:
<img width="979" alt="Screenshot 2024-03-07 at 01 40 56" src="https://github.com/zed-industries/zed/assets/2690773/bc274a5c-70f6-4f3d-87b4-04aff3594089">

* Scroll to the end of the query when a menu label is reused as a query:
<img width="658" alt="Screenshot 2024-03-07 at 01 41 03" src="https://github.com/zed-industries/zed/assets/2690773/972857f4-36db-49dc-8fa1-dd15e0470660">

Release Notes:

- Improved task modal UX with long bash-like commands