### PR TITLE
Fix the linux keymap

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1,4 +1,5 @@
 [
+  // Standard Linux bindings
   {
     "bindings": {
       "up": "menu::SelectPrev",
@@ -9,16 +10,13 @@
       "pagedown": "menu::SelectLast",
       "shift-pagedown": "menu::SelectFirst",
       "ctrl-n": "menu::SelectNext",
-      "ctrl-up": "menu::SelectFirst",
-      "ctrl-down": "menu::SelectLast",
       "enter": "menu::Confirm",
-      "shift-f10": "menu::ShowContextMenu",
       "ctrl-enter": "menu::SecondaryConfirm",
       "escape": "menu::Cancel",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
       "shift-enter": "menu::UseSelectedQuery",
-      "ctrl-shift-w": "workspace::CloseWindow",
+      "cmd-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "ctrl-o": "workspace::Open",
       "ctrl-=": "zed::IncreaseBufferFontSize",
@@ -28,8 +26,6 @@
       "ctrl-,": "zed::OpenSettings",
       "ctrl-q": "zed::Quit",
       "ctrl-h": "zed::Hide",
-      "alt-ctrl-h": "zed::HideOthers",
-      "ctrl-m": "zed::Minimize",
       "f11": "zed::ToggleFullScreen"
     }
   },
@@ -46,80 +42,109 @@
       "shift-tab": "editor::TabPrev",
       "ctrl-k": "editor::CutToEndOfLine",
       "ctrl-t": "editor::Transpose",
-      "ctrl-backspace": "editor::DeleteToBeginningOfLine",
-      "ctrl-delete": "editor::DeleteToEndOfLine",
-      "alt-backspace": "editor::DeleteToPreviousWordStart",
-      "alt-delete": "editor::DeleteToNextWordEnd",
-      "alt-h": "editor::DeleteToPreviousWordStart",
-      "alt-d": "editor::DeleteToNextWordEnd",
+      // "ctrl-backspace": "editor::DeleteToBeginningOfLine",
+      // "ctrl-delete": "editor::DeleteToEndOfLine",
+      "ctrl-backspace": "editor::DeleteToPreviousWordStart",
+      // "ctrl-w": "editor::DeleteToPreviousWordStart",
+      "ctrl-delete": "editor::DeleteToNextWordEnd",
+      // "alt-h": "editor::DeleteToPreviousWordStart",
+      // "alt-d": "editor::DeleteToNextWordEnd",
       "ctrl-x": "editor::Cut",
       "ctrl-c": "editor::Copy",
       "ctrl-v": "editor::Paste",
       "ctrl-z": "editor::Undo",
       "ctrl-shift-z": "editor::Redo",
-      "ctrl-y": "editor::Redo",
       "up": "editor::MoveUp",
-      "ctrl-up": "editor::MoveToStartOfParagraph",
+      // "ctrl-up": "editor::MoveToStartOfParagraph", todo(linux) Should be "scroll down by 1 line"
       "pageup": "editor::PageUp",
-      "shift-pageup": "editor::MovePageUp",
+      // "shift-pageup": "editor::MovePageUp", todo(linux) should be 'select page up'
       "home": "editor::MoveToBeginningOfLine",
       "down": "editor::MoveDown",
-      "ctrl-down": "editor::MoveToEndOfParagraph",
+      // "ctrl-down": "editor::MoveToEndOfParagraph", todo(linux) should be "scroll up by 1 line"
       "pagedown": "editor::PageDown",
-      "shift-pagedown": "editor::MovePageDown",
+      // "shift-pagedown": "editor::MovePageDown", todo(linux) should be 'select page down'
       "end": "editor::MoveToEndOfLine",
       "left": "editor::MoveLeft",
       "right": "editor::MoveRight",
-      "ctrl-p": "editor::MoveUp",
-      "ctrl-n": "editor::MoveDown",
-      "ctrl-b": "editor::MoveLeft",
-      "ctrl-f": "editor::MoveRight",
-      "ctrl-shift-l": "editor::NextScreen", // todo(linux): What is this
+      // "ctrl-p": "editor::MoveUp",
+      // "ctrl-n": "editor::MoveDown",
+      // "ctrl-b": "editor::MoveLeft",
+      // "ctrl-f": "editor::MoveRight",
+      // "ctrl-l": "editor::NextScreen",
       "ctrl-left": "editor::MoveToPreviousWordStart",
-      "alt-b": "editor::MoveToPreviousWordStart",
+      // "alt-b": "editor::MoveToPreviousWordStart",
       "ctrl-right": "editor::MoveToNextWordEnd",
-      "alt-f": "editor::MoveToNextWordEnd",
-      "ctrl-e": "editor::MoveToEndOfLine",
+      // "alt-f": "editor::MoveToNextWordEnd",
+      // "cmd-left": "editor::MoveToBeginningOfLine",
+      // "ctrl-a": "editor::MoveToBeginningOfLine",
+      // "cmd-right": "editor::MoveToEndOfLine",
+      // "ctrl-e": "editor::MoveToEndOfLine", 
       "ctrl-home": "editor::MoveToBeginning",
-      "ctrl-=end": "editor::MoveToEnd",
+      "ctrl-end": "editor::MoveToEnd",
       "shift-up": "editor::SelectUp",
+      // "ctrl-shift-p": "editor::SelectUp",
       "shift-down": "editor::SelectDown",
-      "ctrl-shift-n": "editor::SelectDown",
+      // "ctrl-shift-n": "editor::SelectDown",
       "shift-left": "editor::SelectLeft",
-      "ctrl-shift-b": "editor::SelectLeft",
+      // "ctrl-shift-b": "editor::SelectLeft",
       "shift-right": "editor::SelectRight",
-      "ctrl-shift-f": "editor::SelectRight",
+      // "ctrl-shift-f": "editor::SelectRight",
       "ctrl-shift-left": "editor::SelectToPreviousWordStart",
-      "alt-shift-b": "editor::SelectToPreviousWordStart",
+      // "alt-shift-b": "editor::SelectToPreviousWordStart",
       "ctrl-shift-right": "editor::SelectToNextWordEnd",
-      "alt-shift-f": "editor::SelectToNextWordEnd",
-      "ctrl-shift-up": "editor::SelectToStartOfParagraph",
-      "ctrl-shift-down": "editor::SelectToEndOfParagraph",
+      // "alt-shift-f": "editor::SelectToNextWordEnd",
+      // "ctrl-shift-up": "editor::SelectToStartOfParagraph", todo(convert to multi cursor)
+      // "ctrl-shift-down": "editor::SelectToEndOfParagraph",
       "ctrl-shift-home": "editor::SelectToBeginning",
       "ctrl-shift-end": "editor::SelectToEnd",
       "ctrl-a": "editor::SelectAll",
       "ctrl-l": "editor::SelectLine",
       "ctrl-shift-i": "editor::Format",
+      // "cmd-shift-left": [
+      //   "editor::SelectToBeginningOfLine",
+      //   {
+      //     "stop_at_soft_wraps": true
+      //   }
+      // ],
       "shift-home": [
         "editor::SelectToBeginningOfLine",
         {
           "stop_at_soft_wraps": true
         }
       ],
+      // "ctrl-shift-a": [
+      //   "editor::SelectToBeginningOfLine",
+      //   {
+      //     "stop_at_soft_wraps": true
+      //   }
+      // ],
+      // "cmd-shift-right": [
+      //   "editor::SelectToEndOfLine",
+      //   {
+      //     "stop_at_soft_wraps": true
+      //   }
+      // ],
       "shift-end": [
         "editor::SelectToEndOfLine",
         {
           "stop_at_soft_wraps": true
         }
       ],
-      "ctrl-shift-e": [
-        "editor::SelectToEndOfLine",
-        {
-          "stop_at_soft_wraps": true
-        }
-      ],
+      // "ctrl-shift-e": [
+      //   "editor::SelectToEndOfLine",
+      //   {
+      //     "stop_at_soft_wraps": true
+      //   }
+      // ],
+      // "alt-v": [
+      //   "editor::MovePageUp",
+      //   {
+      //     "center_cursor": true
+      //   }
+      // ],
+      // "ctrl-cmd-space": "editor::ShowCharacterPalette",
       "ctrl-;": "editor::ToggleLineNumbers",
-      "ctrl-alt-z": "editor::RevertSelectedHunks"
+      "ctrl-k ctrl-r": "editor::RevertSelectedHunks"
     }
   },
   {
@@ -127,8 +152,8 @@
     "bindings": {
       "enter": "editor::Newline",
       "shift-enter": "editor::Newline",
-      "ctrl-shift-enter": "editor::NewlineAbove",
-      "ctrl-enter": "editor::NewlineBelow",
+      "ctrl-shift-enter": "editor::NewlineBelow",
+      "ctrl-enter": "editor::NewlineAbove",
       "alt-z": "editor::ToggleSoftWrap",
       "ctrl-f": [
         "buffer_search::Deploy",
@@ -136,6 +161,12 @@
           "focus": true
         }
       ],
+      // "cmd-e": [
+      //   "buffer_search::Deploy",
+      //   {
+      //     "focus": false
+      //   }
+      // ],
       "ctrl->": "assistant::QuoteSelection"
     }
   },
