### PR TITLE
Add alias_map parameter to tasks configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Support for additional platforms is on our [roadmap](https://zed.dev/roadmap):
 - Web ([tracking issue](https://github.com/zed-industries/zed/issues/5396))
 
 For macOS users, you can also install Zed from Homebrew:
+
 ```sh
 brew install zed
 ```

--- a/crates/task/src/oneshot_source.rs
+++ b/crates/task/src/oneshot_source.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 
-use crate::{SpawnInTerminal, Task, TaskContext, TaskId, TaskSource};
+use crate::{
+    convert_task_env, SpawnInTerminal, Task, TaskAliasMap, TaskContext, TaskId, TaskSource,
+};
 use gpui::{AppContext, Context, Model};
 
 /// A storage and source of tasks generated out of user command prompt inputs.
@@ -45,7 +47,7 @@ impl Task for OneshotTask {
             command: self.id().0.clone(),
             args: vec![],
             cwd,
-            env,
+            env: convert_task_env(&TaskAliasMap::default(), env),
             use_new_terminal: Default::default(),
             allow_concurrent_runs: Default::default(),
         })

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -5,7 +5,7 @@ use gpui::{AppContext, ViewContext, WindowContext};
 use language::Point;
 use modal::TasksModal;
 use project::{Location, WorktreeId};
-use task::{Task, TaskContext};
+use task::{Task, TaskContext, TaskEnvVariables};
 use util::ResultExt;
 use workspace::Workspace;
 
@@ -117,19 +117,19 @@ fn task_context(
                 let selected_text = buffer.read(cx).chars_for_range(selection_range).collect();
 
                 let mut env = HashMap::from_iter([
-                    ("ZED_ROW".into(), row.to_string()),
-                    ("ZED_COLUMN".into(), column.to_string()),
-                    ("ZED_SELECTED_TEXT".into(), selected_text),
+                    (TaskEnvVariables::Row, row.to_string()),
+                    (TaskEnvVariables::Column, column.to_string()),
+                    (TaskEnvVariables::SelectedText, selected_text),
                 ]);
                 if let Some(path) = current_file {
-                    env.insert("ZED_FILE".into(), path);
+                    env.insert(TaskEnvVariables::ActiveFile, path);
                 }
                 if let Some(worktree_path) = worktree_path {
-                    env.insert("ZED_WORKTREE_ROOT".into(), worktree_path);
+                    env.insert(TaskEnvVariables::WorktreeRoot, worktree_path);
                 }
                 if let Some(language_context) = context {
                     if let Some(symbol) = language_context.symbol {
-                        env.insert("ZED_SYMBOL".into(), symbol);
+                        env.insert(TaskEnvVariables::ActiveSymbol, symbol);
                     }
                 }
 


### PR DESCRIPTION
Alias_map allows a user to change a task's environment variables names based on an IDE. The default IDE and only choice currently is vs code.

I still need to update the task_ui tests to work correctly with my changes, and I'll also appreciate feedback from the community regarding this commit. 

#8893
