### PR TITLE
windows: Prevent command line from opening in release mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5570,6 +5570,7 @@ dependencies = [
  "serde_json",
  "smol",
  "util",
+ "windows 0.53.0",
 ]
 
 [[package]]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -31,6 +31,9 @@ smol.workspace = true
 util.workspace = true
 release_channel.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows.workspace = true
+
 [dev-dependencies]
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
 ctor.workspace = true

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -220,7 +220,7 @@ impl LanguageServer {
         );
 
         let mut command = process::Command::new(&binary.path);
-        command 
+        command
             .current_dir(working_dir)
             .args(binary.arguments)
             .envs(binary.env.unwrap_or_default())
@@ -231,17 +231,6 @@ impl LanguageServer {
         #[cfg(windows)]
         command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
         let mut server = command.spawn()?;
-
-        #[cfg(not(target_os = "windows"))]
-        let mut server = process::Command::new(&binary.path)
-            .current_dir(working_dir)
-            .args(binary.arguments)
-            .envs(binary.env.unwrap_or_default())
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()?;
 
         let stdin = server.stdin.take().unwrap();
         let stdout = server.stdout.take().unwrap();

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -234,7 +234,6 @@ impl LanguageServer {
         } else {
             process::Command::new(&binary.path)
                 .current_dir(working_dir)
-                .creation_flags(0x08000000) // CREATE_NO_WINDOW
                 .args(binary.arguments)
                 .envs(binary.env.unwrap_or_default())
                 .stdin(Stdio::piped())

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -13,7 +13,7 @@ use serde_json::{json, value::RawValue, Value};
 use smol::{
     channel,
     io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
-    process::{self, Child},
+    process::{self, windows::CommandExt, Child},
 };
 use std::{
     ffi::OsString,
@@ -217,6 +217,7 @@ impl LanguageServer {
 
         let mut server = process::Command::new(&binary.path)
             .current_dir(working_dir)
+            .creation_flags(0x08000000) // CREATE_NO_WINDOW
             .args(binary.arguments)
             .envs(binary.env.unwrap_or_default())
             .stdin(Stdio::piped())

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -219,17 +219,18 @@ impl LanguageServer {
             &binary.arguments
         );
 
-        #[cfg(target_os = "windows")]
-        let mut server = process::Command::new(&binary.path)
+        let mut command = process::Command::new(&binary.path);
+        command 
             .current_dir(working_dir)
-            .creation_flags(0x08000000) // CREATE_NO_WINDOW
             .args(binary.arguments)
             .envs(binary.env.unwrap_or_default())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()?;
+            .kill_on_drop(true);
+        #[cfg(windows)]
+        command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
+        let mut server = command.spawn()?;
 
         #[cfg(not(target_os = "windows"))]
         let mut server = process::Command::new(&binary.path)

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -17,7 +17,7 @@ use smol::{
 };
 
 #[cfg(target_os = "windows")]
-use smol::process::windows::CommandExt
+use smol::process::windows::CommandExt;
 
 use std::{
     ffi::OsString,

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -17,7 +17,7 @@ use smol::{
 };
 
 #[cfg(target_os = "windows")]
-use smoll::process::windows::CommandExt
+use smol::process::windows::CommandExt
 
 use std::{
     ffi::OsString,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1,6 +1,5 @@
 // Allow binary to be called Zed for a nice application menu when running executable directly
 #![allow(non_snake_case)]
-
 // Disable command line from opening on release mode
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1,6 +1,9 @@
 // Allow binary to be called Zed for a nice application menu when running executable directly
 #![allow(non_snake_case)]
 
+// Disable command line from opening on release mode
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 mod zed;
 
 use anyhow::{anyhow, Context as _, Result};


### PR DESCRIPTION

Release Notes:

- Prevents the terminal from opening on release mode on Windows

Note: this also prevents Zed from logging to the terminal when it is launched from the terminal. Is this expected behaviour on other platforms?