### PR TITLE
Fix keyboard symbols

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -155,12 +155,13 @@ impl std::fmt::Display for Keystroke {
         }
         let key = match self.key.as_str() {
             "backspace" => '⌫',
-            "up" => '↑',
-            "down" => '↓',
-            "left" => '←',
-            "right" => '→',
+            "up" => '▲',
+            "down" => '▼',
+            "left" => '◀',
+            "right" => '▶',
             "tab" => '⇥',
             "escape" => '⎋',
+            "delete" => '⌦',
             key => {
                 if key.len() == 1 {
                     key.chars().next().unwrap().to_ascii_uppercase()

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -159,7 +159,7 @@ impl Render for BufferSearchBar {
                     .zip(down_keystrokes)
                     .map(|(up_keystrokes, down_keystrokes)| {
                         Arc::from(format!(
-                            "Search ({}/{} for previous/next query)",
+                            "Search ({} or {} for previous/next query)",
                             up_keystrokes.join(" "),
                             down_keystrokes.join(" ")
                         ))

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1602,7 +1602,7 @@ impl ProjectSearchBar {
             });
         let new_placeholder_text = match (previous_query_keystrokes, next_query_keystrokes) {
             (Some(previous_query_keystrokes), Some(next_query_keystrokes)) => Some(format!(
-                "Search ({}/{} for previous/next query)",
+                "Search ({} or {} for previous/next query)",
                 previous_query_keystrokes.join(" "),
                 next_query_keystrokes.join(" ")
             )),


### PR DESCRIPTION
Release Notes:

- Update keyboard symbols, use better arrow symbols.

## Before

<img width="644" alt="image" src="https://github.com/zed-industries/zed/assets/5518/de846d9f-7e64-4fdd-8401-bcfd98e53e89">

## After

Same as the Menu

![SCR-20240313-qfq](https://github.com/zed-industries/zed/assets/5518/18044077-4528-4c41-b244-71fff21de99d)
![SCR-20240313-qi8](https://github.com/zed-industries/zed/assets/5518/f15c318e-5755-40dd-b9c2-d08b4b416e7f)


