### PR TITLE
Default SCSS and LESS to CSS language

### DIFF
--- a/crates/languages/src/css/config.toml
+++ b/crates/languages/src/css/config.toml
@@ -1,6 +1,6 @@
 name = "CSS"
 grammar = "css"
-path_suffixes = ["css"]
+path_suffixes = ["css", "scss", "less"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION

Release Notes:

Default SCSS, and LESS prefixes to use CSS language whilst SCSS support is pending.

<img width="1035" alt="CleanShot 2024-03-15 at 15 20 04@2x" src="https://github.com/zed-industries/zed/assets/8562933/638d6cce-578a-43b2-ad24-b193badeda59">
