### PR TITLE
Make UniformList non-occluding.

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -898,9 +898,7 @@ impl CompletionsMenu {
                     .max_w(px(640.))
                     .w(px(500.))
                     .overflow_y_scroll()
-                    // Prevent a mouse down on documentation from being propagated to the editor,
-                    // because that would move the cursor.
-                    .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
+                    .occlude()
             })
         } else {
             None
@@ -989,6 +987,7 @@ impl CompletionsMenu {
                     .collect()
             },
         )
+        .occlude()
         .max_h(max_height)
         .track_scroll(self.scroll_handle.clone())
         .with_width_from_item(widest_completion_ix);
@@ -1212,6 +1211,7 @@ impl CodeActionsMenu {
         .px_2()
         .py_1()
         .max_h(max_height)
+        .occlude()
         .track_scroll(self.scroll_handle.clone())
         .with_width_from_item(
             self.actions

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -48,7 +48,6 @@ where
         interactivity: Interactivity {
             element_id: Some(id),
             base_style: Box::new(base_style),
-            occlude_mouse: true,
 
             #[cfg(debug_assertions)]
             location: Some(*core::panic::Location::caller()),


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/9723

Move the `occlude` in the places where they are needed.

Release Notes:

- Fixed right click in the project panel's empty region ([9723](https://github.com/zed-industries/zed/issues/9723))