### PR TITLE
Respect language server's capabilities when calling `GetReferences`

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4659,9 +4659,16 @@ async fn test_references(
     let active_call_a = cx_a.read(ActiveCall::global);
 
     client_a.language_registry().add(rust_lang());
-    let mut fake_language_servers = client_a
-        .language_registry()
-        .register_fake_lsp_adapter("Rust", Default::default());
+    let mut fake_language_servers = client_a.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                references_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
 
     client_a
         .fs()

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -903,6 +903,14 @@ impl LspCommand for GetReferences {
         return Some("Finding references...".to_owned());
     }
 
+    fn check_capabilities(&self, capabilities: &ServerCapabilities) -> bool {
+        match &capabilities.references_provider {
+            Some(OneOf::Left(has_support)) => *has_support,
+            Some(OneOf::Right(_)) => true,
+            None => false,
+        }
+    }
+
     fn to_lsp(
         &self,
         path: &Path,


### PR DESCRIPTION
This PR makes Zed respect the language server's capabilities when calling the `GetReferences` command (used in "Find All References", etc.).

This fixes a crash that could occur when using Zed with Gleam v1.0.

Release Notes:

- Made "Find All References" respect the language server's capabilities. This fixes some instances where certain language servers would stop working after receiving a "Find All References" request.