### PR TITLE
Revert "Fix key repeat after releasing a different key on Wayland"

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -796,12 +796,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientState {
                             })
                         };
 
-                        if !keysym.is_modifier_key()
-                            && (match state.repeat.current_keysym {
-                                Some(repeat_keysym) => keysym == repeat_keysym,
-                                None => false,
-                            })
-                        {
+                        if !keysym.is_modifier_key() {
                             state.repeat.current_keysym = None;
                         }
 


### PR DESCRIPTION
Reverts zed-industries/zed#9768

That change didn't seem necessary and it made symbols that need a key shortcut to be written (e.g. SHIFT + 2 for a quote)  infinitely repeat.
 
Release Notes:

- N/A
