### PR TITLE
Project Panel Sorting Options (dirs first)

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -187,7 +187,8 @@
     // Whether to reveal it in the project panel automatically,
     // when a corresponding project entry becomes active.
     // Gitignored entries are never auto revealed.
-    "auto_reveal_entries": true
+    "auto_reveal_entries": true,
+    "sort_order": "default"
   },
   "collaboration_panel": {
     // Whether to show the collaboration panel button in the status bar.

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -11,6 +11,13 @@ pub enum ProjectPanelDockPosition {
     Right,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectPanelSortOrder {
+    Default,
+    DirsFirst,
+}
+
 #[derive(Deserialize, Debug)]
 pub struct ProjectPanelSettings {
     pub default_width: Pixels,
@@ -20,6 +27,7 @@ pub struct ProjectPanelSettings {
     pub git_status: bool,
     pub indent_size: f32,
     pub auto_reveal_entries: bool,
+    pub sort_order: ProjectPanelSortOrder,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -54,6 +62,9 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub auto_reveal_entries: Option<bool>,
+
+    /// The sort order of the project panel entries.
+    pub sort_order: Option<ProjectPanelSortOrder>,
 }
 
 impl Settings for ProjectPanelSettings {


### PR DESCRIPTION

Release Notes:

- Added a project panel sort setting, `sort_order`, with one additional sorting option `dirs_first` which sorts by directory first at each level of the directory. Default setting is the current production project panel setting. Issue: ([#4533](https://github.com/zed-industries/zed/issues/4533)).


Some examples of the `dirs_first` setting:
<img width="315" alt="Screenshot 2024-03-08 at 8 40 41 PM" src="https://github.com/zed-industries/zed/assets/63214891/7118dbbd-a7ed-4031-b0ee-bb34a999e069">
<img width="318" alt="Screenshot 2024-03-08 at 8 40 21 PM" src="https://github.com/zed-industries/zed/assets/63214891/03c8b045-1ee6-48ac-8202-e81e095a3608">

The project panel setting:
<img width="326" alt="Screenshot 2024-03-08 at 8 41 51 PM" src="https://github.com/zed-industries/zed/assets/63214891/258604ca-97a9-46d7-aa7f-135382eee51a">

