### PR TITLE
Restore `--all-targets` for clippy

### DIFF
--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -337,7 +337,7 @@ mod tests {
         workspace: &View<Workspace>,
         cx: &mut VisualTestContext,
     ) -> View<GoToLine> {
-        cx.dispatch_action(Toggle::default());
+        cx.dispatch_action(Toggle);
         workspace.update(cx, |workspace, cx| {
             workspace.active_modal::<GoToLine>(cx).unwrap().clone()
         })

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -447,7 +447,7 @@ mod tests {
         workspace: &View<Workspace>,
         cx: &mut VisualTestContext,
     ) -> View<Picker<OutlineViewDelegate>> {
-        cx.dispatch_action(Toggle::default());
+        cx.dispatch_action(Toggle);
         workspace.update(cx, |workspace, cx| {
             workspace
                 .active_modal::<OutlineView>(cx)

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -47,7 +47,10 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
         clippy_command.arg("--workspace");
     }
 
-    clippy_command.arg("--release").arg("--all-features");
+    clippy_command
+        .arg("--release")
+        .arg("--all-targets")
+        .arg("--all-features");
 
     if args.fix {
         clippy_command.arg("--fix");


### PR DESCRIPTION
This PR restores the `--all-targets` flag when running `cargo clippy`.

Without it, there are areas that Clippy does not check, as evidenced by the violations that were caught once the flag was re-added.

Release Notes:

- N/A
