### PR TITLE
Correctly re-render mouse cursor when hovering over pane group divider

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -941,19 +941,25 @@ mod element {
                         let flexes = self.flexes.clone();
                         let child_bounds = child.bounds;
                         let axis = self.axis;
+                        let handle_hitbox = handle.hitbox.clone();
+                        let was_hovered = handle_hitbox.is_hovered(cx);
                         move |e: &MouseMoveEvent, phase, cx| {
                             let dragged_handle = dragged_handle.borrow();
-                            if phase.bubble() && *dragged_handle == Some(ix) {
-                                Self::compute_resize(
-                                    &flexes,
-                                    e,
-                                    ix,
-                                    axis,
-                                    child_bounds.origin,
-                                    bounds.size,
-                                    workspace.clone(),
-                                    cx,
-                                )
+                            if phase.bubble() {
+                                if *dragged_handle == Some(ix) {
+                                    Self::compute_resize(
+                                        &flexes,
+                                        e,
+                                        ix,
+                                        axis,
+                                        child_bounds.origin,
+                                        bounds.size,
+                                        workspace.clone(),
+                                        cx,
+                                    )
+                                } else if was_hovered != handle_hitbox.is_hovered(cx) {
+                                    cx.refresh();
+                                }
                             }
                         }
                     });


### PR DESCRIPTION
Before this change, the hitbox felt one-sided because the cursor didn't consistently change into the drag-handle cursor.

The reason was that we didn't trigger a redraw on hover, so we'd only change the cursor if we detected hover AND something else caused a redraw.

Release Notes:

- Fixed the pane resize handler not consistently triggering on mouse hover.