### PR TITLE
Bump collab min version

### DIFF
--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -4,7 +4,7 @@ use collections::{BTreeMap, HashMap, HashSet};
 use rpc::ConnectionId;
 use serde::Serialize;
 use tracing::instrument;
-use util::SemanticVersion;
+use util::{semver, SemanticVersion};
 
 #[derive(Default, Serialize)]
 pub struct ConnectionPool {
@@ -29,11 +29,8 @@ impl fmt::Display for ZedVersion {
 }
 
 impl ZedVersion {
-    pub fn is_supported(&self) -> bool {
-        self.0 != SemanticVersion::new(0, 123, 0)
-    }
-    pub fn supports_talker_role(&self) -> bool {
-        self.0 >= SemanticVersion::new(0, 125, 0)
+    pub fn can_collaborate(&self) -> bool {
+        self.0 >= semver(0, 127, 3) || (self.0 >= semver(0, 126, 3) && self.0 < semver(0, 127, 0))
     }
 }
 

--- a/crates/util/src/semantic_version.rs
+++ b/crates/util/src/semantic_version.rs
@@ -14,6 +14,14 @@ pub struct SemanticVersion {
     pub patch: usize,
 }
 
+pub fn semver(major: usize, minor: usize, patch: usize) -> SemanticVersion {
+    SemanticVersion {
+        major,
+        minor,
+        patch,
+    }
+}
+
 impl SemanticVersion {
     pub fn new(major: usize, minor: usize, patch: usize) -> Self {
         Self {

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -10,7 +10,7 @@ pub mod test;
 use futures::Future;
 use lazy_static::lazy_static;
 use rand::{seq::SliceRandom, Rng};
-pub use semantic_version::SemanticVersion;
+pub use semantic_version::*;
 use std::{
     borrow::Cow,
     cmp::{self, Ordering},


### PR DESCRIPTION
We made a change last week to allow creating files with names. This
means some files have null saved_mtime, which old versions of zed panic
on.

A fix is available in 0.126.3 and above

Release Notes:


- N/A
