### PR TITLE
assistant: Remove timeout in HttpClient to allow slow local LLMs

### DIFF
--- a/crates/assistant/src/completion_provider/open_ai.rs
+++ b/crates/assistant/src/completion_provider/open_ai.rs
@@ -114,6 +114,7 @@ impl OpenAiCompletionProvider {
         let api_url = self.api_url.clone();
         async move {
             let api_key = api_key.ok_or_else(|| anyhow!("missing api key"))?;
+            // TODO here it might be nice to have an assistant setting for timeout, including NOT setting one to get NO TIMEOUT in isahc library used in util/http.rs
             let request = stream_completion(http_client.as_ref(), &api_url, &api_key, request);
             let response = request.await?;
             let stream = response

--- a/crates/util/src/http.rs
+++ b/crates/util/src/http.rs
@@ -126,8 +126,11 @@ pub trait HttpClient: Send + Sync {
 pub fn client() -> Arc<dyn HttpClient> {
     Arc::new(
         isahc::HttpClient::builder()
-            .connect_timeout(Duration::from_secs(5))
-            .low_speed_timeout(100, Duration::from_secs(5))
+// from https://docs.rs/isahc/latest/isahc/config/trait.Configurable.html#method.timeout
+// > If not set, no timeout will be enforced.
+// let's start with that :)
+            //            .connect_timeout(Duration::from_secs(5))
+//            .low_speed_timeout(100, Duration::from_secs(5))
             .proxy(http_proxy_from_env())
             .build()
             .unwrap(),


### PR DESCRIPTION
I am using ollama with mistral model.

my local settings.json:

```
{
  "theme": "One Dark",
  "ui_font_size": 16,
  "buffer_font_size": 16,
  "assistant": {
    "version": "1",
    "provider": {
      "name": "openai",
      "api_url": "http://localhost:11434/v1"
    }
  }
}
```

Release Notes:

- Fixed #9913 