### PR TITLE
Workspace configuration for elixir-ls LSP

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -39,3 +39,21 @@ If you prefer to format your code with [Mix](https://hexdocs.pm/mix/Mix.html), u
   }
 }
 ```
+
+### Additional workspace configuration options (requires Zed `0.128.0`):
+
+You can pass additional elixir-ls workspace configuration options via lsp settings in `settings.json`.
+
+The following example disables dialyzer:
+
+```json
+"lsp": {
+  "elixir-ls": {
+    "settings": {
+      "dialyzerEnabled": false
+    }
+  }
+}
+```
+
+See [ElixirLS configuration settings](https://github.com/elixir-lsp/elixir-ls#elixirls-configuration-settings) for more options.


### PR DESCRIPTION
This allows the workspace configuration settings to be passed to the elixir-ls LSP via lsp settings.

This following example settings disable dialyzer in the LSP:

```
"lsp": {
  "elixir-ls": {
    "settings": {
      "dialyzerEnabled": false
    }
  }
}
```

It follows the same pattern used in [#8568](https://github.com/zed-industries/zed/pull/8568) and resolves [#4260](https://github.com/zed-industries/zed/issues/4260).

Zed's language server logs show the settings are being sent to the language server:

```
Received client configuration via workspace/configuration
%{"dialyzerEnabled" => false}
Registering for workspace/didChangeConfiguration notifications
Starting build with MIX_ENV: test MIX_TARGET: host
client/registerCapability succeeded
Registering for workspace/didChangeWatchedFiles notifications
client/registerCapability succeeded
Received workspace/didChangeConfiguration
Received client configuration via workspace/didChangeConfiguration
%{"dialyzerEnabled" => false}
```

Release Notes:

- Added workspace configuration settings support for elixir-ls language server.  Those can now be configured by setting `{"lsp":  {"elixir-ls": { "settings: { "your-settings-here": "here"} } }` in Zed settings. [#4260](https://github.com/zed-industries/zed/issues/4260).

