### PR TITLE
gpui: editable text element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4400,6 +4400,7 @@ dependencies = [
  "thiserror",
  "time",
  "tiny-skia",
+ "unicode-segmentation",
  "usvg",
  "util",
  "uuid",
@@ -10903,9 +10904,9 @@ checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-vo"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -72,6 +72,7 @@ usvg = { version = "0.14", features = [] }
 util.workspace = true
 uuid = { version = "1.1.2", features = ["v4", "v5"] }
 waker-fn = "1.1.0"
+unicode-segmentation = "1.11.0"
 
 [dev-dependencies]
 backtrace = "0.3"

--- a/crates/gpui/examples/editable_text.rs
+++ b/crates/gpui/examples/editable_text.rs
@@ -1,0 +1,175 @@
+use gpui::*;
+
+fn main() {
+    App::new().run(|cx: &mut AppContext| {
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        cx.on_action(quit);
+        cx.set_menus(vec![Menu {
+            name: "editable_text",
+            items: vec![MenuItem::action("Quit", Quit)],
+        }]);
+        cx.open_window(WindowOptions::default(), |cx| {
+            cx.new_view(|cx| EditableText {
+                text: cx.new_model(|_| "Hello, world!".into()),
+                poem: cx.new_model(|_| {
+                    r#"Two roads diverged in a yellow wood,
+And sorry I could not travel both
+And be one traveler, long I stood
+And looked down one as far as I could
+To where it bent in the undergrowth;
+
+Then took the other, as just as fair,
+And having perhaps the better claim,
+Because it was grassy and wanted wear;
+Though as for that the passing there
+Had worn them really about the same,
+
+And both that morning equally lay
+In leaves no step had trodden black.
+Oh, I kept the first for another day!
+Yet knowing how way leads on to way,
+I doubted if I should ever come back.
+
+I shall be telling this with a sigh
+Somewhere ages and ages hence:
+Two roads diverged in a wood, and I—
+I took the one less traveled by,
+And that has made all the difference."#
+                        .into()
+                }),
+                before_focus_handle: cx.focus_handle(),
+                after_focus_handle: cx.focus_handle(),
+            })
+        });
+    });
+}
+
+actions!(editable_text, [Quit]);
+
+fn quit(_: &Quit, cx: &mut AppContext) {
+    cx.quit();
+}
+
+struct EditableText {
+    text: Model<String>,
+    poem: Model<String>,
+    before_focus_handle: FocusHandle,
+    after_focus_handle: FocusHandle,
+}
+
+impl Render for EditableText {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .bg(rgb(0x2e7d32))
+            .size_full()
+            .p_3()
+            .items_start()
+            .text_2xl()
+            .text_color(rgb(0xffffff))
+            .flex()
+            .flex_row()
+            .justify_around()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .child(
+                        div()
+                            .track_focus(&self.before_focus_handle)
+                            .text_sm()
+                            .text_color(rgb(0x000000))
+                            .focus(|this| this.border_1().border_color(rgb(0xffffff)))
+                            .child("Before (this is focusable, not editable)"),
+                    )
+                    .child(
+                        editable_text(ElementId::View(self.text.entity_id()), self.text.clone())
+                            .on_focus_next({
+                                let after_focus_handle = self.after_focus_handle.clone();
+
+                                move |cx| {
+                                    cx.focus(&after_focus_handle);
+                                }
+                            })
+                            .on_focus_prev({
+                                let before_focus_handle = self.before_focus_handle.clone();
+
+                                move |cx| {
+                                    cx.focus(&before_focus_handle);
+                                }
+                            })
+                            .on_enter({
+                                let text = self.text.clone();
+
+                                move |cx| {
+                                    let prompt_task = cx.prompt(
+                                        PromptLevel::Info,
+                                        "Enter was pressed",
+                                        Some(&format!("The value is: `{}`", text.read(cx))),
+                                        &[],
+                                    );
+
+                                    cx.background_executor()
+                                        .spawn(async {
+                                            prompt_task.await.unwrap();
+                                        })
+                                        .detach();
+                                }
+                            }),
+                    )
+                    .child(
+                        div()
+                            .track_focus(&self.after_focus_handle)
+                            .text_sm()
+                            .text_color(rgb(0x000000))
+                            .focus(|this| this.border_1().border_color(rgb(0xffffff)))
+                            .child("After (this is focusable, not editable)"),
+                    ),
+            )
+            .child(
+                div()
+                    .child(div().text_xl().child(String::from("The Road Not Taken")))
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(rgb(0xc0c0c0))
+                            .py_2()
+                            .child(String::from("By Robert Frost")),
+                    )
+                    .child(
+                        div().text_base().justify_center().items_center().child(
+                            editable_text(
+                                ElementId::View(self.poem.entity_id()),
+                                self.poem.clone(),
+                            )
+                            .multiline()
+                            .on_focus_prev({
+                                let before_focus_handle = self.after_focus_handle.clone();
+
+                                move |cx| {
+                                    cx.focus(&before_focus_handle);
+                                }
+                            })
+                            .on_enter({
+                                let poem = self.poem.clone();
+
+                                move |cx| {
+                                    let prompt_task = cx.prompt(
+                                        PromptLevel::Info,
+                                        "Enter was pressed",
+                                        Some(&format!("The value is: `{}`", poem.read(cx))),
+                                        &[],
+                                    );
+
+                                    cx.background_executor()
+                                        .spawn(async {
+                                            prompt_task.await.unwrap();
+                                        })
+                                        .detach();
+                                }
+                            }),
+                        ),
+                    ),
+            )
+    }
+}

