### PR TITLE
gpui: Make SVGs render at the correct size

### DIFF
--- a/crates/gpui/src/asset_cache.rs
+++ b/crates/gpui/src/asset_cache.rs
@@ -25,6 +25,15 @@ impl From<Arc<PathBuf>> for UriOrPath {
     }
 }
 
+impl AsRef<str> for UriOrPath {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Uri(uri) => uri.as_ref(),
+            Self::Path(path) => path.as_ref().to_str().unwrap(),
+        }
+    }
+}
+
 /// A trait for asynchronous asset loading.
 pub trait Asset {
     /// The source of the asset.

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -205,7 +205,7 @@ impl<C: RenderOnce> IntoElement for Component<C> {
 
 /// A globally unique identifier for an element, used to track state across frames.
 #[derive(Deref, DerefMut, Default, Clone, Debug, Eq, PartialEq, Hash)]
-pub(crate) struct GlobalElementId(SmallVec<[ElementId; 32]>);
+pub struct GlobalElementId(SmallVec<[ElementId; 32]>);
 
 trait ElementObject {
     fn inner_element(&mut self) -> &mut dyn Any;

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -17,10 +17,6 @@ pub(crate) struct SvgRenderer {
     asset_source: Arc<dyn AssetSource>,
 }
 
-pub enum SvgSize {
-    Size(Size<DevicePixels>),
-}
-
 impl SvgRenderer {
     pub fn new(asset_source: Arc<dyn AssetSource>) -> Self {
         Self { asset_source }
@@ -35,7 +31,7 @@ impl SvgRenderer {
         let bytes = self.asset_source.load(&params.path)?;
 
         let tree = self.tree(&bytes)?;
-        let pixmap = self.render_pixmap(&tree, SvgSize::Size(params.size))?;
+        let pixmap = self.render_pixmap(&tree, params.size)?;
 
         // Convert the pixmap's pixels into an alpha mask.
         let alpha_mask = pixmap
@@ -53,12 +49,8 @@ impl SvgRenderer {
     pub fn render_pixmap(
         &self,
         tree: &resvg::usvg::Tree,
-        size: SvgSize,
-    ) -> Result<Pixmap, resvg::usvg::Error> {
-        let size = match size {
-            SvgSize::Size(size) => size,
-        };
-
+        size: Size<DevicePixels>,
+    ) -> Result<Pixmap> {
         let ratio = size.width.0 as f32 / tree.size().width();
 
         // Render the SVG to a pixmap with the specified width and height.
@@ -66,7 +58,7 @@ impl SvgRenderer {
             (tree.size().width() * ratio) as u32,
             (tree.size().height() * ratio) as u32,
         )
-        .unwrap();
+        .ok_or_else(|| anyhow!("zero size pixmap"))?;
 
         resvg::render(
             &tree,


### PR DESCRIPTION
in #9931 @mikayla-maki removed some code that already achieved this, but in a very memory-leaky fashion. This one now only keeps a single rasterized SVG size per element. To achieve this I made the asset_loading abortable and reintroduced the RasterOrVector Asset.

Before:
<img width="997" alt="image" src="https://github.com/zed-industries/zed/assets/50196894/513c5fb7-5eb7-4f39-8b77-e71399ee3623">


After:
<img width="997" alt="image" src="https://github.com/zed-industries/zed/assets/50196894/54d1c81b-99f6-46a9-9186-eeadce3d0510">


