### PR TITLE
Fix crash when launching `Zed.exe` directly from `target/debug` dir

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1035,6 +1035,3 @@ fn watch_file_types(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
 
 #[cfg(not(debug_assertions))]
 fn watch_file_types(_fs: Arc<dyn fs::Fs>, _cx: &mut AppContext) {}
-
-#[cfg(not(debug_assertions))]
-async fn watch_languages(_fs: Arc<dyn fs::Fs>, _languages: Arc<LanguageRegistry>) {}

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1004,10 +1004,6 @@ fn watch_themes(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
 fn watch_file_types(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
     use std::time::Duration;
 
-    #[cfg(not(target_os = "windows"))]
-    let path = Path::new("assets/icons/file_icons/file_types.json");
-
-    #[cfg(target_os = "windows")]
     let path = {
         let p = Path::new("assets/icons/file_icons/file_types.json");
         let Ok(full_path) = p.canonicalize() else {
@@ -1017,9 +1013,6 @@ fn watch_file_types(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
     };
 
     cx.spawn(|cx| async move {
-        #[cfg(not(target_os = "windows"))]
-        let mut events = fs.watch(path, Duration::from_millis(100)).await;
-        #[cfg(target_os = "windows")]
         let mut events = fs.watch(path.as_path(), Duration::from_millis(100)).await;
         while (events.next().await).is_some() {
             cx.update(|cx| {


### PR DESCRIPTION
As I described in #9111 , the PR fixs this crash.


Release Notes:

- N/A
