### PR TITLE
Fix panel drag leaking through overlay

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2773,6 +2773,7 @@ impl Render for CollabPanel {
                         .anchor(gpui::AnchorCorner::TopLeft)
                         .child(menu.clone()),
                 )
+                .with_priority(1)
             }))
     }
 }

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -408,11 +408,14 @@ impl PickerDelegate for ChannelModalDelegate {
                             .when(is_me, |el| el.child(Label::new("You").color(Color::Muted)))
                             .children(
                                 if let (Some((menu, _)), true) = (&self.context_menu, selected) {
-                                    Some(deferred(
-                                        anchored()
-                                            .anchor(gpui::AnchorCorner::TopRight)
-                                            .child(menu.clone()),
-                                    ))
+                                    Some(
+                                        deferred(
+                                            anchored()
+                                                .anchor(gpui::AnchorCorner::TopRight)
+                                                .child(menu.clone()),
+                                        )
+                                        .with_priority(1),
+                                    )
                                 } else {
                                     None
                                 },

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1812,6 +1812,7 @@ impl EditorElement {
                 .anchor(AnchorCorner::TopLeft)
                 .snap_to_window(),
         )
+        .with_priority(1)
         .into_any();
 
         element.layout(gpui::Point::default(), AvailableSpace::min_size(), cx);

--- a/crates/gpui/src/elements/deferred.rs
+++ b/crates/gpui/src/elements/deferred.rs
@@ -15,6 +15,15 @@ pub struct Deferred {
     priority: usize,
 }
 
+impl Deferred {
+    /// The `priority` parameter determines the drawing order relative to other deferred elements,
+    /// with higher values being drawn on top.
+    pub fn with_priority(mut self, priority: usize) -> Self {
+        self.priority = priority;
+        self
+    }
+}
+
 impl Element for Deferred {
     type BeforeLayout = ();
     type AfterLayout = ();

--- a/crates/gpui/src/elements/deferred.rs
+++ b/crates/gpui/src/elements/deferred.rs
@@ -16,7 +16,8 @@ pub struct Deferred {
 }
 
 impl Deferred {
-    /// The `priority` parameter determines the drawing order relative to other deferred elements,
+    /// Sets the `priority` value of the `deferred` element, which
+    /// determines the drawing order relative to other deferred elements,
     /// with higher values being drawn on top.
     pub fn with_priority(mut self, priority: usize) -> Self {
         self.priority = priority;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1590,6 +1590,7 @@ impl Render for ProjectPanel {
                             .anchor(gpui::AnchorCorner::TopLeft)
                             .child(menu.clone()),
                     )
+                    .with_priority(1)
                 }))
         } else {
             v_flex()

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -771,6 +771,7 @@ impl Render for TerminalView {
                         .anchor(gpui::AnchorCorner::TopLeft)
                         .child(menu.clone()),
                 )
+                .with_priority(1)
             }))
     }
 }

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -182,8 +182,9 @@ impl<M: ManagedView> Element for PopoverMenu<M> {
                         this.resolved_attach().corner(child_bounds) + this.resolved_offset(cx),
                     );
                 }
-                let mut element =
-                    deferred(anchored.child(div().occlude().child(menu.clone()))).into_any();
+                let mut element = deferred(anchored.child(div().occlude().child(menu.clone())))
+                    .with_priority(1)
+                    .into_any();
 
                 menu_layout_id = Some(element.before_layout(cx));
                 element

--- a/crates/ui/src/components/right_click_menu.rs
+++ b/crates/ui/src/components/right_click_menu.rs
@@ -110,8 +110,9 @@ impl<M: ManagedView> Element for RightClickMenu<M> {
                 }
                 anchored = anchored.position(*element_state.position.borrow());
 
-                let mut element =
-                    deferred(anchored.child(div().occlude().child(menu.clone()))).into_any();
+                let mut element = deferred(anchored.child(div().occlude().child(menu.clone())))
+                    .with_priority(1)
+                    .into_any();
 
                 menu_layout_id = Some(element.before_layout(cx));
                 element

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1562,16 +1562,14 @@ impl Pane {
     }
 
     fn render_menu_overlay(menu: &View<ContextMenu>) -> Div {
-        div()
-            .absolute()
-            .bottom_0()
-            .right_0()
-            .size_0()
-            .child(deferred(
+        div().absolute().bottom_0().right_0().size_0().child(
+            deferred(
                 anchored()
                     .anchor(AnchorCorner::TopRight)
                     .child(menu.clone()),
-            ))
+            )
+            .with_priority(1),
+        )
     }
 
     pub fn set_zoomed(&mut self, zoomed: bool, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
Closes #10017. While reworking the `overlay` element in #9911, I did not realize that all overlay elements called `defer_draw` with a priority of `1`.

/cc @as-cii 

Not including release notes, since it was only present in nightly.

Release Notes:

- N/A
