### PR TITLE
gpui: Add SVG rendering to `img` element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,12 +240,6 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
@@ -2933,12 +2927,9 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "data-url"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
-dependencies = [
- "matches",
-]
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "db"
@@ -3584,6 +3575,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "feature_flags"
 version = "0.1.0"
 dependencies = [
@@ -3690,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.5.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75224bec9bfe1a65e2d34132933f2de7fe79900c96a0174307554244ece8150e"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "float-ord"
@@ -3754,18 +3754,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d"
 dependencies = [
- "roxmltree 0.19.0",
-]
-
-[[package]]
-name = "fontdb"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58903f4f8d5b58c7d300908e4ebe5289c1bfdf5587964330f12023b8ff17fd1"
-dependencies = [
- "log",
- "memmap2 0.2.3",
- "ttf-parser 0.12.3",
+ "roxmltree",
 ]
 
 [[package]]
@@ -3780,6 +3769,20 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser 0.19.2",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2 0.9.4",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -4141,6 +4144,16 @@ name = "gif"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
 dependencies = [
  "color_quant",
  "weezl",
@@ -4754,17 +4767,18 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "gif",
- "jpeg-decoder",
+ "gif 0.11.4",
+ "jpeg-decoder 0.1.22",
  "num-iter",
  "num-rational 0.3.2",
  "num-traits",
- "png",
+ "png 0.16.8",
  "scoped_threadpool",
  "tiff",
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "image_viewer"
 version = "0.1.0"
 dependencies = [
@@ -4776,6 +4790,12 @@ dependencies = [
  "util",
  "workspace",
 ]
+=======
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+>>>>>>> ec2647a64 (gpui: Add SVG rendering to img element)
 
 [[package]]
 name = "indexmap"
@@ -5065,6 +5085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,11 +5146,21 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.8.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449"
+checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440"
+dependencies = [
+ "arrayvec",
+ "smallvec",
 ]
 
 [[package]]
@@ -5636,12 +5672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5687,15 +5717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
  "rustix 0.38.30",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -5804,6 +5825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -6718,7 +6740,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
@@ -6738,9 +6760,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -6846,6 +6868,19 @@ dependencies = [
  "crc32fast",
  "deflate",
  "miniz_oxide 0.3.7",
+]
+
+[[package]]
+name = "png"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -7403,12 +7438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rctree"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9e29cb19c8fe84169fcb07f8f11e66bc9e6e0280efd4715c54818296f8a4a8"
-
-[[package]]
 name = "read-fonts"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7609,16 +7638,17 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.14.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09697862c5c3f940cbaffef91969c62188b5c8ed385b0aef43a5ff01ddc8000f"
+checksum = "024e40e1ba7313fc315b1720298988c0cd6f8bfe3754b52838aafecebd11355a"
 dependencies = [
- "jpeg-decoder",
+ "gif 0.12.0",
+ "jpeg-decoder 0.3.1",
  "log",
  "pico-args",
- "png",
+ "png 0.17.13",
  "rgb",
- "svgfilters",
+ "svgtypes",
  "tiny-skia",
  "usvg",
 ]
@@ -7749,7 +7779,7 @@ dependencies = [
 name = "rope"
 version = "0.1.0"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "bromberg_sl2",
  "gpui",
  "log",
@@ -7757,15 +7787,6 @@ dependencies = [
  "smallvec",
  "sum_tree",
  "util",
-]
-
-[[package]]
-name = "roxmltree"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
-dependencies = [
- "xmlparser",
 ]
 
 [[package]]
@@ -7881,7 +7902,7 @@ version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "borsh",
  "bytes 1.5.0",
  "num-traits",
@@ -8003,22 +8024,6 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rustybuzz"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab463a295d00f3692e0974a0bfd83c7a9bcd119e27e07c2beecdb1b44a09d10"
-dependencies = [
- "bitflags 1.3.2",
- "bytemuck",
- "smallvec",
- "ttf-parser 0.9.0",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-general-category",
- "unicode-script",
-]
-
-[[package]]
-name = "rustybuzz"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa"
@@ -8035,19 +8040,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustybuzz"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ae5692c5beaad6a9e22830deeed7874eae8a4e3ba4076fb48e12c56856222c"
+dependencies = [
+ "bitflags 2.4.2",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser 0.20.0",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "safe_arch"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "safemem"
@@ -8592,6 +8604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8634,12 +8652,6 @@ dependencies = [
  "log",
  "termcolor",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "siphasher"
@@ -9132,6 +9144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9190,7 +9211,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 name = "sum_tree"
 version = "0.1.0"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "ctor",
  "env_logger",
  "log",
@@ -9273,23 +9294,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
-name = "svgfilters"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0dce2fee79ac40c21dafba48565ff7a5fa275e23ffe9ce047a40c9574ba34e"
-dependencies = [
- "float-cmp",
- "rgb",
-]
-
-[[package]]
 name = "svgtypes"
-version = "0.5.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c536faaff1a10837cfe373142583f6e27d81e96beba339147e77b67c9f260ff"
+checksum = "59d7618f12b51be8171a7cfdda1e7a93f79cbc57c4e7adf89a749cf671125241"
 dependencies = [
- "float-cmp",
- "siphasher 0.2.3",
+ "kurbo 0.10.4",
+ "siphasher",
 ]
 
 [[package]]
@@ -9376,7 +9387,7 @@ name = "taffy"
 version = "0.3.11"
 source = "git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b#1876f72bee5e376023eaa518aa7b8a34c769bd1b"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "grid",
  "num-traits",
  "slotmap",
@@ -9666,7 +9677,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
 dependencies = [
- "jpeg-decoder",
+ "jpeg-decoder 0.1.22",
  "miniz_oxide 0.4.4",
  "weezl",
 ]
@@ -9726,16 +9737,28 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia"
-version = "0.5.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf81f2900d2e235220e6f31ec9f63ade6a7f59090c556d74fe949bb3b15e9fe"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "bytemuck",
  "cfg-if",
- "png",
- "safe_arch",
+ "log",
+ "png 0.17.13",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -10539,18 +10562,6 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "ttf-parser"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ddb402ac6c2af6f7a2844243887631c4e94b51585b229fcfddb43958cd55ca"
-
-[[package]]
-name = "ttf-parser"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae2f58a822f08abdaf668897e96a5656fe72f5a9ce66422423e8849384872e6"
-
-[[package]]
-name = "ttf-parser"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
@@ -10661,12 +10672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
 
 [[package]]
-name = "unicode-general-category"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9af028e052a610d99e066b33304625dea9613170a2563314490a4e6ec5cf7f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10767,25 +10772,25 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
-version = "0.14.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8352f317d8f9a918ba5154797fb2a93e2730244041cf7d5be35148266adfa5"
+checksum = "c04150a94f0bfc3b2c15d4e151524d14cd06765fc6641d8b1c59a248360d4474"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.4",
  "data-url",
  "flate2",
- "fontdb 0.5.4",
- "kurbo",
+ "fontdb 0.16.2",
+ "imagesize",
+ "kurbo 0.9.5",
  "log",
- "memmap2 0.2.3",
  "pico-args",
- "rctree",
- "roxmltree 0.14.1",
- "rustybuzz 0.3.0",
+ "roxmltree",
+ "rustybuzz 0.12.1",
  "simplecss",
- "siphasher 0.2.3",
+ "siphasher",
+ "strict-num",
  "svgtypes",
- "ttf-parser 0.12.3",
+ "tiny-skia-path",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4776,7 +4776,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "image_viewer"
 version = "0.1.0"
 dependencies = [
@@ -4788,12 +4787,12 @@ dependencies = [
  "util",
  "workspace",
 ]
-=======
+
+[[package]]
 name = "imagesize"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
->>>>>>> ec2647a64 (gpui: Add SVG rendering to img element)
 
 [[package]]
 name = "indexmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4368,8 +4368,6 @@ dependencies = [
  "taffy",
  "thiserror",
  "time",
- "tiny-skia",
- "usvg",
  "util",
  "uuid",
  "waker-fn",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -67,8 +67,6 @@ sum_tree.workspace = true
 taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1876f72bee5e376023eaa518aa7b8a34c769bd1b" }
 thiserror.workspace = true
 time.workspace = true
-tiny-skia = "0.11"
-usvg = { version = "0.40", features = [] }
 util.workspace = true
 uuid = { version = "1.1.2", features = ["v4", "v5"] }
 waker-fn = "1.1.0"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -54,7 +54,7 @@ profiling.workspace = true
 rand.workspace = true
 raw-window-handle = "0.6"
 refineable.workspace = true
-resvg = "0.14"
+resvg = "0.40"
 schemars.workspace = true
 seahash = "4.1"
 serde.workspace = true
@@ -67,8 +67,8 @@ sum_tree.workspace = true
 taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1876f72bee5e376023eaa518aa7b8a34c769bd1b" }
 thiserror.workspace = true
 time.workspace = true
-tiny-skia = "0.5"
-usvg = { version = "0.14", features = [] }
+tiny-skia = "0.11"
+usvg = { version = "0.40", features = [] }
 util.workspace = true
 uuid = { version = "1.1.2", features = ["v4", "v5"] }
 waker-fn = "1.1.0"

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -1,5 +1,6 @@
 use crate::{
-    size, AppContext, DevicePixels, FetchImageTask, ImageCacheError, Result, SharedString, Size,
+    size, svg_fontdb, AppContext, DevicePixels, FetchImageTask, ImageCacheError, Result,
+    SharedString, Size,
 };
 use anyhow::anyhow;
 use collections::HashMap;
@@ -84,7 +85,7 @@ impl ImageData {
             let data = resvg::usvg::Tree::from_data(
                 bytes,
                 &resvg::usvg::Options::default(),
-                &resvg::usvg::fontdb::Database::default(),
+                svg_fontdb(),
             )?;
             Ok(Self::Vector {
                 id: ImageId(NEXT_ID.fetch_add(1, SeqCst)),

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -56,7 +56,7 @@ pub enum ImageData {
         /// The unique identifier for this image.
         id: ImageId,
         /// The SVG tree for this image.
-        data: usvg::Tree,
+        data: resvg::usvg::Tree,
         /// Rendered image cache.
         rendered: Arc<Mutex<HashMap<Size<DevicePixels>, FetchImageTask>>>,
     },
@@ -81,10 +81,10 @@ impl ImageData {
                 data,
             })
         } else {
-            let data = usvg::Tree::from_data(
+            let data = resvg::usvg::Tree::from_data(
                 bytes,
-                &usvg::Options::default(),
-                &usvg::fontdb::Database::default(),
+                &resvg::usvg::Options::default(),
+                &resvg::usvg::fontdb::Database::default(),
             )?;
             Ok(Self::Vector {
                 id: ImageId(NEXT_ID.fetch_add(1, SeqCst)),
@@ -116,7 +116,7 @@ impl ImageData {
                             let ratio = size.width.0 as f32 / tree.size().width();
                             resvg::render(
                                 &tree,
-                                tiny_skia::Transform::from_scale(ratio, ratio),
+                                resvg::tiny_skia::Transform::from_scale(ratio, ratio),
                                 &mut pixmap.as_mut(),
                             );
                             let png = pixmap.encode_png().unwrap();

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -1,11 +1,19 @@
-use crate::{size, DevicePixels, Result, SharedString, Size};
+use crate::{
+    size, AppContext, DevicePixels, FetchImageTask, ImageCacheError, Result, SharedString, Size,
+};
 use anyhow::anyhow;
+use collections::HashMap;
+use futures::FutureExt;
 use image::{Bgra, ImageBuffer};
+use parking_lot::Mutex;
 use std::{
     borrow::Cow,
     fmt,
     hash::Hash,
-    sync::atomic::{AtomicUsize, Ordering::SeqCst},
+    sync::{
+        atomic::{AtomicUsize, Ordering::SeqCst},
+        Arc,
+    },
 };
 
 /// A source of assets for this app to use.
@@ -35,40 +43,135 @@ impl AssetSource for () {
 pub struct ImageId(usize);
 
 /// A cached and processed image.
-pub struct ImageData {
-    /// The ID associated with this image
-    pub id: ImageId,
-    data: ImageBuffer<Bgra<u8>, Vec<u8>>,
+pub enum ImageData {
+    /// A raster image.
+    Raster {
+        /// The unique identifier for this image.
+        id: ImageId,
+        /// The image buffer for this image.
+        data: ImageBuffer<Bgra<u8>, Vec<u8>>,
+    },
+    /// A vector image.
+    Vector {
+        /// The unique identifier for this image.
+        id: ImageId,
+        /// The SVG tree for this image.
+        data: usvg::Tree,
+        /// Rendered image cache.
+        rendered: Arc<Mutex<HashMap<Size<DevicePixels>, FetchImageTask>>>,
+    },
 }
 
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 impl ImageData {
     /// Create a new image from the given data.
     pub fn new(data: ImageBuffer<Bgra<u8>, Vec<u8>>) -> Self {
-        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
-
-        Self {
+        Self::Raster {
             id: ImageId(NEXT_ID.fetch_add(1, SeqCst)),
             data,
         }
     }
 
+    /// Try to create a new image from the given bytes.
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, ImageCacheError> {
+        if let Ok(format) = image::guess_format(bytes) {
+            let data = image::load_from_memory_with_format(bytes, format)?.into_bgra8();
+            Ok(Self::Raster {
+                id: ImageId(NEXT_ID.fetch_add(1, SeqCst)),
+                data,
+            })
+        } else {
+            let data = usvg::Tree::from_data(
+                bytes,
+                &usvg::Options::default(),
+                &usvg::fontdb::Database::default(),
+            )?;
+            Ok(Self::Vector {
+                id: ImageId(NEXT_ID.fetch_add(1, SeqCst)),
+                data,
+                rendered: Default::default(),
+            })
+        }
+    }
+
+    /// Get the rendered image for the given size.
+    pub fn rendered(&self, size: Size<DevicePixels>, cx: &AppContext) -> Option<FetchImageTask> {
+        match self {
+            Self::Raster { .. } => None,
+            Self::Vector { rendered, data, .. } => {
+                let mut rendered = rendered.lock();
+                if let Some(task) = rendered.get(&size) {
+                    return Some(task.clone());
+                }
+                let task = cx
+                    .background_executor()
+                    .spawn({
+                        let tree = data.clone();
+                        async move {
+                            let mut pixmap = resvg::tiny_skia::Pixmap::new(
+                                size.width.0 as u32,
+                                size.height.0 as u32,
+                            )
+                            .unwrap();
+                            let ratio = size.width.0 as f32 / tree.size().width();
+                            resvg::render(
+                                &tree,
+                                tiny_skia::Transform::from_scale(ratio, ratio),
+                                &mut pixmap.as_mut(),
+                            );
+                            let png = pixmap.encode_png().unwrap();
+                            let image =
+                                image::load_from_memory_with_format(&png, image::ImageFormat::Png)?;
+                            Ok(Arc::new(ImageData::new(image.into_bgra8())))
+                        }
+                    })
+                    .shared();
+                rendered.insert(size, task.clone());
+                Some(task)
+            }
+        }
+    }
+
     /// Convert this image into a byte slice.
     pub fn as_bytes(&self) -> &[u8] {
-        &self.data
+        match self {
+            Self::Raster { data, .. } => data.as_ref(),
+            // Should be unreachable as we always fall down to raster before rendering
+            Self::Vector { .. } => &[],
+        }
     }
 
     /// Get the size of this image, in pixels
     pub fn size(&self) -> Size<DevicePixels> {
-        let (width, height) = self.data.dimensions();
-        size(width.into(), height.into())
+        match self {
+            Self::Raster { data, .. } => {
+                let (width, height) = data.dimensions();
+                size(width.into(), height.into())
+            }
+            Self::Vector { data, .. } => {
+                let tree_size = data.size();
+                size(
+                    (tree_size.width() as u32).into(),
+                    (tree_size.height() as u32).into(),
+                )
+            }
+        }
+    }
+
+    /// Get the unique identifier for this image.
+    pub fn id(&self) -> ImageId {
+        match self {
+            Self::Raster { id, .. } => *id,
+            Self::Vector { id, .. } => *id,
+        }
     }
 }
 
 impl fmt::Debug for ImageData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ImageData")
-            .field("id", &self.id)
-            .field("size", &self.data.dimensions())
+            .field("id", &self.id())
+            .field("size", &self.size())
             .finish()
     }
 }

--- a/crates/gpui/src/image_cache.rs
+++ b/crates/gpui/src/image_cache.rs
@@ -15,19 +15,27 @@ pub(crate) struct RenderImageParams {
     pub(crate) image_id: ImageId,
 }
 
+/// An error that can occur when interacting with the image cache.
 #[derive(Debug, Error, Clone)]
 pub enum ImageCacheError {
+    /// An error that occurred while fetching an image from a remote source.
     #[error("http error: {0}")]
     Client(#[from] http::Error),
+    /// An error that occurred while reading the image from disk.
     #[error("IO error: {0}")]
     Io(Arc<std::io::Error>),
+    /// An error that occurred while processing an image.
     #[error("unexpected http status: {status}, body: {body}")]
     BadStatus {
+        /// The HTTP status code.
         status: http::StatusCode,
+        /// The HTTP response body.
         body: String,
     },
+    /// An error that occurred while processing an image.
     #[error("image error: {0}")]
     Image(Arc<ImageError>),
+    /// An error that occurred while processing an SVG.
     #[error("svg error: {0}")]
     Usvg(Arc<resvg::usvg::Error>),
 }
@@ -73,6 +81,7 @@ impl From<Arc<PathBuf>> for UriOrPath {
     }
 }
 
+/// A task to complete fetching an image.
 pub type FetchImageTask = Shared<Task<Result<Arc<ImageData>, ImageCacheError>>>;
 
 impl ImageCache {
@@ -133,6 +142,7 @@ impl ImageCache {
     }
 }
 
+/// Returns the global SVG font database.
 pub fn svg_fontdb() -> &'static resvg::usvg::fontdb::Database {
     static FONTDB: OnceLock<resvg::usvg::fontdb::Database> = OnceLock::new();
     FONTDB.get_or_init(|| {

--- a/crates/gpui/src/image_cache.rs
+++ b/crates/gpui/src/image_cache.rs
@@ -3,7 +3,7 @@ use collections::HashMap;
 use futures::{future::Shared, AsyncReadExt, FutureExt, TryFutureExt};
 use image::ImageError;
 use parking_lot::Mutex;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::{fs, path::PathBuf};
 use thiserror::Error;
 use util::http::{self, HttpClient};
@@ -131,4 +131,13 @@ impl ImageCache {
             }
         }
     }
+}
+
+pub fn svg_fontdb() -> &'static resvg::usvg::fontdb::Database {
+    static FONTDB: OnceLock<resvg::usvg::fontdb::Database> = OnceLock::new();
+    FONTDB.get_or_init(|| {
+        let mut fontdb = resvg::usvg::fontdb::Database::new();
+        fontdb.load_system_fonts();
+        fontdb
+    })
 }

--- a/crates/gpui/src/image_cache.rs
+++ b/crates/gpui/src/image_cache.rs
@@ -29,7 +29,7 @@ pub enum ImageCacheError {
     #[error("image error: {0}")]
     Image(Arc<ImageError>),
     #[error("svg error: {0}")]
-    Usvg(Arc<usvg::Error>),
+    Usvg(Arc<resvg::usvg::Error>),
 }
 
 impl From<std::io::Error> for ImageCacheError {
@@ -44,8 +44,8 @@ impl From<ImageError> for ImageCacheError {
     }
 }
 
-impl From<usvg::Error> for ImageCacheError {
-    fn from(error: usvg::Error) -> Self {
+impl From<resvg::usvg::Error> for ImageCacheError {
+    fn from(error: resvg::usvg::Error) -> Self {
         Self::Usvg(Arc::new(error))
     }
 }

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -24,20 +24,21 @@ impl SvgRenderer {
 
         // Load the tree.
         let bytes = self.asset_source.load(&params.path)?;
-        let tree = usvg::Tree::from_data(
+        let tree = resvg::usvg::Tree::from_data(
             &bytes,
-            &usvg::Options::default(),
-            &usvg::fontdb::Database::default(),
+            &resvg::usvg::Options::default(),
+            &resvg::usvg::fontdb::Database::default(),
         )?;
 
         // Render the SVG to a pixmap with the specified width and height.
         let mut pixmap =
-            tiny_skia::Pixmap::new(params.size.width.into(), params.size.height.into()).unwrap();
+            resvg::tiny_skia::Pixmap::new(params.size.width.into(), params.size.height.into())
+                .unwrap();
 
         let ratio = params.size.width.0 as f32 / tree.size().width();
         resvg::render(
             &tree,
-            tiny_skia::Transform::from_scale(ratio, ratio),
+            resvg::tiny_skia::Transform::from_scale(ratio, ratio),
             &mut pixmap.as_mut(),
         );
 

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -24,15 +24,21 @@ impl SvgRenderer {
 
         // Load the tree.
         let bytes = self.asset_source.load(&params.path)?;
-        let tree = usvg::Tree::from_data(&bytes, &usvg::Options::default())?;
+        let tree = usvg::Tree::from_data(
+            &bytes,
+            &usvg::Options::default(),
+            &usvg::fontdb::Database::default(),
+        )?;
 
         // Render the SVG to a pixmap with the specified width and height.
         let mut pixmap =
             tiny_skia::Pixmap::new(params.size.width.into(), params.size.height.into()).unwrap();
+
+        let ratio = params.size.width.0 as f32 / tree.size().width();
         resvg::render(
             &tree,
-            usvg::FitTo::Width(params.size.width.into()),
-            pixmap.as_mut(),
+            tiny_skia::Transform::from_scale(ratio, ratio),
+            &mut pixmap.as_mut(),
         );
 
         // Convert the pixmap's pixels into an alpha mask.

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -1,4 +1,4 @@
-use crate::{AssetSource, DevicePixels, IsZero, Result, SharedString, Size};
+use crate::{svg_fontdb, AssetSource, DevicePixels, IsZero, Result, SharedString, Size};
 use anyhow::anyhow;
 use std::{hash::Hash, sync::Arc};
 
@@ -24,11 +24,8 @@ impl SvgRenderer {
 
         // Load the tree.
         let bytes = self.asset_source.load(&params.path)?;
-        let tree = resvg::usvg::Tree::from_data(
-            &bytes,
-            &resvg::usvg::Options::default(),
-            &resvg::usvg::fontdb::Database::default(),
-        )?;
+        let tree =
+            resvg::usvg::Tree::from_data(&bytes, &resvg::usvg::Options::default(), svg_fontdb())?;
 
         // Render the SVG to a pixmap with the specified width and height.
         let mut pixmap =

--- a/crates/gpui/src/window/element_cx.rs
+++ b/crates/gpui/src/window/element_cx.rs
@@ -1122,7 +1122,9 @@ impl<'a> ElementContext<'a> {
     ) -> Result<()> {
         let scale_factor = self.scale_factor();
         let bounds = bounds.scale(scale_factor);
-        let params = RenderImageParams { image_id: data.id };
+        let params = RenderImageParams {
+            image_id: data.id(),
+        };
 
         let tile = self
             .window


### PR DESCRIPTION
Release Notes:

- Updated dependencies `tiny_skia`, `usvg`, `resvg`
- Added SVG rendering to `img` element


Up for discussion:
~~I implemented the rasterization of the SVG in the img.rs, because I wanted to make sure it gets rasterized at the correct size everytime. This is probably too expensive and should be optimized still. Not sure how to approach this yet.~~


Edit:
To add some reasoning as to why I think SVG rendering support belongs into the img element:

- The `svg` element seems to be specifically for embedded and monochrome SVGs.
- Having SVG support in the `img` element allows GPUI to be closer to the HTML img tag.

User Story:
While working on the [Loungy](https://github.com/MatthiasGrandl/loungy) Linux port, we discovered that app icons are either PNGs or SVGs. Having the ability to display both in the same element would save us lots of code and additional dependencies.