### PR TITLE
Add missed pad

### DIFF
--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -168,6 +168,7 @@ fn quad_sdf(point: vec2<f32>, bounds: Bounds, corner_radii: Corners) -> f32 {
 
 struct Quad {
     order: u32,
+    pad: u32,
     bounds: Bounds,
     content_mask: Bounds,
     background: Hsla,


### PR DESCRIPTION
Sorry I missed explicitly `Quad::pad` insertion at #9172.

The struct layout is unchanged and does not affect the behavior.

Release Notes:

- N/A
