### PR TITLE
Pin Vue language server to 1.8

### DIFF
--- a/crates/languages/src/vue.rs
+++ b/crates/languages/src/vue.rs
@@ -48,11 +48,7 @@ impl super::LspAdapter for VueLspAdapter {
         _: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
         Ok(Box::new(VueLspVersion {
-            // TODO: Temporarily fixed to 1.8 as @vue/language-server 2.0 is not yet supported
-            // vue_version: self
-            //     .node
-            //     .npm_package_latest_version("@vue/language-server")
-            //     .await?,
+            // We hardcode the version to 1.8 since we do not support @vue/language-server 2.0 yet.
             vue_version: "1.8".to_string(),
             ts_version: self.node.npm_package_latest_version("typescript").await?,
         }) as Box<_>)

--- a/crates/languages/src/vue.rs
+++ b/crates/languages/src/vue.rs
@@ -48,10 +48,12 @@ impl super::LspAdapter for VueLspAdapter {
         _: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
         Ok(Box::new(VueLspVersion {
-            vue_version: self
-                .node
-                .npm_package_latest_version("@vue/language-server")
-                .await?,
+            // TODO: Temporarily fixed to 1.8 as @vue/language-server 2.0 is not yet supported
+            // vue_version: self
+            //     .node
+            //     .npm_package_latest_version("@vue/language-server")
+            //     .await?,
+            vue_version: "1.8".to_string(),
             ts_version: self.node.npm_package_latest_version("typescript").await?,
         }) as Box<_>)
     }


### PR DESCRIPTION
After `@vue/language-server` release 2.0, vue lsp doesn't work. I tried to support 2.0, but since I'm not familiar with `@vue/language-server` and `zed` I was unsuccessful. To avoid long-term unavailability, I temporarily fixed the version to 1.8 until we have 2.0 support.

Release Notes:

- Pinned `@vue/language-server` to version `1.8` until Zed supports `2.x`. ([#9388](https://github.com/zed-industries/zed/issues/9388) & [#9329](https://github.com/zed-industries/zed/issues/9329)).