### PR TITLE
wayland: fix handling of non-discrete scroll events

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -966,8 +966,9 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientState {
                 value,
                 ..
             } => {
+                // We handle discrete scroll events with `AxisValue120`.
                 if wl_pointer.version() >= wl_pointer::EVT_AXIS_VALUE120_SINCE
-                    && state.axis_source != AxisSource::Continuous
+                    && state.axis_source == AxisSource::Wheel
                 {
                     return;
                 }


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/9103 broke touchpad scrolling on Wayland
This PR correctly filters the `Axis` to handle all non-discrete scroll events (see https://wayland.app/protocols/wayland#wl_pointer:enum:axis_source)

Should fix https://github.com/zed-industries/zed/issues/9525

Release Notes:

- N/A
