### PR TITLE
Use `.is_some_and()` instead of `.is_some() && .unwrap()`

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -74,7 +74,7 @@ impl Default for LinuxPlatform {
 impl LinuxPlatform {
     pub(crate) fn new() -> Self {
         let wayland_display = env::var_os("WAYLAND_DISPLAY");
-        let use_wayland = wayland_display.is_some() && !wayland_display.unwrap().is_empty();
+        let use_wayland = wayland_display.is_some_and(|dp| !dp.is_empty());
 
         let (main_sender, main_receiver) = calloop::channel::channel::<Runnable>();
         let text_system = Arc::new(LinuxTextSystem::new());

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -74,7 +74,7 @@ impl Default for LinuxPlatform {
 impl LinuxPlatform {
     pub(crate) fn new() -> Self {
         let wayland_display = env::var_os("WAYLAND_DISPLAY");
-        let use_wayland = wayland_display.is_some_and(|dp| !dp.is_empty());
+        let use_wayland = wayland_display.is_some_and(|display| !display.is_empty());
 
         let (main_sender, main_receiver) = calloop::channel::channel::<Runnable>();
         let text_system = Arc::new(LinuxTextSystem::new());


### PR DESCRIPTION
That's nicer & more readable.

(I just noticed that this looks weird while trying to understand why zed changes my cursor, so decided to make a quick fix (btw the issue with the cursor is that zed always loads cursor named "default" on wayland))

Release Notes:

- N/A
