### PR TITLE
Fix git blame not working correctly with submodules

### DIFF
--- a/crates/fs/src/repository.rs
+++ b/crates/fs/src/repository.rs
@@ -232,10 +232,10 @@ impl GitRepository for RealGitRepository {
     }
 
     fn blame(&self, path: &Path, content: Rope) -> Result<git::blame::Blame> {
-        let git_dir_path = self.repository.path();
-        let working_directory = git_dir_path.parent().with_context(|| {
-            format!("failed to get git working directory for {:?}", git_dir_path)
-        })?;
+        let working_directory = self
+            .repository
+            .workdir()
+            .with_context(|| format!("failed to get git working directory for file {:?}", path))?;
 
         const REMOTE_NAME: &str = "origin";
         let remote_url = self.remote_url(REMOTE_NAME);


### PR DESCRIPTION
This fixes #9958 by using the correct working directory in which to run `git blame`.

This wasn't an issue for a single repository, because we could go from `.git` one directory up, but it doesn't work for submodules.

Luckily there's a `workdir()` method on `self.repository` that does exactly what we need.

In submodule:

![screenshot-2024-04-03-12 37 18@2x](https://github.com/zed-industries/zed/assets/1185253/67e89abb-d04c-4e9d-802f-5b8468e0962e)

Not in submodule:

![screenshot-2024-04-03-12 37 36@2x](https://github.com/zed-industries/zed/assets/1185253/cfe59f59-798b-43e1-980d-2225db4c0302)

Release Notes:

- N/A
