### PR TITLE
docs: Fix warning hint visualization

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -19,9 +19,8 @@ brew install elixir-ls
 
 3. Restart Zed
 
-{% hint style="warning" %}
-If `elixir-ls` is not running in an elixir project, check the error log via the command palette action `zed: open log`. If you find an error message mentioning: `invalid LSP message header "Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\") [Yn]`, you might need to install [`Hex`](https://hex.pm). You run `elixir-ls` from the command line and accept the prompt to install `Hex`.
-{% endhint %}
+> [!WARNING]
+> If `elixir-ls` is not running in an elixir project, check the error log via the command palette action `zed: open log`. If you find an error message mentioning: `invalid LSP message header "Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\") [Yn]`, you might need to install [`Hex`](https://hex.pm). You run `elixir-ls` from the command line and accept the prompt to install `Hex`.
 
 ### Formatting with Mix
 

--- a/docs/src/system_requirements.md
+++ b/docs/src/system_requirements.md
@@ -4,9 +4,8 @@
 
 Supported versions: Catalina (10.15) - Sonoma (14.x).
 
-{% hint style="info" %}
-The implementation of our screen sharing feature makes use of [LiveKit](https://livekit.io). The LiveKit SDK requires macOS Catalina (10.15); consequently, in v0.62.4, we dropped support for earlier macOS versions that we were initially supporting.
-{% endhint %}
+> [!WARNING]
+> The implementation of our screen sharing feature makes use of [LiveKit](https://livekit.io). The LiveKit SDK requires macOS Catalina (10.15); consequently, in v0.62.4, we dropped support for earlier macOS versions that we were initially supporting.
 
 ## Linux, Windows, and Web
 


### PR DESCRIPTION
This PR fixes a not optimal warning hint visualization. 

An example:

<img width="1021" alt="Screenshot 2024-03-18 at 13 50 46" src="https://github.com/zed-industries/zed/assets/3492584/b750d93b-75de-4fd7-b5e5-94795d4ed48f">

Proposed visualization:

<img width="1018" alt="Screenshot 2024-03-18 at 13 51 31" src="https://github.com/zed-industries/zed/assets/3492584/434b6938-e8de-4bc8-9da0-0987d660d9a3">

