### PR TITLE
gpui: Do not emit MouseUpEvent when exiting drag & drop

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1157,12 +1157,10 @@ impl<'a> WindowContext<'a> {
                         click_count: 1,
                     })
                 }
-                FileDropEvent::Exited => PlatformInput::MouseUp(MouseUpEvent {
-                    button: MouseButton::Left,
-                    position: Point::default(),
-                    modifiers: Modifiers::default(),
-                    click_count: 1,
-                }),
+                FileDropEvent::Exited => {
+                    self.active_drag.take();
+                    PlatformInput::FileDrop(FileDropEvent::Exited)
+                }
             },
             PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) => event,
         };


### PR DESCRIPTION
Fixes #9198

Release Notes:

- Fixed a bug where empty panes could be created during drag & drop.
