### PR TITLE
Windows: Add a fallback font ID

### DIFF
--- a/crates/gpui/src/platform/windows/text_system.rs
+++ b/crates/gpui/src/platform/windows/text_system.rs
@@ -372,7 +372,7 @@ impl WindowsTextSystemState {
                 self.fonts
                     .iter()
                     .position(|font| font.id() == font_id)
-                    .unwrap(),
+                    .unwrap_or(usize::try_from(0).unwrap()),
             );
             let mut glyphs = SmallVec::new();
             // todo(windows) this is definitely wrong, each glyph in glyphs from cosmic-text is a cluster with one glyph, ShapedRun takes a run of glyphs with the same font and direction


### PR DESCRIPTION
On windows opening the extensions panel crashes zed because of a missing font id. Added a fallback font id to work around the crash.
