### PR TITLE
Revert "Add working directories for eslint (#9738)"

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -277,9 +277,6 @@ impl LspAdapter for EsLintLspAdapter {
         let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
             .iter()
             .any(|file| workspace_root.join(file).is_file());
-        let working_directories = eslint_user_settings
-            .get("workingDirectories")
-            .unwrap_or(&Value::Null);
 
         json!({
             "": {
@@ -295,7 +292,6 @@ impl LspAdapter for EsLintLspAdapter {
                 },
                 "problems": {},
                 "codeActionOnSave": code_action_on_save,
-                "workingDirectories": working_directories,
                 "experimental": {
                     "useFlatConfig": use_flat_config,
                 },

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -85,19 +85,3 @@ You can configure ESLint's `nodePath` setting (requires Zed `0.127.0`):
   }
 }
 ```
-
-#### Configure ESLint's `workingDirectories`:
-
-You can configure ESLint's `workingDirectories` setting (requires Zed `0.130.x`):
-
-```json
-{
-  "lsp": {
-    "eslint": {
-      "settings": {
-        "workingDirectories": ["./client", "./server"]
-      }
-    }
-  }
-}
-```


### PR DESCRIPTION
This reverts commit 96a1af7b0f939d7c85e8519164086da47c7077ca from https://github.com/zed-industries/zed/pull/9738 since it doesn't seem to do anything. See: https://github.com/zed-industries/zed/issues/9648#issuecomment-2025132087



Release Notes:

- N/A
