### PR TITLE
windows: Support dropping targets with filenames longer than 260 characters

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -22,7 +22,7 @@ use smallvec::SmallVec;
 use windows::{
     core::{implement, w, HSTRING, PCWSTR},
     Win32::{
-        Foundation::{FALSE, HINSTANCE, HWND, LPARAM, LRESULT, MAX_PATH, POINTL, S_OK, WPARAM},
+        Foundation::{FALSE, HINSTANCE, HWND, LPARAM, LRESULT, POINTL, S_OK, WPARAM},
         Graphics::Gdi::{BeginPaint, EndPaint, InvalidateRect, PAINTSTRUCT},
         System::{
             Com::{IDataObject, DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL},
@@ -980,9 +980,9 @@ impl IDropTarget_Impl for WindowsDragDropHandler {
                 let hdrop = idata.u.hGlobal.0 as *mut HDROP;
                 let file_count = DragQueryFileW(*hdrop, DRAGDROP_GET_FILES_COUNT, None);
                 for file_index in 0..file_count {
-                    let mut buffer = [0u16; MAX_PATH as _];
                     let filename_length = DragQueryFileW(*hdrop, file_index, None) as usize;
-                    let ret = DragQueryFileW(*hdrop, file_index, Some(&mut buffer));
+                    let mut buffer = vec![0u16; filename_length + 1];
+                    let ret = DragQueryFileW(*hdrop, file_index, Some(buffer.as_mut_slice()));
                     if ret == 0 {
                         log::error!("unable to read file name");
                         continue;


### PR DESCRIPTION
use `Vec` instead of slice to support dynamic filename length.

Release Notes:
- N/A
