### PR TITLE
Remove `Copy` trait for enum Operator

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -46,7 +46,7 @@ impl Default for Mode {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub enum Operator {
     Change,
     Delete,
@@ -192,7 +192,7 @@ impl EditorState {
     }
 
     pub fn active_operator(&self) -> Option<Operator> {
-        self.operator_stack.last().copied()
+        self.operator_stack.last().cloned()
     }
 
     pub fn keymap_context_layer(&self) -> KeyContext {
@@ -219,7 +219,7 @@ impl EditorState {
 
         let active_operator = self.active_operator();
 
-        if let Some(active_operator) = active_operator {
+        if let Some(active_operator) = active_operator.clone() {
             for context_flag in active_operator.context_flags().into_iter() {
                 context.add(*context_flag);
             }
@@ -227,7 +227,10 @@ impl EditorState {
 
         context.set(
             "vim_operator",
-            active_operator.map(|op| op.id()).unwrap_or_else(|| "none"),
+            active_operator
+                .clone()
+                .map(|op| op.id())
+                .unwrap_or_else(|| "none"),
         );
 
         if self.mode == Mode::Replace {

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -124,7 +124,7 @@ impl VimTestContext {
 
     pub fn active_operator(&mut self) -> Option<Operator> {
         self.cx
-            .read(|cx| cx.global::<Vim>().state().operator_stack.last().clone())
+            .read(|cx| cx.global::<Vim>().state().operator_stack.last().cloned())
     }
 
     pub fn set_state(&mut self, text: &str, mode: Mode) {

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -124,7 +124,7 @@ impl VimTestContext {
 
     pub fn active_operator(&mut self) -> Option<Operator> {
         self.cx
-            .read(|cx| cx.global::<Vim>().state().operator_stack.last().copied())
+            .read(|cx| cx.global::<Vim>().state().operator_stack.last().clone())
     }
 
     pub fn set_state(&mut self, text: &str, mode: Mode) {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -106,8 +106,8 @@ fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
         Vim::update(cx, |vim, cx| vim.switch_mode(mode, false, cx))
     });
     workspace.register_action(
-        |_: &mut Workspace, &PushOperator(operator): &PushOperator, cx| {
-            Vim::update(cx, |vim, cx| vim.push_operator(operator, cx))
+        |_: &mut Workspace, PushOperator(operator): &PushOperator, cx| {
+            Vim::update(cx, |vim, cx| vim.push_operator(operator.clone(), cx))
         },
     );
     workspace.register_action(|_: &mut Workspace, n: &Number, cx: _| {
@@ -493,7 +493,7 @@ impl Vim {
     }
 
     fn active_operator(&self) -> Option<Operator> {
-        self.state().operator_stack.last().copied()
+        self.state().operator_stack.last().cloned()
     }
 
     fn transaction_begun(&mut self, transaction_id: TransactionId, _: &mut WindowContext) {


### PR DESCRIPTION
In this commit, the Copy trait has been removed from Operator. This change was necessary due to the value of operator may wish to attach a motion type, which is not compatible with the Copy trait.

All instances where Operator was previously copied have been updated to use the clone() or cloned() method instead. This includes function parameters, variable assignments, and closures.


