### PR TITLE
Add logic for automatically searching for extensions when editing files with unsupported extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,6 +3551,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "client",
+ "db",
  "editor",
  "extension",
  "fuzzy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,6 +3556,7 @@ dependencies = [
  "fuzzy",
  "gpui",
  "language",
+ "serde",
  "settings",
  "smallvec",
  "theme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "extension",
  "fuzzy",
  "gpui",
+ "language",
  "settings",
  "smallvec",
  "theme",

--- a/Session.vim
+++ b/Session.vim
@@ -1,0 +1,97 @@
+let SessionLoad = 1
+let s:so_save = &g:so | let s:siso_save = &g:siso | setg so=0 siso=0 | setl so=-1 siso=-1
+let v:this_session=expand("<sfile>:p")
+silent only
+silent tabonly
+cd ~/coding/OpenSource/use/zed
+if expand('%') == '' && !&modified && line('$') <= 1 && getline(1) == ''
+  let s:wipebuf = bufnr('%')
+endif
+let s:shortmess_save = &shortmess
+if &shortmess =~ 'A'
+  set shortmess=aoOA
+else
+  set shortmess=aoO
+endif
+badd +171 crates/extensions_ui/src/extension_suggest.rs
+badd +32 crates/extensions_ui/Cargo.toml
+badd +489 crates/auto_update/src/auto_update.rs
+badd +6 crates/project_panel/src/project_panel.rs
+badd +5 crates/db/src/kvp.rs
+argglobal
+%argdel
+edit crates/extensions_ui/src/extension_suggest.rs
+wincmd t
+let s:save_winminheight = &winminheight
+let s:save_winminwidth = &winminwidth
+set winminheight=0
+set winheight=1
+set winminwidth=0
+set winwidth=1
+argglobal
+balt crates/db/src/kvp.rs
+setlocal fdm=expr
+setlocal fde=nvim_treesitter#foldexpr()
+setlocal fmr={{{,}}}
+setlocal fdi=#
+setlocal fdl=99
+setlocal fml=1
+setlocal fdn=99
+setlocal fen
+16
+normal! zo
+19
+normal! zo
+19
+normal! zo
+22
+normal! zo
+26
+normal! zo
+26
+normal! zo
+26
+normal! zo
+26
+normal! zo
+35
+normal! zo
+53
+normal! zo
+54
+normal! zo
+56
+normal! zo
+88
+normal! zo
+89
+normal! zo
+133
+normal! zo
+146
+normal! zo
+let s:l = 171 - ((32 * winheight(0) + 27) / 55)
+if s:l < 1 | let s:l = 1 | endif
+keepjumps exe s:l
+normal! zt
+keepjumps 171
+normal! 041|
+lcd ~/coding/OpenSource/use/zed
+tabnext 1
+if exists('s:wipebuf') && len(win_findbuf(s:wipebuf)) == 0 && getbufvar(s:wipebuf, '&buftype') isnot# 'terminal'
+  silent exe 'bwipe ' . s:wipebuf
+endif
+unlet! s:wipebuf
+set winheight=1 winwidth=20
+let &shortmess = s:shortmess_save
+let &winminheight = s:save_winminheight
+let &winminwidth = s:save_winminwidth
+let s:sx = expand("<sfile>:p:r")."x.vim"
+if filereadable(s:sx)
+  exe "source " . fnameescape(s:sx)
+endif
+let &g:so = s:so_save | let &g:siso = s:siso_save
+nohlsearch
+doautoall SessionLoadPost
+unlet SessionLoad
+" vim: set ft=vim :

--- a/Untitled
+++ b/Untitled
@@ -1,0 +1,35 @@
+ id  |          name           |       external_id       
+-----+-------------------------+-------------------------
+  18 | Assembly Syntax         | assembly      --          
+   5 | Beancount               | beancount     Y         
+  13 | Brainfuck               | brainfuck     --         
+  26 | Dockerfile              | dockerfile      X        
+  70 | Elisp                   | elisp         Y         
+ 110 | Fish                    | fish            X        
+  84 | GDScript                | gdscript                
+  
+128 | Git Firefly             | git-firefly            https://github.com/d1y/git_firefly/tree/8bb3a5f6769ad6de95ec0bfe430a17ecfd4128c1/languages 
+
+  56 | GraphQL                 | graphql         --        
+  44 | Horizon                 | horizon          X       
+  25 | Java                    | java             X       
+  88 | Kotlin                  | kotlin           --       
+ 104 | LaTeX                   | latex            --       
+  34 | LOG                     | log                     
+  91 | Make                    | make             X       
+ 122 | MATLAB                  | matlab           --       
+  17 | Mellow                  | mellow                  
+  67 | Muted                   | muted                   
+  30 | Navi                    | navi                    
+ 107 | Nix                     | nix              --       
+   7 | Nu                      | nu                --      
+  97 | PactLang                | pact                    
+   3 | Pkl                     | pkl                     
+  54 | R                       | r                   --    
+  63 | Smithy                  | smithy              --    
+  98 | Solidity                | solidity           --     
+  55 | SQL                     | sql                X     
+  47 | Swift                   | swift              --     
+  92 | Templ                   | templ              --     
+  27 | Wgsl                    | wgsl               --     
+(68 rows)

