### PR TITLE
Use hard tabs for Makefiles

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -560,6 +560,9 @@
         "source.organizeImports": true
       }
     },
+    "Make": {
+      "hard_tabs": true
+    },
     "Markdown": {
       "tab_size": 2,
       "soft_wrap": "preferred_line_length"


### PR DESCRIPTION
If you use soft tabs by default, editing Makefiles will be broken as they require tab indentation to parse correctly.

Release Notes;

- Changed default settings for `Makefile`s to use hard tabs.