### PR TITLE
Prevent long extension descriptions from overflowing

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -391,11 +391,14 @@ impl ExtensionsPage {
             )
             .child(
                 h_flex()
+                    .gap_2()
                     .justify_between()
                     .children(extension.description.as_ref().map(|description| {
-                        Label::new(description.clone())
-                            .size(LabelSize::Small)
-                            .color(Color::Default)
+                        h_flex().overflow_x_hidden().child(
+                            Label::new(description.clone())
+                                .size(LabelSize::Small)
+                                .color(Color::Default),
+                        )
                     }))
                     .child(
                         IconButton::new(


### PR DESCRIPTION
This PR fixes an issue where long extension descriptions could take up more room than intended, pushing the GitHub repository icon off the screen.

<img width="901" alt="Screenshot 2024-03-14 at 12 54 14 PM" src="https://github.com/zed-industries/zed/assets/1486634/befce468-f8df-4183-b3cc-9d088dd53b4e">

Fixes #9331.

Release Notes:

- Fixed an issue where long extension descriptions could push the GitHub repository icon off the screen ([#9331](https://github.com/zed-industries/zed/issues/9331)).
