### PR TITLE
WIP: Vulkan rendering backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,6 +4331,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
+ "ash",
  "ashpd",
  "async-task",
  "backtrace",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -19,6 +19,8 @@ test-support = [
 ]
 runtime_shaders = []
 macos-blade = ["blade-graphics", "blade-macros", "blade-rwh", "bytemuck"]
+vulkan-render = ["ash"]
+# default = ["vulkan-render"]
 
 [lib]
 path = "src/gpui.rs"
@@ -26,6 +28,7 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+ash = { version = "0.37.3", features = ["linked"], optional = true }
 async-task = "4.7"
 backtrace = { version = "0.3", optional = true }
 blade-graphics = { workspace = true, optional = true }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -12,8 +12,14 @@ mod linux;
 #[cfg(target_os = "macos")]
 mod mac;
 
-#[cfg(any(target_os = "linux", target_os = "windows", feature = "macos-blade"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows", feature = "macos-blade"),
+    not(feature = "vulkan-render")
+))]
 mod blade;
+
+#[cfg(all(target_os = "linux", feature = "vulkan-render"))]
+mod vulkan;
 
 #[cfg(any(test, feature = "test-support"))]
 mod test;

--- a/crates/gpui/src/platform/vulkan.rs
+++ b/crates/gpui/src/platform/vulkan.rs
@@ -1,0 +1,5 @@
+mod vulkan_atlas;
+mod vulkan_renderer;
+
+pub(crate) use vulkan_atlas::*;
+pub(crate) use vulkan_renderer::*;

--- a/crates/gpui/src/platform/vulkan.rs
+++ b/crates/gpui/src/platform/vulkan.rs
@@ -1,5 +1,7 @@
 mod vulkan_atlas;
 mod vulkan_renderer;
+mod vulkan_surface;
 
 pub(crate) use vulkan_atlas::*;
 pub(crate) use vulkan_renderer::*;
+pub(crate) use vulkan_surface::*;

