### PR TITLE
Fix accidental leak of text stack between frames

### DIFF
--- a/crates/gpui/src/window/element_cx.rs
+++ b/crates/gpui/src/window/element_cx.rs
@@ -432,6 +432,7 @@ impl<'a> ElementContext<'a> {
         );
         self.window.next_frame.deferred_draws = deferred_draws;
         self.window.element_id_stack.clear();
+        self.window.text_style_stack.clear();
     }
 
     fn paint_deferred_draws(&mut self, deferred_draw_indices: &[usize]) {


### PR DESCRIPTION
Co-Authored-By: Max <max@zed.dev>
Co-Authored-By: Marshall <marshall@zed.dev>

Release Notes:

- Fixed a bug where text styles could leak between frames (preview only)
