### PR TITLE
Remove line breaks when displaying file names in the project panel

### DIFF
--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -60,7 +60,7 @@ impl Render for Breadcrumbs {
             let mut text_style = cx.text_style();
             text_style.color = Color::Muted.color(cx);
 
-            StyledText::new(segment.text)
+            StyledText::new(segment.text.replace('\n', "␤"))
                 .with_highlights(&text_style, segment.highlights.unwrap_or_default())
                 .into_any()
         });

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -82,6 +82,7 @@ impl Item for ImageView {
             .to_string_lossy()
             .to_string();
         Label::new(title)
+            .single_line()
             .color(if selected {
                 Color::Default
             } else {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1442,9 +1442,9 @@ impl ProjectPanel {
                         if let (Some(editor), true) = (Some(&self.filename_editor), show_editor) {
                             h_flex().h_6().w_full().child(editor.clone())
                         } else {
-                            h_flex()
-                                .h_6()
-                                .child(Label::new(file_name).color(filename_text_color))
+                            h_flex().h_6().child(
+                                Label::new(file_name.replace("\n", "")).color(filename_text_color),
+                            )
                         }
                         .ml_1(),
                     )

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1443,7 +1443,7 @@ impl ProjectPanel {
                             h_flex().h_6().w_full().child(editor.clone())
                         } else {
                             h_flex().h_6().child(
-                                Label::new(file_name.replace("\n", "")).color(filename_text_color),
+                                Label::new(file_name.replace('\n', "")).color(filename_text_color),
                             )
                         }
                         .ml_1(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1443,7 +1443,9 @@ impl ProjectPanel {
                             h_flex().h_6().w_full().child(editor.clone())
                         } else {
                             h_flex().h_6().child(
-                                Label::new(file_name.replace('\n', "")).color(filename_text_color),
+                                Label::new(file_name)
+                                    .single_line()
+                                    .color(filename_text_color),
                             )
                         }
                         .ml_1(),

--- a/crates/ui/src/components/label/label.rs
+++ b/crates/ui/src/components/label/label.rs
@@ -34,6 +34,7 @@ use crate::{prelude::*, LabelCommon, LabelLike, LabelSize, LineHeightStyle};
 pub struct Label {
     base: LabelLike,
     label: SharedString,
+    single_line: bool,
 }
 
 impl Label {
@@ -50,7 +51,22 @@ impl Label {
         Self {
             base: LabelLike::new(),
             label: label.into(),
+            single_line: false,
         }
+    }
+
+    /// Make the label display in a single line mode
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ui::prelude::*;
+    ///
+    /// let my_label = Label::new("Hello, World!").single_line(true);
+    /// ```
+    pub fn single_line(mut self) -> Self {
+        self.single_line = true;
+        self
     }
 }
 
@@ -114,6 +130,11 @@ impl LabelCommon for Label {
 
 impl RenderOnce for Label {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
-        self.base.child(self.label)
+        let target_label = if self.single_line {
+            SharedString::from(self.label.replace('\n', "␤"))
+        } else {
+            self.label
+        };
+        self.base.child(target_label)
     }
 }


### PR DESCRIPTION
- Fixed #8603 

For the label title of the project panel, I find that there is no place to use to get the title of the label to do some operations, it should be safe to modify it, but I'm not sure how we need to modify the problem, I can think of two scenarios:
1. Modify every place where you don't want multiple lines to appear
2. Make the label only display a single line (e.g. provide a new parameter, or a new label type?)