### PR TITLE
Improve completion menu sorting

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1091,9 +1091,7 @@ impl CompletionsMenu {
         let completions = self.completions.read();
         matches.sort_unstable_by_key(|mat| {
             let completion = &completions[mat.candidate_id];
-            let sort_key = completion.sort_key();
             let sort_text = completion.lsp_completion.sort_text.as_deref();
-            let score = Reverse(OrderedFloat(mat.score));
             let equals = Reverse(
                 query
                     .as_ref()
@@ -1110,16 +1108,15 @@ impl CompletionsMenu {
                     .chars()
                     .skip(matching_index)
                     .zip(query.unwrap().chars())
-                    .position(|(mat_char, query_char)| mat_char != query_char)
-                    .unwrap_or(query.unwrap().len()),
+                    .filter(|(mat, query)| mat == query)
+                    .count(),
             });
             (
                 equals,
+                Reverse(matching_index != usize::MAX),
+                sort_text,
                 matching_index,
                 matching_case_count,
-                sort_text,
-                score,
-                sort_key,
             )
         });
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1098,25 +1098,29 @@ impl CompletionsMenu {
                     .map_or(true, |query| mat.string.eq_ignore_ascii_case(query)),
             );
 
-            let matching_index = matcher
+            let matched_index = matcher
                 .find(&mat.string)
                 .map_or(usize::MAX, |mat| mat.start());
-            let matching_case_count = Reverse(match matching_index {
+            let matched_cases_score = Reverse(match matched_index {
                 usize::MAX => 0,
-                _ => completion
-                    .new_text
-                    .chars()
-                    .skip(matching_index)
-                    .zip(query.unwrap().chars())
-                    .filter(|(mat, query)| mat == query)
-                    .count(),
+                _ => {
+                    let mut z = completion
+                        .new_text
+                        .chars()
+                        .skip(matched_index)
+                        .zip(query.unwrap().chars());
+
+                    z.clone().filter(|(mat, query)| mat == query).count()
+                        + z.position(|(mat, query)| mat != query)
+                            .unwrap_or(query.unwrap().len())
+                }
             });
             (
                 equals,
-                Reverse(matching_index != usize::MAX),
+                Reverse(matched_index != usize::MAX),
                 sort_text,
-                matching_index,
-                matching_case_count,
+                matched_index,
+                matched_cases_score,
             )
         });
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1086,53 +1086,25 @@ impl CompletionsMenu {
 
         let completions = self.completions.read();
         matches.sort_unstable_by_key(|mat| {
-            // We do want to strike a balance here between what the language server tells us
-            // to sort by (the sort_text) and what are "obvious" good matches (i.e. when you type
-            // `Creat` and there is a local variable called `CreateComponent`).
-            // So what we do is: we bucket all matches into two buckets
-            // - Strong matches
-            // - Weak matches
-            // Strong matches are the ones with a high fuzzy-matcher score (the "obvious" matches)
-            // and the Weak matches are the rest.
-            //
-            // For the strong matches, we sort by the language-servers score first and for the weak
-            // matches, we prefer our fuzzy finder first.
-            //
-            // The thinking behind that: it's useless to take the sort_text the language-server gives
-            // us into account when it's obviously a bad match.
-
-            #[derive(PartialEq, Eq, PartialOrd, Ord)]
-            enum MatchScore<'a> {
-                Strong {
-                    sort_text: Option<&'a str>,
-                    score: Reverse<OrderedFloat<f64>>,
-                    sort_key: (usize, &'a str),
-                },
-                Weak {
-                    score: Reverse<OrderedFloat<f64>>,
-                    sort_text: Option<&'a str>,
-                    sort_key: (usize, &'a str),
-                },
-            }
-
             let completion = &completions[mat.candidate_id];
             let sort_key = completion.sort_key();
             let sort_text = completion.lsp_completion.sort_text.as_deref();
             let score = Reverse(OrderedFloat(mat.score));
-
-            if mat.score >= 0.2 {
-                MatchScore::Strong {
-                    sort_text,
-                    score,
-                    sort_key,
-                }
-            } else {
-                MatchScore::Weak {
-                    score,
-                    sort_text,
-                    sort_key,
-                }
-            }
+            let equals = match query.as_deref() {
+                Some(_) => !mat.string.eq_ignore_ascii_case(query.unwrap()),
+                None => true,
+            };
+            let matching_index = match query.as_deref() {
+                Some(_) => mat.string.to_lowercase().find(&query.unwrap().to_lowercase()).or(Some(usize::MAX)),
+                None => Some(usize::MAX),
+            };
+            (
+                equals,
+                matching_index,
+                sort_text,
+                score,
+                sort_key,
+            )
         });
 
         for mat in &mut matches {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1101,7 +1101,7 @@ impl CompletionsMenu {
             );
             let matching_index = lowercase_query
                 .as_ref()
-                .and_then(|query| mat.string.find(query).or(Some(usize::MAX)));
+                .and_then(|query| mat.string.find(query)).unwrap_or(usize::MAX);
             (equals, matching_index, sort_text, score, sort_key)
         });
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1084,18 +1084,26 @@ impl CompletionsMenu {
             }
         }
 
+        for mat in &mut matches {
+            mat.string = mat.string.to_lowercase();
+        }
         let completions = self.completions.read();
+        let lowercase_query = if let Some(query) = query {
+            Some(query.to_lowercase())
+        } else {
+            None
+        };
         matches.sort_unstable_by_key(|mat| {
             let completion = &completions[mat.candidate_id];
             let sort_key = completion.sort_key();
             let sort_text = completion.lsp_completion.sort_text.as_deref();
             let score = Reverse(OrderedFloat(mat.score));
-            let equals = match query.as_deref() {
-                Some(_) => !mat.string.eq_ignore_ascii_case(query.unwrap()),
+            let equals = match lowercase_query {
+                Some(_) => !mat.string.eq(lowercase_query.as_ref().unwrap()),
                 None => true,
             };
-            let matching_index = match query.as_deref() {
-                Some(_) => mat.string.to_lowercase().find(&query.unwrap().to_lowercase()).or(Some(usize::MAX)),
+            let matching_index = match lowercase_query {
+                Some(_) => mat.string.find(lowercase_query.as_ref().unwrap()).or(Some(usize::MAX)),
                 None => Some(usize::MAX),
             };
             (

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1103,7 +1103,24 @@ impl CompletionsMenu {
                 .as_ref()
                 .and_then(|query| mat.string.find(query))
                 .unwrap_or(usize::MAX);
-            (equals, matching_index, sort_text, score, sort_key)
+            let matching_case_count = Reverse(match matching_index {
+                usize::MAX => 0,
+                _ => completion
+                    .new_text
+                    .chars()
+                    .skip(matching_index)
+                    .zip(query.unwrap().chars())
+                    .position(|(mat_char, query_char)| mat_char != query_char)
+                    .unwrap_or(query.unwrap().len()),
+            });
+            (
+                equals,
+                matching_index,
+                matching_case_count,
+                sort_text,
+                score,
+                sort_key,
+            )
         });
 
         for mat in &mut matches {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -91,7 +91,6 @@ pub use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot, ToOffset,
     ToPoint,
 };
-use ordered_float::OrderedFloat;
 use parking_lot::{Mutex, RwLock};
 use project::project_settings::{GitGutterSetting, ProjectSettings};
 use project::{

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1101,7 +1101,8 @@ impl CompletionsMenu {
             );
             let matching_index = lowercase_query
                 .as_ref()
-                .and_then(|query| mat.string.find(query)).unwrap_or(usize::MAX);
+                .and_then(|query| mat.string.find(query))
+                .unwrap_or(usize::MAX);
             (equals, matching_index, sort_text, score, sort_key)
         });
 


### PR DESCRIPTION
Release Notes:
- Improved Sorting of words in the completion menu.

Fixed #9342 
This fixes the issue by making two things.
1. Ordering first by exact match, lsp sorted text, matching index and then matching cases.
2. Removed Strong and Weak buckets, because short matches would fall into the strong bucket first and would result in an inaccurate match.
 
https://github.com/zed-industries/zed/assets/66138117/bd6fc6a9-57dc-48d0-b2b6-02be9fbd9fd5