### PR TITLE
Fix prettier plugins does not seem to be picked up

### DIFF
--- a/crates/prettier/src/prettier_server.js
+++ b/crates/prettier/src/prettier_server.js
@@ -173,10 +173,15 @@ async function handleMessage(message, prettier) {
         if (params.options.filepath !== undefined) {
             resolvedConfig = (await prettier.prettier.resolveConfig(params.options.filepath)) || {};
         }
+        
+        const plugins = Array.isArray(resolvedConfig?.plugins) && resolvedConfig.plugins.length > 0 ? 
+          resolvedConfig.plugins : 
+          params.options.plugins;
 
         const options = {
             ...(params.options.prettierOptions || prettier.config),
             ...resolvedConfig,
+            plugins,
             parser: params.options.parser,
             path: params.options.filepath,
         };

--- a/crates/prettier/src/prettier_server.js
+++ b/crates/prettier/src/prettier_server.js
@@ -178,7 +178,6 @@ async function handleMessage(message, prettier) {
             ...(params.options.prettierOptions || prettier.config),
             ...resolvedConfig,
             parser: params.options.parser,
-            plugins: params.options.plugins,
             path: params.options.filepath,
         };
         process.stderr.write(


### PR DESCRIPTION
This fixed the issue that prettier plugins were not picked up. The old code would always send an empty array to the prettier plugin that happens inside the `prettier_server.js`.

**Before**
The `options.plugins` key is an empty array, which is not correct.
```log
stderr: Resolved config: {"singleQuote":true,"trailingComma":"all","plugins":["prettier-plugin-organize-imports"]}, will format file '/Users/remcosmits/Documents/code/prettier-test/src/app/page.tsx' with options: {"singleQuote":true,"trailingComma":"all","plugins":[],"parser":"typescript","path":"/Users/remcosmits/Documents/code/prettier-test/src/app/page.tsx"}
```

https://github.com/zed-industries/zed/assets/62463826/52f2aad0-2f96-43a9-81ec-9d4630c495b2

**After**
The `options.plugins` contains the `prettier-plugin-organize-imports` plugin as expected.
```log
stderr: Resolved config: {"singleQuote":true,"trailingComma":"all","plugins":["prettier-plugin-organize-imports"]}, will format file '/Users/remcosmits/Documents/code/prettier-test/src/app/page.tsx' with options: {"singleQuote":true,"trailingComma":"all","plugins":["prettier-plugin-organize-imports"],"parser":"typescript","path":"/Users/remcosmits/Documents/code/prettier-test/src/app/page.tsx"}
```

https://github.com/zed-industries/zed/assets/62463826/9045028d-aeca-4df1-819c-01905d83216c


Release Notes:
- Fixed send plugins correctly to the prettier plugin ([#8841](https://github.com/zed-industries/zed/issues/8841)).