### PR TITLE
Scala extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12598,6 +12598,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed_scala"
+version = "0.0.1"
+dependencies = [
+ "zed_extension_api 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "zed_svelte"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ members = [
     "extensions/haskell",
     "extensions/prisma",
     "extensions/purescript",
+    "extensions/scala",
     "extensions/svelte",
     "extensions/uiua",
 

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -44,6 +44,7 @@ pub fn suggested_extension(file_extension_or_name: &str) -> Option<Arc<str>> {
                 ("r", "r"),
                 ("r", "R"),
                 ("sql", "sql"),
+                ("scala", "scala"),
                 ("svelte", "svelte"),
                 ("swift", "swift"),
                 ("templ", "templ"),

--- a/docs/src/languages/scala.md
+++ b/docs/src/languages/scala.md
@@ -1,0 +1,4 @@
+# Scala
+
+- Tree Sitter: [tree-sitter-scala](https://github.com/tree-sitter/tree-sitter-scala)
+- Language Server: [metals](https://github.com/scalameta/metals)

--- a/extensions/scala/Cargo.toml
+++ b/extensions/scala/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "zed_scala"
+version = "0.0.1"
+edition = "2021"
+publish = false
+license = "Apache-2.0"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/scala.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.0.4"

--- a/extensions/scala/LICENSE-APACHE
+++ b/extensions/scala/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/extensions/scala/extension.toml
+++ b/extensions/scala/extension.toml
@@ -1,0 +1,19 @@
+id = "scala"
+name = "Scala"
+description = "Scala support."
+version = "0.0.1"
+schema_version = 1
+authors = [
+    "Igal Tabachnik <hmemcpy@gmail.com>",
+    "Jamie Thompson <bishbashboshjt@gmail.com>",
+    "Michal Příhoda <michal@prihoda.net>"
+]
+repository = "https://github.com/zed-industries/zed"
+
+[language_servers.metals]
+name = "Metals (Scala Language Server)"
+language = "Scala"
+
+[grammars.scala]
+repository = "https://github.com/tree-sitter/tree-sitter-scala"
+commit = "45b5ba0e749a8477a8fd2666f082f352859bdc3c"

--- a/extensions/scala/languages/scala/brackets.scm
+++ b/extensions/scala/languages/scala/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/extensions/scala/languages/scala/config.toml
+++ b/extensions/scala/languages/scala/config.toml
@@ -1,0 +1,15 @@
+name = "Scala"
+grammar = "scala"
+path_suffixes = ["scala", "sbt", "sc"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "`", end = "`", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] }
+]
+collapsed_placeholder = " /* ... */ "

--- a/extensions/scala/languages/scala/highlights.scm
+++ b/extensions/scala/languages/scala/highlights.scm
@@ -1,0 +1,265 @@
+; CREDITS @stumash (stuart.mashaal@gmail.com)
+
+(class_definition
+  name: (identifier) @type)
+
+(enum_definition
+  name: (identifier) @enum)
+
+(object_definition
+  name: (identifier) @type)
+
+(trait_definition
+  name: (identifier) @type)
+
+(full_enum_case
+  name: (identifier) @type)
+
+(simple_enum_case
+  name: (identifier) @type)
+
+;; variables
+
+(class_parameter
+  name: (identifier) @property)
+
+(self_type (identifier) @property)
+
+(interpolation (identifier) @none)
+(interpolation (block) @none)
+
+;; types
+
+(type_definition
+  name: (type_identifier) @type.definition)
+
+(type_identifier) @type
+
+;; val/var definitions/declarations
+
+(val_definition
+  pattern: (identifier) @variable)
+
+(var_definition
+  pattern: (identifier) @variable)
+
+(val_declaration
+  name: (identifier) @variable)
+
+(var_declaration
+  name: (identifier) @variable)
+
+; method definition
+
+(function_declaration
+      name: (identifier) @function.method)
+
+(function_definition
+      name: (identifier) @function.method)
+
+; imports/exports
+((import_declaration
+  path: (identifier) @type) (#match? @type "^[A-Z]"))
+
+(import_declaration
+  path: (identifier) @namespace)
+
+((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
+
+((stable_identifier (identifier) @namespace))
+
+(export_declaration
+  path: (identifier) @namespace)
+((stable_identifier (identifier) @namespace))
+
+((export_declaration
+  path: (identifier) @type) (#match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
+
+((namespace_selectors (identifier) @type) (#match? @type "^[A-Z]"))
+
+; method invocation
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (operator_identifier) @function)
+
+(call_expression
+  function: (field_expression
+    field: (identifier) @function.method))
+
+((call_expression
+   function: (identifier) @constructor)
+ (#match? @constructor "^[A-Z]"))
+
+(generic_function
+  function: (identifier) @function)
+
+(interpolated_string_expression
+  interpolator: (identifier) @function)
+
+; function definitions
+
+(function_definition
+  name: (identifier) @function)
+
+(parameter
+  name: (identifier) @parameter)
+
+(binding
+  name: (identifier) @parameter)
+
+; expressions
+
+(field_expression field: (identifier) @property)
+(field_expression value: (identifier) @type
+ (#match? @type "^[A-Z]"))
+
+(infix_expression operator: (identifier) @operator)
+(infix_expression operator: (operator_identifier) @operator)
+(infix_type operator: (operator_identifier) @operator)
+(infix_type operator: (operator_identifier) @operator)
+
+; literals
+
+(boolean_literal) @boolean
+(integer_literal) @number
+(floating_point_literal) @float
+
+[
+  (symbol_literal)
+  (string)
+  (character_literal)
+  (interpolated_string_expression)
+] @string
+
+(interpolation "$" @punctuation.special)
+
+;; keywords
+
+(opaque_modifier) @type.qualifier
+(infix_modifier) @keyword
+(transparent_modifier) @type.qualifier
+(open_modifier) @type.qualifier
+
+[
+  "case"
+  "class"
+  "enum"
+  "extends"
+  "derives"
+  "finally"
+;; `forSome` existential types not implemented yet
+;; `macro` not implemented yet
+  "object"
+  "override"
+  "package"
+  "trait"
+  "type"
+  "val"
+  "var"
+  "with"
+  "given"
+  "using"
+  "end"
+  "implicit"
+  "extension"
+  "with"
+] @keyword
+
+[
+  "abstract"
+  "final"
+  "lazy"
+  "sealed"
+  "private"
+  "protected"
+] @type.qualifier
+
+(inline_modifier) @label
+
+(null_literal) @constant
+
+(wildcard) @parameter
+
+(annotation) @attribute
+
+;; special keywords
+
+"new" @operator
+
+[
+  "else"
+  "if"
+  "match"
+  "then"
+] @keyword
+
+[
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+]  @punctuation.bracket
+
+[
+ "."
+ ","
+] @punctuation.delimiter
+
+[
+  "do"
+  "for"
+  "while"
+  "yield"
+] @keyword
+
+"def" @keyword
+
+[
+ "=>"
+ "<-"
+ "@"
+] @operator
+
+["import" "export"] @keyword ; @include
+
+[
+  "try"
+  "catch"
+  "throw"
+] @keyword
+
+"return" @keyword
+
+[
+  (comment)
+  (block_comment)
+  "_end_ident"
+] @comment
+
+;; `case` is a conditional keyword in case_block
+
+(case_block
+  (case_clause ("case") @keyword))
+(indented_cases
+  (case_clause ("case") @keyword))
+
+(operator_identifier) @operator
+
+((identifier) @type (#match? @type "^[A-Z]"))
+((identifier) @variable.special
+ (#match? @variable.special "^this$"))
+
+(
+  (identifier) @function
+  (#match? @function "^super$")
+)
+
+;; Scala CLI using directives
+(using_directive_key) @parameter
+(using_directive_value) @string

--- a/extensions/scala/languages/scala/indents.scm
+++ b/extensions/scala/languages/scala/indents.scm
@@ -1,0 +1,20 @@
+[
+  (block)
+  (arguments)
+  (parameter)
+  (class_definition)
+  (trait_definition)
+  (object_definition)
+  (function_definition)
+  (val_definition)
+  (import_declaration)
+  (while_expression)
+  (do_while_expression)
+  (for_expression)
+  (try_expression)
+  (match_expression)
+] @indent
+
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent

--- a/extensions/scala/languages/scala/injections.scm
+++ b/extensions/scala/languages/scala/injections.scm
@@ -1,0 +1,15 @@
+([(comment) (block_comment)] @injection.content
+ (#set! injection.language "comment"))
+
+
+; TODO for some reason multiline string (triple quotes) interpolation works only if it contains interpolated value
+; Matches these SQL interpolators:
+;  - Doobie: 'sql', 'fr'
+;  - Quill: 'sql', 'infix'
+;  - Slick: 'sql', 'sqlu'
+(interpolated_string_expression
+  interpolator:
+    ((identifier) @interpolator
+     (#any-of? @interpolator "fr" "infix" "sql" "sqlu"))
+  (interpolated_string) @injection.content
+  (#set! injection.language "sql"))

--- a/extensions/scala/languages/scala/outline.scm
+++ b/extensions/scala/languages/scala/outline.scm
@@ -1,0 +1,27 @@
+(class_definition
+    "class" @context
+    name: (_) @name) @item
+
+(enum_definition
+    "enum" @context
+    name: (_) @name) @item
+
+(object_definition
+    "object" @context
+    name: (_) @name) @item
+
+(trait_definition
+    "trait" @context
+    name: (_) @name) @item
+
+(type_definition
+    "type" @context
+    name: (_) @name) @item
+
+(function_definition
+    "def" @context
+    name: (_) @name) @item
+
+(val_definition
+  "val" @context
+  pattern: (identifier) @name) @item

--- a/extensions/scala/src/scala.rs
+++ b/extensions/scala/src/scala.rs
@@ -1,0 +1,27 @@
+use zed_extension_api::{self as zed, Result};
+
+struct ScalaExtension;
+
+impl zed::Extension for ScalaExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        _config: zed::LanguageServerConfig,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let path = worktree
+            .which("metals")
+            .ok_or_else(|| "Metals must be installed via coursier. Please install coursier (https://get-coursier.io/), and then run `cs install metals`.".to_string())?;
+
+        Ok(zed::Command {
+            command: path,
+            args: vec![],
+            env: Default::default(),
+        })
+    }
+}
+
+zed::register_extension!(ScalaExtension);


### PR DESCRIPTION
Release Notes:

- Added an extension for the Scala language via Metals (Scala LSP) ([#7933](https://github.com/zed-industries/zed/issues/7933)).

This consolidates the wonderful efforts of @mprihoda, @bishabosha and others who made suggestion improvements.
Note: this extension assumes Metals is available in the system (using the equivalent of `which metals`), otherwise prompts to download and install it with coursier.

We could further improve the experience by automatically downloading the latest release of Metals from github (as supported by other extensions, such as Gleam)

![image](https://github.com/zed-industries/zed/assets/601206/d9a6004f-a847-4d53-a8a7-1b8e70e72c4d)

