### PR TITLE
Prepare editor to display multiple LSP hover responses for the same place

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4978,11 +4978,16 @@ async fn test_lsp_hover(
         },
     );
 
-    let hover_info = project_b
+    let hovers = project_b
         .update(cx_b, |p, cx| p.hover(&buffer_b, 22, cx))
         .await
-        .unwrap()
         .unwrap();
+    assert_eq!(
+        hovers.len(),
+        1,
+        "Expected exactly one hover but got: {hovers:?}"
+    );
+    let hover_info = hovers.into_iter().next().unwrap();
 
     buffer_b.read_with(cx_b, |buffer, _| {
         let snapshot = buffer.snapshot();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5189,20 +5189,22 @@ impl Project {
         buffer: &Model<Buffer>,
         position: PointUtf16,
         cx: &mut ModelContext<Self>,
-    ) -> Task<Result<Option<Hover>>> {
-        self.request_lsp(
+    ) -> Task<Result<Vec<Hover>>> {
+        let request_task = self.request_lsp(
             buffer.clone(),
             LanguageServerToQuery::Primary,
             GetHover { position },
             cx,
-        )
+        );
+        cx.spawn(|_, _| async move { request_task.await.map(|hover| hover.into_iter().collect()) })
     }
+
     pub fn hover<T: ToPointUtf16>(
         &self,
         buffer: &Model<Buffer>,
         position: T,
         cx: &mut ModelContext<Self>,
-    ) -> Task<Result<Option<Hover>>> {
+    ) -> Task<Result<Vec<Hover>>> {
         let position = position.to_point_utf16(buffer.read(cx));
         self.hover_impl(buffer, position, cx)
     }


### PR DESCRIPTION
Also simplify the hover data structure, as neither `pub project` nor `pub blocks` fields were used in the production code.

Prepares `Editor` for https://github.com/zed-industries/zed/pull/8634 by allowing to have multiple hover pop-ups from different language servers at once.

In the hover fix PR, there's currently a "race" to get a single hover pop-up from language servers:
https://github.com/zed-industries/zed/pull/8634/files#diff-02d1f1a85a2897bb6726ba0eda0245dd944c4bd57cc3911cedc628816efc0fc9R5177-R5181
that gets the first non-empty hover response to show in the editor.

In reality, e.g. a web project might have multiple language servers associated with a `foo.ts` buffer: a, primary, TypeScript language server and Svelte with Tailwind language servers as non-primary ones.
Those servers' semantics may apply more hover results on existing languages, e.g. a CSS part inside of a template inside foo.ts, as in https://github.com/zed-industries/zed/issues/7947

The PR adds a way to show multiple language servers' hover responses at once, by stacking them vertically, above the diagnostics pop-up.
Zed's already stacking the diagnostics pop-up and the primary hover response:
![image](https://github.com/zed-industries/zed/assets/2690773/65f45359-04d1-4c27-8641-237cc4530df0)

Release Notes:

- N/A
