### PR TITLE
Show formatting failure

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -241,6 +241,17 @@ impl ActivityIndicator {
             };
         }
 
+        // Show any formatting failure
+        if let Some(failure) = self.project.read(cx).last_formatting_failure() {
+            return Content {
+                icon: Some(WARNING_ICON),
+                message: format!("Formatting failed: {}. Click to see logs.", failure),
+                on_click: Some(Arc::new(|_, cx| {
+                    cx.dispatch_action(Box::new(workspace::OpenLog));
+                })),
+            };
+        }
+
         // Show any application auto-update info.
         if let Some(updater) = &self.auto_updater {
             return match &updater.read(cx).status() {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4124,6 +4124,7 @@ pub async fn last_opened_workspace_paths() -> Option<WorkspaceLocation> {
 }
 
 actions!(collab, [OpenChannelNotes]);
+actions!(zed, [OpenLog]);
 
 async fn join_channel_internal(
     channel_id: ChannelId,


### PR DESCRIPTION
This fixes #8072 and #9061 by surfacing formatting errors in the activity indicator.

It shows a message in the activity indicator if the last attempt
to format a buffer failed.

It only keeps track of the last attempt, so any further formatting
that succeeds will reset or update the error message.

I chose to only keep track of that, because everything else (keeping
track of formatting state per buffer, per project, per worktree) seems
complicated with little benefit, since we'd have to keep track of that
state, update it, clean it, etc.

We can still do that should we decide that we need to keep track
of the state on a per-buffer basis, but I think for now this is a
good, simple solution.

This also changes the `OpenLog` action to scroll to the end of the buffer
and to not mark the buffer as dirty.


Release Notes:

- Added message to activity indicator if last attempt to format a buffer failed. Message will get reset when next formatting succeeds. Clicking on message opens log with more information. ([#8072](https://github.com/zed-industries/zed/issues/8072) and [#9061](https://github.com/zed-industries/zed/issues/9061)).
- Changed `zed: Open Log` action to not mark the opened log file as dirty and to always scroll to the bottom of the log.

https://github.com/zed-industries/zed/assets/1185253/951fb9ac-8b8b-483a-a46d-712e52878a4d


