### PR TITLE
Use "install" to refer to extension installation process

### DIFF
--- a/crates/extension_api/README.md
+++ b/crates/extension_api/README.md
@@ -52,5 +52,5 @@ zed::register_extension!(MyExtension);
 To run your extension in Zed as you're developing it:
 
 - Open the extensions view using the `zed: extensions` action in the command palette.
-- Click the `Add Dev Extension` button in the top right
+- Click the `Install Dev Extension` button in the top right
 - Choose the path to your extension directory.

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -818,7 +818,7 @@ impl Render for ExtensionsPage {
                             .justify_between()
                             .child(Headline::new("Extensions").size(HeadlineSize::XLarge))
                             .child(
-                                Button::new("add-dev-extension", "Install Dev Extension")
+                                Button::new("install-dev-extension", "Install Dev Extension")
                                     .style(ButtonStyle::Filled)
                                     .size(ButtonSize::Large)
                                     .on_click(|_event, cx| {

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -818,7 +818,7 @@ impl Render for ExtensionsPage {
                             .justify_between()
                             .child(Headline::new("Extensions").size(HeadlineSize::XLarge))
                             .child(
-                                Button::new("add-dev-extension", "Add Dev Extension")
+                                Button::new("add-dev-extension", "Install Dev Extension")
                                     .style(ButtonStyle::Filled)
                                     .size(ButtonSize::Large)
                                     .on_click(|_event, cx| {


### PR DESCRIPTION

Release Notes:

- Improved discoverability of dev extension installation action ([#10048](https://github.com/zed-industries/zed/issues/10048)).
