### PR TITLE
Profile for less time in production

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2413,7 +2413,9 @@ impl ConversationEditor {
                 .read(cx)
                 .messages(cx)
                 .map(|message| BlockProperties {
-                    position: buffer.anchor_in_excerpt(excerpt_id, message.anchor),
+                    position: buffer
+                        .anchor_in_excerpt(excerpt_id, message.anchor)
+                        .unwrap(),
                     height: 2,
                     style: BlockStyle::Sticky,
                     render: Arc::new({

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -294,18 +294,19 @@ fn show_hover(
             let hover_popover = match hover_result {
                 Some(hover_result) if !hover_result.is_empty() => {
                     // Create symbol range of anchors for highlighting and filtering of future requests.
-                    let range = if let Some(range) = hover_result.range {
-                        let start = snapshot
-                            .buffer_snapshot
-                            .anchor_in_excerpt(excerpt_id, range.start);
-                        let end = snapshot
-                            .buffer_snapshot
-                            .anchor_in_excerpt(excerpt_id, range.end);
+                    let range = hover_result
+                        .range
+                        .and_then(|range| {
+                            let start = snapshot
+                                .buffer_snapshot
+                                .anchor_in_excerpt(excerpt_id, range.start)?;
+                            let end = snapshot
+                                .buffer_snapshot
+                                .anchor_in_excerpt(excerpt_id, range.end)?;
 
-                        start..end
-                    } else {
-                        anchor..anchor
-                    };
+                            Some(start..end)
+                        })
+                        .unwrap_or_else(|| anchor..anchor);
 
                     let language_registry =
                         project.update(&mut cx, |p, _| p.languages().clone())?;

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -460,14 +460,15 @@ impl InlayHintCache {
                                     if !old_kinds.contains(&cached_hint.kind)
                                         && new_kinds.contains(&cached_hint.kind)
                                     {
-                                        to_insert.push(Inlay::hint(
-                                            cached_hint_id.id(),
-                                            multi_buffer_snapshot.anchor_in_excerpt(
-                                                *excerpt_id,
-                                                cached_hint.position,
-                                            ),
-                                            &cached_hint,
-                                        ));
+                                        if let Some(anchor) = multi_buffer_snapshot
+                                            .anchor_in_excerpt(*excerpt_id, cached_hint.position)
+                                        {
+                                            to_insert.push(Inlay::hint(
+                                                cached_hint_id.id(),
+                                                anchor,
+                                                &cached_hint,
+                                            ));
+                                        }
                                     }
                                     excerpt_cache.next();
                                 }
@@ -483,12 +484,15 @@ impl InlayHintCache {
                 let maybe_missed_cached_hint = &excerpt_cached_hints.hints_by_id[cached_hint_id];
                 let cached_hint_kind = maybe_missed_cached_hint.kind;
                 if !old_kinds.contains(&cached_hint_kind) && new_kinds.contains(&cached_hint_kind) {
-                    to_insert.push(Inlay::hint(
-                        cached_hint_id.id(),
-                        multi_buffer_snapshot
-                            .anchor_in_excerpt(*excerpt_id, maybe_missed_cached_hint.position),
-                        &maybe_missed_cached_hint,
-                    ));
+                    if let Some(anchor) = multi_buffer_snapshot
+                        .anchor_in_excerpt(*excerpt_id, maybe_missed_cached_hint.position)
+                    {
+                        to_insert.push(Inlay::hint(
+                            cached_hint_id.id(),
+                            anchor,
+                            &maybe_missed_cached_hint,
+                        ));
+                    }
                 }
             }
         }
@@ -1200,11 +1204,13 @@ fn apply_hint_update(
                 .allowed_hint_kinds
                 .contains(&new_hint.kind)
             {
-                let new_hint_position =
-                    multi_buffer_snapshot.anchor_in_excerpt(query.excerpt_id, new_hint.position);
-                splice
-                    .to_insert
-                    .push(Inlay::hint(new_inlay_id, new_hint_position, &new_hint));
+                if let Some(new_hint_position) =
+                    multi_buffer_snapshot.anchor_in_excerpt(query.excerpt_id, new_hint.position)
+                {
+                    splice
+                        .to_insert
+                        .push(Inlay::hint(new_inlay_id, new_hint_position, &new_hint));
+                }
             }
             let new_id = InlayId::Hint(new_inlay_id);
             cached_excerpt_hints.hints_by_id.insert(new_id, new_hint);

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1154,8 +1154,8 @@ impl SearchableItem for Editor {
                                 let end = excerpt
                                     .buffer
                                     .anchor_before(excerpt_range.start + range.end);
-                                buffer.anchor_in_excerpt(excerpt.id, start)
-                                    ..buffer.anchor_in_excerpt(excerpt.id, end)
+                                buffer.anchor_in_excerpt(excerpt.id, start).unwrap()
+                                    ..buffer.anchor_in_excerpt(excerpt.id, end).unwrap()
                             }),
                     );
                 }

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -227,8 +227,12 @@ impl SyntaxTreeView {
         let multibuffer = editor_state.editor.read(cx).buffer();
         let multibuffer = multibuffer.read(cx).snapshot(cx);
         let excerpt_id = buffer_state.excerpt_id;
-        let range = multibuffer.anchor_in_excerpt(excerpt_id, range.start)
-            ..multibuffer.anchor_in_excerpt(excerpt_id, range.end);
+        let range = multibuffer
+            .anchor_in_excerpt(excerpt_id, range.start)
+            .unwrap()
+            ..multibuffer
+                .anchor_in_excerpt(excerpt_id, range.end)
+                .unwrap();
 
         // Update the editor with the anchor range.
         editor_state.editor.update(cx, |editor, cx| {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2788,7 +2788,13 @@ impl MultiBufferSnapshot {
         }
     }
 
-    pub fn anchor_in_excerpt(&self, excerpt_id: ExcerptId, text_anchor: text::Anchor) -> Anchor {
+    /// Returns an anchor for the given excerpt and text anchor,
+    /// returns None if the excerpt_id is no longer valid.
+    pub fn anchor_in_excerpt(
+        &self,
+        excerpt_id: ExcerptId,
+        text_anchor: text::Anchor,
+    ) -> Option<Anchor> {
         let locator = self.excerpt_locator_for_id(excerpt_id);
         let mut cursor = self.excerpts.cursor::<Option<&Locator>>();
         cursor.seek(locator, Bias::Left, &());
@@ -2796,14 +2802,14 @@ impl MultiBufferSnapshot {
             if excerpt.id == excerpt_id {
                 let text_anchor = excerpt.clip_anchor(text_anchor);
                 drop(cursor);
-                return Anchor {
+                return Some(Anchor {
                     buffer_id: Some(excerpt.buffer_id),
                     excerpt_id,
                     text_anchor,
-                };
+                });
             }
         }
-        panic!("excerpt not found");
+        None
     }
 
     pub fn can_resolve(&self, anchor: &Anchor) -> bool {
@@ -3283,13 +3289,15 @@ impl MultiBufferSnapshot {
             outline
                 .items
                 .into_iter()
-                .map(|item| OutlineItem {
-                    depth: item.depth,
-                    range: self.anchor_in_excerpt(*excerpt_id, item.range.start)
-                        ..self.anchor_in_excerpt(*excerpt_id, item.range.end),
-                    text: item.text,
-                    highlight_ranges: item.highlight_ranges,
-                    name_ranges: item.name_ranges,
+                .flat_map(|item| {
+                    Some(OutlineItem {
+                        depth: item.depth,
+                        range: self.anchor_in_excerpt(*excerpt_id, item.range.start)?
+                            ..self.anchor_in_excerpt(*excerpt_id, item.range.end)?,
+                        text: item.text,
+                        highlight_ranges: item.highlight_ranges,
+                        name_ranges: item.name_ranges,
+                    })
                 })
                 .collect(),
         ))
@@ -3310,13 +3318,15 @@ impl MultiBufferSnapshot {
                 .symbols_containing(anchor.text_anchor, theme)
                 .into_iter()
                 .flatten()
-                .map(|item| OutlineItem {
-                    depth: item.depth,
-                    range: self.anchor_in_excerpt(excerpt_id, item.range.start)
-                        ..self.anchor_in_excerpt(excerpt_id, item.range.end),
-                    text: item.text,
-                    highlight_ranges: item.highlight_ranges,
-                    name_ranges: item.name_ranges,
+                .flat_map(|item| {
+                    Some(OutlineItem {
+                        depth: item.depth,
+                        range: self.anchor_in_excerpt(excerpt_id, item.range.start)?
+                            ..self.anchor_in_excerpt(excerpt_id, item.range.end)?,
+                        text: item.text,
+                        highlight_ranges: item.highlight_ranges,
+                        name_ranges: item.name_ranges,
+                    })
                 })
                 .collect(),
         ))


### PR DESCRIPTION
We were seeing panics due to callers assuming they had valid
excerpt_ids, but that cannot easily be guaranteed across await points as
anyone may remove an excerpt.



Release Notes:

- Added/Fixed/Improved ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

**or**

- N/A
