### PR TITLE
Always stop propagation in div's scroll wheel listener

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1949,9 +1949,9 @@ impl Interactivity {
                         scroll_offset.y += delta_y;
                     }
 
+                    cx.stop_propagation();
                     if *scroll_offset != old_scroll_offset {
                         cx.refresh();
-                        cx.stop_propagation();
                     }
                 }
             });


### PR DESCRIPTION
Fixes #9274

This fixes a bug that was preventing the editor hover popovers from being scrolled with the trackpad.

Release Notes:

- N/A