### PR TITLE
Fix GitHub commit permalinks

### DIFF
--- a/crates/git/src/permalink.rs
+++ b/crates/git/src/permalink.rs
@@ -111,7 +111,7 @@ pub(crate) fn build_commit_permalink(params: BuildCommitPermalinkParams) -> Url 
     } = remote;
 
     let path = match provider {
-        GitHostingProvider::Github => format!("{owner}/{repo}/commits/{sha}"),
+        GitHostingProvider::Github => format!("{owner}/{repo}/commit/{sha}"),
         GitHostingProvider::Gitlab => format!("{owner}/{repo}/-/commit/{sha}"),
         GitHostingProvider::Gitee => format!("{owner}/{repo}/commit/{sha}"),
         GitHostingProvider::Bitbucket => format!("{owner}/{repo}/commits/{sha}"),


### PR DESCRIPTION
This PR fixes an issue where GitHub commit permalinks were being constructed with the wrong URL segment.

This would result in clicking on a commit from the Git blame view taking you to the wrong page on GitHub.

### Before

```
https://github.com/zed-industries/zed/commits/a3d985028ccce085e4f5a06694835cd9b3296dba
```

<img width="1654" alt="Screenshot 2024-03-29 at 12 59 51 PM" src="https://github.com/zed-industries/zed/assets/1486634/122fd678-de56-42cb-a0c5-1ce1b9b104b5">

### After

```
https://github.com/zed-industries/zed/commit/a3d985028ccce085e4f5a06694835cd9b3296dba
```

<img width="1654" alt="Screenshot 2024-03-29 at 12 59 56 PM" src="https://github.com/zed-industries/zed/assets/1486634/1c92b2ef-7925-46bc-aebf-b739be1eae74">

Release Notes:

- N/A
