### PR TITLE
editor: Add ability to jump to another file by clicking on a relative path in the code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,6 +2046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "clean-path"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa6b4b263a5d737e9bf6b7c09b72c41a5480aec4d7219af827f6564e950b6a5"
+
+[[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
@@ -3259,6 +3265,7 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "clean-path",
  "client",
  "clock",
  "collections",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -71,6 +71,7 @@ ui.workspace = true
 url.workspace = true
 util.workspace = true
 workspace.workspace = true
+clean-path = "=0.2.1"
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7628,7 +7628,7 @@ impl Editor {
 
         cx.spawn(|editor, mut cx| async move {
             if let Some((_, hover_link)) =
-                find_url(&buffer, buffer_position, Vec::new(), cx.clone())
+                find_url(&buffer, buffer_position, None, None, cx.clone())
             {
                 match hover_link {
                     HoverLink::Url(url) => editor.update(&mut cx, |_, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7661,7 +7661,7 @@ impl Editor {
                     self.compute_target_location(lsp_location, server_id, cx)
                 }
                 HoverLink::Relative(path) => {
-                    self.jump(path, Point::zero(), text::Anchor::MIN, cx);
+                    self.jump(path, Point::zero(), text::Anchor::MIN, 0, cx);
                     Task::ready(Ok(None))
                 }
                 HoverLink::Url(url) => {

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -515,7 +515,7 @@ pub fn show_link_definition(
                 }
 
                 project_files.push(ProjectPath {
-                    path: entry.path.clone(),
+                    path: entry.path.clone(), // TODO: make the path relative to file where the link was found.
                     worktree_id: wrk.read(cx).id(),
                 });
             }


### PR DESCRIPTION
Hi, I'm new to this code base and Rust in general, so I would like to get some feedback and hear from you about whether such a feature is welcome. 

~~For now, the path is resolved from the workspace root rather than from the file where the link is located. Open question: What would be the most reliable way to obtain the path for the file at hand?~~


Release Notes:

- Added the ability to jump to another file by clicking on a relative path in the code

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

https://github.com/zed-industries/zed/assets/2438924/de1f5c40-583e-4a04-ac12-a2d804ae5ca5


