### PR TITLE
Windows: Implement signal in collab

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_os = "linux", allow(dead_code))]
+#![cfg_attr(any(target_os = "linux", target_os = "windows"), allow(dead_code))]
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;

--- a/crates/gpui/src/platform/test.rs
+++ b/crates/gpui/src/platform/test.rs
@@ -7,6 +7,4 @@ mod window;
 pub(crate) use dispatcher::*;
 pub(crate) use display::*;
 pub(crate) use platform::*;
-#[cfg(target_os = "windows")]
-pub(crate) use text_system::*;
 pub(crate) use window::*;

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -125,9 +125,8 @@ impl Platform for TestPlatform {
         #[cfg(target_os = "macos")]
         return Arc::new(crate::platform::mac::MacTextSystem::new());
 
-        // todo("windows")
         #[cfg(target_os = "windows")]
-        unimplemented!()
+        return Arc::new(crate::platform::windows::WindowsTextSystem::new());
     }
 
     fn run(&self, _on_finish_launching: Box<dyn FnOnce()>) {

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -33,12 +33,12 @@ impl WindowsDisplay {
             display_id,
             bounds: Bounds {
                 origin: Point {
-                    x: DevicePixels(size.left as i32),
-                    y: DevicePixels(size.top as i32),
+                    x: DevicePixels(size.left),
+                    y: DevicePixels(size.top),
                 },
                 size: Size {
-                    width: DevicePixels((size.right - size.left) as i32),
-                    height: DevicePixels((size.bottom - size.top) as i32),
+                    width: DevicePixels(size.right - size.left),
+                    height: DevicePixels(size.bottom - size.top),
                 },
             },
             uuid,

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -722,9 +722,7 @@ impl Platform for WindowsPlatform {
                         (*credentials).CredentialBlobSize as usize,
                     )
                 };
-                let mut password: Vec<u8> = Vec::with_capacity(credential_blob.len());
-                password.resize(password.capacity(), 0);
-                password.clone_from_slice(&credential_blob);
+                let password = credential_blob.to_vec();
                 unsafe { CredFree(credentials as *const c_void) };
                 Ok(Some((username, password)))
             }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -68,12 +68,12 @@ impl WindowsWindowInner {
     ) -> Self {
         let monitor_dpi = unsafe { GetDpiForWindow(hwnd) } as f32;
         let origin = Cell::new(Point {
-            x: DevicePixels(cs.x as i32),
-            y: DevicePixels(cs.y as i32),
+            x: DevicePixels(cs.x),
+            y: DevicePixels(cs.y),
         });
         let physical_size = Cell::new(Size {
-            width: DevicePixels(cs.cx as i32),
-            height: DevicePixels(cs.cy as i32),
+            width: DevicePixels(cs.cx),
+            height: DevicePixels(cs.cy),
         });
         let scale_factor = Cell::new(monitor_dpi / USER_DEFAULT_SCREEN_DPI as f32);
         let input_handler = Cell::new(None);
@@ -175,10 +175,10 @@ impl WindowsWindowInner {
             let bounds = self.display.borrow().clone().bounds();
             StyleAndBounds {
                 style,
-                x: bounds.left().0 as i32,
-                y: bounds.top().0 as i32,
-                cx: bounds.size.width.0 as i32,
-                cy: bounds.size.height.0 as i32,
+                x: bounds.left().0,
+                y: bounds.top().0,
+                cx: bounds.size.width.0,
+                cy: bounds.size.height.0,
             }
         };
         unsafe { set_window_long(self.hwnd, GWL_STYLE, style.0 as isize) };
@@ -924,8 +924,8 @@ impl WindowsWindowInner {
         let height = size_rect.bottom - size_rect.top;
 
         self.physical_size.set(Size {
-            width: DevicePixels(width as i32),
-            height: DevicePixels(height as i32),
+            width: DevicePixels(width),
+            height: DevicePixels(height),
         });
 
         if self.hide_title_bar {
@@ -1076,10 +1076,7 @@ impl WindowsWindowInner {
                 y: lparam.signed_hiword().into(),
             };
             unsafe { ScreenToClient(self.hwnd, &mut cursor_point) };
-            let physical_point = point(
-                DevicePixels(cursor_point.x as i32),
-                DevicePixels(cursor_point.y as i32),
-            );
+            let physical_point = point(DevicePixels(cursor_point.x), DevicePixels(cursor_point.y));
             let click_count = self.click_state.borrow_mut().update(button, physical_point);
             let scale_factor = self.scale_factor.get();
             let event = MouseDownEvent {
@@ -1218,10 +1215,10 @@ impl WindowsWindow {
                 .unwrap_or(""),
         );
         let dwstyle = WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
-        let x = options.bounds.origin.x.0 as i32;
-        let y = options.bounds.origin.y.0 as i32;
-        let nwidth = options.bounds.size.width.0 as i32;
-        let nheight = options.bounds.size.height.0 as i32;
+        let x = options.bounds.origin.x.0;
+        let y = options.bounds.origin.y.0;
+        let nwidth = options.bounds.size.width.0;
+        let nheight = options.bounds.size.height.0;
         let hwndparent = HWND::default();
         let hmenu = HMENU::default();
         let hinstance = HINSTANCE::default();

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -11,7 +11,9 @@ use lsp::Url;
 use parking_lot::Mutex;
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use std::{os, task::Poll};
+#[cfg(not(windows))]
+use std::os;
+use std::task::Poll;
 use unindent::Unindent as _;
 use util::{assert_set_eq, paths::PathMatcher, test::temp_tree};
 use worktree::WorktreeModelHandle as _;

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -60,7 +60,7 @@ impl ProcessIdGetter {
             }
             return Some(Pid::from_u32(self.fallback_pid));
         }
-        Some(Pid::from_u32(pid as u32))
+        Some(Pid::from_u32(pid))
     }
 }
 

--- a/tooling/xtask/src/main.rs
+++ b/tooling/xtask/src/main.rs
@@ -59,9 +59,6 @@ fn run_clippy(args: ClippyArgs) -> Result<()> {
     clippy_command.arg("--");
 
     // Deny all warnings.
-    // We don't do this yet on Windows, as it still has some warnings present.
-    // todo(windows)
-    #[cfg(not(target_os = "windows"))]
     clippy_command.args(["--deny", "warnings"]);
 
     eprintln!(


### PR DESCRIPTION
Only `CtrlC` and `CtrlBreak` signals are supported. `CtrlLogoff` and `CtrlShutdown` is service only signal and I have not tried these yet. `CtrlClose` occurs when terminal window is closed, but I found tokio's `ctrl_close` does not work well, so I put comment in code.

Release Notes:

- N/A
