### PR TITLE
Prevent text from wrapping in code actions menu

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1196,6 +1196,7 @@ impl CodeActionsMenu {
                                     }
                                 }),
                             )
+                            .whitespace_nowrap()
                             // TASK: It would be good to make lsp_action.title a SharedString to avoid allocating here.
                             .child(SharedString::from(action.lsp_action.title.clone()))
                     })


### PR DESCRIPTION
Right now we're basing the width of the menu on the longest code action title. That is only an approximation and doesn't always coincide perfectly with the true, longest code action.

Given that it's pretty close, however, this commit simply disables text wrapping on the code action menu.

Release Notes:

- Fixed a rendering glitch that could cause code actions to not display correctly ([#8341](https://github.com/zed-industries/zed/issues/8341))