### PR TITLE
Use correct file extension for Haskell suggestions

### DIFF
--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -32,7 +32,7 @@ pub fn suggested_extension(file_extension_or_name: &str) -> Option<Arc<str>> {
                 ("gleam", "gleam"),
                 ("graphql", "gql"),
                 ("graphql", "graphql"),
-                ("haskell", "haskell"),
+                ("haskell", "hs"),
                 ("java", "java"),
                 ("kotlin", "kt"),
                 ("latex", "tex"),


### PR DESCRIPTION
This PR fixes the file extension used for suggesting the Haskell extension.

Release Notes:

- N/A