--- a/crates/gpui/src/platform/vulkan/vulkan_atlas.rs
+++ b/crates/gpui/src/platform/vulkan/vulkan_atlas.rs
@@ -1,0 +1,273 @@
+use std::borrow::Cow;
+
+use anyhow::Result;
+use ash::vk;
+use collections::FxHashMap;
+use etagere::BucketedAtlasAllocator;
+use parking_lot::Mutex;
+
+use crate::{
+    AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTile, Bounds, DevicePixels, PlatformAtlas,
+    Point, Size,
+};
+
+pub(crate) struct VulkanAtlas(Mutex<VulkanAtlasState>);
+
+impl VulkanAtlas {
+    pub fn new(device: ash::Device, memory_properties: vk::PhysicalDeviceMemoryProperties) -> Self {
+        Self(Mutex::new(VulkanAtlasState {
+            device,
+            memory_properties,
+            monochrome_textures: Default::default(),
+            polychrome_textures: Default::default(),
+            path_textures: Default::default(),
+            tiles_by_key: Default::default(),
+        }))
+    }
+
+    pub fn destroy(&self) {
+        self.0.lock().destroy();
+    }
+}
+
+impl PlatformAtlas for VulkanAtlas {
+    fn get_or_insert_with<'a>(
+        &self,
+        key: &AtlasKey,
+        build: &mut dyn FnMut() -> Result<(Size<DevicePixels>, Cow<'a, [u8]>)>,
+    ) -> Result<AtlasTile> {
+        let mut lock = self.0.lock();
+        if let Some(tile) = lock.tiles_by_key.get(key) {
+            Ok(tile.clone())
+        } else {
+            let (size, bytes) = build()?;
+            let tile = lock.allocate(size, key.texture_kind());
+            let texture = lock.texture(tile.texture_id);
+            texture.upload(tile.bounds, &bytes);
+            lock.tiles_by_key.insert(key.clone(), tile.clone());
+            Ok(tile)
+        }
+    }
+}
+
+struct VulkanAtlasState {
+    device: ash::Device,
+    memory_properties: vk::PhysicalDeviceMemoryProperties,
+    monochrome_textures: Vec<VulkanAtlasTexture>,
+    polychrome_textures: Vec<VulkanAtlasTexture>,
+    path_textures: Vec<VulkanAtlasTexture>,
+    tiles_by_key: FxHashMap<AtlasKey, AtlasTile>,
+}
+
+impl VulkanAtlasState {
+    fn allocate(&mut self, size: Size<DevicePixels>, texture_kind: AtlasTextureKind) -> AtlasTile {
+        let textures = match texture_kind {
+            AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
+            AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
+            AtlasTextureKind::Path => &mut self.path_textures,
+        };
+
+        textures
+            .iter_mut()
+            .rev()
+            .find_map(|texture| texture.allocate(size))
+            .unwrap_or_else(|| {
+                let texture = self.push_texture(size, texture_kind);
+                texture.allocate(size).unwrap()
+            })
+    }
+
+    fn push_texture(
+        &mut self,
+        min_size: Size<DevicePixels>,
+        kind: AtlasTextureKind,
+    ) -> &mut VulkanAtlasTexture {
+        const DEFAULT_ATLAS_SIZE: Size<DevicePixels> = Size {
+            width: DevicePixels(1024),
+            height: DevicePixels(1024),
+        };
+        let size = min_size.max(&DEFAULT_ATLAS_SIZE);
+
+        let (format, usage) = match kind {
+            AtlasTextureKind::Monochrome => (vk::Format::R8_UNORM, vk::ImageUsageFlags::SAMPLED),
+            AtlasTextureKind::Polychrome => {
+                (vk::Format::B8G8R8A8_UNORM, vk::ImageUsageFlags::SAMPLED)
+            }
+            AtlasTextureKind::Path => (vk::Format::R16_SFLOAT, vk::ImageUsageFlags::SAMPLED),
+        };
+
+        // Create image
+        let image_create_info = vk::ImageCreateInfo::builder()
+            .image_type(vk::ImageType::TYPE_2D)
+            .format(format)
+            .extent(vk::Extent3D {
+                width: size.width.into(),
+                height: size.height.into(),
+                depth: 1,
+            })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::TYPE_1)
+            .tiling(vk::ImageTiling::OPTIMAL)
+            .usage(usage)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .build();
+        let image = unsafe { self.device.create_image(&image_create_info, None) }.unwrap();
+
+        // Allocate memory
+        let memory_requirements = unsafe { self.device.get_image_memory_requirements(image) };
+        let mut memory_type_index = None;
+        for (idx, memory_type) in self.memory_properties.memory_types
+            [0..self.memory_properties.memory_type_count as usize]
+            .iter()
+            .enumerate()
+        {
+            // Ensure correct memory type
+            let memory_type_bit_mask = 1u32 << idx;
+            if memory_requirements.memory_type_bits & memory_type_bit_mask == 0 {
+                continue;
+            }
+
+            // Ensure memory property requirements are met
+            if (memory_type.property_flags & vk::MemoryPropertyFlags::DEVICE_LOCAL)
+                != vk::MemoryPropertyFlags::DEVICE_LOCAL
+            {
+                continue;
+            }
+
+            memory_type_index = Some(idx);
+            break;
+        }
+
+        let memory_allocate_info = vk::MemoryAllocateInfo::builder()
+            .allocation_size(memory_requirements.size)
+            .memory_type_index(match memory_type_index {
+                Some(memory_type_index) => memory_type_index as u32,
+                None => panic!("No valid memory type found"),
+            })
+            .build();
+        let image_memory =
+            unsafe { self.device.allocate_memory(&memory_allocate_info, None) }.unwrap();
+        unsafe { self.device.bind_image_memory(image, image_memory, 0) }.unwrap();
+
+        // Create image view
+        let image_view_create_info = vk::ImageViewCreateInfo::builder()
+            .image(image)
+            .view_type(vk::ImageViewType::TYPE_2D)
+            .format(format)
+            .components(
+                vk::ComponentMapping::builder()
+                    .r(vk::ComponentSwizzle::IDENTITY)
+                    .g(vk::ComponentSwizzle::IDENTITY)
+                    .b(vk::ComponentSwizzle::IDENTITY)
+                    .a(vk::ComponentSwizzle::IDENTITY)
+                    .build(),
+            )
+            .subresource_range(
+                vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .base_mip_level(0)
+                    .level_count(1)
+                    .base_array_layer(0)
+                    .layer_count(1)
+                    .build(),
+            )
+            .build();
+        let image_view =
+            unsafe { self.device.create_image_view(&image_view_create_info, None) }.unwrap();
+
+        let textures = match kind {
+            AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
+            AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
+            AtlasTextureKind::Path => &mut self.path_textures,
+        };
+        let atlas_texture = VulkanAtlasTexture {
+            id: AtlasTextureId {
+                index: textures.len() as u32,
+                kind,
+            },
+            allocator: etagere::BucketedAtlasAllocator::new(size.into()),
+            image,
+            image_memory,
+            image_view,
+        };
+        textures.push(atlas_texture);
+        textures.last_mut().unwrap()
+    }
+
+    fn texture(&self, id: AtlasTextureId) -> &VulkanAtlasTexture {
+        let textures = match id.kind {
+            AtlasTextureKind::Monochrome => &self.monochrome_textures,
+            AtlasTextureKind::Polychrome => &self.polychrome_textures,
+            AtlasTextureKind::Path => &self.path_textures,
+        };
+        &textures[id.index as usize]
+    }
+
+    fn destroy(&mut self) {
+        self.monochrome_textures
+            .drain(0..)
+            .for_each(|texture| texture.destroy(&self.device));
+        self.polychrome_textures
+            .drain(0..)
+            .for_each(|texture| texture.destroy(&self.device));
+        self.path_textures
+            .drain(0..)
+            .for_each(|texture| texture.destroy(&self.device));
+    }
+}
+
+struct VulkanAtlasTexture {
+    id: AtlasTextureId,
+    allocator: BucketedAtlasAllocator,
+    image: vk::Image,
+    image_memory: vk::DeviceMemory,
+    image_view: vk::ImageView,
+}
+
+impl VulkanAtlasTexture {
+    fn clear(&mut self) {
+        self.allocator.clear();
+    }
+
+    fn allocate(&mut self, size: Size<DevicePixels>) -> Option<AtlasTile> {
+        let allocation = self.allocator.allocate(size.into())?;
+        let tile = AtlasTile {
+            texture_id: self.id,
+            tile_id: allocation.id.into(),
+            bounds: Bounds {
+                origin: allocation.rectangle.min.into(),
+                size,
+            },
+            padding: 0,
+        };
+        Some(tile)
+    }
+
+    fn upload(&self, _bounds: Bounds<DevicePixels>, _bytes: &[u8]) {
+        // todo!("vulkan")
+    }
+
+    fn destroy(&self, device: &ash::Device) {
+        unsafe {
+            device.destroy_image(self.image, None);
+            device.destroy_image_view(self.image_view, None);
+            device.free_memory(self.image_memory, None);
+        }
+    }
+}
+
+impl From<Size<DevicePixels>> for etagere::Size {
+    fn from(size: Size<DevicePixels>) -> Self {
+        etagere::Size::new(size.width.into(), size.height.into())
+    }
+}
+
+impl From<etagere::Point> for Point<DevicePixels> {
+    fn from(value: etagere::Point) -> Self {
+        Point {
+            x: DevicePixels::from(value.x),
+            y: DevicePixels::from(value.y),
+        }
+    }
+}

