### PR TITLE
Do not push invisible local worktrees into recent documents

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -6772,10 +6772,12 @@ impl Project {
                         project
                             .update(&mut cx, |project, cx| project.add_worktree(&worktree, cx))?;
 
-                        cx.update(|cx| {
-                            cx.add_recent_document(&path);
-                        })
-                        .log_err();
+                        if visible {
+                            cx.update(|cx| {
+                                cx.add_recent_document(&path);
+                            })
+                            .log_err();
+                        }
 
                         Ok(worktree)
                     }


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/9919 that removes invisible worktrees from the list, to avoid things like
![image](https://github.com/zed-industries/zed/assets/2690773/90ce1c29-a1dd-4a03-b09a-effdba620c8f)

Release Notes:

- N/A
