### PR TITLE
Use different icons for terminal tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.23.0-rc1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2c16faa5425a10be102dda76f73d76049b44746e18ddeefc44d78bbe76cbce"
+checksum = "f6d1ea4484c8676f295307a4892d478c70ac8da1dbd8c7c10830a504b7f1022f"
 dependencies = [
  "base64 0.22.0",
  "bitflags 2.4.2",

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -6,7 +6,7 @@ use smol::channel::bounded;
 use std::path::{Path, PathBuf};
 use terminal::{
     terminal_settings::{self, Shell, TerminalSettings, VenvSettingsContent},
-    SpawnTask, TaskState, Terminal, TerminalBuilder,
+    SpawnTask, TaskState, TaskStatus, Terminal, TerminalBuilder,
 };
 use util::ResultExt;
 
@@ -53,8 +53,7 @@ impl Project {
                 Some(TaskState {
                     id: spawn_task.id,
                     label: spawn_task.label,
-                    running: true,
-                    completed_successfully: None,
+                    status: TaskStatus::Running,
                     completion_rx,
                 }),
                 Shell::WithArguments {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -53,7 +53,8 @@ impl Project {
                 Some(TaskState {
                     id: spawn_task.id,
                     label: spawn_task.label,
-                    completed: false,
+                    running: true,
+                    completed_successfully: None,
                     completion_rx,
                 }),
                 Shell::WithArguments {

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -14,8 +14,7 @@ doctest = false
 
 
 [dependencies]
-# TODO: when new version of this crate is released, change it
-alacritty_terminal = "0.23.0-rc1"
+alacritty_terminal = "0.23"
 anyhow.workspace = true
 collections.workspace = true
 dirs = "4.0.0"

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -595,9 +595,34 @@ pub struct Terminal {
 pub struct TaskState {
     pub id: TaskId,
     pub label: String,
-    pub running: bool,
-    pub completed_successfully: Option<bool>,
+    pub status: TaskStatus,
     pub completion_rx: Receiver<()>,
+}
+
+/// A status of the current terminal tab's task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatus {
+    /// The task had been started, but got cancelled or somehow otherwise it did not
+    /// report its exit code before the terminal event loop was shut down.
+    Unknown,
+    /// The task is started and running currently.
+    Running,
+    /// After the start, the task stopped running and reported its error code back.
+    Completed { success: bool },
+}
+
+impl TaskStatus {
+    fn register_terminal_exit(&mut self) {
+        if self == &Self::Running {
+            *self = Self::Unknown;
+        }
+    }
+
+    fn register_task_exit(&mut self, error_code: i32) {
+        *self = TaskStatus::Completed {
+            success: error_code == 0,
+        };
+    }
 }
 
 impl Terminal {
@@ -631,7 +656,7 @@ impl Terminal {
             }
             AlacTermEvent::Exit => match &mut self.task {
                 Some(task) => {
-                    task.running = false;
+                    task.status.register_terminal_exit();
                     self.completion_tx.try_send(()).ok();
                 }
                 None => cx.emit(Event::CloseTerminal),
@@ -650,10 +675,9 @@ impl Terminal {
                 self.events
                     .push_back(InternalEvent::ColorRequest(*idx, fun_ptr.clone()));
             }
-            AlacTermEvent::ChildExit(exit_code) => {
+            AlacTermEvent::ChildExit(error_code) => {
                 if let Some(task) = &mut self.task {
-                    task.completed_successfully = Some(*exit_code == 0);
-                    task.running = false;
+                    task.status.register_task_exit(*error_code);
                     self.completion_tx.try_send(()).ok();
                 }
             }
@@ -1387,7 +1411,7 @@ impl Terminal {
 
     pub fn wait_for_completed_task(&self, cx: &mut AppContext) -> Task<()> {
         if let Some(task) = self.task() {
-            if task.running {
+            if task.status == TaskStatus::Running {
                 let mut completion_receiver = task.completion_rx.clone();
                 return cx.spawn(|_| async move {
                     completion_receiver.next().await;

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -788,10 +788,19 @@ impl Item for TerminalView {
     ) -> AnyElement {
         let terminal = self.terminal().read(cx);
         let title = terminal.title(true);
-        let icon = if terminal.task().is_some() {
-            IconName::Play
-        } else {
-            IconName::Terminal
+        let icon = match terminal.task() {
+            Some(terminal_task) => match &terminal_task.completed_successfully {
+                Some(true) => IconName::Check,
+                Some(false) => IconName::XCircle,
+                None => {
+                    if terminal_task.running {
+                        IconName::Play
+                    } else {
+                        IconName::ExclamationTriangle
+                    }
+                }
+            },
+            None => IconName::Terminal,
         };
         h_flex()
             .gap_2()
@@ -829,7 +838,7 @@ impl Item for TerminalView {
 
     fn is_dirty(&self, cx: &gpui::AppContext) -> bool {
         match self.terminal.read(cx).task() {
-            Some(task) => !task.completed,
+            Some(task) => task.running,
             None => self.has_bell(),
         }
     }


### PR DESCRIPTION
Distinguish "running", "aborted", "failed" and "succeeded" tasks by using different icons in the terminal pane.

Also update alacritty_terminal to the latest stable version.

* success
![success](https://github.com/zed-industries/zed/assets/2690773/915ca5a0-5d6a-4438-89d6-842f936c531d)

* failure
![failure](https://github.com/zed-industries/zed/assets/2690773/04c7486b-7b66-439a-9e53-84b8c33ba051)

* cancelled
![cancelled](https://github.com/zed-industries/zed/assets/2690773/f5a6cd9c-14f7-4b4e-80d2-08b9d22bccc5)

* running
![running](https://github.com/zed-industries/zed/assets/2690773/5640448a-b9b7-4f78-8423-1244d6fd3b5a)

Release Notes:

- Improved task tabs in terminal and show different icons based on task state