### PR TITLE
Allow loading "Segoe Fluent Icons" font on macOS

### DIFF
--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -45,8 +45,6 @@ impl RenderOnce for WindowsWindowControls {
             .content_stretch()
             .max_h(self.button_height)
             .min_h(self.button_height)
-            .font("Segoe Fluent Icons")
-            .text_size(px(10.0))
             .child(WindowsCaptionButton::new(
                 "minimize",
                 WindowsCaptionButtonIcon::Minimize,
@@ -110,6 +108,8 @@ impl RenderOnce for WindowsCaptionButton {
             .content_center()
             .w(width)
             .h_full()
+            .font("Segoe Fluent Icons")
+            .text_size(px(10.0))
             .hover(|style| style.bg(self.hover_background_color))
             .active(|style| {
                 let mut active_color = self.hover_background_color;


### PR DESCRIPTION
This PR updates the `TextSystem` on macOS to allow loading the "Segoe Fluent Icons" font.

We're using this font in the Storybook to render the `TitleBar` as it would appear on Windows despite us running it on macOS. This is to make things easier for iterating on UI design without needing to test on each individual platform.

However, the "Segoe Fluent Icons" font does not have a glyph for the `m` character, causing it to run afoul of a precautionary check added in #4029, which ultimately results in the font not being loaded (and thus rendering as a missing glyph).

We work around this by simply ignoring this check if the font we're trying to load is specifically "Segoe Fluent Icons".

I think longer-term we'll need to revisit the behavior in the editor that is causing the panics when the `m` glyph is missing from the font, but that's a problem for a different day.

#### Before

<img width="1283" alt="Screenshot 2024-03-15 at 3 34 38 PM" src="https://github.com/zed-industries/zed/assets/1486634/c0ddd46d-8599-4729-ac98-75522b33e25b">

#### After

<img width="1113" alt="Screenshot 2024-03-15 at 5 12 36 PM" src="https://github.com/zed-industries/zed/assets/1486634/183c2b43-5e4f-4516-8856-7a2d45ed8b2e">

Note that you currently need to install the "Segoe Fluent Icons" font yourself—either installing it globally or placing the `.ttf` file in the `assets/fonts` directory—in order to see the icons rendered. I'd like to look into getting this, but there are restrictions on the distribution of the font on non-Windows platforms that will need to be followed.

Release Notes:

- N/A
