### PR TITLE
Redraw when toggling between windows

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -416,6 +416,7 @@ impl Window {
                             .activation_observers
                             .clone()
                             .retain(&(), |callback| callback(cx));
+                        cx.refresh();
                     })
                     .log_err();
             }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5158,6 +5158,11 @@ mod tests {
         cx.deactivate_window();
         item.update(cx, |item, _| assert_eq!(item.save_count, 1));
 
+        // Re-activating the window doesn't save the file.
+        cx.update(|cx| cx.activate_window());
+        cx.executor().run_until_parked();
+        item.update(cx, |item, _| assert_eq!(item.save_count, 1));
+
         // Autosave on focus change.
         item.update(cx, |item, cx| {
             cx.focus_self();
@@ -5175,13 +5180,11 @@ mod tests {
         item.update(cx, |item, _| assert_eq!(item.save_count, 2));
 
         // Deactivating the window still saves the file.
-        cx.update(|cx| cx.activate_window());
         item.update(cx, |item, cx| {
             cx.focus_self();
             item.is_dirty = true;
         });
         cx.deactivate_window();
-
         item.update(cx, |item, _| assert_eq!(item.save_count, 3));
 
         // Autosave after delay.


### PR DESCRIPTION
Before this change we didn't consistently trigger focus events when toggling between with windows `Cmd-backtick`. We only triggered them when the OS decided to trigger a redraw.

That lead to a nasty bug that showed up in Vim mode where a cursor would still be active in the hidden window, even though it was deactivated.

One then had to manually try to trigger a focus event in the new window to activate the cursor.

With this change, we call `cx.refresh` when the window activation status changed which triggers focus events consistently and fixes this bug.

With logging we can observe this:

**BEFORE**:

https://github.com/zed-industries/zed/assets/1185253/e1ad8878-129c-44ba-9d8b-c720f9dca5b6


**AFTER**:

https://github.com/zed-industries/zed/assets/1185253/733fdadb-d1ea-47fe-a2c1-7b50af299cc0


Release Notes:

- Fixed focus not being consistently changed when switching between multiple Zed windows via `Cmd-backtick`.

