### PR TITLE
Fix empty tooltip on Recent Projects.

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -325,14 +325,21 @@ impl PickerDelegate for RecentProjectsDelegate {
 
         let highlighted_match = HighlightedMatchWithPaths {
             match_label: HighlightedText::join(match_labels.into_iter().flatten(), ", "),
-            paths: if self.render_paths { paths } else { Vec::new() },
+            paths,
         };
+
         Some(
             ListItem::new(ix)
                 .inset(true)
                 .spacing(ListItemSpacing::Sparse)
                 .selected(selected)
-                .child(highlighted_match.clone().render(cx))
+                .child({
+                    let mut highlighted = highlighted_match.clone();
+                    if !self.render_paths {
+                        highlighted.paths.clear();
+                    }
+                    highlighted.render(cx)
+                })
                 .when(!is_current_workspace, |el| {
                     let delete_button = div()
                         .child(
@@ -344,7 +351,7 @@ impl PickerDelegate for RecentProjectsDelegate {
 
                                     this.delegate.delete_recent_project(ix, cx)
                                 }))
-                                .tooltip(|cx| Tooltip::text("Delete From Recent Projects...", cx)),
+                                .tooltip(|cx| Tooltip::text("Delete from Recent Projects...", cx)),
                         )
                         .into_any_element();
 


### PR DESCRIPTION
Release Notes:

- Fixed empty tooltip on Recent Projects.

## Before

![empty-tooltip](https://github.com/zed-industries/zed/assets/5518/4a00158c-5ae1-4ef9-8686-d4c188a99050)

## After

![output](https://github.com/zed-industries/zed/assets/5518/b30f8272-485d-40e1-989a-facd122e96c8)
