### PR TITLE
Only apply host-side executable fix to binaries downloaded by the extension

### DIFF
--- a/crates/extension/src/extension_lsp_adapter.rs
+++ b/crates/extension/src/extension_lsp_adapter.rs
@@ -79,7 +79,9 @@ impl LspAdapter for ExtensionLspAdapter {
             // We can remove once the following extension versions no longer see any use:
             // - toml@0.0.2
             // - zig@0.0.1
-            if ["toml", "zig"].contains(&self.extension.manifest.id.as_ref()) {
+            if ["toml", "zig"].contains(&self.extension.manifest.id.as_ref())
+                && path.starts_with(&self.host.work_dir)
+            {
                 #[cfg(not(windows))]
                 {
                     use std::fs::{self, Permissions};


### PR DESCRIPTION
This PR makes it so our temporary host-side workaround for setting certain language server binaries as executable only applies to binaries that are downloaded by the extension.

Previously we would do this for any binary, including ones that could have been sourced from the $PATH.

Release Notes:

- Fixed a file permissions issue when trying to use a Zig language server (`zls`) present on the $PATH.