### PR TITLE
Use correct font family and line_height in git blame sidebar

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1111,6 +1111,7 @@ impl EditorElement {
         let start_x = em_width * 1;
 
         let mut last_used_color: Option<(PlayerColor, Oid)> = None;
+        let text_style = &self.style.text;
 
         let shaped_lines = blamed_rows
             .into_iter()
@@ -1121,6 +1122,7 @@ impl EditorElement {
                         ix,
                         &blame,
                         blame_entry,
+                        text_style,
                         &mut last_used_color,
                         self.editor.clone(),
                         cx,
@@ -2845,6 +2847,7 @@ fn render_blame_entry(
     ix: usize,
     blame: &gpui::Model<GitBlame>,
     blame_entry: BlameEntry,
+    text_style: &TextStyle,
     last_used_color: &mut Option<(PlayerColor, Oid)>,
     editor: View<Editor>,
     cx: &mut ElementContext<'_>,
@@ -2888,6 +2891,8 @@ fn render_blame_entry(
     let commit_message = blame.read(cx).message_for_entry(&blame_entry);
 
     h_flex()
+        .font(text_style.font().family)
+        .line_height(text_style.line_height)
         .id(("blame", ix))
         .children([
             div()


### PR DESCRIPTION
This fixes the git blame sidebar looking wrong if the buffer font size is higher than the UI font size (which is what was previously used).

It fixes this:

![screenshot-2024-03-28-19 46 48@2x](https://github.com/zed-industries/zed/assets/1185253/eca360ac-c8e8-41e0-85a1-52bdd05b9413)

To now look like this:

![screenshot-2024-03-28-19 47 42@2x](https://github.com/zed-industries/zed/assets/1185253/1fe93370-b7a2-44d4-a505-6368d72e2659)


Release Notes:

- N/A
