### PR TITLE
Add support for reading proxy from settings or system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9593,6 +9593,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys 0.8.6",
+ "libc",
+]
+
+[[package]]
 name = "system-interface"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11025,6 +11046,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "system-configuration",
  "take-until",
  "tempfile",
  "tendril",

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -8,7 +8,9 @@ use util::asset_str;
 
 pub use keymap_file::KeymapFile;
 pub use settings_file::*;
-pub use settings_store::{Settings, SettingsJsonSchemaParams, SettingsLocation, SettingsStore};
+pub use settings_store::{
+    parse_json_with_comments, Settings, SettingsJsonSchemaParams, SettingsLocation, SettingsStore,
+};
 
 #[derive(RustEmbed)]
 #[folder = "../../assets"]

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -37,6 +37,9 @@ tempfile = { workspace = true, optional = true }
 unicase.workspace = true
 url.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+system-configuration = "0.5.1"
+
 [target.'cfg(windows)'.dependencies]
 tendril = "0.4.3"
 

--- a/crates/util/src/http.rs
+++ b/crates/util/src/http.rs
@@ -1,4 +1,4 @@
-use crate::http_proxy_from_env;
+use crate::proxy::http_proxy_from_env;
 pub use anyhow::{anyhow, Result};
 use futures::future::BoxFuture;
 use futures_lite::FutureExt;

