### PR TITLE
Windows: fix crash with unhandled window

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -302,8 +302,8 @@ impl WindowsWindowInner {
         if let Some(callback) = callbacks.close.take() {
             callback()
         }
-        let mut window_handles = self.platform_inner.window_handles.borrow_mut();
-        window_handles.remove(&self.handle);
+        let mut window_handles = self.platform_inner.window_handle_values.borrow_mut();
+        window_handles.remove(&self.hwnd.0);
         if window_handles.is_empty() {
             self.platform_inner
                 .foreground_executor
@@ -680,7 +680,10 @@ impl WindowsWindow {
             inner: context.inner.unwrap(),
             drag_drop_handler,
         };
-        platform_inner.window_handles.borrow_mut().insert(handle);
+        platform_inner
+            .window_handle_values
+            .borrow_mut()
+            .insert(wnd.inner.hwnd.0);
         match options.bounds {
             WindowBounds::Fullscreen => wnd.toggle_full_screen(),
             WindowBounds::Maximized => wnd.maximize(),


### PR DESCRIPTION
On Windows, some windows may be created that are not managed by the application.
For example, the Japanese IME creates pop-ups like this one.

<img width="325" alt="image" src="https://github.com/zed-industries/zed/assets/6465609/503aaa0a-7568-485a-a138-e689ae67001c">

The internal data associated with such a window is different from `WindowsWindowInner` and will crash if referenced.
Therefore, before calling `try_get_window_inner`, it checks if it is an owned window.


Release Notes:

- N/A
