### PR TITLE
Fix regressions introduced by flicker fix

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -467,10 +467,6 @@ impl ChatPanel {
             .group("")
             .when(!is_continuation_from_previous, |this| this.pt_2())
             .child(
-                self.render_popover_buttons(&cx, message_id, can_delete_message)
-                    .neg_mt_2p5(),
-            )
-            .child(
                 div()
                     .group("")
                     .bg(background)
@@ -582,6 +578,10 @@ impl ChatPanel {
                             .child(div().w_full().h_0p5().bg(cx.theme().colors().border)),
                     )
                 },
+            )
+            .child(
+                self.render_popover_buttons(&cx, message_id, can_delete_message)
+                    .neg_mt_2p5(),
             )
     }
 


### PR DESCRIPTION
This pull request fixes a couple of easy regressions we discovered right after using #9012 on nightly:

- Popover buttons for a chat message were being occluded by the message itself.
- Scrolling was not working on the `List` element.

Release Notes:

- N/A