### PR TITLE
Terminal panel: Add hide panel button

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -107,12 +107,12 @@ impl TerminalPanel {
                             .icon_size(IconSize::Small)
                             .on_click(move |_, cx| {
                                 let dock = TerminalSettings::get_global(cx).dock;
-                                let positon = match dock {
+                                let position = match dock {
                                     TerminalDockPosition::Bottom => ToggleBottomDock.boxed_clone(),
                                     TerminalDockPosition::Left => ToggleLeftDock.boxed_clone(),
                                     TerminalDockPosition::Right => ToggleRightDock.boxed_clone(),
                                 };
-                                cx.dispatch_action(positon);
+                                cx.dispatch_action(position);
                             })
                             .tooltip(move |cx| Tooltip::text("Hide Terminal Panel", cx)),
                     )

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -103,7 +103,7 @@ impl TerminalPanel {
                             })
                     })
                     .child(
-                        IconButton::new("hide_terminal", IconName::Close)
+                        IconButton::new("hide_terminal", IconName::Dash)
                             .icon_size(IconSize::Small)
                             .on_click(move |_, cx| {
                                 let dock = TerminalSettings::get_global(cx).dock;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -114,7 +114,7 @@ impl TerminalPanel {
                                 };
                                 cx.dispatch_action(positon);
                             })
-                            .tooltip(move |cx| Tooltip::text("Hide Terminal Panel.", cx)),
+                            .tooltip(move |cx| Tooltip::text("Hide Terminal Panel", cx)),
                     )
                     .into_any_element()
             });

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -26,7 +26,7 @@ use workspace::{
     item::Item,
     pane,
     ui::IconName,
-    DraggedTab, NewTerminal, Pane, Workspace,
+    DraggedTab, NewTerminal, Pane, ToggleBottomDock, ToggleLeftDock, ToggleRightDock, Workspace,
 };
 
 use anyhow::Result;
@@ -102,6 +102,20 @@ impl TerminalPanel {
                                 Tooltip::text(if zoomed { "Zoom Out" } else { "Zoom In" }, cx)
                             })
                     })
+                    .child(
+                        IconButton::new("hide_terminal", IconName::Close)
+                            .icon_size(IconSize::Small)
+                            .on_click(move |_, cx| {
+                                let dock = TerminalSettings::get_global(cx).dock;
+                                let positon = match dock {
+                                    TerminalDockPosition::Bottom => ToggleBottomDock.boxed_clone(),
+                                    TerminalDockPosition::Left => ToggleLeftDock.boxed_clone(),
+                                    TerminalDockPosition::Right => ToggleRightDock.boxed_clone(),
+                                };
+                                cx.dispatch_action(positon);
+                            })
+                            .tooltip(move |cx| Tooltip::text("Hide Terminal Panel.", cx)),
+                    )
                     .into_any_element()
             });
 


### PR DESCRIPTION
Release Notes:

- Added a hide terminal button on the top right of the terminal panel

<img width="1550" alt="317248918-ddb42a37-550d-462a-ab64-80c51083ba16" src="https://github.com/zed-industries/zed/assets/54421947/abdddfca-7f88-4958-8b49-ccc217d06d8d">

