### PR TITLE
X11: Don't emit keypress events for modifiers

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -624,6 +624,24 @@ impl Keystroke {
     }
 }
 
+impl Modifiers {
+    pub(super) fn from_xkb(keymap_state: &State) -> Self {
+        let shift = keymap_state.mod_name_is_active(xkb::MOD_NAME_SHIFT, xkb::STATE_MODS_EFFECTIVE);
+        let alt = keymap_state.mod_name_is_active(xkb::MOD_NAME_ALT, xkb::STATE_MODS_EFFECTIVE);
+        let control =
+            keymap_state.mod_name_is_active(xkb::MOD_NAME_CTRL, xkb::STATE_MODS_EFFECTIVE);
+        let platform =
+            keymap_state.mod_name_is_active(xkb::MOD_NAME_LOGO, xkb::STATE_MODS_EFFECTIVE);
+        Modifiers {
+            shift,
+            alt,
+            control,
+            platform,
+            function: false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -588,20 +588,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClient {
 
                 let keymap_state = state.keymap_state.as_mut().unwrap();
                 keymap_state.update_mask(mods_depressed, mods_latched, mods_locked, 0, 0, group);
-
-                let shift =
-                    keymap_state.mod_name_is_active(xkb::MOD_NAME_SHIFT, xkb::STATE_MODS_EFFECTIVE);
-                let alt =
-                    keymap_state.mod_name_is_active(xkb::MOD_NAME_ALT, xkb::STATE_MODS_EFFECTIVE);
-                let control =
-                    keymap_state.mod_name_is_active(xkb::MOD_NAME_CTRL, xkb::STATE_MODS_EFFECTIVE);
-                let command =
-                    keymap_state.mod_name_is_active(xkb::MOD_NAME_LOGO, xkb::STATE_MODS_EFFECTIVE);
-
-                state.modifiers.shift = shift;
-                state.modifiers.alt = alt;
-                state.modifiers.control = control;
-                state.modifiers.platform = command;
+                state.modifiers = Modifiers::from_xkb(keymap_state);
 
                 let input = PlatformInput::ModifiersChanged(ModifiersChangedEvent {
                     modifiers: state.modifiers,


### PR DESCRIPTION
This fixes certain shortcuts/motions on X11 like in vim mode "v i )", where previously zed would interpret it as "v i SHIFT )" due to the x11 backend emitting key press events for modifier keys even though other platforms like Wayland don't. This also adds support for ModifiersChanged events to X11

Release Notes:

- Fixed vim motions like "v i )" not working on X11 ([#10199](https://github.com/zed-industries/zed/issues/10199)).
