### PR TITLE
Fix scrollbar markers in large files

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3876,9 +3876,6 @@ impl ScrollbarLayout {
             .map(|range| {
                 let start_y = self.first_row_y_offset + range.start as f32 * self.row_height;
                 let mut end_y = self.first_row_y_offset + (range.end + 1) as f32 * self.row_height;
-                if end_y - start_y < Self::MIN_MARKER_HEIGHT {
-                    end_y = start_y + Self::MIN_MARKER_HEIGHT;
-                }
                 ColoredRange {
                     start: start_y,
                     end: end_y,
@@ -3889,11 +3886,14 @@ impl ScrollbarLayout {
 
         let mut quads = Vec::new();
         while let Some(mut pixel_range) = background_pixel_ranges.next() {
+            pixel_range.end = pixel_range
+                .end
+                .max(pixel_range.start + Self::MIN_MARKER_HEIGHT);
             while let Some(next_pixel_range) = background_pixel_ranges.peek() {
                 if pixel_range.end >= next_pixel_range.start
                     && pixel_range.color == next_pixel_range.color
                 {
-                    pixel_range.end = next_pixel_range.end;
+                    pixel_range.end = next_pixel_range.end.max(pixel_range.end);
                     background_pixel_ranges.next();
                 } else {
                     break;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3875,7 +3875,7 @@ impl ScrollbarLayout {
             .into_iter()
             .map(|range| {
                 let start_y = self.first_row_y_offset + range.start as f32 * self.row_height;
-                let mut end_y = self.first_row_y_offset + (range.end + 1) as f32 * self.row_height;
+                let end_y = self.first_row_y_offset + (range.end + 1) as f32 * self.row_height;
                 ColoredRange {
                     start: start_y,
                     end: end_y,


### PR DESCRIPTION
#10080 introduced a minor change in how the min marker height is enforced. Before the change, it was applied to the aggregated marker, but after the change it's applied to each individual marker before aggregation.

The difference is not noticeable on small files, where even single row markers are higher than `MIN_MARKER_HEIGHT`, but it leads to visible differences in large files with repeating blocks of highlighted and not-highlighted blocks, like in [this case](https://github.com/zed-industries/zed/pull/9080#issuecomment-2006796376).

This PR fixes how the `MIN_MARKER_HEIGHT` is applied.

Before the fix:

<img width="727" alt="zed-scroll-markers-before" src="https://github.com/zed-industries/zed/assets/2101250/a1c34746-af4f-4054-8de2-edabf3db7cee">

After the fix:

<img width="736" alt="zed-scroll-markers-after" src="https://github.com/zed-industries/zed/assets/2101250/b9ee843d-055e-42a6-af26-e7fd4f7729f8">


Release Notes:

- N/A

/cc @mrnugget 

