### PR TITLE
vim: Fix cgn backwards movement when there is no matches

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1100,6 +1100,11 @@ impl BufferSearchBar {
             }
         }
     }
+    
+    pub fn exists_match(&mut self, cx: &mut ViewContext<Self>) -> bool {
+        self.update_match_index(cx);
+        self.active_match_index.is_some() 
+    }
 }
 
 #[cfg(test)]

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1100,10 +1100,10 @@ impl BufferSearchBar {
             }
         }
     }
-    
-    pub fn exists_match(&mut self, cx: &mut ViewContext<Self>) -> bool {
+
+    pub fn match_exists(&mut self, cx: &mut ViewContext<Self>) -> bool {
         self.update_match_index(cx);
-        self.active_match_index.is_some() 
+        self.active_match_index.is_some()
     }
 }
 

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -172,6 +172,10 @@ pub(crate) fn repeat(cx: &mut WindowContext, from_insert_mode: bool) {
             editor.show_local_selections = false;
         })?;
         for action in actions {
+            if cx.update(|cx| Vim::read(cx).workspace_state.replaying) != Ok(true) {
+                break;
+            }
+
             match action {
                 ReplayableAction::Action(action) => {
                     if should_replay(&action) {

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -172,7 +172,10 @@ pub(crate) fn repeat(cx: &mut WindowContext, from_insert_mode: bool) {
             editor.show_local_selections = false;
         })?;
         for action in actions {
-            if !matches!(cx.update(|cx| Vim::read(cx).workspace_state.replaying), Ok(true)) {
+            if !matches!(
+                cx.update(|cx| Vim::read(cx).workspace_state.replaying),
+                Ok(true)
+            ) {
                 break;
             }
 

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -172,7 +172,7 @@ pub(crate) fn repeat(cx: &mut WindowContext, from_insert_mode: bool) {
             editor.show_local_selections = false;
         })?;
         for action in actions {
-            if cx.update(|cx| Vim::read(cx).workspace_state.replaying) != Ok(true) {
+            if !matches!(cx.update(|cx| Vim::read(cx).workspace_state.replaying), Ok(true)) {
                 break;
             }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -332,6 +332,10 @@ impl Vim {
         }
     }
 
+    pub fn stop_replaying(&mut self) {
+        self.workspace_state.replaying = false;
+    }
+
     /// When finishing an action that modifies the buffer, stop recording.
     /// as you usually call this within a keystroke handler we also ensure that
     /// the current action is recorded.
@@ -490,6 +494,7 @@ impl Vim {
         self.sync_vim_settings(cx);
         popped_operator
     }
+
     fn clear_operator(&mut self, cx: &mut WindowContext) {
         self.take_count(cx);
         self.update_state(|state| state.operator_stack.clear());

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -15,7 +15,7 @@ use workspace::{searchable::Direction, Workspace};
 
 use crate::{
     motion::{start_of_line, Motion},
-    normal::substitute::substitute,
+    normal::{move_cursor, substitute::substitute},
     object::Object,
     state::{Mode, Operator},
     utils::{copy_selections_content, yank_selections_content},
@@ -513,6 +513,8 @@ pub fn select_match(
     if !exists_match {
         if !vim.workspace_state.replaying {
             vim.clear_operator(cx);
+        } else {
+            move_cursor(vim, Motion::Right, Some(1), cx);
         }
         // clear recording
         vim.workspace_state.recording = false;

--- a/crates/vim/test_data/test_cgn_nomatch.json
+++ b/crates/vim/test_data/test_cgn_nomatch.json
@@ -1,0 +1,28 @@
+{"Put":{"state":"aaˇ aa aa aa aa"}}
+{"Key":"/"}
+{"Key":"b"}
+{"Key":"b"}
+{"Key":"enter"}
+{"Get":{"state":"aaˇ aa aa aa aa","mode":"Normal"}}
+{"Key":"c"}
+{"Key":"g"}
+{"Key":"n"}
+{"Key":"x"}
+{"Key":"escape"}
+{"Get":{"state":"aaˇaa aa aa aa","mode":"Normal"}}
+{"Key":"."}
+{"Get":{"state":"aaˇa aa aa aa","mode":"Normal"}}
+{"Put":{"state":"aaˇ bb aa aa aa"}}
+{"Key":"/"}
+{"Key":"b"}
+{"Key":"b"}
+{"Key":"enter"}
+{"Get":{"state":"aa ˇbb aa aa aa","mode":"Normal"}}
+{"Key":"c"}
+{"Key":"g"}
+{"Key":"n"}
+{"Key":"x"}
+{"Key":"escape"}
+{"Get":{"state":"aa ˇx aa aa aa","mode":"Normal"}}
+{"Key":"."}
+{"Get":{"state":"aa ˇx aa aa aa","mode":"Normal"}}


### PR DESCRIPTION

Release Notes:

- Fixed `cgn` backwards movement problem in #9982

There are two issues:

- When there are no more matches, the next repetition still moves the cursor to the left. After that, the recording is cleared. For this I simply move the cursor to the right, but it doesn't work when the cursor is at the end of the line.
- If `cgn` is used when there are no matches, it cleans the previous recorded actions. Maybe there should be a way to revert the recording. This also happens when using `c` and `esc`

