### PR TITLE
Don't panic on missing mtime

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7747,10 +7747,13 @@ impl Project {
                     }
 
                     let buffer_id = BufferId::new(state.id)?;
-                    let buffer = cx.new_model(|_| {
-                        Buffer::from_proto(this.replica_id(), this.capability(), state, buffer_file)
-                            .unwrap()
-                    });
+                    let buffer = Buffer::from_proto(
+                        this.replica_id(),
+                        this.capability(),
+                        state,
+                        buffer_file,
+                    )?;
+                    let buffer = cx.new_model(|_| buffer);
                     this.incomplete_remote_buffers
                         .insert(buffer_id, Some(buffer));
                 }


### PR DESCRIPTION
This is expected as of zed 0.128 when a new unsaved file is created

Release Notes:

- Fixed a panic when collaborating with newer zed versions
