### PR TITLE
Split `DuplicateLine` into `DuplicateLineUp` and `DuplicateLineDown`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -444,6 +444,8 @@
   {
     "context": "Editor",
     "bindings": {
+      "ctrl-shift-k": "editor::DeleteLine",
+      "ctrl-shift-d": "editor::DuplicateLineDown",
       "ctrl-j": "editor::JoinLines",
       "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -317,13 +317,8 @@
       "cmd-shift-k": "editor::DeleteLine",
       "alt-up": "editor::MoveLineUp",
       "alt-down": "editor::MoveLineDown",
-      "alt-shift-up": [
-        "editor::DuplicateLine",
-        {
-          "move_upwards": true
-        }
-      ],
-      "alt-shift-down": "editor::DuplicateLine",
+      "alt-shift-up": "editor::DuplicateLineUp",
+      "alt-shift-down": "editor::DuplicateLineDown",
       "ctrl-shift-right": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-left": "editor::SelectSmallerSyntaxNode",
       "cmd-d": [

--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -11,7 +11,7 @@
       "ctrl->": "zed::IncreaseBufferFontSize",
       "ctrl-<": "zed::DecreaseBufferFontSize",
       "ctrl-shift-j": "editor::JoinLines",
-      "cmd-d": "editor::DuplicateLine",
+      "cmd-d": "editor::DuplicateLineDown",
       "cmd-backspace": "editor::DeleteLine",
       "cmd-pagedown": "editor::MovePageDown",
       "cmd-pageup": "editor::MovePageUp",

--- a/assets/keymaps/textmate.json
+++ b/assets/keymaps/textmate.json
@@ -9,7 +9,7 @@
     "context": "Editor",
     "bindings": {
       "cmd-l": "go_to_line::Toggle",
-      "ctrl-shift-d": "editor::DuplicateLine",
+      "ctrl-shift-d": "editor::DuplicateLineDown",
       "cmd-b": "editor::GoToDefinition",
       "cmd-j": "editor::ScrollCursorCenter",
       "cmd-enter": "editor::NewlineBelow",

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -95,10 +95,10 @@ pub struct SelectDownByLines {
 }
 
 #[derive(PartialEq, Clone, Deserialize, Default)]
-pub struct DuplicateLine {
-    #[serde(default)]
-    pub move_upwards: bool,
-}
+pub struct DuplicateLineUp {}
+
+#[derive(PartialEq, Clone, Deserialize, Default)]
+pub struct DuplicateLineDown {}
 
 impl_actions!(
     editor,
@@ -119,7 +119,8 @@ impl_actions!(
         MoveDownByLines,
         SelectUpByLines,
         SelectDownByLines,
-        DuplicateLine
+        DuplicateLineUp,
+        DuplicateLineDown,
     ]
 );
 

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -94,12 +94,6 @@ pub struct SelectDownByLines {
     pub(super) lines: u32,
 }
 
-#[derive(PartialEq, Clone, Deserialize, Default)]
-pub struct DuplicateLineUp {}
-
-#[derive(PartialEq, Clone, Deserialize, Default)]
-pub struct DuplicateLineDown {}
-
 impl_actions!(
     editor,
     [
@@ -119,8 +113,6 @@ impl_actions!(
         MoveDownByLines,
         SelectUpByLines,
         SelectDownByLines,
-        DuplicateLineUp,
-        DuplicateLineDown,
     ]
 );
 
@@ -161,6 +153,8 @@ gpui::actions!(
         DeleteToPreviousSubwordStart,
         DeleteToPreviousWordStart,
         DisplayCursorNames,
+        DuplicateLineUp,
+        DuplicateLineDown,
         ExpandMacroRecursively,
         FindAllReferences,
         Fold,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5121,7 +5121,7 @@ impl Editor {
         });
     }
 
-    pub fn duplicate_line(&mut self, action: &DuplicateLine, cx: &mut ViewContext<Self>) {
+    pub fn duplicate_line(&mut self, upwards: bool, cx: &mut ViewContext<Self>) {
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = &display_map.buffer_snapshot;
         let selections = self.selections.all::<Point>(cx);
@@ -5150,7 +5150,7 @@ impl Editor {
                 .text_for_range(start..end)
                 .chain(Some("\n"))
                 .collect::<String>();
-            let insert_location = if action.move_upwards {
+            let insert_location = if upwards {
                 Point::new(rows.end, 0)
             } else {
                 start
@@ -5165,6 +5165,14 @@ impl Editor {
 
             this.request_autoscroll(Autoscroll::fit(), cx);
         });
+    }
+
+    pub fn duplicate_line_up(&mut self, _: &DuplicateLineUp, cx: &mut ViewContext<Self>) {
+        self.duplicate_line(true, cx);
+    }
+
+    pub fn duplicate_line_down(&mut self, _: &DuplicateLineDown, cx: &mut ViewContext<Self>) {
+        self.duplicate_line(false, cx);
     }
 
     pub fn move_line_up(&mut self, _: &MoveLineUp, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3116,7 +3116,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(3, 0)..DisplayPoint::new(3, 0),
             ])
         });
-        view.duplicate_line(&DuplicateLine::default(), cx);
+        view.duplicate_line_down(&DuplicateLineDown::default(), cx);
         assert_eq!(view.display_text(cx), "abc\nabc\ndef\ndef\nghi\n\n");
         assert_eq!(
             view.selections.display_ranges(cx),
@@ -3140,7 +3140,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(1, 2)..DisplayPoint::new(2, 1),
             ])
         });
-        view.duplicate_line(&DuplicateLine::default(), cx);
+        view.duplicate_line_down(&DuplicateLineDown::default(), cx);
         assert_eq!(view.display_text(cx), "abc\ndef\nghi\nabc\ndef\nghi\n");
         assert_eq!(
             view.selections.display_ranges(cx),
@@ -3166,7 +3166,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(3, 0)..DisplayPoint::new(3, 0),
             ])
         });
