### PR TITLE
Add a setting for custom associations between languages and files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -532,6 +532,19 @@
     "enable": false
   },
   "code_actions_on_format": {},
+  // An object whose keys are language names, and whose values
+  // are arrays of filenames or extensions of files that should
+  // use those languages.
+  //
+  // For example, to treat files like `foo.notjs` as JavaScript,
+  // and 'Embargo.lock' as TOML:
+  //
+  // {
+  //   "JavaScript": ["notjs"],
+  //   "TOML": ["Embargo.lock"]
+  // }
+  //
+  "file_types": {},
   // Different settings for specific languages.
   "languages": {
     "Plain Text": {

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3268,7 +3268,7 @@ mod tests {
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
         init(cx);
-        let registry = Arc::new(LanguageRegistry::test());
+        let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
 
         let completion_provider = Arc::new(FakeCompletionProvider::new());
         let conversation = cx.new_model(|cx| Conversation::new(registry, cx, completion_provider));
@@ -3399,7 +3399,7 @@ mod tests {
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
         init(cx);
-        let registry = Arc::new(LanguageRegistry::test());
+        let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         let completion_provider = Arc::new(FakeCompletionProvider::new());
 
         let conversation = cx.new_model(|cx| Conversation::new(registry, cx, completion_provider));
@@ -3498,7 +3498,7 @@ mod tests {
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
         init(cx);
-        let registry = Arc::new(LanguageRegistry::test());
+        let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         let completion_provider = Arc::new(FakeCompletionProvider::new());
         let conversation = cx.new_model(|cx| Conversation::new(registry, cx, completion_provider));
         let buffer = conversation.read(cx).buffer.clone();
@@ -3582,7 +3582,7 @@ mod tests {
         let settings_store = cx.update(SettingsStore::test);
         cx.set_global(settings_store);
         cx.update(init);
-        let registry = Arc::new(LanguageRegistry::test());
+        let registry = Arc::new(LanguageRegistry::test(cx.executor()));
         let completion_provider = Arc::new(FakeCompletionProvider::new());
         let conversation =
             cx.new_model(|cx| Conversation::new(registry.clone(), cx, completion_provider));

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -257,13 +257,12 @@ impl TestServer {
         let fs = FakeFs::new(cx.executor());
         let user_store = cx.new_model(|cx| UserStore::new(client.clone(), cx));
         let workspace_store = cx.new_model(|cx| WorkspaceStore::new(client.clone(), cx));
-        let mut language_registry = LanguageRegistry::test();
-        language_registry.set_executor(cx.executor());
+        let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
         let app_state = Arc::new(workspace::AppState {
             client: client.clone(),
             user_store: user_store.clone(),
             workspace_store,
-            languages: Arc::new(language_registry),
+            languages: language_registry,
             fs: fs.clone(),
             build_window_options: |_, _, _| Default::default(),
             node_runtime: FakeNodeRuntime::new(),

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -1041,8 +1041,8 @@ mod tests {
     use util::test::marked_text_ranges;
 
     #[gpui::test]
-    fn test_render_markdown_with_mentions() {
-        let language_registry = Arc::new(LanguageRegistry::test());
+    fn test_render_markdown_with_mentions(cx: &mut AppContext) {
+        let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         let (body, ranges) = marked_text_ranges("*hi*, «@abc», let's **call** «@fgh»", false);
         let message = channel::ChannelMessage {
             id: ChannelMessageId::Saved(0),
@@ -1089,8 +1089,8 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_render_markdown_with_auto_detect_links() {
-        let language_registry = Arc::new(LanguageRegistry::test());
+    fn test_render_markdown_with_auto_detect_links(cx: &mut AppContext) {
+        let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         let message = channel::ChannelMessage {
             id: ChannelMessageId::Saved(0),
             body: "Here is a link https://zed.dev to zeds website".to_string(),
@@ -1129,8 +1129,8 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_render_markdown_with_auto_detect_links_and_additional_formatting() {
-        let language_registry = Arc::new(LanguageRegistry::test());
+    fn test_render_markdown_with_auto_detect_links_and_additional_formatting(cx: &mut AppContext) {
+        let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         let message = channel::ChannelMessage {
             id: ChannelMessageId::Saved(0),
             body: "**Here is a link https://zed.dev to zeds website**".to_string(),

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -624,7 +624,7 @@ mod tests {
             MessageEditorSettings::register(cx);
         });
 
-        let language_registry = Arc::new(LanguageRegistry::test());
+        let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
         language_registry.add(Arc::new(Language::new(
             LanguageConfig {
                 name: "Markdown".into(),

--- a/crates/copilot_ui/src/copilot_button.rs
+++ b/crates/copilot_ui/src/copilot_button.rs
@@ -225,12 +225,14 @@ impl CopilotButton {
         let suggestion_anchor = editor.selections.newest_anchor().start;
         let language = snapshot.language_at(suggestion_anchor);
         let file = snapshot.file_at(suggestion_anchor).cloned();
-
-        self.editor_enabled = Some(
-            file.as_ref().map(|file| !file.is_private()).unwrap_or(true)
-                && all_language_settings(self.file.as_ref(), cx)
-                    .copilot_enabled(language, file.as_ref().map(|file| file.path().as_ref())),
-        );
+        self.editor_enabled = {
+            let file = file.as_ref().map(|f| f.as_ref());
+            Some(
+                file.map(|file| !file.is_private()).unwrap_or(true)
+                    && all_language_settings(file.map(|file| file.into()), cx)
+                        .copilot_enabled(language, file.map(|file| file.path().as_ref())),
+            )
+        };
         self.language = language.cloned();
         self.file = file;
 

--- a/crates/copilot_ui/src/copilot_button.rs
+++ b/crates/copilot_ui/src/copilot_button.rs
@@ -226,10 +226,10 @@ impl CopilotButton {
         let language = snapshot.language_at(suggestion_anchor);
         let file = snapshot.file_at(suggestion_anchor).cloned();
         self.editor_enabled = {
-            let file = file.as_ref().map(|f| f.as_ref());
+            let file = file.as_ref();
             Some(
                 file.map(|file| !file.is_private()).unwrap_or(true)
-                    && all_language_settings(file.map(|file| file.into()), cx)
+                    && all_language_settings(file, cx)
                         .copilot_enabled(language, file.map(|file| file.path().as_ref())),
             )
         };

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9644,22 +9644,16 @@ impl Editor {
         telemetry.report_copilot_event(suggestion_id, suggestion_accepted, file_extension)
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    fn report_editor_event(
-        &self,
-        _operation: &'static str,
-        _file_extension: Option<String>,
-        _cx: &AppContext,
-    ) {
-    }
-
-    #[cfg(not(any(test, feature = "test-support")))]
     fn report_editor_event(
         &self,
         operation: &'static str,
         file_extension: Option<String>,
         cx: &AppContext,
     ) {
+        if cfg!(any(test, feature = "test-support")) {
+            return;
+        }
+
         let Some(project) = &self.project else { return };
 
         // If None, we are in a file without an extension
@@ -9679,8 +9673,7 @@ impl Editor {
             .raw_user_settings()
             .get("vim_mode")
             == Some(&serde_json::Value::Bool(true));
-        let copilot_enabled =
-            all_language_settings(file.map(|f| f.as_ref().into()), cx).copilot_enabled(None, None);
+        let copilot_enabled = all_language_settings(file, cx).copilot_enabled(None, None);
         let copilot_enabled_for_language = self
             .buffer
             .read(cx)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9619,7 +9619,8 @@ impl Editor {
             .raw_user_settings()
             .get("vim_mode")
             == Some(&serde_json::Value::Bool(true));
-        let copilot_enabled = all_language_settings(file, cx).copilot_enabled(None, None);
+        let copilot_enabled =
+            all_language_settings(file.map(|f| f.as_ref().into()), cx).copilot_enabled(None, None);
         let copilot_enabled_for_language = self
             .buffer
             .read(cx)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4130,7 +4130,7 @@ impl Editor {
     ) -> bool {
         let file = snapshot.file_at(location);
         let language = snapshot.language_at(location);
-        let settings = all_language_settings(file, cx);
+        let settings = all_language_settings(file.map(|f| f.as_ref().into()), cx);
         self.show_copilot_suggestions
             && settings.copilot_enabled(language, file.map(|f| f.path().as_ref()))
     }
@@ -9242,8 +9242,7 @@ impl Editor {
             .redacted_ranges(search_range, |file| {
                 if let Some(file) = file {
                     file.is_private()
-                        && EditorSettings::get(Some((file.worktree_id(), file.path())), cx)
-                            .redact_private_values
+                        && EditorSettings::get(Some(file.as_ref().into()), cx).redact_private_values
                 } else {
                     false
                 }
@@ -9931,7 +9930,7 @@ fn inlay_hint_settings(
 ) -> InlayHintSettings {
     let file = snapshot.file_at(location);
     let language = snapshot.language_at(location);
-    let settings = all_language_settings(file, cx);
+    let settings = all_language_settings(file.map(|f| f.as_ref().into()), cx);
     settings
         .language(language.map(|l| l.name()).as_deref())
         .inlay_hints

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4130,7 +4130,7 @@ impl Editor {
     ) -> bool {
         let file = snapshot.file_at(location);
         let language = snapshot.language_at(location);
-        let settings = all_language_settings(file.map(|f| f.as_ref().into()), cx);
+        let settings = all_language_settings(file, cx);
         self.show_copilot_suggestions
             && settings.copilot_enabled(language, file.map(|f| f.path().as_ref()))
     }
@@ -9931,7 +9931,7 @@ fn inlay_hint_settings(
 ) -> InlayHintSettings {
     let file = snapshot.file_at(location);
     let language = snapshot.language_at(location);
-    let settings = all_language_settings(file.map(|f| f.as_ref().into()), cx);
+    let settings = all_language_settings(file, cx);
     settings
         .language(language.map(|l| l.name()).as_deref())
         .inlay_hints

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -15,8 +15,7 @@ use language::{
     language_settings::{AllLanguageSettings, AllLanguageSettingsContent, LanguageSettingsContent},
     BracketPairConfig,
     Capability::ReadWrite,
-    FakeLspAdapter, LanguageConfig, LanguageConfigOverride, LanguageMatcher, LanguageRegistry,
-    Override, Point,
+    FakeLspAdapter, LanguageConfig, LanguageConfigOverride, LanguageMatcher, Override, Point,
 };
 use parking_lot::Mutex;
 use project::project_settings::{LspSettings, ProjectSettings};
@@ -4447,10 +4446,8 @@ async fn test_autoclose_pairs(cx: &mut gpui::TestAppContext) {
         Some(tree_sitter_rust::language()),
     ));
 
-    let registry = Arc::new(LanguageRegistry::test());
-    registry.add(language.clone());
+    cx.language_registry().add(language.clone());
     cx.update_buffer(|buffer, cx| {
-        buffer.set_language_registry(registry);
         buffer.set_language(Some(language), cx);
     });
 
@@ -4649,12 +4646,10 @@ async fn test_autoclose_with_embedded_language(cx: &mut gpui::TestAppContext) {
         Some(tree_sitter_typescript::language_tsx()),
     ));
 
-    let registry = Arc::new(LanguageRegistry::test());
-    registry.add(html_language.clone());
-    registry.add(javascript_language.clone());
+    cx.language_registry().add(html_language.clone());
+    cx.language_registry().add(javascript_language.clone());
 
     cx.update_buffer(|buffer, cx| {
-        buffer.set_language_registry(registry);
         buffer.set_language(Some(html_language), cx);
     });
 
@@ -4829,11 +4824,8 @@ async fn test_autoclose_with_overrides(cx: &mut gpui::TestAppContext) {
         .unwrap(),
     );
 
-    let registry = Arc::new(LanguageRegistry::test());
-    registry.add(rust_language.clone());
-
+    cx.language_registry().add(rust_language.clone());
     cx.update_buffer(|buffer, cx| {
-        buffer.set_language_registry(registry);
         buffer.set_language(Some(rust_language), cx);
     });
 
@@ -6139,12 +6131,10 @@ async fn test_advance_downward_on_toggle_comment(cx: &mut gpui::TestAppContext) 
         Some(tree_sitter_rust::language()),
     ));
 
-    let registry = Arc::new(LanguageRegistry::test());
-    registry.add(language.clone());
-
     let mut cx = EditorTestContext::new(cx).await;
+
+    cx.language_registry().add(language.clone());
     cx.update_buffer(|buffer, cx| {
-        buffer.set_language_registry(registry);
         buffer.set_language(Some(language), cx);
     });
 
@@ -6294,12 +6284,9 @@ async fn test_toggle_block_comment(cx: &mut gpui::TestAppContext) {
         Some(tree_sitter_typescript::language_tsx()),
     ));
 
-    let registry = Arc::new(LanguageRegistry::test());
-    registry.add(html_language.clone());
-    registry.add(javascript_language.clone());
-
+    cx.language_registry().add(html_language.clone());
+    cx.language_registry().add(javascript_language.clone());
     cx.update_buffer(|buffer, cx| {
-        buffer.set_language_registry(registry);
         buffer.set_language(Some(html_language), cx);
     });
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -824,6 +824,8 @@ mod tests {
         .next()
         .await;
 
+        let languages = cx.language_registry().clone();
+
         cx.condition(|editor, _| editor.hover_state.visible()).await;
         cx.editor(|editor, _| {
             let blocks = editor.hover_state.info_popover.clone().unwrap().blocks;
@@ -835,7 +837,7 @@ mod tests {
                 }],
             );
 
-            let rendered = smol::block_on(parse_blocks(&blocks, &Default::default(), None));
+            let rendered = smol::block_on(parse_blocks(&blocks, &languages, None));
             assert_eq!(
                 rendered.text,
                 code_str.trim(),
@@ -916,6 +918,7 @@ mod tests {
     fn test_render_blocks(cx: &mut gpui::TestAppContext) {
         init_test(cx, |_| {});
 
+        let languages = Arc::new(LanguageRegistry::test(cx.executor()));
         let editor = cx.add_window(|cx| Editor::single_line(cx));
         editor
             .update(cx, |editor, _cx| {
@@ -1028,7 +1031,7 @@ mod tests {
                     expected_styles,
                 } in &rows[0..]
                 {
-                    let rendered = smol::block_on(parse_blocks(&blocks, &Default::default(), None));
+                    let rendered = smol::block_on(parse_blocks(&blocks, &languages, None));
 
                     let (expected_text, ranges) = marked_text_ranges(expected_marked_text, false);
                     let expected_highlights = ranges

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -3386,17 +3386,7 @@ pub mod tests {
         let project = Project::test(fs, ["/a".as_ref()], cx).await;
 
         let language_registry = project.read_with(cx, |project, _| project.languages().clone());
-        language_registry.add(Arc::new(Language::new(
-            LanguageConfig {
-                name: "Rust".into(),
-                matcher: LanguageMatcher {
-                    path_suffixes: vec!["rs".to_string()],
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            Some(tree_sitter_rust::language()),
-        )));
+        language_registry.add(crate::editor_tests::rust_lang());
         let mut fake_servers = language_registry.register_fake_lsp_adapter(
             "Rust",
             FakeLspAdapter {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1247,65 +1247,15 @@ fn path_for_file<'a>(
 mod tests {
     use super::*;
     use gpui::AppContext;
-    use std::{
-        path::{Path, PathBuf},
-        sync::Arc,
-        time::SystemTime,
-    };
+    use language::TestFile;
+    use std::path::Path;
 
     #[gpui::test]
     fn test_path_for_file(cx: &mut AppContext) {
         let file = TestFile {
             path: Path::new("").into(),
-            full_path: PathBuf::from(""),
+            root_name: String::new(),
         };
         assert_eq!(path_for_file(&file, 0, false, cx), None);
-    }
-
-    struct TestFile {
-        path: Arc<Path>,
-        full_path: PathBuf,
-    }
-
-    impl language::File for TestFile {
-        fn path(&self) -> &Arc<Path> {
-            &self.path
-        }
-
-        fn full_path(&self, _: &gpui::AppContext) -> PathBuf {
-            self.full_path.clone()
-        }
-
-        fn as_local(&self) -> Option<&dyn language::LocalFile> {
-            unimplemented!()
-        }
-
-        fn mtime(&self) -> SystemTime {
-            unimplemented!()
-        }
-
-        fn file_name<'a>(&'a self, _: &'a gpui::AppContext) -> &'a std::ffi::OsStr {
-            unimplemented!()
-        }
-
-        fn worktree_id(&self) -> usize {
-            0
-        }
-
-        fn is_deleted(&self) -> bool {
-            unimplemented!()
-        }
-
-        fn as_any(&self) -> &dyn std::any::Any {
-            unimplemented!()
-        }
-
-        fn to_proto(&self) -> rpc::proto::File {
-            unimplemented!()
-        }
-
-        fn is_private(&self) -> bool {
-            false
-        }
     }
 }

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -9,7 +9,7 @@ use gpui::{
 };
 use indoc::indoc;
 use itertools::Itertools;
-use language::{Buffer, BufferSnapshot};
+use language::{Buffer, BufferSnapshot, LanguageRegistry};
 use parking_lot::RwLock;
 use project::{FakeFs, Project};
 use std::{
@@ -117,6 +117,18 @@ impl EditorTestContext {
         self.multibuffer(|multibuffer, cx| {
             let buffer = multibuffer.as_singleton().unwrap().read(cx);
             read(buffer, cx)
+        })
+    }
+
+    pub fn language_registry(&mut self) -> Arc<LanguageRegistry> {
+        self.editor(|editor, cx| {
+            editor
+                .project
+                .as_ref()
+                .unwrap()
+                .read(cx)
+                .languages()
+                .clone()
         })
     }
 

--- a/crates/extension/src/extension_store_test.rs
+++ b/crates/extension/src/extension_store_test.rs
@@ -249,7 +249,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
         .collect(),
     };
 
-    let language_registry = Arc::new(LanguageRegistry::test());
+    let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
     let theme_registry = Arc::new(ThemeRegistry::new(Box::new(())));
     let node_runtime = FakeNodeRuntime::new();
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3526,6 +3526,55 @@ impl Completion {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
+pub struct TestFile {
+    pub path: Arc<Path>,
+    pub root_name: String,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl File for TestFile {
+    fn path(&self) -> &Arc<Path> {
+        &self.path
+    }
+
+    fn full_path(&self, _: &gpui::AppContext) -> PathBuf {
+        PathBuf::from(&self.root_name).join(self.path.as_ref())
+    }
+
+    fn as_local(&self) -> Option<&dyn LocalFile> {
+        None
+    }
+
+    fn mtime(&self) -> SystemTime {
+        unimplemented!()
+    }
+
+    fn file_name<'a>(&'a self, _: &'a gpui::AppContext) -> &'a std::ffi::OsStr {
+        self.path().file_name().unwrap_or(self.root_name.as_ref())
+    }
+
+    fn worktree_id(&self) -> usize {
+        0
+    }
+
+    fn is_deleted(&self) -> bool {
+        unimplemented!()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        unimplemented!()
+    }
+
+    fn to_proto(&self) -> rpc::proto::File {
+        unimplemented!()
+    }
+
+    fn is_private(&self) -> bool {
+        false
+    }
+}
+
 pub(crate) fn contiguous_ranges(
     values: impl Iterator<Item = u32>,
     max_len: usize,

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -70,6 +70,8 @@ fn test_line_endings(cx: &mut gpui::AppContext) {
 
 #[gpui::test]
 fn test_select_language(cx: &mut AppContext) {
+    init_settings(cx, |_| {});
+
     let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     registry.add(Arc::new(Language::new(
         LanguageConfig {
@@ -145,6 +147,8 @@ fn test_select_language(cx: &mut AppContext) {
 
 #[gpui::test(iterations = 10)]
 async fn test_first_line_pattern(cx: &mut TestAppContext) {
+    cx.update(|cx| init_settings(cx, |_| {}));
+
     let languages = LanguageRegistry::test(cx.executor());
     let languages = Arc::new(languages);
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -852,11 +852,7 @@ struct BracketConfig {
 
 impl Language {
     pub fn new(config: LanguageConfig, ts_language: Option<tree_sitter::Language>) -> Self {
-        Self::new_with_id(
-            LanguageId(NEXT_LANGUAGE_ID.fetch_add(1, SeqCst)),
-            config,
-            ts_language,
-        )
+        Self::new_with_id(LanguageId::new(), config, ts_language)
     }
 
     fn new_with_id(

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1571,8 +1571,7 @@ mod tests {
 
     #[gpui::test(iterations = 10)]
     async fn test_language_loading(cx: &mut TestAppContext) {
-        let mut languages = LanguageRegistry::test();
-        languages.set_executor(cx.executor());
+        let languages = LanguageRegistry::test(cx.executor());
         let languages = Arc::new(languages);
         languages.register_native_grammars([
             ("json", tree_sitter_json::language()),

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1570,40 +1570,6 @@ mod tests {
     use gpui::TestAppContext;
 
     #[gpui::test(iterations = 10)]
-    async fn test_first_line_pattern(cx: &mut TestAppContext) {
-        let mut languages = LanguageRegistry::test();
-
-        languages.set_executor(cx.executor());
-        let languages = Arc::new(languages);
-        languages.register_test_language(LanguageConfig {
-            name: "JavaScript".into(),
-            matcher: LanguageMatcher {
-                path_suffixes: vec!["js".into()],
-                first_line_pattern: Some(Regex::new(r"\bnode\b").unwrap()),
-            },
-            ..Default::default()
-        });
-
-        languages
-            .language_for_file("the/script".as_ref(), None)
-            .await
-            .unwrap_err();
-        languages
-            .language_for_file("the/script".as_ref(), Some(&"nothing".into()))
-            .await
-            .unwrap_err();
-        assert_eq!(
-            languages
-                .language_for_file("the/script".as_ref(), Some(&"#!/bin/env node".into()))
-                .await
-                .unwrap()
-                .name()
-                .as_ref(),
-            "JavaScript"
-        );
-    }
-
-    #[gpui::test(iterations = 10)]
     async fn test_language_loading(cx: &mut TestAppContext) {
         let mut languages = LanguageRegistry::test();
         languages.set_executor(cx.executor());

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -1,5 +1,5 @@
 use crate::{
-    language_settings::all_language_settings, CachedLspAdapter, Language, LanguageConfig,
+    language_settings::all_language_settings, CachedLspAdapter, File, Language, LanguageConfig,
     LanguageContextProvider, LanguageId, LanguageMatcher, LanguageServerName, LspAdapter,
     LspAdapterDelegate, PARSER, PLAIN_TEXT,
 };
@@ -14,7 +14,6 @@ use gpui::{AppContext, BackgroundExecutor, Task};
 use lsp::{LanguageServerBinary, LanguageServerId};
 use parking_lot::{Mutex, RwLock};
 use postage::watch;
-use settings::SettingsLocation;
 use std::{
     borrow::Cow,
     ffi::OsStr,
@@ -394,12 +393,16 @@ impl LanguageRegistry {
 
     pub fn language_for_file(
         self: &Arc<Self>,
-        file: SettingsLocation,
+        file: &Arc<dyn File>,
         content: Option<&Rope>,
         cx: &AppContext,
     ) -> impl Future<Output = Result<Arc<Language>>> {
         let user_file_types = all_language_settings(Some(file), cx);
-        self.language_for_file_internal(file.path, content, Some(&user_file_types.file_types))
+        self.language_for_file_internal(
+            &file.full_path(cx),
+            content,
+            Some(&user_file_types.file_types),
+        )
     }
 
     pub fn language_for_file_path(

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -465,7 +465,6 @@ impl LanguageRegistry {
             .iter()
             .filter_map(|language| {
                 let score = callback(&language.name, &language.matcher);
-                dbg!(&language.name, score);
                 if score > 0 {
                     Some((language.clone(), score))
                 } else {
@@ -478,8 +477,6 @@ impl LanguageRegistry {
             let _ = tx.send(Err(anyhow!("language not found")));
             return rx;
         };
-
-        dbg!(&language.name);
 
         // If the language is already loaded, resolve with it immediately.
         for loaded_language in state.languages.iter() {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -34,15 +34,15 @@ pub fn language_settings<'a>(
     cx: &'a AppContext,
 ) -> &'a LanguageSettings {
     let language_name = language.map(|l| l.name());
-    all_language_settings(file.map(|c| c.as_ref().into()), cx).language(language_name.as_deref())
+    all_language_settings(file, cx).language(language_name.as_deref())
 }
 
 /// Returns the settings for all languages from the provided file.
 pub fn all_language_settings<'a>(
-    file: Option<SettingsLocation>,
+    file: Option<&Arc<dyn File>>,
     cx: &'a AppContext,
 ) -> &'a AllLanguageSettings {
-    let location = file.map(|f| f.into());
+    let location = file.map(|f| f.as_ref().into());
     AllLanguageSettings::get(location, cx)
 }
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -10,8 +10,17 @@ use schemars::{
     JsonSchema,
 };
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use std::{num::NonZeroU32, path::Path, sync::Arc};
+
+impl<'a> Into<SettingsLocation<'a>> for &'a dyn File {
+    fn into(self) -> SettingsLocation<'a> {
+        SettingsLocation {
+            worktree_id: self.worktree_id(),
+            path: self.path().as_ref(),
+        }
+    }
+}
 
 /// Initializes the language settings.
 pub fn init(cx: &mut AppContext) {
@@ -25,15 +34,15 @@ pub fn language_settings<'a>(
     cx: &'a AppContext,
 ) -> &'a LanguageSettings {
     let language_name = language.map(|l| l.name());
-    all_language_settings(file, cx).language(language_name.as_deref())
+    all_language_settings(file.map(|c| c.as_ref().into()), cx).language(language_name.as_deref())
 }
 
 /// Returns the settings for all languages from the provided file.
 pub fn all_language_settings<'a>(
-    file: Option<&Arc<dyn File>>,
+    file: Option<SettingsLocation>,
     cx: &'a AppContext,
 ) -> &'a AllLanguageSettings {
-    let location = file.map(|f| (f.worktree_id(), f.path().as_ref()));
+    let location = file.map(|f| f.into());
     AllLanguageSettings::get(location, cx)
 }
 
@@ -44,6 +53,7 @@ pub struct AllLanguageSettings {
     pub copilot: CopilotSettings,
     defaults: LanguageSettings,
     languages: HashMap<Arc<str>, LanguageSettings>,
+    pub(crate) file_types: HashMap<Arc<str>, Vec<String>>,
 }
 
 /// The settings for a particular language.
@@ -121,6 +131,10 @@ pub struct AllLanguageSettingsContent {
     /// The settings for individual languages.
     #[serde(default, alias = "language_overrides")]
     pub languages: HashMap<Arc<str>, LanguageSettingsContent>,
+    /// Settings for associating file extensions and filenames
+    /// with languages.
+    #[serde(default)]
+    pub file_types: HashMap<Arc<str>, Vec<String>>,
 }
 
 /// The settings for a particular language.
@@ -502,6 +516,16 @@ impl settings::Settings for AllLanguageSettings {
             }
         }
 
+        let mut file_types: HashMap<Arc<str>, Vec<String>> = HashMap::default();
+        for user_file_types in user_settings.iter().map(|s| &s.file_types) {
+            for (language, suffixes) in user_file_types {
+                file_types
+                    .entry(language.clone())
+                    .or_default()
+                    .extend_from_slice(suffixes);
+            }
+        }
+
         Ok(Self {
             copilot: CopilotSettings {
                 feature_enabled: copilot_enabled,
@@ -512,6 +536,7 @@ impl settings::Settings for AllLanguageSettings {
             },
             defaults,
             languages,
+            file_types,
         })
     }
 

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{LanguageConfig, LanguageMatcher};
+use gpui::AppContext;
 use rand::rngs::StdRng;
 use std::{env, ops::Range, sync::Arc};
 use text::{Buffer, BufferId};
@@ -79,8 +80,8 @@ fn test_splice_included_ranges() {
 }
 
 #[gpui::test]
-fn test_syntax_map_layers_for_range() {
-    let registry = Arc::new(LanguageRegistry::test());
+fn test_syntax_map_layers_for_range(cx: &mut AppContext) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let language = Arc::new(rust_lang());
     registry.add(language.clone());
 
@@ -176,8 +177,8 @@ fn test_syntax_map_layers_for_range() {
 }
 
 #[gpui::test]
-fn test_dynamic_language_injection() {
-    let registry = Arc::new(LanguageRegistry::test());
+fn test_dynamic_language_injection(cx: &mut AppContext) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let markdown = Arc::new(markdown_lang());
     registry.add(markdown.clone());
     registry.add(Arc::new(rust_lang()));
@@ -254,7 +255,7 @@ fn test_dynamic_language_injection() {
 }
 
 #[gpui::test]
-fn test_typing_multiple_new_injections() {
+fn test_typing_multiple_new_injections(cx: &mut AppContext) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Rust",
         &[
@@ -272,6 +273,7 @@ fn test_typing_multiple_new_injections() {
             "fn a() { test_macro!(b.c(vec![d«.»])) }",
             "fn a() { test_macro!(b.c(vec![d.«e»])) }",
         ],
+        cx,
     );
 
     assert_capture_ranges(
@@ -283,7 +285,7 @@ fn test_typing_multiple_new_injections() {
 }
 
 #[gpui::test]
-fn test_pasting_new_injection_line_between_others() {
+fn test_pasting_new_injection_line_between_others(cx: &mut AppContext) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Rust",
         &[
@@ -309,6 +311,7 @@ fn test_pasting_new_injection_line_between_others() {
                 }
             ",
         ],
+        cx,
     );
 
     assert_capture_ranges(
@@ -330,7 +333,7 @@ fn test_pasting_new_injection_line_between_others() {
 }
 
 #[gpui::test]
-fn test_joining_injections_with_child_injections() {
+fn test_joining_injections_with_child_injections(cx: &mut AppContext) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Rust",
         &[
@@ -355,6 +358,7 @@ fn test_joining_injections_with_child_injections() {
                 }
             ",
         ],
+        cx,
     );
 
     assert_capture_ranges(
@@ -374,7 +378,7 @@ fn test_joining_injections_with_child_injections() {
 }
 
 #[gpui::test]
-fn test_editing_edges_of_injection() {
+fn test_editing_edges_of_injection(cx: &mut AppContext) {
     test_edit_sequence(
         "Rust",
         &[
@@ -399,11 +403,12 @@ fn test_editing_edges_of_injection() {
                 }
             ",
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_edits_preceding_and_intersecting_injection() {
+fn test_edits_preceding_and_intersecting_injection(cx: &mut AppContext) {
     test_edit_sequence(
         "Rust",
         &[
@@ -411,11 +416,12 @@ fn test_edits_preceding_and_intersecting_injection() {
             "const aaaaaaaaaaaa: B = c!(d(e.f));",
             "const aˇa: B = c!(d(eˇ));",
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_non_local_changes_create_injections() {
+fn test_non_local_changes_create_injections(cx: &mut AppContext) {
     test_edit_sequence(
         "Rust",
         &[
@@ -430,11 +436,12 @@ fn test_non_local_changes_create_injections() {
                 ˇ}
             ",
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_creating_many_injections_in_one_edit() {
+fn test_creating_many_injections_in_one_edit(cx: &mut AppContext) {
     test_edit_sequence(
         "Rust",
         &[
@@ -460,11 +467,12 @@ fn test_creating_many_injections_in_one_edit() {
                 }
             ",
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_editing_across_injection_boundary() {
+fn test_editing_across_injection_boundary(cx: &mut AppContext) {
     test_edit_sequence(
         "Rust",
         &[
@@ -488,11 +496,12 @@ fn test_editing_across_injection_boundary() {
                 }
             ",
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_removing_injection_by_replacing_across_boundary() {
+fn test_removing_injection_by_replacing_across_boundary(cx: &mut AppContext) {
     test_edit_sequence(
         "Rust",
         &[
@@ -514,11 +523,12 @@ fn test_removing_injection_by_replacing_across_boundary() {
                 }
             ",
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_combined_injections_simple() {
+fn test_combined_injections_simple(cx: &mut AppContext) {
     let (buffer, syntax_map) = test_edit_sequence(
         "ERB",
         &[
@@ -549,6 +559,7 @@ fn test_combined_injections_simple() {
                 </body>
             ",
         ],
+        cx,
     );
 
     assert_capture_ranges(
@@ -565,7 +576,7 @@ fn test_combined_injections_simple() {
 }
 
 #[gpui::test]
-fn test_combined_injections_empty_ranges() {
+fn test_combined_injections_empty_ranges(cx: &mut AppContext) {
     test_edit_sequence(
         "ERB",
         &[
@@ -579,11 +590,12 @@ fn test_combined_injections_empty_ranges() {
                 ˇ<% end %>
             ",
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_combined_injections_edit_edges_of_ranges() {
+fn test_combined_injections_edit_edges_of_ranges(cx: &mut AppContext) {
     let (buffer, syntax_map) = test_edit_sequence(
         "ERB",
         &[
@@ -600,6 +612,7 @@ fn test_combined_injections_edit_edges_of_ranges() {
                 <%= three @four %>
             ",
         ],
+        cx,
     );
 
     assert_capture_ranges(
@@ -614,7 +627,7 @@ fn test_combined_injections_edit_edges_of_ranges() {
 }
 
 #[gpui::test]
-fn test_combined_injections_splitting_some_injections() {
+fn test_combined_injections_splitting_some_injections(cx: &mut AppContext) {
     let (_buffer, _syntax_map) = test_edit_sequence(
         "ERB",
         &[
@@ -635,11 +648,12 @@ fn test_combined_injections_splitting_some_injections() {
                 <% f %>
             "#,
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_combined_injections_editing_after_last_injection() {
+fn test_combined_injections_editing_after_last_injection(cx: &mut AppContext) {
     test_edit_sequence(
         "ERB",
         &[
@@ -655,11 +669,12 @@ fn test_combined_injections_editing_after_last_injection() {
                 more text»
             "#,
         ],
+        cx,
     );
 }
 
 #[gpui::test]
-fn test_combined_injections_inside_injections() {
+fn test_combined_injections_inside_injections(cx: &mut AppContext) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Markdown",
         &[
@@ -709,6 +724,7 @@ fn test_combined_injections_inside_injections() {
                 ```
             "#,
         ],
+        cx,
     );
 
     // Check that the code directive below the ruby comment is
@@ -735,7 +751,7 @@ fn test_combined_injections_inside_injections() {
 }
 
 #[gpui::test]
-fn test_empty_combined_injections_inside_injections() {
+fn test_empty_combined_injections_inside_injections(cx: &mut AppContext) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Markdown",
         &[r#"
@@ -745,6 +761,7 @@ fn test_empty_combined_injections_inside_injections() {
 
             goodbye
         "#],
+        cx,
     );
 
     assert_layers_for_range(
@@ -763,7 +780,7 @@ fn test_empty_combined_injections_inside_injections() {
 }
 
 #[gpui::test(iterations = 50)]
-fn test_random_syntax_map_edits_rust_macros(rng: StdRng) {
+fn test_random_syntax_map_edits_rust_macros(rng: StdRng, cx: &mut AppContext) {
     let text = r#"
         fn test_something() {
             let vec = vec![5, 1, 3, 8];
@@ -781,7 +798,7 @@ fn test_random_syntax_map_edits_rust_macros(rng: StdRng) {
     .unindent()
     .repeat(2);
 
-    let registry = Arc::new(LanguageRegistry::test());
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let language = Arc::new(rust_lang());
     registry.add(language.clone());
 
@@ -789,7 +806,7 @@ fn test_random_syntax_map_edits_rust_macros(rng: StdRng) {
 }
 
 #[gpui::test(iterations = 50)]
-fn test_random_syntax_map_edits_with_erb(rng: StdRng) {
+fn test_random_syntax_map_edits_with_erb(rng: StdRng, cx: &mut AppContext) {
     let text = r#"
         <div id="main">
         <% if one?(:two) %>
@@ -808,7 +825,7 @@ fn test_random_syntax_map_edits_with_erb(rng: StdRng) {
     .unindent()
     .repeat(5);
 
-    let registry = Arc::new(LanguageRegistry::test());
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let language = Arc::new(erb_lang());
     registry.add(language.clone());
     registry.add(Arc::new(ruby_lang()));
@@ -818,7 +835,7 @@ fn test_random_syntax_map_edits_with_erb(rng: StdRng) {
 }
 
 #[gpui::test(iterations = 50)]
-fn test_random_syntax_map_edits_with_heex(rng: StdRng) {
+fn test_random_syntax_map_edits_with_heex(rng: StdRng, cx: &mut AppContext) {
     let text = r#"
         defmodule TheModule do
             def the_method(assigns) do
@@ -841,7 +858,7 @@ fn test_random_syntax_map_edits_with_heex(rng: StdRng) {
     .unindent()
     .repeat(3);
 
-    let registry = Arc::new(LanguageRegistry::test());
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let language = Arc::new(elixir_lang());
     registry.add(language.clone());
     registry.add(Arc::new(heex_lang()));
@@ -1025,8 +1042,12 @@ fn check_interpolation(
     }
 }
 
-fn test_edit_sequence(language_name: &str, steps: &[&str]) -> (Buffer, SyntaxMap) {
-    let registry = Arc::new(LanguageRegistry::test());
+fn test_edit_sequence(
+    language_name: &str,
+    steps: &[&str],
+    cx: &mut AppContext,
+) -> (Buffer, SyntaxMap) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     registry.add(Arc::new(elixir_lang()));
     registry.add(Arc::new(heex_lang()));
     registry.add(Arc::new(rust_lang()));

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -1079,9 +1079,7 @@ fn main() {
 
     #[gpui::test]
     async fn test_code_block_with_language(executor: BackgroundExecutor) {
-        let mut language_registry = LanguageRegistry::test();
-        language_registry.set_executor(executor);
-        let language_registry = Arc::new(language_registry);
+        let language_registry = Arc::new(LanguageRegistry::test(executor.clone()));
         language_registry.add(rust_lang());
 
         let parsed = parse_markdown(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4884,10 +4884,15 @@ impl Project {
             let mut requests = Vec::new();
             for ((worktree_id, _), server_id) in self.language_server_ids.iter() {
                 let worktree_id = *worktree_id;
-                let worktree_handle = self.worktree_for_id(worktree_id, cx);
-                let worktree = match worktree_handle.and_then(|tree| tree.read(cx).as_local()) {
-                    Some(worktree) => worktree,
-                    None => continue,
+                let Some(worktree_handle) = self.worktree_for_id(worktree_id, cx) else {
+                    continue;
+                };
+                let worktree = worktree_handle.read(cx);
+                if !worktree.is_visible() {
+                    continue;
+                }
+                let Some(worktree) = worktree.as_local() else {
+                    continue;
                 };
                 let worktree_abs_path = worktree.abs_path().clone();
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4963,14 +4963,16 @@ impl Project {
                         symbols.extend(lsp_symbols.into_iter().filter_map(
                             |(symbol_name, symbol_kind, symbol_location)| {
                                 let abs_path = symbol_location.uri.to_file_path().ok()?;
-                                let mut worktree_id = source_worktree_id;
+
                                 let path;
+                                let worktree_id;
                                 if let Some((worktree, rel_path)) =
                                     this.find_local_worktree(&abs_path, cx)
                                 {
                                     worktree_id = worktree.read(cx).id();
                                     path = rel_path;
                                 } else {
+                                    worktree_id = source_worktree_id;
                                     path = relativize_path(&worktree_abs_path, &abs_path);
                                 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -861,8 +861,7 @@ impl Project {
     ) -> Model<Project> {
         use clock::FakeSystemClock;
 
-        let mut languages = LanguageRegistry::test();
-        languages.set_executor(cx.executor());
+        let languages = LanguageRegistry::test(cx.executor());
         let clock = Arc::new(FakeSystemClock::default());
         let http_client = util::http::FakeHttpClient::with_404_response();
         let client = cx.update(|cx| client::Client::new(clock, http_client.clone(), cx));

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -580,7 +580,7 @@ impl SemanticIndex {
                                 }
 
                                 if let Ok(language) = language_registry
-                                    .language_for_file(&absolute_path, None)
+                                    .language_for_file_path(&absolute_path)
                                     .await
                                 {
                                     // Test if file is valid parseable file
@@ -1141,7 +1141,7 @@ impl SemanticIndex {
 
                     for mut pending_file in pending_files {
                         if let Ok(language) = language_registry
-                            .language_for_file(&pending_file.relative_path, None)
+                            .language_for_file_path(&pending_file.relative_path)
                             .await
                         {
                             if !PARSEABLE_ENTIRE_FILE_TYPES.contains(&language.name().as_ref())

--- a/crates/semantic_index/src/semantic_index_tests.rs
+++ b/crates/semantic_index/src/semantic_index_tests.rs
@@ -1719,6 +1719,7 @@ fn init_test(cx: &mut TestAppContext) {
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
         SemanticIndexSettings::register(cx);
+        language::init(cx);
         Project::init_settings(cx);
     });
 }

--- a/crates/semantic_index/src/semantic_index_tests.rs
+++ b/crates/semantic_index/src/semantic_index_tests.rs
@@ -5,8 +5,7 @@ use crate::{
     FileToEmbed, JobHandle, SearchResult, SemanticIndex, EMBEDDING_QUEUE_FLUSH_TIMEOUT,
 };
 use ai::test::FakeEmbeddingProvider;
-
-use gpui::{Task, TestAppContext};
+use gpui::TestAppContext;
 use language::{Language, LanguageConfig, LanguageMatcher, LanguageRegistry, ToOffset};
 use parking_lot::Mutex;
 use pretty_assertions::assert_eq;
@@ -57,7 +56,7 @@ async fn test_semantic_index(cx: &mut TestAppContext) {
     )
     .await;
 
-    let languages = Arc::new(LanguageRegistry::new(Task::ready(())));
+    let languages = Arc::new(LanguageRegistry::test(cx.executor().clone()));
     let rust_language = rust_lang();
     let toml_language = toml_lang();
     languages.add(rust_language);

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -8,7 +8,7 @@ use util::asset_str;
 
 pub use keymap_file::KeymapFile;
 pub use settings_file::*;
-pub use settings_store::{Settings, SettingsJsonSchemaParams, SettingsStore};
+pub use settings_store::{Settings, SettingsJsonSchemaParams, SettingsLocation, SettingsStore};
 
 #[derive(RustEmbed)]
 #[folder = "../../assets"]

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -86,9 +86,8 @@ pub trait Settings: 'static + Send + Sync {
         });
     }
 
-    /// path is a (worktree ID, Path)
     #[track_caller]
-    fn get<'a>(path: Option<(usize, &Path)>, cx: &'a AppContext) -> &'a Self
+    fn get<'a>(path: Option<SettingsLocation>, cx: &'a AppContext) -> &'a Self
     where
         Self: Sized,
     {
@@ -118,6 +117,12 @@ pub trait Settings: 'static + Send + Sync {
     {
         cx.global_mut::<SettingsStore>().override_global(settings)
     }
+}
+
+#[derive(Clone, Copy)]
+pub struct SettingsLocation<'a> {
+    pub worktree_id: usize,
+    pub path: &'a Path,
 }
 
 pub struct SettingsJsonSchemaParams<'a> {
@@ -168,7 +173,7 @@ trait AnySettingValue: 'static + Send + Sync {
         custom: &[DeserializedSetting],
         cx: &mut AppContext,
     ) -> Result<Box<dyn Any>>;
-    fn value_for_path(&self, path: Option<(usize, &Path)>) -> &dyn Any;
+    fn value_for_path(&self, path: Option<SettingsLocation>) -> &dyn Any;
     fn set_global_value(&mut self, value: Box<dyn Any>);
     fn set_local_value(&mut self, root_id: usize, path: Arc<Path>, value: Box<dyn Any>);
     fn json_schema(
@@ -234,7 +239,7 @@ impl SettingsStore {
     ///
     /// Panics if the given setting type has not been registered, or if there is no
     /// value for this setting.
-    pub fn get<T: Settings>(&self, path: Option<(usize, &Path)>) -> &T {
+    pub fn get<T: Settings>(&self, path: Option<SettingsLocation>) -> &T {
         self.setting_values
             .get(&TypeId::of::<T>())
             .unwrap_or_else(|| panic!("unregistered setting type {}", type_name::<T>()))
@@ -659,10 +664,10 @@ impl<T: Settings> AnySettingValue for SettingValue<T> {
         Ok(DeserializedSetting(Box::new(value)))
     }
 
-    fn value_for_path(&self, path: Option<(usize, &Path)>) -> &dyn Any {
-        if let Some((root_id, path)) = path {
+    fn value_for_path(&self, path: Option<SettingsLocation>) -> &dyn Any {
+        if let Some(SettingsLocation { worktree_id, path }) = path {
             for (settings_root_id, settings_path, value) in self.local_values.iter().rev() {
-                if root_id == *settings_root_id && path.starts_with(settings_path) {
+                if worktree_id == *settings_root_id && path.starts_with(settings_path) {
                     return value;
                 }
             }
@@ -1010,7 +1015,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            store.get::<UserSettings>(Some((1, Path::new("/root1/something")))),
+            store.get::<UserSettings>(Some(SettingsLocation {
+                worktree_id: 1,
+                path: Path::new("/root1/something")
+            })),
             &UserSettings {
                 name: "John Doe".to_string(),
                 age: 31,
@@ -1018,7 +1026,10 @@ mod tests {
             }
         );
         assert_eq!(
-            store.get::<UserSettings>(Some((1, Path::new("/root1/subdir/something")))),
+            store.get::<UserSettings>(Some(SettingsLocation {
+                worktree_id: 1,
+                path: Path::new("/root1/subdir/something")
+            })),
             &UserSettings {
                 name: "Jane Doe".to_string(),
                 age: 31,
@@ -1026,7 +1037,10 @@ mod tests {
             }
         );
         assert_eq!(
-            store.get::<UserSettings>(Some((1, Path::new("/root2/something")))),
+            store.get::<UserSettings>(Some(SettingsLocation {
+                worktree_id: 1,
+                path: Path::new("/root2/something")
+            })),
             &UserSettings {
                 name: "John Doe".to_string(),
                 age: 42,
@@ -1034,7 +1048,10 @@ mod tests {
             }
         );
         assert_eq!(
-            store.get::<MultiKeySettings>(Some((1, Path::new("/root2/something")))),
+            store.get::<MultiKeySettings>(Some(SettingsLocation {
+                worktree_id: 1,
+                path: Path::new("/root2/something")
+            })),
             &MultiKeySettings {
                 key1: "a".to_string(),
                 key2: "b".to_string(),

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1017,7 +1017,7 @@ mod tests {
         assert_eq!(
             store.get::<UserSettings>(Some(SettingsLocation {
                 worktree_id: 1,
-                path: Path::new("/root1/something")
+                path: Path::new("/root1/something"),
             })),
             &UserSettings {
                 name: "John Doe".to_string(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -405,7 +405,7 @@ impl AppState {
         }
 
         let fs = fs::FakeFs::new(cx.background_executor().clone());
-        let languages = Arc::new(LanguageRegistry::test());
+        let languages = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         let clock = Arc::new(clock::FakeSystemClock::default());
         let http_client = util::http::FakeHttpClient::with_404_response();
         let client = Client::new(clock, http_client.clone(), cx);

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -46,7 +46,7 @@ use postage::{
     watch,
 };
 use serde::Serialize;
-use settings::{Settings, SettingsStore};
+use settings::{Settings, SettingsLocation, SettingsStore};
 use smol::channel::{self, Sender};
 use std::{
     any::Any,
@@ -352,7 +352,10 @@ impl Worktree {
                         "file_scan_exclusions",
                     );
                     let new_private_files = path_matchers(
-                        WorktreeSettings::get(Some((cx.handle().entity_id().as_u64() as usize, &Path::new(""))), cx).private_files.as_deref(),
+                        WorktreeSettings::get(Some(settings::SettingsLocation {
+                            worktree_id: cx.handle().entity_id().as_u64() as usize,
+                            path: Path::new("")
+                        }), cx).private_files.as_deref(),
                         "private_files",
                     );
 
@@ -408,7 +411,10 @@ impl Worktree {
                     "file_scan_exclusions",
                 ),
                 private_files: path_matchers(
-                    WorktreeSettings::get(Some((cx.handle().entity_id().as_u64() as usize, &Path::new(""))), cx).private_files.as_deref(),
+                    WorktreeSettings::get(Some(SettingsLocation {
+                        worktree_id: cx.handle().entity_id().as_u64() as usize,
+                        path: Path::new(""),
+                    }), cx).private_files.as_deref(),
                     "private_files",
                 ),
                 ignores_by_parent_abs_path: Default::default(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -142,9 +142,9 @@ fn main() {
         ));
 
         let client = client::Client::new(clock, http.clone(), cx);
-        let mut languages = LanguageRegistry::new(login_shell_env_loaded);
+        let mut languages =
+            LanguageRegistry::new(login_shell_env_loaded, cx.background_executor().clone());
         let copilot_language_server_id = languages.next_language_server_id();
-        languages.set_executor(cx.background_executor().clone());
         languages.set_language_server_download_dir(paths::LANGUAGES_DIR.clone());
         let languages = Arc::new(languages);
         let node_runtime = RealNodeRuntime::new(http.clone());

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2832,8 +2832,7 @@ mod tests {
     async fn test_bundled_languages(cx: &mut TestAppContext) {
         let settings = cx.update(|cx| SettingsStore::test(cx));
         cx.set_global(settings);
-        let mut languages = LanguageRegistry::test();
-        languages.set_executor(cx.executor().clone());
+        let languages = LanguageRegistry::test(cx.executor());
         let languages = Arc::new(languages);
         let node_runtime = node_runtime::FakeNodeRuntime::new();
         cx.update(|cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3031,7 +3031,11 @@ mod tests {
             languages::init(languages.clone(), node_runtime, cx);
         });
         for name in languages.language_names() {
-            languages.language_for_name(&name).await.unwrap();
+            languages
+                .language_for_name(&name)
+                .await
+                .with_context(|| format!("language name {name}"))
+                .unwrap();
         }
         cx.run_until_parked();
     }

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -380,6 +380,25 @@ To override settings for a language, add an entry for that language server's nam
 
 `boolean` values
 
+## File Types
+
+- Setting: `file_types`
+- Description: Configure how Zed selects a language for a file based on its filename or extension.
+- Default: `{}`
+
+**Examples**
+
+To interpret all `.c` files as C++, and files called `MyLockFile` as TOML:
+
+```json
+{
+  "file_types": {
+    "C++": ["c"],
+    "TOML": ["MyLockFile"]
+  }
+}
+```
+
 ## Git
 
 - Description: Configuration for git-related features.


### PR DESCRIPTION
Closes #5178

Release Notes:

- Added a `file_types` setting that can be used to associate languages with file names and file extensions. For example, to interpret all `.c` files as C++, and files called `MyLockFile` as TOML, add the following to `settings.json`:

    ```json
    {
      "file_types": {
        "C++": ["c"],
        "TOML": ["MyLockFile"]
      }
    }
    ```

    As with most zed settings, this can be configured on a per-directory basis by including a local `.zed/settings.json` file in that directory.