### PR TITLE
Use v0.0.6 of the `zed_extension_api` for extensions that need it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12490,7 +12490,7 @@ dependencies = [
 name = "zed_dart"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12535,17 +12535,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed_extension_api"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "zed_gleam"
 version = "0.0.2"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_haskell"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12580,7 +12591,7 @@ dependencies = [
 name = "zed_svelte"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/extensions/dart/Cargo.toml
+++ b/extensions/dart/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/dart.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = { path = "../../crates/extension_api" }
+zed_extension_api = "0.0.6"

--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/gleam.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-# zed_extension_api = "0.0.4"
-zed_extension_api = { path = "../../crates/extension_api" }
+zed_extension_api = "0.0.6"

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/haskell.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-# zed_extension_api = "0.0.4"
-zed_extension_api = { path = "../../crates/extension_api" }
+zed_extension_api = "0.0.6"

--- a/extensions/svelte/Cargo.toml
+++ b/extensions/svelte/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/svelte.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = { path = "../../crates/extension_api" }
-# zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"


### PR DESCRIPTION
This PR updates the extensions dependent on v0.0.6 of the `zed_extension_api` crate to use the now-published version on crates.io instead of a path dependency.

The impacted extensions are:

- `dart`
- `gleam`
- `haskell`
- `svelte`


Release Notes:

- N/A
