### PR TITLE
Fix relative glob patterns not working for language servers

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3894,9 +3894,12 @@ impl Project {
                     let glob_is_inside_worktree = worktree.update(cx, |tree, _| {
                         if let Some(abs_path) = tree.abs_path().to_str() {
                             let relative_glob_pattern = match &watcher.glob_pattern {
-                                lsp::GlobPattern::String(s) => s
-                                    .strip_prefix(abs_path)
-                                    .and_then(|s| s.strip_prefix(std::path::MAIN_SEPARATOR)),
+                                lsp::GlobPattern::String(s) => Some(
+                                    s.strip_prefix(abs_path)
+                                        .unwrap_or(s)
+                                        .strip_prefix(std::path::MAIN_SEPARATOR)
+                                        .unwrap_or(s),
+                                ),
                                 lsp::GlobPattern::Relative(rp) => {
                                     let base_uri = match &rp.base_uri {
                                         lsp::OneOf::Left(workspace_folder) => &workspace_folder.uri,


### PR DESCRIPTION
If a language server would send us a glob pattern like `**/*.rb` or `**/{package.json}` we'd end up ignoring it and never sending the language server any notifications, because we try to `strip_prefix` the projects absolute path from the pattern, BUT if that path is not in the pattern, we'd return `None`.

This change fixes that.

Release Notes:

- Fixed language server glob patterns for file watching being ignored if they were relative patterns.