--- a/crates/gpui/src/platform/vulkan/vulkan_renderer.rs
+++ b/crates/gpui/src/platform/vulkan/vulkan_renderer.rs
@@ -1,0 +1,275 @@
+use std::ffi::CStr;
+use std::os::raw::c_void;
+use std::sync::Arc;
+
+use ash::extensions::ext::DebugUtils;
+use ash::vk;
+
+use crate::Pixels;
+use crate::Scene;
+use crate::Size;
+
+use super::VulkanAtlas;
+
+pub(crate) enum SurfaceExtensionLoader {
+    XCB(ash::extensions::khr::XcbSurface),
+    Wayland(ash::extensions::khr::WaylandSurface),
+}
+
+pub(crate) trait VulkanRawWindow {
+    fn extension_name(&self) -> &CStr;
+    fn extension_loader(
+        &self,
+        entry: &ash::Entry,
+        instance: &ash::Instance,
+    ) -> SurfaceExtensionLoader;
+    fn create_surface(&self, loader: &SurfaceExtensionLoader) -> vk::SurfaceKHR;
+    fn get_physical_device_presentation_support(
+        &self,
+        loader: &SurfaceExtensionLoader,
+        physical_device: vk::PhysicalDevice,
+        queue_family_index: u32,
+    ) -> bool;
+}
+
+unsafe extern "system" fn validation_layer_callback(
+    severity: vk::DebugUtilsMessageSeverityFlagsEXT,
+    message_type: vk::DebugUtilsMessageTypeFlagsEXT,
+    callback_data: *const vk::DebugUtilsMessengerCallbackDataEXT,
+    _user_data: *mut c_void,
+) -> vk::Bool32 {
+    match severity {
+        vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => {
+            log::trace!(
+                "Vulkan Validation (verbose, {:?}): {}",
+                message_type,
+                CStr::from_ptr((*callback_data).p_message).to_string_lossy()
+            )
+        }
+        vk::DebugUtilsMessageSeverityFlagsEXT::INFO => {
+            log::info!(
+                "Vulkan Validation (info, {:?}): {}",
+                message_type,
+                CStr::from_ptr((*callback_data).p_message).to_string_lossy()
+            )
+        }
+        vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => {
+            log::warn!(
+                "Vulkan Validation (warning, {:?}): {}",
+                message_type,
+                CStr::from_ptr((*callback_data).p_message).to_string_lossy()
+            )
+        }
+        vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => {
+            log::error!(
+                "Vulkan Validation (error, {:?}): {}",
+                message_type,
+                CStr::from_ptr((*callback_data).p_message).to_string_lossy()
+            )
+        }
+        _ => unreachable!(),
+    }
+
+    vk::FALSE
+}
+
+pub(crate) struct VulkanRenderer {
+    instance: ash::Instance,
+    surface: vk::SurfaceKHR,
+    debug_callback: vk::DebugUtilsMessengerEXT,
+    device: ash::Device,
+    atlas: Arc<VulkanAtlas>,
+
+    debug_utils_loader: DebugUtils,
+    surface_loader: ash::extensions::khr::Surface,
+
+    viewport_size: Size<Pixels>,
+}
+
+impl VulkanRenderer {
+    pub fn new(raw_window: Box<dyn VulkanRawWindow>, viewport_size: Size<Pixels>) -> Self {
+        // Entry point
+        let entry = ash::Entry::linked();
+
+        // Check instance extension support
+        let required_instance_extensions = [
+            DebugUtils::name(),
+            raw_window.extension_name(),
+            ash::extensions::khr::Surface::name(),
+        ];
+        let available_instance_extensions =
+            entry.enumerate_instance_extension_properties(None).unwrap();
+        for required in required_instance_extensions {
+            if !available_instance_extensions
+                .iter()
+                .any(|available| unsafe {CStr::from_ptr(available.extension_name.as_ptr())} == required)
+            {
+                panic!("Missing vulkan extension: {:?}", required);
+            }
+        }
+
+        // Check validation layer support
+        let required_validation_layers =
+            [CStr::from_bytes_with_nul(b"VK_LAYER_KHRONOS_validation\0").unwrap()];
+        let available_validation_layers = entry.enumerate_instance_layer_properties().unwrap();
+        for required in required_validation_layers {
+            if !available_validation_layers.iter().any(
+                |available| unsafe { CStr::from_ptr(available.layer_name.as_ptr()) } == required,
+            ) {
+                panic!("Missing vulkan layer: {:?}", required);
+            }
+        }
+
+        // Create instance
+        let app_info = vk::ApplicationInfo::builder()
+            .engine_name(CStr::from_bytes_with_nul(b"GPUI\0").unwrap())
+            .engine_version(vk::make_api_version(
+                0,
+                env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().unwrap(),
+                env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().unwrap(),
+                env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().unwrap(),
+            ))
+            .api_version(vk::API_VERSION_1_3)
+            .build();
+
+        let instance_create_info = vk::InstanceCreateInfo::builder()
+            .application_info(&app_info)
+            .enabled_extension_names(&required_instance_extensions.map(|name| name.as_ptr()))
+            .enabled_layer_names(&required_validation_layers.map(|name| name.as_ptr()))
+            .build();
+
+        let instance = unsafe { entry.create_instance(&instance_create_info, None) }.unwrap();
+
+        // Load extensions
+        let platform_surface_loader = raw_window.extension_loader(&entry, &instance);
+        let surface_loader = ash::extensions::khr::Surface::new(&entry, &instance);
+        let debug_utils_loader = DebugUtils::new(&entry, &instance);
+
+        // Validation callback
+        let debug_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+            .message_severity(
+                vk::DebugUtilsMessageSeverityFlagsEXT::ERROR
+                    | vk::DebugUtilsMessageSeverityFlagsEXT::WARNING,
+            )
+            .message_type(
+                vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                    | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
+                    | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
+            )
+            .pfn_user_callback(Some(validation_layer_callback));
+
+        let debug_callback = unsafe {
+            debug_utils_loader.create_debug_utils_messenger(&debug_messenger_create_info, None)
+        }
+        .unwrap();
+
+        // Physical device
+        let required_extensions = [ash::extensions::khr::Swapchain::name().as_ptr()];
+
+        let physical_device = unsafe { instance.enumerate_physical_devices() }
+            .unwrap()
+            .into_iter()
+            .filter(|device| {
+                let queue_family_props =
+                    unsafe { instance.get_physical_device_queue_family_properties(*device) };
+
+                queue_family_props.iter().enumerate().any(|(idx, props)| {
+                    props.queue_flags.contains(vk::QueueFlags::GRAPHICS)
+                        && raw_window.get_physical_device_presentation_support(
+                            &platform_surface_loader,
+                            *device,
+                            idx as u32,
+                        )
+                })
+            })
+            .find(|device| {
+                let extensions =
+                    unsafe { instance.enumerate_device_extension_properties(*device) }.unwrap();
+                required_extensions.iter().all(|required| {
+                    extensions.iter().any(|extension| unsafe {
+                        CStr::from_ptr(extension.extension_name.as_ptr())
+                            == CStr::from_ptr(*required)
+                    })
+                })
+            })
+            .expect("No physical device with vulkan support found");
+        let memory_properties =
+            unsafe { instance.get_physical_device_memory_properties(physical_device) };
+
+        // Get queue family index
+        let graphics_family =
+            unsafe { instance.get_physical_device_queue_family_properties(physical_device) }
+                .iter()
+                .enumerate()
+                .filter(|(idx, queue_family)| {
+                    queue_family.queue_flags.contains(vk::QueueFlags::GRAPHICS)
+                        && raw_window.get_physical_device_presentation_support(
+                            &platform_surface_loader,
+                            physical_device,
+                            *idx as u32,
+                        )
+                })
+                .max_by_key(|(_, queue_family)| queue_family.queue_count)
+                .unwrap()
+                .0;
+
+        // Device
+        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+            .queue_family_index(graphics_family as u32)
+            .queue_priorities(&[1.0])
+            .build();
+
+        let device_create_info = vk::DeviceCreateInfo::builder()
+            .queue_create_infos(&[queue_create_info])
+            .enabled_extension_names(&required_extensions)
+            .build();
+
+        let device =
+            unsafe { instance.create_device(physical_device, &device_create_info, None) }.unwrap();
+
+        // Surface
+        let surface = raw_window.create_surface(&platform_surface_loader);
+
+        // Atlas
+        let atlas = Arc::new(VulkanAtlas::new(device.clone(), memory_properties));
+
+        Self {
+            instance,
+            surface,
+            debug_callback,
+            device,
+            atlas,
+            debug_utils_loader,
+            surface_loader,
+            viewport_size,
+        }
+    }
+
+    pub fn destroy(&self) {
+        unsafe {
+            self.device.device_wait_idle().unwrap();
+            self.atlas.destroy();
+            self.device.destroy_device(None);
+            self.surface_loader.destroy_surface(self.surface, None);
+            self.debug_utils_loader
+                .destroy_debug_utils_messenger(self.debug_callback, None);
+            self.instance.destroy_instance(None);
+        }
+    }
+
+    pub fn update_drawable_size(&self, size: Size<Pixels>) {
+        if size != self.viewport_size {
+            // todo!("vulkan")
+        }
+    }
+
+    pub fn viewport_size(&self) -> Size<Pixels> {
+        self.viewport_size
+    }
+
+    pub fn sprite_atlas(&self) -> &Arc<VulkanAtlas> {
+        &self.atlas
+    }
+
+    pub fn draw(&mut self, _scene: &Scene) {}
+}

