### PR TITLE
Make search context larger

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4288,7 +4288,8 @@ where
         .peekable();
     while let Some(range) = range_iter.next() {
         let excerpt_start = Point::new(range.start.row.saturating_sub(context_line_count), 0);
-        let mut excerpt_end = Point::new(range.end.row + 1 + context_line_count, 0).min(max_point);
+        let mut excerpt_end = Point::new(range.end.row + context_line_count, 0).min(max_point);
+
         let mut ranges_in_excerpt = 1;
 
         while let Some(next_range) = range_iter.peek() {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4780,7 +4780,7 @@ mod tests {
         let snapshot = multibuffer.read(cx).snapshot(cx);
         assert_eq!(
             snapshot.text(),
-            "bbb\nccc\nddd\neee\nfff\nggg\nhhh\niii\njjj\n\nnnn\nooo\nppp\nqqq\nrrr\n"
+            "bbb\nccc\nddd\neee\nfff\nggg\nhhh\niii\njjj\n\nnnn\nooo\nppp\nqqq\n"
         );
 
         assert_eq!(
@@ -4822,7 +4822,7 @@ mod tests {
         let snapshot = multibuffer.update(cx, |multibuffer, cx| multibuffer.snapshot(cx));
         assert_eq!(
             snapshot.text(),
-            "bbb\nccc\nddd\neee\nfff\nggg\nhhh\niii\njjj\n\nnnn\nooo\nppp\nqqq\nrrr\n"
+            "bbb\nccc\nddd\neee\nfff\nggg\nhhh\niii\njjj\n\nnnn\nooo\nppp\nqqq\n"
         );
 
         assert_eq!(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -55,6 +55,8 @@ struct ActiveSettings(HashMap<WeakModel<Project>, ProjectSearchSettings>);
 
 impl Global for ActiveSettings {}
 
+const SEARCH_CONTEXT: u32 = 2;
+
 pub fn init(cx: &mut AppContext) {
     cx.set_global(ActiveSettings::default());
     cx.observe_new_views(|workspace: &mut Workspace, _cx| {
@@ -235,8 +237,12 @@ impl ProjectSearch {
                             .update(&mut cx, |this, cx| {
                                 this.no_results = Some(false);
                                 this.excerpts.update(cx, |excerpts, cx| {
-                                    excerpts
-                                        .stream_excerpts_with_context_lines(buffer, ranges, 1, cx)
+                                    excerpts.stream_excerpts_with_context_lines(
+                                        buffer,
+                                        ranges,
+                                        SEARCH_CONTEXT,
+                                        cx,
+                                    )
                                 })
                             })
                             .ok()?;


### PR DESCRIPTION
This increases search context from 1 above, 2 below, to 2 above and 2 below, matching the Sublime Text search results.

Release Notes:

- Increased search result context from 3 lines to 4 lines