### PR TITLE
Add default keybinding for ToggleGitBlame

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -138,7 +138,8 @@
       // ],
       "ctrl-alt-space": "editor::ShowCharacterPalette",
       "ctrl-;": "editor::ToggleLineNumbers",
-      "ctrl-k ctrl-r": "editor::RevertSelectedHunks"
+      "ctrl-k ctrl-r": "editor::RevertSelectedHunks",
+      "ctrl-alt-g b": "editor::ToggleGitBlame"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -158,7 +158,8 @@
       ],
       "ctrl-cmd-space": "editor::ShowCharacterPalette",
       "cmd-;": "editor::ToggleLineNumbers",
-      "cmd-alt-z": "editor::RevertSelectedHunks"
+      "cmd-alt-z": "editor::RevertSelectedHunks",
+      "cmd-alt-g b": "editor::ToggleGitBlame"
     }
   },
   {


### PR DESCRIPTION
I already want to have quicker access to this feature. This matches the binding that [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) uses in VS Code to toggle the blame view. I'm unable to test on Linux, but seems ok to ship.

<img width="595" alt="SCR-20240329-osix" src="https://github.com/zed-industries/zed/assets/19867440/567c7bf6-fe88-4df9-95b8-16228fa9067f">

Release Notes:

- Added default keybinding (`cmd-alt-g b`) for `editor: toggle git blame`.