--- a/crates/gpui/src/platform/vulkan/vulkan_surface.rs
+++ b/crates/gpui/src/platform/vulkan/vulkan_surface.rs
@@ -1,0 +1,23 @@
+use std::{any::Any, ffi::CStr};
+
+use ash::{vk, Entry, Instance};
+
+pub(crate) trait VulkanExtensionLoader {
+    fn as_any(&self) -> &dyn Any;
+}
+
+pub(crate) trait VulkanSurface {
+    fn extension_name(&self) -> &CStr;
+    fn extension_loader(
+        &self,
+        entry: &Entry,
+        instance: &Instance,
+    ) -> Box<dyn VulkanExtensionLoader>;
+    fn create_surface(&self, loader: &Box<dyn VulkanExtensionLoader>) -> vk::SurfaceKHR;
+    fn presentation_support(
+        &self,
+        loader: &Box<dyn VulkanExtensionLoader>,
+        physical_device: vk::PhysicalDevice,
+        queue_family_index: u32,
+    ) -> bool;
+}


### PR DESCRIPTION
Status: *Very* early stage WIP, just working through the Vulkan boilerplate, but I have next week off so it should progress fairly quick. Currently there isn't much in the way of a structure, with everything just being thrown into a single function, but I will separate parts out once its up and running and a good structure becomes apparent.

This is a PR to add a Vulkan renderer to GPUI using [ash](https://github.com/ash-rs/ash), which are Vulkan bindings for Rust. This would be more similar to the Metal renderer in that it is directly using the unsafe bindings for the underlying library which allows more control over the tech stack.

Release Notes:

- Added Vulkan rendering backend to GPUI