### PR TITLE
Fix binary name for extension CLI

### DIFF
--- a/crates/extension_cli/Cargo.toml
+++ b/crates/extension_cli/Cargo.toml
@@ -8,6 +8,10 @@ license = "GPL-3.0-or-later"
 [lints]
 workspace = true
 
+[[bin]]
+name = "zed-extension"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
This PR fixes the binary name for the extension CLI.

This was originally done in #9541, but got accidentally reverted in #9549.

Release Notes:

- N/A
