### PR TITLE
windows: Dispatch missing foreground tasks

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -245,6 +245,9 @@ impl Platform for WindowsPlatform {
                             DispatchMessageW(&msg);
                         }
                     }
+
+                    // foreground tasks may have been queued in the message handlers
+                    self.run_foreground_tasks();
                 }
                 _ => {
                     log::error!("Something went wrong while waiting {:?}", wait_result);


### PR DESCRIPTION
Some foreground tasks were being missed causing some unresponsiveness in Zed. The foreground tasks used to happen but it was changed in #9351 (here: https://github.com/zed-industries/zed/pull/9351/files#diff-5b5e706f04c15d77efd23989ec5b1b1cf73d36144e2d066a074de165533ecaeaL227)

Release Notes:

- N/A
