### PR TITLE
Fall back to FindAllReferences if cmd-click did not preform GoToDefinition elsewhere

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7733,6 +7733,7 @@ impl Editor {
                         let range = target.range.to_offset(target.buffer.read(cx));
                         let range = editor.range_for_match(&range);
                         if Some(&target.buffer) == editor.buffer.read(cx).as_singleton().as_ref() {
+                            dbg!("TODO kb check that the definition clicked and selected are the same (range contains the point clicked?) and call `find all references`");
                             editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                                 s.select_ranges([range]);
                             });

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7610,36 +7610,52 @@ impl Editor {
         }
     }
 
-    pub fn go_to_definition(&mut self, _: &GoToDefinition, cx: &mut ViewContext<Self>) {
-        self.go_to_definition_of_kind(GotoDefinitionKind::Symbol, false, cx);
+    pub fn go_to_definition(
+        &mut self,
+        _: &GoToDefinition,
+        cx: &mut ViewContext<Self>,
+    ) -> Task<Result<bool>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Symbol, false, cx)
     }
 
-    pub fn go_to_implementation(&mut self, _: &GoToImplementation, cx: &mut ViewContext<Self>) {
-        self.go_to_definition_of_kind(GotoDefinitionKind::Implementation, false, cx);
+    pub fn go_to_implementation(
+        &mut self,
+        _: &GoToImplementation,
+        cx: &mut ViewContext<Self>,
+    ) -> Task<Result<bool>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Implementation, false, cx)
     }
 
     pub fn go_to_implementation_split(
         &mut self,
         _: &GoToImplementationSplit,
         cx: &mut ViewContext<Self>,
-    ) {
-        self.go_to_definition_of_kind(GotoDefinitionKind::Implementation, true, cx);
+    ) -> Task<Result<bool>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Implementation, true, cx)
     }
 
-    pub fn go_to_type_definition(&mut self, _: &GoToTypeDefinition, cx: &mut ViewContext<Self>) {
-        self.go_to_definition_of_kind(GotoDefinitionKind::Type, false, cx);
+    pub fn go_to_type_definition(
+        &mut self,
+        _: &GoToTypeDefinition,
+        cx: &mut ViewContext<Self>,
+    ) -> Task<Result<bool>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Type, false, cx)
     }
 
-    pub fn go_to_definition_split(&mut self, _: &GoToDefinitionSplit, cx: &mut ViewContext<Self>) {
-        self.go_to_definition_of_kind(GotoDefinitionKind::Symbol, true, cx);
+    pub fn go_to_definition_split(
+        &mut self,
+        _: &GoToDefinitionSplit,
+        cx: &mut ViewContext<Self>,
+    ) -> Task<Result<bool>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Symbol, true, cx)
     }
 
     pub fn go_to_type_definition_split(
         &mut self,
         _: &GoToTypeDefinitionSplit,
         cx: &mut ViewContext<Self>,
-    ) {
-        self.go_to_definition_of_kind(GotoDefinitionKind::Type, true, cx);
+    ) -> Task<Result<bool>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Type, true, cx)
     }
 
     fn go_to_definition_of_kind(
@@ -7647,16 +7663,16 @@ impl Editor {
         kind: GotoDefinitionKind,
         split: bool,
         cx: &mut ViewContext<Self>,
-    ) {
+    ) -> Task<Result<bool>> {
         let Some(workspace) = self.workspace() else {
-            return;
+            return Task::ready(Ok(false));
         };
         let buffer = self.buffer.read(cx);
         let head = self.selections.newest::<usize>(cx).head();
         let (buffer, head) = if let Some(text_anchor) = buffer.text_anchor_for_position(head, cx) {
             text_anchor
         } else {
-            return;
+            return Task::ready(Ok(false));
         };
 
         let project = workspace.read(cx).project().clone();
@@ -7668,17 +7684,18 @@ impl Editor {
 
         cx.spawn(|editor, mut cx| async move {
             let definitions = definitions.await?;
-            editor.update(&mut cx, |editor, cx| {
-                editor.navigate_to_hover_links(
-                    Some(kind),
-                    definitions.into_iter().map(HoverLink::Text).collect(),
-                    split,
-                    cx,
-                );
-            })?;
-            Ok::<(), anyhow::Error>(())
+            let navigated = editor
+                .update(&mut cx, |editor, cx| {
+                    editor.navigate_to_hover_links(
+                        Some(kind),
+                        definitions.into_iter().map(HoverLink::Text).collect(),
+                        split,
+                        cx,
+                    )
+                })?
+                .await?;
+            anyhow::Ok(navigated)
         })
-        .detach_and_log_err(cx);
     }
 
     pub fn open_url(&mut self, _: &OpenUrl, cx: &mut ViewContext<Self>) {
@@ -7707,7 +7724,7 @@ impl Editor {
         mut definitions: Vec<HoverLink>,
         split: bool,
         cx: &mut ViewContext<Editor>,
-    ) {
+    ) -> Task<Result<bool>> {
         // If there is one definition, just open it directly
         if definitions.len() == 1 {
             let definition = definitions.pop().unwrap();
@@ -7726,14 +7743,13 @@ impl Editor {
                 if let Some(target) = target {
                     editor.update(&mut cx, |editor, cx| {
                         let Some(workspace) = editor.workspace() else {
-                            return;
+                            return false;
                         };
                         let pane = workspace.read(cx).active_pane().clone();
 
                         let range = target.range.to_offset(target.buffer.read(cx));
                         let range = editor.range_for_match(&range);
                         if Some(&target.buffer) == editor.buffer.read(cx).as_singleton().as_ref() {
-                            dbg!("TODO kb check that the definition clicked and selected are the same (range contains the point clicked?) and call `find all references`");
                             editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                                 s.select_ranges([range]);
                             });
@@ -7764,12 +7780,12 @@ impl Editor {
                                 });
                             });
                         }
+                        true
                     })
                 } else {
-                    Ok(())
+                    Ok(false)
                 }
             })
