### PR TITLE
Windows: Use create_dir_link instead of create_symlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,6 +3906,7 @@ dependencies = [
  "futures 0.3.28",
  "git2",
  "gpui",
+ "junction",
  "lazy_static",
  "libc",
  "log",
@@ -5094,6 +5095,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "junction"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca39ef0d69b18e6a2fd14c2f0a1d593200f4a4ed949b240b5917ab51fac754cb"
+dependencies = [
+ "scopeguard",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -555,7 +555,7 @@ impl ExtensionStore {
             let output_path = &extensions_dir.join(extension_id.as_ref());
             if let Some(metadata) = fs.metadata(&output_path).await? {
                 if metadata.is_symlink {
-                    fs.remove_file(
+                    fs.remove_dir_link(
                         &output_path,
                         RemoveOptions {
                             recursive: false,
@@ -568,7 +568,7 @@ impl ExtensionStore {
                 }
             }
 
-            fs.create_symlink(output_path, extension_source_path)
+            fs.create_dir_link(output_path, extension_source_path)
                 .await?;
 
             this.update(&mut cx, |this, cx| this.reload(None, cx))?

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -44,6 +44,7 @@ notify = "6.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true
+junction = "1"
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
The preceding PR #9365, is unsafe and overstated to launch a privileged process to create a symbolic link.

Currently, the only use case for symbolic links is to link directories of extensions under development. This PR adds a `create_dir_link` that first tries to create a symbolic link, and if that fails, tries a [junction](https://learn.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions#junctions).

Also, since removing a junction cannot be done with `remove_file`, added `remove_dir_link` instead.

Both of these work as aliases for `create_symlink` and `remove_file` in non-Windows environments, so they do not break existing behavior.

Release Notes:

- N/A
