### PR TITLE
Open Log Buffer with read-only mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1694,6 +1694,14 @@ impl Editor {
         }
     }
 
+    pub fn with_log_mode(mut self) -> Self {
+        self.read_only = true;
+        self.soft_wrap_mode_override = Some(language_settings::SoftWrap::EditorWidth);
+        self.show_wrap_guides = Some(false);
+        self.show_breadcrumbs = false;
+        self
+    }
+
     pub fn replica_id(&self, cx: &AppContext) -> ReplicaId {
         self.buffer.read(cx).replica_id()
     }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -568,8 +568,11 @@ fn open_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
                         let buffer = cx.new_model(|cx| {
                             MultiBuffer::singleton(buffer, cx).with_title("Log".into())
                         });
-                        let editor =
-                            cx.new_view(|cx| Editor::for_multibuffer(buffer, Some(project), cx));
+                        let editor = cx.new_view(|cx| {
+                            let mut editor = Editor::for_multibuffer(buffer, Some(project), cx);
+                            editor.set_read_only(true);
+                            editor
+                        });
 
                         editor.update(cx, |editor, cx| {
                             let last_multi_buffer_offset = editor.buffer().read(cx).len(cx);
@@ -795,7 +798,11 @@ fn open_telemetry_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Works
                     MultiBuffer::singleton(buffer, cx).with_title("Telemetry Log".into())
                 });
                 workspace.add_item_to_active_pane(
-                    Box::new(cx.new_view(|cx| Editor::for_multibuffer(buffer, Some(project), cx))),
+                    Box::new(cx.new_view(|cx| {
+                        let mut editor = Editor::for_multibuffer(buffer, Some(project), cx);
+                        editor.set_read_only(true);
+                        editor
+                    })),
                     cx,
                 );
             }).log_err()?;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -569,9 +569,7 @@ fn open_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
                             MultiBuffer::singleton(buffer, cx).with_title("Log".into())
                         });
                         let editor = cx.new_view(|cx| {
-                            let mut editor = Editor::for_multibuffer(buffer, Some(project), cx);
-                            editor.set_read_only(true);
-                            editor
+                            Editor::for_multibuffer(buffer, Some(project), cx).with_log_mode()
                         });
 
                         editor.update(cx, |editor, cx| {
@@ -798,11 +796,7 @@ fn open_telemetry_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Works
                     MultiBuffer::singleton(buffer, cx).with_title("Telemetry Log".into())
                 });
                 workspace.add_item_to_active_pane(
-                    Box::new(cx.new_view(|cx| {
-                        let mut editor = Editor::for_multibuffer(buffer, Some(project), cx);
-                        editor.set_read_only(true);
-                        editor
-                    })),
+                    Box::new(cx.new_view(|cx| Editor::for_multibuffer(buffer, Some(project), cx).with_log_mode())),
                     cx,
                 );
             }).log_err()?;


### PR DESCRIPTION
Release Notes:

- Improved to open Log with (no_wrap_guides, no_breadcrumbs, wrap_mode = editor_width and read_only).

![2024-03-25 15 24 30](https://github.com/zed-industries/zed/assets/5518/04c889fe-e452-4fdd-b1e9-b4d40dda8ed1)

