### PR TITLE
windows: Avoid recording minimized position to database

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -171,6 +171,7 @@ unsafe impl Send for DisplayId {}
 pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn bounds(&self) -> Bounds<GlobalPixels>;
     fn is_maximized(&self) -> bool;
+    fn is_minimized(&self) -> bool;
     fn content_size(&self) -> Size<Pixels>;
     fn scale_factor(&self) -> f32;
     fn appearance(&self) -> WindowAppearance;

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -283,6 +283,11 @@ impl PlatformWindow for WaylandWindow {
         false
     }
 
+    // todo(linux)
+    fn is_minimized(&self) -> bool {
+        false
+    }
+
     fn content_size(&self) -> Size<Pixels> {
         let inner = self.0.inner.borrow();
         Size {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -338,6 +338,11 @@ impl PlatformWindow for X11Window {
         false
     }
 
+    // todo(linux)
+    fn is_minimized(&self) -> bool {
+        false
+    }
+
     fn content_size(&self) -> Size<Pixels> {
         self.0.inner.borrow_mut().content_size()
     }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -419,6 +419,11 @@ impl MacWindowState {
         }
     }
 
+    // todo(macos)
+    fn is_minimized(&self) -> bool {
+        false
+    }
+
     fn is_fullscreen(&self) -> bool {
         unsafe {
             let style_mask = self.native_window.styleMask();
@@ -726,6 +731,10 @@ impl PlatformWindow for MacWindow {
 
     fn is_maximized(&self) -> bool {
         self.0.as_ref().lock().is_maximized()
+    }
+
+    fn is_minimized(&self) -> bool {
+        self.0.as_ref().lock().is_minimized()
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -115,6 +115,10 @@ impl PlatformWindow for TestWindow {
         false
     }
 
+    fn is_minimized(&self) -> bool {
+        false
+    }
+
     fn content_size(&self) -> Size<Pixels> {
         self.bounds().size.into()
     }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -126,12 +126,11 @@ impl WindowsWindowInner {
     }
 
     fn is_maximized(&self) -> bool {
-        let mut placement = WINDOWPLACEMENT::default();
-        placement.length = std::mem::size_of::<WINDOWPLACEMENT>() as u32;
-        if unsafe { GetWindowPlacement(self.hwnd, &mut placement) }.is_ok() {
-            return placement.showCmd == SW_SHOWMAXIMIZED.0 as u32;
-        }
-        return false;
+        unsafe { IsZoomed(self.hwnd) }.as_bool()
+    }
+
+    fn is_minimized(&self) -> bool {
+        unsafe { IsIconic(self.hwnd) }.as_bool()
     }
 
     pub(crate) fn title_bar_padding(&self) -> Pixels {
@@ -1190,10 +1189,6 @@ impl WindowsWindow {
         unsafe { ShowWindow(wnd.inner.hwnd, SW_SHOW) };
         wnd
     }
-
-    fn maximize(&self) {
-        unsafe { ShowWindowAsync(self.inner.hwnd, SW_MAXIMIZE) };
-    }
 }
 
 impl HasWindowHandle for WindowsWindow {
@@ -1235,6 +1230,10 @@ impl PlatformWindow for WindowsWindow {
 
     fn is_maximized(&self) -> bool {
         self.inner.is_maximized()
+    }
+
+    fn is_minimized(&self) -> bool {
+        self.inner.is_minimized()
     }
 
     /// get the logical size of the app's drawable area.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -721,6 +721,12 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.is_maximized()
     }
 
+    /// Check if the platform window is minimized
+    /// On some platforms (namely Windows) the position is incorrect when minimized
+    pub fn is_minimized(&self) -> bool {
+        self.window.platform_window.is_minimized()
+    }
+
     /// Dispatch the given action on the currently focused element.
     pub fn dispatch_action(&mut self, action: Box<dyn Action>) {
         let focus_handle = self.focused();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -754,7 +754,7 @@ impl Workspace {
                             cx.background_executor()
                                 .spawn(DB.set_fullscreen(workspace_id, true))
                                 .detach_and_log_err(cx);
-                        } else {
+                        } else if !cx.is_minimized() {
                             cx.background_executor()
                                 .spawn(DB.set_fullscreen(workspace_id, false))
                                 .detach_and_log_err(cx);


### PR DESCRIPTION
Minimizing window records strange position to DB. When Zed is restarted, the window goes far away.
<img width="975" alt="image" src="https://github.com/zed-industries/zed/assets/6465609/98dbab71-fdbb-4911-b41a-9c3e498e5478">

So I fixed.

Release Notes:

- N/A
