### PR TITLE
markdown preview: Improve live preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5676,6 +5676,7 @@ dependencies = [
 name = "markdown_preview"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-recursion 1.0.5",
  "editor",
  "gpui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5681,6 +5681,7 @@ dependencies = [
  "gpui",
  "language",
  "linkify",
+ "log",
  "pretty_assertions",
  "pulldown-cmark",
  "theme",

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -11,7 +11,7 @@ use gpui::{
 };
 use isahc::AsyncBody;
 
-use markdown_preview::markdown_preview_view::MarkdownPreviewView;
+use markdown_preview::markdown_preview_view::{MarkdownPreviewMode, MarkdownPreviewView};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_derive::Serialize;
@@ -238,10 +238,11 @@ fn view_release_notes_locally(workspace: &mut Workspace, cx: &mut ViewContext<Wo
                                 .new_view(|cx| Editor::for_multibuffer(buffer, Some(project), cx));
                             let workspace_handle = workspace.weak_handle();
                             let view: View<MarkdownPreviewView> = MarkdownPreviewView::new(
+                                MarkdownPreviewMode::Default,
                                 editor,
                                 workspace_handle,
-                                Some(tab_description),
                                 language_registry,
+                                Some(tab_description),
                                 cx,
                             );
                             workspace.add_item_to_active_pane(Box::new(view.clone()), cx);

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -20,6 +20,7 @@ editor.workspace = true
 gpui.workspace = true
 language.workspace = true
 linkify.workspace = true
+log.workspace = true
 pretty_assertions.workspace = true
 pulldown-cmark.workspace = true
 theme.workspace = true

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/markdown_preview.rs"
 test-support = []
 
 [dependencies]
+anyhow.workspace = true
 async-recursion.workspace = true
 editor.workspace = true
 gpui.workspace = true

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -270,7 +270,7 @@ impl<'a> MarkdownParser<'a> {
                             regions.push(ParsedRegion {
                                 code: false,
                                 link: Some(Link::Web {
-                                    url: t[range].to_string(),
+                                    url: link.as_str().to_string(),
                                 }),
                             });
 

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -6,7 +6,7 @@ pub mod markdown_parser;
 pub mod markdown_preview_view;
 pub mod markdown_renderer;
 
-actions!(markdown, [OpenPreview]);
+actions!(markdown, [OpenPreview, OpenPreviewToTheSide]);
 
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(|workspace: &mut Workspace, cx| {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -4,9 +4,9 @@ use std::{ops::Range, path::PathBuf};
 use editor::scroll::{Autoscroll, AutoscrollStrategy};
 use editor::{Editor, EditorEvent};
 use gpui::{
-    list, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
-    IntoElement, ListState, ParentElement, Render, Styled, Subscription, View, ViewContext,
-    WeakView,
+    list, AnyElement, AppContext, ClickEvent, EventEmitter, FocusHandle, FocusableView,
+    InteractiveElement, IntoElement, ListState, MouseDownEvent, ParentElement, Render, Styled,
+    Subscription, View, ViewContext, WeakView,
 };
 use language::LanguageRegistry;
 use ui::prelude::*;
@@ -123,12 +123,16 @@ impl MarkdownPreviewView {
                                     .pl_4()
                                     .pb_3()
                                     .id(ix)
-                                    .on_click(cx.listener(move |this, _, cx| {
-                                        if let Some(block) =
-                                            this.contents.as_ref().and_then(|c| c.children.get(ix))
-                                        {
-                                            let start = block.source_range().start;
-                                            this.update_editor_selection(cx, start..start);
+                                    .on_click(cx.listener(move |this, event: &ClickEvent, cx| {
+                                        if event.down.click_count == 2 {
+                                            if let Some(block) = this
+                                                .contents
+                                                .as_ref()
+                                                .and_then(|c| c.children.get(ix))
+                                            {
+                                                let start = block.source_range().start;
+                                                this.update_editor_selection(cx, start..start);
+                                            }
                                         }
                                     }));
 

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -60,7 +60,7 @@ impl MarkdownPreviewView {
 
         workspace.register_action(move |workspace, _: &OpenPreviewToTheSide, cx| {
             if let Some(editor) = Self::resolve_active_item_as_markdown_editor(workspace, cx) {
-                let view = Self::create_markdown_view(workspace, editor, cx);
+                let view = Self::create_markdown_view(workspace, editor.clone(), cx);
                 let pane = workspace
                     .find_pane_in_direction(workspace::SplitDirection::Right, cx)
                     .unwrap_or_else(|| {
@@ -73,6 +73,7 @@ impl MarkdownPreviewView {
                 pane.update(cx, |pane, cx| {
                     pane.add_item(Box::new(view.clone()), false, false, None, cx)
                 });
+                editor.focus_handle(cx).focus(cx);
                 cx.notify();
             }
         });

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -147,7 +147,7 @@ impl MarkdownPreviewView {
                                                 .and_then(|c| c.children.get(ix))
                                             {
                                                 let start = block.source_range().start;
-                                                this.update_editor_selection(cx, start..start);
+                                                this.move_cursor_to_block(cx, start..start);
                                             }
                                         }
                                     }));
@@ -286,7 +286,7 @@ impl MarkdownPreviewView {
         }
     }
 
-    fn update_editor_selection(&self, cx: &mut ViewContext<Self>, selection: Range<usize>) {
+    fn move_cursor_to_block(&self, cx: &mut ViewContext<Self>, selection: Range<usize>) {
         if let Some(state) = &self.active_editor {
             state.editor.update(cx, |editor, cx| {
                 editor.change_selections(
@@ -294,6 +294,7 @@ impl MarkdownPreviewView {
                     cx,
                     |selections| selections.select_ranges(vec![selection]),
                 );
+                editor.focus(cx);
             });
         }
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2266,7 +2266,7 @@ impl Workspace {
         }
     }
 
-    fn find_pane_in_direction(
+    pub fn find_pane_in_direction(
         &mut self,
         direction: SplitDirection,
         cx: &WindowContext,


### PR DESCRIPTION
This PR contains various improvements for the markdown preview (some of which were originally part of #7601).
Some improvements can be seen in the video (see also release notes down below):

https://github.com/zed-industries/zed/assets/53836821/93324ee8-d366-464a-9728-981eddbfdaf7

Release Notes:
- Added action to open markdown preview in the same pane
- Added support for displaying channel notes in markdown preview
- Added support for displaying the current active editor when opening markdown preview
- Added support for scrolling the editor to the corresponding block when double clicking an element in markdown preview
- Improved pane creation handling when opening markdown preview
- Fixed markdown preview displaying non-markdown files
