### PR TITLE
Adjust image viewer tab title font

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -73,15 +73,23 @@ impl Item for ImageView {
     fn tab_content(
         &self,
         _detail: Option<usize>,
-        _selected: bool,
+        selected: bool,
         _cx: &WindowContext,
     ) -> AnyElement {
-        self.path
+        let title = self
+            .path
             .file_name()
             .unwrap_or_else(|| self.path.as_os_str())
             .to_string_lossy()
-            .to_string()
-            .into_any_element()
+            .to_string();
+        h_flex()
+            .gap_2()
+            .child(Label::new(lab).color(if selected {
+                Color::Default
+            } else {
+                Color::Muted
+            }))
+            .into_any()
     }
 
     fn added_to_workspace(&mut self, workspace: &mut Workspace, cx: &mut ViewContext<Self>) {

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -82,14 +82,13 @@ impl Item for ImageView {
             .unwrap_or_else(|| self.path.as_os_str())
             .to_string_lossy()
             .to_string();
-        h_flex()
-            .gap_2()
-            .child(Label::new(title).color(if selected {
+        Label::new(title)
+            .color(if selected {
                 Color::Default
             } else {
                 Color::Muted
-            }))
-            .into_any()
+            })
+            .into_any_element()
     }
 
     fn added_to_workspace(&mut self, workspace: &mut Workspace, cx: &mut ViewContext<Self>) {

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -84,7 +84,7 @@ impl Item for ImageView {
             .to_string();
         h_flex()
             .gap_2()
-            .child(Label::new(lab).color(if selected {
+            .child(Label::new(title).color(if selected {
                 Color::Default
             } else {
                 Color::Muted


### PR DESCRIPTION
Fix #9895 

Release notes:

- Changed the tab title of the image preview to be the same as the other tabs ([#9895](https://github.com/zed-industries/zed/issues/9895)).