### PR TITLE
chat panel: Fix new messages indicator appearing when message was deleted

### DIFF
--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -652,13 +652,28 @@ impl ChannelChat {
         let mut messages = cursor.slice(&ChannelMessageId::Saved(id), Bias::Left, &());
         if let Some(item) = cursor.item() {
             if item.id == ChannelMessageId::Saved(id) {
-                let ix = messages.summary().count;
+                let deleted_message_ix = messages.summary().count;
                 cursor.next(&());
                 messages.append(cursor.suffix(&()), &());
                 drop(cursor);
                 self.messages = messages;
+
+                // If the message that was deleted was the last acknowledged message,
+                // replace the acknowledged message with an earlier one.
+                self.channel_store.update(cx, |store, _| {
+                    let summary = self.messages.summary();
+                    if summary.count == 0 {
+                        store.set_acknowledged_message_id(self.channel_id, None);
+                    } else if deleted_message_ix == summary.count {
+                        let latest_id = summary.max_id;
+                        if let ChannelMessageId::Saved(id) = latest_id {
+                            store.set_acknowledged_message_id(self.channel_id, Some(id));
+                        }
+                    }
+                });
+
                 cx.emit(ChannelChatEvent::MessagesUpdated {
-                    old_range: ix..ix + 1,
+                    old_range: deleted_message_ix..deleted_message_ix + 1,
                     new_count: 0,
                 });
             }

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -665,8 +665,7 @@ impl ChannelChat {
                     if summary.count == 0 {
                         store.set_acknowledged_message_id(self.channel_id, None);
                     } else if deleted_message_ix == summary.count {
-                        let latest_id = summary.max_id;
-                        if let ChannelMessageId::Saved(id) = latest_id {
+                        if let ChannelMessageId::Saved(id) = summary.max_id {
                             store.set_acknowledged_message_id(self.channel_id, Some(id));
                         }
                     }

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -380,6 +380,12 @@ impl ChannelStore {
             .is_some_and(|state| state.has_new_messages())
     }
 
+    pub fn set_acknowledged_message_id(&mut self, channel_id: ChannelId, message_id: Option<u64>) {
+        if let Some(state) = self.channel_states.get_mut(&channel_id) {
+            state.latest_chat_message = message_id;
+        }
+    }
+
     pub fn last_acknowledge_message_id(&self, channel_id: ChannelId) -> Option<u64> {
         self.channel_states.get(&channel_id).and_then(|state| {
             if let Some(last_message_id) = state.latest_chat_message {


### PR DESCRIPTION
Release Notes:

Fixed an issue where the "New messages" indicator in the channel chat would be shown even if the message was deleted