### PR TITLE
Fix status bar icons gap

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -721,7 +721,7 @@ impl Render for PanelButtons {
                 )
             });
 
-        h_flex().gap_0p5().children(buttons)
+        h_flex().gap_2().children(buttons)
     }
 }
 


### PR DESCRIPTION
Release Notes:

- Fixed StatusBar to use same gap for each icon.

## Before Issue

![SCR-20240313-o33](https://github.com/zed-industries/zed/assets/5518/484434c9-7702-4266-804f-669ac1804224)

## After

![SCR-20240313-owl](https://github.com/zed-industries/zed/assets/5518/9294e323-c5fa-45c3-acad-3d18a0f2ad8f)
> The Front is After, Back is Before.
