### PR TITLE
Assign OPENAI_API_KEY from a k8s secret in the collab deployment

### DIFF
--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -125,6 +125,11 @@ spec:
                 secretKeyRef:
                   name: livekit
                   key: secret
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openai
+                  key: api_key
             - name: BLOB_STORE_ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The ability to use this will be feature-flagged for the moment.

Release Notes:

- N/A