### PR TITLE
Clean up `Picker` constructor signature

### DIFF
--- a/crates/picker/src/head.rs
+++ b/crates/picker/src/head.rs
@@ -16,8 +16,8 @@ pub(crate) enum Head {
 impl Head {
     pub fn editor<V: 'static>(
         placeholder_text: Arc<str>,
-        cx: &mut ViewContext<V>,
         edit_handler: impl FnMut(&mut V, View<Editor>, &EditorEvent, &mut ViewContext<'_, V>) + 'static,
+        cx: &mut ViewContext<V>,
     ) -> Self {
         let editor = cx.new_view(|cx| {
             let mut editor = Editor::single_line(cx);


### PR DESCRIPTION
This PR cleans up the (internal) `Picker` constructor signature, mainly to remove the consecutive boolean parameters.

Release Notes:

- N/A
