### PR TITLE
Fix file git status refresh on .gitignore update

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4,7 +4,7 @@ use client::{ErrorCode, ErrorExt};
 use settings::Settings;
 
 use db::kvp::KEY_VALUE_STORE;
-use editor::{actions::Cancel, scroll::Autoscroll, Editor};
+use editor::{actions::Cancel, items::entry_git_aware_label_color, scroll::Autoscroll, Editor};
 use file_associations::FileAssociations;
 
 use anyhow::{anyhow, Result};
@@ -1396,29 +1396,8 @@ impl ProjectPanel {
             .selection
             .map_or(false, |selection| selection.entry_id == entry_id);
         let width = self.size(cx);
-
-        let filename_text_color = details
-            .git_status
-            .as_ref()
-            .map(|status| {
-                if details.is_ignored {
-                    Color::Disabled
-                } else {
-                    match status {
-                        GitFileStatus::Added => Color::Created,
-                        GitFileStatus::Modified => Color::Modified,
-                        GitFileStatus::Conflict => Color::Conflict,
-                    }
-                }
-            })
-            .unwrap_or(if is_selected {
-                Color::Default
-            } else if details.is_ignored {
-                Color::Disabled
-            } else {
-                Color::Muted
-            });
-
+        let filename_text_color =
+            entry_git_aware_label_color(details.git_status, details.is_ignored, is_selected);
         let file_name = details.filename.clone();
         let icon = details.icon.clone();
         let depth = details.depth;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1168,7 +1168,7 @@ impl ProjectPanel {
                         inode: 0,
                         mtime: entry.mtime,
                         is_symlink: false,
-                        is_ignored: false,
+                        is_ignored: entry.is_ignored,
                         is_external: false,
                         is_private: false,
                         git_status: entry.git_status,
@@ -1400,10 +1400,16 @@ impl ProjectPanel {
         let filename_text_color = details
             .git_status
             .as_ref()
-            .map(|status| match status {
-                GitFileStatus::Added => Color::Created,
-                GitFileStatus::Modified => Color::Modified,
-                GitFileStatus::Conflict => Color::Conflict,
+            .map(|status| {
+                if details.is_ignored {
+                    Color::Disabled
+                } else {
+                    match status {
+                        GitFileStatus::Added => Color::Created,
+                        GitFileStatus::Modified => Color::Modified,
+                        GitFileStatus::Conflict => Color::Conflict,
+                    }
+                }
             })
             .unwrap_or(if is_selected {
                 Color::Default

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4267,7 +4267,7 @@ impl BackgroundScanner {
                         if let Some(mtime) = &entry.mtime {
                             let repo_path = RepoPath(entry.path.to_path_buf());
                             let repo = repo.repo_ptr.lock();
-                            entry.git_status = repo.status(&repo_path, mtime.clone());
+                            entry.git_status = repo.status(&repo_path, *mtime);
                         }
                     }
                 }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4225,6 +4225,9 @@ impl BackgroundScanner {
         let mut entries_by_id_edits = Vec::new();
         let mut entries_by_path_edits = Vec::new();
         let path = job.abs_path.strip_prefix(&snapshot.abs_path).unwrap();
+        let repo = snapshot
+            .local_repo_for_path(path)
+            .map_or(None, |local_repo| Some(local_repo.1));
         for mut entry in snapshot.child_entries(path).cloned() {
             let was_ignored = entry.is_ignored;
             let abs_path: Arc<Path> = snapshot.abs_path().join(&entry.path).into();
@@ -4259,6 +4262,15 @@ impl BackgroundScanner {
                 let mut path_entry = snapshot.entries_by_id.get(&entry.id, &()).unwrap().clone();
                 path_entry.scan_id = snapshot.scan_id;
                 path_entry.is_ignored = entry.is_ignored;
+                if !entry.is_dir() && !entry.is_ignored && !entry.is_external {
+                    if let Some(repo) = repo {
+                        if let Some(mtime) = &entry.mtime {
+                            let repo_path = RepoPath(entry.path.to_path_buf());
+                            let repo = repo.repo_ptr.lock();
+                            entry.git_status = repo.status(&repo_path, mtime.clone());
+                        }
+                    }
+                }
                 entries_by_id_edits.push(Edit::Insert(path_entry));
                 entries_by_path_edits.push(Edit::Insert(entry));
             }

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -858,14 +858,7 @@ async fn test_rescan_with_gitignore(cx: &mut TestAppContext) {
 
     fs.set_status_for_repo_via_working_copy_change(
         &Path::new("/root/tree/.git"),
-        &[
-            (Path::new("tracked-dir/tracked-file2"), GitFileStatus::Added),
-            (
-                Path::new("tracked-dir/ancestor-ignored-file2"),
-                GitFileStatus::Added,
-            ),
-            (Path::new("ignored-dir/ignored-file2"), GitFileStatus::Added),
-        ],
+        &[(Path::new("tracked-dir/tracked-file2"), GitFileStatus::Added)],
     );
 
     fs.create_file(

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -851,23 +851,22 @@ async fn test_rescan_with_gitignore(cx: &mut TestAppContext) {
 
     cx.read(|cx| {
         let tree = tree.read(cx);
-        assert!(
-            !tree
-                .entry_for_path("tracked-dir/tracked-file1")
-                .unwrap()
-                .is_ignored
-        );
-        assert!(
-            tree.entry_for_path("tracked-dir/ancestor-ignored-file1")
-                .unwrap()
-                .is_ignored
-        );
-        assert!(
-            tree.entry_for_path("ignored-dir/ignored-file1")
-                .unwrap()
-                .is_ignored
-        );
+        assert_entry_git_state(tree, "tracked-dir/tracked-file1", None, false);
+        assert_entry_git_state(tree, "tracked-dir/ancestor-ignored-file1", None, true);
+        assert_entry_git_state(tree, "ignored-dir/ignored-file1", None, true);
     });
+
+    fs.set_status_for_repo_via_working_copy_change(
+        &Path::new("/root/tree/.git"),
+        &[
+            (Path::new("tracked-dir/tracked-file2"), GitFileStatus::Added),
+            (
+                Path::new("tracked-dir/ancestor-ignored-file2"),
+                GitFileStatus::Added,
+            ),
+            (Path::new("ignored-dir/ignored-file2"), GitFileStatus::Added),
+        ],
+    );
 
     fs.create_file(
         "/root/tree/tracked-dir/tracked-file2".as_ref(),
@@ -891,23 +890,74 @@ async fn test_rescan_with_gitignore(cx: &mut TestAppContext) {
     cx.executor().run_until_parked();
     cx.read(|cx| {
         let tree = tree.read(cx);
-        assert!(
-            !tree
-                .entry_for_path("tracked-dir/tracked-file2")
-                .unwrap()
-                .is_ignored
+        assert_entry_git_state(
+            tree,
+            "tracked-dir/tracked-file2",
+            Some(GitFileStatus::Added),
+            false,
         );
-        assert!(
-            tree.entry_for_path("tracked-dir/ancestor-ignored-file2")
-                .unwrap()
-                .is_ignored
-        );
-        assert!(
-            tree.entry_for_path("ignored-dir/ignored-file2")
-                .unwrap()
-                .is_ignored
-        );
+        assert_entry_git_state(tree, "tracked-dir/ancestor-ignored-file2", None, true);
+        assert_entry_git_state(tree, "ignored-dir/ignored-file2", None, true);
         assert!(tree.entry_for_path(".git").unwrap().is_ignored);
+    });
+}
+
+#[gpui::test]
+async fn test_update_gitignore(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".git": {},
+            ".gitignore": "*.txt\n",
+            "a.xml": "<a></a>",
+            "b.txt": "Some text"
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        build_client(cx),
+        "/root".as_ref(),
+        true,
+        fs.clone(),
+        Default::default(),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    tree.read_with(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .refresh_entries_for_paths(vec![Path::new("").into()])
+    })
+    .recv()
+    .await;
+
+    cx.read(|cx| {
+        let tree = tree.read(cx);
+        assert_entry_git_state(tree, "a.xml", None, false);
+        assert_entry_git_state(tree, "b.txt", None, true);
+    });
+
+    fs.atomic_write("/root/.gitignore".into(), "*.xml".into())
+        .await
+        .unwrap();
+
+    fs.set_status_for_repo_via_working_copy_change(
+        &Path::new("/root/.git"),
+        &[(Path::new("b.txt"), GitFileStatus::Added)],
+    );
+
+    cx.executor().run_until_parked();
+    cx.read(|cx| {
+        let tree = tree.read(cx);
+        assert_entry_git_state(tree, "a.xml", None, true);
+        assert_entry_git_state(tree, "b.txt", Some(GitFileStatus::Added), false);
     });
 }
 
@@ -2579,4 +2629,15 @@ fn init_test(cx: &mut gpui::TestAppContext) {
         cx.set_global(settings_store);
         WorktreeSettings::register(cx);
     });
+}
+
+fn assert_entry_git_state(
+    tree: &Worktree,
+    path: &str,
+    git_status: Option<GitFileStatus>,
+    is_ignored: bool,
+) {
+    let entry = tree.entry_for_path(path).expect("entry {path} not found");
+    assert_eq!(entry.git_status, git_status);
+    assert_eq!(entry.is_ignored, is_ignored);
 }


### PR DESCRIPTION
This PR fixes file name coloring in the project panel and tabs when .gitignore file is updated. It's intended to fix #7831.

There's another, less vivid, problem with git-aware labels coloring. It's about files that are both ignored and contained in the git index. I'll file a separate issue for it to keep this fix focused.

Release Notes:

- Fixed file Git status refreshing on .gitignore update (#7831).
