### PR TITLE
Disable format on save for C and C++

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -545,6 +545,12 @@
   "file_types": {},
   // Different settings for specific languages.
   "languages": {
+    "C++": {
+      "format_on_save": "off"
+    },
+    "C": {
+      "format_on_save": "off"
+    },
     "Plain Text": {
       "soft_wrap": "preferred_line_length"
     },


### PR DESCRIPTION
We want Zed to be opinionated and low-configuration. Your code editor should get out of the way, and just do the right thing.

However, some ecosystems aren't opinionated enough for us to automatically detect the right way to format your code, so let's turn it off.

Release Notes:

- Disabled `format_on_save` by default in C and C++.