### PR TITLE
Fix segfault when dropping MacWindow

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -695,10 +695,11 @@ impl Drop for MacWindow {
         this.renderer.destroy();
         let window = this.native_window;
         this.display_link.take();
-        unsafe {
-            this.native_window.setDelegate_(nil);
-        }
         if !this.native_window_was_closed {
+            unsafe {
+                this.native_window.setDelegate_(nil);
+            }
+
             this.executor
                 .spawn(async move {
                     unsafe {


### PR DESCRIPTION
This avoids calling `window.setDelegate(nil)` when the window was already closed.

Release Notes:

- Fixed a segfault that could show up when closing windows.  
