### PR TITLE
Fix interpretation of \n in hovers

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -375,12 +375,12 @@ async fn parse_blocks(
         match &block.kind {
             HoverBlockKind::PlainText => {
                 markdown::new_paragraph(&mut text, &mut Vec::new());
-                text.push_str(&block.text);
+                text.push_str(&block.text.replace("\\n", "\n"));
             }
 
             HoverBlockKind::Markdown => {
                 markdown::parse_markdown_block(
-                    &block.text,
+                    &block.text.replace("\\n", "\n"),
                     language_registry,
                     language.clone(),
                     &mut text,


### PR DESCRIPTION
I ran into this specifically when looking at the documentation of https://crates.io/crates/wayland-client

Release Notes:

- Fixed a bug where some hover popovers would render `\n` instead of a new line.