### PR TITLE
Slow down reconnection logic

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -68,8 +68,13 @@ use util::SemanticVersion;
 
 pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
-// kubernetes gives terminated pods 10s to shutdown gracefully. After they're gone, we can clean up old resources.
-pub const CLEANUP_TIMEOUT: Duration = Duration::from_secs(15);
+// This timeout must be longer than the kubernetes graceful shutdown period (10s) so that
+// we can be sure the old server is gone.
+// It also needs to be long enough that clients have a chance to reconnect before we kick
+// them out of any rooms. They have a 15s timeout, so 35s should give enough time for them
+// to try ~twice.
+// This is all to paper over our server restarts causing a huge stampede, more work is needed.
+pub const CLEANUP_TIMEOUT: Duration = Duration::from_secs(35);
 
 const MESSAGE_COUNT_PER_PAGE: usize = 100;
 const MAX_MESSAGE_LEN: usize = 1024;


### PR DESCRIPTION
Currently when we deploy a new version of collab clients get kicked out
of rooms.

This is because we currently can't respond to the hello fast enough, so
the client disconnects and tries again. If this happens more than twice,
the client is now racing with the CLEANUP_TIMEOUT, which will mark any
connections to the old server as gone.

As we expect that reconnections will work fine, this just slows
everything down a bit to give the server more time.


Release Notes:

- Reduced likelihood of dropping a call during server deploys.
