### PR TITLE
Suppress typos in `basic.conf`

### DIFF
--- a/script/squawk
+++ b/script/squawk
@@ -17,7 +17,9 @@ SQUAWK_ARGS="--assume-in-transaction --config script/lib/squawk.toml"
 
 if  [ ! -f "$SQUAWK_BIN" ]; then
   pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto || /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+  ls "./target"
   curl -L -o "$SQUAWK_BIN" "https://github.com/sbdchd/squawk/releases/download/v$SQUAWK_VERSION/squawk-darwin-x86_64"
+  ls "./target"
   chmod +x "$SQUAWK_BIN"
 fi
 

--- a/script/squawk
+++ b/script/squawk
@@ -17,9 +17,9 @@ SQUAWK_ARGS="--assume-in-transaction --config script/lib/squawk.toml"
 
 if  [ ! -f "$SQUAWK_BIN" ]; then
   pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto || /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-  ls "./target"
+  # When bootstrapping a brand new CI machine, the `target` directory may not exist yet.
+  mkdir -p "./target"
   curl -L -o "$SQUAWK_BIN" "https://github.com/sbdchd/squawk/releases/download/v$SQUAWK_VERSION/squawk-darwin-x86_64"
-  ls "./target"
   chmod +x "$SQUAWK_BIN"
 fi
 

--- a/typos.toml
+++ b/typos.toml
@@ -17,8 +17,10 @@ extend-exclude = [
     "crates/editor/src/editor_tests.rs",
     # Clojure uses .edn filename extension, which is not a misspelling of "end"
     "extensions/clojure/languages/clojure/config.toml",
-    # Windows likes it's abbreviations
+    # Windows likes its abbreviations
     "crates/gpui/src/platform/windows/",
+    # False positive in one of the configuration values.
+    "crates/collab/basic.conf"
 ]
 
 [default]


### PR DESCRIPTION
This PR updates the `typos` configuration to suppress some typos in `basic.conf`.

AFAICT there must have been an update to `typos` that caused this new warning to appear.

Release Notes:

- N/A
