### PR TITLE
Small cleanup of gpui manifest file

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [features]
 test-support = [
     "backtrace",
-    "env_logger",
     "collections/test-support",
     "util/test-support",
 ]
@@ -35,7 +34,7 @@ bytemuck = { version = "1", optional = true }
 collections.workspace = true
 ctor.workspace = true
 derive_more.workspace = true
-env_logger = { version = "0.9", optional = true }
+env_logger.workspace = true
 etagere = "0.2"
 futures.workspace = true
 font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "5a5c4d4" }
@@ -76,7 +75,6 @@ waker-fn = "1.1.0"
 [dev-dependencies]
 backtrace = "0.3"
 collections = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 util = { workspace = true, features = ["test-support"] }
 
 [build-dependencies]


### PR DESCRIPTION
Currently, gpui depends on env_logger as both a normal dependency and a dev-dependency without
using the workspace defined version. This fixes it.