### PR TITLE
Do not start searching if query is empty

### DIFF
--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -327,6 +327,10 @@ impl SearchQuery {
         matches
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.as_str().is_empty()
+    }
+
     pub fn as_str(&self) -> &str {
         self.as_inner().as_str()
     }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1231,6 +1231,9 @@ impl ProjectSearchView {
         if !self.panels_with_errors.is_empty() {
             return None;
         }
+        if query.as_ref().is_some_and(|query| query.is_empty()) {
+            return None;
+        }
         query
     }
 


### PR DESCRIPTION
This avoids the problem of a search being kicked off involuntarily and potentially using a large amount of CPU when toggling on the `Search Ignored Files` option.

What would happen is that someone would turn the option on, we'd kick off a search, and go through all of the files in, say, `node_modules`. Even if no query was given.

This avoids that.

Release Notes:

- Fixed an empty search being kicked off involuntarily if no query was typed in yet but an option was toggled.