### PR TITLE
Remove git diff base from symlinked files

### DIFF
--- a/crates/fs/src/repository.rs
+++ b/crates/fs/src/repository.rs
@@ -25,6 +25,9 @@ pub struct Branch {
 
 pub trait GitRepository: Send {
     fn reload_index(&self);
+
+    /// Loads a git repository entry's contents.
+    /// Note that for symlink entries, this will return the contents of the symlink, not the target.
     fn load_index_text(&self, relative_file_path: &Path) -> Option<String>;
 
     /// Returns the URL of the remote with the given name.


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/4730
![image](https://github.com/zed-industries/zed/assets/2690773/d3c5317f-8120-45b5-b57c-c0fb5d8c066d)

To the left is a symlink, to the right — the real file.
The issue was due to the fact, that symlinks files contain the file path to the real file, and git (properly) treats that symlink file contents as diff base, returning in `load_index_text` (via `let content = repo.find_blob(oid)?.content().to_owned();`) the contents of that symlink file — the path.

The fix checks for FS metadata before fetching the git diff base, and skips it entirely for symlinks: Zed opens the symlink file contents instead, fully obscuring the git symlink diff hunks.

Interesting, that VSCode behaves as Zed before the fix; while the fix makes Zed behave like Intellij* IDEs now.

Release Notes:

- Fixed git diff hunks appearing in the symlinked files ([4730](https://github.com/zed-industries/zed/issues/4730))