-            .detach_and_log_err(cx);
         } else if !definitions.is_empty() {
             let replica_id = self.replica_id(cx);
             cx.spawn(|editor, mut cx| async move {
@@ -7818,9 +7834,9 @@ impl Editor {
                     .context("location tasks")?;
 
                 let Some(workspace) = workspace else {
-                    return Ok(());
+                    return Ok(false);
                 };
-                workspace
+                let opened = workspace
                     .update(&mut cx, |workspace, cx| {
                         Self::open_locations_in_multibuffer(
                             workspace, locations, replica_id, title, split, cx,
@@ -7828,9 +7844,10 @@ impl Editor {
                     })
                     .ok();
 
-                anyhow::Ok(())
+                anyhow::Ok(opened.is_some())
             })
-            .detach_and_log_err(cx);
+        } else {
+            Task::ready(Ok(false))
         }
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -258,12 +258,28 @@ impl EditorElement {
         register_action(view, cx, Editor::go_to_prev_diagnostic);
         register_action(view, cx, Editor::go_to_hunk);
         register_action(view, cx, Editor::go_to_prev_hunk);
-        register_action(view, cx, Editor::go_to_definition);
-        register_action(view, cx, Editor::go_to_definition_split);
-        register_action(view, cx, Editor::go_to_implementation);
-        register_action(view, cx, Editor::go_to_implementation_split);
-        register_action(view, cx, Editor::go_to_type_definition);
-        register_action(view, cx, Editor::go_to_type_definition_split);
+        register_action(view, cx, |editor, a, cx| {
+            editor.go_to_definition(a, cx).detach_and_log_err(cx);
+        });
+        register_action(view, cx, |editor, a, cx| {
+            editor.go_to_definition_split(a, cx).detach_and_log_err(cx);
+        });
+        register_action(view, cx, |editor, a, cx| {
+            editor.go_to_implementation(a, cx).detach_and_log_err(cx);
+        });
+        register_action(view, cx, |editor, a, cx| {
+            editor
+                .go_to_implementation_split(a, cx)
+                .detach_and_log_err(cx);
+        });
+        register_action(view, cx, |editor, a, cx| {
+            editor.go_to_type_definition(a, cx).detach_and_log_err(cx);
+        });
+        register_action(view, cx, |editor, a, cx| {
+            editor
+                .go_to_type_definition_split(a, cx)
+                .detach_and_log_err(cx);
+        });
         register_action(view, cx, Editor::open_url);
         register_action(view, cx, Editor::fold);
         register_action(view, cx, Editor::fold_at);

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -554,6 +554,11 @@ pub fn show_link_definition(
                                 .highlight_inlays::<HoveredLinkState>(vec![highlight], style, cx),
                         }
                     } else {
+                        dbg!(
+                            any_definition_does_not_contain_current_location,
+                            "TODO kb here we do not show the underline because it's the same definition we're hovering. \
+                            Now, we want to allow `find all references` for this case and need to underline"
+                        );
                         this.hide_hovered_link(cx);
                     }
                 }

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -156,7 +156,6 @@ impl Editor {
                     if definition_revealed && revealed_elsewhere(editor, before_revealing, cx) {
                         return None;
                     }
-                    // TODO kb docs + tests
                     editor.find_all_references(&FindAllReferences, cx)
                 })
                 .ok()
@@ -701,7 +700,10 @@ mod tests {
     use gpui::Modifiers;
     use indoc::indoc;
     use language::language_settings::InlayHintSettings;
-    use lsp::request::{GotoDefinition, GotoTypeDefinition};
+    use lsp::{
+        request::{GotoDefinition, GotoTypeDefinition},
+        References,
+    };
     use util::assert_set_eq;
     use workspace::item::Item;
 
@@ -1270,11 +1272,21 @@ mod tests {
     #[gpui::test]
     async fn test_cmd_click_back_and_forth(cx: &mut gpui::TestAppContext) {
         init_test(cx, |_| {});
-
         let mut cx = EditorLspTestContext::new_rust(lsp::ServerCapabilities::default(), cx).await;
-
         cx.set_state(indoc! {"
-            fn ˇtest() {
+            fn test() {
+                do_work();
+            }ˇ
+
+            fn do_work() {
+                test();
+            }
+        "});
+
+        // cmd-click on `test` definition and usage, and expect Zed to allow going back and forth,
+        // because cmd-click first searches for definitions to go to, and then fall backs to symbol usages to go to.
+        let definition_hover_point = cx.pixel_position(indoc! {"
+            fn testˇ() {
                 do_work();
             }
 
@@ -1282,245 +1294,121 @@ mod tests {
                 test();
             }
         "});
+        let definition_display_point = cx.display_point(indoc! {"
+            fn testˇ() {
+                do_work();
+            }
 
-        // Basic hold cmd, expect highlight in region if response contains definition
-        let hover_point = cx.pixel_position(indoc! {"
-                fn test() { do_wˇork(); }
-                fn do_work() { test(); }
-            "});
-        let symbol_range = cx.lsp_range(indoc! {"
-                fn test() { «do_work»(); }
-                fn do_work() { test(); }
-            "});
-        let target_range = cx.lsp_range(indoc! {"
-                fn test() { do_work(); }
-                fn «do_work»() { test(); }
-            "});
+            fn do_work() {
+                test();
+            }
+        "});
+        let definition_range = cx.lsp_range(indoc! {"
+            fn «test»() {
+                do_work();
+            }
 
-        let mut requests = cx.handle_request::<GotoDefinition, _, _>(move |url, _, _| async move {
-            Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                lsp::LocationLink {
-                    origin_selection_range: Some(symbol_range),
-                    target_uri: url.clone(),
-                    target_range,
-                    target_selection_range: target_range,
-                },
-            ])))
-        });
-        cx.simulate_mouse_move(hover_point, Modifiers::command());
-        requests.next().await;
-        cx.background_executor.run_until_parked();
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { «do_work»(); }
-                fn do_work() { test(); }
-            "});
+            fn do_work() {
+                test();
+            }
+        "});
+        let reference_hover_point = cx.pixel_position(indoc! {"
+            fn test() {
+                do_work();
+            }
 
-        // Unpress cmd causes highlight to go away
-        cx.simulate_modifiers_change(Modifiers::none());
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { test(); }
-            "});
+            fn do_work() {
+                testˇ();
+            }
+        "});
+        let reference_display_point = cx.display_point(indoc! {"
+            fn test() {
+                do_work();
+            }
 
-        let mut requests = cx.handle_request::<GotoDefinition, _, _>(move |url, _, _| async move {
-            Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                lsp::LocationLink {
-                    origin_selection_range: Some(symbol_range),
-                    target_uri: url.clone(),
-                    target_range,
-                    target_selection_range: target_range,
-                },
-            ])))
-        });
+            fn do_work() {
+                testˇ();
+            }
+        "});
+        let reference_range = cx.lsp_range(indoc! {"
+            fn test() {
+                do_work();
+            }
 
-        cx.simulate_mouse_move(hover_point, Modifiers::command());
-        requests.next().await;
-        cx.background_executor.run_until_parked();
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { «do_work»(); }
-                fn do_work() { test(); }
-            "});
-
-        // Moving mouse to location with no response dismisses highlight
-        let hover_point = cx.pixel_position(indoc! {"
-                fˇn test() { do_work(); }
-                fn do_work() { test(); }
-            "});
-        let mut requests = cx
-            .lsp
-            .handle_request::<GotoDefinition, _, _>(move |_, _| async move {
-                // No definitions returned
-                Ok(Some(lsp::GotoDefinitionResponse::Link(vec![])))
-            });
-        cx.simulate_mouse_move(hover_point, Modifiers::command());
-
-        requests.next().await;
-        cx.background_executor.run_until_parked();
-
-        // Assert no link highlights
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { test(); }
-            "});
-
-        // // Move mouse without cmd and then pressing cmd triggers highlight
-        let hover_point = cx.pixel_position(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { teˇst(); }
-            "});
-        cx.simulate_mouse_move(hover_point, Modifiers::none());
-
-        // Assert no link highlights
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { test(); }
-            "});
-
-        let symbol_range = cx.lsp_range(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { «test»(); }
-            "});
-        let target_range = cx.lsp_range(indoc! {"
-                fn «test»() { do_work(); }
-                fn do_work() { test(); }
-            "});
-
-        let mut requests = cx.handle_request::<GotoDefinition, _, _>(move |url, _, _| async move {
-            Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                lsp::LocationLink {
-                    origin_selection_range: Some(symbol_range),
-                    target_uri: url,
-                    target_range,
-                    target_selection_range: target_range,
-                },
-            ])))
-        });
-
-        cx.simulate_modifiers_change(Modifiers::command());
-
-        requests.next().await;
-        cx.background_executor.run_until_parked();
-
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { «test»(); }
-            "});
-
-        cx.deactivate_window();
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { test(); }
-            "});
-
-        cx.simulate_mouse_move(hover_point, Modifiers::command());
-        cx.background_executor.run_until_parked();
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { «test»(); }
-            "});
-
-        // Moving again within the same symbol range doesn't re-request
-        let hover_point = cx.pixel_position(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { tesˇt(); }
-            "});
-        cx.simulate_mouse_move(hover_point, Modifiers::command());
-        cx.background_executor.run_until_parked();
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { «test»(); }
-            "});
-
-        // Cmd click with existing definition doesn't re-request and dismisses highlight
-        cx.simulate_click(hover_point, Modifiers::command());
+            fn do_work() {
+                «test»();
+            }
+        "});
+        let expected_uri = cx.buffer_lsp_url.clone();
         cx.lsp
-            .handle_request::<GotoDefinition, _, _>(move |_, _| async move {
-                // Empty definition response to make sure we aren't hitting the lsp and using
-                // the cached location instead
-                Ok(Some(lsp::GotoDefinitionResponse::Link(vec![])))
+            .handle_request::<GotoDefinition, _, _>(move |params, _| {
+                let expected_uri = expected_uri.clone();
+                async move {
+                    assert_eq!(
+                        params.text_document_position_params.text_document.uri,
+                        expected_uri
+                    );
+                    let position = params.text_document_position_params.position;
+                    Ok(Some(lsp::GotoDefinitionResponse::Link(
+                        if position.line == reference_display_point.row()
+                            && position.character == reference_display_point.column()
+                        {
+                            vec![lsp::LocationLink {
+                                origin_selection_range: None,
+                                target_uri: params.text_document_position_params.text_document.uri,
+                                target_range: definition_range,
+                                target_selection_range: definition_range,
+                            }]
+                        } else {
+                            // We cannot navigate to the definition outside of its reference point
+                            Vec::new()
+                        },
+                    )))
+                }
             });
-        cx.background_executor.run_until_parked();
-        cx.assert_editor_state(indoc! {"
-                fn «testˇ»() { do_work(); }
-                fn do_work() { test(); }
-            "});
-
-        // Assert no link highlights after jump
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { test(); }
-            "});
-
-        // Cmd click without existing definition requests and jumps
-        let hover_point = cx.pixel_position(indoc! {"
-                fn test() { do_wˇork(); }
-                fn do_work() { test(); }
-            "});
-        let target_range = cx.lsp_range(indoc! {"
-                fn test() { do_work(); }
-                fn «do_work»() { test(); }
-            "});
-
-        let mut requests = cx.handle_request::<GotoDefinition, _, _>(move |url, _, _| async move {
-            Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                lsp::LocationLink {
-                    origin_selection_range: None,
-                    target_uri: url,
-                    target_range,
-                    target_selection_range: target_range,
-                },
-            ])))
-        });
-        cx.simulate_click(hover_point, Modifiers::command());
-        requests.next().await;
-        cx.background_executor.run_until_parked();
-        cx.assert_editor_state(indoc! {"
-                fn test() { do_work(); }
-                fn «do_workˇ»() { test(); }
-            "});
-
-        // 1. We have a pending selection, mouse point is over a symbol that we have a response for, hitting cmd and nothing happens
-        // 2. Selection is completed, hovering
-        let hover_point = cx.pixel_position(indoc! {"
-                fn test() { do_wˇork(); }
-                fn do_work() { test(); }
-            "});
-        let target_range = cx.lsp_range(indoc! {"
-                fn test() { do_work(); }
-                fn «do_work»() { test(); }
-            "});
-        let mut requests = cx.handle_request::<GotoDefinition, _, _>(move |url, _, _| async move {
-            Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
-                lsp::LocationLink {
-                    origin_selection_range: None,
-                    target_uri: url,
-                    target_range,
-                    target_selection_range: target_range,
-                },
-            ])))
+        let expected_uri = cx.buffer_lsp_url.clone();
+        cx.lsp.handle_request::<References, _, _>(move |params, _| {
+            let expected_uri = expected_uri.clone();
+            async move {
+                assert_eq!(
+                    params.text_document_position.text_document.uri,
+                    expected_uri
+                );
+                let position = params.text_document_position.position;
+                // Zed should not look for references if GotoDefinition works or returns non-empty result
+                assert_eq!(position.line, definition_display_point.row());
+                assert_eq!(position.character, definition_display_point.column());
+                Ok(Some(vec![lsp::Location {
+                    uri: params.text_document_position.text_document.uri,
+                    range: reference_range,
+                }]))
+            }
         });
 
-        // create a pending selection
-        let selection_range = cx.ranges(indoc! {"
-                fn «test() { do_w»ork(); }
-                fn do_work() { test(); }
-            "})[0]
-            .clone();
-        cx.update_editor(|editor, cx| {
-            let snapshot = editor.buffer().read(cx).snapshot(cx);
-            let anchor_range = snapshot.anchor_before(selection_range.start)
-                ..snapshot.anchor_after(selection_range.end);
-            editor.change_selections(Some(crate::Autoscroll::fit()), cx, |s| {
-                s.set_pending_anchor_range(anchor_range, crate::SelectMode::Character)
-            });
-        });
-        cx.simulate_mouse_move(hover_point, Modifiers::command());
-        cx.background_executor.run_until_parked();
-        assert!(requests.try_next().is_err());
-        cx.assert_editor_text_highlights::<HoveredLinkState>(indoc! {"
-                fn test() { do_work(); }
-                fn do_work() { test(); }
+        for _ in 0..5 {
+            cx.simulate_click(definition_hover_point, Modifiers::command());
+            cx.background_executor.run_until_parked();
+            cx.assert_editor_state(indoc! {"
+                fn test() {
+                    do_work();
+                }
+
+                fn do_work() {
+                    «testˇ»();
+                }
             "});
-        cx.background_executor.run_until_parked();
+
+            cx.simulate_click(reference_hover_point, Modifiers::command());
+            cx.background_executor.run_until_parked();
+            cx.assert_editor_state(indoc! {"
+                fn «testˇ»() {
+                    do_work();
+                }
+
+                fn do_work() {
+                    test();
+                }
+            "});
+        }
     }
 }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -97,7 +97,7 @@ pub(crate) struct PerformRename {
     pub push_to_history: bool,
 }
 
-pub(crate) struct GetDefinition {
+pub struct GetDefinition {
     pub position: PointUtf16,
 }
 


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/5351

Allows using cmd-click universally across the editor for navigation, similar to what VSCode provides: first, Zed tries to do GoToDefinition/GoToTypeDefinition and if that is not performed for some reason or the selection is moved to the same element that was under cmd-click, Zed now follows-up with FindAllReferences call.

Similar to VSCode, if this LSP call takes a long time, no visual feedback happens and the user has to wait.
https://github.com/zed-industries/zed/pull/9242 fixes obvious issues with this, but Zed should do better at some point later.

Also, more types and definitions are underlined now, as something that may result in FindAllReferences navigating away, to show that it's possible to do a cmd-click there.

Release Notes:

- Improved cmd-click navigation around the editor: now, if cmd-click did not find a reference to go to, Zed calls FindAllReferences for the same position ([9242](https://github.com/zed-industries/zed/pull/9242))
