### PR TITLE
extension_cli: Clear out existing manifest collections for old `extension.json`

### DIFF
--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -109,6 +109,14 @@ async fn main() -> Result<()> {
 }
 
 fn populate_default_paths(manifest: &mut ExtensionManifest, extension_path: &Path) -> Result<()> {
+    // For legacy extensions on the v0 schema (aka, using `extension.json`), clear out any existing
+    // contents of the computed fields, since we don't care what the existing values are.
+    if manifest.schema_version == 0 {
+        manifest.languages.clear();
+        manifest.grammars.clear();
+        manifest.themes.clear();
+    }
+
     let cargo_toml_path = extension_path.join("Cargo.toml");
     if cargo_toml_path.exists() {
         manifest.lib.kind = Some(ExtensionLibraryKind::Rust);


### PR DESCRIPTION
This PR fixes an issue in the extension CLI when building extensions using the old manifest schema (`extension.json`).

If there were values provided for the `languages`, `grammars`, or `themes` collections, these could interfere with the packaging process.

We aren't expecting these fields to be set in the source `extension.json` (just in the generated one), so we can clear them out when building up the manifest.

Release Notes:

- N/A
