### PR TITLE
tasks: Use icons instead of secondary text in a modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9496,6 +9496,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "editor",
+ "file_icons",
  "fuzzy",
  "gpui",
  "itertools 0.11.0",

--- a/crates/file_icons/src/file_icons.rs
+++ b/crates/file_icons/src/file_icons.rs
@@ -54,18 +54,20 @@ impl FileIcons {
             let suffix = path.icon_stem_or_suffix()?;
 
             if let Some(type_str) = this.stems.get(suffix) {
-                return this
-                    .types
-                    .get(type_str)
-                    .map(|type_config| type_config.icon.clone());
+                return this.get_type_icon(type_str);
             }
 
             this.suffixes
                 .get(suffix)
-                .and_then(|type_str| this.types.get(type_str))
-                .map(|type_config| type_config.icon.clone())
+                .and_then(|type_str| this.get_type_icon(type_str))
         })
-        .or_else(|| this.types.get("default").map(|config| config.icon.clone()))
+        .or_else(|| this.get_type_icon("default"))
+    }
+
+    pub fn get_type_icon(&self, typ: &str) -> Option<Arc<str>> {
+        self.types
+            .get(typ)
+            .map(|type_config| type_config.icon.clone())
     }
 
     pub fn get_folder_icon(expanded: bool, cx: &AppContext) -> Option<Arc<str>> {
@@ -77,9 +79,7 @@ impl FileIcons {
             COLLAPSED_DIRECTORY_TYPE
         };
 
-        this.types
-            .get(key)
-            .map(|type_config| type_config.icon.clone())
+        this.get_type_icon(key)
     }
 
     pub fn get_chevron_icon(expanded: bool, cx: &AppContext) -> Option<Arc<str>> {
@@ -91,8 +91,6 @@ impl FileIcons {
             COLLAPSED_CHEVRON_TYPE
         };
 
-        this.types
-            .get(key)
-            .map(|type_config| type_config.icon.clone())
+        this.get_type_icon(key)
     }
 }

--- a/crates/tasks_ui/Cargo.toml
+++ b/crates/tasks_ui/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 editor.workspace = true
+file_icons.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 picker.workspace = true
@@ -22,6 +23,7 @@ util.workspace = true
 workspace.workspace = true
 language.workspace = true
 itertools.workspace = true
+
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
Before:
![image](https://github.com/zed-industries/zed/assets/24362066/feae9c98-37d4-437d-965a-047d2e089a7b)
After:
![image](https://github.com/zed-industries/zed/assets/24362066/43e48985-5aba-44d9-9128-cfafb9b61fd4)

Release Notes:

- N/A
