### PR TITLE
Update to vscode-eslint 2.4.4 & support flat config file extensions

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -20,7 +20,7 @@ use std::{
 use util::{
     async_maybe,
     fs::remove_matching,
-    github::{github_release_with_tag, GitHubLspBinaryVersion},
+    github::{build_tarball_url, GitHubLspBinaryVersion},
     ResultExt,
 };
 
@@ -230,8 +230,13 @@ pub struct EsLintLspAdapter {
 }
 
 impl EsLintLspAdapter {
+    const CURRENT_VERSION: &'static str = "release/2.4.4";
+
     const SERVER_PATH: &'static str = "vscode-eslint/server/out/eslintServer.js";
     const SERVER_NAME: &'static str = "eslint";
+
+    const FLAT_CONFIG_FILE_NAMES: &'static [&'static str] =
+        &["eslint.config.js", "eslint.config.mjs", "eslint.config.cjs"];
 
     pub fn new(node: Arc<dyn NodeRuntime>) -> Self {
         EsLintLspAdapter { node }
@@ -269,6 +274,9 @@ impl LspAdapter for EsLintLspAdapter {
         }
 
         let node_path = eslint_user_settings.get("nodePath").unwrap_or(&Value::Null);
+        let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
+            .iter()
+            .any(|file| workspace_root.join(file).is_file());
 
         json!({
             "": {
@@ -285,7 +293,7 @@ impl LspAdapter for EsLintLspAdapter {
                 "problems": {},
                 "codeActionOnSave": code_action_on_save,
                 "experimental": {
-                    "useFlatConfig": workspace_root.join("eslint.config.js").is_file(),
+                    "useFlatConfig": use_flat_config,
                 },
             }
         })
@@ -297,19 +305,13 @@ impl LspAdapter for EsLintLspAdapter {
 
     async fn fetch_latest_server_version(
         &self,
-        delegate: &dyn LspAdapterDelegate,
+        _delegate: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
-        // We're using this hardcoded release tag, because ESLint's API changed with
-        // >= 2.3 and we haven't upgraded yet.
-        let release = github_release_with_tag(
-            "microsoft/vscode-eslint",
-            "release/2.2.20-Insider",
-            delegate.http_client(),
-        )
-        .await?;
+        let url = build_tarball_url("microsoft/vscode-eslint", Self::CURRENT_VERSION)?;
+
         Ok(Box::new(GitHubLspBinaryVersion {
-            name: release.tag_name,
-            url: release.tarball_url,
+            name: Self::CURRENT_VERSION.into(),
+            url,
         }))
     }
 


### PR DESCRIPTION
This upgrades to vscode-eslint 2.4.4 to support flat configs, in multiple configuration files, ending in `.js`, `.cjs`, `.mjs`.

We changed the code to not use the GitHub release because we actually don't need the artifacts of the release, we just need the source code, which we compile anyway.

Fixes #7271.

Release Notes:

- Added support for ESLint flat config files. ([#7271](https://github.com/zed-industries/zed/issues/7271)).
