### PR TITLE
Foundations for Open All the Things

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -118,6 +118,13 @@ const SERVER_LAUNCHING_BEFORE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5
 pub const SERVER_PROGRESS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub trait Item {
+    fn try_open(
+        project: &Model<Project>,
+        path: &ProjectPath,
+        cx: &mut AppContext,
+    ) -> Option<Task<Result<Model<Self>>>>
+    where
+        Self: Sized;
     fn entry_id(&self, cx: &AppContext) -> Option<ProjectEntryId>;
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
 }
@@ -9616,6 +9623,14 @@ fn resolve_path(base: &Path, path: &Path) -> PathBuf {
 }
 
 impl Item for Buffer {
+    fn try_open(
+        project: &Model<Project>,
+        path: &ProjectPath,
+        cx: &mut AppContext,
+    ) -> Option<Task<Result<Model<Self>>>> {
+        Some(project.update(cx, |project, cx| project.open_buffer(path.clone(), cx)))
+    }
+
     fn entry_id(&self, cx: &AppContext) -> Option<ProjectEntryId> {
         File::from_dyn(self.file()).and_then(|file| file.project_entry_id(cx))
     }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -32,6 +32,7 @@ use std::{
     time::Duration,
 };
 use theme::Theme;
+use ui::Element as _;
 
 pub const LEADER_UPDATE_THROTTLE: Duration = Duration::from_millis(200);
 
@@ -100,6 +101,15 @@ pub struct BreadcrumbText {
 
 pub trait Item: FocusableView + EventEmitter<Self::Event> {
     type Event;
+    fn tab_content(
+        &self,
+        _detail: Option<usize>,
+        _selected: bool,
+        _cx: &WindowContext,
+    ) -> AnyElement {
+        gpui::Empty.into_any()
+    }
+    fn to_item_events(_event: &Self::Event, _f: impl FnMut(ItemEvent)) {}
 
     fn deactivated(&mut self, _: &mut ViewContext<Self>) {}
     fn workspace_deactivated(&mut self, _: &mut ViewContext<Self>) {}
@@ -112,9 +122,10 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
     fn tab_description(&self, _: usize, _: &AppContext) -> Option<SharedString> {
         None
     }
-    fn tab_content(&self, detail: Option<usize>, selected: bool, cx: &WindowContext) -> AnyElement;
 
-    fn telemetry_event_text(&self) -> Option<&'static str>;
+    fn telemetry_event_text(&self) -> Option<&'static str> {
+        None
+    }
 
     /// (model id, Item)
     fn for_each_project_item(
@@ -169,8 +180,6 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
     ) -> Task<Result<()>> {
         unimplemented!("reload() must be implemented if can_save() returns true")
     }
-
-    fn to_item_events(event: &Self::Event, f: impl FnMut(ItemEvent));
 
     fn act_as_type<'a>(
         &'a self,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -847,6 +847,14 @@ pub mod test {
     }
 
     impl project::Item for TestProjectItem {
+        fn try_open(
+            project: &Model<Project>,
+            path: &ProjectPath,
+            cx: &mut AppContext,
+        ) -> Option<Task<gpui::Result<Model<Self>>>> {
+            unimplemented!()
+        }
+
         fn entry_id(&self, _: &AppContext) -> Option<ProjectEntryId> {
             self.entry_id
         }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -857,11 +857,11 @@ pub mod test {
 
     impl project::Item for TestProjectItem {
         fn try_open(
-            project: &Model<Project>,
-            path: &ProjectPath,
-            cx: &mut AppContext,
+            _project: &Model<Project>,
+            _path: &ProjectPath,
+            _cx: &mut AppContext,
         ) -> Option<Task<gpui::Result<Model<Self>>>> {
-            unimplemented!()
+            None
         }
 
         fn entry_id(&self, _: &AppContext) -> Option<ProjectEntryId> {


### PR DESCRIPTION
This is the beginning of setting up a flexible way to open items beyond the text buffer -- think notebooks, images, GeoJSON, etc. The primary requirement to allow opening an arbitrary file is `try_open` on the `project::Item` trait. Now we can make new `Item`s for other types with their own ways to render.

Under the hood, `register_project_item` uses this new opening scheme. It supports a dynamic array of opener functions, that will handle specific item types. By default, a `Buffer` should be able to be able to open any file that another opener did not.

A key detail here is that the order of registration matters. The last item has primacy. Here's an example:

```rust
workspace::register_project_item::<Editor>(cx);
workspace::register_project_item::<Notebook>(cx);
workspace::register_project_item::<ImageViewer>(cx);
```

When a project item (file) is attempted to be opened, it's first tried with the `ImageViewer`, followed by the `Notebook`, then the `Editor`.

The tests are set up in a way that should make it _hopefully_ easy to learn how to write a new opener. First to go after should probably be image files.

Release Notes:

N/A