### PR TITLE
Add Tailwind autocomplete for Vue

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -312,7 +312,10 @@ pub fn init(
     language!("ocaml-interface", vec![Arc::new(ocaml::OCamlLspAdapter)]);
     language!(
         "vue",
-        vec![Arc::new(vue::VueLspAdapter::new(node_runtime.clone()))]
+        vec![
+            Arc::new(vue::VueLspAdapter::new(node_runtime.clone())),
+            Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
+        ]
     );
     language!("proto");
     language!("terraform", vec![Arc::new(terraform::TerraformLspAdapter)]);

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -127,6 +127,7 @@ impl LspAdapter for TailwindLspAdapter {
             ("HEEX".to_string(), "phoenix-heex".to_string()),
             ("ERB".to_string(), "erb".to_string()),
             ("PHP".to_string(), "php".to_string()),
+            ("Vue.js".to_string(), "vue".to_string()),
         ])
     }
 }

--- a/crates/languages/src/vue/config.toml
+++ b/crates/languages/src/vue/config.toml
@@ -14,4 +14,9 @@ brackets = [
     { start = "`", end = "`", close = true, newline = false, not_in = ["string"] },
 ]
 word_characters = ["-"]
+scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "vue"
+
+[overrides.string]
+word_characters = ["-"]
+opt_into_language_servers = ["tailwindcss-language-server"]

--- a/crates/languages/src/vue/overrides.scm
+++ b/crates/languages/src/vue/overrides.scm
@@ -1,0 +1,7 @@
+(comment) @comment
+
+[
+  (raw_text)
+  (attribute_value)
+  (quoted_attribute_value)
+] @string


### PR DESCRIPTION
This fixes #4403 by adding TailwindLsp to .vue files too and autocomplete aswell

![image](https://github.com/zed-industries/zed/assets/49145060/8b06a478-cade-4cbc-9da7-f31f5197f304)

Release Notes:

- Added Tailwind support in `.vue` files ([#4403](https://github.com/zed-industries/zed/issues/4403)).
