### PR TITLE
Allow `clippy::single_range_in_vec_init` as a permanent rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,6 +388,10 @@ codegen-units = 1
 dbg_macro = "deny"
 todo = "deny"
 
+# Motivation: We use `vec![a..b]` a lot when dealing with ranges in text, so
+# warning on this rule produces a lot of noise.
+single_range_in_vec_init = "allow"
+
 # These are all of the rules that currently have violations in the Zed
 # codebase.
 #
@@ -414,7 +418,6 @@ map_entry = "allow"
 non_canonical_clone_impl = "allow"
 non_canonical_partial_ord_impl = "allow"
 reversed_empty_ranges = "allow"
-single_range_in_vec_init = "allow"
 type_complexity = "allow"
 
 [workspace.metadata.cargo-machete]


### PR DESCRIPTION
This PR promotes the allowance of the [`clippy::single_range_in_vec_init`](https://rust-lang.github.io/rust-clippy/master/index.html#/single_range_in_vec_init) rule to a permanent one.

This rule complains about a pretty common pattern we use that doesn't seem to have any adverse effects, so we're going to continue allowing this rule.

Release Notes:

- N/A