@@ -164,8 +195,8 @@
   {
     "context": "AssistantPanel",
     "bindings": {
-      "f3": "search::SelectNextMatch",
-      "shift-f3": "search::SelectPrevMatch"
+      "ctrl-g": "search::SelectNextMatch",
+      "ctrl-shift-g": "search::SelectPrevMatch"
     }
   },
   {
@@ -185,15 +216,15 @@
       "tab": "buffer_search::FocusEditor",
       "enter": "search::SelectNextMatch",
       "shift-enter": "search::SelectPrevMatch",
-      "alt-enter": "search::SelectAllMatches",
-      "alt-tab": "search::CycleMode"
+      "alt-enter": "search::SelectAllMatches"
+      // "alt-tab": "search::CycleMode"
     }
   },
   {
     "context": "BufferSearchBar && in_replace",
     "bindings": {
       "enter": "search::ReplaceNext",
-      "ctrl-enter": "search::ReplaceAll"
+      "cmd-enter": "search::ReplaceAll"
     }
   },
   {
@@ -207,11 +238,10 @@
     "context": "ProjectSearchBar",
     "bindings": {
       "escape": "project_search::ToggleFocus",
-      "alt-tab": "search::CycleMode",
+      // "alt-tab": "search::CycleMode",
       "ctrl-shift-h": "search::ToggleReplace",
-      "ctrl-alt-g": "search::ActivateRegexMode",
-      "ctrl-alt-s": "search::ActivateSemanticMode",
-      "ctrl-alt-x": "search::ActivateTextMode"
+      "alt-ctrl-g": "search::ActivateRegexMode",
+      "alt-ctrl-x": "search::ActivateTextMode"
     }
   },
   {
@@ -225,7 +255,7 @@
     "context": "ProjectSearchBar && in_replace",
     "bindings": {
       "enter": "search::ReplaceNext",
-      "ctrl-enter": "search::ReplaceAll"
+      "ctrl-alt-enter": "search::ReplaceAll"
     }
   },
   {
@@ -233,103 +263,113 @@
     "bindings": {
       "escape": "project_search::ToggleFocus",
       "alt-tab": "search::CycleMode",
-      "ctrl-shift-h": "search::ToggleReplace",
-      "ctrl-alt-g": "search::ActivateRegexMode",
-      "ctrl-alt-s": "search::ActivateSemanticMode",
-      "ctrl-alt-x": "search::ActivateTextMode"
+      "cmd-shift-h": "search::ToggleReplace",
+      "alt-ctrl-g": "search::ActivateRegexMode",
+      "alt-ctrl-x": "search::ActivateTextMode"
     }
   },
   {
     "context": "Pane",
     "bindings": {
-      "ctrl-{": "pane::ActivatePrevItem",
-      "ctrl-}": "pane::ActivateNextItem",
-      "ctrl-alt-left": "pane::ActivatePrevItem",
-      "ctrl-alt-right": "pane::ActivateNextItem",
-      "ctrl-w": "pane::CloseActiveItem",
-      "ctrl-alt-t": "pane::CloseInactiveItems",
-      "ctrl-alt-shift-w": "workspace::CloseInactiveTabsAndPanes",
-      "ctrl-k u": "pane::CloseCleanItems",
-      "ctrl-k ctrl-w": "pane::CloseAllItems",
-      "ctrl-f": "project_search::ToggleFocus",
-      "f3": "search::SelectNextMatch",
-      "shift-f3": "search::SelectPrevMatch",
-      "ctrl-shift-h": "search::ToggleReplace",
+      "cmd-{": "pane::ActivatePrevItem",
+      "cmd-}": "pane::ActivateNextItem",
+      "alt-cmd-left": "pane::ActivatePrevItem",
+      "alt-cmd-right": "pane::ActivateNextItem",
+      "cmd-w": "pane::CloseActiveItem",
+      "alt-cmd-t": "pane::CloseInactiveItems",
+      "ctrl-alt-cmd-w": "workspace::CloseInactiveTabsAndPanes",
+      "cmd-k u": "pane::CloseCleanItems",
+      "cmd-k cmd-w": "pane::CloseAllItems",
+      "cmd-f": "project_search::ToggleFocus",
+      "cmd-g": "search::SelectNextMatch",
+      "cmd-shift-g": "search::SelectPrevMatch",
+      "cmd-shift-h": "search::ToggleReplace",
       "alt-enter": "search::SelectAllMatches",
-      "ctrl-alt-c": "search::ToggleCaseSensitive",
-      "ctrl-alt-w": "search::ToggleWholeWord",
+      "alt-cmd-c": "search::ToggleCaseSensitive",
+      "alt-cmd-w": "search::ToggleWholeWord",
       "alt-tab": "search::CycleMode",
-      "ctrl-alt-f": "project_search::ToggleFilters",
-      "ctrl-alt-g": "search::ActivateRegexMode",
-      "ctrl-alt-s": "search::ActivateSemanticMode",
-      "ctrl-alt-x": "search::ActivateTextMode"
+      "alt-cmd-f": "project_search::ToggleFilters",
+      "alt-cmd-g": "search::ActivateRegexMode",
+      "alt-cmd-x": "search::ActivateTextMode"
     }
   },
   // Bindings from VS Code
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-[": "editor::Outdent",
-      "ctrl-]": "editor::Indent",
-      "ctrl-alt-up": "editor::AddSelectionAbove",
-      "ctrl-alt-down": "editor::AddSelectionBelow",
-      "ctrl-d": [
+      "cmd-[": "editor::Outdent",
+      "cmd-]": "editor::Indent",
+      "cmd-alt-up": "editor::AddSelectionAbove",
+      "cmd-ctrl-p": "editor::AddSelectionAbove",
+      "cmd-alt-down": "editor::AddSelectionBelow",
+      "cmd-ctrl-n": "editor::AddSelectionBelow",
+      "cmd-shift-k": "editor::DeleteLine",
+      "alt-up": "editor::MoveLineUp",
+      "alt-down": "editor::MoveLineDown",
+      "alt-shift-up": [
+        "editor::DuplicateLine",
+        {
+          "move_upwards": true
+        }
+      ],
+      "alt-shift-down": "editor::DuplicateLine",
+      "ctrl-shift-right": "editor::SelectLargerSyntaxNode",
+      "ctrl-shift-left": "editor::SelectSmallerSyntaxNode",
+      "cmd-d": [
         "editor::SelectNext",
         {
           "replace_newest": false
         }
       ],
-      "ctrl-shift-l": "editor::SelectAllMatches",
-      "ctrl-shift-d": [
+      "cmd-shift-l": "editor::SelectAllMatches",
+      "ctrl-cmd-d": [
         "editor::SelectPrevious",
         {
           "replace_newest": false
         }
       ],
-      "ctrl-k ctrl-d": [
+      "cmd-k cmd-d": [
         "editor::SelectNext",
         {
           "replace_newest": true
         }
       ],
-      "ctrl-k ctrl-shift-d": [
+      "cmd-k ctrl-cmd-d": [
         "editor::SelectPrevious",
         {
           "replace_newest": true
         }
       ],
-      "ctrl-k ctrl-i": "editor::Hover",
-      "ctrl-/": [
+      "cmd-k cmd-i": "editor::Hover",
+      "cmd-/": [
         "editor::ToggleComments",
         {
           "advance_downwards": false
         }
       ],
-      "alt-up": "editor::SelectLargerSyntaxNode",
-      "alt-down": "editor::SelectSmallerSyntaxNode",
-      "ctrl-u": "editor::UndoSelection",
-      "ctrl-shift-u": "editor::RedoSelection",
+      "cmd-u": "editor::UndoSelection",
+      "cmd-shift-u": "editor::RedoSelection",
       "f8": "editor::GoToDiagnostic",
       "shift-f8": "editor::GoToPrevDiagnostic",
       "f2": "editor::Rename",
       "f12": "editor::GoToDefinition",
       "alt-f12": "editor::GoToDefinitionSplit",
-      "ctrl-f12": "editor::GoToTypeDefinition",
-      "ctrl-alt-f12": "editor::GoToTypeDefinitionSplit",
+      "cmd-f12": "editor::GoToTypeDefinition",
+      "alt-cmd-f12": "editor::GoToTypeDefinitionSplit",
       "alt-shift-f12": "editor::FindAllReferences",
       "ctrl-m": "editor::MoveToEnclosingBracket",
-      "ctrl-alt-[": "editor::Fold",
-      "ctrl-alt-]": "editor::UnfoldLines",
+      "alt-cmd-[": "editor::Fold",
+      "alt-cmd-]": "editor::UnfoldLines",
       "ctrl-space": "editor::ShowCompletions",
-      "ctrl-.": "editor::ToggleCodeActions",
-      "ctrl-alt-r": "editor::RevealInFinder",
-      "ctrl-alt-c": "editor::DisplayCursorNames"
+      "cmd-.": "editor::ToggleCodeActions",
+      "alt-cmd-r": "editor::RevealInFinder",
+      "ctrl-cmd-c": "editor::DisplayCursorNames"
     }
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
-      "ctrl-shift-o": "outline::Toggle",
+      "cmd-shift-o": "outline::Toggle",
       "ctrl-g": "go_to_line::Toggle"
     }
   },
@@ -348,8 +388,8 @@
       "ctrl-0": "pane::ActivateLastItem",
       "ctrl--": "pane::GoBack",
       "ctrl-_": "pane::GoForward",
-      "ctrl-shift-t": "pane::ReopenClosedItem",
-      "ctrl-shift-f": "project_search::ToggleFocus"
+      "cmd-shift-t": "pane::ReopenClosedItem",
+      "cmd-shift-f": "project_search::ToggleFocus"
     }
   },
   {
@@ -362,62 +402,57 @@
       //         "create_new_window": true
       //     }
       // ]
-      "ctrl-alt-o": "projects::OpenRecent",
-      "ctrl-alt-b": "branches::OpenRecent",
+      "alt-cmd-o": "projects::OpenRecent",
+      "alt-cmd-b": "branches::OpenRecent",
       "ctrl-~": "workspace::NewTerminal",
-      "ctrl-s": "workspace::Save",
-      "ctrl-k s": "workspace::SaveWithoutFormat",
-      "ctrl-shift-s": "workspace::SaveAs",
-      "ctrl-n": "workspace::NewFile",
-      "ctrl-shift-n": "workspace::NewWindow",
+      "cmd-s": "workspace::Save",
+      "cmd-k s": "workspace::SaveWithoutFormat",
+      "cmd-shift-s": "workspace::SaveAs",
+      "cmd-n": "workspace::NewFile",
+      "cmd-shift-n": "workspace::NewWindow",
       "ctrl-`": "terminal_panel::ToggleFocus",
-      "ctrl-1": ["workspace::ActivatePane", 0],
-      "ctrl-2": ["workspace::ActivatePane", 1],
-      "ctrl-3": ["workspace::ActivatePane", 2],
-      "ctrl-4": ["workspace::ActivatePane", 3],
-      "ctrl-5": ["workspace::ActivatePane", 4],
-      "ctrl-6": ["workspace::ActivatePane", 5],
-      "ctrl-7": ["workspace::ActivatePane", 6],
-      "ctrl-8": ["workspace::ActivatePane", 7],
-      "ctrl-9": ["workspace::ActivatePane", 8],
-      "ctrl-b": "workspace::ToggleLeftDock",
-      "ctrl-r": "workspace::ToggleRightDock",
-      "ctrl-j": "workspace::ToggleBottomDock",
-      "ctrl-alt-y": "workspace::CloseAllDocks",
-      "ctrl-shift-f": "pane::DeploySearch",
-      "ctrl-k ctrl-t": "theme_selector::Toggle",
-      "ctrl-k ctrl-s": "zed::OpenKeymap",
-      "ctrl-t": "project_symbols::Toggle",
-      "ctrl-p": "file_finder::Toggle",
-      "ctrl-shift-p": "command_palette::Toggle",
-      "ctrl-shift-m": "diagnostics::Deploy",
-      "ctrl-shift-e": "project_panel::ToggleFocus",
-      "ctrl-?": "assistant::ToggleFocus",
-      "ctrl-alt-s": "workspace::SaveAll",
-      "ctrl-k m": "language_selector::Toggle",
+      "cmd-1": ["workspace::ActivatePane", 0],
+      "cmd-2": ["workspace::ActivatePane", 1],
+      "cmd-3": ["workspace::ActivatePane", 2],
+      "cmd-4": ["workspace::ActivatePane", 3],
+      "cmd-5": ["workspace::ActivatePane", 4],
+      "cmd-6": ["workspace::ActivatePane", 5],
+      "cmd-7": ["workspace::ActivatePane", 6],
+      "cmd-8": ["workspace::ActivatePane", 7],
+      "cmd-9": ["workspace::ActivatePane", 8],
+      "cmd-b": "workspace::ToggleLeftDock",
+      "cmd-r": "workspace::ToggleRightDock",
+      "cmd-j": "workspace::ToggleBottomDock",
+      "alt-cmd-y": "workspace::CloseAllDocks",
+      "cmd-shift-f": "pane::DeploySearch",
+      "cmd-k cmd-s": "zed::OpenKeymap",
+      "cmd-k cmd-t": "theme_selector::Toggle",
+      "cmd-t": "project_symbols::Toggle",
+      "cmd-p": "file_finder::Toggle", // todo(linux) also do ctrl-e
+      "cmd-shift-p": "command_palette::Toggle",
+      "cmd-shift-m": "diagnostics::Deploy",
+      "cmd-shift-e": "project_panel::ToggleFocus",
+      "cmd-?": "assistant::ToggleFocus",
+      "cmd-alt-s": "workspace::SaveAll",
+      "cmd-k m": "language_selector::Toggle",
       "escape": "workspace::Unfollow",
-      "ctrl-k ctrl-left": ["workspace::ActivatePaneInDirection", "Left"],
-      "ctrl-k ctrl-right": ["workspace::ActivatePaneInDirection", "Right"],
-      "ctrl-k ctrl-up": ["workspace::ActivatePaneInDirection", "Up"],
-      "ctrl-k ctrl-down": ["workspace::ActivatePaneInDirection", "Down"],
-      "ctrl-k shift-left": ["workspace::SwapPaneInDirection", "Left"],
-      "ctrl-k shift-right": ["workspace::SwapPaneInDirection", "Right"],
-      "ctrl-k shift-up": ["workspace::SwapPaneInDirection", "Up"],
-      "ctrl-k shift-down": ["workspace::SwapPaneInDirection", "Down"],
+      "cmd-k cmd-left": ["workspace::ActivatePaneInDirection", "Left"],
+      "cmd-k cmd-right": ["workspace::ActivatePaneInDirection", "Right"],
+      "cmd-k cmd-up": ["workspace::ActivatePaneInDirection", "Up"],
+      "cmd-k cmd-down": ["workspace::ActivatePaneInDirection", "Down"],
+      "cmd-k shift-left": ["workspace::SwapPaneInDirection", "Left"],
+      "cmd-k shift-right": ["workspace::SwapPaneInDirection", "Right"],
+      "cmd-k shift-up": ["workspace::SwapPaneInDirection", "Up"],
+      "cmd-k shift-down": ["workspace::SwapPaneInDirection", "Down"],
       "alt-t": "task::Rerun",
       "alt-shift-t": "task::Spawn"
     }
   },
   // Bindings from Sublime Text
