### PR TITLE
clojure: Add license file

### DIFF
--- a/extensions/clojure/LICENSE-APACHE
+++ b/extensions/clojure/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE


### PR DESCRIPTION
This PR adds a symlink to the `LICENSE-APACHE` file for the Clojure extension.

I knew I was forgetting something 😓

Release Notes:

- N/A
