### PR TITLE
ui: Make `top_padding` an associated function on the `TitleBar`

### DIFF
--- a/crates/ui/src/components/title_bar/title_bar.rs
+++ b/crates/ui/src/components/title_bar/title_bar.rs
@@ -10,27 +10,6 @@ pub struct TitleBar {
     content: Stateful<Div>,
     children: SmallVec<[AnyElement; 2]>,
 }
-#[cfg(not(target_os = "windows"))]
-fn title_bar_top_padding(_cx: &WindowContext) -> Pixels {
-    px(0.)
-}
-
-#[cfg(target_os = "windows")]
-fn title_bar_top_padding(cx: &WindowContext) -> Pixels {
-    use windows::Win32::UI::{
-        HiDpi::GetSystemMetricsForDpi,
-        WindowsAndMessaging::{SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI},
-    };
-
-    // this top padding is not dependent on the title bar style and is instead a quirk of maximized windows on Windows
-    // https://devblogs.microsoft.com/oldnewthing/20150304-00/?p=44543
-    let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI) };
-    if cx.is_maximized() {
-        px((padding * 2) as f32)
-    } else {
-        px(0.)
-    }
-}
 
 impl TitleBar {
     #[cfg(not(target_os = "windows"))]
@@ -42,6 +21,28 @@ impl TitleBar {
     pub fn height(_cx: &mut WindowContext) -> Pixels {
         // todo(windows) instead of hard coded size report the actual size to the Windows platform API
         px(32.)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn top_padding(_cx: &WindowContext) -> Pixels {
+        px(0.)
+    }
+
+    #[cfg(target_os = "windows")]
+    fn top_padding(cx: &WindowContext) -> Pixels {
+        use windows::Win32::UI::{
+            HiDpi::GetSystemMetricsForDpi,
+            WindowsAndMessaging::{SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI},
+        };
+
+        // This top padding is not dependent on the title bar style and is instead a quirk of maximized windows on Windows:
+        // https://devblogs.microsoft.com/oldnewthing/20150304-00/?p=44543
+        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI) };
+        if cx.is_maximized() {
+            px((padding * 2) as f32)
+        } else {
+            px(0.)
+        }
     }
 
     pub fn new(id: impl Into<ElementId>) -> Self {
@@ -79,8 +80,8 @@ impl RenderOnce for TitleBar {
         h_flex()
             .id("titlebar")
             .w_full()
-            .pt(title_bar_top_padding(cx))
-            .h(height + title_bar_top_padding(cx))
+            .pt(Self::top_padding(cx))
+            .h(height + Self::top_padding(cx))
             .map(|this| {
                 if cx.is_fullscreen() {
                     this.pl_2()


### PR DESCRIPTION
This PR makes the function for computing the top padding for the `TitleBar` an associated function.

Release Notes:

- N/A
