### PR TITLE
Linux: remove duplicate key bind to "ctrl-shift-p" preventing the command palette from showing up

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -82,7 +82,6 @@
       "ctrl-home": "editor::MoveToBeginning",
       "ctrl-=end": "editor::MoveToEnd",
       "shift-up": "editor::SelectUp",
-      "ctrl-shift-p": "editor::SelectUp",
       "shift-down": "editor::SelectDown",
       "ctrl-shift-n": "editor::SelectDown",
       "shift-left": "editor::SelectLeft",


### PR DESCRIPTION
Linux: remove duplicate key bind to "ctrl-shift-p" preventing the command palette from showing up

Release Notes:
- N/A
