### PR TITLE
Fix `prettier-plugin-organize-imports` plugin removes used imports

### DIFF
--- a/crates/prettier/src/prettier_server.js
+++ b/crates/prettier/src/prettier_server.js
@@ -202,7 +202,7 @@ async function handleMessage(message, prettier) {
       ...resolvedConfig,
       plugins,
       parser: params.options.parser,
-      path: params.options.filepath,
+      filepath: params.options.filepath,
     };
     process.stderr.write(
       `Resolved config: ${JSON.stringify(resolvedConfig)}, will format file '${


### PR DESCRIPTION
### Issue
So this pull request fixes an issue that was driven me crazy. The issue was that when you use the `prettier-plugin-organize-imports` It would remove some imports that should not be removed before they were used inside the module itself. 

You can reproduce it with the following `prettierrc.json` config and source code. When you **save** the file, it would remove the `import clsx from "clsx";` import from the file. 

**Prettier config**
```json
{
  "semi": true,
  "tabWidth": 4,
  "trailingComma": "es5",
  "useTabs": true,
  "plugins": [
    "prettier-plugin-tailwindcss",
    "prettier-plugin-organize-imports"
  ]
}
```

**Source code**
```typescript
import clsx from "clsx";

export default function Home() {
  return (
      <main>
	      {clsx("asdjklasdjlkasd", "asdjlkasjdjlk")}
      </main>
  );
}
``` 

### Findings
After a deep dive with @mrnugget, I was debugging deep down the prettier plugin system and found the issue that was causing this issue. When I was looking inside the `node_modules/prettier-plugin-organize-imports/lib/organize.js`. I saw the following code that looked strange to me because it falls back to `file.ts` if `filepath` is not passed through inside the prettier config options.

<img width="860" alt="Screenshot 2024-03-20 at 21 31 46" src="https://github.com/zed-industries/zed/assets/62463826/47177fe5-e5a9-41d8-9f2f-0304b2c2159f">

So the issue was small, if you look at the following code, the `path` key should be `filepath` inside the `crates/prettier/src/prettier_server.js:205`
![Screenshot 2024-03-20 at 21 35 25](https://github.com/zed-industries/zed/assets/62463826/1eea0a88-c886-4632-9c69-9f3095126971)

Release Notes:

- Fixed prettier integration not using the correct filepath when invoking prettier, which could lead to some prettier plugins failing to format correctly. ([#9496](https://github.com/zed-industries/zed/issues/9496)).