### PR TITLE
Add support for using a language server with multiple languages

### DIFF
--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -99,7 +99,9 @@ pub struct GrammarManifestEntry {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct LanguageServerManifestEntry {
     /// Deprecated in favor of `languages`.
-    language: Arc<str>,
+    #[serde(default)]
+    language: Option<Arc<str>>,
+    /// The list of languages this language server should work with.
     #[serde(default)]
     languages: Vec<Arc<str>>,
     #[serde(default)]
@@ -107,10 +109,20 @@ pub struct LanguageServerManifestEntry {
 }
 
 impl LanguageServerManifestEntry {
-    pub fn languages(&self) -> Vec<Arc<str>> {
-        let mut languages = self.languages.clone();
-        languages.push(self.language.clone());
-        languages
+    /// Returns the list of languages for the language server.
+    ///
+    /// Prefer this over accessing the `language` or `languages` fields directly,
+    /// as we currently support both.
+    ///
+    /// We can replace this with just field access for the `languages` field once
+    /// we have removed `language`.
+    pub fn languages(&self) -> impl IntoIterator<Item = Arc<str>> + '_ {
+        let language = if self.languages.is_empty() {
+            self.language.clone()
+        } else {
+            None
+        };
+        self.languages.iter().cloned().chain(language)
     }
 }
 

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -98,9 +98,20 @@ pub struct GrammarManifestEntry {
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct LanguageServerManifestEntry {
-    pub language: Arc<str>,
+    /// Deprecated in favor of `languages`.
+    language: Arc<str>,
+    #[serde(default)]
+    languages: Vec<Arc<str>>,
     #[serde(default)]
     pub language_ids: HashMap<String, String>,
+}
+
+impl LanguageServerManifestEntry {
+    pub fn languages(&self) -> Vec<Arc<str>> {
+        let mut languages = self.languages.clone();
+        languages.push(self.language.clone());
+        languages
+    }
 }
 
 impl ExtensionManifest {

--- a/extensions/emmet/extension.toml
+++ b/extensions/emmet/extension.toml
@@ -9,3 +9,4 @@ repository = "https://github.com/zed-industries/zed"
 [language_servers.emmet-language-server]
 name = "Emmet Language Server"
 language = "HTML"
+languages = ["HTML", "PHP", "ERB"]


### PR DESCRIPTION
This PR updates the `extension.toml` to allow specifying multiple languages for a language server to work with.

The `languages` field takes precedence over `language`. In the future the `language` field will be removed.

As part of this, the Emmet extension has been extended with support for PHP and ERB.

Release Notes:

- N/A
