### PR TITLE
Splice remove suggesion hints when those are cleared in the editor.

### DIFF
--- a/crates/copilot_ui/src/copilot_button.rs
+++ b/crates/copilot_ui/src/copilot_button.rs
@@ -149,7 +149,7 @@ impl CopilotButton {
     pub fn build_copilot_menu(&mut self, cx: &mut ViewContext<Self>) -> View<ContextMenu> {
         let fs = self.fs.clone();
 
-        return ContextMenu::build(cx, move |mut menu, cx| {
+        ContextMenu::build(cx, move |mut menu, cx| {
             if let Some(language) = self.language.clone() {
                 let fs = fs.clone();
                 let language_enabled =
@@ -216,7 +216,7 @@ impl CopilotButton {
                 .boxed_clone(),
             )
             .action("Sign Out", SignOut.boxed_clone())
-        });
+        })
     }
 
     pub fn update_enabled(&mut self, editor: View<Editor>, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -1255,7 +1255,7 @@ fn apply_hint_update(
         editor.inlay_hint_cache.version += 1;
     }
     if displayed_inlays_changed {
-        editor.splice_inlay_hints(to_remove, to_insert, cx)
+        editor.splice_inlays(to_remove, to_insert, cx)
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/6793

Release Notes:

- Fixed copilot suggestions not disappearing after disabling the tool ([6793](https://github.com/zed-industries/zed/issues/6793))