### PR TITLE
GPUI custom window prompts

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -28,14 +28,14 @@ use util::{
     ResultExt,
 };
 
-use crate::WindowAppearance;
 use crate::{
     current_platform, image_cache::ImageCache, init_app_menus, Action, ActionRegistry, Any,
     AnyView, AnyWindowHandle, AppMetadata, AssetSource, BackgroundExecutor, ClipboardItem, Context,
     DispatchPhase, Entity, EventEmitter, ForegroundExecutor, Global, KeyBinding, Keymap, Keystroke,
-    LayoutId, Menu, PathPromptOptions, Pixels, Platform, PlatformDisplay, Point, Render,
-    SharedString, SubscriberSet, Subscription, SvgRenderer, Task, TextStyle, TextStyleRefinement,
-    TextSystem, View, ViewContext, Window, WindowContext, WindowHandle, WindowId,
+    LayoutId, Menu, PathPromptOptions, Pixels, Platform, PlatformDisplay, Point, PromptHandle,
+    PromptLevel, Render, SharedString, SubscriberSet, Subscription, SvgRenderer, Task, TextStyle,
+    TextStyleRefinement, TextSystem, View, ViewContext, Window, WindowAppearance, WindowContext,
+    WindowHandle, WindowId,
 };
 
 mod async_context;
@@ -204,6 +204,13 @@ type QuitHandler = Box<dyn FnOnce(&mut AppContext) -> LocalBoxFuture<'static, ()
 type ReleaseListener = Box<dyn FnOnce(&mut dyn Any, &mut AppContext) + 'static>;
 type NewViewListener = Box<dyn FnMut(AnyView, &mut WindowContext) + 'static>;
 
+enum PromptRenderer {
+    Default,
+    Custom(
+        Box<dyn Fn(PromptLevel, &str, Option<&str>, &[&str], &mut WindowContext) -> PromptHandle>,
+    ),
+}
+
 /// Contains the state of the full application, and passed as a reference to a variety of callbacks.
 /// Other contexts such as [ModelContext], [WindowContext], and [ViewContext] deref to this type, making it the most general context type.
 /// You need a reference to an `AppContext` to access the state of a [Model].
@@ -242,6 +249,7 @@ pub struct AppContext {
     pub(crate) quit_observers: SubscriberSet<(), QuitHandler>,
     pub(crate) layout_id_buffer: Vec<LayoutId>, // We recycle this memory across layout requests.
     pub(crate) propagate_event: bool,
+    prompt_renderer: PromptRenderer,
 }
 
 impl AppContext {
@@ -301,6 +309,7 @@ impl AppContext {
                 quit_observers: SubscriberSet::new(),
                 layout_id_buffer: Default::default(),
                 propagate_event: true,
+                prompt_renderer: PromptRenderer::Default,
             }),
         });
 
@@ -1206,6 +1215,16 @@ impl AppContext {
     /// Is there currently something being dragged?
     pub fn has_active_drag(&self) -> bool {
         self.active_drag.is_some()
+    }
+
+    /// Set the prompt renderer for GPUI. This will replace the default or platform specific
+    /// prompts with this custom implementation.
+    pub fn set_prompt_renderer(
+        &mut self,
+        renderer: impl Fn(PromptLevel, &str, Option<&str>, &[&str], &mut WindowContext) -> PromptHandle
+            + 'static,
+    ) {
+        self.prompt_renderer = PromptRenderer::Custom(Box::new(renderer))
     }
 }
 

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -247,7 +247,7 @@ pub fn transparent_black() -> Hsla {
     }
 }
 
