### PR TITLE
Fix double-clicking titlebar to zoom

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1330,6 +1330,7 @@ impl Interactivity {
         !self.mouse_up_listeners.is_empty()
             || !self.mouse_down_listeners.is_empty()
             || !self.mouse_move_listeners.is_empty()
+            || !self.click_listeners.is_empty()
             || !self.scroll_wheel_listeners.is_empty()
             || self.drag_listener.is_some()
             || !self.drop_listeners.is_empty()


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/9300

This was a regression caused by not inserting a hitbox when a div only had click listeners on it.

Release Notes:

- Fixed a regression that disabled double-clicking on the titlebar to zoom the window. ([#9300](https://github.com/zed-industries/zed/issues/9300)) (preview-only)