### PR TITLE
Avoid scrolling when clicking near editor top/bottom

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -157,7 +157,7 @@
     // Whether to show fold buttons in the gutter.
     "folds": true
   },
-  // The number of lines to keep above/below the cursor when scrolling.
+  // The number of lines to keep above/below the cursor when moving the cursor.
   "vertical_scroll_margin": 3,
   "relative_line_numbers": false,
   // When to populate a new search's query based on the text under the cursor.


### PR DESCRIPTION
Gonna be honest, I way overthought this

We want to have a reasonable margin at the top and bottom of the editor where the cursor cannot enter by moving vertically, to give it room to breath and let the user read the lines above/below the cursor even when at the vertical extremes. However we don't want it to scroll to preserve that margin when the user clicks to place the cursor in that area.

If we "just" do the simple thing and avoid scrolling on the initial click, then the user can click there fine. However it will jump the scroll position as soon as anything else moves the cursor, such as typing or pressing a direction key. I spent a bunch of brain cycles trying to figure out a way around this with no luck. Thankfully for us, this is exactly the behavior that VSCode has so it's fine, ship it.

Along the way I played around with removing the margin by default and realized that we don't handle go-to style navigation operations very well when this cursor movement margin is set to zero. We rely on this value for how we make sure that the thing you navigate to isn't at the extreme top or bottom of the editor if we can help it.

So as a little bonus I added new autoscroll strategies to combat this, which guarantee some sort of margin for those jumping navigations. As a side effect it may actually be a little better as these navigations now use either this guaranteed margin, or the user's cursor scroll margin, whichever is larger, which seems like a good thing to me.

Nothing seems weird with any of these values with the screen size and font size combinations I tested so I'm pretty confident in the added behavior but I'd be able to revert easily if it turned out to be problematic.

Closes https://github.com/zed-industries/zed/issues/5219

Release Notes:

- Fixed an issue where the editor would scroll when clicking with the mouse near the top or bottom of the editor ([#5219](https://github.com/zed-industries/zed/issues/5219)).
- Improved cursor positioning when performing various jump-to navigations with a small `vertical_scroll_margin` setting value.