### PR TITLE
Automatically create a hitbox for focusable elements

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1307,6 +1307,7 @@ impl Interactivity {
                             || self.has_hover_styles()
                             || self.has_mouse_listeners()
                             || self.scroll_offset.is_some()
+                            || self.tracked_focus_handle.is_some()
                         {
                             Some(cx.insert_hitbox(bounds, self.occlude_mouse))
                         } else {


### PR DESCRIPTION
Closes #9462

This fixes the focus story in the storybook.

Release Notes:

- N/A
