### PR TITLE
Fix broken ESLint by pinning to `2.2.20-Insiders` release

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -20,7 +20,7 @@ use std::{
 use util::{
     async_maybe,
     fs::remove_matching,
-    github::{latest_github_release, GitHubLspBinaryVersion},
+    github::{github_release_with_tag, GitHubLspBinaryVersion},
     ResultExt,
 };
 
@@ -285,13 +285,11 @@ impl LspAdapter for EsLintLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
-        // At the time of writing the latest vscode-eslint release was released in 2020 and requires
-        // special custom LSP protocol extensions be handled to fully initialize. Download the latest
-        // prerelease instead to sidestep this issue
-        let release = latest_github_release(
+        // We're using this hardcoded release tag, because ESLint's API changed with
+        // >= 2.3 and we haven't upgraded yet.
+        let release = github_release_with_tag(
             "microsoft/vscode-eslint",
-            false,
-            true,
+            "release/2.2.20-Insider",
             delegate.http_client(),
         )
         .await?;

--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use futures::AsyncReadExt;
 use serde::Deserialize;
 use std::sync::Arc;
+use url::Url;
 
 pub struct GitHubLspBinaryVersion {
     pub name: String,
@@ -73,4 +74,71 @@ pub async fn latest_github_release(
         .filter(|release| !require_assets || !release.assets.is_empty())
         .find(|release| release.pre_release == pre_release)
         .ok_or(anyhow!("Failed to find a release"))
+}
+
+pub async fn github_release_with_tag(
+    repo_name_with_owner: &str,
+    tag: &str,
+    http: Arc<dyn HttpClient>,
+) -> Result<GithubRelease, anyhow::Error> {
+    let url = build_tagged_release_url(repo_name_with_owner, tag)?;
+    let mut response = http
+        .get(&url, Default::default(), true)
+        .await
+        .context("error fetching latest release")?;
+
+    let mut body = Vec::new();
+    response
+        .body_mut()
+        .read_to_end(&mut body)
+        .await
+        .context("error reading latest release")?;
+
+    if response.status().is_client_error() {
+        let text = String::from_utf8_lossy(body.as_slice());
+        bail!(
+            "status error {}, response: {text:?}",
+            response.status().as_u16()
+        );
+    }
+
+    match serde_json::from_slice::<GithubRelease>(body.as_slice()) {
+        Ok(release) => Ok(release),
+
+        Err(err) => {
+            log::error!("Error deserializing: {:?}", err);
+            log::error!(
+                "GitHub API response text: {:?}",
+                String::from_utf8_lossy(body.as_slice())
+            );
+            return Err(anyhow!("error deserializing latest release"));
+        }
+    }
+}
+
+fn build_tagged_release_url(repo_name_with_owner: &str, tag: &str) -> Result<String> {
+    let mut url = Url::parse(&format!(
+        "https://api.github.com/repos/{repo_name_with_owner}/releases/tags"
+    ))?;
+    // We're pushing this here, because tags may contain `/` and other characters
+    // that need to be escaped.
+    url.path_segments_mut()
+        .map_err(|_| anyhow!("cannot modify url path segments"))?
+        .push(tag);
+    Ok(url.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_tagged_release_url;
+
+    #[test]
+    fn test_build_tagged_release_url() {
+        let tag = "release/2.2.20-Insider";
+        let repo_name_with_owner = "microsoft/vscode-eslint";
+
+        let have = build_tagged_release_url(repo_name_with_owner, tag).unwrap();
+
+        assert_eq!(have, "https://api.github.com/repos/microsoft/vscode-eslint/releases/tags/release%2F2.2.20-Insider");
+    }
 }


### PR DESCRIPTION
This fixes #9213 by pinning ESLint to `2.2.20-Insiders` which is the last known version to work well with Zed.

Once this fix is out, we can take a closer look at upgrading to 2.4.x or even 3.x once that's out of prerelease.

Release Notes:

- Fixed ESLint integration being broken after Mar 7 2024 due to ESLint 3.0.1 alpha release being pushed. ([#9213](https://github.com/zed-industries/zed/issues/9213)).
