### PR TITLE
Add script for setting up WASI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: cargo clippy
         run: cargo xtask clippy
 
+      - name: Install WASI dependencies
+        run: script/setup-wasm
+
       - name: Run tests
         uses: ./.github/actions/run_tests
 

--- a/script/setup-wasm
+++ b/script/setup-wasm
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+
+WASI_ADAPTER_URL="https://github.com/bytecodealliance/wasmtime/releases/download/v18.0.2/wasi_snapshot_preview1.reactor.wasm"
+WASI_SDK_URL="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-macos.tar.gz"
+
+echo "Downloading WASI adapter: $WASI_ADAPTER_URL"
+curl -L $WASI_ADAPTER_URL -o target/wasi_snapshot_preview1.reactor.wasm
+
+echo "Downloading WASI SDK: $WASI_SDK_URL"
+mkdir -p target/wasi-sdk.archive
+curl -L $WASI_SDK_URL | tar -xz - -C target/wasi-sdk.archive
+rm -rf target/wasi-sdk/
+mv -f target/wasi-sdk.archive/wasi-sdk-21.0/ target/wasi-sdk


### PR DESCRIPTION
This PR adds a script for setting up the WASI dependencies needed for extensions.

These already get downloaded when needed when using Zed, but in the tests the HTTP client is faked out, so if you don't already have them installed the `test_extension_store_with_gleam_extension` test will fail.

Release Notes:

- N/A
