### PR TITLE
Revert "chore: Bump Rust version to 1.77 (#9631)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 
-FROM rust:1.77-bookworm as builder
+FROM rust:1.76-bookworm as builder
 WORKDIR app
 COPY . .
 

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -94,7 +94,6 @@ pub fn new_journal_entry(app_state: Arc<AppState>, cx: &mut WindowContext) {
         std::fs::create_dir_all(month_dir)?;
         OpenOptions::new()
             .create(true)
-            .truncate(false)
             .write(true)
             .open(&entry_path)?;
         Ok::<_, std::io::Error>((journal_dir, entry_path))

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -80,11 +80,8 @@ struct AvailableLanguage {
 
 enum AvailableGrammar {
     Native(tree_sitter::Language),
-    Loaded(#[allow(unused)] PathBuf, tree_sitter::Language),
-    Loading(
-        #[allow(unused)] PathBuf,
-        Vec<oneshot::Sender<Result<tree_sitter::Language>>>,
-    ),
+    Loaded(#[allow(dead_code)] PathBuf, tree_sitter::Language),
+    Loading(PathBuf, Vec<oneshot::Sender<Result<tree_sitter::Language>>>),
     Unloaded(PathBuf),
 }
 

--- a/crates/project/src/prettier_support.rs
+++ b/crates/project/src/prettier_support.rs
@@ -530,7 +530,7 @@ impl Project {
         if buffer_language.prettier_parser_name().is_none() {
             return Task::ready(None);
         }
-        let Some(node) = self.node.clone() else {
+        let Some(node) = self.node.as_ref().map(Arc::clone) else {
             return Task::ready(None);
         };
         match File::from_dyn(buffer_file).map(|file| (file.worktree_id(cx), file.abs_path(cx))) {

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -590,7 +590,7 @@ mod tests {
             (TaskSourceKind::UserInput, common_name.to_string()),
             (TaskSourceKind::UserInput, "user_input".to_string()),
         ];
-        let worktree_1_tasks = [
+        let worktree_1_tasks = vec![
             (
                 TaskSourceKind::Worktree {
                     id: worktree_1,
@@ -606,7 +606,7 @@ mod tests {
                 "worktree_1".to_string(),
             ),
         ];
-        let worktree_2_tasks = [
+        let worktree_2_tasks = vec![
             (
                 TaskSourceKind::Worktree {
                     id: worktree_2,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77"
+channel = "1.76"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi" ]


### PR DESCRIPTION
This reverts commit 6184278faf3a4c4034b3b3488a5ec71ef50b5274.

We can't upgrade to Rust 1.77 until there are Rust 1.77 Docker images available (https://github.com/docker-library/official-images/pull/16457).


Release Notes:

- N/A
