### PR TITLE
Adjust string splitting function

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -609,6 +609,12 @@ mod tests {
             NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
             Some(NumericPrefixWithSuffix(12, "_ab"))
         );
+
+        let target = "1_2ab";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(1, "_2ab"))
+        );
     }
 
     #[test]

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -508,9 +508,8 @@ pub struct NumericPrefixWithSuffix<'a>(i32, &'a str);
 
 impl<'a> NumericPrefixWithSuffix<'a> {
     pub fn from_numeric_prefixed_str(str: &'a str) -> Option<Self> {
-        let mut chars = str.chars();
-        let prefix: String = chars.by_ref().take_while(|c| c.is_ascii_digit()).collect();
-        let remainder = chars.as_str();
+        let i = str.chars().take_while(|c| c.is_ascii_digit()).count();
+        let (prefix, remainder) = str.split_at(i);
 
         match prefix.parse::<i32>() {
             Ok(prefix) => Some(NumericPrefixWithSuffix(prefix, remainder)),
@@ -589,6 +588,27 @@ mod tests {
         assert_eq!(truncate_and_trailoff("èèèèèè", 7), "èèèèèè");
         assert_eq!(truncate_and_trailoff("èèèèèè", 6), "èèèèèè");
         assert_eq!(truncate_and_trailoff("èèèèèè", 5), "èèèèè…");
+    }
+
+    #[test]
+    fn test_numeric_prefix_str_method() {
+        let target = "1a";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(1, "a"))
+        );
+
+        let target = "12ab";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(12, "ab"))
+        );
+
+        let target = "12_ab";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(12, "_ab"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
This commit fixes an issue where the string splitting function was handling characters in the input string improperly. We adjusted the use of the `take_while` function to calculate the length of the numeric prefix, rather than directly splitting the string, thus correctly splitting the string into a numeric prefix part and the remaining part

Release Notes:
- Fixed #9729 and #10193

