### PR TITLE
Add spawning of tasks without saving them in the task stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6880,6 +6880,7 @@ dependencies = [
  "env_logger",
  "gpui",
  "menu",
+ "serde",
  "serde_json",
  "ui",
  "workspace",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -16,7 +16,7 @@
       "escape": "menu::Cancel",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
-      "shift-enter": "menu::UseSelectedQuery",
+      "shift-enter": "picker::UseSelectedQuery",
       "ctrl-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "ctrl-o": "workspace::Open",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -17,6 +17,8 @@
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
       "shift-enter": "picker::UseSelectedQuery",
+      "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
+      "ctrl-alt-enter": ["picker::ConfirmInput", { "secondary": true }],
       "ctrl-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "ctrl-o": "workspace::Open",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -20,6 +20,8 @@
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
       "shift-enter": "picker::UseSelectedQuery",
+      "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
+      "cmd-alt-enter": ["picker::ConfirmInput", { "secondary": true }],
       "cmd-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "cmd-o": "workspace::Open",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -19,7 +19,7 @@
       "cmd-escape": "menu::Cancel",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
-      "shift-enter": "menu::UseSelectedQuery",
+      "shift-enter": "picker::UseSelectedQuery",
       "cmd-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
       "cmd-o": "workspace::Open",

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 editor.workspace = true
 gpui.workspace = true
 menu.workspace = true
+serde.workspace = true
 ui.workspace = true
 workspace.workspace = true
 

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use editor::{scroll::Autoscroll, Editor};
 use gpui::{
-    div, list, prelude::*, uniform_list, AnyElement, AppContext, ClickEvent, DismissEvent,
+    actions, div, list, prelude::*, uniform_list, AnyElement, AppContext, ClickEvent, DismissEvent,
     EventEmitter, FocusHandle, FocusableView, Length, ListState, MouseButton, MouseUpEvent, Render,
     Task, UniformListScrollHandle, View, ViewContext, WindowContext,
 };
@@ -17,6 +17,8 @@ enum ElementContainer {
     List(ListState),
     UniformList(UniformListScrollHandle),
 }
+
+actions!(picker, [UseSelectedQuery]);
 
 struct PendingUpdateMatches {
     delegate_update_matches: Option<Task<()>>,
@@ -278,7 +280,7 @@ impl<D: PickerDelegate> Picker<D> {
         }
     }
 
-    fn use_selected_query(&mut self, _: &menu::UseSelectedQuery, cx: &mut ViewContext<Self>) {
+    fn use_selected_query(&mut self, _: &UseSelectedQuery, cx: &mut ViewContext<Self>) {
         if let Some(new_query) = self.delegate.selected_as_query() {
             self.set_query(new_query, cx);
             cx.stop_propagation();

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -247,7 +247,6 @@ impl PickerDelegate for TasksModalDelegate {
                     .as_ref()
                     .map(|candidates| candidates[ix].1.clone())
             });
-        dbg!(omit_history_entry);
         let Some(task) = task else {
             return;
         };

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -464,6 +464,28 @@ mod tests {
             vec![query_str],
             "Only custom task should be listed"
         );
+
+        let query_str = "0";
+        cx.simulate_input(query_str);
+        assert_eq!(query(&tasks_picker, cx), "echo 40");
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            Vec::<String>::new(),
+            "New oneshot should not match any command query"
+        );
+
+        cx.dispatch_action(picker::ConfirmInput { secondary: true });
+        let tasks_picker = open_spawn_tasks(&workspace, cx);
+        assert_eq!(
+            query(&tasks_picker, cx),
+            "",
+            "Query should be reset after confirming"
+        );
+        assert_eq!(
+            task_names(&tasks_picker, cx),
+            vec!["echo 4", "another one", "example task", "echo 40"],
+            "Last recently used one show task should be listed last, as it is a fire-and-forget task"
+        );
     }
 
     fn open_spawn_tasks(

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -169,7 +169,7 @@ impl PickerDelegate for TasksModalDelegate {
     fn placeholder_text(&self, cx: &mut WindowContext) -> Arc<str> {
         Arc::from(format!(
             "{} use task name as prompt, {} spawns a bash-like task from the prompt, {} runs the selected task",
-            cx.keystroke_text_for(&menu::UseSelectedQuery),
+            cx.keystroke_text_for(&picker::UseSelectedQuery),
             cx.keystroke_text_for(&menu::SecondaryConfirm),
             cx.keystroke_text_for(&menu::Confirm),
         ))
@@ -391,7 +391,7 @@ mod tests {
             "Only one task should match the query {query_str}"
         );
 
-        cx.dispatch_action(menu::UseSelectedQuery);
+        cx.dispatch_action(picker::UseSelectedQuery);
         assert_eq!(
             query(&tasks_picker, cx),
             "echo 4",
@@ -438,7 +438,7 @@ mod tests {
             "Last recently used one show task should be listed first"
         );
 
-        cx.dispatch_action(menu::UseSelectedQuery);
+        cx.dispatch_action(picker::UseSelectedQuery);
         assert_eq!(
             query(&tasks_picker, cx),
             query_str,


### PR DESCRIPTION
These tasks are not considered for reruns with `task::Rerun`. 
This PR tears a bunch of stuff up around tasks:
- `menu::SecondaryConfirm` for tasks is gonna spawn a task without storing it in history instead of being occupied by oneshot tasks. This is done so that cmd-clicking on the menu item actually does something meaningful.
- `menu::UseSelectedQuery` got moved into picker, as tasks are it's only user (and it doesn't really make sense as a menu action).

TODO:
- [x] add release note
- [x] Actually implement the core of this feature, which is spawning a task without saving it in history, lol.

Fixes #9804 
Release Notes:

- Added "fire-and-forget" task spawning; `menu::SecondaryConfirm` in tasks modal now spawns a task without registering it as the last spawned task for the purposes of `task::Rerun`. By default you can spawn a task in this fashion with cmd+enter or by holding cmd and clicking on a task entry in a list. Spawning oneshots has been rebound to `option-enter` (under a `picker::ConfirmInput` name). Fixes #9804 (breaking change) 
- Moved `menu::UseSelectedQuery` action to `picker` namespace (breaking change).