-/// Opague grey in [`Hsla`], values will be clamped to the range [0, 1]
+/// Opaque grey in [`Hsla`], values will be clamped to the range [0, 1]
 pub fn opaque_grey(lightness: f32, opacity: f32) -> Hsla {
     Hsla {
         h: 0.,

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -247,6 +247,16 @@ pub fn transparent_black() -> Hsla {
     }
 }
 
+/// Opague grey in [`Hsla`], values will be clamped to the range [0, 1]
+pub fn opaque_grey(lightness: f32, opacity: f32) -> Hsla {
+    Hsla {
+        h: 0.,
+        s: 0.,
+        l: lightness.clamp(0., 1.),
+        a: opacity.clamp(0., 1.),
+    }
+}
+
 /// Pure white in [`Hsla`]
 pub fn white() -> Hsla {
     Hsla {

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -499,7 +499,7 @@ pub trait InteractiveElement: Sized {
         self
     }
 
-    /// Assign this elements
+    /// Assign this element an ID, so that it can be used with interactivity
     fn id(mut self, id: impl Into<ElementId>) -> Stateful<Self> {
         self.interactivity().element_id = Some(id.into());
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -183,7 +183,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         msg: &str,
         detail: Option<&str>,
         answers: &[&str],
-    ) -> oneshot::Receiver<usize>;
+    ) -> Option<oneshot::Receiver<usize>>;
     fn activate(&self);
     fn set_title(&mut self, title: &str);
     fn set_edited(&mut self, edited: bool);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -306,15 +306,14 @@ impl PlatformWindow for WaylandWindow {
         self.0.inner.borrow_mut().input_handler.take()
     }
 
-    // todo(linux)
     fn prompt(
         &self,
         level: PromptLevel,
         msg: &str,
         detail: Option<&str>,
         answers: &[&str],
-    ) -> Receiver<usize> {
-        unimplemented!()
+    ) -> Option<Receiver<usize>> {
+        None
     }
 
     fn activate(&self) {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -399,15 +399,14 @@ impl PlatformWindow for X11Window {
         self.0.inner.borrow_mut().input_handler.take()
     }
 
-    // todo(linux)
     fn prompt(
         &self,
         _level: PromptLevel,
         _msg: &str,
         _detail: Option<&str>,
         _answers: &[&str],
-    ) -> futures::channel::oneshot::Receiver<usize> {
-        unimplemented!()
+    ) -> Option<futures::channel::oneshot::Receiver<usize>> {
+        None
     }
 
     fn activate(&self) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -840,7 +840,7 @@ impl PlatformWindow for MacWindow {
         msg: &str,
         detail: Option<&str>,
         answers: &[&str],
-    ) -> oneshot::Receiver<usize> {
+    ) -> Option<oneshot::Receiver<usize>> {
         // macOs applies overrides to modal window buttons after they are added.
         // Two most important for this logic are:
         // * Buttons with "Cancel" title will be displayed as the last buttons in the modal
@@ -913,7 +913,7 @@ impl PlatformWindow for MacWindow {
                 })
                 .detach();
 
-            done_rx
+            Some(done_rx)
         }
     }
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -169,13 +169,15 @@ impl PlatformWindow for TestWindow {
         _msg: &str,
         _detail: Option<&str>,
         _answers: &[&str],
-    ) -> futures::channel::oneshot::Receiver<usize> {
-        self.0
-            .lock()
-            .platform
-            .upgrade()
-            .expect("platform dropped")
-            .prompt()
+    ) -> Option<futures::channel::oneshot::Receiver<usize>> {
+        Some(
+            self.0
+                .lock()
+                .platform
+                .upgrade()
+                .expect("platform dropped")
+                .prompt(),
+        )
     }
 
     fn activate(&self) {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -746,7 +746,7 @@ impl PlatformWindow for WindowsWindow {
         msg: &str,
         detail: Option<&str>,
         answers: &[&str],
-    ) -> Receiver<usize> {
+    ) -> Option<Receiver<usize>> {
         unimplemented!()
     }
 

--- a/crates/gpui/src/view.rs
+++ b/crates/gpui/src/view.rs
@@ -203,7 +203,7 @@ impl<V> Eq for WeakView<V> {}
 #[derive(Clone, Debug)]
 pub struct AnyView {
     model: AnyModel,
-    request_layout: fn(&AnyView, &mut ElementContext) -> (LayoutId, AnyElement),
+    pub(crate) request_layout: fn(&AnyView, &mut ElementContext) -> (LayoutId, AnyElement),
     cache: bool,
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -35,7 +35,10 @@ use std::{
 use util::{measure, ResultExt};
 
 mod element_cx;
+mod prompts;
+
 pub use element_cx::*;
+pub use prompts::*;
 
 const ACTIVE_DRAG_Z_INDEX: u16 = 1;
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1563,6 +1563,7 @@ impl<'a> WindowContext<'a> {
         self.window
             .platform_window
             .prompt(level, message, detail, answers)
+            .unwrap()
     }
 
     /// Returns all available actions for the focused element.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1582,7 +1582,7 @@ impl<'a> WindowContext<'a> {
             unreachable!("Re-entrant window prompting is not supported by GPUI");
         };
 
-        let reciever = match &prompt_builder {
+        let receiver = match &prompt_builder {
             PromptBuilder::Default => self
                 .window
                 .platform_window
@@ -1597,7 +1597,7 @@ impl<'a> WindowContext<'a> {
 
         self.app.prompt_builder = Some(prompt_builder);
 
-        reciever
+        receiver
     }
 
     fn build_custom_prompt(

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -283,6 +283,7 @@ pub struct Window {
     pub(crate) focus: Option<FocusId>,
     focus_enabled: bool,
     pending_input: Option<PendingInput>,
+    prompt: Option<RenderablePromptHandle>,
 }
 
 #[derive(Default, Debug)]
@@ -476,6 +477,7 @@ impl Window {
             focus: None,
             focus_enabled: true,
             pending_input: None,
+            prompt: None,
         }
     }
     fn new_focus_listener(
@@ -1554,16 +1556,48 @@ impl<'a> WindowContext<'a> {
     /// The provided message will be presented, along with buttons for each answer.
     /// When a button is clicked, the returned Receiver will receive the index of the clicked button.
     pub fn prompt(
-        &self,
+        &mut self,
         level: PromptLevel,
         message: &str,
         detail: Option<&str>,
         answers: &[&str],
     ) -> oneshot::Receiver<usize> {
-        self.window
-            .platform_window
-            .prompt(level, message, detail, answers)
-            .unwrap()
+        let prompt_builder = self.app.prompt_builder.take();
+        let Some(prompt_builder) = prompt_builder else {
+            unreachable!("Re-entrant window prompting is not supported by GPUI");
+        };
+
+        let reciever = match &prompt_builder {
+            PromptBuilder::Default => self
+                .window
+                .platform_window
+                .prompt(level, message, detail, answers)
+                .unwrap_or_else(|| {
+                    self.build_custom_prompt(&prompt_builder, level, message, detail, answers)
+                }),
+            PromptBuilder::Custom(_) => {
+                self.build_custom_prompt(&prompt_builder, level, message, detail, answers)
+            }
+        };
+
+        self.app.prompt_builder = Some(prompt_builder);
+
+        reciever
+    }
+
+    fn build_custom_prompt(
+        &mut self,
+        prompt_builder: &PromptBuilder,
+        level: PromptLevel,
+        message: &str,
+        detail: Option<&str>,
+        answers: &[&str],
+    ) -> oneshot::Receiver<usize> {
+        let (sender, receiver) = oneshot::channel();
+        let handle = PromptHandle::new(sender);
+        let handle = (prompt_builder)(level, message, detail, answers, handle, self);
+        self.window.prompt = Some(handle);
+        receiver
     }
 
     /// Returns all available actions for the focused element.

--- a/crates/gpui/src/window/prompts.rs
+++ b/crates/gpui/src/window/prompts.rs
@@ -1,0 +1,65 @@
+use crate::{
+    Element, Empty, EventEmitter, IntoElement, PromptLevel, Render, View, ViewContext,
+    VisualContext, WindowContext,
+};
+
+/// The event emitted when a prompt's option is selected.
+/// The usize is the index of the selected option, from the actions
+/// passed to the prompt. If the prompt was dismissed without action taken, response is None.
+pub struct PromptResponse(pub Option<usize>);
+
+/// A prompt that can be rendered in the window.
+pub trait Prompt: EventEmitter<PromptResponse> + Render {}
+
+impl<V: EventEmitter<PromptResponse> + Render> Prompt for V {}
+
+/// A handle to a prompt that can be used to interact with it.
+pub struct PromptHandle {
+    view: Box<dyn PromptViewHandle>,
+}
+
+impl PromptHandle {
+    /// Construct a new prompt handle from a view of the appropriate types
+    pub fn new<V: Prompt>(view: View<V>) -> Self {
+        Self {
+            view: Box::new(view),
+        }
+    }
+}
+
+trait PromptViewHandle {}
+
+impl<V: Prompt> PromptViewHandle for View<V> {}
+
+/// The default GPUI fallback for rendering prompts, when the platform doesn't support it.
+pub struct FallbackPromptRenderer {
+    level: PromptLevel,
+    message: String,
+    detail: Option<String>,
+    actions: Vec<String>,
+}
+
+impl Render for FallbackPromptRenderer {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        Empty
+    }
+}
+
+impl EventEmitter<PromptResponse> for FallbackPromptRenderer {}
+
+/// Use this function in conjunction with [AppContext::set_prompt_renderer] to force
+/// GPUI to always use the fallback prompt renderer.
+pub fn fallback_prompt_renderer(
+    level: PromptLevel,
+    message: &str,
+    detail: Option<&str>,
+    actions: &[&str],
+    cx: &mut WindowContext,
+) -> PromptHandle {
+    PromptHandle::new(cx.new_view(|_| FallbackPromptRenderer {
+        level,
+        message: message.to_string(),
+        detail: detail.map(ToString::to_string),
+        actions: actions.iter().map(ToString::to_string).collect(),
+    }))
+}

--- a/crates/gpui/src/window/prompts.rs
+++ b/crates/gpui/src/window/prompts.rs
@@ -1,12 +1,16 @@
+use std::ops::Deref;
+
+use futures::channel::oneshot;
+
 use crate::{
-    Element, Empty, EventEmitter, IntoElement, PromptLevel, Render, View, ViewContext,
-    VisualContext, WindowContext,
+    Empty, EventEmitter, IntoElement, PromptLevel, Render, View, ViewContext, VisualContext,
+    WindowContext,
 };
 
 /// The event emitted when a prompt's option is selected.
 /// The usize is the index of the selected option, from the actions
-/// passed to the prompt. If the prompt was dismissed without action taken, response is None.
-pub struct PromptResponse(pub Option<usize>);
+/// passed to the prompt.
+pub struct PromptResponse(pub usize);
 
 /// A prompt that can be rendered in the window.
 pub trait Prompt: EventEmitter<PromptResponse> + Render {}
@@ -15,21 +19,58 @@ impl<V: EventEmitter<PromptResponse> + Render> Prompt for V {}
 
 /// A handle to a prompt that can be used to interact with it.
 pub struct PromptHandle {
-    view: Box<dyn PromptViewHandle>,
+    sender: oneshot::Sender<usize>,
 }
 
 impl PromptHandle {
+    pub(crate) fn new(sender: oneshot::Sender<usize>) -> Self {
+        Self { sender }
+    }
+
     /// Construct a new prompt handle from a view of the appropriate types
-    pub fn new<V: Prompt>(view: View<V>) -> Self {
-        Self {
+    pub fn with_view<V: Prompt>(
+        self,
+        view: View<V>,
+        cx: &mut WindowContext,
+    ) -> RenderablePromptHandle {
+        let mut sender = Some(self.sender);
+        cx.subscribe(&view, move |_, e: &PromptResponse, _| {
+            if let Some(sender) = sender.take() {
+                sender.send(e.0).ok();
+            }
+        })
+        .detach();
+
+        RenderablePromptHandle {
             view: Box::new(view),
         }
     }
 }
 
-trait PromptViewHandle {}
+/// A prompt handle capable of being rendered in a window.
+pub struct RenderablePromptHandle {
+    view: Box<dyn PromptViewHandle>,
+}
 
-impl<V: Prompt> PromptViewHandle for View<V> {}
+/// Use this function in conjunction with [AppContext::set_prompt_renderer] to force
+/// GPUI to always use the fallback prompt renderer.
+pub fn fallback_prompt_renderer(
+    level: PromptLevel,
+    message: &str,
+    detail: Option<&str>,
+    actions: &[&str],
+    handle: PromptHandle,
+    cx: &mut WindowContext,
+) -> RenderablePromptHandle {
+    let renderer = cx.new_view(|_| FallbackPromptRenderer {
+        level,
+        message: message.to_string(),
+        detail: detail.map(ToString::to_string),
+        actions: actions.iter().map(ToString::to_string).collect(),
+    });
+
+    handle.with_view(renderer, cx)
+}
 
 /// The default GPUI fallback for rendering prompts, when the platform doesn't support it.
 pub struct FallbackPromptRenderer {
@@ -47,19 +88,40 @@ impl Render for FallbackPromptRenderer {
 
 impl EventEmitter<PromptResponse> for FallbackPromptRenderer {}
 
-/// Use this function in conjunction with [AppContext::set_prompt_renderer] to force
-/// GPUI to always use the fallback prompt renderer.
-pub fn fallback_prompt_renderer(
-    level: PromptLevel,
-    message: &str,
-    detail: Option<&str>,
-    actions: &[&str],
-    cx: &mut WindowContext,
-) -> PromptHandle {
-    PromptHandle::new(cx.new_view(|_| FallbackPromptRenderer {
-        level,
-        message: message.to_string(),
-        detail: detail.map(ToString::to_string),
-        actions: actions.iter().map(ToString::to_string).collect(),
-    }))
+trait PromptViewHandle {}
+
+impl<V: Prompt> PromptViewHandle for View<V> {}
+
+pub(crate) enum PromptBuilder {
+    Default,
+    Custom(
+        Box<
+            dyn Fn(
+                PromptLevel,
+                &str,
+                Option<&str>,
+                &[&str],
+                PromptHandle,
+                &mut WindowContext,
+            ) -> RenderablePromptHandle,
+        >,
+    ),
+}
+
+impl Deref for PromptBuilder {
+    type Target = dyn Fn(
+        PromptLevel,
+        &str,
+        Option<&str>,
+        &[&str],
+        PromptHandle,
+        &mut WindowContext,
+    ) -> RenderablePromptHandle;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Default => &fallback_prompt_renderer,
+            Self::Custom(f) => f.as_ref(),
+        }
+    }
 }


### PR DESCRIPTION
This adds a GPUI fallback for window prompts. Linux does not support this feature by default, so we have to implement it ourselves. 

This implementation also makes it possible for GPUI clients to override the platform prompts with their own implementations.

This is just a first pass. These alerts are not keyboard accessible yet, does not reflect the prompt level,  they're implemented in-window, rather than as popups, and the whole feature need a pass from a designer. Regardless, this gets us one step closer to Linux support :)

<img width="650" alt="Screenshot 2024-03-06 at 5 58 08 PM" src="https://github.com/zed-industries/zed/assets/2280405/972ebb55-fd1f-4066-969c-a87f63b22a6f">

Release Notes:

- N/A