### PR TITLE
Add `crate` keyword to Rust

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -70,11 +70,11 @@
   "else"
   "enum"
   "extern"
-  "for"
   "fn"
+  "for"
   "if"
-  "in"
   "impl"
+  "in"
   "let"
   "loop"
   "macro_rules!"
@@ -88,11 +88,12 @@
   "struct"
   "trait"
   "type"
+  "union"
+  "unsafe"
   "use"
   "where"
   "while"
-  "union"
-  "unsafe"
+  (crate)
   (mutable_specifier)
   (super)
 ] @keyword


### PR DESCRIPTION

Release Notes:

- Added `crate` keyword to Rust

Ref: #10104 

And I make a sort for them.