### PR TITLE
windows: Don't propagate window char message

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -546,7 +546,9 @@ impl WindowsWindowInner {
             keystroke,
             is_held: lparam.0 & (0x1 << 30) > 0,
         };
-        if func(PlatformInput::KeyDown(event)).default_prevented {
+
+        let dispatch_event_result = func(PlatformInput::KeyDown(event));
+        if dispatch_event_result.default_prevented || !dispatch_event_result.propagate {
             self.invalidate_client_area();
             return LRESULT(0);
         }


### PR DESCRIPTION
we were accidentally calling the input handler even when the keydown event asked it not to be propagated

Release Notes:

- N/A