-  // todo(linux) make sure these match linux bindings or remove above comment?
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-k": "editor::DeleteLine",
-      "ctrl-shift-d": "editor::DuplicateLine",
       "ctrl-j": "editor::JoinLines",
-      "ctrl-alt-up": "editor::MoveLineUp",
-      "ctrl-alt-down": "editor::MoveLineDown",
       "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",
@@ -433,14 +468,13 @@
     }
   },
   // Bindings from Atom
-  // todo(linux) make sure these match linux bindings or remove above comment?
   {
     "context": "Pane",
     "bindings": {
-      "ctrl-k up": "pane::SplitUp",
-      "ctrl-k down": "pane::SplitDown",
-      "ctrl-k left": "pane::SplitLeft",
-      "ctrl-k right": "pane::SplitRight"
+      "cmd-k up": "pane::SplitUp",
+      "cmd-k down": "pane::SplitDown",
+      "cmd-k left": "pane::SplitLeft",
+      "cmd-k right": "pane::SplitRight"
     }
   },
   // Bindings that should be unified with bindings for more general actions
@@ -477,10 +511,10 @@
   // Custom bindings
   {
     "bindings": {
-      "ctrl-alt-shift-f": "workspace::FollowNextCollaborator",
+      "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
       // TODO: Move this to a dock open action
-      "ctrl-alt-c": "collab_panel::ToggleFocus",
-      "ctrl-alt-i": "zed::DebugElements",
+      "cmd-shift-c": "collab_panel::ToggleFocus",
+      "cmd-alt-i": "zed::DebugElements",
       "ctrl-:": "editor::ToggleInlayHints"
     }
   },
