### PR TITLE
Insert hitbox when an interactive element can be scrolled

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1306,6 +1306,7 @@ impl Interactivity {
                             || self.group.is_some()
                             || self.has_hover_styles()
                             || self.has_mouse_listeners()
+                            || self.scroll_offset.is_some()
                         {
                             Some(cx.insert_hitbox(bounds, self.occlude_mouse))
                         } else {

--- a/crates/gpui/src/window/element_cx.rs
+++ b/crates/gpui/src/window/element_cx.rs
@@ -61,7 +61,7 @@ impl HitboxId {
 
 /// A rectangular region that potentially blocks hitboxes inserted prior.
 /// See [ElementContext::insert_hitbox] for more details.
-#[derive(Clone, Debug, Eq, PartialEq, Deref)]
+#[derive(Clone, Debug, Deref)]
 pub struct Hitbox {
     /// A unique identifier for the hitbox
     pub id: HitboxId,


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/9199


Release Notes:

- N/A
