### PR TITLE
linux: remap command modifiers to control

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -461,7 +461,7 @@ impl EditorElement {
             let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
             let multi_cursor_modifier = match multi_cursor_setting {
                 MultiCursorModifier::Alt => modifiers.alt,
-                MultiCursorModifier::Cmd => modifiers.command,
+                MultiCursorModifier::Cmd => modifiers.cmd_or_ctrl_held(),
             };
             editor.select(
                 SelectPhase::Begin {
@@ -513,7 +513,7 @@ impl EditorElement {
 
         let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
         let multi_cursor_modifier = match multi_cursor_setting {
-            MultiCursorModifier::Alt => event.modifiers.command,
+            MultiCursorModifier::Alt => event.modifiers.cmd_or_ctrl_held(),
             MultiCursorModifier::Cmd => event.modifiers.alt,
         };
 

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -93,7 +93,7 @@ impl Editor {
         modifiers: Modifiers,
         cx: &mut ViewContext<Self>,
     ) {
-        if !modifiers.command || self.has_pending_selection() {
+        if !modifiers.cmd_or_ctrl_held() || self.has_pending_selection() {
             self.hide_hovered_link(cx);
             return;
         }
@@ -113,7 +113,7 @@ impl Editor {
                     &snapshot,
                     point_for_position,
                     self,
-                    modifiers.command,
+                    modifiers.cmd_or_ctrl_held(),
                     modifiers.shift,
                     cx,
                 );

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -200,6 +200,16 @@ impl Modifiers {
         self.control || self.alt || self.shift || self.command || self.function
     }
 
+    /// Checks whether the command key is held (on macOS) or
+    /// if the control key is held (on any other platform)
+    pub fn cmd_or_ctrl_held(&self) -> bool {
+        if cfg!(macos) {
+            self.command
+        } else {
+            self.control
+        }
+    }
+
     /// helper method for Modifiers with no modifiers
     pub fn none() -> Modifiers {
         Default::default()

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -418,7 +418,7 @@ impl<D: PickerDelegate> Picker<D> {
             .id(("item", ix))
             .cursor_pointer()
             .on_click(cx.listener(move |this, event: &ClickEvent, cx| {
-                this.handle_click(ix, event.down.modifiers.command, cx)
+                this.handle_click(ix, event.down.modifiers.cmd_or_ctrl_held(), cx)
             }))
             // As of this writing, GPUI intercepts `ctrl-[mouse-event]`s on macOS
             // and produces right mouse button events. This matches platforms norms
@@ -427,7 +427,7 @@ impl<D: PickerDelegate> Picker<D> {
             .on_mouse_up(
                 MouseButton::Right,
                 cx.listener(move |this, event: &MouseUpEvent, cx| {
-                    this.handle_click(ix, event.modifiers.command, cx)
+                    this.handle_click(ix, event.modifiers.cmd_or_ctrl_held(), cx)
                 }),
             )
             .children(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1456,7 +1456,7 @@ impl ProjectPanel {
                             if kind.is_dir() {
                                 this.toggle_expanded(entry_id, cx);
                             } else {
-                                if event.down.modifiers.command {
+                                if event.down.modifiers.cmd_or_ctrl_held() {
                                     this.split_entry(entry_id, cx);
                                 } else {
                                     this.open_entry(entry_id, event.up.click_count > 1, cx);


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/9237

An unrelated issue I noticed is that the cursor icon doesn't update until we manually move it (Wayland)
On X11, we don't even change the cursor.

Release Notes:

- N/A
