### PR TITLE
Normalize `-` to `_` in resulting Wasm file names

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -138,7 +138,11 @@ impl ExtensionBuilder {
             "target",
             RUST_TARGET,
             if options.release { "release" } else { "debug" },
-            cargo_toml.package.name.as_str(),
+            &cargo_toml
+                .package
+                .name
+                // The wasm32-wasi target normalizes `-` in package names to `_` in the resulting `.wasm` file.
+                .replace('-', "_"),
         ]);
         wasm_path.set_extension("wasm");
 


### PR DESCRIPTION
This PR updates the extension builder to normalize `-` to `_` in the Rust package names when computing the resulting `.wasm` file name.

The `wasm32-wasi` target does this normalization internally already, so we need to do the same to ensure we're looking for the resulting `.wasm` file in the right spot.

Release Notes:

- N/A
