### PR TITLE
channel chat: Set first loaded message ID when sending a message

### DIFF
--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -222,6 +222,9 @@ impl ChannelChat {
             let message = ChannelMessage::from_proto(response, &user_store, &mut cx).await?;
             this.update(&mut cx, |this, cx| {
                 this.insert_messages(SumTree::from_item(message, &()), cx);
+                if this.first_loaded_message_id.is_none() {
+                    this.first_loaded_message_id = Some(id);
+                }
             })?;
             Ok(id)
         }))


### PR DESCRIPTION
Discovered while looking into #10024.

When clicking on a reply message text, the original message should be highlighted accordingly. However this would not work when the channel was just created and the user is the only one that sent messages.
 
Release Notes:

- Fixed highlighting of messages when clicking on the reply message text in the chat and there were no other messages from other users
