### PR TITLE
Check license generation for every PR to avoid license-less crate additions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Check unused dependencies
         uses: bnjbvr/cargo-machete@main
 
+      - name: Check license generation
+        run: script/generate-licenses /tmp/zed_licenses_output
+
       - name: Ensure fresh merge
         shell: bash -euxo pipefail {0}
         run: |

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -2,8 +2,8 @@
 name = "anthropic"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
+license = "AGPL-3.0-or-later"
 
 [lib]
 path = "src/anthropic.rs"

--- a/crates/anthropic/LICENSE-AGPL
+++ b/crates/anthropic/LICENSE-AGPL
@@ -1,0 +1,1 @@
+../../LICENSE-AGPL

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-OUTPUT_FILE=$(pwd)/assets/licenses.md
+OUTPUT_FILE="${1:-$(pwd)/assets/licenses.md}"
 
 > $OUTPUT_FILE
 


### PR DESCRIPTION
Also fix `anthropic` crate and make it AGPL-licensed, as it's used in the AGPL-licensed collab part only.

Release Notes:

- N/A
