### PR TITLE
Fix dependency install script on RHEL derivatives

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -40,10 +40,12 @@ if [[ -n $dnf ]]; then
     libzstd-devel
     vulkan-loader
   )
-  # libxkbcommon-x11-devel is in the crb repo
-  $maysudo "$dnf" config-manager --set-enabled crb
-  $maysudo "$dnf" install epel-release epel-next-release
-
+  # libxkbcommon-x11-devel is in the crb repo on RHEL and CentOS, not needed for Fedora
+  if ! grep -q "Fedora" /etc/redhat-release; then
+    $maysudo "$dnf" config-manager --set-enabled crb
+    $maysudo "$dnf" install epel-release epel-next-release
+  fi
+  
   $maysudo "$dnf" install -y "${deps[@]}"
   exit 0
 fi

--- a/script/linux
+++ b/script/linux
@@ -40,12 +40,12 @@ if [[ -n $dnf ]]; then
     libzstd-devel
     vulkan-loader
   )
+
   # libxkbcommon-x11-devel is in the crb repo on RHEL and CentOS, not needed for Fedora
   if ! grep -q "Fedora" /etc/redhat-release; then
     $maysudo "$dnf" config-manager --set-enabled crb
-    $maysudo "$dnf" install epel-release epel-next-release
   fi
-  
+
   $maysudo "$dnf" install -y "${deps[@]}"
   exit 0
 fi


### PR DESCRIPTION
Added a check to `script/linux` so the script does not try to enable CSB or add EPEL if the user is on Fedora, which does not need these steps. The script now runs nicely on Fedora! :)

Release Notes:

- N/A