-        view.duplicate_line(&DuplicateLine { move_upwards: true }, cx);
+        view.duplicate_line_up(&DuplicateLineUp::default(), cx);
         assert_eq!(view.display_text(cx), "abc\nabc\ndef\ndef\nghi\n\n");
         assert_eq!(
             view.selections.display_ranges(cx),
@@ -3190,7 +3190,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(1, 2)..DisplayPoint::new(2, 1),
             ])
         });
-        view.duplicate_line(&DuplicateLine { move_upwards: true }, cx);
+        view.duplicate_line_down(&DuplicateLineDown::default(), cx);
         assert_eq!(view.display_text(cx), "abc\ndef\nghi\nabc\ndef\nghi\n");
         assert_eq!(
             view.selections.display_ranges(cx),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3190,7 +3190,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(1, 2)..DisplayPoint::new(2, 1),
             ])
         });
-        view.duplicate_line_down(&DuplicateLineDown::default(), cx);
+        view.duplicate_line_up(&DuplicateLineUp::default(), cx);
         assert_eq!(view.display_text(cx), "abc\ndef\nghi\nabc\ndef\nghi\n");
         assert_eq!(
             view.selections.display_ranges(cx),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3116,7 +3116,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(3, 0)..DisplayPoint::new(3, 0),
             ])
         });
-        view.duplicate_line_down(&DuplicateLineDown::default(), cx);
+        view.duplicate_line_down(&DuplicateLineDown, cx);
         assert_eq!(view.display_text(cx), "abc\nabc\ndef\ndef\nghi\n\n");
         assert_eq!(
             view.selections.display_ranges(cx),
@@ -3140,7 +3140,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(1, 2)..DisplayPoint::new(2, 1),
             ])
         });
-        view.duplicate_line_down(&DuplicateLineDown::default(), cx);
+        view.duplicate_line_down(&DuplicateLineDown, cx);
         assert_eq!(view.display_text(cx), "abc\ndef\nghi\nabc\ndef\nghi\n");
         assert_eq!(
             view.selections.display_ranges(cx),
@@ -3166,7 +3166,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(3, 0)..DisplayPoint::new(3, 0),
             ])
         });
-        view.duplicate_line_up(&DuplicateLineUp::default(), cx);
+        view.duplicate_line_up(&DuplicateLineUp, cx);
         assert_eq!(view.display_text(cx), "abc\nabc\ndef\ndef\nghi\n\n");
         assert_eq!(
             view.selections.display_ranges(cx),
@@ -3190,7 +3190,7 @@ fn test_duplicate_line(cx: &mut TestAppContext) {
                 DisplayPoint::new(1, 2)..DisplayPoint::new(2, 1),
             ])
         });
-        view.duplicate_line_up(&DuplicateLineUp::default(), cx);
+        view.duplicate_line_up(&DuplicateLineUp, cx);
         assert_eq!(view.display_text(cx), "abc\ndef\nghi\nabc\ndef\nghi\n");
         assert_eq!(
             view.selections.display_ranges(cx),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -177,7 +177,8 @@ impl EditorElement {
         register_action(view, cx, Editor::delete_to_beginning_of_line);
         register_action(view, cx, Editor::delete_to_end_of_line);
         register_action(view, cx, Editor::cut_to_end_of_line);
-        register_action(view, cx, Editor::duplicate_line);
+        register_action(view, cx, Editor::duplicate_line_up);
+        register_action(view, cx, Editor::duplicate_line_down);
         register_action(view, cx, Editor::move_line_up);
         register_action(view, cx, Editor::move_line_down);
         register_action(view, cx, Editor::transpose);

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -100,7 +100,7 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 MenuItem::action("Move Line Down", editor::actions::MoveLineDown),
                 MenuItem::action(
                     "Duplicate Selection",
-                    editor::actions::DuplicateLine::default(),
+                    editor::actions::DuplicateLineDown::default(),
                 ),
             ],
         },

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -98,10 +98,7 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 MenuItem::separator(),
                 MenuItem::action("Move Line Up", editor::actions::MoveLineUp),
                 MenuItem::action("Move Line Down", editor::actions::MoveLineDown),
-                MenuItem::action(
-                    "Duplicate Selection",
-                    editor::actions::DuplicateLineDown::default(),
-                ),
+                MenuItem::action("Duplicate Selection", editor::actions::DuplicateLineDown),
             ],
         },
         Menu {


### PR DESCRIPTION
Fixes #9601

Release Notes:
- `DuplicateLine` is now split into `DuplicateLineUp` and `DuplicateLineDown`