### PR TITLE
Fix vertical alignment of labels in file tree

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1435,15 +1435,15 @@ impl ProjectPanel {
                     .indent_step_size(px(settings.indent_size))
                     .selected(is_selected)
                     .child(if let Some(icon) = &icon {
-                        div().child(Icon::from_path(icon.to_string()).color(filename_text_color))
+                        h_flex().child(Icon::from_path(icon.to_string()).color(filename_text_color))
                     } else {
-                        div().size(IconSize::default().rems()).invisible()
+                        h_flex().size(IconSize::default().rems()).invisible()
                     })
                     .child(
                         if let (Some(editor), true) = (Some(&self.filename_editor), show_editor) {
                             h_flex().h_6().w_full().child(editor.clone())
                         } else {
-                            div()
+                            h_flex()
                                 .h_6()
                                 .child(Label::new(file_name).color(filename_text_color))
                         }


### PR DESCRIPTION
This PR fixes the vertical alignment of the labels in the file tree in the project panel.

This appears to have been introduced in https://github.com/zed-industries/zed/pull/8988 through the addition of the `.h_6` in conjunction with a `div`, causing the contents to not be vertically aligned.

### Before

<img width="287" alt="Screenshot 2024-03-29 at 12 44 15 PM" src="https://github.com/zed-industries/zed/assets/1486634/b275b66c-55eb-4980-95b9-6751d0b4998a">

### After

<img width="259" alt="Screenshot 2024-03-29 at 12 44 42 PM" src="https://github.com/zed-industries/zed/assets/1486634/8d7c1799-255f-4e01-8980-ccb19f49279a">


Release Notes:

- Fixed the vertical alignment of labels in the file tree to better align with the file icons.
