### PR TITLE
Look up extensions in the new index when reporting extension events

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -761,7 +761,7 @@ impl ExtensionStore {
 
         if let Some(telemetry) = &self.telemetry {
             for extension_id in &extensions_to_load {
-                if let Some(extension) = self.extension_index.extensions.get(extension_id) {
+                if let Some(extension) = new_index.extensions.get(extension_id) {
                     telemetry.report_extension_event(
                         extension_id.clone(),
                         extension.manifest.version.clone(),


### PR DESCRIPTION
This PR fixes a bug that was causing extension telemetry events to not be reported.

We need to look up the extensions in the new index, as the extensions to load won't be found in the old index.

Release Notes:

- N/A
