### PR TITLE
Query code actions and hovers from all related local language servers

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4980,8 +4980,7 @@ async fn test_lsp_hover(
 
     let hovers = project_b
         .update(cx_b, |p, cx| p.hover(&buffer_b, 22, cx))
-        .await
-        .unwrap();
+        .await;
     assert_eq!(
         hovers.len(),
         1,

--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -832,7 +832,7 @@ impl RandomizedTest for ProjectCollaborationTest {
                         .boxed(),
                     LspRequestKind::CodeAction => project
                         .code_actions(&buffer, offset..offset, cx)
-                        .map_ok(|_| ())
+                        .map(|_| Ok(()))
                         .boxed(),
                     LspRequestKind::Definition => project
                         .definition(&buffer, offset, cx)

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -376,6 +376,7 @@ impl Copilot {
         use node_runtime::FakeNodeRuntime;
 
         let (server, fake_server) = FakeLanguageServer::new(
+            LanguageServerId(0),
             LanguageServerBinary {
                 path: "path/to/copilot".into(),
                 arguments: vec![],

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3758,19 +3758,17 @@ impl Editor {
             let actions = if let Ok(code_actions) = project.update(&mut cx, |project, cx| {
                 project.code_actions(&start_buffer, start..end, cx)
             }) {
-                code_actions.await.log_err()
+                code_actions.await
             } else {
-                None
+                Vec::new()
             };
 
             this.update(&mut cx, |this, cx| {
-                this.available_code_actions = actions.and_then(|actions| {
-                    if actions.is_empty() {
-                        None
-                    } else {
-                        Some((start_buffer, actions.into()))
-                    }
-                });
+                this.available_code_actions = if actions.is_empty() {
+                    None
+                } else {
+                    Some((start_buffer, actions.into()))
+                };
                 cx.notify();
             })
             .log_err();

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -295,7 +295,7 @@ fn show_hover(
                     });
             })?;
 
-            let hovers_response = hover_request.await.ok().unwrap_or_default();
+            let hovers_response = hover_request.await;
             let language_registry = project.update(&mut cx, |p, _| p.languages().clone())?;
             let snapshot = this.update(&mut cx, |this, cx| this.snapshot(cx))?;
             let mut hover_highlights = Vec::with_capacity(hovers_response.len());

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1855,6 +1855,17 @@ impl GetCodeActions {
             })
             .unwrap_or(false)
     }
+
+    pub fn supports_code_actions(capabilities: &ServerCapabilities) -> bool {
+        capabilities
+            .code_action_provider
+            .as_ref()
+            .map(|options| match options {
+                lsp::CodeActionProviderCapability::Simple(is_supported) => *is_supported,
+                lsp::CodeActionProviderCapability::Options(_) => true,
+            })
+            .unwrap_or(false)
+    }
 }
 
 #[async_trait(?Send)]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5200,7 +5200,11 @@ impl Project {
 
             let mut hover_responses = self
                 .language_servers_for_buffer(buffer.read(cx), cx)
-                .filter(|(_, server)| server.capabilities().hover_provider.is_some())
+                .filter(|(_, server)| match server.capabilities().hover_provider {
+                    Some(lsp::HoverProviderCapability::Simple(enabled)) => enabled,
+                    Some(lsp::HoverProviderCapability::Options(_)) => true,
+                    None => false,
+                })
                 .filter(|(adapter, _)| {
                     scope
                         .as_ref()

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5221,6 +5221,7 @@ impl Project {
             cx.spawn(|_, _| async move {
                 let mut hovers = Vec::with_capacity(hover_responses.len());
                 while let Some(hover_response) = hover_responses.next().await {
+                    // TODO kb one faulty langserver will spoil all hovers?
                     if let Some(hover) = hover_response? {
                         hovers.push(hover);
                     }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -4544,7 +4544,6 @@ async fn test_multiple_language_server_hovers(cx: &mut gpui::TestAppContext) {
         vec!["TailwindServer hover", "TypeScriptServer hover"],
         hover_task
             .await
-            .unwrap()
             .into_iter()
             .map(|hover| hover.contents.iter().map(|block| &block.text).join("|"))
             .sorted()

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -4404,6 +4404,155 @@ async fn test_create_entry(cx: &mut gpui::TestAppContext) {
     assert!(result.is_err())
 }
 
+#[gpui::test]
+async fn test_multiple_language_server_hovers(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/dir",
+        json!({
+            "a.tsx": "a",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, ["/dir".as_ref()], cx).await;
+
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(tsx_lang());
+    let language_server_names = vec![
+        "TypeScriptServer",
+        "TailwindServer",
+        "ESLintServer",
+        "NoHoverCapabilitiesServer",
+    ];
+    let mut fake_tsx_language_servers = language_registry.register_specific_fake_lsp_adapter(
+        "tsx",
+        true,
+        FakeLspAdapter {
+            name: &language_server_names[0],
+            capabilities: lsp::ServerCapabilities {
+                hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+    let _a = language_registry.register_specific_fake_lsp_adapter(
+        "tsx",
+        false,
+        FakeLspAdapter {
+            name: &language_server_names[1],
+            capabilities: lsp::ServerCapabilities {
+                hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+    let _b = language_registry.register_specific_fake_lsp_adapter(
+        "tsx",
+        false,
+        FakeLspAdapter {
+            name: &language_server_names[2],
+            capabilities: lsp::ServerCapabilities {
+                hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+    let _c = language_registry.register_specific_fake_lsp_adapter(
+        "tsx",
+        false,
+        FakeLspAdapter {
+            name: &language_server_names[3],
+            ..FakeLspAdapter::default()
+        },
+    );
+
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer("/dir/a.tsx", cx))
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    let mut servers_with_hover_requests = HashMap::default();
+    for i in 0..language_server_names.len() {
+        let new_server = fake_tsx_language_servers
+            .next()
+            .await
+            .unwrap_or_else(|| panic!("Failed to get language server #{i}"));
+        let new_server_name = new_server.server.name();
+        assert!(
+            !servers_with_hover_requests.contains_key(new_server_name),
+            "Unexpected: initialized server with the same name twice. Name: `{new_server_name}`"
+        );
+        let new_server_name = new_server_name.to_string();
+        match new_server_name.as_str() {
+            "TailwindServer" | "TypeScriptServer" => {
+                servers_with_hover_requests.insert(
+                    new_server_name.clone(),
+                    new_server.handle_request::<lsp::request::HoverRequest, _, _>(move |_, _| {
+                        let name = new_server_name.clone();
+                        async move {
+                            Ok(Some(lsp::Hover {
+                                contents: lsp::HoverContents::Scalar(lsp::MarkedString::String(
+                                    format!("{name} hover"),
+                                )),
+                                range: None,
+                            }))
+                        }
+                    }),
+                );
+            }
+            "ESLintServer" => {
+                servers_with_hover_requests.insert(
+                    new_server_name,
+                    new_server.handle_request::<lsp::request::HoverRequest, _, _>(
+                        |_, _| async move { Ok(None) },
+                    ),
+                );
+            }
+            "NoHoverCapabilitiesServer" => {
+                let _never_handled = new_server.handle_request::<lsp::request::HoverRequest, _, _>(
+                    |_, _| async move {
+                        panic!(
+                            "Should not call for hovers server with no corresponding capabilities"
+                        )
+                    },
+                );
+            }
+            unexpected => panic!("Unexpected server name: {unexpected}"),
+        }
+    }
+
+    let hover_task = project.update(cx, |project, cx| {
+        project.hover(&buffer, Point::new(0, 0), cx)
+    });
+    let _: Vec<()> = futures::future::join_all(servers_with_hover_requests.into_values().map(
+        |mut hover_request| async move {
+            hover_request
+                .next()
+                .await
+                .expect("All hover requests should have been triggered")
+        },
+    ))
+    .await;
+    assert_eq!(
+        vec!["TailwindServer hover", "TypeScriptServer hover"],
+        hover_task
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|hover| hover.contents.iter().map(|block| &block.text).join("|"))
+            .sorted()
+            .collect::<Vec<_>>(),
+        "Should receive hover responses from all related servers with hover capabilities"
+    );
+}
+
 async fn search(
     project: &Model<Project>,
     query: SearchQuery,
@@ -4506,5 +4655,19 @@ fn typescript_lang() -> Arc<Language> {
             ..Default::default()
         },
         Some(tree_sitter_typescript::language_typescript()),
+    ))
+}
+
+fn tsx_lang() -> Arc<Language> {
+    Arc::new(Language::new(
+        LanguageConfig {
+            name: "tsx".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["tsx".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        Some(tree_sitter_typescript::language_tsx()),
     ))
 }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2522,7 +2522,7 @@ async fn test_apply_code_actions_with_commands(cx: &mut gpui::TestAppContext) {
         .next()
         .await;
 
-    let action = actions.await.unwrap()[0].clone();
+    let action = actions.await[0].clone();
     let apply = project.update(cx, |project, cx| {
         project.apply_code_action(buffer.clone(), action, true, cx)
     });


### PR DESCRIPTION
<img width="1122" alt="Screenshot 2024-03-28 at 21 51 18" src="https://github.com/zed-industries/zed/assets/2690773/37ef7202-f10f-462f-a2fa-044b2d806191">


Part of https://github.com/zed-industries/zed/issues/7947 and https://github.com/zed-industries/zed/issues/9912 that adds makes Zed query all related language servers instead of the primary one.

Collab clients are still querying the primary one only, but this is quite hard to solve, https://github.com/zed-industries/zed/pull/8634 drafts a part of it.
The local part is useful per se, as many people use Zed & Tailwind but do not use collab features.

Unfortunately, eslint still returns empty actions list when queried, but querying actions for all related language servers looks reasonable and rare enough to be dangerous.

Release Notes:

- Added Tailwind CSS hover popovers for Zed in single player mode ([7947](https://github.com/zed-industries/zed/issues/7947))