### PR TITLE
Fix skip prompt warning

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -108,6 +108,7 @@ pub struct EntryDetails {
 
 #[derive(PartialEq, Clone, Default, Debug, Deserialize)]
 pub struct Delete {
+    #[serde(default)]
     pub skip_prompt: bool,
 }
 


### PR DESCRIPTION
This fixes a non-panicking log error caused by https://github.com/zed-industries/zed/pull/9452

Release Notes:

- N/A