### PR TITLE
Respect language server's capabilities when calling `GetReferences` (cherry-pick #10285)

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4641,9 +4641,16 @@ async fn test_references(
     let active_call_a = cx_a.read(ActiveCall::global);
 
     client_a.language_registry().add(rust_lang());
-    let mut fake_language_servers = client_a
-        .language_registry()
-        .register_fake_lsp_adapter("Rust", Default::default());
+    let mut fake_language_servers = client_a.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                references_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
 
     client_a
         .fs()

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -896,6 +896,14 @@ impl LspCommand for GetReferences {
     type LspRequest = lsp::request::References;
     type ProtoRequest = proto::GetReferences;
 
+    fn check_capabilities(&self, capabilities: &ServerCapabilities) -> bool {
+        match &capabilities.references_provider {
+            Some(OneOf::Left(has_support)) => *has_support,
+            Some(OneOf::Right(_)) => true,
+            None => false,
+        }
+    }
+
     fn to_lsp(
         &self,
         path: &Path,


### PR DESCRIPTION
Cherry-pick 56c0345cf30737d4d6db8adad9373c93fce338a0 into `v0.130.x`.

This PR makes Zed respect the language server's capabilities when calling the `GetReferences` command (used in "Find All References", etc.).

This fixes a crash that could occur when using Zed with Gleam v1.0.

Release Notes:

- Made "Find All References" respect the language server's capabilities. This fixes some instances where certain language servers would stop working after receiving a "Find All References" request.
