### PR TITLE
Fix using system zls not working

### DIFF
--- a/crates/extension/src/extension_lsp_adapter.rs
+++ b/crates/extension/src/extension_lsp_adapter.rs
@@ -85,8 +85,12 @@ impl LspAdapter for ExtensionLspAdapter {
                     use std::fs::{self, Permissions};
                     use std::os::unix::fs::PermissionsExt;
 
-                    fs::set_permissions(&path, Permissions::from_mode(0o755))
-                        .context("failed to set file permissions")?;
+                    let metadata = fs::metadata(&path).context("failed to get file metadata")?;
+                    let permissions = metadata.permissions();
+                    if permissions.mode() & 0o111 == 0 {
+                        fs::set_permissions(&path, Permissions::from_mode(0o755))
+                            .context("failed to set file permissions")?;
+                    }
                 }
             }
 


### PR DESCRIPTION
When using zls, Zed try to set the permission to 755 even if the file is already executable. As the user doesn't own zls when installed using package manager, Zed fails to load zls.

This PR fixes this by checking if the file is not executable before trying to set the permissions.

Release Notes:

- Fixed loading of zls when it is a system install.