### PR TITLE
wayland: implement click count

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -22,8 +22,8 @@ use wayland_client::Connection;
 use crate::platform::linux::client::Client;
 use crate::platform::linux::wayland::WaylandClient;
 use crate::{
-    Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId,
-    ForegroundExecutor, Keymap, LinuxDispatcher, LinuxTextSystem, Menu, PathPromptOptions,
+    px, Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId,
+    ForegroundExecutor, Keymap, LinuxDispatcher, LinuxTextSystem, Menu, PathPromptOptions, Pixels,
     Platform, PlatformDisplay, PlatformInput, PlatformTextSystem, PlatformWindow, Result,
     SemanticVersion, Task, WindowOptions, WindowParams,
 };
@@ -31,6 +31,11 @@ use crate::{
 use super::x11::X11Client;
 
 pub(super) const SCROLL_LINES: f64 = 3.0;
+
+// Values match the defaults on GTK.
+// Taken from https://github.com/GNOME/gtk/blob/main/gtk/gtksettings.c#L320
+pub(super) const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(400);
+pub(super) const DOUBLE_CLICK_DISTANCE: Pixels = px(5.0);
 
 #[derive(Default)]
 pub(crate) struct Callbacks {
@@ -311,7 +316,7 @@ impl Platform for LinuxPlatform {
     }
 
     fn double_click_interval(&self) -> Duration {
-        Duration::default()
+        DOUBLE_CLICK_INTERVAL
     }
 
     fn os_version(&self) -> Result<SemanticVersion> {

--- a/crates/gpui/src/platform/linux/util.rs
+++ b/crates/gpui/src/platform/linux/util.rs
@@ -1,6 +1,7 @@
 use xkbcommon::xkb::{self, Keycode, Keysym, State};
 
-use crate::{Keystroke, Modifiers};
+use super::DOUBLE_CLICK_DISTANCE;
+use crate::{Keystroke, Modifiers, Pixels, Point};
 
 impl Keystroke {
     pub(super) fn from_xkb(state: &State, modifiers: Modifiers, keycode: Keycode) -> Self {
@@ -91,5 +92,38 @@ impl Keystroke {
             key,
             ime_key,
         }
+    }
+}
+
+// TODO: account scale?
+pub(super) fn is_within_click_distance(a: Point<Pixels>, b: Point<Pixels>) -> bool {
+    let diff = a - b;
+    diff.x.abs() <= DOUBLE_CLICK_DISTANCE && diff.y.abs() <= DOUBLE_CLICK_DISTANCE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{px, Point};
+
+    #[test]
+    fn test_is_within_click_distance() {
+        let zero = Point::new(px(0.0), px(0.0));
+        assert_eq!(
+            is_within_click_distance(zero, Point::new(px(5.0), px(5.0))),
+            true
+        );
+        assert_eq!(
+            is_within_click_distance(zero, Point::new(px(-4.9), px(5.0))),
+            true
+        );
+        assert_eq!(
+            is_within_click_distance(Point::new(px(3.0), px(2.0)), Point::new(px(-2.0), px(-2.0))),
+            true
+        );
+        assert_eq!(
+            is_within_click_distance(zero, Point::new(px(5.0), px(5.1))),
+            false
+        );
     }
 }


### PR DESCRIPTION
Allows double and triple clicks to happen on Wayland.

I've tested it by clicking randomly and seems to work fine, but feedback is appreciated

- [ ] Code is a bit ugly
- [ ] Need to account for the display scale (?)
- [ ] Investigate if X11 needs a similar solution and if does, move the code to some interface
- [ ] Is the test I wrote even needed? Should it be a UI test instead? (if so, I'll need some help with that)

Release Notes:

- Allow double and triple clicks on Wayland
