### PR TITLE
linux: wayland cursor fixes

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -268,6 +268,9 @@ impl Client for WaylandClient {
     }
 
     fn set_cursor_style(&self, style: CursorStyle) {
+        // Based on cursor names from https://gitlab.gnome.org/GNOME/adwaita-icon-theme (GNOME)
+        // and https://github.com/KDE/breeze (KDE). Both of them seem to be also derived from
+        // Web CSS cursor names: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values
         let cursor_icon_name = match style {
             CursorStyle::Arrow => "arrow".to_string(),
             CursorStyle::IBeam => "text".to_string(),

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -273,8 +273,8 @@ impl Client for WaylandClient {
             CursorStyle::IBeam => "text".to_string(),
             CursorStyle::Crosshair => "crosshair".to_string(),
             CursorStyle::ClosedHand => "grabbing".to_string(),
-            CursorStyle::OpenHand => "openhand".to_string(),
-            CursorStyle::PointingHand => "hand".to_string(),
+            CursorStyle::OpenHand => "grab".to_string(),
+            CursorStyle::PointingHand => "pointer".to_string(),
             CursorStyle::ResizeLeft => "w-resize".to_string(),
             CursorStyle::ResizeRight => "e-resize".to_string(),
             CursorStyle::ResizeLeftRight => "ew-resize".to_string(),
@@ -284,8 +284,8 @@ impl Client for WaylandClient {
             CursorStyle::DisappearingItem => "grabbing".to_string(), // todo(linux) - couldn't find equivalent icon in linux
             CursorStyle::IBeamCursorForVerticalLayout => "vertical-text".to_string(),
             CursorStyle::OperationNotAllowed => "not-allowed".to_string(),
-            CursorStyle::DragLink => "dnd-link".to_string(),
-            CursorStyle::DragCopy => "dnd-copy".to_string(),
+            CursorStyle::DragLink => "alias".to_string(),
+            CursorStyle::DragCopy => "copy".to_string(),
             CursorStyle::ContextualMenu => "context-menu".to_string(),
         };
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -272,25 +272,25 @@ impl Client for WaylandClient {
         // and https://github.com/KDE/breeze (KDE). Both of them seem to be also derived from
         // Web CSS cursor names: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values
         let cursor_icon_name = match style {
-            CursorStyle::Arrow => "arrow".to_string(),
-            CursorStyle::IBeam => "text".to_string(),
-            CursorStyle::Crosshair => "crosshair".to_string(),
-            CursorStyle::ClosedHand => "grabbing".to_string(),
-            CursorStyle::OpenHand => "grab".to_string(),
-            CursorStyle::PointingHand => "pointer".to_string(),
-            CursorStyle::ResizeLeft => "w-resize".to_string(),
-            CursorStyle::ResizeRight => "e-resize".to_string(),
-            CursorStyle::ResizeLeftRight => "ew-resize".to_string(),
-            CursorStyle::ResizeUp => "n-resize".to_string(),
-            CursorStyle::ResizeDown => "s-resize".to_string(),
-            CursorStyle::ResizeUpDown => "ns-resize".to_string(),
-            CursorStyle::DisappearingItem => "grabbing".to_string(), // todo(linux) - couldn't find equivalent icon in linux
-            CursorStyle::IBeamCursorForVerticalLayout => "vertical-text".to_string(),
-            CursorStyle::OperationNotAllowed => "not-allowed".to_string(),
-            CursorStyle::DragLink => "alias".to_string(),
-            CursorStyle::DragCopy => "copy".to_string(),
-            CursorStyle::ContextualMenu => "context-menu".to_string(),
-        };
+            CursorStyle::Arrow => "arrow",
+            CursorStyle::IBeam => "text",
+            CursorStyle::Crosshair => "crosshair",
+            CursorStyle::ClosedHand => "grabbing",
+            CursorStyle::OpenHand => "grab",
+            CursorStyle::PointingHand => "pointer",
+            CursorStyle::ResizeLeft => "w-resize",
+            CursorStyle::ResizeRight => "e-resize",
+            CursorStyle::ResizeLeftRight => "ew-resize",
+            CursorStyle::ResizeUp => "n-resize",
+            CursorStyle::ResizeDown => "s-resize",
+            CursorStyle::ResizeUpDown => "ns-resize",
+            CursorStyle::DisappearingItem => "grabbing", // todo(linux) - couldn't find equivalent icon in linux
+            CursorStyle::IBeamCursorForVerticalLayout => "vertical-text",
+            CursorStyle::OperationNotAllowed => "not-allowed",
+            CursorStyle::DragLink => "alias",
+            CursorStyle::DragCopy => "copy",
+            CursorStyle::ContextualMenu => "context-menu",
+        }.to_string();
 
         let mut cursor_state = self.state.cursor_state.borrow_mut();
         cursor_state.cursor_icon_name = cursor_icon_name;

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -290,7 +290,8 @@ impl Client for WaylandClient {
             CursorStyle::DragLink => "alias",
             CursorStyle::DragCopy => "copy",
             CursorStyle::ContextualMenu => "context-menu",
-        }.to_string();
+        }
+        .to_string();
 
         let mut cursor_state = self.state.cursor_state.borrow_mut();
         cursor_state.cursor_icon_name = cursor_icon_name;

--- a/crates/gpui/src/platform/linux/wayland/cursor.rs
+++ b/crates/gpui/src/platform/linux/wayland/cursor.rs
@@ -37,12 +37,12 @@ impl Cursor {
     pub fn set_icon(&mut self, wl_pointer: &WlPointer, cursor_icon_name: String) {
         let mut cursor_icon_name = cursor_icon_name.clone();
         if self.current_icon_name != cursor_icon_name {
-            if self.theme.is_ok() {
+            if let Ok(theme) = &mut self.theme {
                 let mut buffer: Option<&CursorImageBuffer>;
 
-                if let Some(cursor) = self.theme.as_mut().unwrap().get_cursor(&cursor_icon_name) {
+                if let Some(cursor) = theme.get_cursor(&cursor_icon_name) {
                     buffer = Some(&cursor[0]);
-                } else if let Some(cursor) = self.theme.as_mut().unwrap().get_cursor("default") {
+                } else if let Some(cursor) = theme.get_cursor("default") {
                     buffer = Some(&cursor[0]);
                     cursor_icon_name = "default".to_string();
                     log::warn!(
@@ -54,9 +54,9 @@ impl Cursor {
                     log::warn!("Linux: Wayland: Unable to get default cursor too!");
                 }
 
-                if buffer.is_some(){
-                    let (width, height) = buffer.unwrap().dimensions();
-                    let (hot_x, hot_y) = buffer.unwrap().hotspot();
+                if let Some(buffer) = &mut buffer {
+                    let (width, height) = buffer.dimensions();
+                    let (hot_x, hot_y) = buffer.hotspot();
 
                     wl_pointer.set_cursor(
                         self.serial_id,
@@ -64,7 +64,7 @@ impl Cursor {
                         hot_x as i32,
                         hot_y as i32,
                     );
-                    self.surface.attach(Some(&buffer.unwrap()), 0, 0);
+                    self.surface.attach(Some(&buffer), 0, 0);
                     self.surface.damage(0, 0, width as i32, height as i32);
                     self.surface.commit();
 


### PR DESCRIPTION

Release Notes:

- Fixed wayland cursor style handling


In upcoming Gnome 46, cursor icon names are considerably changing. For example: this commit https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/commit/74e9b79471236320d2af4925d6c5bb7df22380ce removed/modified a lot of cursor names. Then some of the names were reintroduced in this commit https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/commit/6f64dc55dcaae24a14564494e24564a120cb4f33. I also tried upcoming KDE Plasma 6. Some of the cursor names are not used commonly between Gnome and KDE. From my analysis, these set of cursor names should be more widely available in both previous and upcoming release of Gnome and KDE.

Also, If a cursor style is not available, let's fallback to default cursor style. This avoids scenarios where we get stuck with special cursor styles like IBeam/Resize* because the current cursor style is not available. This will lead to an unpleasant/broken experience. Falling back to default cursor seems to be more acceptable.