@@ -488,16 +522,16 @@
     "context": "Editor && mode == full",
     "bindings": {
       "alt-enter": "editor::OpenExcerpts",
-      "ctrl-k enter": "editor::OpenExcerptsSplit",
-      "ctrl-f8": "editor::GoToHunk",
-      "ctrl-shift-f8": "editor::GoToPrevHunk",
+      "cmd-k enter": "editor::OpenExcerptsSplit",
+      "cmd-f8": "editor::GoToHunk",
+      "cmd-shift-f8": "editor::GoToPrevHunk",
       "ctrl-enter": "assistant::InlineAssist"
     }
   },
   {
     "context": "ProjectSearchBar && !in_replace",
     "bindings": {
-      "ctrl-enter": "project_search::SearchInNew"
+      "cmd-enter": "project_search::SearchInNew"
     }
   },
   {
@@ -505,20 +539,20 @@
     "bindings": {
       "left": "project_panel::CollapseSelectedEntry",
       "right": "project_panel::ExpandSelectedEntry",
-      "ctrl-n": "project_panel::NewFile",
-      "ctrl-alt-n": "project_panel::NewDirectory",
-      "ctrl-x": "project_panel::Cut",
-      "ctrl-c": "project_panel::Copy",
-      "ctrl-v": "project_panel::Paste",
-      "ctrl-alt-c": "project_panel::CopyPath",
-      "ctrl-alt-shift-c": "project_panel::CopyRelativePath",
+      "cmd-n": "project_panel::NewFile",
+      "alt-cmd-n": "project_panel::NewDirectory",
+      "cmd-x": "project_panel::Cut",
+      "cmd-c": "project_panel::Copy",
+      "cmd-v": "project_panel::Paste",
+      "cmd-alt-c": "project_panel::CopyPath",
+      "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
       "backspace": "project_panel::Delete",
       "delete": "project_panel::Delete",
-      "ctrl-backspace": ["project_panel::Delete", { "skip_prompt": true }],
-      "ctrl-delete": ["project_panel::Delete", { "skip_prompt": true }],
-      "ctrl-alt-r": "project_panel::RevealInFinder",
+      "cmd-backspace": ["project_panel::Delete", { "skip_prompt": true }],
+      "cmd-delete": ["project_panel::Delete", { "skip_prompt": true }],
+      "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }
   },
@@ -566,14 +600,14 @@
   {
     "context": "Terminal",
     "bindings": {
-      "ctrl-alt-space": "terminal::ShowCharacterPalette",
-      "ctrl-shift-c": "terminal::Copy",
-      "ctrl-shift-v": "terminal::Paste",
-      "ctrl-k": "terminal::Clear",
+      "ctrl-cmd-space": "terminal::ShowCharacterPalette",
+      "cmd-c": "terminal::Copy",
+      "cmd-v": "terminal::Paste",
+      "cmd-k": "terminal::Clear",
       // Some nice conveniences
-      "ctrl-backspace": ["terminal::SendText", "\u0015"],
-      "ctrl-right": ["terminal::SendText", "\u0005"],
-      "ctrl-left": ["terminal::SendText", "\u0001"],
+      "cmd-backspace": ["terminal::SendText", "\u0015"],
+      "cmd-right": ["terminal::SendText", "\u0005"],
+      "cmd-left": ["terminal::SendText", "\u0001"],
       // Terminal.app compatibility
       "alt-left": ["terminal::SendText", "\u001bb"],
       "alt-right": ["terminal::SendText", "\u001bf"],

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -16,7 +16,7 @@
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
       "shift-enter": "menu::UseSelectedQuery",
-      "cmd-shift-w": "workspace::CloseWindow",
+      "ctrl-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "ctrl-o": "workspace::Open",
       "ctrl-=": "zed::IncreaseBufferFontSize",
@@ -271,99 +271,97 @@
   {
     "context": "Pane",
     "bindings": {
-      "cmd-{": "pane::ActivatePrevItem",
-      "cmd-}": "pane::ActivateNextItem",
-      "alt-cmd-left": "pane::ActivatePrevItem",
-      "alt-cmd-right": "pane::ActivateNextItem",
-      "cmd-w": "pane::CloseActiveItem",
-      "alt-cmd-t": "pane::CloseInactiveItems",
-      "ctrl-alt-cmd-w": "workspace::CloseInactiveTabsAndPanes",
-      "cmd-k u": "pane::CloseCleanItems",
-      "cmd-k cmd-w": "pane::CloseAllItems",
-      "cmd-f": "project_search::ToggleFocus",
-      "cmd-g": "search::SelectNextMatch",
-      "cmd-shift-g": "search::SelectPrevMatch",
-      "cmd-shift-h": "search::ToggleReplace",
+      "ctrl-shift-tab": "pane::ActivatePrevItem",
+      "ctrl-pageup": "pane::ActivatePrevItem",
+      "ctrl-tab": "pane::ActivateNextItem",
+      "ctrl-pagedown": "pane::ActivateNextItem",
+      "ctrl-w": "pane::CloseActiveItem",
+      "alt-ctrl-t": "pane::CloseInactiveItems",
+      "alt-ctrl-shift-w": "workspace::CloseInactiveTabsAndPanes",
+      "ctrl-k u": "pane::CloseCleanItems",
+      "ctrl-k w": "pane::CloseAllItems",
+      "ctrl-shift-f": "project_search::ToggleFocus",
+      "ctrl-alt-g": "search::SelectNextMatch",
+      "ctrl-alt-shift-g": "search::SelectPrevMatch",
+      "ctrl-alt-shift-h": "search::ToggleReplace",
       "alt-enter": "search::SelectAllMatches",
-      "alt-cmd-c": "search::ToggleCaseSensitive",
-      "alt-cmd-w": "search::ToggleWholeWord",
-      "alt-tab": "search::CycleMode",
-      "alt-cmd-f": "project_search::ToggleFilters",
-      "alt-cmd-g": "search::ActivateRegexMode",
-      "alt-cmd-x": "search::ActivateTextMode"
+      "alt-c": "search::ToggleCaseSensitive",
+      "alt-w": "search::ToggleWholeWord",
+      "alt-r": "search::CycleMode",
+      "alt-ctrl-f": "project_search::ToggleFilters",
+      "ctrl-alt-shift-r": "search::ActivateRegexMode",
+      "ctrl-alt-shift-x": "search::ActivateTextMode"
     }
   },
   // Bindings from VS Code
   {
     "context": "Editor",
     "bindings": {
-      "cmd-[": "editor::Outdent",
-      "cmd-]": "editor::Indent",
-      "cmd-alt-up": "editor::AddSelectionAbove",
-      "cmd-ctrl-p": "editor::AddSelectionAbove",
-      "cmd-alt-down": "editor::AddSelectionBelow",
-      "cmd-ctrl-n": "editor::AddSelectionBelow",
-      "cmd-shift-k": "editor::DeleteLine",
+      "ctrl-[": "editor::Outdent",
+      "ctrl-]": "editor::Indent",
+      "shift-alt-up": "editor::AddSelectionAbove",
+      "shift-alt-down": "editor::AddSelectionBelow",
+      "ctrl-shift-k": "editor::DeleteLine",
       "alt-up": "editor::MoveLineUp",
       "alt-down": "editor::MoveLineDown",
-      "alt-shift-up": [
+      "ctrl-alt-shift-up": [
         "editor::DuplicateLine",
         {
           "move_upwards": true
         }
       ],
-      "alt-shift-down": "editor::DuplicateLine",
+      "ctrl-alt-shift-down": "editor::DuplicateLine",
       "ctrl-shift-right": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-left": "editor::SelectSmallerSyntaxNode",
-      "cmd-d": [
+      "ctrl-d": [
         "editor::SelectNext",
         {
           "replace_newest": false
         }
       ],
-      "cmd-shift-l": "editor::SelectAllMatches",
-      "ctrl-cmd-d": [
+      "ctrl-shift-l": "editor::SelectAllMatches",
+      "ctrl-shift-d": [
         "editor::SelectPrevious",
         {
           "replace_newest": false
         }
       ],
-      "cmd-k cmd-d": [
+      "ctrl-k ctrl-d": [
         "editor::SelectNext",
         {
           "replace_newest": true
         }
       ],
-      "cmd-k ctrl-cmd-d": [
+      "ctrl-k ctrl-shift-d": [
         "editor::SelectPrevious",
         {
           "replace_newest": true
         }
       ],
-      "cmd-k cmd-i": "editor::Hover",
-      "cmd-/": [
+      "ctrl-k ctrl-i": "editor::Hover",
+      "ctrl-/": [
         "editor::ToggleComments",
         {
           "advance_downwards": false
         }
       ],
-      "cmd-u": "editor::UndoSelection",
-      "cmd-shift-u": "editor::RedoSelection",
+      "ctrl-u": "editor::UndoSelection",
+      "ctrl-shift-u": "editor::RedoSelection",
       "f8": "editor::GoToDiagnostic",
       "shift-f8": "editor::GoToPrevDiagnostic",
       "f2": "editor::Rename",
       "f12": "editor::GoToDefinition",
       "alt-f12": "editor::GoToDefinitionSplit",
-      "cmd-f12": "editor::GoToTypeDefinition",
-      "alt-cmd-f12": "editor::GoToTypeDefinitionSplit",
+      "ctrl-f12": "editor::GoToTypeDefinition",
+      "alt-ctrl-f12": "editor::GoToTypeDefinitionSplit",
       "alt-shift-f12": "editor::FindAllReferences",
       "ctrl-m": "editor::MoveToEnclosingBracket",
-      "alt-cmd-[": "editor::Fold",
-      "alt-cmd-]": "editor::UnfoldLines",
+      "ctrl-shift-[": "editor::Fold",
+      "ctrl-shift-]": "editor::UnfoldLines",
       "ctrl-space": "editor::ShowCompletions",
-      "cmd-.": "editor::ToggleCodeActions",
-      "alt-cmd-r": "editor::RevealInFinder",
-      "ctrl-cmd-c": "editor::DisplayCursorNames"
+      "ctrl-.": "editor::ToggleCodeActions",
+      // "alt-cmd-r": "editor::RevealInFinder", 
+      "ctrl-alt-shift-c": "editor::DisplayCursorNames"
     }
   },
   {
@@ -376,20 +374,20 @@
   {
     "context": "Pane",
     "bindings": {
-      "ctrl-1": ["pane::ActivateItem", 0],
-      "ctrl-2": ["pane::ActivateItem", 1],
-      "ctrl-3": ["pane::ActivateItem", 2],
-      "ctrl-4": ["pane::ActivateItem", 3],
-      "ctrl-5": ["pane::ActivateItem", 4],
-      "ctrl-6": ["pane::ActivateItem", 5],
-      "ctrl-7": ["pane::ActivateItem", 6],
-      "ctrl-8": ["pane::ActivateItem", 7],
-      "ctrl-9": ["pane::ActivateItem", 8],
-      "ctrl-0": "pane::ActivateLastItem",
-      "ctrl--": "pane::GoBack",
-      "ctrl-_": "pane::GoForward",
-      "cmd-shift-t": "pane::ReopenClosedItem",
-      "cmd-shift-f": "project_search::ToggleFocus"
+      "alt-1": ["pane::ActivateItem", 0],
+      "alt-2": ["pane::ActivateItem", 1],
+      "alt-3": ["pane::ActivateItem", 2],
+      "alt-4": ["pane::ActivateItem", 3],
+      "alt-5": ["pane::ActivateItem", 4],
+      "alt-6": ["pane::ActivateItem", 5],
+      "alt-7": ["pane::ActivateItem", 6],
+      "alt-8": ["pane::ActivateItem", 7],
+      "alt-9": ["pane::ActivateItem", 8],
+      "alt-0": "pane::ActivateLastItem",
+      "ctrl-alt--": "pane::GoBack",
+      "ctrl-alt-_": "pane::GoForward",
+      "ctrl-shift-t": "pane::ReopenClosedItem",
+      "ctrl-shift-f": "project_search::ToggleFocus"
     }
   },
   {
@@ -402,48 +400,48 @@
       //         "create_new_window": true
       //     }
       // ]
-      "alt-cmd-o": "projects::OpenRecent",
-      "alt-cmd-b": "branches::OpenRecent",
+      "alt-ctrl-o": "projects::OpenRecent",
+      // "alt-cmd-b": "branches::OpenRecent",
       "ctrl-~": "workspace::NewTerminal",
-      "cmd-s": "workspace::Save",
-      "cmd-k s": "workspace::SaveWithoutFormat",
-      "cmd-shift-s": "workspace::SaveAs",
-      "cmd-n": "workspace::NewFile",
-      "cmd-shift-n": "workspace::NewWindow",
+      "ctrl-s": "workspace::Save",
+      "ctrl-k s": "workspace::SaveWithoutFormat",
+      "ctrl-shift-s": "workspace::SaveAs",
+      "ctrl-n": "workspace::NewFile",
+      "ctrl-shift-n": "workspace::NewWindow",
       "ctrl-`": "terminal_panel::ToggleFocus",
-      "cmd-1": ["workspace::ActivatePane", 0],
-      "cmd-2": ["workspace::ActivatePane", 1],
-      "cmd-3": ["workspace::ActivatePane", 2],
-      "cmd-4": ["workspace::ActivatePane", 3],
-      "cmd-5": ["workspace::ActivatePane", 4],
-      "cmd-6": ["workspace::ActivatePane", 5],
-      "cmd-7": ["workspace::ActivatePane", 6],
-      "cmd-8": ["workspace::ActivatePane", 7],
-      "cmd-9": ["workspace::ActivatePane", 8],
-      "cmd-b": "workspace::ToggleLeftDock",
-      "cmd-r": "workspace::ToggleRightDock",
-      "cmd-j": "workspace::ToggleBottomDock",
-      "alt-cmd-y": "workspace::CloseAllDocks",
-      "cmd-shift-f": "pane::DeploySearch",
-      "cmd-k cmd-s": "zed::OpenKeymap",
-      "cmd-k cmd-t": "theme_selector::Toggle",
-      "cmd-t": "project_symbols::Toggle",
-      "cmd-p": "file_finder::Toggle", // todo(linux) also do ctrl-e
-      "cmd-shift-p": "command_palette::Toggle",
-      "cmd-shift-m": "diagnostics::Deploy",
-      "cmd-shift-e": "project_panel::ToggleFocus",
-      "cmd-?": "assistant::ToggleFocus",
-      "cmd-alt-s": "workspace::SaveAll",
-      "cmd-k m": "language_selector::Toggle",
+      "alt-1": ["workspace::ActivatePane", 0],
+      "alt-2": ["workspace::ActivatePane", 1],
+      "alt-3": ["workspace::ActivatePane", 2],
+      "alt-4": ["workspace::ActivatePane", 3],
+      "alt-5": ["workspace::ActivatePane", 4],
+      "alt-6": ["workspace::ActivatePane", 5],
+      "alt-7": ["workspace::ActivatePane", 6],
+      "alt-8": ["workspace::ActivatePane", 7],
+      "alt-9": ["workspace::ActivatePane", 8],
+      "ctrl-alt-b": "workspace::ToggleLeftDock",
+      "ctrl-b": "workspace::ToggleRightDock",
+      "ctrl-j": "workspace::ToggleBottomDock",
+      "ctrl-alt-y": "workspace::CloseAllDocks",
+      "ctrl-shift-f": "pane::DeploySearch",
+      "ctrl-k ctrl-s": "zed::OpenKeymap",
+      "ctrl-k ctrl-t": "theme_selector::Toggle",
+      "ctrl-t": "project_symbols::Toggle",
+      "ctrl-p": "file_finder::Toggle", // todo(linux) also do ctrl-e
+      "ctrl-shift-p": "command_palette::Toggle",
+      "ctrl-shift-m": "diagnostics::Deploy",
+      "ctrl-shift-e": "project_panel::ToggleFocus",
+      "ctrl-?": "assistant::ToggleFocus",
+      "ctrl-alt-s": "workspace::SaveAll",
+      "ctrl-k m": "language_selector::Toggle",
       "escape": "workspace::Unfollow",
-      "cmd-k cmd-left": ["workspace::ActivatePaneInDirection", "Left"],
-      "cmd-k cmd-right": ["workspace::ActivatePaneInDirection", "Right"],
-      "cmd-k cmd-up": ["workspace::ActivatePaneInDirection", "Up"],
-      "cmd-k cmd-down": ["workspace::ActivatePaneInDirection", "Down"],
-      "cmd-k shift-left": ["workspace::SwapPaneInDirection", "Left"],
-      "cmd-k shift-right": ["workspace::SwapPaneInDirection", "Right"],
-      "cmd-k shift-up": ["workspace::SwapPaneInDirection", "Up"],
-      "cmd-k shift-down": ["workspace::SwapPaneInDirection", "Down"],
+      "ctrl-k ctrl-left": ["workspace::ActivatePaneInDirection", "Left"],
+      "ctrl-k ctrl-right": ["workspace::ActivatePaneInDirection", "Right"],
+      "ctrl-k ctrl-up": ["workspace::ActivatePaneInDirection", "Up"],
+      "ctrl-k ctrl-down": ["workspace::ActivatePaneInDirection", "Down"],
+      "ctrl-k shift-left": ["workspace::SwapPaneInDirection", "Left"],
+      "ctrl-k shift-right": ["workspace::SwapPaneInDirection", "Right"],
+      "ctrl-k shift-up": ["workspace::SwapPaneInDirection", "Up"],
+      "ctrl-k shift-down": ["workspace::SwapPaneInDirection", "Down"],
       "alt-t": "task::Rerun",
       "alt-shift-t": "task::Spawn"
     }
@@ -471,10 +469,10 @@
   {
     "context": "Pane",
     "bindings": {
-      "cmd-k up": "pane::SplitUp",
-      "cmd-k down": "pane::SplitDown",
-      "cmd-k left": "pane::SplitLeft",
-      "cmd-k right": "pane::SplitRight"
+      "ctrl-k up": "pane::SplitUp",
+      "ctrl-k down": "pane::SplitDown",
+      "ctrl-k left": "pane::SplitLeft",
+      "ctrl-k right": "pane::SplitRight"
     }
   },
   // Bindings that should be unified with bindings for more general actions
@@ -511,10 +509,10 @@
   // Custom bindings
   {
     "bindings": {
-      "ctrl-alt-cmd-f": "workspace::FollowNextCollaborator",
+      "ctrl-alt-shift-f": "workspace::FollowNextCollaborator",
       // TODO: Move this to a dock open action
-      "cmd-shift-c": "collab_panel::ToggleFocus",
-      "cmd-alt-i": "zed::DebugElements",
+      "ctrl-shift-c": "collab_panel::ToggleFocus",
+      "ctrl-alt-i": "zed::DebugElements",
       "ctrl-:": "editor::ToggleInlayHints"
     }
   },
@@ -522,16 +520,16 @@
     "context": "Editor && mode == full",
     "bindings": {
       "alt-enter": "editor::OpenExcerpts",
-      "cmd-k enter": "editor::OpenExcerptsSplit",
-      "cmd-f8": "editor::GoToHunk",
-      "cmd-shift-f8": "editor::GoToPrevHunk",
+      "ctrl-k enter": "editor::OpenExcerptsSplit",
+      "ctrl-f8": "editor::GoToHunk",
+      "ctrl-shift-f8": "editor::GoToPrevHunk",
       "ctrl-enter": "assistant::InlineAssist"
     }
   },
   {
     "context": "ProjectSearchBar && !in_replace",
     "bindings": {
-      "cmd-enter": "project_search::SearchInNew"
+      "ctrl-enter": "project_search::SearchInNew"
     }
   },
   {
@@ -539,20 +537,20 @@
     "bindings": {
       "left": "project_panel::CollapseSelectedEntry",
       "right": "project_panel::ExpandSelectedEntry",
-      "cmd-n": "project_panel::NewFile",
-      "alt-cmd-n": "project_panel::NewDirectory",
-      "cmd-x": "project_panel::Cut",
-      "cmd-c": "project_panel::Copy",
-      "cmd-v": "project_panel::Paste",
-      "cmd-alt-c": "project_panel::CopyPath",
-      "alt-cmd-shift-c": "project_panel::CopyRelativePath",
+      "ctrl-n": "project_panel::NewFile",
+      "alt-ctrl-n": "project_panel::NewDirectory",
+      "ctrl-x": "project_panel::Cut",
+      "ctrl-c": "project_panel::Copy",
+      "ctrl-v": "project_panel::Paste",
+      "ctrl-alt-c": "project_panel::CopyPath",
+      "alt-ctrl-shift-c": "project_panel::CopyRelativePath",
       "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
       "backspace": "project_panel::Delete",
       "delete": "project_panel::Delete",
-      "cmd-backspace": ["project_panel::Delete", { "skip_prompt": true }],
-      "cmd-delete": ["project_panel::Delete", { "skip_prompt": true }],
-      "alt-cmd-r": "project_panel::RevealInFinder",
+      "ctrl-backspace": ["project_panel::Delete", { "skip_prompt": true }],
+      "ctrl-delete": ["project_panel::Delete", { "skip_prompt": true }],
+      // "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }
   },
@@ -600,19 +598,9 @@
   {
     "context": "Terminal",
     "bindings": {
-      "ctrl-cmd-space": "terminal::ShowCharacterPalette",
-      "cmd-c": "terminal::Copy",
-      "cmd-v": "terminal::Paste",
-      "cmd-k": "terminal::Clear",
-      // Some nice conveniences
-      "cmd-backspace": ["terminal::SendText", "\u0015"],
-      "cmd-right": ["terminal::SendText", "\u0005"],
-      "cmd-left": ["terminal::SendText", "\u0001"],
-      // Terminal.app compatibility
-      "alt-left": ["terminal::SendText", "\u001bb"],
-      "alt-right": ["terminal::SendText", "\u001bf"],
-      // There are conflicting bindings for these keys in the global context.
-      // these bindings override them, remove at your own risk:
+      // "ctrl-cmd-space": "terminal::ShowCharacterPalette",
+      "shift-ctrl-c": "terminal::Copy",
+      "shift-ctrl-v": "terminal::Paste",
       "up": ["terminal::SendKeystroke", "up"],
       "pageup": ["terminal::SendKeystroke", "pageup"],
       "down": ["terminal::SendKeystroke", "down"],

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1,4 +1,5 @@
 [
+  // todo(linux): Review the editor bindings
   // Standard Linux bindings
   {
     "bindings": {
@@ -66,11 +67,6 @@
       "end": "editor::MoveToEndOfLine",
       "left": "editor::MoveLeft",
       "right": "editor::MoveRight",
-      // "ctrl-p": "editor::MoveUp",
-      // "ctrl-n": "editor::MoveDown",
-      // "ctrl-b": "editor::MoveLeft",
-      // "ctrl-f": "editor::MoveRight",
-      // "ctrl-l": "editor::NextScreen",
       "ctrl-left": "editor::MoveToPreviousWordStart",
       // "alt-b": "editor::MoveToPreviousWordStart",
       "ctrl-right": "editor::MoveToNextWordEnd",
@@ -82,18 +78,14 @@
       "ctrl-home": "editor::MoveToBeginning",
       "ctrl-end": "editor::MoveToEnd",
       "shift-up": "editor::SelectUp",
-      // "ctrl-shift-p": "editor::SelectUp",
       "shift-down": "editor::SelectDown",
-      // "ctrl-shift-n": "editor::SelectDown",
       "shift-left": "editor::SelectLeft",
-      // "ctrl-shift-b": "editor::SelectLeft",
       "shift-right": "editor::SelectRight",
-      // "ctrl-shift-f": "editor::SelectRight",
       "ctrl-shift-left": "editor::SelectToPreviousWordStart",
-      // "alt-shift-b": "editor::SelectToPreviousWordStart",
       "ctrl-shift-right": "editor::SelectToNextWordEnd",
-      // "alt-shift-f": "editor::SelectToNextWordEnd",
-      // "ctrl-shift-up": "editor::SelectToStartOfParagraph", todo(convert to multi cursor)
+      "ctrl-shift-up": "editor::AddSelectionAbove",
+      "ctrl-shift-down": "editor::AddSelectionBelow",
+      // "ctrl-shift-up": "editor::SelectToStartOfParagraph",
       // "ctrl-shift-down": "editor::SelectToEndOfParagraph",
       "ctrl-shift-home": "editor::SelectToBeginning",
       "ctrl-shift-end": "editor::SelectToEnd",
@@ -142,7 +134,7 @@
       //     "center_cursor": true
       //   }
       // ],
-      // "ctrl-cmd-space": "editor::ShowCharacterPalette",
+      "ctrl-alt-space": "editor::ShowCharacterPalette",
       "ctrl-;": "editor::ToggleLineNumbers",
       "ctrl-k ctrl-r": "editor::RevertSelectedHunks"
     }
@@ -599,7 +591,7 @@
   {
     "context": "Terminal",
     "bindings": {
-      // "ctrl-cmd-space": "terminal::ShowCharacterPalette", todo(linux)
+      "ctrl-alt-space": "terminal::ShowCharacterPalette",
       "shift-ctrl-c": "terminal::Copy",
       "shift-ctrl-v": "terminal::Paste",
       "up": ["terminal::SendKeystroke", "up"],

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -216,8 +216,8 @@
       "tab": "buffer_search::FocusEditor",
       "enter": "search::SelectNextMatch",
       "shift-enter": "search::SelectPrevMatch",
-      "alt-enter": "search::SelectAllMatches"
-      // "alt-tab": "search::CycleMode"
+      "alt-enter": "search::SelectAllMatches",
+      "alt-tab": "search::CycleMode"
     }
   },
   {
@@ -238,7 +238,7 @@
     "context": "ProjectSearchBar",
     "bindings": {
       "escape": "project_search::ToggleFocus",
-      // "alt-tab": "search::CycleMode",
+      "alt-tab": "search::CycleMode",
       "ctrl-shift-h": "search::ToggleReplace",
       "alt-ctrl-g": "search::ActivateRegexMode",
       "alt-ctrl-x": "search::ActivateTextMode"
@@ -360,7 +360,7 @@
       "ctrl-shift-]": "editor::UnfoldLines",
       "ctrl-space": "editor::ShowCompletions",
       "ctrl-.": "editor::ToggleCodeActions",
-      // "alt-cmd-r": "editor::RevealInFinder", 
+      "alt-cmd-r": "editor::RevealInFinder",
       "ctrl-alt-shift-c": "editor::DisplayCursorNames"
     }
   },
@@ -401,7 +401,7 @@
       //     }
       // ]
       "alt-ctrl-o": "projects::OpenRecent",
-      // "alt-cmd-b": "branches::OpenRecent",
+      "alt-ctrl-shift-b": "branches::OpenRecent",
       "ctrl-~": "workspace::NewTerminal",
       "ctrl-s": "workspace::Save",
       "ctrl-k s": "workspace::SaveWithoutFormat",
@@ -426,7 +426,8 @@
       "ctrl-k ctrl-s": "zed::OpenKeymap",
       "ctrl-k ctrl-t": "theme_selector::Toggle",
       "ctrl-t": "project_symbols::Toggle",
-      "ctrl-p": "file_finder::Toggle", // todo(linux) also do ctrl-e
+      "ctrl-p": "file_finder::Toggle",
+      "ctrl-e": "file_finder::Toggle",
       "ctrl-shift-p": "command_palette::Toggle",
       "ctrl-shift-m": "diagnostics::Deploy",
       "ctrl-shift-e": "project_panel::ToggleFocus",
@@ -550,7 +551,7 @@
       "delete": "project_panel::Delete",
       "ctrl-backspace": ["project_panel::Delete", { "skip_prompt": true }],
       "ctrl-delete": ["project_panel::Delete", { "skip_prompt": true }],
-      // "alt-cmd-r": "project_panel::RevealInFinder",
+      "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }
   },
@@ -598,7 +599,7 @@
   {
     "context": "Terminal",
     "bindings": {
-      // "ctrl-cmd-space": "terminal::ShowCharacterPalette",
+      // "ctrl-cmd-space": "terminal::ShowCharacterPalette", todo(linux)
       "shift-ctrl-c": "terminal::Copy",
       "shift-ctrl-v": "terminal::Paste",
       "up": ["terminal::SendKeystroke", "up"],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -13,7 +13,7 @@
       "cmd-up": "menu::SelectFirst",
       "cmd-down": "menu::SelectLast",
       "enter": "menu::Confirm",
-      "ctrl-enter": "menu::ShowContextMenu",
+      "ctrl-enter": "menu::SecondaryConfirm",
       "cmd-enter": "menu::SecondaryConfirm",
       "escape": "menu::Cancel",
       "cmd-escape": "menu::Cancel",

--- a/assets/keymaps/storybook.json
+++ b/assets/keymaps/storybook.json
@@ -13,7 +13,7 @@
       "cmd-up": "menu::SelectFirst",
       "cmd-down": "menu::SelectLast",
       "enter": "menu::Confirm",
-      "ctrl-enter": "menu::ShowContextMenu",
+      "ctrl-enter": "menu::SecondaryConfirm",
       "cmd-enter": "menu::SecondaryConfirm",
       "escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1802,7 +1802,7 @@ impl CollabPanel {
         }
     }
 
-    fn show_inline_context_menu(&mut self, _: &menu::ShowContextMenu, cx: &mut ViewContext<Self>) {
+    fn show_inline_context_menu(&mut self, _: &menu::SecondaryConfirm, cx: &mut ViewContext<Self>) {
         let Some(bounds) = self
             .selection
             .and_then(|ix| self.list_state.bounds_for_item(ix))

--- a/crates/menu/src/menu.rs
+++ b/crates/menu/src/menu.rs
@@ -19,7 +19,6 @@ actions!(
         SelectNext,
         SelectFirst,
         SelectLast,
-        ShowContextMenu,
         UseSelectedQuery,
     ]
 );

--- a/crates/storybook/src/stories/picker.rs
+++ b/crates/storybook/src/stories/picker.rs
@@ -129,7 +129,7 @@ impl PickerStory {
                 KeyBinding::new("cmd-up", menu::SelectFirst, Some("picker")),
                 KeyBinding::new("cmd-down", menu::SelectLast, Some("picker")),
                 KeyBinding::new("enter", menu::Confirm, Some("picker")),
-                KeyBinding::new("ctrl-enter", menu::ShowContextMenu, Some("picker")),
+                KeyBinding::new("ctrl-enter", menu::SecondaryConfirm, Some("picker")),
                 KeyBinding::new("cmd-enter", menu::SecondaryConfirm, Some("picker")),
                 KeyBinding::new("escape", menu::Cancel, Some("picker")),
                 KeyBinding::new("ctrl-c", menu::Cancel, Some("picker")),


### PR DESCRIPTION
Earlier versions where a simple find-replace of `cmd` => `ctrl`. In this PR, I've gone over every keybinding individually and checked them.

Release Notes:

- Removed the `ShowContextMenu` action, it's only usage was in the collab panel and it's been rebound to `SecondaryConfirm`