### PR TITLE
Send along diagnostics when requesting code actions

### DIFF
--- a/crates/language/src/diagnostic_set.rs
+++ b/crates/language/src/diagnostic_set.rs
@@ -1,4 +1,4 @@
-use crate::Diagnostic;
+use crate::{range_to_lsp, Diagnostic};
 use collections::HashMap;
 use lsp::LanguageServerId;
 use std::{
@@ -51,7 +51,7 @@ pub struct Summary {
     count: usize,
 }
 
-impl<T> DiagnosticEntry<T> {
+impl DiagnosticEntry<PointUtf16> {
     /// Returns a raw LSP diagnostic ssed to provide diagnostic context to LSP
     /// codeAction request
     pub fn to_lsp_diagnostic_stub(&self) -> lsp::Diagnostic {
@@ -61,9 +61,14 @@ impl<T> DiagnosticEntry<T> {
             .clone()
             .map(lsp::NumberOrString::String);
 
+        let range = range_to_lsp(self.range.clone());
+
         lsp::Diagnostic {
             code,
+            range,
             severity: Some(self.diagnostic.severity),
+            source: self.diagnostic.source.clone(),
+            message: self.diagnostic.message.clone(),
             ..Default::default()
         }
     }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1699,9 +1699,10 @@ impl LspCommand for GetCodeActions {
     ) -> lsp::CodeActionParams {
         let relevant_diagnostics = buffer
             .snapshot()
-            .diagnostics_in_range::<_, usize>(self.range.clone(), false)
+            .diagnostics_in_range::<_, language::PointUtf16>(self.range.clone(), false)
             .map(|entry| entry.to_lsp_diagnostic_stub())
-            .collect();
+            .collect::<Vec<_>>();
+
         lsp::CodeActionParams {
             text_document: lsp::TextDocumentIdentifier::new(
                 lsp::Url::from_file_path(path).unwrap(),


### PR DESCRIPTION
This fixes #10177 by sending along the correct diagnostics when querying the language server for diagnostics for a given cursor location.

Turns out that `gopls` takes the `range`, `source`, `message` of the diagnostics sent along to check whether it has any code actions for the given location.

Release Notes:

- Fixed "quickfix" code actions that were based on diagnostics not showing up in Go files ([#10177](https://github.com/zed-industries/zed/issues/10177)).
