### PR TITLE
Add `editor::RevertSelectedHunks` to revert git diff hunks in the editor

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -118,7 +118,8 @@
           "stop_at_soft_wraps": true
         }
       ],
-      "ctrl-;": "editor::ToggleLineNumbers"
+      "ctrl-;": "editor::ToggleLineNumbers",
+      "cmd-alt-z": "editor::RevertSelectedChunks"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -119,7 +119,7 @@
         }
       ],
       "ctrl-;": "editor::ToggleLineNumbers",
-      "cmd-alt-z": "editor::RevertSelectedChunks"
+      "cmd-alt-z": "editor::RevertSelectedHunks"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -119,7 +119,7 @@
         }
       ],
       "ctrl-;": "editor::ToggleLineNumbers",
-      "cmd-alt-z": "editor::RevertSelectedHunks"
+      "ctrl-alt-z": "editor::RevertSelectedHunks"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -153,7 +153,8 @@
         }
       ],
       "ctrl-cmd-space": "editor::ShowCharacterPalette",
-      "cmd-;": "editor::ToggleLineNumbers"
+      "cmd-;": "editor::ToggleLineNumbers",
+      "cmd-alt-z": "editor::RevertSelectedChunks"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -154,7 +154,7 @@
       ],
       "ctrl-cmd-space": "editor::ShowCharacterPalette",
       "cmd-;": "editor::ToggleLineNumbers",
