### PR TITLE
tab_switcher: Add support for tab switcher in terminal panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9581,6 +9581,7 @@ dependencies = [
  "project",
  "serde",
  "serde_json",
+ "terminal_view",
  "theme",
  "ui",
  "util",

--- a/crates/tab_switcher/Cargo.toml
+++ b/crates/tab_switcher/Cargo.toml
@@ -15,6 +15,7 @@ gpui.workspace = true
 menu.workspace = true
 picker.workspace = true
 serde.workspace = true
+terminal_view.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -591,6 +591,9 @@ impl TerminalPanel {
 
         Some(())
     }
+    pub fn pane(&self) -> &View<Pane> {
+        &self.pane
+    }
 }
 
 async fn wait_for_terminals_tasks(


### PR DESCRIPTION
tab switcher retrieves active pane from workspace, but that function is not aware of Terminal Panel's pane. Thus in this PR we retrieve it manually and use it as the active pane if terminal panel has focus.

Release Notes:

- Fixed tab switcher not working in terminal panel.

