### PR TITLE
Open excerpt on double click in multibuffer by default.

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -140,6 +140,15 @@
     // Whether to show diagnostic indicators in the scrollbar.
     "diagnostics": true
   },
+  // What to do when multibuffer is double clicked in some of its excerpts
+  // (parts of singleton buffers).
+  // May take 2 values:
+  //  1. Behave as a regular buffer and select the whole word.
+  //         "double_click_in_multibuffer": "select"
+  //  2. Open the excerpt clicked as a new buffer in the new tab (default).
+  //         "double_click_in_multibuffer": "open",
+  // For the case of "open", regular selection behavior can be achieved by holding `alt` when double clicking.
+  "double_click_in_multibuffer": "open",
   "gutter": {
     // Whether to show line numbers in the gutter.
     "line_numbers": true,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -17,6 +17,8 @@ pub struct EditorSettings {
     pub relative_line_numbers: bool,
     pub seed_search_query_from_cursor: SeedQuerySetting,
     pub redact_private_values: bool,
+    #[serde(default)]
+    pub double_click_in_multibuffer: DoubleClickInMultibuffer,
 }
 
 /// When to populate a new search's query based on the text under the cursor.
@@ -29,6 +31,18 @@ pub enum SeedQuerySetting {
     Selection,
     /// Never populate the search query
     Never,
+}
+
+/// What to do when multibuffer is double clicked in some of its excerpts (parts of singleton buffers).
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DoubleClickInMultibuffer {
+    /// Behave as a regular buffer and select the whole word.
+    Select,
+    #[default]
+    /// Open the excerpt clicked as a new buffer in the new tab, if no `alt` modifier was pressed during double click.
+    /// Otherwise, behave as a regular buffer and select the whole word.
+    Open,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -127,6 +141,12 @@ pub struct EditorSettingsContent {
     ///
     /// Default: false
     pub redact_private_values: Option<bool>,
+
+    /// What to do when multibuffer is double clicked in some of its excerpts
+    /// (parts of singleton buffers).
+    ///
+    /// Default: open
+    pub double_click_in_multibuffer: Option<DoubleClickInMultibuffer>,
 }
 
 // Toolbar related settings


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/5275

Double click with `alt` modifier pressed will do the regular word selection. 

Adds a setting to disable this behavior and instead select a word, as in the regular buffer.

```
// What to do when multibuffer is double clicked in some of its excerpts
// (parts of singleton buffers).
// May take 2 values:
//  1. Behave as a regular buffer and select the whole word (default).
//         "double_click_in_multibuffer": "select"
//  2. Open the excerpt clicked as a new buffer in the new tab.
//         "double_click_in_multibuffer": "open",
// For the case of "open", regular selection behavior can be achieved by holding `alt` when double clicking.
"double_click_in_multibuffer": "open",
```


Release Notes:

- Allow multibuffer to open excerpts in new tabs on double click (with the corresponding settings; keeping alt restores the word selection behavior). ([5275](https://github.com/zed-industries/zed/issues/5275))