### PR TITLE
pane: Always notify status bar items on Pane::Focused events

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2314,11 +2314,13 @@ impl Workspace {
     }
 
     fn handle_pane_focused(&mut self, pane: View<Pane>, cx: &mut ViewContext<Self>) {
+        // This is explicitly hoisted out of the following check for pane identity as
+        // terminal panel panes are not registered as a center panes.
+        self.status_bar.update(cx, |status_bar, cx| {
+            status_bar.set_active_pane(&pane, cx);
+        });
         if self.active_pane != pane {
             self.active_pane = pane.clone();
-            self.status_bar.update(cx, |status_bar, cx| {
-                status_bar.set_active_pane(&self.active_pane, cx);
-            });
             self.active_item_path_changed(cx);
             self.last_active_center_pane = Some(pane.downgrade());
         }


### PR DESCRIPTION
Due to peculiarities in handling of terminal panes (namely the fact that they are not actually tracked by the Workspace::active_pane member), it was possible to get into a state where status bar items "lost track" of an active pane item; one way to reproduce it was to open a new terminal via "workspace: new terminal" with a pane open in a central view; once a new terminal is opened, the language selector and line number indicator lose track of an active item. Focusing central view does nothing - it will only go away after switching a tab in the central view.

To remedy this, we now always notify the status bar items of a pane focus change, even if Workspace::active_pane points to the same pane.

Release Notes:

- Fixed status bar focus issues when spawning a terminal via `workspace: new terminal` action.
