### PR TITLE
tab_switcher: Add tab close buttons

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -591,7 +591,10 @@
   },
   {
     "context": "TabSwitcher",
-    "bindings": { "ctrl-shift-tab": "menu::SelectPrev" }
+    "bindings": {
+      "ctrl-shift-tab": "menu::SelectPrev",
+      "ctrl-backspace": "tab_switcher::CloseSelectedItem"
+    }
   },
   {
     "context": "Terminal",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -608,7 +608,10 @@
   },
   {
     "context": "TabSwitcher",
-    "bindings": { "ctrl-shift-tab": "menu::SelectPrev" }
+    "bindings": {
+      "ctrl-shift-tab": "menu::SelectPrev",
+      "ctrl-backspace": "tab_switcher::CloseSelectedItem"
+    }
   },
   {
     "context": "Terminal",

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -49,6 +49,9 @@ pub trait PickerDelegate: Sized + 'static {
     fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Picker<Self>>);
 
     fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str>;
+    fn no_matches_text(&self, _cx: &mut WindowContext) -> Arc<str> {
+        "No matches".into()
+    }
     fn update_matches(&mut self, query: String, cx: &mut ViewContext<Picker<Self>>) -> Task<()>;
 
     // Delegates that support this method (e.g. the CommandPalette) can chose to block on any background
@@ -502,7 +505,9 @@ impl<D: PickerDelegate> Render for Picker<D> {
                             .inset(true)
                             .spacing(ListItemSpacing::Sparse)
                             .disabled(true)
-                            .child(Label::new("No matches").color(Color::Muted)),
+                            .child(
+                                Label::new(self.delegate.no_matches_text(cx)).color(Color::Muted),
+                            ),
                     ),
                 )
             })

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -49,7 +49,7 @@ pub trait PickerDelegate: Sized + 'static {
     fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Picker<Self>>);
 
     fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str>;
-    fn no_matches_text(&self, _cx: &mut WindowContext) -> Arc<str> {
+    fn no_matches_text(&self, _cx: &mut WindowContext) -> SharedString {
         "No matches".into()
     }
     fn update_matches(&mut self, query: String, cx: &mut ViewContext<Picker<Self>>) -> Task<()>;

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -256,7 +256,7 @@ impl PickerDelegate for TabSwitcherDelegate {
         "".into()
     }
 
-    fn no_matches_text(&self, _cx: &mut WindowContext) -> Arc<str> {
+    fn no_matches_text(&self, _cx: &mut WindowContext) -> SharedString {
         "No tabs".into()
     }
 

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -159,7 +159,7 @@ impl TabSwitcherDelegate {
                         let selected_item_id = picker.delegate.selected_item_id();
                         picker.delegate.update_matches(cx);
                         if let Some(item_id) = selected_item_id {
-                            picker.delegate.select_item_id(item_id, cx);
+                            picker.delegate.select_item(item_id, cx);
                         }
                         cx.notify();
                     })
@@ -222,7 +222,7 @@ impl TabSwitcherDelegate {
             .map(|tab_match| tab_match.item.item_id())
     }
 
-    fn select_item_id(
+    fn select_item(
         &mut self,
         item_id: EntityId,
         cx: &mut ViewContext<'_, Picker<TabSwitcherDelegate>>,
@@ -254,6 +254,10 @@ impl PickerDelegate for TabSwitcherDelegate {
 
     fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
         "".into()
+    }
+
+    fn no_matches_text(&self, _cx: &mut WindowContext) -> Arc<str> {
+        "No tabs".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -353,7 +353,7 @@ impl PickerDelegate for TabSwitcherDelegate {
                 .inset(true)
                 .selected(selected)
                 .child(h_flex().w_full().child(label))
-                .when(true, |el| {
+                .map(|el| {
                     if self.selected_index == ix {
                         el.end_slot::<AnyElement>(close_button)
                     } else {

--- a/crates/tab_switcher/src/tab_switcher_tests.rs
+++ b/crates/tab_switcher/src/tab_switcher_tests.rs
@@ -214,7 +214,6 @@ async fn test_close_selected_item(cx: &mut gpui::TestAppContext) {
 
     cx.simulate_modifiers_change(Modifiers::control());
     cx.dispatch_action(CloseSelectedItem);
-    cx.run_until_parked();
     tab_switcher.update(cx, |tab_switcher, _| {
         assert_eq!(tab_switcher.delegate.matches.len(), 1);
         assert_match_selection(tab_switcher, 0, tab_2);

--- a/crates/tab_switcher/src/tab_switcher_tests.rs
+++ b/crates/tab_switcher/src/tab_switcher_tests.rs
@@ -183,6 +183,52 @@ async fn test_open_with_single_item(cx: &mut gpui::TestAppContext) {
     });
 }
 
+#[gpui::test]
+async fn test_close_selected_item(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            "/root",
+            json!({
+                "1.txt": "First file",
+                "2.txt": "Second file",
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), ["/root".as_ref()], cx).await;
+    let (workspace, cx) = cx.add_window_view(|cx| Workspace::test_new(project.clone(), cx));
+
+    let tab_1 = open_buffer("1.txt", &workspace, cx).await;
+    let tab_2 = open_buffer("2.txt", &workspace, cx).await;
+
+    cx.simulate_modifiers_change(Modifiers::control());
+    let tab_switcher = open_tab_switcher(false, &workspace, cx);
+    tab_switcher.update(cx, |tab_switcher, _| {
+        assert_eq!(tab_switcher.delegate.matches.len(), 2);
+        assert_match_at_position(tab_switcher, 0, tab_2.boxed_clone());
+        assert_match_selection(tab_switcher, 1, tab_1.boxed_clone());
+    });
+
+    cx.simulate_modifiers_change(Modifiers::control());
+    cx.dispatch_action(CloseSelectedItem);
+    cx.run_until_parked();
+    tab_switcher.update(cx, |tab_switcher, _| {
+        assert_eq!(tab_switcher.delegate.matches.len(), 1);
+        assert_match_selection(tab_switcher, 0, tab_2);
+    });
+
+    // Still switches tab on modifiers release
+    cx.simulate_modifiers_change(Modifiers::none());
+    cx.read(|cx| {
+        let active_editor = workspace.read(cx).active_item_as::<Editor>(cx).unwrap();
+        assert_eq!(active_editor.read(cx).title(cx), "2.txt");
+    });
+    assert_tab_switcher_is_closed(workspace, cx);
+}
+
 fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
     cx.update(|cx| {
         let state = AppState::test(cx);

--- a/crates/ui/src/components/indicator.rs
+++ b/crates/ui/src/components/indicator.rs
@@ -13,7 +13,7 @@ pub enum IndicatorStyle {
 pub struct Indicator {
     position: Position,
     style: IndicatorStyle,
-    color: Color,
+    pub color: Color,
 }
 
 impl Indicator {


### PR DESCRIPTION
Support for closing tabs from Tab Switcher:

- Close button color matches the indicator color to preserve the information that the buffer is dirty (as in SublimeText).
- `ctrl-backspace` closes the currently selected item.

https://github.com/zed-industries/zed/assets/2101250/8ea33911-2f62-4199-826d-c17556db8e9a
