### PR TITLE
Fix invalid highlight position for `(edited)` text

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -762,7 +762,7 @@ impl ChatPanel {
 
         if message.edited_at.is_some() {
             rich_text.highlights.push((
-                message.body.len()..(message.body.len() + MESSAGE_UPDATED.len()),
+                (rich_text.text.len() - MESSAGE_UPDATED.len())..rich_text.text.len(),
                 Highlight::Highlight(HighlightStyle {
                     fade_out: Some(0.8),
                     ..Default::default()


### PR DESCRIPTION
This pull request fixes a bug that was inserting the wrong position for the `(edited)` text. This is only an issue when you have other styling inside the markdown that causes the `richt_text.text.len()` to increase.

**Before**
<img wdth="234" alt="Screenshot 2024-03-21 at 19 53 34" src="https://github.com/zed-industries/zed/assets/62463826/bf9e7fec-1563-415b-9b14-f7b95fc7d784">
**After**
<img width="234" alt="Screenshot 2024-03-21 at 19 53 48" src="https://github.com/zed-industries/zed/assets/62463826/c0b7ba3a-5bdc-4b9e-a4f2-c3df4064f0ec">

Release Notes:

- N/A