### PR TITLE
Hoist `profile.dev.package` setting to workspace-level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,6 +394,7 @@ debug = "limited"
 [profile.dev.package]
 taffy = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }
+resvg = { opt-level = 3 }
 rustybuzz = { opt-level = 3 }
 ttf-parser = { opt-level = 3 }
 wasmtime-cranelift = { opt-level = 3 }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -72,9 +72,6 @@ util.workspace = true
 uuid = { version = "1.1.2", features = ["v4", "v5"] }
 waker-fn = "1.1.0"
 
-[profile.dev.package]
-resvg = { opt-level = 3 }
-
 [dev-dependencies]
 backtrace = "0.3"
 collections = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
This PR hoists the `profile.dev.package` settings for compiling the `resvg` crate with optimizations up to the workspace level, since Cargo was complaining:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/maxdeviant/projects/zed/crates/gpui/Cargo.toml
workspace: /Users/maxdeviant/projects/zed/Cargo.toml
```

Release Notes:

- N/A
