### PR TITLE
Fix the double click and update the default settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -143,12 +143,12 @@
   // What to do when multibuffer is double clicked in some of its excerpts
   // (parts of singleton buffers).
   // May take 2 values:
-  //  1. Behave as a regular buffer and select the whole word.
+  //  1. Behave as a regular buffer and select the whole word (default).
   //         "double_click_in_multibuffer": "select"
-  //  2. Open the excerpt clicked as a new buffer in the new tab (default).
+  //  2. Open the excerpt clicked as a new buffer in the new tab.
   //         "double_click_in_multibuffer": "open",
   // For the case of "open", regular selection behavior can be achieved by holding `alt` when double clicking.
-  "double_click_in_multibuffer": "open",
+  "double_click_in_multibuffer": "select",
   "gutter": {
     // Whether to show line numbers in the gutter.
     "line_numbers": true,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -38,8 +38,8 @@ pub enum SeedQuerySetting {
 #[serde(rename_all = "snake_case")]
 pub enum DoubleClickInMultibuffer {
     /// Behave as a regular buffer and select the whole word.
-    Select,
     #[default]
+    Select,
     /// Open the excerpt clicked as a new buffer in the new tab, if no `alt` modifier was pressed during double click.
     /// Otherwise, behave as a regular buffer and select the whole word.
     Open,
@@ -145,7 +145,7 @@ pub struct EditorSettingsContent {
     /// What to do when multibuffer is double clicked in some of its excerpts
     /// (parts of singleton buffers).
     ///
-    /// Default: open
+    /// Default: select
     pub double_click_in_multibuffer: Option<DoubleClickInMultibuffer>,
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -400,7 +400,7 @@ impl EditorElement {
             return;
         }
 
-        if click_count == 2 {
+        if click_count == 2 && !editor.buffer().read(cx).is_singleton() {
             match EditorSettings::get_global(cx).double_click_in_multibuffer {
                 DoubleClickInMultibuffer::Select => {
                     // do nothing special on double click, all selection logic is below


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/9196 fixing the double click in singleton buffers bug introduced by the PR and moving the default to what's had been before that PR (select).

Release Notes:

- N/A