--- a/crates/util/src/proxy.rs
+++ b/crates/util/src/proxy.rs
@@ -1,0 +1,108 @@
+#[cfg(target_os = "macos")]
+use system_configuration::{
+    core_foundation::{
+        base::CFType,
+        dictionary::CFDictionary,
+        number::CFNumber,
+        string::{CFString, CFStringRef},
+    },
+    dynamic_store::SCDynamicStoreBuilder,
+    sys::schema_definitions::{
+        kSCPropNetProxiesHTTPEnable, kSCPropNetProxiesHTTPPort, kSCPropNetProxiesHTTPProxy,
+        kSCPropNetProxiesHTTPSEnable, kSCPropNetProxiesHTTPSPort, kSCPropNetProxiesHTTPSProxy,
+        kSCPropNetProxiesSOCKSEnable, kSCPropNetProxiesSOCKSPort, kSCPropNetProxiesSOCKSProxy,
+    },
+};
+
+pub fn http_proxy_from_env() -> Option<isahc::http::Uri> {
+    let all_keys = [
+        "ALL_PROXY",
+        "all_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+    ];
+    for env_key in all_keys {
+        if let Ok(env) = std::env::var(env_key) {
+            return env.parse::<isahc::http::Uri>().ok();
+        }
+    }
+    proxy_from_platform()
+}
+
+#[cfg(target_os = "macos")]
+fn proxy_from_platform() -> Option<isahc::http::Uri> {
+    let store_map = SCDynamicStoreBuilder::new("Zed").build();
+    let Some(proxies_map) = store_map.get_proxies() else {
+        return None;
+    };
+    unsafe {
+        let entries = [
+            (
+                "http",
+                kSCPropNetProxiesHTTPEnable,
+                kSCPropNetProxiesHTTPProxy,
+                kSCPropNetProxiesHTTPPort,
+            ),
+            (
+                "https",
+                kSCPropNetProxiesHTTPSEnable,
+                kSCPropNetProxiesHTTPSProxy,
+                kSCPropNetProxiesHTTPSPort,
+            ),
+            (
+                "socks5",
+                kSCPropNetProxiesSOCKSEnable,
+                kSCPropNetProxiesSOCKSProxy,
+                kSCPropNetProxiesSOCKSPort,
+            ),
+        ];
+        for entry in entries {
+            if let Some(url) =
+                load_url_from_dynamic_store(&proxies_map, entry.1, entry.2, entry.3, entry.0)
+            {
+                return url.parse().ok();
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn load_url_from_dynamic_store(
+    proxies_map: &CFDictionary<CFString, CFType>,
+    type_key: CFStringRef,
+    host_key: CFStringRef,
+    port_key: CFStringRef,
+    scheme: &str,
+) -> Option<String> {
+    let support = proxies_map
+        .find(type_key)
+        .and_then(|val| val.downcast::<CFNumber>())
+        .and_then(|val| val.to_i32())
+        .unwrap_or_default()
+        == 1;
+    if support {
+        let host_val = proxies_map
+            .find(host_key)
+            .and_then(|val| val.downcast::<CFString>())
+            .map(|val| val.to_string());
+        let port_val = proxies_map
+            .find(port_key)
+            .and_then(|val| val.downcast::<CFNumber>())
+            .and_then(|val| val.to_i32());
+
+        return match (host_val, port_val) {
+            (Some(host), Some(port)) => Some(format!("{}://{}:{}", scheme, host, port)),
+            (Some(host), None) => Some(format!("{}://{}", scheme, host)),
+            _ => None,
+        };
+    }
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+fn proxy_from_platform() -> Option<isahc::http::Uri> {
+    None
+}

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -3,6 +3,7 @@ pub mod fs;
 pub mod github;
 pub mod http;
 pub mod paths;
+pub mod proxy;
 mod semantic_version;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test;
@@ -42,28 +43,6 @@ pub fn truncate(s: &str, max_chars: usize) -> &str {
         None => s,
         Some((idx, _)) => &s[..idx],
     }
-}
-
-pub fn http_proxy_from_env() -> Option<isahc::http::Uri> {
-    macro_rules! try_env {
-        ($($env:literal),+) => {
-            $(
-                if let Ok(env) = std::env::var($env) {
-                    return env.parse::<isahc::http::Uri>().ok();
-                }
-            )+
-        };
-    }
-
-    try_env!(
-        "ALL_PROXY",
-        "all_proxy",
-        "HTTPS_PROXY",
-        "https_proxy",
-        "HTTP_PROXY",
-        "http_proxy"
-    );
-    None
 }
 
 /// Removes characters from the end of the string if its length is greater than `max_chars` and

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -539,18 +539,22 @@ fn init_stdout_logger() {
 }
 
 fn init_proxy() {
-    let Some(mut fp) = std::fs::File::open(&*paths::SETTINGS).log_err() else {
+    let Some(mut settings_file) = std::fs::File::open(&*paths::SETTINGS).log_err() else {
         return;
     };
     let mut settings_json = String::new();
-    if fp.read_to_string(&mut settings_json).log_err().is_none() {
+    if settings_file
+        .read_to_string(&mut settings_json)
+        .log_err()
+        .is_none()
+    {
         return;
     }
-    let settings: serde_json::Value =
+    let settings_value: serde_json::Value =
         settings::parse_json_with_comments(&settings_json).unwrap_or_default();
-    if let Some(proxys) = settings.get("proxy") {
-        if let Some(proxys_map) = proxys.as_object() {
-            for (k_str, v_val) in proxys_map {
+    if let Some(proxies) = settings_value.get("proxy") {
+        if let Some(proxies_map) = proxies.as_object() {
+            for (k_str, v_val) in proxies_map {
                 let v_str = v_val.as_str().unwrap_or_default();
                 if k_str.is_empty() || v_str.is_empty() {
                     continue;
@@ -558,10 +562,10 @@ fn init_proxy() {
                 std::env::set_var(k_str.to_lowercase(), v_str.to_lowercase());
             }
         } else {
-            log::error!("not supported proxys: {:?}", proxys);
+            log::error!("not supported proxies: {:?}", proxies);
         }
     } else {
-        log::error!("could load proxy from settings");
+        log::error!("could not load proxy from settings");
     }
 }
 


### PR DESCRIPTION

Release Notes:

- Added support for reading proxy from settings or system

The `proxy` in settings can be configured as follows:
```json
{
  "proxy": {
    "http_proxy": "http://127.0.0.1:7890",
    "all_proxy": "socks5://127.0.0.1:7890"
  }
}
```