### PR TITLE
Fix extension_builder when the extension crate name used `-`

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -106,7 +106,6 @@ impl ExtensionBuilder {
     ) -> Result<(), anyhow::Error> {
         self.install_rust_wasm_target_if_needed()?;
         let adapter_bytes = self.install_wasi_preview1_adapter_if_needed().await?;
-
         let cargo_toml_content = fs::read_to_string(&extension_dir.join("Cargo.toml"))?;
         let cargo_toml: CargoToml = toml::from_str(&cargo_toml_content)?;
 
@@ -126,14 +125,15 @@ impl ExtensionBuilder {
             );
         }
 
+        // cargo build output wasm32-wasi, the filename is use underscore instead of dash.
+        let wasm_name = format!("{}.wasm", cargo_toml.package.name.replace('-', "_"));
         let mut wasm_path = PathBuf::from(extension_dir);
         wasm_path.extend([
             "target",
             RUST_TARGET,
             if options.release { "release" } else { "debug" },
-            cargo_toml.package.name.as_str(),
+            &wasm_name,
         ]);
-        wasm_path.set_extension("wasm");
 
         let wasm_bytes = fs::read(&wasm_path)
             .with_context(|| format!("failed to read output module `{}`", wasm_path.display()))?;

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -257,7 +257,7 @@ fn test_languages(
             Some(
                 grammars
                     .get(name.as_ref())
-                    .ok_or_else(|| anyhow!("language"))?,
+                    .ok_or_else(|| anyhow!("failed to find grammar {}", name))?,
             )
         } else {
             None


### PR DESCRIPTION
Output better error message when load language error.



Release Notes:

- Fixed Extension Cli to match the extension wasm output file.


## Case 

My Extension `Cargo.toml` named `zed-navi`, but by my test, `cargo build --target wasm32-wasi` will output `zed_navi.wasm`.

![SCR-20240321-ngb](https://github.com/zed-industries/zed/assets/5518/845f1d44-35e9-4ad0-bb2f-33b8bc473e28)

<img width="552" alt="image" src="https://github.com/zed-industries/zed/assets/5518/7217fd45-583a-41f5-a892-2b72ee0c60c9">

So I make this change to make sure the builder will found the right `.wasm` file.


