### PR TITLE
Log the user keymap that didn't parse properly

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -619,7 +619,9 @@ pub fn handle_keymap_file_changes(
                         if let Some(keymap_content) = KeymapFile::parse(&user_keymap_content).log_err() {
                             user_keymap = keymap_content;
                         } else {
-                            continue
+                            // TODO: Show which file failed to parse
+                            log::error!("Failed to parse keymap file content: {}", user_keymap_content);
+                            continue;
                         }
                     }
                 }


### PR DESCRIPTION
When a keymap file fails to parse, the terminal logs the parse error with little context about the file

```
[2024-03-07T08:14:42-08:00 ERROR util] crates/zed/src/zed.rs:619: EOF while parsing a value at line 1 column 0
```

In my case, the keymap file it was trying to load was empty. 

For now, this adds logging of the keymap file contents. I'd like to follow this up with logging the actual filename. It looks like I'd need to pass the filename in, but wasn't sure whether to add it to the function directly or if there was another structure the keymap full path was located.

Release Notes:

- Added logging for keymap parse fail