### PR TITLE
Fix folder watching that is access denied

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -381,9 +381,10 @@ impl Fs for RealFs {
             .configure(Config::default().with_poll_interval(latency))
             .unwrap();
 
-        watcher
-            .watch(path, notify::RecursiveMode::Recursive)
-            .unwrap();
+        match watcher.watch(path, notify::RecursiveMode::Recursive) {
+            Ok(_) => {}
+            Err(err) => log::error!("watch error: {}", err),
+        };
 
         Box::pin(rx)
     }


### PR DESCRIPTION
```
Thread "<unnamed>" panicked with "called `Result::unwrap()` on an `Err` value: Error { kind: Io(Os { code: 13, kind: PermissionDenied, message: \"Permission denied\" }), paths: [\"/mnt/Dev/@xxxxxxxx/sentry-pg-data\"] }" at crates/fs/src/fs.rs:384:14
   0: Zed::init_panic_hook::{closure#0}
```

The data is owned by root (because it is from a Docker container)

Release Notes:

- Fixed folder watching when the folder is not owned by the user (access denied). 

