### PR TITLE
Add the ability for extensions to provide language settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -556,52 +556,16 @@
     "C": {
       "format_on_save": "off"
     },
-    "Plain Text": {
-      "soft_wrap": "preferred_line_length"
-    },
-    "Elixir": {
-      "tab_size": 2
-    },
     "Gleam": {
       "tab_size": 2
     },
     "Go": {
-      "tab_size": 4,
-      "hard_tabs": true,
       "code_actions_on_format": {
         "source.organizeImports": true
       }
     },
     "Make": {
       "hard_tabs": true
-    },
-    "Markdown": {
-      "tab_size": 2,
-      "soft_wrap": "preferred_line_length"
-    },
-    "JavaScript": {
-      "tab_size": 2
-    },
-    "Terraform": {
-      "tab_size": 2
-    },
-    "TypeScript": {
-      "tab_size": 2
-    },
-    "TSX": {
-      "tab_size": 2
-    },
-    "YAML": {
-      "tab_size": 2
-    },
-    "JSON": {
-      "tab_size": 2
-    },
-    "OCaml": {
-      "tab_size": 2
-    },
-    "OCaml Interface": {
-      "tab_size": 2
     },
     "Prisma": {
       "tab_size": 2

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -10,7 +10,7 @@ use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum ZedDotDevModel {
@@ -332,13 +332,12 @@ impl Settings for AssistantSettings {
     type FileContent = AssistantSettingsContent;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
         let mut settings = AssistantSettings::default();
 
-        for value in [default_value].iter().chain(user_values) {
+        for value in sources.defaults_and_customizations() {
             let value = value.upgrade();
             merge(&mut settings.enabled, value.enabled);
             merge(&mut settings.button, value.button);

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use serde_derive::Serialize;
 use smol::io::AsyncReadExt;
 
-use settings::{Settings, SettingsStore};
+use settings::{Settings, SettingsSources, SettingsStore};
 use smol::{fs::File, process::Command};
 
 use release_channel::{AppCommitSha, AppVersion, ReleaseChannel};
@@ -91,13 +91,12 @@ impl Settings for AutoUpdateSetting {
 
     type FileContent = AutoUpdateSettingOverride;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut AppContext,
-    ) -> Result<Self> {
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
         Ok(Self(
-            Self::json_merge(default_value, user_values)?
+            sources
+                .release_channel
+                .or(sources.user)
+                .unwrap_or(sources.default)
                 .0
                 .ok_or_else(Self::missing_default)?,
         ))

--- a/crates/call/src/call_settings.rs
+++ b/crates/call/src/call_settings.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use gpui::AppContext;
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 
 #[derive(Deserialize, Debug)]
 pub struct CallSettings {
@@ -29,14 +29,7 @@ impl Settings for CallSettings {
 
     type FileContent = CallSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _cx: &mut AppContext,
-    ) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }

--- a/crates/collab_ui/src/panel_settings.rs
+++ b/crates/collab_ui/src/panel_settings.rs
@@ -2,7 +2,7 @@ use anyhow;
 use gpui::Pixels;
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 use workspace::dock::DockPosition;
 
 #[derive(Deserialize, Debug)]
@@ -53,48 +53,52 @@ pub struct MessageEditorSettings {
 
 impl Settings for CollaborationPanelSettings {
     const KEY: Option<&'static str> = Some("collaboration_panel");
+
     type FileContent = PanelSettingsContent;
+
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }
 
 impl Settings for ChatPanelSettings {
     const KEY: Option<&'static str> = Some("chat_panel");
+
     type FileContent = PanelSettingsContent;
+
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }
 
 impl Settings for NotificationPanelSettings {
     const KEY: Option<&'static str> = Some("notification_panel");
+
     type FileContent = PanelSettingsContent;
+
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }
 
 impl Settings for MessageEditorSettings {
     const KEY: Option<&'static str> = Some("message_editor");
+
     type FileContent = MessageEditorSettings;
+
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }

--- a/crates/diagnostics/src/project_diagnostics_settings.rs
+++ b/crates/diagnostics/src/project_diagnostics_settings.rs
@@ -1,5 +1,8 @@
+use anyhow::Result;
+use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use settings::{Settings, SettingsSources};
 
 #[derive(Deserialize, Debug)]
 pub struct ProjectDiagnosticsSettings {
@@ -15,18 +18,11 @@ pub struct ProjectDiagnosticsSettingsContent {
     include_warnings: Option<bool>,
 }
 
-impl settings::Settings for ProjectDiagnosticsSettings {
+impl Settings for ProjectDiagnosticsSettings {
     const KEY: Option<&'static str> = Some("diagnostics");
     type FileContent = ProjectDiagnosticsSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _cx: &mut gpui::AppContext,
-    ) -> anyhow::Result<Self>
-    where
-        Self: Sized,
-    {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -1,6 +1,7 @@
+use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 
 #[derive(Deserialize, Clone)]
 pub struct EditorSettings {
@@ -224,10 +225,9 @@ impl Settings for EditorSettings {
     type FileContent = EditorSettingsContent;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut gpui::AppContext,
+        sources: SettingsSources<Self::FileContent>,
+        _: &mut AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }

--- a/crates/extension/src/extension_settings.rs
+++ b/crates/extension/src/extension_settings.rs
@@ -3,7 +3,7 @@ use collections::HashMap;
 use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 use std::sync::Arc;
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, JsonSchema)]
@@ -26,14 +26,7 @@ impl Settings for ExtensionSettings {
 
     type FileContent = Self;
 
-    fn load(
-        _default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _cx: &mut AppContext,
-    ) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        Ok(user_values.get(0).copied().cloned().unwrap_or_default())
+    fn load(sources: SettingsSources<Self::FileContent>, _cx: &mut AppContext) -> Result<Self> {
+        Ok(sources.user.cloned().unwrap_or_default())
     }
 }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -5,7 +5,7 @@ use editor::Editor;
 use gpui::{actions, AppContext, ViewContext, WindowContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 use std::{
     fs::OpenOptions,
     path::{Path, PathBuf},
@@ -50,12 +50,8 @@ impl settings::Settings for JournalSettings {
 
     type FileContent = Self;
 
-    fn load(
-        defaults: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut AppContext,
-    ) -> Result<Self> {
-        Self::load_via_json_merge(defaults, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -38,6 +38,7 @@ use schemars::{
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use smol::future::FutureExt as _;
+use std::num::NonZeroU32;
 use std::{
     any::Any,
     cell::RefCell,
@@ -73,6 +74,8 @@ pub use syntax_map::{OwnedSyntaxLayer, SyntaxLayer};
 pub use text::LineEnding;
 pub use tree_sitter::{Parser, Tree};
 
+use crate::language_settings::SoftWrap;
+
 /// Initializes the `language` crate.
 ///
 /// This should be called before making use of items from the create.
@@ -99,6 +102,7 @@ lazy_static! {
     pub static ref PLAIN_TEXT: Arc<Language> = Arc::new(Language::new(
         LanguageConfig {
             name: "Plain Text".into(),
+            soft_wrap: Some(SoftWrap::PreferredLineLength),
             ..Default::default()
         },
         None,
@@ -576,6 +580,17 @@ pub struct LanguageConfig {
     /// The names of any Prettier plugins that should be used for this language.
     #[serde(default)]
     pub prettier_plugins: Vec<Arc<str>>,
+
+    /// Whether to indent lines using tab characters, as opposed to multiple
+    /// spaces.
+    #[serde(default)]
+    pub hard_tabs: Option<bool>,
+    /// How many columns a tab should occupy.
+    #[serde(default)]
+    pub tab_size: Option<NonZeroU32>,
+    /// How to soft-wrap long lines of text.
+    #[serde(default)]
+    pub soft_wrap: Option<SoftWrap>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, JsonSchema)]
@@ -660,6 +675,9 @@ impl Default for LanguageConfig {
             prettier_parser_name: None,
             prettier_plugins: Default::default(),
             collapsed_placeholder: Default::default(),
+            hard_tabs: Default::default(),
+            tab_size: Default::default(),
+            soft_wrap: Default::default(),
         }
     }
 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -119,7 +119,7 @@ pub struct CopilotSettings {
 }
 
 /// The settings for all languages.
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct AllLanguageSettingsContent {
     /// The settings for enabling/disabling features.
     #[serde(default)]
@@ -140,7 +140,7 @@ pub struct AllLanguageSettingsContent {
 }
 
 /// The settings for a particular language.
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct LanguageSettingsContent {
     /// How many columns a tab should occupy.
     ///
@@ -249,7 +249,7 @@ pub struct LanguageSettingsContent {
 }
 
 /// The contents of the GitHub Copilot settings.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
 pub struct CopilotSettingsContent {
     /// A list of globs representing files that Copilot should be disabled for.
     #[serde(default)]
@@ -257,7 +257,7 @@ pub struct CopilotSettingsContent {
 }
 
 /// The settings for enabling/disabling features.
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct FeaturesContent {
     /// Whether the GitHub Copilot feature is enabled.

--- a/crates/languages/src/deno.rs
+++ b/crates/languages/src/deno.rs
@@ -2,12 +2,13 @@ use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
+use gpui::AppContext;
 use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::{CodeActionKind, LanguageServerBinary};
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 use smol::{fs, fs::File};
 use std::{any::Any, env::consts, ffi::OsString, path::PathBuf, sync::Arc};
 use util::{
@@ -31,15 +32,8 @@ impl Settings for DenoSettings {
 
     type FileContent = DenoSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut gpui::AppContext,
-    ) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }
 

--- a/crates/languages/src/elixir.rs
+++ b/crates/languages/src/elixir.rs
@@ -1,14 +1,14 @@
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use futures::StreamExt;
-use gpui::{AsyncAppContext, Task};
+use gpui::{AppContext, AsyncAppContext, Task};
 pub use language::*;
 use lsp::{CompletionItemKind, LanguageServerBinary, SymbolKind};
 use project::project_settings::ProjectSettings;
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 use smol::fs::{self, File};
 use std::{
     any::Any,
@@ -56,15 +56,8 @@ impl Settings for ElixirSettings {
 
     type FileContent = ElixirSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut gpui::AppContext,
-    ) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }
 

--- a/crates/languages/src/elixir/config.toml
+++ b/crates/languages/src/elixir/config.toml
@@ -10,6 +10,7 @@ brackets = [
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]
+tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 
 [overrides.string]

--- a/crates/languages/src/go/config.toml
+++ b/crates/languages/src/go/config.toml
@@ -11,3 +11,5 @@ brackets = [
     { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
 ]
+tab_size = 4
+hard_tabs = true

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -15,6 +15,7 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 word_characters = ["$", "#"]
+tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "babel"
 

--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -9,3 +9,4 @@ brackets = [
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
 ]
 prettier_parser_name = "json"
+tab_size = 2

--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -12,3 +12,6 @@ brackets = [
     { start = "`", end = "`", close = false, newline = false },
 ]
 prettier_parser_name = "markdown"
+
+tab_size = 2
+soft_wrap = "preferred_line_length"

--- a/crates/languages/src/ocaml-interface/config.toml
+++ b/crates/languages/src/ocaml-interface/config.toml
@@ -10,3 +10,4 @@ brackets = [
   { start = "[", end = "]", close = true, newline = true },
   { start = "(", end = ")", close = true, newline = true }
 ]
+tab_size = 2

--- a/crates/languages/src/ocaml/config.toml
+++ b/crates/languages/src/ocaml/config.toml
@@ -11,3 +11,4 @@ brackets = [
   { start = "(", end = ")", close = true, newline = true },
   { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] }
 ]
+tab_size = 2

--- a/crates/languages/src/terraform/config.toml
+++ b/crates/languages/src/terraform/config.toml
@@ -12,3 +12,4 @@ brackets = [
     { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
 ]
+tab_size = 2

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -16,6 +16,7 @@ brackets = [
 word_characters = ["#", "$"]
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "typescript"
+tab_size = 2
 
 [overrides.element]
 line_comments = { remove = true }

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -15,3 +15,4 @@ brackets = [
 ]
 word_characters = ["#", "$"]
 prettier_parser_name = "typescript"
+tab_size = 2

--- a/crates/languages/src/yaml/config.toml
+++ b/crates/languages/src/yaml/config.toml
@@ -11,3 +11,4 @@ brackets = [
 
 increase_indent_pattern = ":\\s*[|>]?\\s*$"
 prettier_parser_name = "yaml"
+tab_size = 2

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -2,7 +2,7 @@ use collections::HashMap;
 use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 use std::sync::Arc;
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -61,10 +61,9 @@ impl Settings for ProjectSettings {
     type FileContent = Self;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -2,7 +2,7 @@ use anyhow;
 use gpui::Pixels;
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -62,10 +62,9 @@ impl Settings for ProjectPanelSettings {
     type FileContent = ProjectPanelSettingsContent;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -8,7 +8,9 @@ use util::asset_str;
 
 pub use keymap_file::KeymapFile;
 pub use settings_file::*;
-pub use settings_store::{Settings, SettingsJsonSchemaParams, SettingsLocation, SettingsStore};
+pub use settings_store::{
+    Settings, SettingsJsonSchemaParams, SettingsLocation, SettingsSources, SettingsStore,
+};
 
 #[derive(RustEmbed)]
 #[folder = "../../assets"]

--- a/crates/tasks_ui/src/settings.rs
+++ b/crates/tasks_ui/src/settings.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use settings::{Settings, SettingsSources};
 
 #[derive(Serialize, Deserialize, PartialEq, Default)]
 pub(crate) struct TaskSettings {
@@ -13,22 +14,15 @@ pub(crate) struct TaskSettingsContent {
     show_status_indicator: Option<bool>,
 }
 
-impl settings::Settings for TaskSettings {
+impl Settings for TaskSettings {
     const KEY: Option<&'static str> = Some("task");
 
     type FileContent = TaskSettingsContent;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
-    ) -> gpui::Result<Self>
-    where
-        Self: Sized,
-    {
-        let this = Self::json_merge(default_value, user_values)?;
-        Ok(Self {
-            show_status_indicator: this.show_status_indicator.unwrap_or(true),
-        })
+    ) -> gpui::Result<Self> {
+        sources.json_merge()
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -7,7 +7,7 @@ use schemars::{
 };
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
-use settings::SettingsJsonSchemaParams;
+use settings::{SettingsJsonSchemaParams, SettingsSources};
 use std::path::PathBuf;
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -171,12 +171,12 @@ impl settings::Settings for TerminalSettings {
     type FileContent = TerminalSettingsContent;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
+
     fn json_schema(
         generator: &mut SchemaGenerator,
         params: &SettingsJsonSchemaParams,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -763,12 +763,9 @@ impl Settings for VimModeSetting {
     type FileContent = Option<bool>;
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
-        Ok(Self(
-            sources
-                .user
-                .unwrap_or(sources.default)
-                .ok_or_else(Self::missing_default)?,
-        ))
+        Ok(Self(sources.user.copied().flatten().unwrap_or(
+            sources.default.ok_or_else(Self::missing_default)?,
+        )))
     }
 }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -35,7 +35,7 @@ use replace::multi_replace;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_derive::Serialize;
-use settings::{update_settings_file, Settings, SettingsStore};
+use settings::{update_settings_file, Settings, SettingsSources, SettingsStore};
 use state::{EditorState, Mode, Operator, RecordedSelection, WorkspaceState};
 use std::{ops::Range, sync::Arc};
 use surrounds::{add_surrounds, change_surrounds, delete_surrounds};
@@ -762,14 +762,13 @@ impl Settings for VimModeSetting {
 
     type FileContent = Option<bool>;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut AppContext,
-    ) -> Result<Self> {
-        Ok(Self(user_values.iter().rev().find_map(|v| **v).unwrap_or(
-            default_value.ok_or_else(Self::missing_default)?,
-        )))
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        Ok(Self(
+            sources
+                .user
+                .unwrap_or(sources.default)
+                .ok_or_else(Self::missing_default)?,
+        ))
     }
 }
 
@@ -807,11 +806,7 @@ impl Settings for VimSettings {
 
     type FileContent = VimSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut AppContext,
-    ) -> Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }

--- a/crates/welcome/src/base_keymap_setting.rs
+++ b/crates/welcome/src/base_keymap_setting.rs
@@ -73,9 +73,9 @@ impl Settings for BaseKeymap {
         sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
-        Ok(sources
-            .user
-            .unwrap_or(sources.default)
-            .ok_or_else(Self::missing_default)?)
+        if let Some(Some(user_value)) = sources.user.cloned() {
+            return Ok(user_value);
+        }
+        Ok(sources.default.ok_or_else(Self::missing_default)?.clone())
     }
 }

--- a/crates/welcome/src/base_keymap_setting.rs
+++ b/crates/welcome/src/base_keymap_setting.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 
 /// Base key bindings scheme. Base keymaps can be overridden with user keymaps.
 ///
@@ -70,16 +70,12 @@ impl Settings for BaseKeymap {
     type FileContent = Option<Self>;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
-    ) -> anyhow::Result<Self>
-    where
-        Self: Sized,
-    {
-        Ok(user_values
-            .first()
-            .and_then(|v| **v)
-            .unwrap_or(default_value.unwrap()))
+    ) -> anyhow::Result<Self> {
+        Ok(sources
+            .user
+            .unwrap_or(sources.default)
+            .ok_or_else(Self::missing_default)?)
     }
 }

--- a/crates/welcome/src/base_keymap_setting.rs
+++ b/crates/welcome/src/base_keymap_setting.rs
@@ -73,9 +73,9 @@ impl Settings for BaseKeymap {
         sources: SettingsSources<Self::FileContent>,
         _: &mut gpui::AppContext,
     ) -> anyhow::Result<Self> {
-        if let Some(Some(user_value)) = sources.user.cloned() {
+        if let Some(Some(user_value)) = sources.user.copied() {
             return Ok(user_value);
         }
-        Ok(sources.default.ok_or_else(Self::missing_default)?.clone())
+        sources.default.ok_or_else(Self::missing_default)
     }
 }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -20,7 +20,7 @@ use gpui::{
 use project::{Project, ProjectEntryId, ProjectPath};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 use smallvec::SmallVec;
 use std::{
     any::{Any, TypeId},
@@ -76,12 +76,8 @@ impl Settings for ItemSettings {
 
     type FileContent = ItemSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut AppContext,
-    ) -> Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -1,6 +1,8 @@
+use anyhow::Result;
+use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 
 #[derive(Deserialize)]
 pub struct WorkspaceSettings {
@@ -63,12 +65,8 @@ impl Settings for WorkspaceSettings {
 
     type FileContent = WorkspaceSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut gpui::AppContext,
-    ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }
 
@@ -77,11 +75,7 @@ impl Settings for TabBarSettings {
 
     type FileContent = TabBarSettingsContent;
 
-    fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
-        _: &mut gpui::AppContext,
-    ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
     }
 }

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -1,7 +1,7 @@
 use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsSources};
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct WorktreeSettings {
@@ -31,10 +31,9 @@ impl Settings for WorktreeSettings {
     type FileContent = Self;
 
     fn load(
-        default_value: &Self::FileContent,
-        user_values: &[&Self::FileContent],
+        sources: SettingsSources<Self::FileContent>,
         _: &mut AppContext,
     ) -> anyhow::Result<Self> {
-        Self::load_via_json_merge(default_value, user_values)
+        sources.json_merge()
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -608,8 +608,6 @@ pub fn handle_keymap_file_changes(
         let new_base_keymap = *BaseKeymap::get_global(cx);
         let new_vim_enabled = VimModeSetting::get_global(cx).0;
 
-        dbg!(&new_base_keymap, &old_base_keymap);
-
         if new_base_keymap != old_base_keymap || new_vim_enabled != old_vim_enabled {
             old_base_keymap = new_base_keymap;
             old_vim_enabled = new_vim_enabled;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -607,6 +607,9 @@ pub fn handle_keymap_file_changes(
     cx.observe_global::<SettingsStore>(move |cx| {
         let new_base_keymap = *BaseKeymap::get_global(cx);
         let new_vim_enabled = VimModeSetting::get_global(cx).0;
+
+        dbg!(&new_base_keymap, &old_base_keymap);
+
         if new_base_keymap != old_base_keymap || new_vim_enabled != old_vim_enabled {
             old_base_keymap = new_base_keymap;
             old_vim_enabled = new_vim_enabled;
@@ -3062,6 +3065,7 @@ mod tests {
             let mut app_state = AppState::test(cx);
 
             let state = Arc::get_mut(&mut app_state).unwrap();
+            env_logger::try_init().ok();
 
             state.build_window_options = build_window_options;
             theme::init(theme::LoadThemes::JustBase, cx);

--- a/extensions/gleam/languages/gleam/config.toml
+++ b/extensions/gleam/languages/gleam/config.toml
@@ -9,3 +9,4 @@ brackets = [
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
 ]
+tab_size = 2

--- a/extensions/prisma/languages/prisma/config.toml
+++ b/extensions/prisma/languages/prisma/config.toml
@@ -7,3 +7,4 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true }
 ]
+tab_size = 2


### PR DESCRIPTION
This PR adds the ability for extensions to provide certain language settings via the language `config.toml`.

These settings are then merged in with the rest of the settings when the language is loaded from the extension.

The language settings that are available are:

- `tab_size`
- `hard_tabs`
- `soft_wrap`

Additionally, for bundled languages we moved these settings out of the `settings/default.json` and into their respective `config.toml`s .

For languages currently provided by extensions, we are leaving the values in the `settings/default.json` temporarily until all released versions of Zed are able to load these settings from the extension.

---

Along the way we ended up refactoring the `Settings::load` method slightly, introducing a new `SettingsSources` struct to better convey where the settings are being loaded from.

This makes it easier to load settings from specific locations/sets of locations in an explicit way.

Release Notes:

- N/A
