### PR TITLE
Suppress error logs from `CopilotCompletionProvider` when Copilot is disabled

### DIFF
--- a/crates/copilot_ui/src/copilot_completion_provider.rs
+++ b/crates/copilot_ui/src/copilot_completion_provider.rs
@@ -3,7 +3,9 @@ use client::telemetry::Telemetry;
 use copilot::Copilot;
 use editor::{Direction, InlineCompletionProvider};
 use gpui::{AppContext, EntityId, Model, ModelContext, Task};
+use language::language_settings::AllLanguageSettings;
 use language::{language_settings::all_language_settings, Buffer, OffsetRangeExt, ToOffset};
+use settings::Settings;
 use std::{path::Path, sync::Arc, time::Duration};
 
 pub const COPILOT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
@@ -193,6 +195,11 @@ impl InlineCompletionProvider for CopilotCompletionProvider {
     }
 
     fn discard(&mut self, cx: &mut ModelContext<Self>) {
+        let settings = AllLanguageSettings::get_global(cx);
+        if !settings.copilot.feature_enabled {
+            return;
+        }
+
         self.copilot
             .update(cx, |copilot, cx| {
                 copilot.discard_completions(&self.completions, cx)


### PR DESCRIPTION
This PR fixes some noisy error logs from the `CopilotCompletionProvider` when Copilot is disabled entirely via the settings.

I have the following in my settings file:

```json
{
  "features": {
    "copilot": false
  },
}
```

After #9777 I started seeing my Zed logs getting filled up with messages like this:

```
[2024-03-26T14:33:09-04:00 ERROR util] crates/copilot_ui/src/copilot_completion_provider.rs:206: copilot is disabled
```

Release Notes:

- N/A
