### PR TITLE
Fix visual glitches in titlebar when there's an active prompt

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -95,7 +95,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         titlebar: Some(TitlebarOptions {
             title: None,
             appears_transparent: true,
-            traffic_light_position: Some(point(px(9.5), px(9.5))),
+            traffic_light_position: Some(point(px(9.0), px(9.0))),
         }),
         bounds: None,
         focus: false,


### PR DESCRIPTION
It looks like a fractional traffic lights position doesn't play well with Mac 12+. Fixed #9775 and #9588. Related to #7339 and #8128


Release Notes:

- Fixed visual artifacts on titlebar that appeared when there was a prompt active
