### PR TITLE
Update binary name for extension CLI

### DIFF
--- a/crates/extension_cli/Cargo.toml
+++ b/crates/extension_cli/Cargo.toml
@@ -8,6 +8,10 @@ license = "GPL-3.0-or-later"
 [lints]
 workspace = true
 
+[[bin]]
+name = "zed-extension"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
This PR updates the binary name used by the extension CLI from `extension_cli` to `zed-extension`.

Release Notes:

- N/A
