### PR TITLE
markdown preview: Handle line breaks in between task list items correctly

### DIFF
--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -824,6 +824,29 @@ Some other content
     }
 
     #[gpui::test]
+    async fn test_list_with_linebreak_is_handled_correctly() {
+        let parsed = parse(
+            "\
+- [ ] Task 1
+
+- [x] Task 2
+",
+        )
+        .await;
+
+        assert_eq!(
+            parsed.children,
+            vec![list(
+                vec![
+                    list_item(1, Task(false), vec![p("Task 1", 2..5)]),
+                    list_item(1, Task(true), vec![p("Task 2", 16..19)]),
+                ],
+                0..27
+            ),]
+        );
+    }
+
+    #[gpui::test]
     async fn test_list_nested() {
         let parsed = parse(
             "\

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -458,21 +458,16 @@ impl<'a> MarkdownParser<'a> {
                             self.cursor += 1;
                         }
 
-                        if let Some(event) = self.current_event() {
-                            match event {
-                                Event::TaskListMarker(checked) => {
-                                    task_item = Some(*checked);
-                                    self.cursor += 1;
-                                }
-                                _ => {}
-                            }
+                        if let Some(Event::TaskListMarker(checked)) = self.current_event() {
+                            task_item = Some(*checked);
+                            self.cursor += 1;
                         }
                     }
 
-                    if let Some(next) = self.current() {
+                    if let Some(event) = self.current_event() {
                         // This is a plain list item.
                         // For example `- some text` or `1. [Docs](./docs.md)`
-                        if MarkdownParser::is_text_like(&next.0) {
+                        if MarkdownParser::is_text_like(event) {
                             let text = self.parse_text(false);
                             let block = ParsedMarkdownElement::Paragraph(text);
                             current_list_items.push(Box::new(block));


### PR DESCRIPTION
Closes #9783 

Release Notes:

- Fixed task list rendering when there was a line break between two list items ([#9783](https://github.com/zed-industries/zed/issues/9783))
