### PR TITLE
windows: Support compiling with MinGW toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,6 +3294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embed-manifest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cd446c890d6bed1d8b53acef5f240069ebef91d6fae7c5f52efe61fe8b5eae"
+
+[[package]]
 name = "emojis"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12526,6 +12532,7 @@ dependencies = [
  "db",
  "diagnostics",
  "editor",
+ "embed-manifest",
  "env_logger",
  "extension",
  "extensions_ui",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -91,6 +91,7 @@ workspace.workspace = true
 zed_actions.workspace = true
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
+embed-manifest = "1.4.0"
 winresource = "0.1"
 
 [dev-dependencies]

--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -46,19 +46,18 @@ fn main() {
 
     #[cfg(target_os = "windows")]
     {
-        // todo(windows): This is to avoid stack overflow. Remove it when solved.
-        println!("cargo:rustc-link-arg=/stack:{}", 8 * 1024 * 1024);
+        if std::env::var("CARGO_CFG_TARGET_ENV").ok() == Some("msvc".to_string()) {
+            // todo(windows): This is to avoid stack overflow. Remove it when solved.
+            println!("cargo:rustc-link-arg=/stack:{}", 8 * 1024 * 1024);
+        }
 
         let manifest = std::path::Path::new("resources/windows/manifest.xml");
         let icon = std::path::Path::new("resources/windows/app-icon.ico");
         println!("cargo:rerun-if-changed={}", manifest.display());
         println!("cargo:rerun-if-changed={}", icon.display());
 
-        println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
-        println!(
-            "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
-            manifest.canonicalize().unwrap().display()
-        );
+        embed_manifest::embed_manifest(embed_manifest::new_manifest(manifest.to_str().unwrap()))
+            .unwrap();
 
         let mut res = winresource::WindowsResource::new();
         res.set_icon(icon.to_str().unwrap());


### PR DESCRIPTION
Fixes #9757: compile manifest using `embed-manifest` crate, which supports both MSVC and MinGW

Release Notes:

- N/A
