### PR TITLE
windows: fix window activate action

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -10,7 +10,6 @@ use std::{
     path::{Path, PathBuf},
     rc::Rc,
     sync::{Arc, OnceLock},
-    time::Duration,
 };
 
 use ::util::{ResultExt, SemanticVersion};

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -839,12 +839,10 @@ impl WindowsWindowInner {
             }
         }
         let activated = wparam.loword() > 0;
-        println!("Window activated: {}", activated);
         let mut callbacks = self.callbacks.borrow_mut();
         if let Some(mut cb) = callbacks.active_status_change.as_mut() {
             cb(activated);
         }
-
         None
     }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -192,9 +192,8 @@ impl WindowsWindowInner {
 
     fn handle_msg(&self, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
         let handled = match msg {
-            WM_ACTIVATE => self.handle_activate_msg(),
+            WM_ACTIVATE => self.handle_activate_msg(wparam),
             WM_CREATE => self.handle_create_msg(lparam),
-            WM_SETFOCUS => self.handle_set_focus_msg(msg, wparam, lparam),
             WM_MOVE => self.handle_move_msg(lparam),
             WM_SIZE => self.handle_size_msg(lparam),
             WM_NCCALCSIZE => self.handle_calc_client_size(wparam, lparam),
@@ -833,12 +832,19 @@ impl WindowsWindowInner {
         Some(0)
     }
 
-    fn handle_activate_msg(&self) -> Option<isize> {
+    fn handle_activate_msg(&self, wparam: WPARAM) -> Option<isize> {
         if self.hide_title_bar {
             if let Some(titlebar_rect) = self.get_titlebar_rect().log_err() {
                 unsafe { InvalidateRect(self.hwnd, Some(&titlebar_rect), FALSE) };
             }
         }
+        let activated = wparam.loword() > 0;
+        println!("Window activated: {}", activated);
+        let mut callbacks = self.callbacks.borrow_mut();
+        if let Some(mut cb) = callbacks.active_status_change.as_mut() {
+            cb(activated);
+        }
+
         None
     }
 
@@ -1066,28 +1072,6 @@ impl WindowsWindowInner {
         }
 
         None
-    }
-
-    fn handle_set_focus_msg(&self, _msg: u32, wparam: WPARAM, _lparam: LPARAM) -> Option<isize> {
-        // wparam is the window that just lost focus (may be null)
-        // SEE: https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-setfocus
-        let lost_focus_hwnd = HWND(wparam.0 as isize);
-        if let Some(lost_focus_window) = self
-            .platform_inner
-            .try_get_windows_inner_from_hwnd(lost_focus_hwnd)
-        {
-            let mut callbacks = lost_focus_window.callbacks.borrow_mut();
-            if let Some(mut cb) = callbacks.active_status_change.as_mut() {
-                cb(false);
-            }
-        }
-
-        let mut callbacks = self.callbacks.borrow_mut();
-        if let Some(mut cb) = callbacks.active_status_change.as_mut() {
-            cb(true);
-        }
-
-        Some(0)
     }
 }
 


### PR DESCRIPTION
Now, the window activation event can be triggered correctly. As shown in the video, when the window is activated, the caret blinks; when the window loses activation due to me clicking on the PowerShell window, the caret stops blinking.


https://github.com/zed-industries/zed/assets/14981363/4c1b2bec-319d-4f21-879e-5a0af0a00d8e



Release Notes:

- N/A
