### PR TITLE
Enable `clippy::suspicious_to_owned`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,7 +400,6 @@ non_canonical_clone_impl = "allow"
 non_canonical_partial_ord_impl = "allow"
 reversed_empty_ranges = "allow"
 single_range_in_vec_init = "allow"
-suspicious_to_owned = "allow"
 type_complexity = "allow"
 
 [workspace.metadata.cargo-machete]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -224,7 +224,7 @@ impl Clone for Toast {
     fn clone(&self) -> Self {
         Toast {
             id: self.id,
-            msg: self.msg.to_owned(),
+            msg: self.msg.clone(),
             on_click: self.on_click.clone(),
         }
     }


### PR DESCRIPTION
Another small change: calling to owned on the `Cow` was cloning the `Cow`, not its contents and so calling `clone` makes this more explicit
