### PR TITLE
vim: Make `cc` and `S` auto-indent

### DIFF
--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -6,8 +6,7 @@ use crate::{
     Vim,
 };
 use editor::{
-    display_map::DisplaySnapshot, movement::TextLayoutDetails, scroll::Autoscroll, Bias,
-    DisplayPoint,
+    display_map::DisplaySnapshot, movement::TextLayoutDetails, scroll::Autoscroll, DisplayPoint,
 };
 use gpui::WindowContext;
 use language::{char_kind, CharKind, Selection};

--- a/crates/vim/test_data/test_change_cc.json
+++ b/crates/vim/test_data/test_change_cc.json
@@ -1,0 +1,12 @@
+{"Put":{"state":"The quick\n  brownˇ fox\njumps over\nthe lazy"}}
+{"Key":"c"}
+{"Key":"c"}
+{"Get":{"state":"The quick\n  ˇ\njumps over\nthe lazy","mode":"Insert"}}
+{"Put":{"state":"ˇThe quick\nbrown fox\njumps over\nthe lazy"}}
+{"Key":"c"}
+{"Key":"c"}
+{"Get":{"state":"ˇ\nbrown fox\njumps over\nthe lazy","mode":"Insert"}}
+{"Put":{"state":"The quick\n  broˇwn fox\njumˇps over\nthe lazy"}}
+{"Key":"c"}
+{"Key":"c"}
+{"Get":{"state":"The quick\n  ˇ\nˇ\nthe lazy","mode":"Insert"}}


### PR DESCRIPTION
Fix #9612 

Release notes:

* Changed `cc` and `S` in Vim mode to only change the current line after its indentation. #9612 