### PR TITLE
gleam: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12594,7 +12594,7 @@ dependencies = [
 
 [[package]]
 name = "zed_gleam"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_gleam"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/gleam/extension.toml
+++ b/extensions/gleam/extension.toml
@@ -1,7 +1,7 @@
 id = "gleam"
 name = "Gleam"
 description = "Gleam support for Zed"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Gleam extension to v0.0.2.

Release Notes:

- N/A
