### PR TITLE
task: make ZED_FILE return abs path, for real this time

### DIFF
--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -93,7 +93,8 @@ fn task_context(
                     .buffer
                     .read(cx)
                     .file()
-                    .map(|file| file.path().to_string_lossy().to_string());
+                    .and_then(|file| file.as_local())
+                    .map(|file| file.abs_path(cx).to_string_lossy().to_string());
                 let worktree_id = location
                     .buffer
                     .read(cx)
@@ -316,7 +317,7 @@ mod tests {
                 TaskContext {
                     cwd: Some("/dir".into()),
                     env: HashMap::from_iter([
-                        ("ZED_FILE".into(), "rust/b.rs".into()),
+                        ("ZED_FILE".into(), "/dir/rust/b.rs".into()),
                         ("ZED_WORKTREE_ROOT".into(), "/dir".into()),
                         ("ZED_ROW".into(), "1".into()),
                         ("ZED_COLUMN".into(), "1".into()),
@@ -332,7 +333,7 @@ mod tests {
                 TaskContext {
                     cwd: Some("/dir".into()),
                     env: HashMap::from_iter([
-                        ("ZED_FILE".into(), "rust/b.rs".into()),
+                        ("ZED_FILE".into(), "/dir/rust/b.rs".into()),
                         ("ZED_WORKTREE_ROOT".into(), "/dir".into()),
                         ("ZED_SYMBOL".into(), "this_is_a_rust_file".into()),
                         ("ZED_ROW".into(), "1".into()),
@@ -348,7 +349,7 @@ mod tests {
                 TaskContext {
                     cwd: Some("/dir".into()),
                     env: HashMap::from_iter([
-                        ("ZED_FILE".into(), "a.ts".into()),
+                        ("ZED_FILE".into(), "/dir/a.ts".into()),
                         ("ZED_WORKTREE_ROOT".into(), "/dir".into()),
                         ("ZED_SYMBOL".into(), "this_is_a_test".into()),
                         ("ZED_ROW".into(), "1".into()),


### PR DESCRIPTION
Release Notes:

- Fixed ZED_FILE environment variable containing a relative path, not an absolute one.
