### PR TITLE
Fix reference to `soft_wrap` option in comment

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -70,7 +70,7 @@
   // documentation when not included in original completion list.
   "completion_documentation_secondary_query_debounce": 300,
   // Whether to show wrap guides in the editor. Setting this to true will
-  // show a guide at the 'preferred_line_length' value if softwrap is set to
+  // show a guide at the 'preferred_line_length' value if 'soft_wrap' is set to
   // 'preferred_line_length', and will show any additional guides as specified
   // by the 'wrap_guides' setting.
   "show_wrap_guides": true,


### PR DESCRIPTION
Brought this up briefly in Discord: https://discord.com/channels/869392257814519848/873293828805771284/1226224505760776192

Release Notes:

- Fixed an incorrect reference to the `soft_wrap` setting in the default settings documentation.