### PR TITLE
linux: scrolling improvements

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -30,6 +30,8 @@ use crate::{
 
 use super::x11::X11Client;
 
+pub(super) const SCROLL_LINES: f64 = 3.0;
+
 #[derive(Default)]
 pub(crate) struct Callbacks {
     open_urls: Option<Box<dyn FnMut(Vec<String>)>>,

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -23,7 +23,7 @@ use crate::{
     ScrollDelta, Size, TouchPhase, WindowParams,
 };
 
-use super::{X11Display, X11Window, X11WindowState, XcbAtoms};
+use super::{super::SCROLL_LINES, X11Display, X11Window, X11WindowState, XcbAtoms};
 use calloop::{
     generic::{FdWrapper, Generic},
     RegistrationToken,
@@ -221,12 +221,13 @@ impl X11Client {
                     }));
                 } else if event.detail >= 4 && event.detail <= 5 {
                     // https://stackoverflow.com/questions/15510472/scrollwheel-event-in-x11
-                    let delta_x = if event.detail == 4 { 1.0 } else { -1.0 };
+                    let scroll_direction = if event.detail == 4 { 1.0 } else { -1.0 };
+                    let scroll_y = SCROLL_LINES * scroll_direction;
                     window.handle_input(PlatformInput::ScrollWheel(crate::ScrollWheelEvent {
                         position,
-                        delta: ScrollDelta::Lines(Point::new(0.0, delta_x)),
+                        delta: ScrollDelta::Lines(Point::new(0.0, scroll_y as f32)),
                         modifiers,
-                        touch_phase: TouchPhase::default(),
+                        touch_phase: TouchPhase::Moved,
                     }));
                 } else {
                     log::warn!("Unknown button press: {event:?}");

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -70,7 +70,10 @@ actions!(
 ///Scrolling is unbearably sluggish by default. Alacritty supports a configurable
 ///Scroll multiplier that is set to 3 by default. This will be removed when I
 ///Implement scroll bars.
+#[cfg(target_os = "macos")]
 const SCROLL_MULTIPLIER: f32 = 4.;
+#[cfg(not(target_os = "macos"))]
+const SCROLL_MULTIPLIER: f32 = 1.;
 const MAX_SEARCH_LINES: usize = 100;
 const DEBUG_TERMINAL_WIDTH: Pixels = px(500.);
 const DEBUG_TERMINAL_HEIGHT: Pixels = px(30.);


### PR DESCRIPTION
This PR adjusts scrolling to be a lot faster on Linux and also makes terminal scrolling work.

For Wayland, it makes scrolling faster by handling the `AxisValue120` event (which also allows high-resolution scrolling on supported mice)
On X11, changed the 1 line per scroll to 3.

### Different solutions

I tried replicating Chromium's scrolling behaviour, but it was inconsistent in X11/Wayland and found it too fast on Wayland. Plus, it also didn't match VSCode, since it seems that they do something different.

Release Notes:

- Made scrolling faster on Linux
- Made terminal scroll on Linux