### PR TITLE
Hide hover popover when mouse hovers over negative space

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -543,6 +543,8 @@ impl EditorElement {
             if let Some(point) = point_for_position.as_valid() {
                 hover_at(editor, Some(point), cx);
                 Self::update_visible_cursor(editor, point, position_map, cx);
+            } else {
+                hover_at(editor, None, cx);
             }
         } else {
             editor.hide_hovered_link(cx);


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/8340

Release Notes:

- Fixed a bug that would cause hover information to not be dismissed when hovering over negative space. ([#8340](https://github.com/zed-industries/zed/issues/8340))