### PR TITLE
Add `label_for_symbol` to extension API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12539,7 +12539,7 @@ dependencies = [
 name = "zed_haskell"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.4",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -5,7 +5,6 @@ mod since_v0_0_6;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use anyhow::bail;
 use anyhow::{Context, Result};
 use language::{LanguageServerName, LspAdapterDelegate};
 use semantic_version::SemanticVersion;
@@ -19,7 +18,7 @@ use super::{wasm_engine, WasmState};
 use since_v0_0_6 as latest;
 
 pub use latest::{
-    zed::extension::lsp::{Completion, CompletionKind, InsertTextFormat},
+    zed::extension::lsp::{Completion, CompletionKind, InsertTextFormat, Symbol, SymbolKind},
     CodeLabel, CodeLabelSpan, Command, Range,
 };
 pub use since_v0_0_4::LanguageServerConfig;
@@ -156,11 +155,24 @@ impl Extension {
         completions: Vec<latest::Completion>,
     ) -> Result<Result<Vec<Option<CodeLabel>>, String>> {
         match self {
-            Extension::V001(_) | Extension::V004(_) => {
-                bail!("unsupported function: 'labels_for_completions'")
-            }
+            Extension::V001(_) | Extension::V004(_) => Ok(Ok(Vec::new())),
             Extension::V006(ext) => {
                 ext.call_labels_for_completions(store, &language_server_id.0, &completions)
+                    .await
+            }
+        }
+    }
+
+    pub async fn call_labels_for_symbols(
+        &self,
+        store: &mut Store<WasmState>,
+        language_server_id: &LanguageServerName,
+        symbols: Vec<latest::Symbol>,
+    ) -> Result<Result<Vec<Option<CodeLabel>>, String>> {
+        match self {
+            Extension::V001(_) | Extension::V004(_) => Ok(Ok(Vec::new())),
+            Extension::V006(ext) => {
+                ext.call_labels_for_symbols(store, &language_server_id.0, &symbols)
                     .await
             }
         }

--- a/crates/extension_api/wit/since_v0.0.6/extension.wit
+++ b/crates/extension_api/wit/since_v0.0.6/extension.wit
@@ -3,7 +3,7 @@ package zed:extension;
 world extension {
     import lsp;
 
-    use lsp.{completion};
+    use lsp.{completion, symbol};
 
     export init-extension: func();
 
@@ -117,4 +117,5 @@ world extension {
     }
 
     export labels-for-completions: func(language-server-id: string, completions: list<completion>) -> result<list<option<code-label>>, string>;
+    export labels-for-symbols: func(language-server-id: string, symbols: list<symbol>) -> result<list<option<code-label>>, string>;
 }

--- a/crates/extension_api/wit/since_v0.0.6/lsp.wit
+++ b/crates/extension_api/wit/since_v0.0.6/lsp.wit
@@ -41,4 +41,39 @@ interface lsp {
         snippet,
         other(s32),
     }
+
+    record symbol {
+        kind: symbol-kind,
+        name: string,
+    }
+
+    variant symbol-kind {
+        file,
+        module,
+        namespace,
+        %package,
+        class,
+        method,
+        property,
+        field,
+        %constructor,
+        %enum,
+        %interface,
+        function,
+        variable,
+        constant,
+        %string,
+        number,
+        boolean,
+        array,
+        object,
+        key,
+        null,
+        enum-member,
+        struct,
+        event,
+        operator,
+        type-parameter,
+        other(s32),
+    }
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -9876,7 +9876,9 @@ async fn populate_labels_for_symbols(
             if let Some(lsp_adapter) = lsp_adapter {
                 labels = lsp_adapter
                     .labels_for_symbols(&label_params, &language)
-                    .await;
+                    .await
+                    .log_err()
+                    .unwrap_or_default();
             }
         }
 

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -13,4 +13,5 @@ path = "src/haskell.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+# zed_extension_api = "0.0.4"
+zed_extension_api = { path = "../../crates/extension_api" }

--- a/extensions/haskell/src/haskell.rs
+++ b/extensions/haskell/src/haskell.rs
@@ -1,3 +1,5 @@
+use zed::lsp::{Symbol, SymbolKind};
+use zed::{CodeLabel, CodeLabelSpan};
 use zed_extension_api::{self as zed, Result};
 
 struct HaskellExtension;
@@ -9,7 +11,7 @@ impl zed::Extension for HaskellExtension {
 
     fn language_server_command(
         &mut self,
-        _config: zed::LanguageServerConfig,
+        _language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let path = worktree
@@ -20,6 +22,44 @@ impl zed::Extension for HaskellExtension {
             command: path,
             args: vec!["lsp".to_string()],
             env: Default::default(),
+        })
+    }
+
+    fn label_for_symbol(
+        &self,
+        _language_server_id: &zed::LanguageServerId,
+        symbol: Symbol,
+    ) -> Option<CodeLabel> {
+        let name = &symbol.name;
+
+        let (code, display_range, filter_range) = match symbol.kind {
+            SymbolKind::Struct => {
+                let data_decl = "data ";
+                let code = format!("{data_decl}{name} = A");
+                let display_range = 0..data_decl.len() + name.len();
+                let filter_range = data_decl.len()..display_range.end;
+                (code, display_range, filter_range)
+            }
+            SymbolKind::Constructor => {
+                let data_decl = "data A = ";
+                let code = format!("{data_decl}{name}");
+                let display_range = data_decl.len()..data_decl.len() + name.len();
+                let filter_range = 0..name.len();
+                (code, display_range, filter_range)
+            }
+            SymbolKind::Variable => {
+                let code = format!("{name} :: T");
+                let display_range = 0..name.len();
+                let filter_range = 0..name.len();
+                (code, display_range, filter_range)
+            }
+            _ => return None,
+        };
+
+        Some(CodeLabel {
+            spans: vec![CodeLabelSpan::code_range(display_range)],
+            filter_range: filter_range.into(),
+            code,
         })
     }
 }


### PR DESCRIPTION
This PR adds `label_for_symbol` to the extension API.

As a motivating example, we implemented `label_for_symbol` for the Haskell extension.

Release Notes:

- N/A
