### PR TITLE
collab ui: Dismiss project shared notifications when leaving room

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -375,9 +375,7 @@ impl ActiveCall {
         Audio::end_call(cx);
 
         let channel_id = self.channel_id(cx);
-        dbg!("Channel ID: {:?}", channel_id);
         if let Some((room, _)) = self.room.take() {
-            dbg!("Emitting");
             cx.emit(Event::RoomLeft { channel_id });
             room.update(cx, |room, cx| room.leave(cx))
         } else {

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -373,7 +373,10 @@ impl ActiveCall {
         self.report_call_event("hang up", cx);
 
         Audio::end_call(cx);
+
+        let channel_id = self.channel_id(cx);
         if let Some((room, _)) = self.room.take() {
+            cx.emit(Event::Left { channel_id });
             room.update(cx, |room, cx| room.leave(cx))
         } else {
             Task::ready(Ok(()))

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -375,8 +375,10 @@ impl ActiveCall {
         Audio::end_call(cx);
 
         let channel_id = self.channel_id(cx);
+        dbg!("Channel ID: {:?}", channel_id);
         if let Some((room, _)) = self.room.take() {
-            cx.emit(Event::Left { channel_id });
+            dbg!("Emitting");
+            cx.emit(Event::RoomLeft { channel_id });
             room.update(cx, |room, cx| room.leave(cx))
         } else {
             Task::ready(Ok(()))

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -52,7 +52,7 @@ pub enum Event {
     RemoteProjectInvitationDiscarded {
         project_id: u64,
     },
-    Left {
+    RoomLeft {
         channel_id: Option<ChannelId>,
     },
 }

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -366,9 +366,6 @@ impl Room {
 
     pub(crate) fn leave(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
         cx.notify();
-        cx.emit(Event::Left {
-            channel_id: self.channel_id(),
-        });
         self.leave_internal(cx)
     }
 

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -156,7 +156,7 @@ impl ChatPanel {
                             }
                         }
                     }
-                    room::Event::Left { channel_id } => {
+                    room::Event::RoomLeft { channel_id } => {
                         if channel_id == &this.channel_id(cx) {
                             cx.emit(PanelEvent::Close)
                         }

--- a/crates/collab_ui/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui/src/notifications/project_shared_notification.rs
@@ -58,7 +58,7 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
             }
         }
 
-        room::Event::Left { .. } => {
+        room::Event::RoomLeft { .. } => {
             for (_, windows) in notification_windows.drain() {
                 for window in windows {
                     window


### PR DESCRIPTION
When leaving a call/room in which a project was shared, the shared project notification was not getting dismissed when the person that shared the project left the room.
Although there was a `cx.emit(Event::Left)` call inside room, the event was never received in the `project_shared_notification` module, because the room is dropped before the event can be dispatched. Moving the `cx.emit(Event::Left)` to the active call fixed the problem. Also renamed `Event::Left` to `Event::RoomLeft` because the room join equivalent is also called `Event::RoomJoined`.


Release Notes:

- Fixed project shared notification staying open, when the user that shared the project left the room
