### PR TITLE
Fix IconButton to make it in square.

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2243,7 +2243,7 @@ impl CollabPanel {
                 let channel_link_copy = channel_link.clone();
                 IconButton::new("channel-link", IconName::Copy)
                     .icon_size(IconSize::Small)
-                    .size(ButtonSize::None)
+                    .size(ButtonSize::Compact)
                     .visible_on_hover("section-header")
                     .on_click(move |_, cx| {
                         let item = ClipboardItem::new(channel_link_copy.clone());

--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -8,7 +8,7 @@ use gpui::{
 };
 use search::{buffer_search, BufferSearchBar};
 use settings::{Settings, SettingsStore};
-use ui::{prelude::*, ButtonSize, ButtonStyle, IconButton, IconName, IconSize, Tooltip};
+use ui::{prelude::*, ButtonStyle, IconButton, IconName, IconSize, Tooltip};
 use workspace::{
     item::ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
 };
@@ -171,7 +171,6 @@ impl RenderOnce for QuickActionBarButton {
         let action = self.action.boxed_clone();
 
         IconButton::new(self.id.clone(), self.icon)
-            .size(ButtonSize::Compact)
             .icon_size(IconSize::Small)
             .style(ButtonStyle::Subtle)
             .selected(self.toggled)

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -276,7 +276,7 @@ pub enum ButtonSize {
 }
 
 impl ButtonSize {
-    fn height(self) -> Rems {
+    pub fn height(self) -> Rems {
         match self {
             ButtonSize::Large => rems(32. / 16.),
             ButtonSize::Default => rems(22. / 16.),

--- a/crates/ui/src/components/button/icon_button.rs
+++ b/crates/ui/src/components/button/icon_button.rs
@@ -15,6 +15,7 @@ pub enum IconButtonShape {
 #[derive(IntoElement)]
 pub struct IconButton {
     base: ButtonLike,
+    size: ButtonSize,
     shape: IconButtonShape,
     icon: IconName,
     icon_size: IconSize,
@@ -26,6 +27,7 @@ impl IconButton {
     pub fn new(id: impl Into<ElementId>, icon: IconName) -> Self {
         let mut this = Self {
             base: ButtonLike::new(id),
+            size: ButtonSize::default(),
             shape: IconButtonShape::Wide,
             icon,
             icon_size: IconSize::default(),
@@ -112,6 +114,7 @@ impl ButtonCommon for IconButton {
 
     fn size(mut self, size: ButtonSize) -> Self {
         self.base = self.base.size(size);
+        self.size = size;
         self
     }
 
@@ -145,10 +148,13 @@ impl RenderOnce for IconButton {
                         IconSize::Medium => px(2.),
                     };
 
-                    this.width((icon_size + padding * 2.).into())
-                        .height((icon_size + padding * 2.).into())
+                    let width = (icon_size + padding * 2.).into();
+                    this.width(width).height(width)
                 }
-                IconButtonShape::Wide => this,
+                IconButtonShape::Wide => {
+                    let width = self.size.height().into();
+                    this.width(width).height(width)
+                }
             })
             .child(
                 ButtonIcon::new(self.icon)


### PR DESCRIPTION
- Fixed IconButton to make it in square.


## Before

<img width="368" alt="image" src="https://github.com/zed-industries/zed/assets/5518/418c1102-e403-4ed6-8846-eab7b04842f4">
<img width="789" alt="image" src="https://github.com/zed-industries/zed/assets/5518/2c088c6d-def6-4082-977d-a98d3b11e698">
<img width="390" alt="image" src="https://github.com/zed-industries/zed/assets/5518/743d1f92-3c4a-4ea5-827f-9112cf2ba956">
<img width="431" alt="image" src="https://github.com/zed-industries/zed/assets/5518/0ccfdc0f-9720-4bc8-a9e2-2bae561fa508">



## After

<img width="389" alt="image" src="https://github.com/zed-industries/zed/assets/5518/cce75156-6a06-4112-a975-e5cfb7639e37">
<img width="381" alt="image" src="https://github.com/zed-industries/zed/assets/5518/b3238bf3-5823-4722-b044-6f5fb5fb334f">
<img width="663" alt="image" src="https://github.com/zed-industries/zed/assets/5518/e985521b-c50b-441f-9df3-fc2259cf9999">


Other Icon Buttons:

![output](https://github.com/zed-industries/zed/assets/5518/c2450fbf-f020-4cd1-9cb1-037c9dfd142a)

