### PR TITLE
Fix typos in default `settings.json`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -189,7 +189,7 @@
   "project_panel": {
     // Default width of the project panel.
     "default_width": 240,
-    // Where to dock project panel. Can be 'left' or 'right'.
+    // Where to dock the project panel. Can be 'left' or 'right'.
     "dock": "left",
     // Whether to show file icons in the project panel.
     "file_icons": true,
@@ -207,17 +207,17 @@
   "collaboration_panel": {
     // Whether to show the collaboration panel button in the status bar.
     "button": true,
-    // Where to dock channels panel. Can be 'left' or 'right'.
+    // Where to dock the collaboration panel. Can be 'left' or 'right'.
     "dock": "left",
-    // Default width of the channels panel.
+    // Default width of the collaboration panel.
     "default_width": 240
   },
   "chat_panel": {
-    // Whether to show the collaboration panel button in the status bar.
+    // Whether to show the chat panel button in the status bar.
     "button": true,
-    // Where to dock channels panel. Can be 'left' or 'right'.
+    // Where to the chat panel. Can be 'left' or 'right'.
     "dock": "right",
-    // Default width of the channels panel.
+    // Default width of the chat panel.
     "default_width": 240
   },
   "message_editor": {
@@ -226,17 +226,17 @@
     "auto_replace_emoji_shortcode": true
   },
   "notification_panel": {
-    // Whether to show the collaboration panel button in the status bar.
+    // Whether to show the notification panel button in the status bar.
     "button": true,
-    // Where to dock channels panel. Can be 'left' or 'right'.
+    // Where to dock the notification panel. Can be 'left' or 'right'.
     "dock": "right",
-    // Default width of the channels panel.
+    // Default width of the notification panel.
     "default_width": 380
   },
   "assistant": {
     // Whether to show the assistant panel button in the status bar.
     "button": true,
-    // Where to dock the assistant. Can be 'left', 'right' or 'bottom'.
+    // Where to dock the assistant panel. Can be 'left', 'right' or 'bottom'.
     "dock": "right",
     // Default width when the assistant is docked to the left or right.
     "default_width": 640,


### PR DESCRIPTION
This PR fixes some typos in the comments within the default `settings.json` file.

Fixes #4257.

Release Notes:

- Fixed some incorrect comments in the default `settings.json` file ([#4257](https://github.com/zed-industries/zed/issues/4257)).
