### PR TITLE
Fix `<!DOCTYPE html>` syntax highlighting

### DIFF
--- a/crates/languages/src/html/highlights.scm
+++ b/crates/languages/src/html/highlights.scm
@@ -10,6 +10,7 @@
 [
   "<"
   ">"
+  "<!"
   "</"
   "/>"
 ] @punctuation.bracket


### PR DESCRIPTION
closes #4318