### PR TITLE
windows: Fix incorrect titlebar behavior with a scale factor greater than 1.0

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -144,7 +144,10 @@ impl WindowsWindowInner {
         let mut height = title_bar_size.cy + TOP_BOTTOM_BORDERS;
 
         if self.is_maximized() {
-            height += unsafe { GetSystemMetrics(SM_CXPADDEDBORDER) * 2 };
+            // let dpi = unsafe { GetDpiForWindow(self.hwnd) };
+            height += unsafe {
+                (GetSystemMetricsForDpi(SM_CXPADDEDBORDER, DEFAULT_DPI_VALUE) * 2) as i32
+            };
         }
 
         let mut rect = RECT::default();

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -752,10 +752,9 @@ impl WindowsWindowInner {
         }
 
         // let dpi = unsafe { GetDpiForWindow(self.hwnd) };
-
-        let frame_x = unsafe { GetSystemMetricsForDpi(SM_CXFRAME, 96) };
-        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, 96) };
-        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, 96) };
+        let frame_x = unsafe { GetSystemMetricsForDpi(SM_CXFRAME, DEFAULT_DPI_VALUE) };
+        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, DEFAULT_DPI_VALUE) };
+        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, DEFAULT_DPI_VALUE) };
 
         // wparam is TRUE so lparam points to an NCCALCSIZE_PARAMS structure
         let mut params = lparam.0 as *mut NCCALCSIZE_PARAMS;
@@ -826,8 +825,8 @@ impl WindowsWindowInner {
         }
 
         // let dpi = unsafe { GetDpiForWindow(self.hwnd) };
-        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, 96) };
-        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, 96) };
+        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, DEFAULT_DPI_VALUE) };
+        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, DEFAULT_DPI_VALUE) };
 
         let mut cursor_point = POINT {
             x: lparam.signed_loword().into(),
@@ -841,7 +840,8 @@ impl WindowsWindowInner {
         let titlebar_rect = self.get_titlebar_rect();
         if let Ok(titlebar_rect) = titlebar_rect {
             if cursor_point.y < titlebar_rect.bottom {
-                let caption_btn_width = unsafe { GetSystemMetricsForDpi(SM_CXSIZE, 96) };
+                let caption_btn_width =
+                    unsafe { GetSystemMetricsForDpi(SM_CXSIZE, DEFAULT_DPI_VALUE) };
                 if cursor_point.x >= titlebar_rect.right - caption_btn_width {
                     return LRESULT(HTCLOSE as _);
                 } else if cursor_point.x >= titlebar_rect.right - caption_btn_width * 2 {
@@ -945,7 +945,6 @@ impl WindowsWindowInner {
         drop(callbacks);
 
         if button == MouseButton::Left {
-            println!("Button: {}", wparam.0);
             match wparam.0 as u32 {
                 HTMINBUTTON => unsafe {
                     ShowWindowAsync(self.hwnd, SW_MINIMIZE);
@@ -1594,3 +1593,4 @@ fn oemkey_vkcode_to_string(code: u16) -> Option<String> {
 
 // https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-dragqueryfilew
 const DRAGDROP_GET_FILES_COUNT: u32 = 0xFFFFFFFF;
+const DEFAULT_DPI_VALUE: i32 = 96;

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -146,7 +146,7 @@ impl WindowsWindowInner {
         if self.is_maximized() {
             // let dpi = unsafe { GetDpiForWindow(self.hwnd) };
             height += unsafe {
-                (GetSystemMetricsForDpi(SM_CXPADDEDBORDER, DEFAULT_DPI_VALUE) * 2) as i32
+                (GetSystemMetricsForDpi(SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI) * 2) as i32
             };
         }
 
@@ -755,9 +755,9 @@ impl WindowsWindowInner {
         }
 
         // let dpi = unsafe { GetDpiForWindow(self.hwnd) };
-        let frame_x = unsafe { GetSystemMetricsForDpi(SM_CXFRAME, DEFAULT_DPI_VALUE) };
-        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, DEFAULT_DPI_VALUE) };
-        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, DEFAULT_DPI_VALUE) };
+        let frame_x = unsafe { GetSystemMetricsForDpi(SM_CXFRAME, USER_DEFAULT_SCREEN_DPI) };
+        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, USER_DEFAULT_SCREEN_DPI) };
+        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI) };
 
         // wparam is TRUE so lparam points to an NCCALCSIZE_PARAMS structure
         let mut params = lparam.0 as *mut NCCALCSIZE_PARAMS;
@@ -828,8 +828,8 @@ impl WindowsWindowInner {
         }
 
         // let dpi = unsafe { GetDpiForWindow(self.hwnd) };
-        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, DEFAULT_DPI_VALUE) };
-        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, DEFAULT_DPI_VALUE) };
+        let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, USER_DEFAULT_SCREEN_DPI) };
+        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI) };
 
         let mut cursor_point = POINT {
             x: lparam.signed_loword().into(),
@@ -844,7 +844,7 @@ impl WindowsWindowInner {
         if let Ok(titlebar_rect) = titlebar_rect {
             if cursor_point.y < titlebar_rect.bottom {
                 let caption_btn_width =
-                    unsafe { GetSystemMetricsForDpi(SM_CXSIZE, DEFAULT_DPI_VALUE) };
+                    unsafe { GetSystemMetricsForDpi(SM_CXSIZE, USER_DEFAULT_SCREEN_DPI) };
                 if cursor_point.x >= titlebar_rect.right - caption_btn_width {
                     return LRESULT(HTCLOSE as _);
                 } else if cursor_point.x >= titlebar_rect.right - caption_btn_width * 2 {
@@ -1596,4 +1596,3 @@ fn oemkey_vkcode_to_string(code: u16) -> Option<String> {
 
 // https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-dragqueryfilew
 const DRAGDROP_GET_FILES_COUNT: u32 = 0xFFFFFFFF;
-const DEFAULT_DPI_VALUE: u32 = 96;

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1593,4 +1593,4 @@ fn oemkey_vkcode_to_string(code: u16) -> Option<String> {
 
 // https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-dragqueryfilew
 const DRAGDROP_GET_FILES_COUNT: u32 = 0xFFFFFFFF;
-const DEFAULT_DPI_VALUE: i32 = 96;
+const DEFAULT_DPI_VALUE: u32 = 96;


### PR DESCRIPTION
Fixed the issue where the titlebar functionality was not working correctly when the scale factor was greater than 1.0.

As I mentioned in #8809 , support for scale factors greater than 1.0 will require more efforts on the `blade` side.

### Titlebar incorrect behaviour (with scale factor 1.5):


https://github.com/zed-industries/zed/assets/14981363/92ebf228-8f9a-4003-b65a-15a4e1124e5e



Release Notes:

- N/A
