### PR TITLE
Flip the optionality of the `auto_update` setting

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -82,29 +82,25 @@ struct AutoUpdateSetting(bool);
 /// Whether or not to automatically check for updates.
 ///
 /// Default: true
-#[derive(Clone, Default, JsonSchema, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, JsonSchema, Deserialize, Serialize)]
 #[serde(transparent)]
-struct AutoUpdateSettingOverride(Option<bool>);
+struct AutoUpdateSettingOverride(bool);
 
 impl Settings for AutoUpdateSetting {
     const KEY: Option<&'static str> = Some("auto_update");
 
-    type FileContent = AutoUpdateSettingOverride;
+    type FileContent = Option<AutoUpdateSettingOverride>;
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
-        if let Some(release_channel_value) = sources.release_channel {
-            if let Some(value) = release_channel_value.0 {
-                return Ok(Self(value));
-            }
+        if let Some(Some(release_channel_value)) = sources.release_channel {
+            return Ok(Self(release_channel_value.0));
         }
 
-        if let Some(user_value) = sources.user {
-            if let Some(value) = user_value.0 {
-                return Ok(Self(value));
-            }
+        if let Some(Some(user_value)) = sources.user {
+            return Ok(Self(user_value.0));
         }
 
-        Ok(Self(sources.default.0.ok_or_else(Self::missing_default)?))
+        Ok(Self(sources.default.ok_or_else(Self::missing_default)?.0))
     }
 }
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -97,10 +97,7 @@ impl Settings for ClientSettings {
 
     type FileContent = ClientSettingsContent;
 
-    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self>
-    where
-        Self: Sized,
-    {
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
         let mut result = sources.json_merge::<Self>()?;
         if let Some(server_url) = &*ZED_SERVER_URL {
             result.server_url = server_url.clone()


### PR DESCRIPTION
This PR flips the optionality of the `AutoUpdateSettingContent` to make it a bit easier to work with.

#### Before

```rs
struct AutoUpdateSettingContent(Option<bool>);

type FileContent = AutoUpdateSettingContent;
```

#### After

```rs
struct AutoUpdateSettingContent(bool);

type FileContent = Option<AutoUpdateSettingContent>;
```

Release Notes:

- N/A
