### PR TITLE
Fix Recent Documents List (continues #8952)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7447,11 +7447,9 @@ dependencies = [
 name = "recent_projects"
 version = "0.1.0"
 dependencies = [
- "collections",
  "editor",
  "fuzzy",
  "gpui",
- "itertools 0.11.0",
  "language",
  "menu",
  "ordered-float 2.10.0",

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1124,17 +1124,14 @@ impl AppContext {
         self.platform.set_menus(menus, &self.keymap.borrow());
     }
 
-    /// Adds given path to list of recent paths for the application.
+    /// Adds given path to the bottom of the list of recent paths for the application.
     /// The list is usually shown on the application icon's context menu in the dock,
     /// and allows to open the recent files via that context menu.
-    pub fn add_recent_documents(&mut self, paths: &[PathBuf]) {
-        self.platform.add_recent_documents(paths);
+    /// If the path is already in the list, it will be moved to the bottom of the list.
+    pub fn add_recent_document(&mut self, path: &Path) {
+        self.platform.add_recent_document(path);
     }
 
-    /// Clears the list of recent paths from the application.
-    pub fn clear_recent_documents(&mut self) {
-        self.platform.clear_recent_documents();
-    }
     /// Dispatch an action to the currently active window or global action handler
     /// See [action::Action] for more information on how actions work
     pub fn dispatch_action(&mut self, action: &dyn Action) {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -118,8 +118,7 @@ pub(crate) trait Platform: 'static {
     fn on_event(&self, callback: Box<dyn FnMut(PlatformInput) -> bool>);
 
     fn set_menus(&self, menus: Vec<Menu>, keymap: &Keymap);
-    fn add_recent_documents(&self, _paths: &[PathBuf]) {}
-    fn clear_recent_documents(&self) {}
+    fn add_recent_document(&self, _path: &Path) {}
     fn on_app_menu_action(&self, callback: Box<dyn FnMut(&dyn Action)>);
     fn on_will_open_app_menu(&self, callback: Box<dyn FnMut()>);
     fn on_validate_app_menu_command(&self, callback: Box<dyn FnMut(&dyn Action) -> bool>);

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -764,26 +764,14 @@ impl Platform for MacPlatform {
         }
     }
 
-    fn add_recent_documents(&self, paths: &[PathBuf]) {
-        for path in paths {
-            let Some(path_str) = path.to_str() else {
-                log::error!("Not adding to recent documents a non-unicode path: {path:?}");
-                continue;
-            };
+    fn add_recent_document(&self, path: &Path) {
+        if let Some(path_str) = path.to_str() {
             unsafe {
                 let document_controller: id =
                     msg_send![class!(NSDocumentController), sharedDocumentController];
                 let url: id = NSURL::fileURLWithPath_(nil, ns_string(path_str));
                 let _: () = msg_send![document_controller, noteNewRecentDocumentURL:url];
             }
-        }
-    }
-
-    fn clear_recent_documents(&self) {
-        unsafe {
-            let document_controller: id =
-                msg_send![class!(NSDocumentController), sharedDocumentController];
-            let _: () = msg_send![document_controller, clearRecentDocuments:nil];
         }
     }
 

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -9,7 +9,7 @@ use futures::channel::oneshot;
 use parking_lot::Mutex;
 use std::{
     cell::RefCell,
-    path::PathBuf,
+    path::{Path, PathBuf},
     rc::{Rc, Weak},
     sync::Arc,
 };
@@ -240,9 +240,7 @@ impl Platform for TestPlatform {
 
     fn set_menus(&self, _menus: Vec<crate::Menu>, _keymap: &Keymap) {}
 
-    fn add_recent_documents(&self, _paths: &[PathBuf]) {}
-
-    fn clear_recent_documents(&self) {}
+    fn add_recent_document(&self, _paths: &Path) {}
 
     fn on_app_menu_action(&self, _callback: Box<dyn FnMut(&dyn crate::Action)>) {}
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -6620,10 +6620,6 @@ impl Project {
             .or_insert_with(|| {
                 cx.spawn(move |project, mut cx| {
                     async move {
-                        cx.update(|cx| {
-                            cx.add_recent_documents(&[path.to_path_buf()]);
-                        })
-                        .log_err();
                         let worktree = Worktree::local(
                             client.clone(),
                             path.clone(),
@@ -6641,6 +6637,12 @@ impl Project {
                         let worktree = worktree?;
                         project
                             .update(&mut cx, |project, cx| project.add_worktree(&worktree, cx))?;
+
+                        cx.update(|cx| {
+                            cx.add_recent_documents(&[path.to_path_buf()]);
+                        })
+                        .log_err();
+
                         Ok(worktree)
                     }
                     .map_err(Arc::new)

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -6620,6 +6620,10 @@ impl Project {
             .or_insert_with(|| {
                 cx.spawn(move |project, mut cx| {
                     async move {
+                        cx.update(|cx| {
+                            cx.add_recent_documents(&[path.to_path_buf()]);
+                        })
+                        .log_err();
                         let worktree = Worktree::local(
                             client.clone(),
                             path.clone(),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -6639,7 +6639,7 @@ impl Project {
                             .update(&mut cx, |project, cx| project.add_worktree(&worktree, cx))?;
 
                         cx.update(|cx| {
-                            cx.add_recent_documents(&[path.to_path_buf()]);
+                            cx.add_recent_document(&path);
                         })
                         .log_err();
 

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -13,10 +13,8 @@ path = "src/recent_projects.rs"
 doctest = false
 
 [dependencies]
-collections.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
-itertools.workspace = true
 menu.workspace = true
 ordered-float.workspace = true
 picker.workspace = true

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -443,7 +443,6 @@ impl RecentProjectsDelegate {
                     .map(|(path, _)| path)
                     .collect::<Vec<_>>();
                 this.update(&mut cx, move |picker, cx| {
-                    cx.clear_recent_documents();
                     cx.add_recent_documents(&updated_paths);
                     picker.delegate.workspaces = workspaces;
                     picker.delegate.set_selected_index(ix - 1, cx);

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1,10 +1,8 @@
-use collections::HashMap;
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Result,
     Subscription, Task, View, ViewContext, WeakView,
 };
-use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use picker::{
     highlighted_match_with_paths::{HighlightedMatchWithPaths, HighlightedText},
@@ -431,19 +429,7 @@ impl RecentProjectsDelegate {
                     .recent_workspaces_on_disk()
                     .await
                     .unwrap_or_default();
-                let mut unique_added_paths = HashMap::default();
-                for (id, workspace) in &workspaces {
-                    for path in workspace.paths().iter() {
-                        unique_added_paths.insert(path.clone(), id);
-                    }
-                }
-                let updated_paths = unique_added_paths
-                    .into_iter()
-                    .sorted_by_key(|(_, id)| *id)
-                    .map(|(path, _)| path)
-                    .collect::<Vec<_>>();
                 this.update(&mut cx, move |picker, cx| {
-                    cx.add_recent_documents(&updated_paths);
                     picker.delegate.workspaces = workspaces;
                     picker.delegate.set_selected_index(ix - 1, cx);
                     picker.delegate.reset_selected_match_index = false;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -605,16 +605,7 @@ impl Workspace {
 
                 project::Event::WorktreeRemoved(_) | project::Event::WorktreeAdded => {
                     this.update_window_title(cx);
-                    let workspace_serialization = this.serialize_workspace(cx);
-                    cx.spawn(|workspace, mut cx| async move {
-                        workspace_serialization.await;
-                        workspace
-                            .update(&mut cx, |workspace, cx| {
-                                workspace.refresh_recent_documents(cx)
-                            })?
-                            .await
-                    })
-                    .detach_and_log_err(cx)
+                    this.serialize_workspace(cx).detach();
                 }
 
                 project::Event::DisconnectedFromHost => {
@@ -944,12 +935,7 @@ impl Workspace {
                 .unwrap_or_default();
 
             window
-                .update(&mut cx, |workspace, cx| {
-                    workspace
-                        .refresh_recent_documents(cx)
-                        .detach_and_log_err(cx);
-                    cx.activate_window()
-                })
+                .update(&mut cx, |_, cx| cx.activate_window())
                 .log_err();
             Ok((window, opened_items))
         })

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3468,32 +3468,6 @@ impl Workspace {
         Task::ready(())
     }
 
-    fn refresh_recent_documents(&self, cx: &mut AppContext) -> Task<Result<()>> {
-        if !self.project.read(cx).is_local() {
-            return Task::ready(Ok(()));
-        }
-        cx.spawn(|cx| async move {
-            let recents = WORKSPACE_DB
-                .recent_workspaces_on_disk()
-                .await
-                .unwrap_or_default();
-            let mut unique_paths = HashMap::default();
-            for (id, workspace) in &recents {
-                for path in workspace.paths().iter() {
-                    unique_paths.insert(path.clone(), id);
-                }
-            }
-            let current_paths = unique_paths
-                .into_iter()
-                .sorted_by_key(|(_, id)| *id)
-                .map(|(path, _)| path)
-                .collect::<Vec<_>>();
-            cx.update(|cx| {
-                cx.add_recent_documents(&current_paths);
-            })
-        })
-    }
-
     pub(crate) fn load_workspace(
         serialized_workspace: SerializedWorkspace,
         paths_to_open: Vec<Option<ProjectPath>>,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3503,7 +3503,6 @@ impl Workspace {
                 .map(|(path, _)| path)
                 .collect::<Vec<_>>();
             cx.update(|cx| {
-                cx.clear_recent_documents();
                 cx.add_recent_documents(&current_paths);
             })
         })


### PR DESCRIPTION
@SomeoneToIgnore This code should 100% work for future Zed users, but for current Zed users, Zed's internal list of recents may not be synced w/ macOS' Recent Documents at first. If needed this can be fixed by calling `cx.refresh_recent_documents` on startup, but that feels a bit unnecessary.

Release Notes:

- Fixes behavior of Recent Documents list on macOS