### PR TITLE
Add keyboard shortcut to suppress prompt while deleting files/dirs

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -515,6 +515,9 @@
       "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
       "backspace": "project_panel::Delete",
+      "delete": "project_panel::Delete",
+      "ctrl-backspace": ["project_panel::Delete", { "skip_prompt": true }],
+      "ctrl-delete": ["project_panel::Delete", { "skip_prompt": true }],
       "ctrl-alt-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -561,8 +561,10 @@
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
+      "backspace": "project_panel::Delete",
       "delete": "project_panel::Delete",
-      "cmd-backspace": "project_panel::Delete",
+      "cmd-backspace": ["project_panel::Delete", { "skip_prompt": true }],
+      "cmd-delete": ["project_panel::Delete", { "skip_prompt": true }],
       "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }

--- a/crates/gpui/src/app/entity_map.rs
+++ b/crates/gpui/src/app/entity_map.rs
@@ -394,7 +394,7 @@ impl<T: 'static> Model<T> {
     ///
     /// The update function receives a context appropriate for its environment.
     /// When updating in an `AppContext`, it receives a `ModelContext`.
-    /// When updating an a `WindowContext`, it receives a `ViewContext`.
+    /// When updating in a `WindowContext`, it receives a `ViewContext`.
     pub fn update<C, R>(
         &self,
         cx: &mut C,

--- a/docs/src/configuring_zed__key_bindings.md
+++ b/docs/src/configuring_zed__key_bindings.md
@@ -378,6 +378,7 @@ But, it was impossible to take into account the `{` and `}` when he was typing s
 | Copy relative path      | Project Panel | `Alt` + `⌘` + `Shift` + `C` |
 | Cut                     | Project Panel | `⌘` + `X`                   |
 | Delete                  | Project Panel | `Backspace`                 |
+| Delete (no prompt)      | Project Panel | `⌘` + `Backspace`           |
 | Expand selected entry   | Project Panel | `Right`                     |
 | New directory           | Project Panel | `Alt` + `⌘` + `N`           |
 | New file                | Project Panel | `Command + N`               |


### PR DESCRIPTION
Completes #7228.
Adds back Backspace as the main delete key binding and makes Linux bindings consistent with macOS

Release Notes:
- ⌘-Delete/⌘-Backspace will now suppress deletion confirmation prompts in project panel ([#7228](https://github.com/zed-industries/zed/issues/7228)).