### PR TITLE
Windows: fix initial active status

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -188,6 +188,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         answers: &[&str],
     ) -> Option<oneshot::Receiver<usize>>;
     fn activate(&self);
+    fn is_active(&self) -> bool;
     fn set_title(&mut self, title: &str);
     fn set_edited(&mut self, edited: bool);
     fn show_character_palette(&self);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -346,6 +346,11 @@ impl PlatformWindow for WaylandWindow {
         // todo(linux)
     }
 
+    // todo(linux)
+    fn is_active(&self) -> bool {
+        false
+    }
+
     fn set_title(&mut self, title: &str) {
         self.0.toplevel.set_title(title.to_string());
     }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -406,6 +406,11 @@ impl PlatformWindow for X11Window {
             .unwrap();
     }
 
+    // todo(linux)
+    fn is_active(&self) -> bool {
+        false
+    }
+
     fn set_title(&mut self, title: &str) {
         self.0
             .xcb_connection

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -913,6 +913,11 @@ impl PlatformWindow for MacWindow {
             .detach();
     }
 
+    // todo(macos)
+    fn is_active(&self) -> bool {
+        false
+    }
+
     fn set_title(&mut self, title: &str) {
         unsafe {
             let app = NSApplication::sharedApplication(nil);

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -913,9 +913,8 @@ impl PlatformWindow for MacWindow {
             .detach();
     }
 
-    // todo(macos)
     fn is_active(&self) -> bool {
-        false
+        unsafe { self.0.lock().native_window.isKeyWindow() == YES }
     }
 
     fn set_title(&mut self, title: &str) {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -181,6 +181,10 @@ impl PlatformWindow for TestWindow {
             .set_active_window(Some(self.clone()))
     }
 
+    fn is_active(&self) -> bool {
+        false
+    }
+
     fn set_title(&mut self, title: &str) {
         self.0.lock().title = Some(title.to_owned());
     }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1362,6 +1362,10 @@ impl PlatformWindow for WindowsWindow {
         unsafe { SetForegroundWindow(self.inner.hwnd) };
     }
 
+    fn is_active(&self) -> bool {
+        self.inner.hwnd == unsafe { GetActiveWindow() }
+    }
+
     // todo(windows)
     fn set_title(&mut self, title: &str) {
         unsafe { SetWindowTextW(self.inner.hwnd, &HSTRING::from(title)) }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -421,7 +421,7 @@ impl Window {
         let appearance = platform_window.appearance();
         let text_system = Arc::new(WindowTextSystem::new(cx.text_system().clone()));
         let dirty = Rc::new(Cell::new(true));
-        let active = Rc::new(Cell::new(false));
+        let active = Rc::new(Cell::new(platform_window.is_active()));
         let needs_present = Rc::new(Cell::new(false));
         let next_frame_callbacks: Rc<RefCell<Vec<FrameCallback>>> = Default::default();
         let last_input_timestamp = Rc::new(Cell::new(Instant::now()));


### PR DESCRIPTION
Separate from #9451

On Windows, a new window may already active immediate after creation.

Release Notes:

- N/A
