### PR TITLE
Improve handling of prettier errors on format

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4676,10 +4676,11 @@ impl Project {
                     }
                 }
                 (Formatter::Auto, FormatOnSave::On | FormatOnSave::Off) => {
-                    if let Some(new_operation) =
-                        prettier_support::format_with_prettier(&project, buffer, &mut cx).await
-                    {
-                        format_operation = Some(new_operation);
+                    let prettier =
+                        prettier_support::format_with_prettier(&project, buffer, &mut cx).await;
+
+                    if let Some(operation) = prettier {
+                        format_operation = Some(operation?);
                     } else if let Some((language_server, buffer_abs_path)) = server_and_buffer {
                         format_operation = Some(FormatOperation::Lsp(
                             Self::format_via_lsp(
@@ -4696,10 +4697,11 @@ impl Project {
                     }
                 }
                 (Formatter::Prettier, FormatOnSave::On | FormatOnSave::Off) => {
-                    if let Some(new_operation) =
-                        prettier_support::format_with_prettier(&project, buffer, &mut cx).await
-                    {
-                        format_operation = Some(new_operation);
+                    let prettier =
+                        prettier_support::format_with_prettier(&project, buffer, &mut cx).await;
+
+                    if let Some(operation) = prettier {
+                        format_operation = Some(operation?);
                     }
                 }
             };


### PR DESCRIPTION
When no formatter for a language is specified, Zed has the default behaviour:

1. Attempt to format the buffer with `prettier`
2. If that doesn't work, use the language server.

The problem was that if `prettier` failed to format a buffer due to legitimate syntax errors, we simply did a fallback to the language server, which would then format over the syntax errors.

With JavaScript/React/TypeScript projects this could lead to a situation where

1. Syntax error was introduced
2. Prettier fails
3. Zed ignores the error
4. typescript-language-server formats the buffer despite syntax errors

This would lead to some very weird formatting issues.

What this PR does is to fix the issue by handling `prettier` errors and results in two user facing changes:

1. When no formatter is set (or set to `auto`) and if we attempted to start a prettier instance to format, we will now display that error and *not* fall back to language server formatting.
2. If the formatter is explicitly set to `prettier`, we will now show errors if we failed to spawn prettier or failed to format with it.

This means that we now might show *more* errors than previously, but I think that's better than not showing anything to the user at all.

And, of course, it also fixes the issue of invalid syntax being formatted by the language server even though `prettier` failed with an error.

Release Notes:

- Improved error handling when formatting buffers with `prettier`. Previously `prettier` errors would be logged but ignored. Now `prettier` errors are shown in the UI, just like language server errors when formatting. And if no formatter is specified (or set to `"auto"`) and Zed attempts to use `prettier` for formatting, then `prettier` errors are no longer skipped. That fixes the issue of `prettier` not formatting invalid syntax, but its error being skipped, leading to `typescript-language-server` or another language server formatting invalid syntax.