### PR TITLE
Fix a few regressions related to the flicker fix

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2083,11 +2083,9 @@ impl EditorElement {
     }
 
     fn paint_cursors(&mut self, layout: &mut EditorLayout, cx: &mut ElementContext) {
-        cx.paint_layer(layout.text_hitbox.bounds, |cx| {
-            for cursor in &mut layout.cursors {
-                cursor.paint(layout.content_origin, cx);
-            }
-        });
+        for cursor in &mut layout.cursors {
+            cursor.paint(layout.content_origin, cx);
+        }
     }
 
     fn paint_scrollbar(&mut self, layout: &mut EditorLayout, cx: &mut ElementContext) {

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -139,15 +139,21 @@ impl Render for ModalLayer {
             return div();
         };
 
-        div().absolute().size_full().top_0().left_0().child(
-            v_flex()
-                .h(px(0.0))
-                .top_20()
-                .flex()
-                .flex_col()
-                .items_center()
-                .track_focus(&active_modal.focus_handle)
-                .child(h_flex().child(active_modal.modal.view())),
-        )
+        div()
+            .occlude()
+            .absolute()
+            .size_full()
+            .top_0()
+            .left_0()
+            .child(
+                v_flex()
+                    .h(px(0.0))
+                    .top_20()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .track_focus(&active_modal.focus_handle)
+                    .child(h_flex().child(active_modal.modal.view())),
+            )
     }
 }


### PR DESCRIPTION
This pull request fixes https://github.com/zed-industries/zed/issues/9187 and fixes also ix a rendering problem that would show cursors on the same plane:

![image](https://github.com/zed-industries/zed/assets/482957/208304a4-286a-4fd9-a3d8-e2913e3a3dc7)


Release Notes:

- N/A
