### PR TITLE
toml: Sync `Cargo.toml` version with `extension.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12724,7 +12724,7 @@ dependencies = [
 
 [[package]]
 name = "zed_toml"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/toml/Cargo.toml
+++ b/extensions/toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_toml"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"


### PR DESCRIPTION
This PR syncs the version number in the `Cargo.toml` with the one in `extension.toml` for the `toml` extension, since they had gotten out-of-sync.

Release Notes:

- N/A
