### PR TITLE
Allow specifying no base keymap

### DIFF
--- a/crates/welcome/src/base_keymap_setting.rs
+++ b/crates/welcome/src/base_keymap_setting.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{Settings, DEFAULT_KEYMAP_PATH};
+use settings::Settings;
 
 /// Base key bindings scheme. Base keymaps can be overridden with user keymaps.
 ///
@@ -32,13 +32,12 @@ impl Display for BaseKeymap {
 }
 
 impl BaseKeymap {
-    pub const OPTIONS: [(&'static str, Self); 6] = [
+    pub const OPTIONS: [(&'static str, Self); 5] = [
         ("VSCode (Default)", Self::VSCode),
         ("Atom", Self::Atom),
         ("JetBrains", Self::JetBrains),
         ("Sublime Text", Self::SublimeText),
         ("TextMate", Self::TextMate),
-        ("None (not recommended)", Self::None),
     ];
 
     pub fn asset_path(&self) -> Option<&'static str> {
@@ -47,7 +46,7 @@ impl BaseKeymap {
             BaseKeymap::SublimeText => Some("keymaps/sublime_text.json"),
             BaseKeymap::Atom => Some("keymaps/atom.json"),
             BaseKeymap::TextMate => Some("keymaps/textmate.json"),
-            BaseKeymap::VSCode => Some(DEFAULT_KEYMAP_PATH),
+            BaseKeymap::VSCode => None,
             BaseKeymap::None => None,
         }
     }

--- a/crates/welcome/src/base_keymap_setting.rs
+++ b/crates/welcome/src/base_keymap_setting.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, DEFAULT_KEYMAP_PATH};
 
 /// Base key bindings scheme. Base keymaps can be overridden with user keymaps.
 ///
@@ -15,6 +15,7 @@ pub enum BaseKeymap {
     SublimeText,
     Atom,
     TextMate,
+    None,
 }
 
 impl Display for BaseKeymap {
@@ -25,17 +26,19 @@ impl Display for BaseKeymap {
             BaseKeymap::SublimeText => write!(f, "Sublime Text"),
             BaseKeymap::Atom => write!(f, "Atom"),
             BaseKeymap::TextMate => write!(f, "TextMate"),
+            BaseKeymap::None => write!(f, "None"),
         }
     }
 }
 
 impl BaseKeymap {
-    pub const OPTIONS: [(&'static str, Self); 5] = [
+    pub const OPTIONS: [(&'static str, Self); 6] = [
         ("VSCode (Default)", Self::VSCode),
         ("Atom", Self::Atom),
         ("JetBrains", Self::JetBrains),
         ("Sublime Text", Self::SublimeText),
         ("TextMate", Self::TextMate),
+        ("None (not recommended)", Self::None),
     ];
 
     pub fn asset_path(&self) -> Option<&'static str> {
@@ -44,7 +47,8 @@ impl BaseKeymap {
             BaseKeymap::SublimeText => Some("keymaps/sublime_text.json"),
             BaseKeymap::Atom => Some("keymaps/atom.json"),
             BaseKeymap::TextMate => Some("keymaps/textmate.json"),
-            BaseKeymap::VSCode => None,
+            BaseKeymap::VSCode => Some(DEFAULT_KEYMAP_PATH),
+            BaseKeymap::None => None,
         }
     }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -636,6 +636,12 @@ fn reload_keymaps(cx: &mut AppContext, keymap_content: &KeymapFile) {
 pub fn load_default_keymap(cx: &mut AppContext) {
     let base_keymap = *BaseKeymap::get_global(cx);
     if let Some(asset_path) = base_keymap.asset_path() {
+        if base_keymap != BaseKeymap::default() {
+            // all base keymaps assume the default keymap (vscode) is loaded
+            if let Some(default_asset_path) = BaseKeymap::default().asset_path() {
+                KeymapFile::load_asset(default_asset_path).unwrap();
+            }
+        }
         KeymapFile::load_asset(asset_path, cx).unwrap();
     }
     if base_keymap != BaseKeymap::None && VimModeSetting::get_global(cx).0 {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -26,7 +26,7 @@ use rope::Rope;
 use search::project_search::ProjectSearchBar;
 use settings::{
     initial_local_settings_content, initial_tasks_content, watch_config_file, KeymapFile, Settings,
-    SettingsStore,
+    SettingsStore, DEFAULT_KEYMAP_PATH,
 };
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
 use task::{oneshot_source::OneshotSource, static_source::StaticSource};
@@ -635,17 +635,17 @@ fn reload_keymaps(cx: &mut AppContext, keymap_content: &KeymapFile) {
 
 pub fn load_default_keymap(cx: &mut AppContext) {
     let base_keymap = *BaseKeymap::get_global(cx);
-    if let Some(asset_path) = base_keymap.asset_path() {
-        if base_keymap != BaseKeymap::default() {
-            // all base keymaps assume the default keymap (vscode) is loaded
-            if let Some(default_asset_path) = BaseKeymap::default().asset_path() {
-                KeymapFile::load_asset(default_asset_path, cx).unwrap();
-            }
-        }
-        KeymapFile::load_asset(asset_path, cx).unwrap();
+    if base_keymap == BaseKeymap::None {
+        return;
     }
-    if base_keymap != BaseKeymap::None && VimModeSetting::get_global(cx).0 {
+
+    KeymapFile::load_asset(DEFAULT_KEYMAP_PATH, cx).unwrap();
+    if VimModeSetting::get_global(cx).0 {
         KeymapFile::load_asset("keymaps/vim.json", cx).unwrap();
+    }
+
+    if let Some(asset_path) = base_keymap.asset_path() {
+        KeymapFile::load_asset(asset_path, cx).unwrap();
     }
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -639,7 +639,7 @@ pub fn load_default_keymap(cx: &mut AppContext) {
         if base_keymap != BaseKeymap::default() {
             // all base keymaps assume the default keymap (vscode) is loaded
             if let Some(default_asset_path) = BaseKeymap::default().asset_path() {
-                KeymapFile::load_asset(default_asset_path).unwrap();
+                KeymapFile::load_asset(default_asset_path, cx).unwrap();
             }
         }
         KeymapFile::load_asset(asset_path, cx).unwrap();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -634,13 +634,12 @@ fn reload_keymaps(cx: &mut AppContext, keymap_content: &KeymapFile) {
 }
 
 pub fn load_default_keymap(cx: &mut AppContext) {
-    KeymapFile::load_asset(DEFAULT_KEYMAP_PATH, cx).unwrap();
-    if VimModeSetting::get_global(cx).0 {
-        KeymapFile::load_asset("keymaps/vim.json", cx).unwrap();
-    }
-
-    if let Some(asset_path) = BaseKeymap::get_global(cx).asset_path() {
+    let base_keymap = *BaseKeymap::get_global(cx);
+    if let Some(asset_path) = base_keymap.asset_path() {
         KeymapFile::load_asset(asset_path, cx).unwrap();
+    }
+    if base_keymap != BaseKeymap::None && VimModeSetting::get_global(cx).0 {
+        KeymapFile::load_asset("keymaps/vim.json", cx).unwrap();
     }
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -26,7 +26,7 @@ use rope::Rope;
 use search::project_search::ProjectSearchBar;
 use settings::{
     initial_local_settings_content, initial_tasks_content, watch_config_file, KeymapFile, Settings,
-    SettingsStore, DEFAULT_KEYMAP_PATH,
+    SettingsStore,
 };
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
 use task::{oneshot_source::OneshotSource, static_source::StaticSource};


### PR DESCRIPTION
This PR is a bit of a shot in the dark. I'm not sure if this will be acceptable and I understand if it gets rejected.

I've been trying to integrate Zed as my daily driver and the key bindings have been a major hurdle for me. Mostly due to the windows/linux keybindings being messed up, but also me wanting to have more chained key bindings similar to helix or common in custom neovim configurations.

I think having a `None` base keymap would allow someone to more easily implement a new base keymap (#4642) and would make my daily use of Zed a little nicer 😅.

Also I am aware that there would need to be a little more work done in this PR for the other base keymaps such as 'atom' since they assume the 'default' (vscode) base keymaps are loaded. I'm happy to do that work if a 'none' base keymap is acceptable.

Release Notes:

- Added ability to specify no base keymap which allows for full keybinding customization
