### PR TITLE
Wayland: Remove bogus `wl_surface::commit`s on resize (with integer scaling)

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -417,7 +417,6 @@ impl Dispatch<wl_surface::WlSurface, ()> for WaylandClientState {
                 }
                 window.rescale(scale as f32);
                 window.surface.set_buffer_scale(scale as i32);
-                window.surface.commit();
             }
             wl_surface::Event::Leave { output } => {
                 // We use `PreferredBufferScale` instead to set the scale if it's available
@@ -435,12 +434,10 @@ impl Dispatch<wl_surface::WlSurface, ()> for WaylandClientState {
                 }
                 window.rescale(scale as f32);
                 window.surface.set_buffer_scale(scale as i32);
-                window.surface.commit();
             }
             wl_surface::Event::PreferredBufferScale { factor } => {
                 window.rescale(factor as f32);
                 surface.set_buffer_scale(factor);
-                window.surface.commit();
             }
             _ => {}
         }


### PR DESCRIPTION
Release Notes:
- N/A

This prevents a crash on sway (on older versions without fractional scaling). This means the resize is delayed until the next this we present a frame, we need to investigate if this is the correct this to do.