### PR TITLE
Add Segoe UI as a font fallback

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -67,6 +67,7 @@ impl TextSystem {
                 font("Cantarell"), // Gnome
                 font("Ubuntu"),    // Gnome (Ubuntu)
                 font("Noto Sans"), // KDE
+                font("Segoe UI"), // Windows
             ],
         }
     }

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -67,7 +67,7 @@ impl TextSystem {
                 font("Cantarell"), // Gnome
                 font("Ubuntu"),    // Gnome (Ubuntu)
                 font("Noto Sans"), // KDE
-                font("Segoe UI"), // Windows
+                font("Segoe UI"),  // Windows
             ],
         }
     }


### PR DESCRIPTION

Release Notes:

- Added Segoe UI as a font fallback for easier development and to make the examples work on Windows.
