### PR TITLE
vim: Avoid removing keymap context when blurred

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -66,6 +66,17 @@ impl KeyBinding {
 impl RenderOnce for KeyBinding {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         h_flex()
+            .debug_selector(|| {
+                format!(
+                    "KEY_BINDING-{}",
+                    self.key_binding
+                        .keystrokes()
+                        .iter()
+                        .map(|k| k.key.to_string())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                )
+            })
             .flex_none()
             .gap_2()
             .children(self.key_binding.keystrokes().iter().map(|keystroke| {

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1038,3 +1038,12 @@ async fn test_undo(cx: &mut gpui::TestAppContext) {
         3"})
         .await;
 }
+
+#[gpui::test]
+async fn test_command_palette(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+    cx.simulate_keystroke(":");
+    cx.simulate_input("go to definition");
+    assert!(cx.debug_bounds("KEY_BINDING-f12").is_none());
+    assert!(cx.debug_bounds("KEY_BINDING-g d").is_some());
+}

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -23,8 +23,8 @@ use editor::{
     Editor, EditorEvent, EditorMode,
 };
 use gpui::{
-    actions, impl_actions, Action, AppContext, EntityId, Global, KeystrokeEvent, Subscription,
-    View, ViewContext, WeakView, WindowContext,
+    actions, impl_actions, Action, AppContext, EntityId, FocusableView, Global, KeystrokeEvent,
+    Subscription, View, ViewContext, WeakView, WindowContext,
 };
 use language::{CursorShape, Point, Selection, SelectionGoal, TransactionId};
 pub use mode_indicator::ModeIndicator;
@@ -700,6 +700,10 @@ impl Vim {
             editor.selections.line_mode = matches!(state.mode, Mode::VisualLine);
             if editor.is_focused(cx) {
                 editor.set_keymap_context_layer::<Self>(state.keymap_context_layer(), cx);
+            // disables vim if the rename editor is focused,
+            // but not if the command palette is open.
+            } else if editor.focus_handle(cx).contains_focused(cx) {
+                editor.remove_keymap_context_layer::<Self>(cx)
             }
         });
     }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -700,8 +700,6 @@ impl Vim {
             editor.selections.line_mode = matches!(state.mode, Mode::VisualLine);
             if editor.is_focused(cx) {
                 editor.set_keymap_context_layer::<Self>(state.keymap_context_layer(), cx);
-            } else {
-                editor.remove_keymap_context_layer::<Self>(cx);
             }
         });
     }


### PR DESCRIPTION

Release Notes:

- Fixes #4502 

Notes:
I removed this line of code which removes the vim keymap contexts when an editor is blurred.

https://github.com/zed-industries/zed/blob/16e6f5643cec67982a88bebee6d8d49537af7306/crates/vim/src/vim.rs#L703-L705

I tried whether the editor context would be poisoned when switching between two editors and disabling vim mode and switching back but the context looked normal. If this change is wrong, please advise. I could not find why this piece of code was required.

This fixes #4502 as the reason why keybinds did not show up was because the vim context was removed from the editor's keymap contexts. Other paths for a fix could be to filter out vim predicates when finding keybinds for actions but I believe that'd add unnecessary complexity.