### PR TITLE
Make comment above `util::fs::remove_matching` a doc comment

### DIFF
--- a/crates/util/src/fs.rs
+++ b/crates/util/src/fs.rs
@@ -4,7 +4,7 @@ use smol::{fs, stream::StreamExt};
 
 use crate::ResultExt;
 
-// Removes all files and directories matching the given predicate
+/// Removes all files and directories matching the given predicate
 pub async fn remove_matching<F>(dir: &Path, predicate: F)
 where
     F: Fn(&Path) -> bool,


### PR DESCRIPTION
Just this one little thing, noticed it while working on an unrelated pull request.

Release Notes:

- N/A
