### PR TITLE
Log when events are written to Clickhouse

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -459,6 +459,12 @@ impl ToUpload {
             }
 
             insert.end().await?;
+
+            let event_count = rows.len();
+            log::info!(
+                "wrote {event_count} {event_specifier} to '{table}'",
+                event_specifier = if event_count == 1 { "event" } else { "events" }
+            );
         }
 
         Ok(())


### PR DESCRIPTION
This PR adds some logging when we write events to Clickhouse in `POST /telemetry/events`, for observability purposes.

Release Notes:

- N/A
