### PR TITLE
Only allow opening one Extensions view

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -29,8 +29,18 @@ pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(move |workspace: &mut Workspace, cx| {
         workspace
             .register_action(move |workspace, _: &Extensions, cx| {
-                let extensions_page = ExtensionsPage::new(workspace, cx);
-                workspace.add_item_to_active_pane(Box::new(extensions_page), cx)
+                let existing = workspace
+                    .active_pane()
+                    .read(cx)
+                    .items()
+                    .find_map(|item| item.downcast::<ExtensionsPage>());
+
+                if let Some(existing) = existing {
+                    workspace.activate_item(&existing, cx);
+                } else {
+                    let extensions_page = ExtensionsPage::new(workspace, cx);
+                    workspace.add_item_to_active_pane(Box::new(extensions_page), cx)
+                }
             })
             .register_action(move |_, _: &InstallDevExtension, cx| {
                 let store = ExtensionStore::global(cx);


### PR DESCRIPTION
Release Notes:

- Changed the extensions view to only allow one open instance at a time.


## Before

<img width="494" alt="image" src="https://github.com/zed-industries/zed/assets/5518/9329e685-1946-4384-bec3-f7eadf18a0cc">

