### PR TITLE
Switch to the system UI font on macOS

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -36,7 +36,7 @@
   //         },
   "buffer_line_height": "comfortable",
   // The name of a font to use for rendering text in the UI
-  "ui_font_family": "Zed Sans",
+  "ui_font_family": ".SystemUIFont",
   // The OpenType features to enable for text in the UI
   "ui_font_features": {
     // Disable ligatures:

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -210,9 +210,16 @@ impl LinuxTextSystemState {
     #[profiling::function]
     fn load_family(
         &mut self,
-        name: &SharedString,
+        name: &str,
         _features: FontFeatures,
     ) -> Result<SmallVec<[FontId; 4]>> {
+        // TODO: Determine the proper system UI font.
+        let name = if name == ".SystemUIFont" {
+            "Zed Sans"
+        } else {
+            name
+        };
+
         let mut font_ids = SmallVec::new();
         let families = self
             .font_system

--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -219,16 +219,18 @@ impl MacTextSystemState {
         Ok(())
     }
 
-    fn load_family(
-        &mut self,
-        name: &SharedString,
-        features: FontFeatures,
-    ) -> Result<SmallVec<[FontId; 4]>> {
+    fn load_family(&mut self, name: &str, features: FontFeatures) -> Result<SmallVec<[FontId; 4]>> {
+        let name = if name == ".SystemUIFont" {
+            ".AppleSystemUIFont"
+        } else {
+            name
+        };
+
         let mut font_ids = SmallVec::new();
         let family = self
             .memory_source
-            .select_family_by_name(name.as_ref())
-            .or_else(|_| self.system_source.select_family_by_name(name.as_ref()))?;
+            .select_family_by_name(name)
+            .or_else(|_| self.system_source.select_family_by_name(name))?;
         for font in family.fonts() {
             let mut font = font.load()?;
 

--- a/crates/gpui/src/platform/windows/text_system.rs
+++ b/crates/gpui/src/platform/windows/text_system.rs
@@ -209,9 +209,16 @@ impl WindowsTextSystemState {
     #[profiling::function]
     fn load_family(
         &mut self,
-        name: &SharedString,
+        name: &str,
         _features: FontFeatures,
     ) -> Result<SmallVec<[FontId; 4]>> {
+        // TODO: Determine the proper system UI font.
+        let name = if name == ".SystemUIFont" {
+            "Zed Sans"
+        } else {
+            name
+        };
+
         let mut font_ids = SmallVec::new();
         let families = self
             .font_system

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -675,6 +675,8 @@ impl Hash for RenderEmojiParams {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Font {
     /// The font family name.
+    ///
+    /// The special name ".SystemUIFont" is used to identify the system UI font, which varies based on platform.
     pub family: SharedString,
 
     /// The font features to use.


### PR DESCRIPTION
To reference the system font, use the special ".SystemUIFont" family name.

/cc @PixelJanitor 

Release Notes:

- Switched to the system UI  font for user interface elements on macOS.