### PR TITLE
Skip `.DS_Store` files when looking for extension directories

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -1107,6 +1107,14 @@ impl ExtensionStore {
                     let Ok(extension_dir) = extension_dir else {
                         continue;
                     };
+
+                    if extension_dir
+                        .file_name()
+                        .map_or(false, |file_name| file_name == ".DS_Store")
+                    {
+                        continue;
+                    }
+
                     Self::add_extension_to_index(fs.clone(), extension_dir, &mut index)
                         .await
                         .log_err();


### PR DESCRIPTION
This PR makes it so `.DS_Store` files are skipped when trying to load extension directories.

Previously it would fail and log an error.

Release Notes:

- Fixed an issue where the presence of a `.DS_Store` file in the extensions directory would produce an error in the logs.
