### PR TITLE
Fix Prisma indentation size

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -585,6 +585,9 @@
     },
     "OCaml Interface": {
       "tab_size": 2
+    },
+    "Prisma": {
+      "tab_size": 2
     }
   },
   // Zed's Prettier integration settings.


### PR DESCRIPTION
This PR fixes #9567 

Release Notes:

- Changed default indentation for Prisma files to 2 spaces ([#9567](https://github.com/zed-industries/zed/issues/9567)).
