### PR TITLE
Improve Ruby Syntax

### DIFF
--- a/crates/languages/src/ruby/highlights.scm
+++ b/crates/languages/src/ruby/highlights.scm
@@ -55,6 +55,8 @@
   (keyword_parameter [name: (identifier) (":")] @variable.parameter)
   ])
 
+(block_parameters (identifier) @variable.parameter)
+
 ; Identifiers
 
 ((identifier) @constant.builtin
@@ -68,12 +70,12 @@
   "**" @operator
 ) @constant.builtin
 
-((constant) @constant
- (#match? @constant "^[A-Z\\d_]+$"))
-
 (global_variable) @constant
 
 (constant) @type
+
+((constant) @constant
+ (#match? @constant "^[A-Z\\d_]+$"))
 
 (superclass
   (constant) @type.super)


### PR DESCRIPTION

Release Notes:

fixes #9995  being able to target constants
<img width="336" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/9e8cc438-10c4-441f-9140-3f4b418bd3bd">

Adds highlighting for parameters In blocks
<img width="318" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/4fa45fbe-104b-4778-994b-3b6d6ba930d4">
