### PR TITLE
Add `[x`/`]x` to select larger/smaller syntax node in Vim

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -353,7 +353,9 @@
       "> >": "vim::Indent",
       "< <": "vim::Outdent",
       "ctrl-pagedown": "pane::ActivateNextItem",
-      "ctrl-pageup": "pane::ActivatePrevItem"
+      "ctrl-pageup": "pane::ActivatePrevItem",
+      "[ x": "editor::SelectLargerSyntaxNode",
+      "] x": "editor::SelectSmallerSyntaxNode"
     }
   },
   {


### PR DESCRIPTION
`[x` will select the larger syntax node, `]x` the smaller one. Inspired by https://github.com/tpope/vim-unimpaired. 

Release Notes:

- Added `[x` and `]x` as default keybindings in Vim mode to select larger and smaller syntax nodes respectively.
