### PR TITLE
windows: fix 'space' keystroke keydown event

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -481,9 +481,13 @@ impl WindowsWindowInner {
             if first_char.to_lowercase().to_string() == first_char.to_uppercase().to_string() {
                 modifiers.shift = false;
             }
+            let key = match first_char {
+                ' ' => "space".to_string(),
+                first_char => first_char.to_lowercase().to_string(),
+            };
             Some(Keystroke {
                 modifiers,
-                key: first_char.to_lowercase().to_string(),
+                key,
                 ime_key: Some(first_char.to_string()),
             })
         }


### PR DESCRIPTION
the space key was being reported as key " " which didn't allow it to be used in keybindings

Release Notes:

- N/A
