### PR TITLE
Query code actions and hovers from all related local language servers (from remote clients)

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -368,6 +368,7 @@ impl Server {
             .add_request_handler(forward_mutating_project_request::<proto::OnTypeFormatting>)
             .add_request_handler(forward_mutating_project_request::<proto::SaveBuffer>)
             .add_request_handler(forward_mutating_project_request::<proto::BlameBuffer>)
+            .add_request_handler(forward_mutating_project_request::<proto::MultiLspQuery>)
             .add_message_handler(create_buffer_for_peer)
             .add_request_handler(update_buffer)
             .add_message_handler(broadcast_project_message_from_host::<proto::RefreshInlayHints>)

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -117,6 +117,7 @@ pub(crate) struct GetDocumentHighlights {
     pub position: PointUtf16,
 }
 
+#[derive(Clone)]
 pub(crate) struct GetHover {
     pub position: PointUtf16,
 }
@@ -125,6 +126,7 @@ pub(crate) struct GetCompletions {
     pub position: PointUtf16,
 }
 
+#[derive(Clone)]
 pub(crate) struct GetCodeActions {
     pub range: Range<Anchor>,
     pub kinds: Option<Vec<lsp::CodeActionKind>>,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -463,7 +463,7 @@ pub enum HoverBlockKind {
     Code { language: String },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Hover {
     pub contents: Vec<HoverBlock>,
     pub range: Option<Range<language::Anchor>>,

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -4484,10 +4484,12 @@ async fn test_multiple_language_server_hovers(cx: &mut gpui::TestAppContext) {
 
     let mut servers_with_hover_requests = HashMap::default();
     for i in 0..language_server_names.len() {
-        let new_server = fake_tsx_language_servers
-            .next()
-            .await
-            .unwrap_or_else(|| panic!("Failed to get language server #{i}"));
+        let new_server = fake_tsx_language_servers.next().await.unwrap_or_else(|| {
+            panic!(
+                "Failed to get language server #{i} with name {}",
+                &language_server_names[i]
+            )
+        });
         let new_server_name = new_server.server.name();
         assert!(
             !servers_with_hover_requests.contains_key(new_server_name),
@@ -4706,10 +4708,12 @@ async fn test_multiple_language_server_actions(cx: &mut gpui::TestAppContext) {
 
     let mut servers_with_actions_requests = HashMap::default();
     for i in 0..language_server_names.len() {
-        let new_server = fake_tsx_language_servers
-            .next()
-            .await
-            .unwrap_or_else(|| panic!("Failed to get language server #{i}"));
+        let new_server = fake_tsx_language_servers.next().await.unwrap_or_else(|| {
+            panic!(
+                "Failed to get language server #{i} with name {}",
+                &language_server_names[i]
+            )
+        });
         let new_server_name = new_server.server.name();
         assert!(
             !servers_with_actions_requests.contains_key(new_server_name),

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -209,8 +209,11 @@ message Envelope {
 
         BlameBuffer blame_buffer = 172;
         BlameBufferResponse blame_buffer_response = 173;
-        
-        UpdateNotification update_notification = 174;  // current max
+
+        UpdateNotification update_notification = 174;
+
+        QueryAllLsp query_all_lsp = 175;
+        QueryAllLspResponse query_all_lsp_response = 176; // current max
     }
 
     reserved 158 to 161;
@@ -1837,4 +1840,25 @@ message BlameBufferResponse {
     repeated BlameEntry entries = 1;
     repeated CommitMessage messages = 2;
     repeated CommitPermalink permalinks = 3;
+}
+
+message QueryAllLsp {
+    oneof strategy {
+        AllLanguageServers all = 1;
+    }
+    oneof request {
+        GetHover get_hover = 2;
+        GetCodeActions get_code_actions = 3;
+    }
+}
+
+message AllLanguageServers {}
+
+message QueryAllLspResponse {
+    repeated LspResponse responses = 1;
+}
+
+message LspResponse {
+    GetHoverResponse get_hover_response = 1;
+    GetCodeActionsResponse get_code_actions_response = 2;
 }

--- a/crates/rpc/proto/zed.proto
+++ b/crates/rpc/proto/zed.proto
@@ -212,8 +212,8 @@ message Envelope {
 
         UpdateNotification update_notification = 174;
 
-        QueryAllLsp query_all_lsp = 175;
-        QueryAllLspResponse query_all_lsp_response = 176; // current max
+        MultiLspQuery multi_lsp_query = 175;
+        MultiLspQueryResponse multi_lsp_query_response = 176; // current max
     }
 
     reserved 158 to 161;
@@ -1842,23 +1842,28 @@ message BlameBufferResponse {
     repeated CommitPermalink permalinks = 3;
 }
 
-message QueryAllLsp {
+message MultiLspQuery {
+    uint64 project_id = 1;
+    uint64 buffer_id = 2;
+    repeated VectorClockEntry version = 3;
     oneof strategy {
-        AllLanguageServers all = 1;
+        AllLanguageServers all = 4;
     }
     oneof request {
-        GetHover get_hover = 2;
-        GetCodeActions get_code_actions = 3;
+        GetHover get_hover = 5;
+        GetCodeActions get_code_actions = 6;
     }
 }
 
 message AllLanguageServers {}
 
-message QueryAllLspResponse {
+message MultiLspQueryResponse {
     repeated LspResponse responses = 1;
 }
 
 message LspResponse {
-    GetHoverResponse get_hover_response = 1;
-    GetCodeActionsResponse get_code_actions_response = 2;
+    oneof response {
+        GetHoverResponse get_hover_response = 1;
+        GetCodeActionsResponse get_code_actions_response = 2;
+    }
 }

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -299,6 +299,8 @@ messages!(
     (SetRoomParticipantRole, Foreground),
     (BlameBuffer, Foreground),
     (BlameBufferResponse, Foreground),
+    (QueryAllLsp, Background),
+    (QueryAllLspResponse, Background),
 );
 
 request_messages!(
@@ -390,6 +392,7 @@ request_messages!(
     (LspExtExpandMacro, LspExtExpandMacroResponse),
     (SetRoomParticipantRole, Ack),
     (BlameBuffer, BlameBufferResponse),
+    (QueryAllLsp, QueryAllLspResponse),
 );
 
 entity_messages!(

--- a/crates/rpc/src/proto.rs
+++ b/crates/rpc/src/proto.rs
@@ -299,8 +299,8 @@ messages!(
     (SetRoomParticipantRole, Foreground),
     (BlameBuffer, Foreground),
     (BlameBufferResponse, Foreground),
-    (QueryAllLsp, Background),
-    (QueryAllLspResponse, Background),
+    (MultiLspQuery, Background),
+    (MultiLspQueryResponse, Background),
 );
 
 request_messages!(
@@ -392,7 +392,7 @@ request_messages!(
     (LspExtExpandMacro, LspExtExpandMacroResponse),
     (SetRoomParticipantRole, Ack),
     (BlameBuffer, BlameBufferResponse),
-    (QueryAllLsp, QueryAllLspResponse),
+    (MultiLspQuery, MultiLspQueryResponse),
 );
 
 entity_messages!(
@@ -421,6 +421,7 @@ entity_messages!(
     InlayHints,
     JoinProject,
     LeaveProject,
+    MultiLspQuery,
     OnTypeFormatting,
     OpenBufferById,
     OpenBufferByPath,


### PR DESCRIPTION
Supersedes https://github.com/zed-industries/zed/pull/8634
Fixes https://github.com/zed-industries/zed/issues/7947 by continuing https://github.com/zed-industries/zed/pull/9943 with the remote part.

Now, clients are able to issue collab requests, that query all related language servers, not only the primary one.
Such mode is enabled for GetHover and GetCodeActions LSP requests only.

Release Notes:

- Added Tailwind CSS hover popovers for Zed in multi player mode ([7947](https://github.com/zed-industries/zed/issues/7947))