### PR TITLE
 Fix key repeat after releasing a different key on Wayland 

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -796,7 +796,12 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                             })
                         };
 
-                        if !keysym.is_modifier_key() {
+                        if !keysym.is_modifier_key()
+                            && (match state.repeat.current_keysym {
+                                Some(repeat_keysym) => keysym == repeat_keysym,
+                                None => false,
+                              })
+                        {
                             state.repeat.current_keysym = None;
                         }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -800,7 +800,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                             && (match state.repeat.current_keysym {
                                 Some(repeat_keysym) => keysym == repeat_keysym,
                                 None => false,
-                              })
+                            })
                         {
                             state.repeat.current_keysym = None;
                         }


### PR DESCRIPTION
Quick fix that fixes key repeat not working when releasing a different key than the current one being held

Don't really know much rust yet, so unsure this is the best way to handle this, but this does seem like a good starting point to get at least a tad familiar with it

Release Notes:
- N/A
