### PR TITLE
windows: Support compiling with MinGW toolchain (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9142,6 +9142,7 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "editor",
+ "embed-manifest",
  "fuzzy",
  "gpui",
  "indoc",

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -34,5 +34,8 @@ strum = { version = "0.25.0", features = ["derive"] }
 theme.workspace = true
 ui = { workspace = true, features = ["stories"] }
 
+[target.'cfg(target_os = "windows")'.build-dependencies]
+embed-manifest = "1.4.0"
+
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/storybook/build.rs
+++ b/crates/storybook/build.rs
@@ -3,16 +3,16 @@ fn main() {
     // TODO: We shouldn't depend on WebRTC in editor
     println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
 
-    if std::env::var("CARGO_CFG_TARGET_ENV").ok() == Some("msvc".to_string()) {
-        println!("cargo:rustc-link-arg=/stack:{}", 8 * 1024 * 1024);
+    #[cfg(target_os = "windows")]
+    {
+        #[cfg(target_env = "msvc")]
+        {
+            println!("cargo:rustc-link-arg=/stack:{}", 8 * 1024 * 1024);
+        }
 
         let manifest = std::path::Path::new("../zed/resources/windows/manifest.xml");
         println!("cargo:rerun-if-changed={}", manifest.display());
-        println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
-
-        println!(
-            "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
-            manifest.canonicalize().unwrap().display()
-        );
+        embed_manifest::embed_manifest(embed_manifest::new_manifest(manifest.to_str().unwrap()))
+            .unwrap();
     }
 }

--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -46,7 +46,8 @@ fn main() {
 
     #[cfg(target_os = "windows")]
     {
-        if std::env::var("CARGO_CFG_TARGET_ENV").ok() == Some("msvc".to_string()) {
+        #[cfg(target_env = "msvc")]
+        {
             // todo(windows): This is to avoid stack overflow. Remove it when solved.
             println!("cargo:rustc-link-arg=/stack:{}", 8 * 1024 * 1024);
         }


### PR DESCRIPTION
crates/languages and extensions/gleam: handle different target envs (a new variant of os: `pc-windows-gnu`)
crates/storybook: compile manifest for all windows targets (same as #9815)
looks like fixes #9807, but there are still errors presented

<details>

```
[2024-03-27T12:07:25+03:00 INFO  Zed] ========== starting zed ==========
[2024-03-27T12:07:26+03:00 INFO  cosmic_text::font::system] Parsed 398 font faces in 60ms.
[2024-03-27T12:07:26+03:00 INFO  db] Opening main db
[2024-03-27T12:07:26+03:00 ERROR util] crates\settings\src\settings_file.rs:76: EOF while parsing a value at line 1 column 0
[2024-03-27T12:07:26+03:00 ERROR util] crates\settings\src\keymap_file.rs:89: invalid binding value for keystroke escape, context Some("ChatPanel > MessageEditor")

Caused by:
    no action type registered for chat_panel::CloseReplyPreview
[2024-03-27T12:07:26+03:00 INFO  gpui::platform::windows::platform] use DCompositionWaitForCompositorClock for vsync
[2024-03-27T12:07:26+03:00 ERROR util] crates\zed\src\zed.rs:629: EOF while parsing a value at line 1 column 0
[2024-03-27T12:07:26+03:00 ERROR util] crates\zed\src/main.rs:720: Системе не удается найти указанный путь. (os error 3)
[2024-03-27T12:07:26+03:00 INFO  db] Opening main db
[2024-03-27T12:07:26+03:00 INFO  node_runtime] Node runtime install_if_needed
[2024-03-27T12:07:26+03:00 ERROR util] crates\workspace\src/workspace.rs:912: Error in last_window, select_row_bound expected single row result but found none for: SELECT
  display,
  window_state,
  window_x,
  window_y,
  window_width,
  window_height,
  fullscreen
FROM
  workspaces
WHERE
  workspace_location IS NOT NULL
ORDER BY
  timestamp DESC
LIMIT
  1
[2024-03-27T12:07:26+03:00 INFO  blade_graphics::hal::init] Adapter "NVIDIA GeForce RTX 3050 Ti Laptop GPU"
[2024-03-27T12:07:26+03:00 INFO  blade_graphics::hal::init] Ray tracing is supported
[2024-03-27T12:07:27+03:00 WARN  blade_graphics::hal::init] Requested size 1x1 is outside of surface capabilities
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_impl")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_device_position_transformed")
[2024-03-27T12:07:27+03:00 INFO  naga::back::spv::writer] Skip function Some("to_tile_position")
[2024-03-27T12:07:27+03:00 INFO  blade_graphics::hal::resource] Creating texture 0x2b2528fec20 of size 1024x1024x1 and format R8Unorm, name 'atlas', handle 0
[2024-03-27T12:07:27+03:00 INFO  blade_graphics::hal::resource] Creating buffer 0x2b2524762a0 of size 65536, name 'chunk-0', handle 1
[2024-03-27T12:07:27+03:00 INFO  blade_graphics::hal::resource] Creating buffer 0x2b252477ba0 of size 4096, name 'chunk-0', handle 2
[2024-03-27T12:07:27+03:00 INFO  blade_graphics::hal::resource] Creating buffer 0x2b2524765c0 of size 9184, name 'chunk-1', handle 3
[2024-03-27T12:07:27+03:00 ERROR util] crates\copilot_ui\src\copilot_completion_provider.rs:207: copilot is still starting
error: process didn't exit successfully: `target\release\Zed.exe` (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
fish: Job 1, 'RUST_BACKTRACE=full RUST_LOG=in…' terminated by signal SIGSEGV (Address boundary error)
```

</details>

Release Notes:

- N/A
