### PR TITLE
Change maximum height of TitleBar

### DIFF
--- a/crates/ui/src/components/title_bar/title_bar.rs
+++ b/crates/ui/src/components/title_bar/title_bar.rs
@@ -14,7 +14,7 @@ pub struct TitleBar {
 impl TitleBar {
     #[cfg(not(target_os = "windows"))]
     pub fn height(cx: &mut WindowContext) -> Pixels {
-        (1.75 * cx.rem_size()).max(px(32.))
+        (1.75 * cx.rem_size()).max(px(34.))
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
 <img width="209" alt="image" src="https://github.com/zed-industries/zed/assets/38318044/0dcc4d0b-db9e-4eba-aa36-5c35f185e7e3">

Release Notes:

- Fixed alignment of items in the title bar ([#9709](https://github.com/zed-industries/zed/issues/9709)).
