### PR TITLE
Add working directories for eslint

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -276,6 +276,9 @@ impl LspAdapter for EsLintLspAdapter {
         let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
             .iter()
             .any(|file| workspace_root.join(file).is_file());
+        let working_directories = eslint_user_settings
+            .get("workingDirectories")
+            .unwrap_or(&Value::Null);
 
         json!({
             "": {
@@ -291,6 +294,7 @@ impl LspAdapter for EsLintLspAdapter {
                 },
                 "problems": {},
                 "codeActionOnSave": code_action_on_save,
+                "workingDirectories":working_directories,
                 "experimental": {
                     "useFlatConfig": use_flat_config,
                 },

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -294,7 +294,7 @@ impl LspAdapter for EsLintLspAdapter {
                 },
                 "problems": {},
                 "codeActionOnSave": code_action_on_save,
-                "workingDirectories":working_directories,
+                "workingDirectories": working_directories,
                 "experimental": {
                     "useFlatConfig": use_flat_config,
                 },

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -85,3 +85,19 @@ You can configure ESLint's `nodePath` setting (requires Zed `0.127.0`):
   }
 }
 ```
+
+#### Configure ESLint's `workingDirectories`:
+
+You can configure ESLint's `workingDirectories` setting (requires Zed `0.128.2`):
+
+```json
+{
+  "lsp": {
+    "eslint": {
+      "settings": {
+        "workingDirectories": ["./client", "./server"]
+      }
+    }
+  }
+}
+```

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -88,7 +88,7 @@ You can configure ESLint's `nodePath` setting (requires Zed `0.127.0`):
 
 #### Configure ESLint's `workingDirectories`:
 
-You can configure ESLint's `workingDirectories` setting (requires Zed `0.128.2`):
+You can configure ESLint's `workingDirectories` setting (requires Zed `0.130.x`):
 
 ```json
 {


### PR DESCRIPTION
Fix #9648 

Release notes:

- Added ability to configure ESLint's `workingDirectories` in settings. Example: `{"lsp":{"eslint":{"settings":{"workingDirectories":["./client","./server"]}}}}`. #9648 