--- a/crates/gpui/examples/set_menus.rs
+++ b/crates/gpui/examples/set_menus.rs
@@ -18,6 +18,8 @@ impl Render for SetMenus {
 
 fn main() {
     App::new().run(|cx: &mut AppContext| {
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+
         // Bring the menu bar to the foreground (so you can see the menu bar)
         cx.activate(true);
         // Register the `quit` function so it can be referenced by the `MenuItem::action` in the menu bar

--- a/crates/gpui/src/elements/text/editable/actions.rs
+++ b/crates/gpui/src/elements/text/editable/actions.rs
@@ -1,0 +1,73 @@
+use crate::{self as gpui, AppContext, KeyBinding, KeyContext};
+
+crate::actions!(
+    text::editable,
+    [
+        Backspace,
+        Copy,
+        Cut,
+        Delete,
+        MoveDown,
+        MoveLeft,
+        MoveRight,
+        MoveUp,
+        MoveToBeginning,
+        MoveToEnd,
+        MoveToNextWordEnd,
+        MoveToPreviousWordStart,
+        Newline,
+        Paste,
+        Redo,
+        SelectAll,
+        SelectLeft,
+        SelectRight,
+        SelectToBeginning,
+        SelectToEnd,
+        SelectToNextWordEnd,
+        SelectToPreviousWordStart,
+        Tab,
+        TabPrev,
+        Undo,
+    ]
+);
+
+const KEY_CONTEXT: &str = "EditableText";
+
+pub fn key_context() -> KeyContext {
+    let mut key_context = KeyContext::default();
+    key_context.add(KEY_CONTEXT);
+    key_context
+}
+
+pub fn bind_keys(cx: &mut AppContext) {
+    cx.bind_keys([
+        KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-c", Copy, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-x", Cut, Some(KEY_CONTEXT)),
+        KeyBinding::new("down", MoveDown, Some(KEY_CONTEXT)),
+        KeyBinding::new("right", MoveRight, Some(KEY_CONTEXT)),
+        KeyBinding::new("left", MoveLeft, Some(KEY_CONTEXT)),
+        KeyBinding::new("up", MoveUp, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-left", MoveToBeginning, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-right", MoveToEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("alt-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("enter", Newline, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-v", Paste, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-z", Redo, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-a", SelectAll, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-left", SelectToBeginning, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-right", SelectToEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("alt-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "alt-shift-left",
+            SelectToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("tab", Tab, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-tab", TabPrev, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-z", Undo, Some(KEY_CONTEXT)),
+    ]);
+}

--- a/crates/gpui/src/elements/text/editable/mod.rs
+++ b/crates/gpui/src/elements/text/editable/mod.rs
@@ -1,0 +1,772 @@
+mod actions;
+mod blink_manager;
+// mod history;
+mod selection;
+mod transaction;
+
+use std::{any::TypeId, ops::Range, sync::Arc, time::Duration};
+
+use crate::{
+    outline, rgb, Action, Bounds, ClipboardItem, Context, CursorStyle, DispatchPhase, Element,
+    ElementContext, ElementId, FocusHandle, HighlightStyle, Hitbox, Hsla, InputHandler,
+    InteractiveText, IntoElement, LayoutId, Model, MouseMoveEvent, Pixels, SharedString, Size,
+    StyledText, TextState, WindowContext,
+};
+
+use actions::{
+    Backspace, Copy, Cut, Delete, MoveDown, MoveLeft, MoveRight, MoveToBeginning, MoveToEnd,
+    MoveToNextWordEnd, MoveToPreviousWordStart, MoveUp, Newline, Paste, Redo, SelectAll,
+    SelectLeft, SelectRight, SelectToBeginning, SelectToEnd, SelectToNextWordEnd,
+    SelectToPreviousWordStart, Tab, TabPrev, Undo,
+};
+use blink_manager::BlinkManager;
+use parking_lot::Mutex;
+use selection::Selection;
+
+use self::transaction::{History, ReplaceTextInRange, ReplaceTextInRangeAndSelect, Transaction};
+
+const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Construct an element with editable text.
+pub fn editable_text(id: ElementId, value: Model<String>) -> EditableText {
+    EditableText {
+        id,
+        value,
+        kind: Kind::Singline,
+        cursor_color: rgb(0x348feb).into(),
+        selection_color: None,
+        enter_listener: None,
+        focus_next_listener: None,
+        focus_prev_listener: None,
+    }
+}
+
+/// Some editable text.
+pub struct EditableText {
+    id: ElementId,
+    value: Model<String>,
+    kind: Kind,
+    cursor_color: Hsla,
+    selection_color: Option<Hsla>,
+    enter_listener: Option<Arc<dyn Fn(&mut WindowContext<'_>)>>,
+    focus_next_listener: Option<Arc<dyn Fn(&mut WindowContext<'_>)>>,
+    focus_prev_listener: Option<Arc<dyn Fn(&mut WindowContext<'_>)>>,
+}
+
+#[derive(Clone)]
+/// The kind of editable text element, either single or multiline.
+pub enum Kind {
+    /// This editable text can only be one line. Like an input of type text on the web.
+    // TODO: there is nothing done to handle multiline text that is passed to a single line
+    // element. Currently this flag just changes functionality like calling `on_enter` instead of
+    // adding a newline to the content.
+    Singline,
+    /// This editable text can have multiple line. Like a textarea on the web.
+    Multiline,
+}
+
+impl EditableText {
+    /// Set the editable text's cursor color.
+    pub fn cursor_color(mut self, cursor_color: impl Into<Hsla>) -> Self {
+        self.cursor_color = cursor_color.into();
+        self
+    }
+
+    /// Set the editable text's selection background color.
+    pub fn selection_color(mut self, selection_color: impl Into<Hsla>) -> Self {
+        self.selection_color = Some(selection_color.into());
+        self
+    }
+
+    /// Set the editable text to multiline.
+    pub fn multiline(mut self) -> Self {
+        self.kind = Kind::Multiline;
+        self
+    }
+
+    /// A function to be called whenever `enter` is pressed on a single line editable text element.
+    pub fn on_enter(mut self, listener: impl Fn(&mut WindowContext<'_>) + 'static) -> Self {
+        self.enter_listener = Some(Arc::new(listener));
+        self
+    }
+
+    /// A function to be called whenever `tab` is pressed on a single line editable text element.
+    pub fn on_focus_next(mut self, listener: impl Fn(&mut WindowContext<'_>) + 'static) -> Self {
+        self.focus_next_listener = Some(Arc::new(listener));
+        self
+    }
+
+    /// A function to be called whenever `shift-tab` is pressed on a single line editable text element.
+    pub fn on_focus_prev(mut self, listener: impl Fn(&mut WindowContext<'_>) + 'static) -> Self {
+        self.focus_prev_listener = Some(Arc::new(listener));
+        self
+    }
+}
+
+impl IntoElement for EditableText {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for EditableText {
+    type BeforeLayout = (InteractiveText, TextState);
+    type AfterLayout = Hitbox;
+
+    fn before_layout(&mut self, cx: &mut ElementContext) -> (LayoutId, Self::BeforeLayout) {
+        cx.with_element_state::<EditableTextState, _>(Some(self.id.clone()), |state, cx| {
+            let state = state.unwrap().unwrap_or_else(|| EditableTextState::new(cx));
+
+            let mut styled_text = self.render_text(&state, cx);
+
+            let (layout_id, text_state) = styled_text.before_layout(cx);
+
+            ((layout_id, (styled_text, text_state)), Some(state))
+        })
+    }
+
+    fn after_layout(
+        &mut self,
+        bounds: Bounds<crate::Pixels>,
+        (styled_text, text_state): &mut Self::BeforeLayout,
+        cx: &mut ElementContext,
+    ) -> Self::AfterLayout {
+        styled_text.after_layout(bounds, text_state, cx);
+        cx.insert_hitbox(bounds, false)
+    }
+
+    fn paint(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        (text, text_state): &mut Self::BeforeLayout,
+        hitbox: &mut Self::AfterLayout,
+        cx: &mut ElementContext,
+    ) {
+        cx.with_element_state::<EditableTextState, _>(Some(self.id.clone()), |state, cx| {
+            let mut state = state.unwrap().unwrap();
+            state.bounds = Some(bounds);
+            state.text_state = Some(Arc::new(text_state.clone()));
+
+            cx.set_focus_handle(&state.focus_handle);
+            cx.set_key_context(actions::key_context());
+            cx.handle_input(&state.focus_handle, self.into_input_handler(&state));
+
+            self.register_paint_mouse_listeners(&hitbox, &state, cx);
+            self.register_paint_action_listeners(
+                &self.value.read(cx).to_owned().into(),
+                &state,
+                cx,
+            );
+
+            text.paint(bounds, text_state, hitbox, cx);
+
+            {
+                let selection = state.selection.read(cx);
+
+                if selection.is_some() {
+                    if !state.focus_handle.is_focused(cx) {
+                        state.blur(cx);
+                    } else {
+                        if state.blink_manager.read(cx).visible() {
+                            let selection = selection.as_ref().unwrap();
+
+                            let index = selection.position();
+
+                            if let Some(origin) = text_state.position_for_index(bounds, index) {
+                                cx.paint_quad(outline(
+                                    Bounds {
+                                        origin,
+                                        size: Size {
+                                            width: Pixels(2.),
+                                            height: text_state.line_height(),
+                                        },
+                                    },
+                                    self.cursor_color,
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+
+            ((), Some(state))
+        })
+    }
+}
+
+impl EditableText {
+    fn render_text(&self, state: &EditableTextState, cx: &mut ElementContext) -> InteractiveText {
+        let selection_color = self.selection_color.unwrap_or_else(|| {
+            let mut cursor_color = self.cursor_color;
+            cursor_color.fade_out(0.5);
+            cursor_color
+        });
+
+        InteractiveText::new(
+            self.id.clone(),
+            StyledText::new(format!("{} ", self.value.read(cx))).with_highlights(
+                &cx.text_style(),
+                state
+                    .selection
+                    .read(cx)
+                    .clone()
+                    .filter(Selection::not_empty)
+                    .map(|selection| {
+                        (
+                            selection.span,
+                            HighlightStyle {
+                                background_color: Some(selection_color),
+                                ..Default::default()
+                            },
+                        )
+                    }),
+            ),
+        )
+        .cursor_style(CursorStyle::IBeam)
+        .on_selection_change({
+            let state = state.clone();
+
+            move |from, to, cx| {
+                state.on_selection_change(from, to, cx);
+            }
+        })
+    }
+}
+
+#[derive(Clone)]
+struct EditableTextState {
+    selection: Model<Option<Selection>>,
+    // TODO: confirm this should be separate from selection
+    marked: Model<Option<Range<usize>>>,
+    history: Model<History>,
+    blink_manager: Model<BlinkManager>,
+    focus_handle: FocusHandle,
+    text_state: Option<Arc<TextState>>,
+    bounds: Option<Bounds<Pixels>>,
+}
+
+impl EditableTextState {
+    fn new(cx: &mut ElementContext) -> Self {
+        let blink_manager = cx.new_model(|cx| BlinkManager::new(CURSOR_BLINK_INTERVAL, cx));
+        let selection = cx.new_model(|_| None);
+
+        // TODO: make selection a model too so we can show cursor when it updates via observe.
+        cx.observe(&blink_manager, |_, cx| cx.refresh()).detach();
+        cx.observe(&selection, {
+            let blink_manager = blink_manager.clone();
+
+            move |_, cx| {
+                blink_manager.update(cx, |this, cx| {
+                    this.show_cursor(cx);
+                });
+            }
+        })
+        .detach();
+
+        actions::bind_keys(cx);
+
+        Self {
+            blink_manager,
+            selection,
+            marked: cx.new_model(|_| None),
+            history: cx.new_model(|_| History::default()),
+            focus_handle: cx.focus_handle(),
+            text_state: None,
+            bounds: None,
+        }
+    }
+
+    fn focus(&self, cx: &mut WindowContext) {
+        cx.focus(&self.focus_handle);
+
+        self.blink_manager.update(cx, |this, cx| {
+            this.enable(cx);
+        });
+    }
+
+    fn blur(&self, cx: &mut WindowContext) {
+        self.blink_manager.update(cx, |this, cx| {
+            this.disable(cx);
+        });
+
+        self.selection.update(cx, |this, cx| {
+            *this = None;
+            cx.notify();
+        });
+    }
+
+    fn on_selection_change(&self, from_index: usize, to_index: usize, cx: &mut WindowContext) {
+        self.selection.update(cx, |this, cx| {
+            *this = Some(Selection::new(from_index, to_index));
+            cx.notify();
+        });
+    }
+}
+
+impl EditableText {
+    fn register_paint_mouse_listeners(
+        &self,
+        hitbox: &Hitbox,
+        state: &EditableTextState,
+        cx: &mut ElementContext,
+    ) {
+        cx.on_mouse_event({
+            let hitbox = hitbox.clone();
+            let state = state.clone();
+
+            move |_event: &MouseMoveEvent, phase, cx| {
+                if phase == DispatchPhase::Bubble && hitbox.is_hovered(cx) {
+                    state.focus(cx);
+                }
+            }
+        });
+    }
+
+    fn register_paint_action_listeners(
+        &self,
+        text: &SharedString,
+        state: &EditableTextState,
+        cx: &mut ElementContext,
+    ) {
+        self.register_movement_action(cx, text, state, EditableTextState::move_down);
+        self.register_movement_action(cx, text, state, EditableTextState::move_left);
+        self.register_movement_action(cx, text, state, EditableTextState::move_right);
+        self.register_movement_action(cx, text, state, EditableTextState::move_up);
+        self.register_movement_action(cx, text, state, EditableTextState::move_to_beginning);
+        self.register_movement_action(cx, text, state, EditableTextState::move_to_end);
+        self.register_movement_action(cx, text, state, EditableTextState::move_to_next_word_end);
+        self.register_movement_action(
+            cx,
+            text,
+            state,
+            EditableTextState::move_to_previous_word_start,
+        );
+        self.register_movement_action(cx, text, state, EditableTextState::select_all);
+        self.register_movement_action(cx, text, state, EditableTextState::select_left);
+        self.register_movement_action(cx, text, state, EditableTextState::select_right);
+        self.register_movement_action(cx, text, state, EditableTextState::select_to_beginning);
+        self.register_movement_action(cx, text, state, EditableTextState::select_to_end);
+        self.register_movement_action(cx, text, state, EditableTextState::select_to_next_word_end);
+        self.register_movement_action(
+            cx,
+            text,
+            state,
+            EditableTextState::select_to_previous_word_start,
+        );
+
+        self.register_input_action(cx, state, EditableTextInputHandler::backspace);
+        self.register_input_action(cx, state, EditableTextInputHandler::copy);
+        self.register_input_action(cx, state, EditableTextInputHandler::cut);
+        self.register_input_action(cx, state, EditableTextInputHandler::newline);
+        self.register_input_action(cx, state, EditableTextInputHandler::paste);
+        self.register_input_action(cx, state, EditableTextInputHandler::redo);
+        self.register_input_action(cx, state, EditableTextInputHandler::tab);
+        self.register_input_action(cx, state, EditableTextInputHandler::tab_prev);
+        self.register_input_action(cx, state, EditableTextInputHandler::undo);
+    }
+
+    fn register_movement_action<T: Action>(
+        &self,
+        cx: &mut WindowContext,
+        text: &SharedString,
+        state: &EditableTextState,
+        listener: impl Fn(&EditableTextState, &T, &SharedString, &mut WindowContext) + 'static,
+    ) {
+        cx.on_action(TypeId::of::<T>(), {
+            let text = text.clone();
+            let state = state.clone();
+
+            move |action, phase, cx| {
+                let action = action.downcast_ref().unwrap();
+
+                if phase == DispatchPhase::Bubble {
+                    listener(&state, action, &text, cx);
+
+                    cx.refresh();
+                }
+            }
+        });
+    }
+
+    fn register_input_action<T: Action>(
+        &self,
+        cx: &mut WindowContext,
+        state: &EditableTextState,
+        listener: impl Fn(&mut EditableTextInputHandler, &T, &mut WindowContext) + 'static,
+    ) {
+        cx.on_action(TypeId::of::<T>(), {
+            let input_handler = Arc::new(Mutex::new(self.into_input_handler(state)));
+
+            move |action, phase, cx| {
+                let action = action.downcast_ref().unwrap();
+
+                if phase == DispatchPhase::Bubble {
+                    listener(&mut input_handler.lock(), action, cx);
+
+                    cx.refresh();
+                }
+            }
+        });
+    }
+}
+
+macro_rules! impl_selection_modifier {
+    {$fn_name:ident, $action:ident} => {
+        fn $fn_name(&self, _: &$action, text: &SharedString, cx: &mut WindowContext) {
+            self.selection.update(cx, |this, cx| {
+                if let Some(this) = this.as_mut() {
+                    this.$fn_name(text.as_ref());
+                    cx.notify();
+                }
+            });
+        }
+    };
+}
+
+macro_rules! impl_all_selection_modifiers {
+    ($(($fn_name:ident, $action:ident)),+) => {
+        impl EditableTextState {
+            $(
+                impl_selection_modifier!{$fn_name, $action}
+            )+
+        }
+    };
+}
+
+impl_all_selection_modifiers!(
+    (move_left, MoveLeft),
+    (move_right, MoveRight),
+    (move_to_beginning, MoveToBeginning),
+    (move_to_end, MoveToEnd),
+    (move_to_next_word_end, MoveToNextWordEnd),
+    (move_to_previous_word_start, MoveToPreviousWordStart),
+    (select_all, SelectAll),
+    (select_left, SelectLeft),
+    (select_right, SelectRight),
+    (select_to_beginning, SelectToBeginning),
+    (select_to_end, SelectToEnd),
+    (select_to_next_word_end, SelectToNextWordEnd),
+    (select_to_previous_word_start, SelectToPreviousWordStart)
+);
+
+impl EditableTextState {
+    fn move_down(&self, _: &MoveDown, text: &SharedString, cx: &mut WindowContext) {
+        let Some(selection) = self.selection.read(cx).clone() else {
+            return;
+        };
+
+        if self.text_state.is_none() || self.bounds.is_none() {
+            return;
+        }
+
+        let text_state = self.text_state.clone().unwrap();
+        let bounds = self.bounds.unwrap();
+
+        let Some(mut position) = self
+            .text_state
+            .clone()
+            .unwrap()
+            .position_for_index(bounds, selection.span.start)
+        else {
+            return;
+        };
+
+        position.y += text_state.line_height() * Pixels(1.5);
+
+        let index = if let Some(mut index) = text_state.index_for_position(bounds, position) {
+            index
+        } else {
+            // Either current is last line or line below is a newline.
+            selection.get_next_line_start(text)
+        };
+
+        self.selection.update(cx, |this, cx| {
+            if let Some(this) = this.as_mut() {
+                this.span = index..index;
+                cx.notify();
+            }
+        });
+    }
+
+    fn move_up(&self, _: &MoveUp, text: &SharedString, cx: &mut WindowContext) {
+        let Some(selection) = self.selection.read(cx).clone() else {
+            return;
+        };
+
+        if self.text_state.is_none() || self.bounds.is_none() {
+            return;
+        }
+
+        let text_state = self.text_state.clone().unwrap();
+        let bounds = self.bounds.unwrap();
+
+        let Some(mut position) = text_state.position_for_index(bounds, selection.span.start) else {
+            return;
+        };
+
+        position.y -= text_state.line_height() / 2.;
+
+        let index = if let Some(mut index) = text_state.index_for_position(bounds, position) {
+            index
+        } else {
+            // Either current is first line or line above is a newline.
+            selection.get_previous_line_end(text)
+        };
+
+        self.selection.update(cx, |this, cx| {
+            if let Some(this) = this.as_mut() {
+                this.span = index..index;
+                cx.notify();
+            }
+        });
+    }
+}
+
+impl EditableText {
+    fn into_input_handler(&self, state: &EditableTextState) -> EditableTextInputHandler {
+        EditableTextInputHandler::new(self, state)
+    }
+}
+
+struct EditableTextInputHandler {
+    state: EditableTextState,
+    kind: Kind,
+    value: Model<String>,
+    enter_listener: Option<Arc<dyn Fn(&mut WindowContext<'_>)>>,
+    focus_next_listener: Option<Arc<dyn Fn(&mut WindowContext<'_>)>>,
+    focus_prev_listener: Option<Arc<dyn Fn(&mut WindowContext<'_>)>>,
+}
+
+impl EditableTextInputHandler {
+    fn new(current: &EditableText, state: &EditableTextState) -> Self {
+        Self {
+            state: state.clone(),
+            kind: current.kind.clone(),
+            value: current.value.clone(),
+            enter_listener: current.enter_listener.clone(),
+            focus_next_listener: current.focus_next_listener.clone(),
+            focus_prev_listener: current.focus_prev_listener.clone(),
+        }
+    }
+}
+
+impl EditableTextInputHandler {
+    fn backspace(&mut self, _: &Backspace, cx: &mut WindowContext) {
+        let mut selection = self.state.selection.read(cx).clone().unwrap();
+
+        if selection.is_empty() {
+            let mut selection = selection.clone();
+            selection.select_left(self.value.read(cx).as_ref());
+            let mut new_selection = selection.clone();
+            new_selection.span.end = new_selection.span.start;
+            self.handle_transaction(
+                ReplaceTextInRangeAndSelect::new(
+                    "".to_string().into(),
+                    Some(selection.span.clone()),
+                    new_selection,
+                ),
+                cx,
+            );
+        } else {
+            let mut selection = selection.clone();
+            selection.move_left(self.value.read(cx).as_ref());
+            self.handle_transaction(
+                ReplaceTextInRangeAndSelect::new("".to_string().into(), None, selection.clone()),
+                cx,
+            );
+        }
+    }
+
+    fn copy(&mut self, _: &Copy, cx: &mut WindowContext) {
+        if let Some(selection) = self.state.selection.read(cx) {
+            let text = &self.value.read(cx)[selection.span.clone()];
+
+            cx.write_to_clipboard(ClipboardItem::new(text.into()));
+        }
+    }
+
+    fn cut(&mut self, _: &Cut, cx: &mut WindowContext) {
+        if let Some(selection) = self.state.selection.read(cx) {
+            cx.write_to_clipboard(ClipboardItem::new(
+                self.value.read(cx)[selection.span.clone()].into(),
+            ));
+
+            self.delete(&Delete, cx);
+        }
+    }
+
+    fn delete(&mut self, _: &Delete, cx: &mut WindowContext) {
+        if let Some(selection) = self.state.selection.read(cx) {
+            self.replace_text_in_range(Some(selection.span.clone()), "", cx);
+        }
+    }
+
+    fn newline(&mut self, _: &Newline, cx: &mut WindowContext) {
+        if matches!(self.kind, Kind::Singline) {
+            if let Some(listener) = &self.enter_listener {
+                listener(cx);
+            }
+        } else {
+            if let Some(selection) = self.state.selection.read(cx) {
+                self.replace_text_in_range(Some(selection.span.clone()), "\n", cx);
+            }
+        }
+    }
+
+    fn paste(&mut self, _: &Paste, cx: &mut WindowContext) {
+        if let Some(value) = cx.read_from_clipboard() {
+            let selection = self.state.selection.read(cx).as_ref().unwrap();
+
+            self.replace_text_in_range(Some(selection.span.clone()), value.text(), cx);
+        }
+    }
+
+    fn redo(&mut self, _: &Redo, cx: &mut WindowContext) {
+        self.state.history.update(cx, |history, cx| {
+            self.state.selection.update(cx, |selection, cx| {
+                if let Some(selection) = selection {
+                    self.value.update(cx, |value, _cx| {
+                        history.redo(value, selection);
+                    });
+                }
+            });
+        });
+    }
+
+    fn tab(&mut self, _: &Tab, cx: &mut WindowContext) {
+        if let Some(listener) = &self.focus_next_listener {
+            listener(cx);
+        }
+    }
+
+    fn tab_prev(&mut self, _: &TabPrev, cx: &mut WindowContext) {
+        if let Some(listener) = &self.focus_prev_listener {
+            listener(cx);
+        }
+    }
+
+    fn undo(&mut self, _: &Undo, cx: &mut WindowContext) {
+        self.state.history.update(cx, |history, cx| {
+            self.state.selection.update(cx, |selection, cx| {
+                if let Some(selection) = selection {
+                    self.value.update(cx, |value, _cx| {
+                        history.undo(value, selection);
+                    });
+                }
+            });
+        });
+    }
+}
+
+impl EditableTextInputHandler {
+    fn handle_transaction(&mut self, tx: impl Transaction + 'static, cx: &mut WindowContext) {
+        self.state.history.update(cx, |history, cx| {
+            self.state.selection.update(cx, |selection, cx| {
+                if let Some(selection) = selection {
+                    self.value.update(cx, |value, _cx| {
+                        history.apply(tx, value, selection);
+                    });
+                }
+            });
+        });
+
+        cx.refresh();
+    }
+}
+
+impl InputHandler for EditableTextInputHandler {
+    fn selected_text_range(&mut self, cx: &mut WindowContext) -> Option<Range<usize>> {
+        self.state
+            .selection
+            .read(cx)
+            .clone()
+            .map(|selection| selection.span)
+    }
+
+    fn marked_text_range(&mut self, cx: &mut WindowContext) -> Option<Range<usize>> {
+        self.state.marked.read(cx).clone()
+    }
+
+    fn text_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        cx: &mut WindowContext,
+    ) -> Option<String> {
+        self.value.read(cx).get(range_utf16).map(ToOwned::to_owned)
+    }
+
+    fn replace_text_in_range(
+        &mut self,
+        replacement_range: Option<Range<usize>>,
+        text: &str,
+        cx: &mut WindowContext,
+    ) {
+        self.handle_transaction(
+            ReplaceTextInRange::new(text.to_owned().into(), replacement_range),
+            cx,
+        );
+    }
+
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        range_utf16: Option<Range<usize>>,
+        new_text: &str,
+        new_selected_range: Option<Range<usize>>,
+        cx: &mut WindowContext,
+    ) {
+        // TODO: confirm this is correct functionality.
+
+        self.replace_text_in_range(range_utf16, new_text, cx);
+
+        self.state.marked.update(cx, |this, cx| {
+            *this = new_selected_range;
+            cx.notify();
+        });
+    }
+
+    fn unmark_text(&mut self, cx: &mut WindowContext) {
+        self.state.marked.update(cx, |this, cx| {
+            *this = None;
+            cx.notify();
+        })
+    }
+
+    fn bounds_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        _cx: &mut WindowContext,
+    ) -> Option<Bounds<Pixels>> {
+        if self.state.text_state.is_none() || self.state.bounds.is_none() {
+            return None;
+        }
+
+        let text_state = self.state.text_state.clone().unwrap();
+        let containing_bounds = self.state.bounds.unwrap();
+
+        let Some(start_position) =
+            text_state.position_for_index(containing_bounds, range_utf16.start)
+        else {
+            return None;
+        };
+
+        let Some(end_position) =
+            text_state.position_for_index(containing_bounds, range_utf16.start)
+        else {
+            return None;
+        };
+
+        // TODO: confirm this works. Just wanna get a draft up and don't know much about IME.
+        // - Might need to adjust for containing bounds
+        // - Might need to adjust for width of final glyph
+
+        Some(Bounds {
+            origin: start_position,
+            size: Size {
+                width: end_position.x - start_position.x,
+                height: text_state.line_height(),
+            },
+        })
+    }
+}

--- a/crates/gpui/src/elements/text/editable/selection.rs
+++ b/crates/gpui/src/elements/text/editable/selection.rs
@@ -1,0 +1,237 @@
+use std::ops::Range;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Clone, Debug)]
+pub struct Selection {
+    /// The direction the selection is trending towards.
+    pub direction: Direction,
+    /// The range the selection covers.
+    pub span: Range<usize>,
+}
+
+impl From<Range<usize>> for Selection {
+    fn from(value: Range<usize>) -> Self {
+        Self {
+            direction: Direction::Right,
+            span: value,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Direction {
+    Left,
+    Right,
+}
+
+impl Selection {
+    pub fn new(from: usize, to: usize) -> Self {
+        let start = from.min(to);
+        let end = from.max(to);
+
+        Self {
+            span: start..end,
+            direction: if from > to {
+                Direction::Left
+            } else {
+                Direction::Right
+            },
+        }
+    }
+
+    pub fn not_empty(&self) -> bool {
+        !self.is_empty()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        Range::is_empty(&self.span)
+    }
+
+    pub fn is_left(&self) -> bool {
+        matches!(self.direction, Direction::Left)
+    }
+
+    pub fn position(&self) -> usize {
+        if self.is_left() {
+            self.span.start
+        } else {
+            self.span.end
+        }
+    }
+
+    pub fn get_left(&self, text: &str, from: usize) -> usize {
+        text[..from]
+            .grapheme_indices(true)
+            .next_back()
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    }
+
+    pub fn get_right(&self, text: &str, from: usize) -> usize {
+        text[from..]
+            .grapheme_indices(true)
+            .skip(1)
+            .next()
+            .map(|(i, _)| i + from)
+            .unwrap_or(text.len())
+    }
+
+    fn get_next_word_end_index(&self, text: &str, from: usize) -> usize {
+        text[from..]
+            .split_word_bound_indices()
+            .next()
+            .map(|(i, word)| from + i + word.len())
+            .unwrap_or(text.len())
+    }
+
+    fn get_previous_word_start_index(&self, text: &str, from: usize) -> usize {
+        text[..from]
+            .split_word_bound_indices()
+            .next_back()
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    }
+
+    fn get_end(&self, text: &str) -> usize {
+        text.grapheme_indices(true)
+            .next_back()
+            .map(|(i, _)| i)
+            .unwrap_or(self.span.end)
+    }
+
+    pub fn get_next_line_start(&self, text: &str) -> usize {
+        let from = self.position();
+
+        if let Some(current) = text[from..].lines().next() {
+            let maybe = from + current.len() + 1;
+
+            if maybe < text.len() {
+                maybe
+            } else {
+                // Is currently in last line.
+                from
+            }
+        } else {
+            from
+        }
+    }
+
+    pub fn get_previous_line_end(&self, text: &str) -> usize {
+        let from = self.position();
+
+        if let Some(current) = text[..from].lines().next_back() {
+            from - current.len() - 1
+        } else {
+            from
+        }
+    }
+}
+
+impl Selection {
+    pub fn move_left(&mut self, text: &str) {
+        if self.is_empty() {
+            let left = self.get_left(text, self.span.start);
+
+            self.span = left..left;
+        } else {
+            self.span.end = self.span.start;
+        }
+    }
+
+    pub fn move_right(&mut self, text: &str) {
+        if Range::is_empty(&self.span) {
+            let right = self.get_right(text, self.span.start);
+
+            self.span = right..right;
+        } else {
+            self.span.start = self.span.end;
+        }
+    }
+
+    pub fn move_to_beginning(&mut self, _: &str) {
+        self.span = 0..0;
+    }
+
+    pub fn move_to_end(&mut self, text: &str) {
+        let end = text.len();
+
+        self.span = end..end;
+    }
+
+    pub fn move_to_next_word_end(&mut self, text: &str) {
+        let from = match self.direction {
+            Direction::Left => self.span.start,
+            Direction::Right => self.span.end,
+        };
+
+        let next_word_end = self.get_next_word_end_index(text, from);
+
+        self.span = next_word_end..next_word_end;
+    }
+
+    pub fn move_to_previous_word_start(&mut self, text: &str) {
+        let from = match self.direction {
+            Direction::Left => self.span.start,
+            Direction::Right => self.span.end,
+        };
+
+        let previous_word_start = self.get_previous_word_start_index(text, from);
+
+        self.span = previous_word_start..previous_word_start;
+    }
+
+    pub fn select_all(&mut self, text: &str) {
+        self.span = 0..self.get_end(text);
+    }
+
+    pub fn select_left(&mut self, text: &str) {
+        if self.is_empty() || self.is_left() {
+            self.span.start = self.get_left(text, self.span.start);
+            self.direction = Direction::Left;
+        } else {
+            self.span.end = self.get_left(text, self.span.start);
+        }
+    }
+
+    pub fn select_right(&mut self, text: &str) {
+        if self.is_empty() || !self.is_left() {
+            self.span.end = self.get_right(text, self.span.end);
+            self.direction = Direction::Right;
+        } else {
+            self.span.start = self.get_right(text, self.span.start);
+        }
+    }
+
+    pub fn select_to_beginning(&mut self, _text: &str) {
+        self.span.start = 0;
+        self.direction = Direction::Left;
+    }
+
+    pub fn select_to_end(&mut self, text: &str) {
+        self.span.end = text.len();
+        self.direction = Direction::Right;
+    }
+
+    pub fn select_to_next_word_end(&mut self, text: &str) {
+        if self.is_empty() {
+            self.span.end = self.get_next_word_end_index(text, self.span.end);
+            self.direction = Direction::Right;
+        } else if self.is_left() {
+            self.span.start = self.span.end;
+        } else {
+            self.span.end = self.get_next_word_end_index(text, self.span.end);
+        }
+    }
+
+    pub fn select_to_previous_word_start(&mut self, text: &str) {
+        if self.is_empty() {
+            self.span.start = self.get_previous_word_start_index(text, self.span.start);
+            self.direction = Direction::Left;
+        } else if self.is_left() {
+            self.span.start = self.get_previous_word_start_index(text, self.span.start);
+        } else {
+            self.span.end = self.span.start;
+        }
+    }
+}

--- a/crates/gpui/src/elements/text/editable/transaction.rs
+++ b/crates/gpui/src/elements/text/editable/transaction.rs
@@ -1,0 +1,151 @@
+use std::{fmt::Debug, ops::Range};
+
+use crate::SharedString;
+
+use super::selection::Selection;
+
+pub trait Transaction: Debug {
+    fn apply(&mut self, value: &mut String, selection: &mut Selection);
+    fn revert(&mut self, value: &mut String, selection: &mut Selection);
+}
+
+#[derive(Debug)]
+pub struct ReplaceTextInRange {
+    text: SharedString,
+    range: Option<Range<usize>>,
+    undo: Option<Box<dyn Transaction>>,
+}
+
+impl ReplaceTextInRange {
+    pub fn new(text: SharedString, range: Option<Range<usize>>) -> Self {
+        Self {
+            text,
+            range,
+            undo: None,
+        }
+    }
+}
+
+impl Transaction for ReplaceTextInRange {
+    fn apply(&mut self, value: &mut String, selection: &mut Selection) {
+        let old_selection = selection.clone();
+
+        let old_selected_text = value[old_selection.span.clone()].to_owned();
+
+        value.replace_range(old_selection.span.clone(), &self.text);
+
+        let next_index = old_selection.span.start + self.text.len();
+
+        selection.span = next_index..next_index;
+
+        self.undo = Some(Box::new(ReplaceTextInRangeAndSelect {
+            range: Some(old_selection.span.start..old_selection.span.start + self.text.len()),
+            text: old_selected_text.into(),
+            new_selection: old_selection,
+            undo: None,
+        }));
+    }
+
+    fn revert(&mut self, value: &mut String, selection: &mut Selection) {
+        self.undo
+            .as_mut()
+            .expect("has not been applied")
+            .apply(value, selection);
+    }
+}
+
+#[derive(Debug)]
+pub struct ReplaceTextInRangeAndSelect {
+    text: SharedString,
+    range: Option<Range<usize>>,
+    new_selection: Selection,
+    undo: Option<Box<dyn Transaction>>,
+}
+
+impl ReplaceTextInRangeAndSelect {
+    pub fn new(text: SharedString, range: Option<Range<usize>>, new_selection: Selection) -> Self {
+        Self {
+            text,
+            range,
+            new_selection,
+            undo: None,
+        }
+    }
+}
+
+impl Transaction for ReplaceTextInRangeAndSelect {
+    fn apply(&mut self, value: &mut String, selection: &mut Selection) {
+        let (range, select_in_undo) = if let Some(range) = &self.range {
+            (range, false)
+        } else {
+            (&selection.span, true)
+        };
+
+        let old_text_in_range = value[range.clone()].to_owned();
+
+        value.replace_range(range.clone(), &self.text);
+
+        let old_selection = selection.clone();
+
+        *selection = self.new_selection.clone();
+
+        self.undo = Some(if select_in_undo {
+            Box::new(ReplaceTextInRangeAndSelect {
+                range: None,
+                text: old_text_in_range.into(),
+                new_selection: old_selection,
+                undo: None,
+            })
+        } else {
+            Box::new(ReplaceTextInRange {
+                range: None,
+                text: old_text_in_range.into(),
+                undo: None,
+            })
+        });
+    }
+
+    fn revert(&mut self, value: &mut String, selection: &mut Selection) {
+        self.undo
+            .as_mut()
+            .expect("has not been applied")
+            .apply(value, selection);
+    }
+}
+
+#[derive(Default)]
+pub struct History {
+    undo_stack: Vec<Box<dyn Transaction>>,
+    redo_stack: Vec<Box<dyn Transaction>>,
+}
+
+impl History {
+    pub fn apply(
+        &mut self,
+        mut tx: impl Transaction + 'static,
+        value: &mut String,
+        selection: &mut Selection,
+    ) {
+        tx.apply(value, selection);
+
+        self.undo_stack.push(Box::new(tx));
+
+        if !self.redo_stack.is_empty() {
+            self.redo_stack.clear();
+        }
+    }
+
+    pub fn undo(&mut self, value: &mut String, selection: &mut Selection) {
+        if let Some(mut tx) = self.undo_stack.pop() {
+            tx.revert(value, selection);
+            self.redo_stack.push(tx);
+        }
+    }
+
+    pub fn redo(&mut self, value: &mut String, selection: &mut Selection) {
+        if let Some(mut tx) = self.redo_stack.pop() {
+            tx.apply(value, selection);
+            self.undo_stack.push(tx);
+        }
+    }
+}


### PR DESCRIPTION
Release Notes:

- Adds an element to gpui that allows editing the data in a `Model<String>`

Test with the `editable_text` example.

```shell
cargo run -p gpui --example editable_text
```

There is definitely some fine tuning to be done, but I wanted to put a draft up to see if there were any comments on the design or direction. Everything is pretty basic but it seems to work for just basic string manipulation. Here are some known problems:

- Mouse down doesn't get reset when mouse up happens outside the text (should be a quick fix)
- Multi line text data can be passed to the element in single line mode and not much changes
- Need to do select down/select up for multi line. I forgot about it
- Multiline support in general is a bit off
- If a line contains only a newline, you cant move the cursor to it by clicking it. The index_for_position code needs to be modified a bit more
- Much more I'm sure. I just kind of brute forced the design. For example it would probably make sense to accept a view that implements `ViewInputHandler` as well as just a `Model<String>` with a custom `InputHandler`.
- I'm sure there are some optimizations that could be done.


https://github.com/zed-industries/zed/assets/11557758/7dac6fdf-31b7-4fac-8ded-b807966bbd66

