### PR TITLE
maintain channel subscriptions in RAM

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -546,7 +546,7 @@ pub struct Channel {
 }
 
 impl Channel {
-    fn from_model(value: channel::Model) -> Self {
+    pub fn from_model(value: channel::Model) -> Self {
         Channel {
             id: value.id,
             visibility: value.visibility,
@@ -604,16 +604,14 @@ pub struct RejoinedChannelBuffer {
 #[derive(Clone)]
 pub struct JoinRoom {
     pub room: proto::Room,
-    pub channel_id: Option<ChannelId>,
-    pub channel_members: Vec<UserId>,
+    pub channel: Option<channel::Model>,
 }
 
 pub struct RejoinedRoom {
     pub room: proto::Room,
     pub rejoined_projects: Vec<RejoinedProject>,
     pub reshared_projects: Vec<ResharedProject>,
-    pub channel_id: Option<ChannelId>,
-    pub channel_members: Vec<UserId>,
+    pub channel: Option<channel::Model>,
 }
 
 pub struct ResharedProject {
@@ -649,8 +647,7 @@ pub struct RejoinedWorktree {
 
 pub struct LeftRoom {
     pub room: proto::Room,
-    pub channel_id: Option<ChannelId>,
-    pub channel_members: Vec<UserId>,
+    pub channel: Option<channel::Model>,
     pub left_projects: HashMap<ProjectId, LeftProject>,
     pub canceled_calls_to_user_ids: Vec<UserId>,
     pub deleted: bool,
@@ -658,8 +655,7 @@ pub struct LeftRoom {
 
 pub struct RefreshedRoom {
     pub room: proto::Room,
-    pub channel_id: Option<ChannelId>,
-    pub channel_members: Vec<UserId>,
+    pub channel: Option<channel::Model>,
     pub stale_participant_user_ids: Vec<UserId>,
     pub canceled_calls_to_user_ids: Vec<UserId>,
 }

--- a/crates/collab/src/db/ids.rs
+++ b/crates/collab/src/db/ids.rs
@@ -91,7 +91,9 @@ id_type!(NotificationKindId);
 id_type!(HostedProjectId);
 
 /// ChannelRole gives you permissions for both channels and calls.
-#[derive(Eq, PartialEq, Copy, Clone, Debug, EnumIter, DeriveActiveEnum, Default, Hash)]
+#[derive(
+    Eq, PartialEq, Copy, Clone, Debug, EnumIter, DeriveActiveEnum, Default, Hash, Serialize,
+)]
 #[sea_orm(rs_type = "String", db_type = "String(None)")]
 pub enum ChannelRole {
     /// Admin can read/write and change permissions.

--- a/crates/collab/src/db/tests/channel_tests.rs
+++ b/crates/collab/src/db/tests/channel_tests.rs
@@ -109,10 +109,9 @@ async fn test_channels(db: &Arc<Database>) {
     assert!(db.get_channel(crdb_id, a_id).await.is_err());
 
     // Remove a channel tree
-    let (mut channel_ids, user_ids) = db.delete_channel(rust_id, a_id).await.unwrap();
+    let (_, mut channel_ids) = db.delete_channel(rust_id, a_id).await.unwrap();
     channel_ids.sort();
     assert_eq!(channel_ids, &[rust_id, cargo_id, cargo_ra_id]);
-    assert_eq!(user_ids, &[a_id]);
 
     assert!(db.get_channel(rust_id, a_id).await.is_err());
     assert!(db.get_channel(cargo_id, a_id).await.is_err());

--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -1,6 +1,6 @@
-use crate::db::UserId;
+use crate::db::{ChannelId, ChannelRole, UserId};
 use anyhow::{anyhow, Result};
-use collections::{BTreeMap, HashSet};
+use collections::{BTreeMap, HashMap, HashSet};
 use rpc::ConnectionId;
 use serde::Serialize;
 use tracing::instrument;
@@ -10,6 +10,7 @@ use util::SemanticVersion;
 pub struct ConnectionPool {
     connections: BTreeMap<ConnectionId, Connection>,
     connected_users: BTreeMap<UserId, ConnectedUser>,
+    channels: ChannelPool,
 }
 
 #[derive(Default, Serialize)]
@@ -47,6 +48,7 @@ impl ConnectionPool {
     pub fn reset(&mut self) {
         self.connections.clear();
         self.connected_users.clear();
+        self.channels.clear();
     }
 
     #[instrument(skip(self))]
@@ -81,6 +83,7 @@ impl ConnectionPool {
         connected_user.connection_ids.remove(&connection_id);
         if connected_user.connection_ids.is_empty() {
             self.connected_users.remove(&user_id);
+            self.channels.remove_user(&user_id);
         }
         self.connections.remove(&connection_id).unwrap();
         Ok(())
@@ -108,6 +111,38 @@ impl ConnectionPool {
             .into_iter()
             .flat_map(|state| &state.connection_ids)
             .copied()
+    }
+
+    pub fn channel_user_ids(
+        &self,
+        channel_id: ChannelId,
+    ) -> impl Iterator<Item = (UserId, ChannelRole)> + '_ {
+        self.channels.users_to_notify(channel_id)
+    }
+
+    pub fn channel_connection_ids(
+        &self,
+        channel_id: ChannelId,
+    ) -> impl Iterator<Item = (ConnectionId, ChannelRole)> + '_ {
+        self.channels
+            .users_to_notify(channel_id)
+            .flat_map(|(user_id, role)| {
+                self.user_connection_ids(user_id)
+                    .map(move |connection_id| (connection_id, role))
+            })
+    }
+
+    pub fn subscribe_to_channel(
+        &mut self,
+        user_id: UserId,
+        channel_id: ChannelId,
+        role: ChannelRole,
+    ) {
+        self.channels.subscribe(user_id, channel_id, role);
+    }
+
+    pub fn unsubscribe_from_channel(&mut self, user_id: &UserId, channel_id: &ChannelId) {
+        self.channels.unsubscribe(user_id, channel_id);
     }
 
     pub fn is_user_online(&self, user_id: UserId) -> bool {
@@ -138,5 +173,72 @@ impl ConnectionPool {
                 );
             }
         }
+    }
+}
+
+#[derive(Default, Serialize)]
+pub struct ChannelPool {
+    by_user: HashMap<UserId, HashMap<ChannelId, ChannelRole>>,
+    by_channel: HashMap<ChannelId, HashSet<UserId>>,
+}
+
+impl ChannelPool {
+    pub fn clear(&mut self) {
+        self.by_user.clear();
+        self.by_channel.clear();
+    }
+
+    pub fn subscribe(&mut self, user_id: UserId, channel_id: ChannelId, role: ChannelRole) {
+        self.by_user
+            .entry(user_id)
+            .or_default()
+            .insert(channel_id, role);
+        self.by_channel
+            .entry(channel_id)
+            .or_default()
+            .insert(user_id);
+    }
+
+    pub fn unsubscribe(&mut self, user_id: &UserId, channel_id: &ChannelId) {
+        if let Some(channels) = self.by_user.get_mut(user_id) {
+            channels.remove(channel_id);
+            if channels.is_empty() {
+                self.by_user.remove(user_id);
+            }
+        }
+        if let Some(users) = self.by_channel.get_mut(channel_id) {
+            users.remove(user_id);
+            if users.is_empty() {
+                self.by_channel.remove(channel_id);
+            }
+        }
+    }
+
+    pub fn remove_user(&mut self, user_id: &UserId) {
+        if let Some(channels) = self.by_user.remove(&user_id) {
+            for channel_id in channels.keys() {
+                self.unsubscribe(user_id, &channel_id)
+            }
+        }
+    }
+
+    pub fn users_to_notify(
+        &self,
+        channel_id: ChannelId,
+    ) -> impl '_ + Iterator<Item = (UserId, ChannelRole)> {
+        self.by_channel
+            .get(&channel_id)
+            .into_iter()
+            .flat_map(move |users| {
+                users.iter().flat_map(move |user_id| {
+                    Some((
+                        *user_id,
+                        self.by_user
+                            .get(user_id)
+                            .and_then(|channels| channels.get(&channel_id))
+                            .copied()?,
+                    ))
+                })
+            })
     }
 }


### PR DESCRIPTION
This avoids a giant database query on every leave/join event.

Release Notes:

- N/A
