### PR TITLE
Allow users to configure ESLint's `problems` settings

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -273,6 +273,17 @@ impl LspAdapter for EsLintLspAdapter {
             }
         }
 
+        let mut problems = json!({});
+
+        if let Some(problems_settings) = eslint_user_settings
+            .get("problems")
+            .and_then(|settings| settings.as_object())
+        {
+            if let Some(shorten_to_single_line) = problems_settings.get("shortenToSingleLine") {
+                problems["shortenToSingleLine"] = shorten_to_single_line.clone();
+            }
+        }
+
         let node_path = eslint_user_settings.get("nodePath").unwrap_or(&Value::Null);
         let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
             .iter()
@@ -290,7 +301,7 @@ impl LspAdapter for EsLintLspAdapter {
                     "name": workspace_root.file_name()
                         .unwrap_or_else(|| workspace_root.as_os_str()),
                 },
-                "problems": {},
+                "problems": problems,
                 "codeActionOnSave": code_action_on_save,
                 "experimental": {
                     "useFlatConfig": use_flat_config,

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -273,16 +273,10 @@ impl LspAdapter for EsLintLspAdapter {
             }
         }
 
-        let mut problems = json!({});
-
-        if let Some(problems_settings) = eslint_user_settings
+        let problems = eslint_user_settings
             .get("problems")
-            .and_then(|settings| settings.as_object())
-        {
-            if let Some(shorten_to_single_line) = problems_settings.get("shortenToSingleLine") {
-                problems["shortenToSingleLine"] = shorten_to_single_line.clone();
-            }
-        }
+            .cloned()
+            .unwrap_or_else(|| json!({}));
 
         let node_path = eslint_user_settings.get("nodePath").unwrap_or(&Value::Null);
         let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -85,3 +85,21 @@ You can configure ESLint's `nodePath` setting (requires Zed `0.127.0`):
   }
 }
 ```
+
+#### Configure ESLint's `problems.shortenToSingleLine`:
+
+You can configure ESLint's `problems.shortenToSingleLine` setting (requires Zed `0.129.2`):
+
+```json
+{
+  "lsp": {
+    "eslint": {
+      "settings": {
+        "problems": {
+          "shortenToSingleLine": true
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -88,7 +88,7 @@ You can configure ESLint's `nodePath` setting (requires Zed `0.127.0`):
 
 #### Configure ESLint's `problems.shortenToSingleLine`:
 
-You can configure ESLint's `problems.shortenToSingleLine` setting (requires Zed `0.129.2`):
+You can configure ESLint's `problems.shortenToSingleLine` setting (requires Zed `0.130.x`):
 
 ```json
 {


### PR DESCRIPTION
Presently the only available setting under `problems` is `shortenToSingleLine`, which defaults to `false`.

Example Zed `settings.json` to shorten eslint error squiggles to only show on the first line of the problem:
```json
{
    "lsp": {
        "eslint": {
            "settings": {
                "problems": {
                    "shortenToSingleLine": true
                }
            }
        }
    }
}
```


Release Notes:

- Added support for configuring ESLint `problems` settings, ie. `{"lsp": {"eslint": {"settings": {"problems": {"shortenToSingleLine": true}}}}}`

Demo:


https://github.com/zed-industries/zed/assets/2072378/379faa75-1f37-4fd1-85da-1510f1397d07

