### PR TITLE
Allow overriding font style and weight via experimental.theme_overrides in settings

### DIFF
--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -92,6 +92,12 @@ impl ThemeStyleContent {
                             .color
                             .as_ref()
                             .and_then(|color| try_parse_color(color).ok()),
+                        font_style: style
+                            .font_style
+                            .map(|font_style| FontStyle::from(font_style)),
+                        font_weight: style
+                            .font_weight
+                            .map(|font_weight| FontWeight::from(font_weight)),
                         ..Default::default()
                     },
                 )


### PR DESCRIPTION

Release Notes:

- Added support for overriding the current theme's syntax font styles and weights in settings ([#9121](https://github.com/zed-industries/zed/issues/9121)).

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-03-09 at 22 20 01@2x](https://github.com/zed-industries/zed/assets/38924/c693468d-1e04-45b4-b7c0-869e2a22a44c) | ![Screenshot 2024-03-09 at 22 21 09@2x](https://github.com/zed-industries/zed/assets/38924/d8b09676-dd8b-46ac-8e9d-6cf2094a9c7e) |
