### PR TITLE
Add settings to hide/show navigation history buttons

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -284,6 +284,8 @@
   // 4. Save when idle for a certain amount of time:
   //     "autosave": { "after_delay": {"milliseconds": 500} },
   "autosave": "off",
+  // Whether or not to show the navigation history buttons in the tab bar.
+  "show_nav_history_buttons": true,
   // Settings related to the editor's tabs
   "tabs": {
     // Show git status colors in the editor tabs.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -284,8 +284,11 @@
   // 4. Save when idle for a certain amount of time:
   //     "autosave": { "after_delay": {"milliseconds": 500} },
   "autosave": "off",
-  // Whether or not to show the navigation history buttons in the tab bar.
-  "show_nav_history_buttons": true,
+  // Settings related to the editor's tab bar.
+  "tab_bar": {
+    // Whether or not to show the navigation history buttons.
+    "show_nav_history_buttons": true
+  },
   // Settings related to the editor's tabs
   "tabs": {
     // Show git status colors in the editor tabs.

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -17,7 +17,7 @@ use gpui::{
 use parking_lot::Mutex;
 use project::{Project, ProjectEntryId, ProjectPath};
 use serde::Deserialize;
-use settings::Settings;
+use settings::{Settings, SettingsStore};
 use std::{
     any::Any,
     cmp, fmt, mem,
@@ -256,6 +256,7 @@ impl Pane {
             cx.on_focus(&focus_handle, Pane::focus_in),
             cx.on_focus_in(&focus_handle, Pane::focus_in),
             cx.on_focus_out(&focus_handle, Pane::focus_out),
+            cx.observe_global::<SettingsStore>(Self::settings_changed),
         ];
 
         let handle = cx.view().downgrade();
@@ -350,7 +351,7 @@ impl Pane {
                     })
                     .into_any_element()
             }),
-            display_nav_history_buttons: true,
+            display_nav_history_buttons: WorkspaceSettings::get_global(cx).show_nav_history_buttons,
             _subscriptions: subscriptions,
             double_click_dispatch_action,
         }
@@ -415,6 +416,12 @@ impl Pane {
         self.toolbar.update(cx, |toolbar, cx| {
             toolbar.focus_changed(false, cx);
         });
+        cx.notify();
+    }
+
+    fn settings_changed(&mut self, cx: &mut ViewContext<Self>) {
+        self.display_nav_history_buttons =
+            WorkspaceSettings::get_global(cx).show_nav_history_buttons;
         cx.notify();
     }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1,7 +1,7 @@
 use crate::{
     item::{ClosePosition, Item, ItemHandle, ItemSettings, WeakItemHandle},
     toolbar::Toolbar,
-    workspace_settings::{AutosaveSetting, WorkspaceSettings},
+    workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings},
     NewCenterTerminal, NewFile, NewSearch, OpenVisible, SplitDirection, ToggleZoom, Workspace,
 };
 use anyhow::Result;
@@ -351,7 +351,7 @@ impl Pane {
                     })
                     .into_any_element()
             }),
-            display_nav_history_buttons: WorkspaceSettings::get_global(cx).show_nav_history_buttons,
+            display_nav_history_buttons: TabBarSettings::get_global(cx).show_nav_history_buttons,
             _subscriptions: subscriptions,
             double_click_dispatch_action,
         }
@@ -420,8 +420,7 @@ impl Pane {
     }
 
     fn settings_changed(&mut self, cx: &mut ViewContext<Self>) {
-        self.display_nav_history_buttons =
-            WorkspaceSettings::get_global(cx).show_nav_history_buttons;
+        self.display_nav_history_buttons = TabBarSettings::get_global(cx).show_nav_history_buttons;
         cx.notify();
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -81,7 +81,7 @@ use ui::{
 };
 use util::ResultExt;
 use uuid::Uuid;
-pub use workspace_settings::{AutosaveSetting, WorkspaceSettings};
+pub use workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings};
 
 use crate::persistence::{
     model::{DockData, DockStructure, SerializedItem, SerializedPane, SerializedPaneGroup},
@@ -260,6 +260,7 @@ impl Column for WorkspaceId {
 pub fn init_settings(cx: &mut AppContext) {
     WorkspaceSettings::register(cx);
     ItemSettings::register(cx);
+    TabBarSettings::register(cx);
 }
 
 pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -8,7 +8,6 @@ pub struct WorkspaceSettings {
     pub confirm_quit: bool,
     pub show_call_status_icon: bool,
     pub autosave: AutosaveSetting,
-    pub show_nav_history_buttons: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -31,6 +30,15 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: off
     pub autosave: Option<AutosaveSetting>,
+}
+
+#[derive(Deserialize)]
+pub struct TabBarSettings {
+    pub show_nav_history_buttons: bool,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct TabBarSettingsContent {
     /// Whether or not to show the navigation history buttons in the tab bar.
     ///
     /// Default: true
@@ -54,6 +62,20 @@ impl Settings for WorkspaceSettings {
     const KEY: Option<&'static str> = None;
 
     type FileContent = WorkspaceSettingsContent;
+
+    fn load(
+        default_value: &Self::FileContent,
+        user_values: &[&Self::FileContent],
+        _: &mut gpui::AppContext,
+    ) -> anyhow::Result<Self> {
+        Self::load_via_json_merge(default_value, user_values)
+    }
+}
+
+impl Settings for TabBarSettings {
+    const KEY: Option<&'static str> = Some("tab_bar");
+
+    type FileContent = TabBarSettingsContent;
 
     fn load(
         default_value: &Self::FileContent,

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -8,6 +8,7 @@ pub struct WorkspaceSettings {
     pub confirm_quit: bool,
     pub show_call_status_icon: bool,
     pub autosave: AutosaveSetting,
+    pub show_nav_history_buttons: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -30,6 +31,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: off
     pub autosave: Option<AutosaveSetting>,
+    /// Whether or not to show the navigation history buttons in the tab bar.
+    ///
+    /// Default: true
+    pub show_nav_history_buttons: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -678,16 +678,6 @@ These values take in the same options as the root-level settings with the same n
 
 `boolean` values
 
-## Show Navigation History Buttons
-
-- Description: Whether or not to show the navigation history buttons in the tab bar.
-  -Setting: `show_nav_history_buttons`
-- Default: `true`
-
-**Options**
-
-`boolean` values
-
 ## Show Whitespaces
 
 - Description: Whether or not to show render whitespace characters in the editor.

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -678,6 +678,16 @@ These values take in the same options as the root-level settings with the same n
 
 `boolean` values
 
+## Show Navigation History Buttons
+
+- Description: Whether or not to show the navigation history buttons in the tab bar.
+  -Setting: `show_nav_history_buttons`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## Show Whitespaces
 
 - Description: Whether or not to show render whitespace characters in the editor.


### PR DESCRIPTION
This is another variant for this [original PR](https://github.com/zed-industries/zed/pull/10091) to add settings to show/hide navigation history buttons that puts the settings under a new section called `tab_bar`:

```
  "tab_bar": {
    // Whether or not to show the navigation history buttons.
    "show_nav_history_buttons": true
  }
```

<img width="314" alt="Screenshot 2024-04-02 at 3 00 53 PM" src="https://github.com/zed-industries/zed/assets/1253505/23c4fa19-5a63-4160-b3b7-1b5e976c36bf">
<img width="329" alt="Screenshot 2024-04-02 at 3 01 03 PM" src="https://github.com/zed-industries/zed/assets/1253505/64c2ebd2-9311-4589-a4e8-bd149c6c4ece">

