### PR TITLE
Fix project panel icon bouncing when renaming

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1426,9 +1426,11 @@ impl ProjectPanel {
                     })
                     .child(
                         if let (Some(editor), true) = (Some(&self.filename_editor), show_editor) {
-                            div().h_full().w_full().child(editor.clone())
+                            h_flex().h_6().w_full().child(editor.clone())
                         } else {
-                            div().child(Label::new(file_name).color(filename_text_color))
+                            div()
+                                .h_6()
+                                .child(Label::new(file_name).color(filename_text_color))
                         }
                         .ml_1(),
                     )


### PR DESCRIPTION
I found the project panel icon has a little bounce when I tried to rename some files.

Release Notes:

- Fix project panel icon bouncing when renaming.

## Before


https://github.com/zed-industries/zed/assets/28998859/76f04c33-da68-40e2-9c83-045e78187679

**Set `buffer_line_height` to `standard`**

https://github.com/zed-industries/zed/assets/28998859/9a9eca93-5fda-4060-ba1d-0cd4e0486eb8



## After

https://github.com/zed-industries/zed/assets/28998859/29b49f1c-a9ae-4281-8921-8f1d8dd74262

**Set `buffer_line_height` to `standard`**

https://github.com/zed-industries/zed/assets/28998859/8f1ccbb5-fe0e-4905-97c4-cb7431e5dc46


