### PR TITLE
Only try keychain when in terminal

### DIFF
--- a/crates/assistant/src/completion_provider/zed.rs
+++ b/crates/assistant/src/completion_provider/zed.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use client::{proto, Client};
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt, TryFutureExt};
 use gpui::{AnyView, AppContext, Task};
+use std::io::IsTerminal;
 use std::{future, sync::Arc};
 use ui::prelude::*;
 
@@ -64,8 +65,10 @@ impl ZedDotDevCompletionProvider {
     }
 
     pub fn authenticate(&self, cx: &AppContext) -> Task<Result<()>> {
+        let try_keychain = std::io::stdout().is_terminal();
+
         let client = self.client.clone();
-        cx.spawn(move |cx| async move { client.authenticate_and_connect(true, &cx).await })
+        cx.spawn(move |cx| async move { client.authenticate_and_connect(try_keychain, &cx).await })
     }
 
     pub fn authentication_prompt(&self, cx: &mut WindowContext) -> AnyView {

--- a/crates/assistant/src/completion_provider/zed.rs
+++ b/crates/assistant/src/completion_provider/zed.rs
@@ -66,13 +66,7 @@ impl ZedDotDevCompletionProvider {
     pub fn authenticate(&self, cx: &AppContext) -> Task<Result<()>> {
         let client = self.client.clone();
         if stdout_is_a_pty() {
-            if client::IMPERSONATE_LOGIN.is_some() {
-                cx.spawn(move |cx| async move { client.authenticate_and_connect(false, &cx).await })
-            } else {
-                Task::ready(Err(anyhow!(
-                    "not authenticated yet, please authenticate first."
-                )))
-            }
+            cx.spawn(move |cx| async move { client.authenticate_and_connect(false, &cx).await })
         } else {
             cx.spawn(move |cx| async move { client.authenticate_and_connect(true, &cx).await })
         }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -35,6 +35,7 @@ use std::{
     convert::TryFrom,
     fmt::Write as _,
     future::Future,
+    io::IsTerminal,
     marker::PhantomData,
     path::PathBuf,
     sync::{
@@ -118,6 +119,12 @@ pub fn init_settings(cx: &mut AppContext) {
     cx.update_global(|store: &mut SettingsStore, cx| {
         store.register_setting::<ClientSettings>(cx);
     });
+}
+
+pub const FORCE_CLI_MODE_ENV_VAR_NAME: &str = "ZED_FORCE_CLI_MODE";
+
+pub fn stdout_is_a_pty() -> bool {
+    std::env::var(FORCE_CLI_MODE_ENV_VAR_NAME).ok().is_none() && std::io::stdout().is_terminal()
 }
 
 pub fn init(client: &Arc<Client>, cx: &mut AppContext) {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -9,10 +9,7 @@ use anyhow::{anyhow, Context as _, Result};
 use backtrace::Backtrace;
 use chrono::Utc;
 use clap::{command, Parser};
-use cli::FORCE_CLI_MODE_ENV_VAR_NAME;
-use client::{
-    parse_zed_link, telemetry::Telemetry, Client, ClientSettings, DevServerToken, UserStore,
-};
+use client::{parse_zed_link, stdout_is_a_pty, telemetry::Telemetry, Client, ClientSettings, DevServerToken, UserStore};
 use collab_ui::channel_view::ChannelView;
 use copilot::Copilot;
 use copilot_ui::CopilotCompletionProvider;
@@ -42,7 +39,7 @@ use std::{
     env,
     ffi::OsStr,
     fs::OpenOptions,
-    io::{IsTerminal, Write},
+    io::Write,
     panic,
     path::Path,
     sync::{
@@ -934,10 +931,6 @@ async fn load_login_shell_environment() -> Result<()> {
     }
 
     Ok(())
-}
-
-fn stdout_is_a_pty() -> bool {
-    std::env::var(FORCE_CLI_MODE_ENV_VAR_NAME).ok().is_none() && std::io::stdout().is_terminal()
 }
 
 #[derive(Parser, Debug)]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -9,7 +9,10 @@ use anyhow::{anyhow, Context as _, Result};
 use backtrace::Backtrace;
 use chrono::Utc;
 use clap::{command, Parser};
-use client::{parse_zed_link, stdout_is_a_pty, telemetry::Telemetry, Client, ClientSettings, DevServerToken, UserStore};
+use client::{
+    parse_zed_link, stdout_is_a_pty, telemetry::Telemetry, Client, ClientSettings, DevServerToken,
+    UserStore,
+};
 use collab_ui::channel_view::ChannelView;
 use copilot::Copilot;
 use copilot_ui::CopilotCompletionProvider;


### PR DESCRIPTION
When zed is launched via, e.g. `cargo run`, this makes the keychain not be used when authenticating with the Zed AI Provider. It was a big bummer to get the keychain popup while hacking on the assistant panel

However, this does not really make the flow much better as the assistant panel automatically opens a browser tab to login instead. That's because the assistant panel will attempt to authenticate so long as it's an active item. Barring another fix, I figured I'd post the branch for now.

Release Notes:

- N/A