### PR TITLE
Fix panic when deleting just-generated text

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2754,10 +2754,13 @@ impl BufferSnapshot {
                         range.start + self.line_len(start.row as u32) as usize - start.column;
                 }
 
-                buffer_ranges.push((range, node_is_name));
+                if !range.is_empty() {
+                    buffer_ranges.push((range, node_is_name));
+                }
             }
 
             if buffer_ranges.is_empty() {
+                matches.advance();
                 continue;
             }
 


### PR DESCRIPTION
We ran into a panic when deleting text that was just generated by a code action.

This fixes it by ensuring we don't run into a 0-minus-1 panic when a buffer_range is empty.

Release Notes:

- Fixed panic that could occur when deleting generated-by-unsaved text.
