### PR TITLE
Set the correct dispatch action for the double-click handler for the pane tab bar

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -5,9 +5,9 @@ use collections::{HashMap, HashSet};
 use db::kvp::KEY_VALUE_STORE;
 use futures::future::join_all;
 use gpui::{
-    actions, AppContext, AsyncWindowContext, Entity, EventEmitter, ExternalPaths, FocusHandle,
-    FocusableView, IntoElement, ParentElement, Pixels, Render, Styled, Subscription, Task, View,
-    ViewContext, VisualContext, WeakView, WindowContext,
+    actions, Action, AppContext, AsyncWindowContext, Entity, EventEmitter, ExternalPaths,
+    FocusHandle, FocusableView, IntoElement, ParentElement, Pixels, Render, Styled, Subscription,
+    Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use itertools::Itertools;
 use project::{Fs, ProjectEntryId};
@@ -26,7 +26,7 @@ use workspace::{
     item::Item,
     pane,
     ui::IconName,
-    DraggedTab, Pane, Workspace,
+    DraggedTab, NewTerminal, Pane, Workspace,
 };
 
 use anyhow::Result;
@@ -69,6 +69,7 @@ impl TerminalPanel {
                 workspace.project().clone(),
                 Default::default(),
                 None,
+                NewTerminal.boxed_clone(),
                 cx,
             );
             pane.set_can_split(false, cx);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -183,6 +183,7 @@ pub struct Pane {
     _subscriptions: Vec<Subscription>,
     tab_bar_scroll_handle: ScrollHandle,
     display_nav_history_buttons: bool,
+    double_click_dispatch_action: Box<dyn Action>,
 }
 
 pub struct ItemNavHistory {
@@ -242,6 +243,7 @@ impl Pane {
         project: Model<Project>,
         next_timestamp: Arc<AtomicUsize>,
         can_drop_predicate: Option<Arc<dyn Fn(&dyn Any, &mut WindowContext) -> bool + 'static>>,
+        double_click_dispatch_action: Box<dyn Action>,
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
@@ -346,6 +348,7 @@ impl Pane {
             }),
             display_nav_history_buttons: true,
             _subscriptions: subscriptions,
+            double_click_dispatch_action,
         }
     }
 
@@ -1550,9 +1553,9 @@ impl Pane {
                         this.drag_split_direction = None;
                         this.handle_external_paths_drop(paths, cx)
                     }))
-                    .on_click(cx.listener(move |_, event: &ClickEvent, cx| {
+                    .on_click(cx.listener(move |this, event: &ClickEvent, cx| {
                         if event.up.click_count == 2 {
-                            cx.dispatch_action(NewFile.boxed_clone());
+                            cx.dispatch_action(this.double_click_dispatch_action.boxed_clone())
                         }
                     })),
             )

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -618,6 +618,7 @@ impl Workspace {
                 project.clone(),
                 pane_history_timestamp.clone(),
                 None,
+                NewFile.boxed_clone(),
                 cx,
             )
         });
@@ -1862,6 +1863,7 @@ impl Workspace {
                 self.project.clone(),
                 self.pane_history_timestamp.clone(),
                 None,
+                NewFile.boxed_clone(),
                 cx,
             )
         });


### PR DESCRIPTION
Fixes #9003



Release Notes:

- Fixed the double-click action on the terminal tab bar opening a new buffer instead of a new terminal ([#9003](https://github.com/zed-industries/zed/issues/9003)).