### PR TITLE
file_icons: Add license file

### DIFF
--- a/crates/file_icons/LICENSE-GPL
+++ b/crates/file_icons/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL


### PR DESCRIPTION
This PR adds a missing license file to the `file_icons` crate.

Release Notes:

- N/A
