### PR TITLE
More C++ path suffixes

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "inc", "inl"]
+path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp"]
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "cpp", "h", "hpp", "cxx", "hxx", "inl"]
+path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "inc", "inl"]
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
There is also `.C` and `.H` (capital), but I can't imagine they are very popular and I'd be worried clashing with C.

Release Notes:

- Added more path suffixes recognized as C++
