### PR TITLE
gleam: Check for `gleam` on the PATH before installing the latest version

### DIFF
--- a/extensions/gleam/src/gleam.rs
+++ b/extensions/gleam/src/gleam.rs
@@ -6,11 +6,20 @@ struct GleamExtension {
 }
 
 impl GleamExtension {
-    fn language_server_binary_path(&mut self, config: zed::LanguageServerConfig) -> Result<String> {
+    fn language_server_binary_path(
+        &mut self,
+        config: zed::LanguageServerConfig,
+        worktree: &zed::Worktree,
+    ) -> Result<String> {
         if let Some(path) = &self.cached_binary_path {
             if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
                 return Ok(path.clone());
             }
+        }
+
+        if let Some(path) = worktree.which("gleam") {
+            self.cached_binary_path = Some(path.clone());
+            return Ok(path);
         }
 
         zed::set_language_server_installation_status(
@@ -88,10 +97,10 @@ impl zed::Extension for GleamExtension {
     fn language_server_command(
         &mut self,
         config: zed::LanguageServerConfig,
-        _worktree: &zed::Worktree,
+        worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         Ok(zed::Command {
-            command: self.language_server_binary_path(config)?,
+            command: self.language_server_binary_path(config, worktree)?,
             args: vec!["lsp".to_string()],
             env: Default::default(),
         })


### PR DESCRIPTION
This PR updates the Gleam extension to give priority to the `gleam` binary that is already on the PATH before downloading/installing a separate Gleam version.

Release Notes:

- N/A
