### PR TITLE
extension_cli: Don't propagate errors caused by trying to read `Cargo.toml`

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -81,18 +81,25 @@ impl ExtensionBuilder {
             );
         }
 
-        fs::create_dir_all(&self.cache_dir)?;
+        fs::create_dir_all(&self.cache_dir).context("failed to create cache dir")?;
 
         let cargo_toml_path = extension_dir.join("Cargo.toml");
         if extension_manifest.lib.kind == Some(ExtensionLibraryKind::Rust)
-            || fs::metadata(&cargo_toml_path)?.is_file()
+            || fs::metadata(&cargo_toml_path)
+                .ok()
+                .map(|metadata| metadata.is_file())
+                .unwrap_or(false)
         {
-            self.compile_rust_extension(extension_dir, options).await?;
+            log::info!("compiling Rust extension {}", extension_dir.display());
+            self.compile_rust_extension(extension_dir, options)
+                .await
+                .context("failed to compile Rust extension")?;
         }
 
         for (grammar_name, grammar_metadata) in &extension_manifest.grammars {
             self.compile_grammar(extension_dir, grammar_name.as_ref(), grammar_metadata)
-                .await?;
+                .await
+                .with_context(|| format!("failed to compile grammar '{grammar_name}'"))?;
         }
 
         log::info!("finished compiling extension {}", extension_dir.display());

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -54,9 +54,11 @@ async fn main() -> Result<()> {
         args.output_dir
     };
 
+    log::info!("loading extension manifest");
     let mut manifest = ExtensionStore::load_extension_manifest(fs.clone(), &extension_path).await?;
     populate_default_paths(&mut manifest, &extension_path)?;
 
+    log::info!("compiling extension");
     let builder = ExtensionBuilder::new(scratch_dir);
     builder
         .compile_extension(
@@ -257,7 +259,7 @@ fn test_languages(
             Some(
                 grammars
                     .get(name.as_ref())
-                    .ok_or_else(|| anyhow!("language"))?,
+                    .ok_or_else(|| anyhow!("grammar not found: '{name}'"))?,
             )
         } else {
             None


### PR DESCRIPTION
This PR fixes an issue where the extension CLI would error if a `Cargo.toml` didn't exist when we were trying to check for its existence. Since we're just checking if it exists for the purposes of detecting a Rust extension, we can safely ignore the errors.

Also improved the logging/error handling in a few spots to make other errors easier to troubleshoot in the future.

Release Notes:

- N/A
