### PR TITLE
Fix segfault in "install:cli" when app is not yet installed

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -553,6 +553,11 @@ impl Platform for MacPlatform {
             let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
             let scheme: id = ns_string(scheme);
             let app: id = msg_send![workspace, URLForApplicationWithBundleIdentifier: bundle_id];
+            if app == nil {
+                return Task::ready(Err(anyhow!(
+                    "Cannot register URL scheme until app is installed"
+                )));
+            }
             let done_tx = Cell::new(Some(done_tx));
             let block = ConcreteBlock::new(move |error: id| {
                 let result = if error == nil {


### PR DESCRIPTION
Release Notes:

- Fixed a panic running `cli: Install` or `cli: Register Zed Scheme` before installing the app.
