### PR TITLE
markdown preview: Insert missing line break on hard break

### DIFF
--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -202,7 +202,7 @@ impl<'a> MarkdownParser<'a> {
                 }
 
                 Event::HardBreak => {
-                    break;
+                    text.push('\n');
                 }
 
                 Event::Text(t) => {


### PR DESCRIPTION
Closes #8990

For this input
```
Test \
Test
```

pulldown_cmark reports
```
Start(Paragraph)
Text(Borrowed("Test "))
HardBreak
Text(Borrowed("Test"))
End(Paragraph)
```

Previously `Event::HardBreak` just marked the paragraph block as completed and ignored all the remaining text inside the paragraph.

Before:
See https://github.com/zed-industries/zed/issues/8990#issue-2173197637

After:
![image](https://github.com/zed-industries/zed/assets/53836821/48237ea6-d749-4207-89a3-b0f146b0e544)


Release Notes:

- Fixed markdown preview not handling hard breaks (e.g. `\`) correctly ([#8990](https://github.com/zed-industries/zed/issues/8990)).
