### PR TITLE
Allow navigating back to multibuffers

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9531,9 +9531,8 @@ impl Editor {
                 } else {
                     workspace.active_pane().clone()
                 };
-                pane.update(cx, |pane, _| pane.disable_history());
 
-                for (buffer, ranges) in new_selections_by_buffer.into_iter() {
+                for (buffer, ranges) in new_selections_by_buffer {
                     let editor = workspace.open_project_item::<Self>(pane.clone(), buffer, cx);
                     editor.update(cx, |editor, cx| {
                         editor.change_selections(Some(Autoscroll::newest()), cx, |s| {
@@ -9541,8 +9540,6 @@ impl Editor {
                         });
                     });
                 }
-
-                pane.update(cx, |pane, _| pane.enable_history());
             })
         });
     }


### PR DESCRIPTION
Fixes https://github.com/orgs/zed-industries/projects/14/views/1?pane=issue&itemId=56263346

Fixes a state where Zed multi buffers were not reachable after going to an excerpt inside it (with alt-enter).
I suspect, we will have to come back to multi buffer history and check the way it behaves on inner excerpts clicking, but now this change seems to restore the main thing: multi buffers not being shown in the history at all.



Release Notes:

- Fixes "go backwards" not considering multibuffers in history
