### PR TITLE
linux: gpui add Keysym::ISO_Left_Tab

### DIFF
--- a/crates/gpui/src/platform/linux/util.rs
+++ b/crates/gpui/src/platform/linux/util.rs
@@ -60,6 +60,11 @@ impl Keystroke {
             Keysym::equal => "=".to_owned(),
             Keysym::plus => "+".to_owned(),
 
+            Keysym::ISO_Left_Tab => {
+                handle_consumed_modifiers = false;
+                "tab".to_owned()
+            }
+
             _ => {
                 handle_consumed_modifiers = false;
                 xkb::keysym_get_name(key_sym).to_lowercase()


### PR DESCRIPTION
Fixes #9089.

On linux, pressing shift and tab together can potentially produce `ISO_Left_Tab`. This PR maps this key to "tab" with the shift modifier, similar to `SHIFT_TAB_KEY` in gpui::platform::mac::events.

Note: The [default linux keymaps](https://github.com/zed-industries/zed/blob/main/assets/keymaps/default-linux.json) have shift-tab mapped to editor::TabPrev and ctrl-[ mapped to editor::Outdent. Both actions appear to have the same effect. 

Release Notes:

- Support shift-tab on linux (#9089).

