### PR TITLE
Make conversions to `wasmtime::Result` postfix-friendly

### DIFF
--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -119,3 +119,13 @@ impl Extension {
         }
     }
 }
+
+trait ToWasmtimeResult<T> {
+    fn to_wasmtime_result(self) -> wasmtime::Result<Result<T, String>>;
+}
+
+impl<T> ToWasmtimeResult<T> for Result<T> {
+    fn to_wasmtime_result(self) -> wasmtime::Result<Result<T, String>> {
+        Ok(self.map_err(|error| error.to_string()))
+    }
+}


### PR DESCRIPTION
This PR refactors the conversions to `wasmtime::Result` to use a trait so that we can perform the conversions in a postfix-friendly way.

Release Notes:

- N/A
