### PR TITLE
Always single-quote directory when cd'ing to get shell env

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -9601,7 +9601,8 @@ async fn load_shell_environment(dir: &Path) -> Result<HashMap<String, String>> {
         });
 
     let command = format!(
-        "cd {dir:?};{} echo {marker}; /usr/bin/env -0; exit 0;",
+        "cd '{}';{} echo {marker}; /usr/bin/env -0; exit 0;",
+        dir.display(),
         additional_command.unwrap_or("")
     );
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -848,7 +848,7 @@ async fn load_login_shell_environment() -> Result<()> {
     // in home directory.
     let shell_cmd_prefix = std::env::var_os("HOME")
         .and_then(|home| home.into_string().ok())
-        .map(|home| format!("cd {home};"));
+        .map(|home| format!("cd '{home}';"));
 
     // The `exit 0` is the result of hours of debugging, trying to find out
     // why running this command here, without `exit 0`, would mess


### PR DESCRIPTION
This avoids us potentially executing code (if someone were to name their directory `$(echo you-are-pwned > /secure-files)`, for example).

Works with zsh, bash, fish, nushell. Tested locally with all of them.

Release Notes:

- N/A
