### PR TITLE
typescript: Highlight variables and enums in completions, add details

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -143,11 +143,12 @@ impl LspAdapter for TypeScriptLspAdapter {
         let len = item.label.len();
         let grammar = language.grammar()?;
         let highlight_id = match item.kind? {
-            Kind::CLASS | Kind::INTERFACE => grammar.highlight_id_for_name("type"),
+            Kind::CLASS | Kind::INTERFACE | Kind::ENUM => grammar.highlight_id_for_name("type"),
             Kind::CONSTRUCTOR => grammar.highlight_id_for_name("type"),
             Kind::CONSTANT => grammar.highlight_id_for_name("constant"),
             Kind::FUNCTION | Kind::METHOD => grammar.highlight_id_for_name("function"),
             Kind::PROPERTY | Kind::FIELD => grammar.highlight_id_for_name("property"),
+            Kind::VARIABLE => grammar.highlight_id_for_name("variable"),
             _ => None,
         }?;
 


### PR DESCRIPTION
This partially fixes #5287 by surfacing origin of a completion.

Before:
![image](https://github.com/zed-industries/zed/assets/24362066/7cae421d-9523-43c5-bfc3-eed613a21ac4)

After:
![image](https://github.com/zed-industries/zed/assets/24362066/3d5e360c-c496-4542-82b5-a22d5d00113d)

Release Notes:

- Improved typescript-language-server integration by surfacing more information about completion items.