### PR TITLE
Fix channel chat notifications are not working anymore

### DIFF
--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -159,7 +159,8 @@ impl AppState {
     pub async fn new(config: Config, executor: Executor) -> Result<Arc<Self>> {
         let mut db_options = db::ConnectOptions::new(config.database_url.clone());
         db_options.max_connections(config.database_max_connections);
-        let db = Database::new(db_options, Executor::Production).await?;
+        let mut db = Database::new(db_options, Executor::Production).await?;
+        db.initialize_notification_kinds().await?;
 
         let live_kit_client = if let Some(((server, key), secret)) = config
             .live_kit_server


### PR DESCRIPTION
This PR will fix the following issues that were introduced by the following pull request #9557.

- Cannot create messages with a mention inside it
- Cannot invite a user
- Cannot accept an invitation

Release Notes:

- Fixed channel chat notifications are not working anymore.