### PR TITLE
editor: Fix "Toggle comments" not respecting multiple line_comments in language config

### DIFF
--- a/crates/languages/src/rust/config.toml
+++ b/crates/languages/src/rust/config.toml
@@ -1,7 +1,7 @@
 name = "Rust"
 grammar = "rust"
 path_suffixes = ["rs"]
-line_comments = ["// ", "/// ", "//! "]
+line_comments = [ "/// ", "//! ", "// "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
This does not try to heuristically pick a comment style based on surroundings anyhow. It does improve our story around uncommenting though.

Fixes #10113.

Release Notes:

- Fixed "Toggle comment" action not working in presence of non-default line comments such as doc comments in Rust ([#10113](https://github.com/zed-industries/zed/issues/10113)).
