### PR TITLE
gpui: Add support for window transparency & blur on macOS

### DIFF
--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -121,6 +121,6 @@ fn notification_window_options(
         is_movable: false,
         display_id: Some(screen.id()),
         fullscreen: false,
-        window_background: WindowBackground::default()
+        window_background: WindowBackground::default(),
     }
 }

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -121,6 +121,6 @@ fn notification_window_options(
         is_movable: false,
         display_id: Some(screen.id()),
         fullscreen: false,
-        window_background: Some(WindowBackground::default()),
+        window_background: WindowBackground::default()
     }
 }

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -13,8 +13,8 @@ use call::{report_call_event_for_room, ActiveCall};
 pub use collab_panel::CollabPanel;
 pub use collab_titlebar_item::CollabTitlebarItem;
 use gpui::{
-    actions, point, AppContext, DevicePixels, Pixels, PlatformDisplay, Size, Task, WindowContext,
-    WindowKind, WindowOptions,
+    actions, point, AppContext, DevicePixels, Pixels, PlatformDisplay, Size, Task,
+    WindowBackground, WindowContext, WindowKind, WindowOptions,
 };
 use panel_settings::MessageEditorSettings;
 pub use panel_settings::{
@@ -121,5 +121,6 @@ fn notification_window_options(
         is_movable: false,
         display_id: Some(screen.id()),
         fullscreen: false,
+        window_background: Some(WindowBackground::default()),
     }
 }

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -14,7 +14,7 @@ pub use collab_panel::CollabPanel;
 pub use collab_titlebar_item::CollabTitlebarItem;
 use gpui::{
     actions, point, AppContext, DevicePixels, Pixels, PlatformDisplay, Size, Task,
-    WindowBackground, WindowContext, WindowKind, WindowOptions,
+    WindowBackgroundAppearance, WindowContext, WindowKind, WindowOptions,
 };
 use panel_settings::MessageEditorSettings;
 pub use panel_settings::{
@@ -121,6 +121,6 @@ fn notification_window_options(
         is_movable: false,
         display_id: Some(screen.id()),
         fullscreen: false,
-        window_background: WindowBackground::default(),
+        window_background: WindowBackgroundAppearance::default(),
     }
 }

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -48,6 +48,7 @@ fn main() {
                     display_id: Some(screen.id()),
 
                     titlebar: None,
+                    window_background: WindowBackgroundAppearance::default(),
                     focus: false,
                     show: true,
                     kind: WindowKind::PopUp,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -534,6 +534,9 @@ pub struct WindowOptions {
     /// The display to create the window on, if this is None,
     /// the window will be created on the main display
     pub display_id: Option<DisplayId>,
+
+    /// The background type of the window
+    pub window_background: Option<WindowBackground>
 }
 
 /// The variables that can be configured when creating a new window
@@ -556,6 +559,8 @@ pub(crate) struct WindowParams {
     pub show: bool,
 
     pub display_id: Option<DisplayId>,
+
+    pub window_background: Option<WindowBackground>
 }
 
 impl Default for WindowOptions {
@@ -573,6 +578,7 @@ impl Default for WindowOptions {
             is_movable: true,
             display_id: None,
             fullscreen: false,
+            window_background: Some(WindowBackground::default()),
         }
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -535,7 +535,7 @@ pub struct WindowOptions {
     /// the window will be created on the main display
     pub display_id: Option<DisplayId>,
 
-    /// The background type of the window
+    /// The appearance of the window background.
     pub window_background: WindowBackgroundAppearance,
 }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -536,7 +536,7 @@ pub struct WindowOptions {
     pub display_id: Option<DisplayId>,
 
     /// The background type of the window
-    pub window_background: Option<WindowBackground>
+    pub window_background: WindowBackground
 }
 
 /// The variables that can be configured when creating a new window
@@ -560,7 +560,7 @@ pub(crate) struct WindowParams {
 
     pub display_id: Option<DisplayId>,
 
-    pub window_background: Option<WindowBackground>
+    pub window_background: WindowBackground,
 }
 
 impl Default for WindowOptions {
@@ -578,7 +578,7 @@ impl Default for WindowOptions {
             is_movable: true,
             display_id: None,
             fullscreen: false,
-            window_background: Some(WindowBackground::default()),
+            window_background: WindowBackground::default(),
         }
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -536,7 +536,7 @@ pub struct WindowOptions {
     pub display_id: Option<DisplayId>,
 
     /// The background type of the window
-    pub window_background: WindowBackground
+    pub window_background: WindowBackground,
 }
 
 /// The variables that can be configured when creating a new window
@@ -642,7 +642,7 @@ impl Default for WindowAppearance {
 
 /// The appearance of the background of the window itself, when there is
 /// no content or the content is transparent.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub enum WindowBackground {
     /// Opaque.
     ///
@@ -651,6 +651,7 @@ pub enum WindowBackground {
     ///
     /// Actual color depends on the system and themes should define a fully
     /// opaque background color instead.
+    #[default]
     Opaque,
     /// Plain alpha transparency.
     Transparent,
@@ -658,12 +659,6 @@ pub enum WindowBackground {
     ///
     /// Not always supported.
     Blurred,
-}
-
-impl Default for WindowBackground {
-    fn default() -> Self {
-        WindowBackground::Opaque
-    }
 }
 
 /// The options that can be configured for a file dialog prompt

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -190,8 +190,8 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn activate(&self);
     fn is_active(&self) -> bool;
     fn set_title(&mut self, title: &str);
+    fn set_background_appearance(&mut self, background_appearance: WindowBackgroundAppearance);
     fn set_edited(&mut self, edited: bool);
-    fn set_background(&mut self, background: WindowBackground);
     fn show_character_palette(&self);
     fn minimize(&self);
     fn zoom(&self);
@@ -536,7 +536,7 @@ pub struct WindowOptions {
     pub display_id: Option<DisplayId>,
 
     /// The background type of the window
-    pub window_background: WindowBackground,
+    pub window_background: WindowBackgroundAppearance,
 }
 
 /// The variables that can be configured when creating a new window
@@ -560,7 +560,7 @@ pub(crate) struct WindowParams {
 
     pub display_id: Option<DisplayId>,
 
-    pub window_background: WindowBackground,
+    pub window_background: WindowBackgroundAppearance,
 }
 
 impl Default for WindowOptions {
@@ -578,7 +578,7 @@ impl Default for WindowOptions {
             is_movable: true,
             display_id: None,
             fullscreen: false,
-            window_background: WindowBackground::default(),
+            window_background: WindowBackgroundAppearance::default(),
         }
     }
 }
@@ -643,7 +643,7 @@ impl Default for WindowAppearance {
 /// The appearance of the background of the window itself, when there is
 /// no content or the content is transparent.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
-pub enum WindowBackground {
+pub enum WindowBackgroundAppearance {
     /// Opaque.
     ///
     /// This lets the window manager know that content behind this

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -191,6 +191,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn is_active(&self) -> bool;
     fn set_title(&mut self, title: &str);
     fn set_edited(&mut self, edited: bool);
+    fn set_background(&mut self, background: WindowBackground);
     fn show_character_palette(&self);
     fn minimize(&self);
     fn zoom(&self);
@@ -630,6 +631,32 @@ pub enum WindowAppearance {
 impl Default for WindowAppearance {
     fn default() -> Self {
         Self::Light
+    }
+}
+
+/// The appearance of the background of the window itself, when there is
+/// no content or the content is transparent.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum WindowBackground {
+    /// Opaque.
+    ///
+    /// This lets the window manager know that content behind this
+    /// window does not need to be drawn.
+    ///
+    /// Actual color depends on the system and themes should define a fully
+    /// opaque background color instead.
+    Opaque,
+    /// Plain alpha transparency.
+    Transparent,
+    /// Transparency, but the contents behind the window are blurred.
+    ///
+    /// Not always supported.
+    Blurred,
+}
+
+impl Default for WindowBackground {
+    fn default() -> Self {
+        WindowBackground::Opaque
     }
 }
 

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -23,7 +23,7 @@ use crate::platform::{PlatformAtlas, PlatformInputHandler, PlatformWindow};
 use crate::scene::Scene;
 use crate::{
     px, size, Bounds, DevicePixels, Modifiers, Pixels, PlatformDisplay, PlatformInput, Point,
-    PromptLevel, Size, WindowAppearance, WindowParams,
+    PromptLevel, Size, WindowAppearance, WindowBackground, WindowParams,
 };
 
 #[derive(Default)]
@@ -382,6 +382,9 @@ impl PlatformWindow for WaylandWindow {
     fn is_fullscreen(&self) -> bool {
         *self.0.fullscreen.borrow()
     }
+
+    // todo(linux)
+    fn set_background(&mut self, background: WindowBackground) {}
 
     fn on_request_frame(&self, callback: Box<dyn FnMut()>) {
         self.0.callbacks.borrow_mut().request_frame = Some(callback);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -23,7 +23,7 @@ use crate::platform::{PlatformAtlas, PlatformInputHandler, PlatformWindow};
 use crate::scene::Scene;
 use crate::{
     px, size, Bounds, DevicePixels, Modifiers, Pixels, PlatformDisplay, PlatformInput, Point,
-    PromptLevel, Size, WindowAppearance, WindowBackground, WindowParams,
+    PromptLevel, Size, WindowAppearance, WindowBackgroundAppearance, WindowParams,
 };
 
 #[derive(Default)]
@@ -355,6 +355,10 @@ impl PlatformWindow for WaylandWindow {
         self.0.toplevel.set_title(title.to_string());
     }
 
+    fn set_background_appearance(&mut self, _background_appearance: WindowBackgroundAppearance) {
+        // todo(linux)
+    }
+
     fn set_edited(&mut self, edited: bool) {
         // todo(linux)
     }
@@ -382,9 +386,6 @@ impl PlatformWindow for WaylandWindow {
     fn is_fullscreen(&self) -> bool {
         *self.0.fullscreen.borrow()
     }
-
-    // todo(linux)
-    fn set_background(&mut self, background: WindowBackground) {}
 
     fn on_request_frame(&self, callback: Box<dyn FnMut()>) {
         self.0.callbacks.borrow_mut().request_frame = Some(callback);

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -4,7 +4,7 @@
 use crate::{
     platform::blade::BladeRenderer, size, Bounds, DevicePixels, Modifiers, Pixels, PlatformAtlas,
     PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptLevel,
-    Scene, Size, WindowAppearance, WindowOptions, WindowParams,
+    Scene, Size, WindowAppearance, WindowBackground, WindowOptions, WindowParams,
 };
 use blade_graphics as gpu;
 use parking_lot::Mutex;
@@ -419,6 +419,9 @@ impl PlatformWindow for X11Window {
             )
             .unwrap();
     }
+
+    // todo(linux)
+    fn set_background(&mut self, background: WindowBackground) {}
 
     // todo(linux)
     fn set_edited(&mut self, edited: bool) {}

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -4,7 +4,7 @@
 use crate::{
     platform::blade::BladeRenderer, size, Bounds, DevicePixels, Modifiers, Pixels, PlatformAtlas,
     PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptLevel,
-    Scene, Size, WindowAppearance, WindowBackground, WindowOptions, WindowParams,
+    Scene, Size, WindowAppearance, WindowBackgroundAppearance, WindowOptions, WindowParams,
 };
 use blade_graphics as gpu;
 use parking_lot::Mutex;
@@ -421,10 +421,11 @@ impl PlatformWindow for X11Window {
     }
 
     // todo(linux)
-    fn set_background(&mut self, background: WindowBackground) {}
-
-    // todo(linux)
     fn set_edited(&mut self, edited: bool) {}
+
+    fn set_background_appearance(&mut self, _background_appearance: WindowBackgroundAppearance) {
+        // todo(linux)
+    }
 
     // todo(linux), this corresponds to `orderFrontCharacterPalette` on macOS,
     // but it looks like the equivalent for Linux is GTK specific:

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -73,7 +73,7 @@ impl MetalRenderer {
         let layer = metal::MetalLayer::new();
         layer.set_device(&device);
         layer.set_pixel_format(MTLPixelFormat::RGBA8Unorm);
-        layer.set_opaque(true);
+        layer.set_opaque(false);
         layer.set_maximum_drawable_count(3);
         unsafe {
             let _: () = msg_send![&*layer, setAllowsNextDrawableTimeout: NO];

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -519,6 +519,7 @@ impl MacWindow {
     pub fn open(
         handle: AnyWindowHandle,
         WindowParams {
+            window_background,
             bounds,
             titlebar,
             kind,
@@ -530,6 +531,7 @@ impl MacWindow {
         executor: ForegroundExecutor,
         renderer_context: renderer::Context,
     ) -> Self {
+
         unsafe {
             let pool = NSAutoreleasePool::new(nil);
 
@@ -616,7 +618,7 @@ impl MacWindow {
                 )
             };
 
-            let window = Self(Arc::new(Mutex::new(MacWindowState {
+            let mut window = Self(Arc::new(Mutex::new(MacWindowState {
                 handle,
                 executor,
                 native_window,
@@ -694,6 +696,11 @@ impl MacWindow {
 
             native_window.setContentView_(native_view.autorelease());
             native_window.makeFirstResponder_(native_view);
+
+
+            if window_background.is_some() {
+                window.set_background(window_background.unwrap());
+            }
 
             match kind {
                 WindowKind::Normal => {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -23,7 +23,7 @@ use cocoa::{
 use core_graphics::display::{CGDirectDisplayID, CGRect};
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
-    // Wildly used private APIs; Apple uses them for their Terminal.app.
+    // Widely used private APIs; Apple uses them for their Terminal.app.
     fn CGSMainConnectionID() -> id;
     fn CGSSetWindowBackgroundBlurRadius(
         connection_id: id,
@@ -531,7 +531,6 @@ impl MacWindow {
         executor: ForegroundExecutor,
         renderer_context: renderer::Context,
     ) -> Self {
-
         unsafe {
             let pool = NSAutoreleasePool::new(nil);
 
@@ -697,10 +696,7 @@ impl MacWindow {
             native_window.setContentView_(native_view.autorelease());
             native_window.makeFirstResponder_(native_view);
 
-
-            if window_background.is_some() {
-                window.set_background(window_background.unwrap());
-            }
+            window.set_background(window_background);
 
             match kind {
                 WindowKind::Normal => {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -21,16 +21,6 @@ use cocoa::{
     },
 };
 use core_graphics::display::{CGDirectDisplayID, CGRect};
-#[link(name = "CoreGraphics", kind = "framework")]
-extern "C" {
-    // Widely used private APIs; Apple uses them for their Terminal.app.
-    fn CGSMainConnectionID() -> id;
-    fn CGSSetWindowBackgroundBlurRadius(
-        connection_id: id,
-        window_id: NSInteger,
-        radius: i64,
-    ) -> i32;
-}
 use ctor::ctor;
 use futures::channel::oneshot;
 use objc::{
@@ -92,6 +82,17 @@ type NSDragOperation = NSUInteger;
 const NSDragOperationNone: NSDragOperation = 0;
 #[allow(non_upper_case_globals)]
 const NSDragOperationCopy: NSDragOperation = 1;
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    // Widely used private APIs; Apple uses them for their Terminal.app.
+    fn CGSMainConnectionID() -> id;
+    fn CGSSetWindowBackgroundBlurRadius(
+        connection_id: id,
+        window_id: NSInteger,
+        radius: i64,
+    ) -> i32;
+}
 
 #[ctor]
 unsafe fn build_classes() {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -2,7 +2,7 @@ use crate::{
     AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, DevicePixels,
     DispatchEventResult, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
-    WindowBackground, WindowParams,
+    WindowBackgroundAppearance, WindowParams,
 };
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -190,7 +190,7 @@ impl PlatformWindow for TestWindow {
         self.0.lock().title = Some(title.to_owned());
     }
 
-    fn set_background(&mut self, _background: WindowBackground) {
+    fn set_background_appearance(&mut self, _background: WindowBackgroundAppearance) {
         unimplemented!()
     }
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -215,6 +215,10 @@ impl PlatformWindow for TestWindow {
         self.0.lock().is_fullscreen
     }
 
+    fn set_background(&mut self, _background: crate::WindowBackground) {
+        unimplemented!()
+    }
+
     fn on_request_frame(&self, _callback: Box<dyn FnMut()>) {}
 
     fn on_input(&self, callback: Box<dyn FnMut(crate::PlatformInput) -> DispatchEventResult>) {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -2,7 +2,7 @@ use crate::{
     AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, DevicePixels,
     DispatchEventResult, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
-    WindowParams,
+    WindowBackground, WindowParams,
 };
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -190,6 +190,10 @@ impl PlatformWindow for TestWindow {
         self.0.lock().title = Some(title.to_owned());
     }
 
+    fn set_background(&mut self, _background: WindowBackground) {
+        unimplemented!()
+    }
+
     fn set_edited(&mut self, edited: bool) {
         self.0.lock().edited = edited;
     }
@@ -213,10 +217,6 @@ impl PlatformWindow for TestWindow {
 
     fn is_fullscreen(&self) -> bool {
         self.0.lock().is_fullscreen
-    }
-
-    fn set_background(&mut self, _background: crate::WindowBackground) {
-        unimplemented!()
     }
 
     fn on_request_frame(&self, _callback: Box<dyn FnMut()>) {}

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1468,8 +1468,9 @@ impl PlatformWindow for WindowsWindow {
             .ok();
     }
 
-    // todo(windows)
-    fn set_background(&mut self, _background: WindowBackground) {}
+    fn set_background_appearance(&mut self, _background_appearance: WindowBackgroundAppearance) {
+        // todo(windows)
+    }
 
     // todo(windows)
     fn set_edited(&mut self, _edited: bool) {}

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1469,7 +1469,7 @@ impl PlatformWindow for WindowsWindow {
     }
 
     // todo(windows)
-    fn set_background(&mut self, background: WindowBackground) {}
+    fn set_background(&mut self, _background: WindowBackground) {}
 
     // todo(windows)
     fn set_edited(&mut self, _edited: bool) {}

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1469,6 +1469,9 @@ impl PlatformWindow for WindowsWindow {
     }
 
     // todo(windows)
+    fn set_background(&mut self, background: WindowBackground) {}
+
+    // todo(windows)
     fn set_edited(&mut self, _edited: bool) {}
 
     // todo(windows)

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -8,7 +8,7 @@ use crate::{
     PlatformAtlas, PlatformDisplay, PlatformInput, PlatformWindow, Point, PromptLevel, Render,
     ScaledPixels, SharedString, Size, SubscriberSet, Subscription, TaffyLayoutEngine, Task,
     TextStyle, TextStyleRefinement, View, VisualContext, WeakView, WindowAppearance,
-    WindowBackground, WindowOptions, WindowParams, WindowTextSystem,
+    WindowBackgroundAppearance, WindowOptions, WindowParams, WindowTextSystem,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::FxHashSet;
@@ -893,11 +893,6 @@ impl<'a> WindowContext<'a> {
         self.window.appearance
     }
 
-    /// Sets the window background style
-    pub fn set_background(&mut self, background: WindowBackground) {
-        self.window.platform_window.set_background(background);
-    }
-
     /// Returns the size of the drawable area within the window.
     pub fn viewport_size(&self) -> Size<Pixels> {
         self.window.viewport_size
@@ -916,6 +911,13 @@ impl<'a> WindowContext<'a> {
     /// Updates the window's title at the platform level.
     pub fn set_window_title(&mut self, title: &str) {
         self.window.platform_window.set_title(title);
+    }
+
+    /// Sets the window background appearance.
+    pub fn set_background_appearance(&mut self, background_appearance: WindowBackgroundAppearance) {
+        self.window
+            .platform_window
+            .set_background_appearance(background_appearance);
     }
 
     /// Mark the window as dirty at the platform level.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -7,8 +7,8 @@ use crate::{
     Modifiers, ModifiersChangedEvent, MouseButton, MouseMoveEvent, MouseUpEvent, Pixels,
     PlatformAtlas, PlatformDisplay, PlatformInput, PlatformWindow, Point, PromptLevel, Render,
     ScaledPixels, SharedString, Size, SubscriberSet, Subscription, TaffyLayoutEngine, Task,
-    TextStyle, TextStyleRefinement, View, VisualContext, WeakView, WindowAppearance, WindowOptions,
-    WindowParams, WindowTextSystem,
+    TextStyle, TextStyleRefinement, View, VisualContext, WeakView, WindowAppearance,
+    WindowBackground, WindowOptions, WindowParams, WindowTextSystem,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::FxHashSet;
@@ -872,7 +872,7 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.bounds()
     }
 
-    /// Retusn whether or not the window is currently fullscreen
+    /// Returns whether or not the window is currently fullscreen
     pub fn is_fullscreen(&self) -> bool {
         self.window.platform_window.is_fullscreen()
     }
@@ -889,6 +889,11 @@ impl<'a> WindowContext<'a> {
     /// Returns the appearance of the current window.
     pub fn appearance(&self) -> WindowAppearance {
         self.window.appearance
+    }
+
+    /// Sets the window background style
+    pub fn set_background(&mut self, background: WindowBackground) {
+        self.window.platform_window.set_background(background);
     }
 
     /// Returns the size of the drawable area within the window.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -398,6 +398,7 @@ impl Window {
             is_movable,
             display_id,
             fullscreen,
+            window_background
         } = options;
 
         let bounds = bounds.unwrap_or_else(|| default_bounds(display_id, cx));
@@ -411,6 +412,7 @@ impl Window {
                 focus,
                 show,
                 display_id,
+                window_background
             },
         );
         let display_id = platform_window.display().id();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -398,7 +398,7 @@ impl Window {
             is_movable,
             display_id,
             fullscreen,
-            window_background
+            window_background,
         } = options;
 
         let bounds = bounds.unwrap_or_else(|| default_bounds(display_id, cx));
@@ -412,7 +412,7 @@ impl Window {
                 focus,
                 show,
                 display_id,
-                window_background
+                window_background,
             },
         );
         let display_id = platform_window.display().id();

--- a/crates/theme/src/default_theme.rs
+++ b/crates/theme/src/default_theme.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use gpui::WindowBackground;
+
 use crate::prelude::*;
 
 use crate::{
@@ -14,6 +16,7 @@ fn zed_pro_daylight() -> Theme {
         id: "zed_pro_daylight".to_string(),
         name: "Zed Pro Daylight".into(),
         appearance: Appearance::Light,
+        window_background: WindowBackground::Opaque,
         styles: ThemeStyles {
             system: SystemColors::default(),
             colors: ThemeColors::light(),
@@ -44,6 +47,7 @@ pub(crate) fn zed_pro_moonlight() -> Theme {
         id: "zed_pro_moonlight".to_string(),
         name: "Zed Pro Moonlight".into(),
         appearance: Appearance::Dark,
+        window_background: WindowBackground::Opaque,
         styles: ThemeStyles {
             system: SystemColors::default(),
             colors: ThemeColors::dark(),

--- a/crates/theme/src/default_theme.rs
+++ b/crates/theme/src/default_theme.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gpui::WindowBackground;
+use gpui::WindowBackgroundAppearance;
 
 use crate::prelude::*;
 
@@ -16,7 +16,7 @@ fn zed_pro_daylight() -> Theme {
         id: "zed_pro_daylight".to_string(),
         name: "Zed Pro Daylight".into(),
         appearance: Appearance::Light,
-        window_background: WindowBackground::Opaque,
+        window_background: WindowBackgroundAppearance::Opaque,
         styles: ThemeStyles {
             system: SystemColors::default(),
             colors: ThemeColors::light(),
@@ -47,7 +47,7 @@ pub(crate) fn zed_pro_moonlight() -> Theme {
         id: "zed_pro_moonlight".to_string(),
         name: "Zed Pro Moonlight".into(),
         appearance: Appearance::Dark,
-        window_background: WindowBackground::Opaque,
+        window_background: WindowBackgroundAppearance::Opaque,
         styles: ThemeStyles {
             system: SystemColors::default(),
             colors: ThemeColors::dark(),

--- a/crates/theme/src/default_theme.rs
+++ b/crates/theme/src/default_theme.rs
@@ -16,8 +16,8 @@ fn zed_pro_daylight() -> Theme {
         id: "zed_pro_daylight".to_string(),
         name: "Zed Pro Daylight".into(),
         appearance: Appearance::Light,
-        window_background: WindowBackgroundAppearance::Opaque,
         styles: ThemeStyles {
+            window_background_appearance: WindowBackgroundAppearance::Opaque,
             system: SystemColors::default(),
             colors: ThemeColors::light(),
             status: StatusColors::light(),
@@ -47,8 +47,8 @@ pub(crate) fn zed_pro_moonlight() -> Theme {
         id: "zed_pro_moonlight".to_string(),
         name: "Zed Pro Moonlight".into(),
         appearance: Appearance::Dark,
-        window_background: WindowBackgroundAppearance::Opaque,
         styles: ThemeStyles {
+            window_background_appearance: WindowBackgroundAppearance::Opaque,
             system: SystemColors::default(),
             colors: ThemeColors::dark(),
             status: StatusColors::dark(),

--- a/crates/theme/src/one_themes.rs
+++ b/crates/theme/src/one_themes.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gpui::{hsla, FontStyle, FontWeight, HighlightStyle};
+use gpui::{hsla, FontStyle, FontWeight, HighlightStyle, WindowBackground};
 
 use crate::{
     default_color_scales, Appearance, PlayerColors, StatusColors, SyntaxTheme, SystemColors, Theme,
@@ -39,6 +39,7 @@ pub(crate) fn one_dark() -> Theme {
         id: "one_dark".to_string(),
         name: "One Dark".into(),
         appearance: Appearance::Dark,
+        window_background: WindowBackground::Opaque,
 
         styles: ThemeStyles {
             system: SystemColors::default(),

--- a/crates/theme/src/one_themes.rs
+++ b/crates/theme/src/one_themes.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gpui::{hsla, FontStyle, FontWeight, HighlightStyle, WindowBackground};
+use gpui::{hsla, FontStyle, FontWeight, HighlightStyle, WindowBackgroundAppearance};
 
 use crate::{
     default_color_scales, Appearance, PlayerColors, StatusColors, SyntaxTheme, SystemColors, Theme,
@@ -39,7 +39,7 @@ pub(crate) fn one_dark() -> Theme {
         id: "one_dark".to_string(),
         name: "One Dark".into(),
         appearance: Appearance::Dark,
-        window_background: WindowBackground::Opaque,
+        window_background: WindowBackgroundAppearance::Opaque,
 
         styles: ThemeStyles {
             system: SystemColors::default(),

--- a/crates/theme/src/one_themes.rs
+++ b/crates/theme/src/one_themes.rs
@@ -39,9 +39,8 @@ pub(crate) fn one_dark() -> Theme {
         id: "one_dark".to_string(),
         name: "One Dark".into(),
         appearance: Appearance::Dark,
-        window_background: WindowBackgroundAppearance::Opaque,
-
         styles: ThemeStyles {
+            window_background_appearance: WindowBackgroundAppearance::Opaque,
             system: SystemColors::default(),
             colors: ThemeColors {
                 border: hsla(225. / 360., 13. / 100., 12. / 100., 1.),

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -12,8 +12,9 @@ use refineable::Refineable;
 use util::ResultExt;
 
 use crate::{
-    try_parse_color, Appearance, AppearanceContent, PlayerColors, StatusColors, SyntaxTheme,
-    SystemColors, Theme, ThemeColors, ThemeContent, ThemeFamily, ThemeFamilyContent, ThemeStyles,
+    try_parse_color, try_parse_window_background, Appearance, AppearanceContent, PlayerColors,
+    StatusColors, SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeContent, ThemeFamily,
+    ThemeFamilyContent, ThemeStyles,
 };
 
 #[derive(Debug, Clone)]
@@ -122,6 +123,8 @@ impl ThemeRegistry {
                 AppearanceContent::Light => SyntaxTheme::light(),
                 AppearanceContent::Dark => SyntaxTheme::dark(),
             };
+            let window_background =
+                try_parse_window_background(&user_theme.window_background).unwrap();
             if !user_theme.style.syntax.is_empty() {
                 syntax_colors.highlights = user_theme
                     .style
@@ -151,6 +154,7 @@ impl ThemeRegistry {
                     AppearanceContent::Light => Appearance::Light,
                     AppearanceContent::Dark => Appearance::Dark,
                 },
+                window_background,
                 styles: ThemeStyles {
                     system: SystemColors::default(),
                     colors: theme_colors,

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -6,9 +6,7 @@ use collections::HashMap;
 use derive_more::{Deref, DerefMut};
 use fs::Fs;
 use futures::StreamExt;
-use gpui::{
-    AppContext, AssetSource, Global, HighlightStyle, SharedString, WindowBackgroundAppearance,
-};
+use gpui::{AppContext, AssetSource, Global, HighlightStyle, SharedString};
 use parking_lot::RwLock;
 use refineable::Refineable;
 use util::ResultExt;
@@ -16,7 +14,6 @@ use util::ResultExt;
 use crate::{
     try_parse_color, Appearance, AppearanceContent, PlayerColors, StatusColors, SyntaxTheme,
     SystemColors, Theme, ThemeColors, ThemeContent, ThemeFamily, ThemeFamilyContent, ThemeStyles,
-    WindowBackgroundContent,
 };
 
 #[derive(Debug, Clone)]
@@ -126,13 +123,10 @@ impl ThemeRegistry {
                 AppearanceContent::Dark => SyntaxTheme::dark(),
             };
 
-            let window_background = user_theme
-                .window_background
-                .map(|background| match background {
-                    WindowBackgroundContent::Opaque => WindowBackgroundAppearance::Opaque,
-                    WindowBackgroundContent::Transparent => WindowBackgroundAppearance::Transparent,
-                    WindowBackgroundContent::Blurred => WindowBackgroundAppearance::Blurred,
-                })
+            let window_background_appearance = user_theme
+                .style
+                .window_background_appearance
+                .map(Into::into)
                 .unwrap_or_default();
 
             if !user_theme.style.syntax.is_empty() {
@@ -164,9 +158,9 @@ impl ThemeRegistry {
                     AppearanceContent::Light => Appearance::Light,
                     AppearanceContent::Dark => Appearance::Dark,
                 },
-                window_background,
                 styles: ThemeStyles {
                     system: SystemColors::default(),
+                    window_background_appearance,
                     colors: theme_colors,
                     status: status_colors,
                     player: player_colors,

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -6,7 +6,9 @@ use collections::HashMap;
 use derive_more::{Deref, DerefMut};
 use fs::Fs;
 use futures::StreamExt;
-use gpui::{AppContext, AssetSource, Global, HighlightStyle, SharedString, WindowBackground};
+use gpui::{
+    AppContext, AssetSource, Global, HighlightStyle, SharedString, WindowBackgroundAppearance,
+};
 use parking_lot::RwLock;
 use refineable::Refineable;
 use util::ResultExt;
@@ -126,10 +128,10 @@ impl ThemeRegistry {
 
             let window_background = user_theme
                 .window_background
-                .map(|bg| match bg {
-                    WindowBackgroundContent::Opaque => WindowBackground::Opaque,
-                    WindowBackgroundContent::Transparent => WindowBackground::Transparent,
-                    WindowBackgroundContent::Blurred => WindowBackground::Blurred,
+                .map(|background| match background {
+                    WindowBackgroundContent::Opaque => WindowBackgroundAppearance::Opaque,
+                    WindowBackgroundContent::Transparent => WindowBackgroundAppearance::Transparent,
+                    WindowBackgroundContent::Blurred => WindowBackgroundAppearance::Blurred,
                 })
                 .unwrap_or_default();
 

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -6,15 +6,15 @@ use collections::HashMap;
 use derive_more::{Deref, DerefMut};
 use fs::Fs;
 use futures::StreamExt;
-use gpui::{AppContext, AssetSource, Global, HighlightStyle, SharedString};
+use gpui::{AppContext, AssetSource, Global, HighlightStyle, SharedString, WindowBackground};
 use parking_lot::RwLock;
 use refineable::Refineable;
 use util::ResultExt;
 
 use crate::{
-    try_parse_color, try_parse_window_background, Appearance, AppearanceContent, PlayerColors,
-    StatusColors, SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeContent, ThemeFamily,
-    ThemeFamilyContent, ThemeStyles,
+    try_parse_color, Appearance, AppearanceContent, PlayerColors, StatusColors, SyntaxTheme,
+    SystemColors, Theme, ThemeColors, ThemeContent, ThemeFamily, ThemeFamilyContent, ThemeStyles,
+    WindowBackgroundContent,
 };
 
 #[derive(Debug, Clone)]
@@ -123,8 +123,16 @@ impl ThemeRegistry {
                 AppearanceContent::Light => SyntaxTheme::light(),
                 AppearanceContent::Dark => SyntaxTheme::dark(),
             };
-            let window_background =
-                try_parse_window_background(&user_theme.window_background).unwrap();
+
+            let window_background = user_theme
+                .window_background
+                .map(|bg| match bg {
+                    WindowBackgroundContent::Opaque => WindowBackground::Opaque,
+                    WindowBackgroundContent::Transparent => WindowBackground::Transparent,
+                    WindowBackgroundContent::Blurred => WindowBackground::Blurred,
+                })
+                .unwrap_or_default();
+
             if !user_theme.style.syntax.is_empty() {
                 syntax_colors.highlights = user_theme
                     .style

--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla};
+use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla, WindowBackground};
 use indexmap::IndexMap;
 use palette::FromColor;
 use schemars::gen::SchemaGenerator;
@@ -26,6 +26,19 @@ pub(crate) fn try_parse_color(color: &str) -> Result<Hsla> {
     Ok(hsla)
 }
 
+pub(crate) fn try_parse_window_background(background: &Option<String>) -> Result<WindowBackground> {
+    if let Some(bg) = background {
+        match bg.as_str() {
+            "opaque" => Ok(WindowBackground::Opaque),
+            "transparent" => Ok(WindowBackground::Transparent),
+            "blurred" => Ok(WindowBackground::Blurred),
+            _ => Ok(WindowBackground::default())
+        }
+    } else {
+        Ok(WindowBackground::default())
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AppearanceContent {
@@ -47,6 +60,9 @@ pub struct ThemeContent {
     pub name: String,
     pub appearance: AppearanceContent,
     pub style: ThemeStyleContent,
+    /// Background style ("opaque", "transparent" or "blurred").
+    #[serde(default, rename = "window.background")]
+    pub window_background: Option<String>,
 }
 
 /// The content of a serialized theme.

--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla};
+use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla, WindowBackgroundAppearance};
 use indexmap::IndexMap;
 use palette::FromColor;
 use schemars::gen::SchemaGenerator;
@@ -42,6 +42,16 @@ pub enum WindowBackgroundContent {
     Blurred,
 }
 
+impl From<WindowBackgroundContent> for WindowBackgroundAppearance {
+    fn from(value: WindowBackgroundContent) -> Self {
+        match value {
+            WindowBackgroundContent::Opaque => WindowBackgroundAppearance::Opaque,
+            WindowBackgroundContent::Transparent => WindowBackgroundAppearance::Transparent,
+            WindowBackgroundContent::Blurred => WindowBackgroundAppearance::Blurred,
+        }
+    }
+}
+
 /// The content of a serialized theme family.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ThemeFamilyContent {
@@ -56,14 +66,15 @@ pub struct ThemeContent {
     pub name: String,
     pub appearance: AppearanceContent,
     pub style: ThemeStyleContent,
-    #[serde(default, rename = "window.background")]
-    pub window_background: Option<WindowBackgroundContent>,
 }
 
 /// The content of a serialized theme.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct ThemeStyleContent {
+    #[serde(default, rename = "background.appearance")]
+    pub window_background_appearance: Option<WindowBackgroundContent>,
+
     #[serde(flatten, default)]
     pub colors: ThemeColorsContent,
 

--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla, WindowBackground};
+use gpui::{FontStyle, FontWeight, HighlightStyle, Hsla};
 use indexmap::IndexMap;
 use palette::FromColor;
 use schemars::gen::SchemaGenerator;
@@ -26,24 +26,20 @@ pub(crate) fn try_parse_color(color: &str) -> Result<Hsla> {
     Ok(hsla)
 }
 
-pub(crate) fn try_parse_window_background(background: &Option<String>) -> Result<WindowBackground> {
-    if let Some(bg) = background {
-        match bg.as_str() {
-            "opaque" => Ok(WindowBackground::Opaque),
-            "transparent" => Ok(WindowBackground::Transparent),
-            "blurred" => Ok(WindowBackground::Blurred),
-            _ => Ok(WindowBackground::default())
-        }
-    } else {
-        Ok(WindowBackground::default())
-    }
-}
-
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AppearanceContent {
     Light,
     Dark,
+}
+
+/// Background style ("opaque", "transparent" or "blurred").
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowBackgroundContent {
+    Opaque,
+    Transparent,
+    Blurred,
 }
 
 /// The content of a serialized theme family.
@@ -60,9 +56,8 @@ pub struct ThemeContent {
     pub name: String,
     pub appearance: AppearanceContent,
     pub style: ThemeStyleContent,
-    /// Background style ("opaque", "transparent" or "blurred").
     #[serde(default, rename = "window.background")]
-    pub window_background: Option<String>,
+    pub window_background: Option<WindowBackgroundContent>,
 }
 
 /// The content of a serialized theme.

--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -33,7 +33,7 @@ pub enum AppearanceContent {
     Dark,
 }
 
-/// Background style ("opaque", "transparent" or "blurred").
+/// The background appearance of the window.
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WindowBackgroundContent {

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -244,6 +244,12 @@ impl ThemeSettings {
         if let Some(theme_overrides) = &self.theme_overrides {
             let mut base_theme = (*self.active_theme).clone();
 
+            if let Some(window_background_appearance) = theme_overrides.window_background_appearance
+            {
+                base_theme.styles.window_background_appearance =
+                    window_background_appearance.into();
+            }
+
             base_theme
                 .styles
                 .colors

--- a/crates/theme/src/styles/colors.rs
+++ b/crates/theme/src/styles/colors.rs
@@ -1,4 +1,4 @@
-use gpui::Hsla;
+use gpui::{Hsla, WindowBackgroundAppearance};
 use refineable::Refineable;
 use std::sync::Arc;
 
@@ -235,6 +235,8 @@ pub struct ThemeColors {
 
 #[derive(Refineable, Clone)]
 pub struct ThemeStyles {
+    /// The background appearance of the window.
+    pub window_background_appearance: WindowBackgroundAppearance,
     pub system: SystemColors,
     /// An array of colors used for theme elements that iterate through a series of colors.
     ///

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -27,7 +27,7 @@ pub use schema::*;
 pub use settings::*;
 pub use styles::*;
 
-use gpui::{AppContext, AssetSource, Hsla, SharedString, WindowAppearance};
+use gpui::{AppContext, AssetSource, Hsla, SharedString, WindowAppearance, WindowBackground};
 use serde::Deserialize;
 
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize)]
@@ -113,6 +113,7 @@ pub struct Theme {
     pub id: String,
     pub name: SharedString,
     pub appearance: Appearance,
+    pub window_background: WindowBackground,
     pub styles: ThemeStyles,
 }
 
@@ -157,6 +158,12 @@ impl Theme {
     #[inline(always)]
     pub fn appearance(&self) -> Appearance {
         self.appearance
+    }
+
+    /// Returns the window background for the theme.
+    #[inline(always)]
+    pub fn window_background(&self) -> WindowBackground {
+       self.window_background
     }
 }
 

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -115,7 +115,6 @@ pub struct Theme {
     pub id: String,
     pub name: SharedString,
     pub appearance: Appearance,
-    pub window_background: WindowBackgroundAppearance,
     pub styles: ThemeStyles,
 }
 
@@ -162,10 +161,10 @@ impl Theme {
         self.appearance
     }
 
-    /// Returns the window background for the theme.
+    /// Returns the [`WindowBackgroundAppearance`] for the theme.
     #[inline(always)]
-    pub fn window_background(&self) -> WindowBackgroundAppearance {
-        self.window_background
+    pub fn window_background_appearance(&self) -> WindowBackgroundAppearance {
+        self.styles.window_background_appearance
     }
 }
 

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -27,7 +27,9 @@ pub use schema::*;
 pub use settings::*;
 pub use styles::*;
 
-use gpui::{AppContext, AssetSource, Hsla, SharedString, WindowAppearance, WindowBackground};
+use gpui::{
+    AppContext, AssetSource, Hsla, SharedString, WindowAppearance, WindowBackgroundAppearance,
+};
 use serde::Deserialize;
 
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize)]
@@ -113,7 +115,7 @@ pub struct Theme {
     pub id: String,
     pub name: SharedString,
     pub appearance: Appearance,
-    pub window_background: WindowBackground,
+    pub window_background: WindowBackgroundAppearance,
     pub styles: ThemeStyles,
 }
 
@@ -162,7 +164,7 @@ impl Theme {
 
     /// Returns the window background for the theme.
     #[inline(always)]
-    pub fn window_background(&self) -> WindowBackground {
+    pub fn window_background(&self) -> WindowBackgroundAppearance {
         self.window_background
     }
 }

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -163,7 +163,7 @@ impl Theme {
     /// Returns the window background for the theme.
     #[inline(always)]
     pub fn window_background(&self) -> WindowBackground {
-       self.window_background
+        self.window_background
     }
 }
 

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -55,6 +55,7 @@ impl VsCodeThemeConverter {
         Ok(ThemeContent {
             name: self.theme_metadata.name,
             appearance,
+            window_background: Some(String::from("opaque")),
             style: ThemeStyleContent {
                 colors: theme_colors,
                 status: status_colors,

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -55,7 +55,7 @@ impl VsCodeThemeConverter {
         Ok(ThemeContent {
             name: self.theme_metadata.name,
             appearance,
-            window_background: Some(String::from("opaque")),
+            window_background: Some(theme::WindowBackgroundContent::Opaque),
             style: ThemeStyleContent {
                 colors: theme_colors,
                 status: status_colors,

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -55,8 +55,8 @@ impl VsCodeThemeConverter {
         Ok(ThemeContent {
             name: self.theme_metadata.name,
             appearance,
-            window_background: Some(theme::WindowBackgroundContent::Opaque),
             style: ThemeStyleContent {
+                window_background_appearance: Some(theme::WindowBackgroundContent::Opaque),
                 colors: theme_colors,
                 status: status_colors,
                 players: Vec::new(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -215,12 +215,14 @@ fn main() {
             let client = client.clone();
 
             move |cx| {
-                cx.windows().iter_mut().for_each(|&mut window| {
-                    let bg = cx.theme().window_background();
+                for &mut window in cx.windows().iter_mut() {
+                    let background_appearance = cx.theme().window_background_appearance();
                     window
-                        .update(cx, |_, cx| cx.set_background_appearance(bg))
+                        .update(cx, |_, cx| {
+                            cx.set_background_appearance(background_appearance)
+                        })
                         .ok();
-                });
+                }
                 languages.set_theme(cx.theme().clone());
                 let new_host = &client::ClientSettings::get_global(cx).server_url;
                 if &http.base_url() != new_host {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -208,12 +208,6 @@ fn main() {
         watch_file_types(fs.clone(), cx);
 
         languages.set_theme(cx.theme().clone());
-        cx.windows().iter_mut().for_each(|&mut w| {
-            let bg = cx.theme().window_background();
-            w.update(cx, |_, wcx| {
-                wcx.set_background(bg)
-            }).ok();
-        });
 
         cx.observe_global::<SettingsStore>({
             let languages = languages.clone();
@@ -221,10 +215,10 @@ fn main() {
             let client = client.clone();
 
             move |cx| {
-                cx.windows().iter_mut().for_each(|&mut w| {
+                cx.windows().iter_mut().for_each(|&mut window| {
                     let bg = cx.theme().window_background();
-                    w.update(cx, |_, wcx| {
-                        wcx.set_background(bg)
+                    window.update(cx, |_, cx| {
+                        cx.set_background(bg)
                     }).ok();
                 });
                 languages.set_theme(cx.theme().clone());

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -217,7 +217,9 @@ fn main() {
             move |cx| {
                 cx.windows().iter_mut().for_each(|&mut window| {
                     let bg = cx.theme().window_background();
-                    window.update(cx, |_, cx| cx.set_background(bg)).ok();
+                    window
+                        .update(cx, |_, cx| cx.set_background_appearance(bg))
+                        .ok();
                 });
                 languages.set_theme(cx.theme().clone());
                 let new_host = &client::ClientSettings::get_global(cx).server_url;

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -208,12 +208,25 @@ fn main() {
         watch_file_types(fs.clone(), cx);
 
         languages.set_theme(cx.theme().clone());
+        cx.windows().iter_mut().for_each(|&mut w| {
+            let bg = cx.theme().window_background();
+            w.update(cx, |_, wcx| {
+                wcx.set_background(bg)
+            }).ok();
+        });
+
         cx.observe_global::<SettingsStore>({
             let languages = languages.clone();
             let http = http.clone();
             let client = client.clone();
 
             move |cx| {
+                cx.windows().iter_mut().for_each(|&mut w| {
+                    let bg = cx.theme().window_background();
+                    w.update(cx, |_, wcx| {
+                        wcx.set_background(bg)
+                    }).ok();
+                });
                 languages.set_theme(cx.theme().clone());
                 let new_host = &client::ClientSettings::get_global(cx).server_url;
                 if &http.base_url() != new_host {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -217,9 +217,7 @@ fn main() {
             move |cx| {
                 cx.windows().iter_mut().for_each(|&mut window| {
                     let bg = cx.theme().window_background();
-                    window.update(cx, |_, cx| {
-                        cx.set_background(bg)
-                    }).ok();
+                    window.update(cx, |_, cx| cx.set_background(bg)).ok();
                 });
                 languages.set_theme(cx.theme().clone());
                 let new_host = &client::ClientSettings::get_global(cx).server_url;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -29,6 +29,7 @@ use settings::{
     initial_local_settings_content, initial_tasks_content, watch_config_file, KeymapFile, Settings,
     SettingsStore, DEFAULT_KEYMAP_PATH,
 };
+use theme::ActiveTheme;
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
 use task::{
     oneshot_source::OneshotSource,
@@ -104,6 +105,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         is_movable: true,
         display_id: display.map(|display| display.id()),
         fullscreen: false,
+        window_background: Some(cx.theme().window_background()) 
     }
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -105,7 +105,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         is_movable: true,
         display_id: display.map(|display| display.id()),
         fullscreen: false,
-        window_background: Some(cx.theme().window_background()) 
+        window_background: cx.theme().window_background(),
     }
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -105,7 +105,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         is_movable: true,
         display_id: display.map(|display| display.id()),
         fullscreen: false,
-        window_background: cx.theme().window_background(),
+        window_background: cx.theme().window_background_appearance(),
     }
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -29,12 +29,12 @@ use settings::{
     initial_local_settings_content, initial_tasks_content, watch_config_file, KeymapFile, Settings,
     SettingsStore, DEFAULT_KEYMAP_PATH,
 };
-use theme::ActiveTheme;
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
 use task::{
     oneshot_source::OneshotSource,
     static_source::{StaticSource, TrackedFile},
 };
+use theme::ActiveTheme;
 
 use terminal_view::terminal_panel::{self, TerminalPanel};
 use util::{


### PR DESCRIPTION
This PR adds support for transparent and blurred window backgrounds on macOS.

Release Notes:

- Added support for transparent and blurred window backgrounds on macOS ([#5040](https://github.com/zed-industries/zed/issues/5040)).
  - This requires themes to specify a new `background.appearance` key ("opaque", "transparent" or "blurred") and to include an alpha value in colors that should be transparent.

<img width="913" alt="image" src="https://github.com/zed-industries/zed/assets/2588851/7547ee2a-e376-4d55-9114-e6fc2f5110bc">
<img width="994" alt="image" src="https://github.com/zed-industries/zed/assets/2588851/b36fbc14-6e4d-4140-9448-69cad803c45a">
<img width="1020" alt="image" src="https://github.com/zed-industries/zed/assets/2588851/d70e2005-54fd-4991-a211-ed484ccf26ef">
