### PR TITLE
vim: Fix `t` operand not working correctly when cursor is on tag

### DIFF
--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -260,8 +260,13 @@ pub fn visual_object(object: Object, cx: &mut WindowContext) {
                         // all our motions assume that the current character is
                         // after the cursor; however in the case of a visual selection
                         // the current character is before the cursor.
+                        // But this will affect the judgment of the html tag
+                        // so the html tag needs to skip this logic.
                         if !selection.reversed && object != Object::Tag {
-                            mut_selection.start = movement::left(map, mut_selection.start);
+                            mut_selection.set_head(
+                                movement::left(map, mut_selection.head()),
+                                mut_selection.goal,
+                            );
                         }
 
                         if let Some(range) = object.range(map, mut_selection, around) {

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -255,16 +255,16 @@ pub fn visual_object(object: Object, cx: &mut WindowContext) {
             vim.update_active_editor(cx, |_, editor, cx| {
                 editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.move_with(|map, selection| {
-                        let mut head = selection.head();
+                        let mut mut_selection = selection.clone();
 
                         // all our motions assume that the current character is
                         // after the cursor; however in the case of a visual selection
                         // the current character is before the cursor.
-                        if !selection.reversed {
-                            head = movement::left(map, head);
+                        if !selection.reversed && object != Object::Tag {
+                            mut_selection.start = movement::left(map, mut_selection.start);
                         }
 
-                        if let Some(range) = object.range(map, head, around) {
+                        if let Some(range) = object.range(map, mut_selection, around) {
                             if !range.is_empty() {
                                 let expand_both_ways = object.always_expands_both_ways()
                                     || selection.is_empty()


### PR DESCRIPTION
Fix #8994 and #9844 

Release notes:
* Fixed the `t` object in Vim mode not working correctly when cursor was on a tag. #9844 and #8994

This mr fixes the above two problems, for #9844, because our previous logic is to only think that the minimum html tag containing the current cursor is qualified, but the approach of nvim is to get the tag after the current cursor first, followed by the tag around the current cursor, so I modified the corresponding condition

For #8994, the situation is a bit more complicated, in our previous implementation, we could only get the range of the object by a `cursor position`, but there are two possible cases for the html tag:
When the current cursor length is 1, nvim will return the first tag after the current cursor, as described above
When the current cursor length is greater than 1, nvim will return just the smallest tag that can cover the current selection

So we may need to pass the current selection to the inside of the method, and the point alone is not enough to support us in calculating these conditions