### PR TITLE
Windows: make `fs` to use workspace `windows` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3920,7 +3920,7 @@ dependencies = [
  "text",
  "time",
  "util",
- "windows-sys 0.52.0",
+ "windows 0.53.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,6 +343,7 @@ features = [
     "Win32_Graphics_DirectComposition",
     "Win32_Graphics_Gdi",
     "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_DataExchange",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -43,10 +43,7 @@ fsevent.workspace = true
 notify = "6.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.52", features = [
-    "Win32_Foundation",
-    "Win32_Storage_FileSystem",
-] }
+windows.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION

Release Notes:

- N/A
