### PR TITLE
Make scrollbar a bit wider

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10200,7 +10200,7 @@ impl Render for Editor {
                 background,
                 local_player: cx.theme().players().local(),
                 text: text_style,
-                scrollbar_width: px(12.),
+                scrollbar_width: px(13.),
                 syntax: cx.theme().syntax().clone(),
                 status: cx.theme().status().clone(),
                 inlay_hints_style: HighlightStyle {


### PR DESCRIPTION
At the moment, the editor scrollbar is 12px wide. One pixel is allocated for the left border, so we have 11 pixels to display markers. It's not enough to make three even marker columns (git, highlights, diagnostics) that fully fill the scrollbar, so the current implementation allocates 3 pixels to each column.

As the result, we have 2 spare pixels on the right (before #10080 they were occupied by the diagnostics column). Making the scrollbar just one pixel wider allows us to give one additional pixel to each marker column and make markers more pronounced ("as is" on the left, "to be" on the right):

<img width="115" alt="zed-scrollbar-markers-1px" src="https://github.com/zed-industries/zed/assets/2101250/4bdf0107-c0f1-4c9c-9063-d2ff461e1c32">

Other options:
- Remove scrollbar thumb border. That'll give us one missing pixel to make markers wide and even. I, personally, prefer this option, but themes now have `scrollbar.thumb.border` colors that differ from `scrollbar.thumb.background` for some reason. This theme setting becomes deprecated in this case. For the reference: VS Code doesn't have scrollbar slider borders, IntelliJ IDEA does have them.
- Don't try to make markers evenly wide. For instance, IntelliJ uses very narrow git-diff markers that are separated from other markers. But it requires much wider scrollbar (it's 20px in IDEA).
- Use the spare two pixels to make diagnostic markers wider (it's the pre #10080 approach), or split them between the highlight and diagnostic markers (have 3px+4px+4px marker columns).
- Do nothing. It leaves us with two unused pixels :(

Release Notes:

- N/A

Related Issues:

- The previous discussion: https://github.com/zed-industries/zed/pull/9080#issuecomment-1997979968