--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -22,6 +22,10 @@ pub fn router() -> Router {
     Router::new()
         .route("/extensions", get(get_extensions))
         .route(
+            "/extensions/:extension_id/download",
+            get(download_latest_extension),
+        )
+        .route(
             "/extensions/:extension_id/:version/download",
             get(download_extension),
         )
@@ -30,6 +34,11 @@ pub fn router() -> Router {
 #[derive(Debug, Deserialize)]
 struct GetExtensionsParams {
     filter: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DownloadLatestExtensionParams {
+    extension_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -58,6 +67,24 @@ async fn get_extensions(
 ) -> Result<Json<GetExtensionsResponse>> {
     let extensions = app.db.get_extensions(params.filter.as_deref(), 500).await?;
     Ok(Json(GetExtensionsResponse { data: extensions }))
+}
+
+async fn download_latest_extension(
+    Extension(app): Extension<Arc<AppState>>,
+    Path(params): Path<GetExtensionParams>,
+) -> Result<Redirect> {
+    let extension = app
+        .db
+        .get_extension(params.extension_id)
+        .await?
+        .ok_or_else(|| anyhow!("unknown extension"))?;
+    download_extension(
+        Extension(app),
+        Path(DownloadExtensionParams {
+            extension_id: params.extension_id,
+            version: extension.latest_version.as_str(),
+        }),
+    )
 }
 
 async fn download_extension(

--- a/crates/collab/src/db/queries/extensions.rs
+++ b/crates/collab/src/db/queries/extensions.rs
@@ -52,6 +52,44 @@ impl Database {
         .await
     }
 
+    pub async fn get_extension(&self, extension_id: &str) -> Result<Option<ExtensionMetadata>> {
+        self.transaction(|tx| async move {
+            let extension = extension::Entity::find()
+                .filter(extension::Column::ExternalId.eq(extension_id))
+                .order_by_desc(extension::Column::TotalDownloadCount)
+                .order_by_asc(extension::Column::Name)
+                .limit(Some(limit as u64))
+                .filter(
+                    extension::Column::LatestVersion
+                        .into_expr()
+                        .eq(extension_version::Column::Version.into_expr()),
+                )
+                .inner_join(extension_version::Entity)
+                .select_also(extension_version::Entity)
+                .one(&*tx)
+                .await?;
+
+            Ok(extension.and_then(|(extension, latest_version)| {
+                let version = latest_version?;
+                Some(ExtensionMetadata {
+                    id: extension.external_id,
+                    name: extension.name,
+                    version: version.version,
+                    authors: version
+                        .authors
+                        .split(',')
+                        .map(|author| author.trim().to_string())
+                        .collect::<Vec<_>>(),
+                    description: version.description,
+                    repository: version.repository,
+                    published_at: version.published_at,
+                    download_count: extension.total_download_count as u64,
+                })
+            }))
+        })
+        .await
+    }
+
     pub async fn get_known_extension_versions<'a>(&self) -> Result<HashMap<String, Vec<String>>> {
         self.transaction(|tx| async move {
             let mut extension_external_ids_by_id = HashMap::default();

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -118,8 +118,8 @@ pub struct ExtensionIndex {
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct ExtensionIndexEntry {
-    manifest: Arc<ExtensionManifest>,
-    dev: bool,
+    pub manifest: Arc<ExtensionManifest>,
+    pub dev: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
@@ -348,6 +348,10 @@ impl ExtensionStore {
                 None => ExtensionStatus::NotInstalled,
             },
         }
+    }
+
+    pub fn installed_extensions(&self) -> &ExtensionIndex {
+        &self.extension_index
     }
 
     pub fn dev_extensions(&self) -> impl Iterator<Item = &Arc<ExtensionManifest>> {

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -27,6 +27,7 @@ theme.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+language.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -29,6 +29,7 @@ util.workspace = true
 workspace.workspace = true
 language.workspace = true
 serde.workspace = true
+db.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -28,6 +28,7 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 language.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -17,19 +17,19 @@ test-support = []
 [dependencies]
 anyhow.workspace = true
 client.workspace = true
+db.workspace = true
 editor.workspace = true
 extension.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+language.workspace = true
+serde.workspace = true
 settings.workspace = true
 smallvec.workspace = true
 theme.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
-language.workspace = true
-serde.workspace = true
-db.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use editor::{Editor, EditorMode};
+use gpui::{AppContext, ViewContext, VisualContext};
+use language::Language;
+use workspace::{Workspace, notifications::simple_message_notification};
+use language::Event;
+
+use crate::LanguageExtensions;
+
+
+pub(crate) fn init(cx: &mut AppContext) {
+
+    // Watch when the editor is opened
+    cx.observe_new_views(move |editor: &mut Editor, cx| {
+
+        // Only if the editor is editing in a programming language
+        if let EditorMode::Full = editor.mode() {
+
+            // Get languages in the current editor
+            let languages = editor
+                .buffer()
+                .read(cx)
+                .all_buffers()
+                .iter()
+                .flat_map(|buffer| 
+                    buffer
+                        .read(cx)
+                        .language()
+                        .cloned()
+                ).collect::<Vec<_>>();
+
+            for language in languages {
+                check_and_suggest(cx, language)
+            }
+
+
+            // Listen to language changes; If a user changes to an unsupported language, extension suggestions should happen
+            let buffers = editor.buffer();
+            let buffers = buffers.read(cx);
+            for buffer_model in buffers.all_buffers().iter() {
+                cx.subscribe(buffer_model, move |_subscriber, emitter, event, cx| {
+
+                    match event {
+                        Event::LanguageChanged => {
+                            let buffer = emitter.read(cx);
+                            let language_option = buffer.language();
+
+                            println!("Language changed/set to {:?}", language_option);
+
+                            if let Some(language) = language_option.cloned() {
+
+                                check_and_suggest(cx, language);
+                            }
+
+                        },
+                        _ => {}
+                    }
+
+                }).detach();
+
+
+            }
+
+        }
+    })
+        .detach();
+}
+
+fn check_and_suggest<T>(cx: &mut ViewContext<T>, language: Arc<Language>) {
+    suggest_extensions(cx, language);
+}
+
+fn suggest_extensions<T>(cx: &mut ViewContext<T>, language: Arc<Language>) -> Option<()> {
+    let workspace = cx.windows().get(0)?.downcast::<Workspace>()?; // for some reason cx.active_window() returns none
+
+    let _ = workspace
+        .update(cx, |workspace, cx| {
+            workspace.show_notification(0, cx, |cx| {
+
+
+                cx.new_view(move |_cx| {
+                    simple_message_notification::MessageNotification::new(
+                        format!("Language Extensions for {language} not installed", language = language.name())
+                    )
+                        .with_click_message("View Extensions for Language")
+                        .on_click(move |cx| {
+
+                            cx.dispatch_action(Box::new(LanguageExtensions{
+                                language_string: language.name().to_string().into()
+                            }));
+
+                        })
+                        .with_secondary_click_message("Install")
+                })
+            })
+        });
+
+    Some(())
+}

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -1,248 +1,195 @@
-use std::{sync::Arc, hash::{DefaultHasher, Hash, Hasher}};
+use std::{
+    hash::{DefaultHasher, Hash, Hasher},
+    sync::Arc,
+};
 
 use db::kvp::KEY_VALUE_STORE;
 
 use editor::{Editor, EditorMode};
-use extension::{ExtensionStore, ExtensionApiResponse, ExtensionIndexEntry};
-use gpui::{AppContext, ViewContext, VisualContext, SharedString};
-use language::Language;
-use workspace::{Workspace, notifications::simple_message_notification};
+use extension::{ExtensionApiResponse, ExtensionIndexEntry, ExtensionStore};
+use gpui::{AppContext, SharedString, ViewContext, VisualContext};
 use language::Event;
+use language::Language;
+use ui::WindowContext;
+use workspace::{notifications::simple_message_notification, Workspace};
 
 use crate::ExtensionsWithQuery;
 
+pub fn suggested_extension(file_extension_or_name: &str) -> Option<String> {
+    static SUGGESTED: OnceLock<HashMap<&str, u64>> = OnceLock::new();
+    SUGGESTED::get_or_init(|| {
+        [
+            ("beancount", "beancount"),
+            ("fish", "fish"),
+            ("templ", "templ"),
+            ("elisp", "elisp"),
+            ("Makefile", "make"),
+            ("sql", "sql"),
+            ("java", "java"),
+            ("swift", "swift"),
+            ("r", "r"),
+            ("Dockerfile", "dockerfile"),
+        ]
+        .collect::<HashMap<String, String>>()
+    });
+    SUGGESTED.get(file_extension_or_name)
+}
 
 /// Function to initialize subscriptions to Editor Open and Buffer Language Change; called in the Extensions UI init function
 pub(crate) fn init(cx: &mut AppContext) {
-
     // Watch when the editor is opened
     cx.observe_new_views(move |editor: &mut Editor, cx| {
-
         // Only check if the editor is editing in a programming language
         if let EditorMode::Full = editor.mode() {
-
-
             // Get languages in the current editor
-            let editor_language_info = editor
-                .buffer()
-                .read(cx)
-                .all_buffers()
-                .iter()
-                .flat_map(|buffer| {
-                    let buffer = buffer.read(cx);
-
-                    // Get the file extension or file name if there is no extension
-                    Some((
-                        match buffer.file()?.path().extension() {
-                            Some(extension) => SharedString::from(extension.to_str()?.to_string()),
-                            None => SharedString::from(buffer.file()?.path().to_str()?.to_string())
-                    },
-                        buffer.language().cloned()
-                    ))
-                }).collect::<Vec<_>>();
-
-            // Check extensions for all languages
-            for (file_name_or_extension, language) in editor_language_info {
-                check_and_suggest(cx, language, Some(file_name_or_extension))
-            }
-
-
-            // Listen to language changes; If a user changes to an unsupported language, extension suggestions should happen
-            let buffers = editor.buffer();
-            let buffers = buffers.read(cx);
-            for buffer_model in buffers.all_buffers().iter() {
-                cx.subscribe(buffer_model, move |_subscriber, emitter, event, cx| {
-
-                    match event {
-                        Event::LanguageChanged => {
-                            let buffer = emitter.read(cx);
-                            let language_option = buffer.language();
-
-                            if let Some(language) = language_option.cloned() {
-
-                                check_and_suggest(cx, Some(language), None);
-                            }
-
-                        },
-                        _ => {}
+            let file_name_or_extension =
+                editor.buffer().read(cx).as_singleton().and_then(|buffer| {
+                    if buffer.language().is_some() {
+                        None
                     }
+                    Some(match buffer.file()?.path().extension() {
+                        Some(extension) => extension.to_str()?.to_string(),
+                        None => buffer.file()?.path().to_str()?.to_string(),
+                    })
+                });
 
-                }).detach();
+            let file_name_or_extension = Some(file_name_or_extension) else {
+                return;
+            };
+            let Some(workspace) = editor.workspace() else {
+                return;
+            };
 
-
-            }
-
+            check_and_suggest(file_name_or_extension, workspace, cx);
         }
     })
-        .detach();
+    .detach();
 }
 
-fn language_extension_key(file_context: &str) -> String {
-    format!("{}_extension_suggest", file_context)
+fn language_extension_key(extension_id: &str) -> String {
+    format!("{}_extension_suggest", extension_id)
 }
-
 
 /// Query the installed extensions to check if any match the language of the document; if none do, call the `suggest_extensions` function
 /// This accepts language and file_context as options, becuase for a language request, there either could be no language associated with
 /// a buffer or no file associated with a buffer
-fn check_and_suggest<T: 'static>(cx: &mut ViewContext<T>, language: Option<Arc<Language>>, file_context: Option<SharedString>) {
-    if let Some(ref f_context) = file_context {
-        let key = language_extension_key(f_context);
+fn check_and_suggest<T: 'static>(
+    file_name_or_extension: &str,
+    workspace: View<Workspace>,
+    cx: &mut WindowContext,
+) {
+    let Some(extension_id) = suggested_extension(&file_name_or_extension) else {
+        return;
+    };
 
-        let value = KEY_VALUE_STORE.read_kvp(&key);
+    let key = language_extension_key(&extension_id);
+    let value = KEY_VALUE_STORE.read_kvp(&key);
 
-        if let Ok(Some(value)) = value {
-            if value == "some" {
-                return
-            }
-        }
+    if value == Ok(Some("dismissed")) {
+        return;
     }
 
-
-    if let Some(ref language) = language {
-        let key = language_extension_key(&language.name());
-
-        let value = KEY_VALUE_STORE.read_kvp(&key);
-
-        if let Ok(Some(value)) = value {
-            if value == "some" {
-                return
-            }
-        }
-    }
-
-    let extension_store = ExtensionStore::global(cx);
-
-    let store = extension_store.read(cx);
-
-    let installed_extensions = &store.installed_extensions().extensions;
-
-    // check if any extensions support the current language; this searches just the descriptions as a sort of hack right now
-    let check = installed_extensions.iter()
-        .any(|(_, ext)| 
-            ext.filter_by_language(language.as_deref(), file_context.clone())
-        );
-
-    if !check {
-        suggest_extensions(cx, language, file_context);
-    }
+    suggest_extensions(file_name_or_extension, &extension_id, workspace, cx);
 }
 
 /// Query for all remote extensions; filter for the ones that match `language`; get the highest downloaded match; send a notification with
 /// An option to install the that extensions and also to go to the extensions page to find all extensions matching the language
-fn suggest_extensions<T: 'static>(cx: &mut ViewContext<T>, language: Option<Arc<Language>>, file_context: Option<SharedString>) -> Option<()> {
+fn suggest_extensions(
+    file_name_or_extension: &str,
+    extension_id: &str,
+    workspace: View<Workspace>,
+    cx: &mut WindowContext,
+) -> Option<()> {
     let extension_store = ExtensionStore::global(cx);
 
-    let search = match (language.clone(), file_context.clone()) {
-        (Some(language), _) => Some(language.name().to_string()),
-        (None, Some(extension)) => Some(extension.to_string()),
-        (None, None) => return None
-    }?;
+    workspace.update(&mut cx, |workspace, cx| {
+        let mut hasher = DefaultHasher::new();
+        search.hash(&mut hasher);
+        let id = hasher.finish();
+        workspace.show_notification(id as usize, cx, |cx| {
+            cx.new_view(move |_cx| {
+                simple_message_notification::MessageNotification::new(format!(
+                    "Do you want to install the recommended '{}' extension?",
+                    file_name_or_extension
+                ))
+                .with_click_message("Install")
+                .on_dismiss(move |cx| {
+                    let key = language_extension_key(&extension_id);
 
-    let remote_extensions_task = extension_store.update(cx, |store, cx| {
-        store.fetch_extensions(None, cx)
-    });
-
-    cx.spawn(|_view, mut cx| async move {
-
-        // Get the most downloaded extension for the language
-        let all_extensions = remote_extensions_task.await.ok()?;
-
-        let most_downloaded = all_extensions
-            .into_iter()
-            .filter(|extension| 
-                extension.filter_by_language(language.as_deref(), file_context.clone().map(Into::into))
-            )
-            .max_by_key(|extension| extension.download_count)?;
-
-
-        // Make the notification
-
-        let workspace = cx.window_handle().downcast::<Workspace>()?;
-
-        let _ = workspace.update(&mut cx, |workspace, cx| {
-
-
-            let mut hasher = DefaultHasher::new();
-            search.hash(&mut hasher);
-            let id = hasher.finish();
-            workspace.show_notification(id as usize, cx, |cx| { // TODO: should we avoid using `as` here?
-                cx.new_view(move |_cx| {
-                    simple_message_notification::MessageNotification::new(
-                        format!("Extensions for {language} not installed", language = search)
-                    )
-                        .with_click_message("View Extensions")
-                        .on_click(move |cx| {
-
-                            cx.dispatch_action(Box::new(ExtensionsWithQuery{
-                                query: search.clone().into()
-                            }));
-
-                        })
-                        .with_secondary_click_message(format!("Install {}", most_downloaded.name))
-                        .secondary_on_click(move |cx| {
-                            let extension_store = ExtensionStore::global(cx);
-                            extension_store.update(cx, |store, cx| {
-                                store.install_extension(most_downloaded.id.clone(), most_downloaded.version.clone(), cx)
-                            });
-
-                            cx.dispatch_action(Box::new(ExtensionsWithQuery{
-                                query: most_downloaded.name.clone().into()
-                            }));
-                        })
+                    db::write_and_log(cx, || {
+                        KEY_VALUE_STORE
+                            .write_kvp(key, "dismissed".to_string())
+                            .await;
+                    });
+                })
+                .on_click(move |mut cx| {
+                    let extension_store = ExtensionStore::global(cx);
+                    extension_store.update(&mut cx, |store, cx| {
+                        store.install_latest_extension(extension_id, cx);
+                    });
                 })
             })
-        });
-
-        // state in the local database that the language was suggested
-        if let Some(ref f_context) = file_context {
-            let _ = KEY_VALUE_STORE.write_kvp(language_extension_key(f_context), "some".into()).await;
-        } 
-        // write to both because either could be None; when checking for keys, we check for both
-        if let Some(ref language) = language {
-            let _ = KEY_VALUE_STORE.write_kvp(language_extension_key(&language.name()), "some".into()).await;
-        }
-
-        Some(())
-    }).detach();
+        })
+    });
 
     Some(())
 }
 
-
 trait LanguageFilterable {
     /// Does an extension match the language of a file? TODO: Use a new backend extension API that has language data
-    fn filter_by_language(&self, language: Option<&Language>, file_extension: Option<SharedString>) -> bool;
+    fn filter_by_language(
+        &self,
+        language: Option<&Language>,
+        file_extension: Option<SharedString>,
+    ) -> bool;
 }
 
 impl LanguageFilterable for ExtensionIndexEntry {
-    fn filter_by_language(&self, language: Option<&Language>, file_extension: Option<SharedString>) -> bool {
-        self.manifest
-            .languages
-            .iter()
-            .any(|extension_language| 
-                extension_language.to_str().is_some_and(|extension_language| 
-                    language.is_some_and(|lang| 
-                        extension_language.to_lowercase().contains(&lang.name().to_string().to_lowercase())
-                        || lang.path_suffixes().iter().any(|suffix| extension_language.contains(suffix))
-                    )
-                || file_extension.clone().is_some_and(|ex| extension_language.to_lowercase().contains(&ex.to_string()))
-            ))
+    fn filter_by_language(
+        &self,
+        language: Option<&Language>,
+        file_extension: Option<SharedString>,
+    ) -> bool {
+        self.manifest.languages.iter().any(|extension_language| {
+            extension_language
+                .to_str()
+                .is_some_and(|extension_language| {
+                    language.is_some_and(|lang| {
+                        extension_language
+                            .to_lowercase()
+                            .contains(&lang.name().to_string().to_lowercase())
+                            || lang
+                                .path_suffixes()
+                                .iter()
+                                .any(|suffix| extension_language.contains(suffix))
+                    }) || file_extension.clone().is_some_and(|ex| {
+                        extension_language.to_lowercase().contains(&ex.to_string())
+                    })
+                })
+        })
     }
 }
 
 impl LanguageFilterable for ExtensionApiResponse {
-    fn filter_by_language(&self, language: Option<&Language>, file_extension: Option<SharedString>) -> bool {
-        language.is_some_and(|lang| 
-            self.description
-                .as_ref()
-                .is_some_and(|description| 
-                    description.to_lowercase().contains(&lang.name().to_lowercase())
-                    || file_extension.clone().is_some_and(|ex| description.to_lowercase().contains(&ex.to_string()))
-                )
-            || self.name.to_lowercase().contains(&lang.name().to_lowercase())
-        )
-        || file_extension.clone().is_some_and(|ex| self.name.to_lowercase().contains(&ex.to_string()))
-
+    fn filter_by_language(
+        &self,
+        language: Option<&Language>,
+        file_extension: Option<SharedString>,
+    ) -> bool {
+        language.is_some_and(|lang| {
+            self.description.as_ref().is_some_and(|description| {
+                description
+                    .to_lowercase()
+                    .contains(&lang.name().to_lowercase())
+                    || file_extension
+                        .clone()
+                        .is_some_and(|ex| description.to_lowercase().contains(&ex.to_string()))
+            }) || self
+                .name
+                .to_lowercase()
+                .contains(&lang.name().to_lowercase())
+        }) || file_extension
+            .clone()
+            .is_some_and(|ex| self.name.to_lowercase().contains(&ex.to_string()))
     }
 }

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -10,12 +10,13 @@ use language::Event;
 use crate::ExtensionsWithQuery;
 
 
+/// Function to initialize subscriptions to Editor Open and Buffer Language Change; called in the Extensions UI init function
 pub(crate) fn init(cx: &mut AppContext) {
 
     // Watch when the editor is opened
     cx.observe_new_views(move |editor: &mut Editor, cx| {
 
-        // Only if the editor is editing in a programming language
+        // Only check if the editor is editing in a programming language
         if let EditorMode::Full = editor.mode() {
 
 
@@ -37,6 +38,7 @@ pub(crate) fn init(cx: &mut AppContext) {
                     ))
                 }).collect::<Vec<_>>();
 
+            // Check extensions for all languages
             for (name_or_extension, language) in editor_language_info {
                 check_and_suggest(cx, language, Some(name_or_extension))
             }
@@ -72,6 +74,7 @@ pub(crate) fn init(cx: &mut AppContext) {
         .detach();
 }
 
+/// Query the installed extensions to check if any match the language of the document; if none do, call the `suggest_extensions` function
 fn check_and_suggest<T: 'static>(cx: &mut ViewContext<T>, language: Option<Arc<Language>>, extension: Option<SharedString>) {
     let extension_store = ExtensionStore::global(cx);
 
@@ -90,6 +93,8 @@ fn check_and_suggest<T: 'static>(cx: &mut ViewContext<T>, language: Option<Arc<L
     }
 }
 
+/// Query for all remote extensions; filter for the ones that match `language`; get the highest downloaded match; send a notification with
+/// An option to install the that extensions and also to go to the extensions page to find all extensions matching the language
 fn suggest_extensions<T: 'static>(cx: &mut ViewContext<T>, language: Option<Arc<Language>>, file_extension: Option<SharedString>) -> Option<()> {
     let extension_store = ExtensionStore::global(cx);
 

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -100,7 +100,7 @@ fn suggest_extensions<T: 'static>(cx: &mut ViewContext<T>, language: Option<Arc<
     }?;
 
     let remote_extensions_task = extension_store.update(cx, |store, cx| {
-        store.fetch_extensions(Some(&search), cx)
+        store.fetch_extensions(None, cx)
     });
 
     cx.spawn(|_view, mut cx| async move {

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use editor::{Editor, EditorMode};
-use gpui::{AppContext, ViewContext, VisualContext};
+use extension::{ExtensionStore, ExtensionApiResponse};
+use gpui::{AppContext, ViewContext, VisualContext, Context};
 use language::Language;
 use workspace::{Workspace, notifications::simple_message_notification};
 use language::Event;
 
-use crate::LanguageExtensions;
+use crate::ExtensionsWithQuery;
 
 
 pub(crate) fn init(cx: &mut AppContext) {
@@ -67,34 +69,80 @@ pub(crate) fn init(cx: &mut AppContext) {
         .detach();
 }
 
-fn check_and_suggest<T>(cx: &mut ViewContext<T>, language: Arc<Language>) {
-    suggest_extensions(cx, language);
+fn check_and_suggest<T: 'static>(cx: &mut ViewContext<T>, language: Arc<Language>) {
+
+    let extension_store = ExtensionStore::global(cx);
+
+    let store = extension_store.read(cx);
+
+    let installed_extensions = &store.installed_extensions().extensions;
+
+    // check if any extensions support the current language; this searches just the descriptions as a sort of hack right now
+    let check = installed_extensions.iter()
+        .any(|(_, ext)| 
+            ext.manifest.description.as_ref().map(|description| description.contains(&language.name().to_lowercase())) == Some(true)
+        );
+
+    if !check {
+        suggest_extensions(cx, language);
+    }
 }
 
-fn suggest_extensions<T>(cx: &mut ViewContext<T>, language: Arc<Language>) -> Option<()> {
-    let workspace = cx.windows().get(0)?.downcast::<Workspace>()?; // for some reason cx.active_window() returns none
+fn suggest_extensions<T: 'static>(cx: &mut ViewContext<T>, language: Arc<Language>) -> Option<()> {
+    let extension_store = ExtensionStore::global(cx);
 
-    let _ = workspace
-        .update(cx, |workspace, cx| {
+
+    let remote_extensions_task = extension_store.update(cx, |store, cx| {
+        store.fetch_extensions(Some(language.name().to_string().as_str()), cx)
+    });
+
+    cx.spawn(|_view, mut cx| async move {
+
+        // Get the most downloaded extension for the language
+        let all_extensions = remote_extensions_task.await.ok()?;
+
+
+        let most_downloaded = all_extensions
+            .into_iter()
+            .filter(|extension| extension.description.clone().is_some_and(|description| description.contains(&language.name().to_string())))
+            .max_by_key(|extension| extension.download_count)?;
+
+        // Make the notification
+
+        let workspace = cx.window_handle().downcast::<Workspace>()?;
+
+        let _ = workspace.update(&mut cx, |workspace, cx| {
+
             workspace.show_notification(0, cx, |cx| {
-
-
                 cx.new_view(move |_cx| {
                     simple_message_notification::MessageNotification::new(
                         format!("Language Extensions for {language} not installed", language = language.name())
                     )
-                        .with_click_message("View Extensions for Language")
+                        .with_click_message("View Extensions")
                         .on_click(move |cx| {
 
-                            cx.dispatch_action(Box::new(LanguageExtensions{
-                                language_string: language.name().to_string().into()
+                            cx.dispatch_action(Box::new(ExtensionsWithQuery{
+                                query: language.name().to_string().into()
                             }));
 
                         })
-                        .with_secondary_click_message("Install")
+                        .with_secondary_click_message(format!("Install {}", most_downloaded.name))
+                        .secondary_on_click(move |cx| {
+                            let extension_store = ExtensionStore::global(cx);
+                            extension_store.update(cx, |store, cx| {
+                                store.install_extension(most_downloaded.id.clone(), most_downloaded.version.clone(), cx)
+                            });
+
+                            cx.dispatch_action(Box::new(ExtensionsWithQuery{
+                                query: most_downloaded.name.clone().into()
+                            }));
+                        })
                 })
             })
         });
+
+        Some(())
+    }).detach();
 
     Some(())
 }

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -53,8 +53,6 @@ pub(crate) fn init(cx: &mut AppContext) {
                             let buffer = emitter.read(cx);
                             let language_option = buffer.language();
 
-                            println!("Language changed/set to {:?}", language_option);
-
                             if let Some(language) = language_option.cloned() {
 
                                 check_and_suggest(cx, Some(language), None);

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -116,7 +116,7 @@ fn suggest_extensions<T: 'static>(cx: &mut ViewContext<T>, language: Arc<Languag
             workspace.show_notification(0, cx, |cx| {
                 cx.new_view(move |_cx| {
                     simple_message_notification::MessageNotification::new(
-                        format!("Language Extensions for {language} not installed", language = language.name())
+                        format!("Extensions for {language} not installed", language = language.name())
                     )
                         .with_click_message("View Extensions")
                         .on_click(move |cx| {

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -36,11 +36,11 @@ use serde::Deserialize;
 actions!(zed, [Extensions, InstallDevExtension]);
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-struct LanguageExtensions {
-    language_string: SharedString,
+struct ExtensionsWithQuery {
+    query: SharedString,
 }
 
-impl_actions!(zed, [LanguageExtensions]);
+impl_actions!(zed, [ExtensionsWithQuery]);
 
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(move |workspace: &mut Workspace, cx| {
@@ -49,9 +49,9 @@ pub fn init(cx: &mut AppContext) {
                 let extensions_page = ExtensionsPage::new(workspace, cx, None);
                 workspace.add_item_to_active_pane(Box::new(extensions_page), cx)
             })
-            .register_action(move |workspace, LanguageExtensions{language_string}: &LanguageExtensions, cx| {
+            .register_action(move |workspace, ExtensionsWithQuery{query}: &ExtensionsWithQuery, cx| {
 
-                let extensions_page = ExtensionsPage::new(workspace, cx, Some(language_string));
+                let extensions_page = ExtensionsPage::new(workspace, cx, Some(query));
                 workspace.add_item_to_active_pane(Box::new(extensions_page), cx)
 
             })

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -285,6 +285,8 @@ pub mod simple_message_notification {
         message: SharedString,
         on_click: Option<Arc<dyn Fn(&mut ViewContext<Self>)>>,
         click_message: Option<SharedString>,
+        secondary_click_message: Option<SharedString>,
+        secondary_on_click: Option<Arc<dyn Fn(&mut ViewContext<Self>)>>,
     }
 
     impl EventEmitter<DismissEvent> for MessageNotification {}
@@ -298,6 +300,8 @@ pub mod simple_message_notification {
                 message: message.into(),
                 on_click: None,
                 click_message: None,
+                secondary_on_click: None,
+                secondary_click_message: None
             }
         }
 
@@ -314,6 +318,23 @@ pub mod simple_message_notification {
             F: 'static + Fn(&mut ViewContext<Self>),
         {
             self.on_click = Some(Arc::new(on_click));
+            self
+        }
+
+
+        pub fn with_secondary_click_message<S>(mut self, message: S) -> Self
+        where
+            S: Into<SharedString>,
+        {
+            self.secondary_click_message = Some(message.into());
+            self
+        }
+
+        pub fn secondary_on_click<F>(mut self, on_click: F) -> Self
+        where
+            F: 'static + Fn(&mut ViewContext<Self>),
+        {
+            self.secondary_on_click = Some(Arc::new(on_click));
             self
         }
 
@@ -339,16 +360,32 @@ pub mod simple_message_notification {
                                 .on_click(cx.listener(|this, _, cx| this.dismiss(cx))),
                         ),
                 )
-                .children(self.click_message.iter().map(|message| {
-                    Button::new(message.clone(), message.clone()).on_click(cx.listener(
-                        |this, _, cx| {
-                            if let Some(on_click) = this.on_click.as_ref() {
-                                (on_click)(cx)
-                            };
-                            this.dismiss(cx)
-                        },
-                    ))
-                }))
+                .child(
+                    h_flex()
+                        .gap_3()
+                        .children(self.click_message.iter().map(|message| {
+                            Button::new(message.clone(), message.clone()).on_click(cx.listener(
+                                |this, _, cx| {
+                                    if let Some(on_click) = this.on_click.as_ref() {
+                                        (on_click)(cx)
+                                    };
+                                    this.dismiss(cx)
+                                },
+                            ))
+                        }))
+                        .children(self.secondary_click_message.iter().map(|message| {
+                            Button::new(message.clone(), message.clone())
+                                .style(ButtonStyle::Filled)
+                                .on_click(cx.listener(
+                                    |this, _, cx| {
+                                        if let Some(on_click) = this.secondary_on_click.as_ref() {
+                                            (on_click)(cx)
+                                        };
+                                        this.dismiss(cx)
+                                    },
+                                ))
+                        }))
+                )
         }
     }
 }

--- a/test.java
+++ b/test.java
@@ -1,0 +1,5 @@
+class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}


### PR DESCRIPTION
Initial support for the task "Add logic for automatically searching for extensions when editing files with unsupported extensions" in issue #7096 

Given that language servers have not been offloaded to plugins yet, this is not useful right now, but it surely will be in the future. Also, the backend API does not yet send a *language* field in the extension manifest, so this PR instead searches the extension name and description to find compatible extensions given the editor's set language and the filename. Ideally, we will filter by a language field from the API response, but we cannot yet. When the backend is updated, the implementations of [this trait](https://github.com/zed-industries/zed/compare/main...Feel-ix-343:zed:main#diff-d4fc4b231ff6a74f424c9832e24479e780027c98fca1cd264d77720db591ef88R166) will change accordingly.

Please leave feedback as I am happy to make changes. 

This was my first attempt at working with the codebase, so I have likely used some of the APIs incorrectly. Please let me know!

![zedupdates](https://github.com/zed-industries/zed/assets/88951499/5b23810f-7e75-4110-9540-9afcf07f958e)
![openfilesnotif](https://github.com/zed-industries/zed/assets/88951499/10a8c41b-2423-483b-8b79-c480bace81ba)


