### PR TITLE
Respect `eslint.nodePath` setting

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -254,14 +254,14 @@ impl LspAdapter for EsLintLspAdapter {
             }
         }
 
-        let nodePath = eslint_user_settings.get("nodePath").unwrap_or(&Value::Null);
+        let node_path = eslint_user_settings.get("nodePath").unwrap_or(&Value::Null);
 
         json!({
             "": {
                 "validate": "on",
                 "rulesCustomizations": [],
                 "run": "onType",
-                "nodePath": nodePath,
+                "nodePath": node_path,
                 "workingDirectory": {"mode": "auto"},
                 "workspaceFolder": {
                     "uri": workspace_root,

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -254,12 +254,14 @@ impl LspAdapter for EsLintLspAdapter {
             }
         }
 
+        let nodePath = eslint_user_settings.get("nodePath").unwrap_or(&Value::Null);
+
         json!({
             "": {
                 "validate": "on",
                 "rulesCustomizations": [],
                 "run": "onType",
-                "nodePath": null,
+                "nodePath": nodePath,
                 "workingDirectory": {"mode": "auto"},
                 "workspaceFolder": {
                     "uri": workspace_root,


### PR DESCRIPTION
I'm using Yarn Plug'n'Play.
In this case, by default, eslint cannot find the path, so configuration like `"eslint.nodePath": ".yarn/sdks"` is required.
So, I want to add this!

Release Notes:

- Added eslint config nodePath