-      "cmd-alt-z": "editor::RevertSelectedChunks"
+      "cmd-alt-z": "editor::RevertSelectedHunks"
     }
   },
   {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -210,6 +210,7 @@ gpui::actions!(
         PageDown,
         PageUp,
         Paste,
+        RevertSelectedChunks,
         Redo,
         RedoSelection,
         Rename,

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -210,7 +210,7 @@ gpui::actions!(
         PageDown,
         PageUp,
         Paste,
-        RevertSelectedChunks,
+        RevertSelectedHunks,
         Redo,
         RedoSelection,
         Rename,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4908,7 +4908,7 @@ impl Editor {
         })
     }
 
-    pub fn revert_selected_chunks(&mut self, _: &RevertSelectedChunks, cx: &mut ViewContext<Self>) {
+    pub fn revert_selected_hunks(&mut self, _: &RevertSelectedHunks, cx: &mut ViewContext<Self>) {
         let mut revert_changes = Vec::new();
 
         self.buffer.update(cx, |multi_buffer, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4909,98 +4909,98 @@ impl Editor {
     }
 
     pub fn revert_selected_hunks(&mut self, _: &RevertSelectedHunks, cx: &mut ViewContext<Self>) {
-        let mut revert_changes =
-            HashMap::<BufferId, Vec<(Range<text::Anchor>, Arc<str>)>>::default();
-        let selections = self.selections.disjoint_anchors();
+        let revert_changes = self.gather_revert_changes(&self.selections.disjoint_anchors(), cx);
+        if !revert_changes.is_empty() {
+            self.transact(cx, |editor, cx| {
+                editor.buffer().update(cx, |multi_buffer, cx| {
+                    for (buffer_id, buffer_revert_ranges) in revert_changes {
+                        if let Some(buffer) = multi_buffer.buffer(buffer_id) {
+                            buffer.update(cx, |buffer, cx| {
+                                buffer.edit(buffer_revert_ranges, None, cx);
+                            });
+                        }
+                    }
+                });
+                editor.change_selections(None, cx, |selections| selections.refresh());
+            });
+        }
+    }
 
+    fn gather_revert_changes(
+        &mut self,
+        selections: &[Selection<Anchor>],
+        cx: &mut ViewContext<'_, Editor>,
+    ) -> HashMap<BufferId, Vec<(Range<text::Anchor>, Arc<str>)>> {
+        let mut revert_changes = HashMap::default();
         self.buffer.update(cx, |multi_buffer, cx| {
             let multi_buffer_snapshot = multi_buffer.snapshot(cx);
             let selected_multi_buffer_rows = selections.iter().filter_map(|selection| {
                 let head = selection.head();
                 let tail = selection.tail();
-                if head.buffer_id != tail.buffer_id {
-                    return None;
-                }
-                let buffer = multi_buffer.buffer(tail.buffer_id?)?;
                 let start = tail.to_point(&multi_buffer_snapshot).row;
                 let end = head.to_point(&multi_buffer_snapshot).row;
                 let multi_buffer_rows = if start > end { end..start } else { start..end };
-                Some((buffer, multi_buffer_rows))
+                Some(multi_buffer_rows)
             });
 
-            let mut processed_multi_buffer_rows = HashSet::default();
-            for (buffer, selected_multi_buffer_rows) in selected_multi_buffer_rows {
+            let mut processed_buffer_rows =
+                HashMap::<BufferId, HashSet<Range<text::Anchor>>>::default();
+            for selected_multi_buffer_rows in selected_multi_buffer_rows {
                 let query_rows =
                     selected_multi_buffer_rows.start..selected_multi_buffer_rows.end + 1;
-                buffer.update(cx, |buffer, _| {
-                    if let Some(diff_base) = buffer.diff_base() {
-                        for hunk in
-                            multi_buffer_snapshot.git_diff_hunks_in_range(query_rows.clone())
+                for hunk in multi_buffer_snapshot.git_diff_hunks_in_range(query_rows.clone()) {
+                    // Deleted hunk is an empty row range, no caret can be placed there and Zed allows to revert it
+                    // when the caret is just above or just below the deleted hunk.
+                    let allow_adjacent = hunk.status() == DiffHunkStatus::Removed;
+                    let related_to_selection = if allow_adjacent {
+                        hunk.associated_range.overlaps(&query_rows)
+                            || hunk.associated_range.start == query_rows.end
+                            || hunk.associated_range.end == query_rows.start
+                    } else {
+                        // `selected_multi_buffer_rows` are inclusive (e.g. [2..2] means 2nd row is selected)
+                        // `hunk.associated_range` is exclusive (e.g. [2..3] means 2nd row is selected)
+                        hunk.associated_range.overlaps(&selected_multi_buffer_rows)
+                            || selected_multi_buffer_rows.end == hunk.associated_range.start
+                    };
+                    if related_to_selection {
+                        if !processed_buffer_rows
+                            .entry(hunk.buffer_id)
+                            .or_default()
+                            .insert(hunk.buffer_range.start..hunk.buffer_range.end)
                         {
-                            let Some(original_text) =
-                                diff_base.get(hunk.diff_base_byte_range.clone())
-                            else {
-                                return;
-                            };
-
-                            // Deleted hunk is an empty row range, no caret can be placed there and Zed allows to revert it
-                            // when the caret is just above or just below the deleted hunk.
-                            let allow_adjacent = hunk.status() == DiffHunkStatus::Removed;
-                            let related_to_selection = if allow_adjacent {
-                                hunk.associated_range.overlaps(&query_rows)
-                                    || hunk.associated_range.start == query_rows.end
-                                    || hunk.associated_range.end == query_rows.start
-                            } else {
-                                // `selected_multi_buffer_rows` are inclusive (e.g. [2..2] means 2nd row is selected)
-                                // `hunk.associated_range` is exclusive (e.g. [2..3] means 2nd row is selected)
-                                hunk.associated_range.overlaps(&selected_multi_buffer_rows)
-                                    || selected_multi_buffer_rows.end == hunk.associated_range.start
-                            };
-                            if related_to_selection {
-                                if !processed_multi_buffer_rows
-                                    .insert(hunk.buffer_range.start..hunk.buffer_range.end)
-                                {
-                                    return;
-                                }
-
-                                let buffer_snapshot = buffer.snapshot();
-                                let buffer_revert_changes =
-                                    revert_changes.entry(buffer.remote_id()).or_default();
-                                if let Err(i) = buffer_revert_changes.binary_search_by(|probe| {
-                                    probe
-                                        .0
-                                        .start
-                                        .cmp(&hunk.buffer_range.start, &buffer_snapshot)
-                                        .then(
-                                            probe
-                                                .0
-                                                .end
-                                                .cmp(&hunk.buffer_range.end, &buffer_snapshot),
-                                        )
-                                        .then(probe.1.as_ref().cmp(original_text))
-                                }) {
-                                    buffer_revert_changes
-                                        .insert(i, (hunk.buffer_range, Arc::from(original_text)));
-                                }
-                            }
+                            continue;
                         }
-                    }
-                })
-            }
-        });
-
-        if !revert_changes.is_empty() {
-            self.transact(cx, |editor, cx| {
-                let multi_buffer = editor.buffer();
-                for (buffer_id, buffer_revert_ranges) in revert_changes {
-                    if let Some(buffer) = multi_buffer.read(cx).buffer(buffer_id) {
-                        buffer.update(cx, |buffer, cx| {
-                            buffer.edit(buffer_revert_ranges, None, cx);
-                        });
+                        Self::prepare_revert_change(&mut revert_changes, &multi_buffer, &hunk, cx);
                     }
                 }
-                editor.change_selections(None, cx, |selections| selections.refresh());
-            });
+            }
+        });
+        revert_changes
+    }
+
+    fn prepare_revert_change(
+        revert_changes: &mut HashMap<BufferId, Vec<(Range<text::Anchor>, Arc<str>)>>,
+        multi_buffer: &MultiBuffer,
+        hunk: &DiffHunk<u32>,
+        cx: &mut AppContext,
+    ) -> Option<()> {
+        let buffer = multi_buffer.buffer(hunk.buffer_id)?;
+        let buffer = buffer.read(cx);
+        let original_text = buffer.diff_base()?.get(hunk.diff_base_byte_range.clone())?;
+        let buffer_snapshot = buffer.snapshot();
+        let buffer_revert_changes = revert_changes.entry(buffer.remote_id()).or_default();
+        if let Err(i) = buffer_revert_changes.binary_search_by(|probe| {
+            probe
+                .0
+                .start
+                .cmp(&hunk.buffer_range.start, &buffer_snapshot)
+                .then(probe.0.end.cmp(&hunk.buffer_range.end, &buffer_snapshot))
+                .then(probe.1.as_ref().cmp(original_text))
+        }) {
+            buffer_revert_changes.insert(i, (hunk.buffer_range.clone(), Arc::from(original_text)));
+            Some(())
+        } else {
+            None
         }
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4934,13 +4934,16 @@ impl Editor {
         let mut revert_changes = HashMap::default();
         self.buffer.update(cx, |multi_buffer, cx| {
             let multi_buffer_snapshot = multi_buffer.snapshot(cx);
-            let selected_multi_buffer_rows = selections.iter().filter_map(|selection| {
+            let selected_multi_buffer_rows = selections.iter().map(|selection| {
                 let head = selection.head();
                 let tail = selection.tail();
                 let start = tail.to_point(&multi_buffer_snapshot).row;
                 let end = head.to_point(&multi_buffer_snapshot).row;
-                let multi_buffer_rows = if start > end { end..start } else { start..end };
-                Some(multi_buffer_rows)
+                if start > end {
+                    end..start
+                } else {
+                    start..end
+                }
             });
 
             let mut processed_buffer_rows =

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8743,6 +8743,7 @@ async fn test_find_all_references(cx: &mut gpui::TestAppContext) {
     "});
 }
 
+// TODO kb assert hunk change types
 #[gpui::test]
 async fn test_addition_reverts(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
@@ -8751,89 +8752,89 @@ async fn test_addition_reverts(cx: &mut gpui::TestAppContext) {
         cx,
     )
     .await;
-    let base_text = indoc! {r#"struct Row1;
+    let base_text = indoc! {r#"struct Row;
+struct Row1;
 struct Row2;
-struct Row3;
 
+struct Row4;
 struct Row5;
 struct Row6;
-struct Row7;
 
+struct Row8;
 struct Row9;
-struct Row10;
-struct Row11;"#};
+struct Row10;"#};
 
     // When addition hunks are not adjacent to carets, no hunk revert is performed
     assert_hunk_revert(
-        indoc! {r#"struct Row1;
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row2;
-                   struct Row3;
-                   struct Row3.1;
-                   struct Row3.2;
+                   struct Row2.1;
+                   struct Row2.2;
                    ˇ
+                   struct Row4;
                    struct Row5;
                    struct Row6;
-                   struct Row7;
                    ˇ
                    struct Row9.1;
                    struct Row9.2;
                    struct Row9.3;
+                   struct Row8;
                    struct Row9;
-                   struct Row10;
-                   struct Row11;"#},
-        indoc! {r#"struct Row1;
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row2;
-                   struct Row3;
-                   struct Row3.1;
-                   struct Row3.2;
+                   struct Row2.1;
+                   struct Row2.2;
                    ˇ
+                   struct Row4;
                    struct Row5;
                    struct Row6;
-                   struct Row7;
                    ˇ
                    struct Row9.1;
                    struct Row9.2;
                    struct Row9.3;
+                   struct Row8;
                    struct Row9;
-                   struct Row10;
-                   struct Row11;"#},
+                   struct Row10;"#},
         base_text,
         &mut cx,
     );
     // Same for selections
     assert_hunk_revert(
-        indoc! {r#"struct Row1;
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row2;
-                   struct Row3;
-                   struct Row3.1;
-                   struct Row3.2;
+                   struct Row2.1;
+                   struct Row2.2;
                    «ˇ
-                   struct Row5;
-                   struct» Row6;
-                   «struct Row7;
+                   struct Row4;
+                   struct» Row5;
+                   «struct Row6;
                    ˇ»
                    struct Row9.1;
                    struct Row9.2;
                    struct Row9.3;
+                   struct Row8;
                    struct Row9;
-                   struct Row10;
-                   struct Row11;"#},
-        indoc! {r#"struct Row1;
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row2;
-                   struct Row3;
-                   struct Row3.1;
-                   struct Row3.2;
+                   struct Row2.1;
+                   struct Row2.2;
                    «ˇ
-                   struct Row5;
-                   struct» Row6;
-                   «struct Row7;
+                   struct Row4;
+                   struct» Row5;
+                   «struct Row6;
                    ˇ»
                    struct Row9.1;
                    struct Row9.2;
                    struct Row9.3;
+                   struct Row8;
                    struct Row9;
-                   struct Row10;
-                   struct Row11;"#},
+                   struct Row10;"#},
         base_text,
         &mut cx,
     );
@@ -8841,39 +8842,39 @@ struct Row11;"#};
     // When carets and selections intersect the addition hunks, those are reverted.
     // Adjacent carets got merged.
     assert_hunk_revert(
-        indoc! {r#"struct Row1;
+        indoc! {r#"struct Row;
                    ˇ// something on the top
+                   struct Row1;
                    struct Row2;
-                   struct Row3;
                    struct Roˇw3.1;
-                   struct Row3.2;
-                   struct Row3.3;ˇ
+                   struct Row2.2;
+                   struct Row2.3;ˇ
 
-                   struct Row5;
+                   struct Row4;
                    struct ˇRow5.1;
                    struct Row5.2;
                    struct «Rowˇ»5.3;
+                   struct Row5;
                    struct Row6;
-                   struct Row7;
                    ˇ
                    struct Row9.1;
                    struct «Rowˇ»9.2;
                    struct «ˇRow»9.3;
+                   struct Row8;
                    struct Row9;
-                   struct Row10;
                    «ˇ// something on bottom»
-                   struct Row11;"#},
-        indoc! {r#"struct Row1;
-                   ˇstruct Row2;
-                   struct Row3;
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   ˇstruct Row1;
+                   struct Row2;
                    ˇ
-                   struct Row5;
-                   ˇstruct Row6;
-                   struct Row7;
+                   struct Row4;
+                   ˇstruct Row5;
+                   struct Row6;
                    ˇ
-                   ˇstruct Row9;
-                   struct Row10;
-                   ˇstruct Row11;"#},
+                   ˇstruct Row8;
+                   struct Row9;
+                   ˇstruct Row10;"#},
         base_text,
         &mut cx,
     );
@@ -8887,69 +8888,211 @@ async fn test_modification_reverts(cx: &mut gpui::TestAppContext) {
         cx,
     )
     .await;
-    let base_text = indoc! {r#"struct Row1;
+    let base_text = indoc! {r#"struct Row;
+struct Row1;
 struct Row2;
-struct Row3;
 
+struct Row4;
 struct Row5;
 struct Row6;
-struct Row7;
 
+struct Row8;
 struct Row9;
-struct Row10;
-struct Row11;"#};
+struct Row10;"#};
 
-    // When addition hunks are not adjacent to carets, no hunk revert is performed
+    // Modification hunks behave the same as the addition ones.
     assert_hunk_revert(
-        indoc! {r#"struct Row1;
-                   struct Row2;
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row33;
                    ˇ
+                   struct Row4;
                    struct Row5;
                    struct Row6;
-                   struct Row7;
                    ˇ
                    struct Row99;
-                   struct Row10;
-                   struct Row11;"#},
-        indoc! {r#"struct Row1;
-                   struct Row2;
+                   struct Row9;
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row33;
                    ˇ
+                   struct Row4;
                    struct Row5;
                    struct Row6;
-                   struct Row7;
                    ˇ
                    struct Row99;
-                   struct Row10;
-                   struct Row11;"#},
+                   struct Row9;
+                   struct Row10;"#},
         base_text,
         &mut cx,
     );
-    // Same for selections
     assert_hunk_revert(
-        indoc! {r#"struct Row1;
-                   struct Row2;
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row33;
                    «ˇ
-                   struct Row5;
-                   struct» Row6;
-                   «struct Row7;
+                   struct Row4;
+                   struct» Row5;
+                   «struct Row6;
                    ˇ»
                    struct Row99;
-                   struct Row10;
-                   struct Row11;"#},
-        indoc! {r#"struct Row1;
-                   struct Row2;
+                   struct Row9;
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row1;
                    struct Row33;
                    «ˇ
-                   struct Row5;
-                   struct» Row6;
-                   «struct Row7;
+                   struct Row4;
+                   struct» Row5;
+                   «struct Row6;
                    ˇ»
                    struct Row99;
-                   struct Row10;
-                   struct Row11;"#},
+                   struct Row9;
+                   struct Row10;"#},
+        base_text,
+        &mut cx,
+    );
+
+    assert_hunk_revert(
+        indoc! {r#"ˇstruct Row1.1;
+                   struct Row1;
+                   «ˇstr»uct Row22;
+
+                   struct ˇRow44;
+                   struct Row5;
+                   struct «Rˇ»ow66;ˇ
+
+                   «struˇ»ct Row88;
+                   struct Row9;
+                   struct Row1011;ˇ"#},
+        indoc! {r#"struct Row;
+                   ˇstruct Row1;
+                   struct Row2;
+                   ˇ
+                   struct Row4;
+                   ˇstruct Row5;
+                   struct Row6;
+                   ˇ
+                   struct Row8;
+                   ˇstruct Row9;
+                   struct Row10;ˇ"#},
+        base_text,
+        &mut cx,
+    );
+}
+
+#[gpui::test]
+async fn test_deletion_reverts(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities::default(),
+        cx,
+    )
+    .await;
+    let base_text = indoc! {r#"struct Row;
+struct Row1;
+struct Row2;
+
+struct Row4;
+struct Row5;
+struct Row6;
+
+struct Row8;
+struct Row9;
+struct Row10;"#};
+
+    // Deletion hunks trigger on ajacent, so carets and selections have to stay farther to avoird the revert
+    assert_hunk_revert(
+        indoc! {r#"struct Row;
+                   struct Row2;
+
+                   ˇstruct Row4;
+                   struct Row5;
+                   struct Row6;
+                   ˇ
+                   struct Row8;
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row2;
+
+                   ˇstruct Row4;
+                   struct Row5;
+                   struct Row6;
+                   ˇ
+                   struct Row8;
+                   struct Row10;"#},
+        base_text,
+        &mut cx,
+    );
+    assert_hunk_revert(
+        indoc! {r#"struct Row;
+                   struct Row2;
+
+                   «ˇstruct Row4;
+                   struct» Row5;
+                   «struct Row6;
+                   ˇ»
+                   struct Row8;
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row2;
+
+                   «ˇstruct Row4;
+                   struct» Row5;
+                   «struct Row6;
+                   ˇ»
+                   struct Row8;
+                   struct Row10;"#},
+        base_text,
+        &mut cx,
+    );
+
+    // Deletion hunks are ephemeral, so it's impossible to place the caret into them — Zed triggers reverts for lines, adjacent to carets and selections.
+    assert_hunk_revert(
+        indoc! {r#"struct Row;
+                   ˇstruct Row2;
+
+                   struct Row4;
+                   struct Row5;
+                   struct Row6;
+
+                   struct Row8;ˇ
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row1;
+                   ˇstruct Row2;
+
+                   struct Row4;
+                   struct Row5;
+                   struct Row6;
+
+                   struct Row8;ˇ
+                   struct Row9;
+                   struct Row10;"#},
+        base_text,
+        &mut cx,
+    );
+    assert_hunk_revert(
+        indoc! {r#"struct Row;
+                   struct Row2«ˇ;
+                   struct Row4;
+                   struct» Row5;
+                   «struct Row6;
+
+                   struct Row8;ˇ»
+                   struct Row10;"#},
+        indoc! {r#"struct Row;
+                   struct Row1;
+                   struct Row2«ˇ;
+
+                   struct Row4;
+                   struct» Row5;
+                   «struct Row6;
+
+                   struct Row8;ˇ»
+                   struct Row9;
+                   struct Row10;"#},
         base_text,
         &mut cx,
     );
@@ -8958,27 +9101,27 @@ struct Row11;"#};
     // Adjacent carets got merged.
     assert_hunk_revert(
         indoc! {r#"ˇstruct Row1.1;
-                   struct Row2;
+                   struct Row1;
                    «ˇstr»uct Row33;
 
                    struct ˇRow55;
-                   struct Row6;
+                   struct Row5;
                    struct «Rˇ»ow77;ˇ
 
                    «struˇ»ct Row99;
-                   struct Row10;
-                   struct Row1111;ˇ"#},
-        indoc! {r#"struct Row1;
-                   ˇstruct Row2;
-                   struct Row3;
-                   ˇ
-                   struct Row5;
-                   ˇstruct Row6;
-                   struct Row7;
-                   ˇ
                    struct Row9;
-                   ˇstruct Row10;
-                   struct Row11;ˇ"#},
+                   struct Row1011;ˇ"#},
+        indoc! {r#"struct Row;
+                   ˇstruct Row1;
+                   struct Row2;
+                   ˇ
+                   struct Row4;
+                   ˇstruct Row5;
+                   struct Row6;
+                   ˇ
+                   struct Row8;
+                   ˇstruct Row9;
+                   struct Row10;ˇ"#},
         base_text,
         &mut cx,
     );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9113,57 +9113,6 @@ struct Row10;"#};
 }
 
 #[gpui::test]
-async fn test_multiple_types_reverts(cx: &mut gpui::TestAppContext) {
-    init_test(cx, |_| {});
-    let mut cx = EditorLspTestContext::new_rust(lsp::ServerCapabilities::default(), cx).await;
-    let base_text = indoc! {r#"struct Row;
-struct Row1;
-struct Row2;
-
-struct Row4;
-struct Row5;
-struct Row6;
-
-struct Row8;
-struct Row9;
-struct Row10;"#};
-
-    assert_hunk_revert(
-        indoc! {r#"«ˇstruct Row;
-                   struct Row0.1;
-                   struct Row0.2;
-                   struct Row1;
-
-                   struct Row4;
-                   struct Row5444;
-                   struct Row6;
-
-                   struct R»ow9;
-                   struct Row1220;"#},
-        vec![
-            DiffHunkStatus::Added,
-            DiffHunkStatus::Removed,
-            DiffHunkStatus::Modified,
-            DiffHunkStatus::Removed,
-            DiffHunkStatus::Modified,
-        ],
-        indoc! {r#"«ˇstruct Row;
-                   struct Row1;
-                   struct Row2;
-
-                   struct Row4;
-                   struct Row5;
-                   struct Row6;
-
-                   struct Row8;
-                   struct R»ow9;
-                   struct Row1220;"#},
-        base_text,
-        &mut cx,
-    );
-}
-
-#[gpui::test]
 async fn test_multibuffer_reverts(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8768,35 +8768,35 @@ struct Row10;"#};
     assert_hunk_revert(
         indoc! {r#"struct Row;
                    struct Row1;
-                   struct Row2;
-                   struct Row2.1;
-                   struct Row2.2;
-                   ˇ
+                   struct Row1.1;
+                   struct Row1.2;
+                   struct Row2;ˇ
+
                    struct Row4;
                    struct Row5;
                    struct Row6;
-                   ˇ
+
+                   struct Row8;
+                   ˇstruct Row9;
                    struct Row9.1;
                    struct Row9.2;
                    struct Row9.3;
-                   struct Row8;
-                   struct Row9;
                    struct Row10;"#},
         indoc! {r#"struct Row;
                    struct Row1;
-                   struct Row2;
-                   struct Row2.1;
-                   struct Row2.2;
-                   ˇ
+                   struct Row1.1;
+                   struct Row1.2;
+                   struct Row2;ˇ
+
                    struct Row4;
                    struct Row5;
                    struct Row6;
-                   ˇ
+
+                   struct Row8;
+                   ˇstruct Row9;
                    struct Row9.1;
                    struct Row9.2;
                    struct Row9.3;
-                   struct Row8;
-                   struct Row9;
                    struct Row10;"#},
         base_text,
         &mut cx,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9435,7 +9435,7 @@ fn assert_hunk_revert(
     });
     cx.executor().run_until_parked();
 
-    cx.update_editor(|editor, cx| {
+    let reverted_hunk_statuses = cx.update_editor(|editor, cx| {
         let snapshot = editor
             .buffer()
             .read(cx)
@@ -9447,10 +9447,11 @@ fn assert_hunk_revert(
             .git_diff_hunks_in_row_range(0..u32::MAX)
             .map(|hunk| hunk.status())
             .collect::<Vec<_>>();
-        assert_eq!(reverted_hunk_statuses, expected_not_reverted_hunk_statuses);
 
         editor.revert_selected_hunks(&RevertSelectedHunks, cx);
+        reverted_hunk_statuses
     });
     cx.executor().run_until_parked();
     cx.assert_editor_state(expected_reverted_text_with_selections);
+    assert_eq!(reverted_hunk_statuses, expected_not_reverted_hunk_statuses);
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -339,6 +339,7 @@ impl EditorElement {
         register_action(view, cx, Editor::unique_lines_case_insensitive);
         register_action(view, cx, Editor::unique_lines_case_sensitive);
         register_action(view, cx, Editor::accept_partial_copilot_suggestion);
+        register_action(view, cx, Editor::revert_selected_chunks);
     }
 
     fn register_key_listeners(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -339,7 +339,7 @@ impl EditorElement {
         register_action(view, cx, Editor::unique_lines_case_insensitive);
         register_action(view, cx, Editor::unique_lines_case_sensitive);
         register_action(view, cx, Editor::accept_partial_copilot_suggestion);
-        register_action(view, cx, Editor::revert_selected_chunks);
+        register_action(view, cx, Editor::revert_selected_hunks);
     }
 
     fn register_key_listeners(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1453,12 +1453,12 @@ impl EditorElement {
                     .buffer_snapshot
                     .git_diff_hunks_in_range(0..(max_row.floor() as u32))
                 {
-                    let start_display = Point::new(hunk.buffer_range.start, 0)
+                    let start_display = Point::new(hunk.associated_range.start, 0)
                         .to_display_point(&layout.position_map.snapshot.display_snapshot);
-                    let end_display = Point::new(hunk.buffer_range.end, 0)
+                    let end_display = Point::new(hunk.associated_range.end, 0)
                         .to_display_point(&layout.position_map.snapshot.display_snapshot);
                     let start_y = y_for_row(start_display.row() as f32);
-                    let mut end_y = if hunk.buffer_range.start == hunk.buffer_range.end {
+                    let mut end_y = if hunk.associated_range.start == hunk.associated_range.end {
                         y_for_row((end_display.row() + 1) as f32)
                     } else {
                         y_for_row((end_display.row()) as f32)

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -46,20 +46,20 @@ impl DisplayDiffHunk {
 }
 
 pub fn diff_hunk_to_display(hunk: DiffHunk<u32>, snapshot: &DisplaySnapshot) -> DisplayDiffHunk {
-    let hunk_start_point = Point::new(hunk.buffer_range.start, 0);
-    let hunk_start_point_sub = Point::new(hunk.buffer_range.start.saturating_sub(1), 0);
+    let hunk_start_point = Point::new(hunk.associated_range.start, 0);
+    let hunk_start_point_sub = Point::new(hunk.associated_range.start.saturating_sub(1), 0);
     let hunk_end_point_sub = Point::new(
-        hunk.buffer_range
+        hunk.associated_range
             .end
             .saturating_sub(1)
-            .max(hunk.buffer_range.start),
+            .max(hunk.associated_range.start),
         0,
     );
 
     let is_removal = hunk.status() == DiffHunkStatus::Removed;
 
-    let folds_start = Point::new(hunk.buffer_range.start.saturating_sub(2), 0);
-    let folds_end = Point::new(hunk.buffer_range.end + 2, 0);
+    let folds_start = Point::new(hunk.associated_range.start.saturating_sub(2), 0);
+    let folds_end = Point::new(hunk.associated_range.end + 2, 0);
     let folds_range = folds_start..folds_end;
 
     let containing_fold = snapshot.folds_in_range(folds_range).find(|fold| {
@@ -79,7 +79,7 @@ pub fn diff_hunk_to_display(hunk: DiffHunk<u32>, snapshot: &DisplaySnapshot) -> 
     } else {
         let start = hunk_start_point.to_display_point(snapshot).row();
 
-        let hunk_end_row = hunk.buffer_range.end.max(hunk.buffer_range.start);
+        let hunk_end_row = hunk.associated_range.end.max(hunk.associated_range.start);
         let hunk_end_point = Point::new(hunk_end_row, 0);
         let end = hunk_end_point.to_display_point(snapshot).row();
 
@@ -264,7 +264,7 @@ mod tests {
         assert_eq!(
             snapshot
                 .git_diff_hunks_in_range(0..12)
-                .map(|hunk| (hunk.status(), hunk.buffer_range))
+                .map(|hunk| (hunk.status(), hunk.associated_range))
                 .collect::<Vec<_>>(),
             &expected,
         );
@@ -272,7 +272,7 @@ mod tests {
         assert_eq!(
             snapshot
                 .git_diff_hunks_in_range_rev(0..12)
-                .map(|hunk| (hunk.status(), hunk.buffer_range))
+                .map(|hunk| (hunk.status(), hunk.associated_range))
                 .collect::<Vec<_>>(),
             expected
                 .iter()

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -274,7 +274,7 @@ impl EditorTestContext {
         let buffer_text = self.buffer_text();
 
         if buffer_text != unmarked_text {
-            panic!("Unmarked text doesn't match buffer text\nBuffer text: {buffer_text:?}\nUnmarked text: {unmarked_text:?}\nRaw buffer text\n{buffer_text}Raw unmarked text\n{unmarked_text}");
+            panic!("Unmarked text doesn't match buffer text\nBuffer text: {buffer_text:?}\nUnmarked text: {unmarked_text:?}\nRaw buffer text\n{buffer_text}\nRaw unmarked text\n{unmarked_text}");
         }
 
         self.assert_selections(expected_selections, marked_text.to_string())

--- a/crates/git/src/diff.rs
+++ b/crates/git/src/diff.rs
@@ -1,6 +1,6 @@
 use std::{iter, ops::Range};
 use sum_tree::SumTree;
-use text::{Anchor, BufferSnapshot, OffsetRangeExt, Point};
+use text::{Anchor, BufferId, BufferSnapshot, OffsetRangeExt, Point};
 
 pub use git2 as libgit;
 use libgit::{DiffLineType as GitDiffLineType, DiffOptions as GitOptions, Patch as GitPatch};
@@ -15,6 +15,7 @@ pub enum DiffHunkStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffHunk<T> {
     pub associated_range: Range<T>,
+    pub buffer_id: BufferId,
     pub buffer_range: Range<Anchor>,
     pub diff_base_byte_range: Range<usize>,
 }
@@ -151,6 +152,7 @@ impl BufferDiff {
                 associated_range: start_point.row..end_point.row,
                 diff_base_byte_range: start_base..end_base,
                 buffer_range: buffer.anchor_before(start_point)..buffer.anchor_after(end_point),
+                buffer_id: buffer.remote_id(),
             })
         })
     }
@@ -181,6 +183,7 @@ impl BufferDiff {
                 associated_range: range.start.row..end_row,
                 diff_base_byte_range: hunk.diff_base_byte_range.clone(),
                 buffer_range: hunk.buffer_range.clone(),
+                buffer_id: hunk.buffer_id,
             })
         })
     }
@@ -301,6 +304,7 @@ impl BufferDiff {
             associated_range: buffer_range.clone(),
             buffer_range,
             diff_base_byte_range,
+            buffer_id: buffer.remote_id(),
         }
     }
 }

--- a/crates/git/src/diff.rs
+++ b/crates/git/src/diff.rs
@@ -12,11 +12,20 @@ pub enum DiffHunkStatus {
     Removed,
 }
 
+/// A diff hunk, representing a range of consequent lines in a singleton buffer, associated with a generic range.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffHunk<T> {
+    /// E.g. a range in multibuffer, that has an excerpt added, singleton buffer for which has this diff hunk.
+    /// Consider a singleton buffer with 10 lines, all of them are modified — so a corresponding diff hunk would have a range 0..10.
+    /// And a multibuffer with the excerpt of lines 2-6 from the singleton buffer.
+    /// If the multibuffer is searched for diff hunks, the associated range would be multibuffer rows, corresponding to rows 2..6 from the singleton buffer.
+    /// But the hunk range would be 0..10, same for any other excerpts from the same singleton buffer.
     pub associated_range: Range<T>,
+    /// Singleton buffer ID this hunk belongs to.
     pub buffer_id: BufferId,
+    /// A consequent range of lines in the singleton buffer, that were changed and produced this diff hunk.
     pub buffer_range: Range<Anchor>,
+    /// Original singleton buffer text before the change, that was instead of the `buffer_range`.
     pub diff_base_byte_range: Range<usize>,
 }
 

--- a/crates/git/src/diff.rs
+++ b/crates/git/src/diff.rs
@@ -14,15 +14,41 @@ pub enum DiffHunkStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffHunk<T> {
-    pub buffer_range: Range<T>,
+    pub associated_range: Range<T>,
+    pub buffer_range: Range<Anchor>,
     pub diff_base_byte_range: Range<usize>,
+}
+
+impl<T> DiffHunk<T> {
+    fn buffer_range_empty(&self) -> bool {
+        if self.buffer_range.start == self.buffer_range.end {
+            return true;
+        }
+
+        // buffer diff hunks are per line, so if we arrive to the same line with different bias, it's the same hunk
+        let Anchor {
+            timestamp: timestamp_start,
+            offset: offset_start,
+            buffer_id: buffer_id_start,
+            bias: _,
+        } = self.buffer_range.start;
+        let Anchor {
+            timestamp: timestamp_end,
+            offset: offset_end,
+            buffer_id: buffer_id_end,
+            bias: _,
+        } = self.buffer_range.end;
+        timestamp_start == timestamp_end
+            && offset_start == offset_end
+            && buffer_id_start == buffer_id_end
+    }
 }
 
 impl DiffHunk<u32> {
     pub fn status(&self) -> DiffHunkStatus {
         if self.diff_base_byte_range.is_empty() {
             DiffHunkStatus::Added
-        } else if self.buffer_range.is_empty() {
+        } else if self.buffer_range_empty() {
             DiffHunkStatus::Removed
         } else {
             DiffHunkStatus::Modified
@@ -35,7 +61,7 @@ impl sum_tree::Item for DiffHunk<Anchor> {
 
     fn summary(&self) -> Self::Summary {
         DiffHunkSummary {
-            buffer_range: self.buffer_range.clone(),
+            buffer_range: self.associated_range.clone(),
         }
     }
 }
@@ -103,8 +129,11 @@ impl BufferDiff {
         })
         .flat_map(move |hunk| {
             [
-                (&hunk.buffer_range.start, hunk.diff_base_byte_range.start),
-                (&hunk.buffer_range.end, hunk.diff_base_byte_range.end),
+                (
+                    &hunk.associated_range.start,
+                    hunk.diff_base_byte_range.start,
+                ),
+                (&hunk.associated_range.end, hunk.diff_base_byte_range.end),
             ]
             .into_iter()
         });
@@ -112,17 +141,16 @@ impl BufferDiff {
         let mut summaries = buffer.summaries_for_anchors_with_payload::<Point, _, _>(anchor_iter);
         iter::from_fn(move || {
             let (start_point, start_base) = summaries.next()?;
-            let (end_point, end_base) = summaries.next()?;
+            let (mut end_point, end_base) = summaries.next()?;
 
-            let end_row = if end_point.column > 0 {
-                end_point.row + 1
-            } else {
-                end_point.row
-            };
+            if end_point.column > 0 {
+                end_point.row += 1;
+            }
 
             Some(DiffHunk {
-                buffer_range: start_point.row..end_row,
+                associated_range: start_point.row..end_point.row,
                 diff_base_byte_range: start_base..end_base,
+                buffer_range: buffer.anchor_before(start_point)..buffer.anchor_after(end_point),
             })
         })
     }
@@ -142,7 +170,7 @@ impl BufferDiff {
             cursor.prev(buffer);
 
             let hunk = cursor.item()?;
-            let range = hunk.buffer_range.to_point(buffer);
+            let range = hunk.associated_range.to_point(buffer);
             let end_row = if range.end.column > 0 {
                 range.end.row + 1
             } else {
@@ -150,8 +178,9 @@ impl BufferDiff {
             };
 
             Some(DiffHunk {
-                buffer_range: range.start.row..end_row,
+                associated_range: range.start.row..end_row,
                 diff_base_byte_range: hunk.diff_base_byte_range.clone(),
+                buffer_range: hunk.buffer_range.clone(),
             })
         })
     }
@@ -269,6 +298,7 @@ impl BufferDiff {
         let end = Point::new(buffer_row_range.end, 0);
         let buffer_range = buffer.anchor_before(start)..buffer.anchor_before(end);
         DiffHunk {
+            associated_range: buffer_range.clone(),
             buffer_range,
             diff_base_byte_range,
         }
@@ -289,12 +319,12 @@ pub fn assert_hunks<Iter>(
     let actual_hunks = diff_hunks
         .map(|hunk| {
             (
-                hunk.buffer_range.clone(),
+                hunk.associated_range.clone(),
                 &diff_base[hunk.diff_base_byte_range],
                 buffer
                     .text_for_range(
-                        Point::new(hunk.buffer_range.start, 0)
-                            ..Point::new(hunk.buffer_range.end, 0),
+                        Point::new(hunk.associated_range.start, 0)
+                            ..Point::new(hunk.associated_range.end, 0),
                     )
                     .collect::<String>(),
             )

--- a/crates/git/src/diff.rs
+++ b/crates/git/src/diff.rs
@@ -57,7 +57,7 @@ impl sum_tree::Summary for DiffHunkSummary {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct BufferDiff {
     last_buffer_version: Option<clock::Global>,
     tree: SumTree<DiffHunk<Anchor>>,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3186,19 +3186,20 @@ impl MultiBufferSnapshot {
                 .map(move |hunk| {
                     let start = multibuffer_start.row
                         + hunk
-                            .buffer_range
+                            .associated_range
                             .start
                             .saturating_sub(excerpt_start_point.row);
                     let end = multibuffer_start.row
                         + hunk
-                            .buffer_range
+                            .associated_range
                             .end
                             .min(excerpt_end_point.row + 1)
                             .saturating_sub(excerpt_start_point.row);
 
                     DiffHunk {
-                        buffer_range: start..end,
+                        associated_range: start..end,
                         diff_base_byte_range: hunk.diff_base_byte_range.clone(),
+                        buffer_range: hunk.buffer_range.clone(),
                     }
                 });
 
@@ -3257,18 +3258,22 @@ impl MultiBufferSnapshot {
                         0..1
                     } else {
                         let start = multibuffer_start.row
-                            + hunk.buffer_range.start.saturating_sub(excerpt_rows.start);
+                            + hunk
+                                .associated_range
+                                .start
+                                .saturating_sub(excerpt_rows.start);
                         let end = multibuffer_start.row
                             + hunk
-                                .buffer_range
+                                .associated_range
                                 .end
                                 .min(excerpt_rows.end + 1)
                                 .saturating_sub(excerpt_rows.start);
                         start..end
                     };
                     DiffHunk {
-                        buffer_range,
+                        associated_range: buffer_range,
                         diff_base_byte_range: hunk.diff_base_byte_range.clone(),
+                        buffer_range: hunk.buffer_range.clone(),
                     }
                 });
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3215,51 +3215,62 @@ impl MultiBufferSnapshot {
     ) -> impl Iterator<Item = DiffHunk<u32>> + '_ {
         let mut cursor = self.excerpts.cursor::<Point>();
 
-        cursor.seek(&Point::new(row_range.start, 0), Bias::Right, &());
+        cursor.seek(&Point::new(row_range.start, 0), Bias::Left, &());
 
         std::iter::from_fn(move || {
             let excerpt = cursor.item()?;
             let multibuffer_start = *cursor.start();
             let multibuffer_end = multibuffer_start + excerpt.text_summary.lines;
-            if multibuffer_start.row >= row_range.end {
-                return None;
-            }
-
             let mut buffer_start = excerpt.range.context.start;
             let mut buffer_end = excerpt.range.context.end;
-            let excerpt_start_point = buffer_start.to_point(&excerpt.buffer);
-            let excerpt_end_point = excerpt_start_point + excerpt.text_summary.lines;
 
-            if row_range.start > multibuffer_start.row {
-                let buffer_start_point =
-                    excerpt_start_point + Point::new(row_range.start - multibuffer_start.row, 0);
-                buffer_start = excerpt.buffer.anchor_before(buffer_start_point);
-            }
+            let excerpt_rows = match multibuffer_start.row.cmp(&row_range.end) {
+                cmp::Ordering::Less => {
+                    let excerpt_start_point = buffer_start.to_point(&excerpt.buffer);
+                    let excerpt_end_point = excerpt_start_point + excerpt.text_summary.lines;
 
-            if row_range.end < multibuffer_end.row {
-                let buffer_end_point =
-                    excerpt_start_point + Point::new(row_range.end - multibuffer_start.row, 0);
-                buffer_end = excerpt.buffer.anchor_before(buffer_end_point);
-            }
+                    if row_range.start > multibuffer_start.row {
+                        let buffer_start_point =
+                            excerpt_start_point + Point::new(row_range.start - multibuffer_start.row, 0);
+                        buffer_start = excerpt.buffer.anchor_before(buffer_start_point);
+                    }
+
+                    if row_range.end < multibuffer_end.row {
+                        let buffer_end_point =
+                            excerpt_start_point + Point::new(row_range.end - multibuffer_start.row, 0);
+                        buffer_end = excerpt.buffer.anchor_before(buffer_end_point);
+                    }
+                    excerpt_start_point.row..excerpt_end_point.row
+                },
+                cmp::Ordering::Equal if row_range.end == 0  => {
+                    buffer_end = buffer_start;
+                    0..0
+                },
+                cmp::Ordering::Greater | cmp::Ordering::Equal => return None,
+            };
 
             let buffer_hunks = excerpt
                 .buffer
                 .git_diff_hunks_intersecting_range(buffer_start..buffer_end)
                 .map(move |hunk| {
-                    let start = multibuffer_start.row
-                        + hunk
-                            .buffer_range
-                            .start
-                            .saturating_sub(excerpt_start_point.row);
-                    let end = multibuffer_start.row
-                        + hunk
-                            .buffer_range
-                            .end
-                            .min(excerpt_end_point.row + 1)
-                            .saturating_sub(excerpt_start_point.row);
-
+                    let buffer_range = if excerpt_rows.start == 0 && excerpt_rows.end == 0 {
+                        0..1
+                    } else {
+                        let start = multibuffer_start.row
+                            + hunk
+                                .buffer_range
+                                .start
+                                .saturating_sub(excerpt_rows.start);
+                        let end = multibuffer_start.row
+                            + hunk
+                                .buffer_range
+                                .end
+                                .min(excerpt_rows.end + 1)
+                                .saturating_sub(excerpt_rows.start);
+                        start..end
+                    };
                     DiffHunk {
-                        buffer_range: start..end,
+                        buffer_range,
                         diff_base_byte_range: hunk.diff_base_byte_range.clone(),
                     }
                 });

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3200,6 +3200,7 @@ impl MultiBufferSnapshot {
                         associated_range: start..end,
                         diff_base_byte_range: hunk.diff_base_byte_range.clone(),
                         buffer_range: hunk.buffer_range.clone(),
+                        buffer_id: hunk.buffer_id,
                     }
                 });
 
@@ -3274,6 +3275,7 @@ impl MultiBufferSnapshot {
                         associated_range: buffer_range,
                         diff_base_byte_range: hunk.diff_base_byte_range.clone(),
                         buffer_range: hunk.buffer_range.clone(),
+                        buffer_id: hunk.buffer_id,
                     }
                 });
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3230,22 +3230,22 @@ impl MultiBufferSnapshot {
                     let excerpt_end_point = excerpt_start_point + excerpt.text_summary.lines;
 
                     if row_range.start > multibuffer_start.row {
-                        let buffer_start_point =
-                            excerpt_start_point + Point::new(row_range.start - multibuffer_start.row, 0);
+                        let buffer_start_point = excerpt_start_point
+                            + Point::new(row_range.start - multibuffer_start.row, 0);
                         buffer_start = excerpt.buffer.anchor_before(buffer_start_point);
                     }
 
                     if row_range.end < multibuffer_end.row {
-                        let buffer_end_point =
-                            excerpt_start_point + Point::new(row_range.end - multibuffer_start.row, 0);
+                        let buffer_end_point = excerpt_start_point
+                            + Point::new(row_range.end - multibuffer_start.row, 0);
                         buffer_end = excerpt.buffer.anchor_before(buffer_end_point);
                     }
                     excerpt_start_point.row..excerpt_end_point.row
-                },
-                cmp::Ordering::Equal if row_range.end == 0  => {
+                }
+                cmp::Ordering::Equal if row_range.end == 0 => {
                     buffer_end = buffer_start;
                     0..0
-                },
+                }
                 cmp::Ordering::Greater | cmp::Ordering::Equal => return None,
             };
 
@@ -3257,10 +3257,7 @@ impl MultiBufferSnapshot {
                         0..1
                     } else {
                         let start = multibuffer_start.row
-                            + hunk
-                                .buffer_range
-                                .start
-                                .saturating_sub(excerpt_rows.start);
+                            + hunk.buffer_range.start.saturating_sub(excerpt_rows.start);
                         let end = multibuffer_start.row
                             + hunk
                                 .buffer_range

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4427,7 +4427,6 @@ impl Project {
                                     project_transaction.0.extend(new.0);
                                 }
 
-                                // TODO kb here too:
                                 if let Some(command) = action.lsp_action.command {
                                     project.update(&mut cx, |this, _| {
                                         this.last_workspace_edits_by_language_server


### PR DESCRIPTION
https://github.com/zed-industries/zed/assets/2690773/653b5658-e3f3-4aee-9a9d-0f2153b4141b

Release Notes:

- Added `editor::RevertSelectedHunks` (`cmd-alt-z` by default) for reverting git hunks from the editor
