### PR TITLE
Improve the ergonomics of creating local buffers

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -31,7 +31,7 @@ use gpui::{
     StatefulInteractiveElement, Styled, Subscription, Task, TextStyle, UniformListScrollHandle,
     View, ViewContext, VisualContext, WeakModel, WeakView, WhiteSpace, WindowContext,
 };
-use language::{language_settings::SoftWrap, Buffer, BufferId, LanguageRegistry, ToOffset as _};
+use language::{language_settings::SoftWrap, Buffer, LanguageRegistry, ToOffset as _};
 use parking_lot::Mutex;
 use project::Project;
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
@@ -1310,7 +1310,7 @@ impl Conversation {
     ) -> Self {
         let markdown = language_registry.language_for_name("Markdown");
         let buffer = cx.new_model(|cx| {
-            let mut buffer = Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "");
+            let mut buffer = Buffer::local("", cx);
             buffer.set_language_registry(language_registry);
             cx.spawn(|buffer, mut cx| async move {
                 let markdown = markdown.await?;
@@ -1398,11 +1398,7 @@ impl Conversation {
         let mut message_anchors = Vec::new();
         let mut next_message_id = MessageId(0);
         let buffer = cx.new_model(|cx| {
-            let mut buffer = Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                saved_conversation.text,
-            );
+            let mut buffer = Buffer::local(saved_conversation.text, cx);
             for message in saved_conversation.messages {
                 message_anchors.push(MessageAnchor {
                     id: message.id,

--- a/crates/assistant/src/codegen.rs
+++ b/crates/assistant/src/codegen.rs
@@ -361,8 +361,8 @@ mod tests {
     use gpui::{Context, TestAppContext};
     use indoc::indoc;
     use language::{
-        language_settings, tree_sitter_rust, Buffer, BufferId, Language, LanguageConfig,
-        LanguageMatcher, Point,
+        language_settings, tree_sitter_rust, Buffer, Language, LanguageConfig, LanguageMatcher,
+        Point,
     };
     use rand::prelude::*;
     use serde::Serialize;
@@ -388,9 +388,8 @@ mod tests {
                 }
             }
         "};
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(0, BufferId::new(1).unwrap(), text).with_language(Arc::new(rust_lang()), cx)
-        });
+        let buffer =
+            cx.new_model(|cx| Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx));
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
         let range = buffer.read_with(cx, |buffer, cx| {
             let snapshot = buffer.snapshot(cx);
@@ -447,9 +446,8 @@ mod tests {
                 le
             }
         "};
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(0, BufferId::new(1).unwrap(), text).with_language(Arc::new(rust_lang()), cx)
-        });
+        let buffer =
+            cx.new_model(|cx| Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx));
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
         let position = buffer.read_with(cx, |buffer, cx| {
             let snapshot = buffer.snapshot(cx);
@@ -506,9 +504,8 @@ mod tests {
             "  \n",
             "}\n" //
         );
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(0, BufferId::new(1).unwrap(), text).with_language(Arc::new(rust_lang()), cx)
-        });
+        let buffer =
+            cx.new_model(|cx| Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx));
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
         let position = buffer.read_with(cx, |buffer, cx| {
             let snapshot = buffer.snapshot(cx);

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1042,9 +1042,7 @@ mod tests {
     async fn test_buffer_management(cx: &mut TestAppContext) {
         let (copilot, mut lsp) = Copilot::fake(cx);
 
-        let buffer_1 = cx.new_model(|cx| {
-            Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "Hello")
-        });
+        let buffer_1 = cx.new_model(|cx| Buffer::local("Hello", cx));
         let buffer_1_uri: lsp::Url = format!("buffer://{}", buffer_1.entity_id().as_u64())
             .parse()
             .unwrap();
@@ -1062,13 +1060,7 @@ mod tests {
             }
         );
 
-        let buffer_2 = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                "Goodbye",
-            )
-        });
+        let buffer_2 = cx.new_model(|cx| Buffer::local("Goodbye", cx));
         let buffer_2_uri: lsp::Url = format!("buffer://{}", buffer_2.entity_id().as_u64())
             .parse()
             .unwrap();

--- a/crates/copilot_ui/src/copilot_completion_provider.rs
+++ b/crates/copilot_ui/src/copilot_completion_provider.rs
@@ -272,7 +272,7 @@ mod tests {
     use indoc::indoc;
     use language::{
         language_settings::{AllLanguageSettings, AllLanguageSettingsContent},
-        BufferId, Point,
+        Point,
     };
     use project::Project;
     use serde_json::json;
@@ -729,20 +729,8 @@ mod tests {
 
         let (copilot, copilot_lsp) = Copilot::fake(cx);
 
-        let buffer_1 = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                "a = 1\nb = 2\n",
-            )
-        });
-        let buffer_2 = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                "c = 3\nd = 4\n",
-            )
-        });
+        let buffer_1 = cx.new_model(|cx| Buffer::local("a = 1\nb = 2\n", cx));
+        let buffer_2 = cx.new_model(|cx| Buffer::local("c = 3\nd = 4\n", cx));
         let multibuffer = cx.new_model(|cx| {
             let mut multibuffer = MultiBuffer::new(0, language::Capability::ReadWrite);
             multibuffer.push_excerpts(

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -984,7 +984,6 @@ pub mod tests {
     use settings::SettingsStore;
     use smol::stream::StreamExt;
     use std::{env, sync::Arc};
-    use text::BufferId;
     use theme::{LoadThemes, SyntaxTheme};
     use util::test::{marked_text_ranges, sample_text};
     use Bias::*;
@@ -1445,10 +1444,7 @@ pub mod tests {
 
         cx.update(|cx| init_test(cx, |s| s.defaults.tab_size = Some(2.try_into().unwrap())));
 
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-                .with_language(language, cx)
-        });
+        let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
         cx.condition(&buffer, |buf, _| !buf.is_parsing()).await;
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
 
@@ -1533,10 +1529,7 @@ pub mod tests {
 
         cx.update(|cx| init_test(cx, |_| {}));
 
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-                .with_language(language, cx)
-        });
+        let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
         cx.condition(&buffer, |buf, _| !buf.is_parsing()).await;
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
 
@@ -1602,10 +1595,7 @@ pub mod tests {
 
         let (text, highlighted_ranges) = marked_text_ranges(r#"constˇ «a»: B = "c «d»""#, false);
 
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-                .with_language(language, cx)
-        });
+        let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
         cx.condition(&buffer, |buf, _| !buf.is_parsing()).await;
 
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1328,37 +1328,19 @@ impl InlayHintRefreshReason {
 
 impl Editor {
     pub fn single_line(cx: &mut ViewContext<Self>) -> Self {
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                String::new(),
-            )
-        });
+        let buffer = cx.new_model(|cx| Buffer::local("", cx));
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
         Self::new(EditorMode::SingleLine, buffer, None, cx)
     }
 
     pub fn multi_line(cx: &mut ViewContext<Self>) -> Self {
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                String::new(),
-            )
-        });
+        let buffer = cx.new_model(|cx| Buffer::local("", cx));
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
         Self::new(EditorMode::Full, buffer, None, cx)
     }
 
     pub fn auto_height(max_lines: usize, cx: &mut ViewContext<Self>) -> Self {
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                String::new(),
-            )
-        });
+        let buffer = cx.new_model(|cx| Buffer::local("", cx));
         let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
         Self::new(EditorMode::AutoHeight { max_lines }, buffer, None, cx)
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -38,8 +38,7 @@ fn test_edit_events(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let buffer = cx.new_model(|cx| {
-        let mut buffer =
-            language::Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "123456");
+        let mut buffer = language::Buffer::local("123456", cx);
         buffer.set_group_interval(Duration::from_secs(1));
         buffer
     });
@@ -154,9 +153,7 @@ fn test_undo_redo_with_selection_restoration(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let mut now = Instant::now();
-    let buffer = cx.new_model(|cx| {
-        language::Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "123456")
-    });
+    let buffer = cx.new_model(|cx| language::Buffer::local("123456", cx));
     let group_interval = buffer.update(cx, |buffer, _| buffer.transaction_group_interval());
     let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
     let editor = cx.add_window(|cx| build_editor(buffer.clone(), cx));
@@ -227,8 +224,7 @@ fn test_ime_composition(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let buffer = cx.new_model(|cx| {
-        let mut buffer =
-            language::Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "abcde");
+        let mut buffer = language::Buffer::local("abcde", cx);
         // Ensure automatic grouping doesn't occur.
         buffer.set_group_interval(Duration::ZERO);
         buffer
@@ -2344,21 +2340,10 @@ fn test_indent_outdent_with_excerpts(cx: &mut TestAppContext) {
         None,
     ));
 
-    let toml_buffer = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            "a = 1\nb = 2\n",
-        )
-        .with_language(toml_language, cx)
-    });
+    let toml_buffer =
+        cx.new_model(|cx| Buffer::local("a = 1\nb = 2\n", cx).with_language(toml_language, cx));
     let rust_buffer = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            "const c: usize = 3;\n",
-        )
-        .with_language(rust_language, cx)
+        Buffer::local("const c: usize = 3;\n", cx).with_language(rust_language, cx)
     });
     let multibuffer = cx.new_model(|cx| {
         let mut multibuffer = MultiBuffer::new(0, ReadWrite);
@@ -4304,10 +4289,7 @@ async fn test_select_larger_smaller_syntax_node(cx: &mut gpui::TestAppContext) {
     "#
     .unindent();
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-            .with_language(language, cx)
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
     let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
     let (view, cx) = cx.add_window_view(|cx| build_editor(buffer, cx));
 
@@ -4471,10 +4453,7 @@ async fn test_autoindent_selections(cx: &mut gpui::TestAppContext) {
 
     let text = "fn a() {}";
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-            .with_language(language, cx)
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
     let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
     let (editor, cx) = cx.add_window_view(|cx| build_editor(buffer, cx));
     editor
@@ -5129,10 +5108,7 @@ async fn test_surround_with_pair(cx: &mut gpui::TestAppContext) {
     "#
     .unindent();
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-            .with_language(language, cx)
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
     let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
     let (view, cx) = cx.add_window_view(|cx| build_editor(buffer, cx));
     view.condition::<crate::EditorEvent>(cx, |view, cx| !view.buffer.read(cx).is_parsing(cx))
@@ -5280,10 +5256,7 @@ async fn test_delete_autoclose_pair(cx: &mut gpui::TestAppContext) {
     "#
     .unindent();
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-            .with_language(language, cx)
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
     let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
     let (editor, cx) = cx.add_window_view(|cx| build_editor(buffer, cx));
     editor
@@ -5470,10 +5443,7 @@ async fn test_auto_replace_emoji_shortcode(cx: &mut gpui::TestAppContext) {
         Some(tree_sitter_rust::language()),
     ));
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "")
-            .with_language(language, cx)
-    });
+    let buffer = cx.new_model(|cx| Buffer::local("", cx).with_language(language, cx));
     let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
     let (editor, cx) = cx.add_window_view(|cx| build_editor(buffer, cx));
     editor
@@ -6920,13 +6890,7 @@ async fn test_toggle_block_comment(cx: &mut gpui::TestAppContext) {
 fn test_editing_disjoint_excerpts(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            sample_text(3, 4, 'a'),
-        )
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(sample_text(3, 4, 'a'), cx));
     let multibuffer = cx.new_model(|cx| {
         let mut multibuffer = MultiBuffer::new(0, ReadWrite);
         multibuffer.push_excerpts(
@@ -7010,13 +6974,7 @@ fn test_editing_overlapping_excerpts(cx: &mut TestAppContext) {
             primary: None,
         }
     });
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            initial_text,
-        )
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(initial_text, cx));
     let multibuffer = cx.new_model(|cx| {
         let mut multibuffer = MultiBuffer::new(0, ReadWrite);
         multibuffer.push_excerpts(buffer, excerpt_ranges, cx);
@@ -7074,13 +7032,7 @@ fn test_editing_overlapping_excerpts(cx: &mut TestAppContext) {
 fn test_refresh_selections(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            sample_text(3, 4, 'a'),
-        )
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(sample_text(3, 4, 'a'), cx));
     let mut excerpt1_id = None;
     let multibuffer = cx.new_model(|cx| {
         let mut multibuffer = MultiBuffer::new(0, ReadWrite);
@@ -7165,13 +7117,7 @@ fn test_refresh_selections(cx: &mut TestAppContext) {
 fn test_refresh_selections_while_selecting_with_mouse(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            sample_text(3, 4, 'a'),
-        )
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(sample_text(3, 4, 'a'), cx));
     let mut excerpt1_id = None;
     let multibuffer = cx.new_model(|cx| {
         let mut multibuffer = MultiBuffer::new(0, ReadWrite);
@@ -7266,10 +7212,7 @@ async fn test_extra_newline_insertion(cx: &mut gpui::TestAppContext) {
         "{{} }\n",     //
     );
 
-    let buffer = cx.new_model(|cx| {
-        Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-            .with_language(language, cx)
-    });
+    let buffer = cx.new_model(|cx| Buffer::local(text, cx).with_language(language, cx));
     let buffer = cx.new_model(|cx| MultiBuffer::singleton(buffer, cx));
     let (view, cx) = cx.add_window_view(|cx| build_editor(buffer, cx));
     view.condition::<crate::EditorEvent>(cx, |view, cx| !view.buffer.read(cx).is_parsing(cx))
@@ -8970,31 +8913,13 @@ async fn test_multibuffer_reverts(cx: &mut gpui::TestAppContext) {
         cx.executor().run_until_parked();
     }
 
-    let buffer_1 = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            sample_text_1.clone(),
-        )
-    });
+    let buffer_1 = cx.new_model(|cx| Buffer::local(sample_text_1.clone(), cx));
     diff_every_buffer_row(&buffer_1, sample_text_1.clone(), cols, cx);
 
-    let buffer_2 = cx.new_model(|cx| {
-        Buffer::new(
-            1,
-            BufferId::new(cx.entity_id().as_u64() + 1).unwrap(),
-            sample_text_2.clone(),
-        )
-    });
+    let buffer_2 = cx.new_model(|cx| Buffer::local(sample_text_2.clone(), cx));
     diff_every_buffer_row(&buffer_2, sample_text_2.clone(), cols, cx);
 
-    let buffer_3 = cx.new_model(|cx| {
-        Buffer::new(
-            2,
-            BufferId::new(cx.entity_id().as_u64() + 2).unwrap(),
-            sample_text_3.clone(),
-        )
-    });
+    let buffer_3 = cx.new_model(|cx| Buffer::local(sample_text_3.clone(), cx));
     diff_every_buffer_row(&buffer_3, sample_text_3.clone(), cols, cx);
 
     let multibuffer = cx.new_model(|cx| {
@@ -9133,29 +9058,9 @@ async fn test_mutlibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
         "vvvv\nwwww\nxxxx\nyyyy\nzzzz\n{{{{\n||||\n}}}}\n~~~~\n\u{7f}\u{7f}\u{7f}\u{7f}"
     );
 
-    let buffer_1 = cx.new_model(|cx| {
-        Buffer::new(
-            0,
-            BufferId::new(cx.entity_id().as_u64()).unwrap(),
-            sample_text_1.clone(),
-        )
-    });
-
-    let buffer_2 = cx.new_model(|cx| {
-        Buffer::new(
-            1,
-            BufferId::new(cx.entity_id().as_u64() + 1).unwrap(),
-            sample_text_2.clone(),
-        )
-    });
-
-    let buffer_3 = cx.new_model(|cx| {
-        Buffer::new(
-            2,
-            BufferId::new(cx.entity_id().as_u64() + 2).unwrap(),
-            sample_text_3.clone(),
-        )
-    });
+    let buffer_1 = cx.new_model(|cx| Buffer::local(sample_text_1.clone(), cx));
+    let buffer_2 = cx.new_model(|cx| Buffer::local(sample_text_2.clone(), cx));
+    let buffer_3 = cx.new_model(|cx| Buffer::local(sample_text_3.clone(), cx));
 
     let multi_buffer = cx.new_model(|cx| {
         let mut multibuffer = MultiBuffer::new(0, ReadWrite);

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -570,7 +570,6 @@ mod tests {
     use language::Capability;
     use project::Project;
     use settings::SettingsStore;
-    use text::BufferId;
     use util::post_inc;
 
     #[gpui::test]
@@ -870,13 +869,7 @@ mod tests {
 
             let font = font("Helvetica");
 
-            let buffer = cx.new_model(|cx| {
-                Buffer::new(
-                    0,
-                    BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                    "abc\ndefg\nhijkl\nmn",
-                )
-            });
+            let buffer = cx.new_model(|cx| Buffer::local("abc\ndefg\nhijkl\nmn", cx));
             let multibuffer = cx.new_model(|cx| {
                 let mut multibuffer = MultiBuffer::new(0, Capability::ReadWrite);
                 multibuffer.push_excerpts(

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -21,7 +21,6 @@ use std::{
         Arc,
     },
 };
-use text::BufferId;
 use ui::Context;
 use util::{
     assert_set_eq,
@@ -76,10 +75,9 @@ impl EditorTestContext {
     ) -> EditorTestContext {
         let mut multibuffer = MultiBuffer::new(0, language::Capability::ReadWrite);
         let buffer = cx.new_model(|cx| {
-            for (i, excerpt) in excerpts.into_iter().enumerate() {
+            for excerpt in excerpts.into_iter() {
                 let (text, ranges) = marked_text_ranges(excerpt, false);
-                let buffer =
-                    cx.new_model(|_| Buffer::new(0, BufferId::new(i as u64 + 1).unwrap(), text));
+                let buffer = cx.new_model(|cx| Buffer::local(text, cx));
                 multibuffer.push_excerpts(
                     buffer,
                     ranges.into_iter().map(|range| ExcerptRange {

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -1,7 +1,7 @@
 use crate::{
     AnyView, AnyWindowHandle, AppCell, AppContext, BackgroundExecutor, BorrowAppContext, Context,
-    DismissEvent, FocusableView, ForegroundExecutor, Global, Model, ModelContext, Render, Result,
-    Task, View, ViewContext, VisualContext, WindowContext, WindowHandle,
+    DismissEvent, FocusableView, ForegroundExecutor, Global, Model, ModelContext, Render,
+    Reservation, Result, Task, View, ViewContext, VisualContext, WindowContext, WindowHandle,
 };
 use anyhow::{anyhow, Context as _};
 use derive_more::{Deref, DerefMut};
@@ -33,6 +33,28 @@ impl Context for AsyncAppContext {
             .ok_or_else(|| anyhow!("app was released"))?;
         let mut app = app.borrow_mut();
         Ok(app.new_model(build_model))
+    }
+
+    fn reserve_model<T: 'static>(&mut self) -> Result<Reservation<T>> {
+        let app = self
+            .app
+            .upgrade()
+            .ok_or_else(|| anyhow!("app was released"))?;
+        let mut app = app.borrow_mut();
+        Ok(app.reserve_model())
+    }
+
+    fn insert_model<T: 'static>(
+        &mut self,
+        reservation: Reservation<T>,
+        build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
+    ) -> Result<Model<T>> {
+        let app = self
+            .app
+            .upgrade()
+            .ok_or_else(|| anyhow!("app was released"))?;
+        let mut app = app.borrow_mut();
+        Ok(app.insert_model(reservation, build_model))
     }
 
     fn update_model<T: 'static, R>(
@@ -278,6 +300,19 @@ impl Context for AsyncWindowContext {
         self.window.update(self, |_, cx| cx.new_model(build_model))
     }
 
+    fn reserve_model<T: 'static>(&mut self) -> Result<Reservation<T>> {
+        self.window.update(self, |_, cx| cx.reserve_model())
+    }
+
+    fn insert_model<T: 'static>(
+        &mut self,
+        reservation: Reservation<T>,
+        build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
+    ) -> Self::Result<Model<T>> {
+        self.window
+            .update(self, |_, cx| cx.insert_model(reservation, build_model))
+    }
+
     fn update_model<T: 'static, R>(
         &mut self,
         handle: &Model<T>,
@@ -285,13 +320,6 @@ impl Context for AsyncWindowContext {
     ) -> Result<R> {
         self.window
             .update(self, |_, cx| cx.update_model(handle, update))
-    }
-
-    fn update_window<T, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<T>
-    where
-        F: FnOnce(AnyView, &mut WindowContext<'_>) -> T,
-    {
-        self.app.update_window(window, update)
     }
 
     fn read_model<T, R>(
@@ -303,6 +331,13 @@ impl Context for AsyncWindowContext {
         T: 'static,
     {
         self.app.read_model(handle, read)
+    }
+
+    fn update_window<T, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<T>
+    where
+        F: FnOnce(AnyView, &mut WindowContext<'_>) -> T,
+    {
+        self.app.update_window(window, update)
     }
 
     fn read_window<T, R>(

--- a/crates/gpui/src/app/model_context.rs
+++ b/crates/gpui/src/app/model_context.rs
@@ -1,6 +1,7 @@
 use crate::{
     AnyView, AnyWindowHandle, AppContext, AsyncAppContext, Context, Effect, Entity, EntityId,
-    EventEmitter, Model, Subscription, Task, View, WeakModel, WindowContext, WindowHandle,
+    EventEmitter, Model, Reservation, Subscription, Task, View, WeakModel, WindowContext,
+    WindowHandle,
 };
 use anyhow::Result;
 use derive_more::{Deref, DerefMut};
@@ -229,19 +230,24 @@ impl<'a, T> Context for ModelContext<'a, T> {
         self.app.new_model(build_model)
     }
 
+    fn reserve_model<U: 'static>(&mut self) -> Reservation<U> {
+        self.app.reserve_model()
+    }
+
+    fn insert_model<U: 'static>(
+        &mut self,
+        reservation: Reservation<U>,
+        build_model: impl FnOnce(&mut ModelContext<'_, U>) -> U,
+    ) -> Self::Result<Model<U>> {
+        self.app.insert_model(reservation, build_model)
+    }
+
     fn update_model<U: 'static, R>(
         &mut self,
         handle: &Model<U>,
         update: impl FnOnce(&mut U, &mut ModelContext<'_, U>) -> R,
     ) -> R {
         self.app.update_model(handle, update)
-    }
-
-    fn update_window<R, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<R>
-    where
-        F: FnOnce(AnyView, &mut WindowContext<'_>) -> R,
-    {
-        self.app.update_window(window, update)
     }
 
     fn read_model<U, R>(
@@ -253,6 +259,13 @@ impl<'a, T> Context for ModelContext<'a, T> {
         U: 'static,
     {
         self.app.read_model(handle, read)
+    }
+
+    fn update_window<R, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<R>
+    where
+        F: FnOnce(AnyView, &mut WindowContext<'_>) -> R,
+    {
+        self.app.update_window(window, update)
     }
 
     fn read_window<U, R>(

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -42,6 +42,20 @@ impl Context for TestAppContext {
         app.new_model(build_model)
     }
 
+    fn reserve_model<T: 'static>(&mut self) -> Self::Result<crate::Reservation<T>> {
+        let mut app = self.app.borrow_mut();
+        app.reserve_model()
+    }
+
+    fn insert_model<T: 'static>(
+        &mut self,
+        reservation: crate::Reservation<T>,
+        build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
+    ) -> Self::Result<Model<T>> {
+        let mut app = self.app.borrow_mut();
+        app.insert_model(reservation, build_model)
+    }
+
     fn update_model<T: 'static, R>(
         &mut self,
         handle: &Model<T>,
@@ -776,6 +790,18 @@ impl Context for VisualTestContext {
         build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
     ) -> Self::Result<Model<T>> {
         self.cx.new_model(build_model)
+    }
+
+    fn reserve_model<T: 'static>(&mut self) -> Self::Result<crate::Reservation<T>> {
+        self.cx.reserve_model()
+    }
+
+    fn insert_model<T: 'static>(
+        &mut self,
+        reservation: crate::Reservation<T>,
+        build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
+    ) -> Self::Result<Model<T>> {
+        self.cx.insert_model(reservation, build_model)
     }
 
     fn update_model<T, R>(

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -165,6 +165,17 @@ pub trait Context {
         build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
     ) -> Self::Result<Model<T>>;
 
+    /// Reserve a slot for a model to be inserted later.
+    /// The returned [Reservation] allows you to obtain the [EntityId] for the future model.
+    fn reserve_model<T: 'static>(&mut self) -> Self::Result<Reservation<T>>;
+
+    /// Insert a new model in the app context based on a [Reservation] previously obtained from [reserve_model].
+    fn insert_model<T: 'static>(
+        &mut self,
+        reservation: Reservation<T>,
+        build_model: impl FnOnce(&mut ModelContext<'_, T>) -> T,
+    ) -> Self::Result<Model<T>>;
+
     /// Update a model in the app context.
     fn update_model<T, R>(
         &mut self,
@@ -196,6 +207,17 @@ pub trait Context {
     ) -> Result<R>
     where
         T: 'static;
+}
+
+/// Returned by [Context::reserve_model] to later be passed to [Context::insert_model].
+/// Allows you to obtain the [EntityId] for a model before it is created.
+pub struct Reservation<T>(pub(crate) Slot<T>);
+
+impl<T: 'static> Reservation<T> {
+    /// Returns the [EntityId] that will be associated with the model once it is inserted.
+    pub fn entity_id(&self) -> EntityId {
+        self.0.entity_id()
+    }
 }
 
 /// This trait is used for the different visual contexts in GPUI that

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -169,7 +169,9 @@ pub trait Context {
     /// The returned [Reservation] allows you to obtain the [EntityId] for the future model.
     fn reserve_model<T: 'static>(&mut self) -> Self::Result<Reservation<T>>;
 
-    /// Insert a new model in the app context based on a [Reservation] previously obtained from [reserve_model].
+    /// Insert a new model in the app context based on a [Reservation] previously obtained from [`reserve_model`].
+    ///
+    /// [`reserve_model`]: Self::reserve_model
     fn insert_model<T: 'static>(
         &mut self,
         reservation: Reservation<T>,

--- a/crates/gpui/src/window/element_cx.rs
+++ b/crates/gpui/src/window/element_cx.rs
@@ -264,6 +264,18 @@ impl<'a> Context for ElementContext<'a> {
         self.cx.new_model(build_model)
     }
 
+    fn reserve_model<T: 'static>(&mut self) -> Self::Result<crate::Reservation<T>> {
+        self.cx.reserve_model()
+    }
+
+    fn insert_model<T: 'static>(
+        &mut self,
+        reservation: crate::Reservation<T>,
+        build_model: impl FnOnce(&mut crate::ModelContext<'_, T>) -> T,
+    ) -> Self::Result<crate::Model<T>> {
+        self.cx.insert_model(reservation, build_model)
+    }
+
     fn update_model<T, R>(
         &mut self,
         handle: &crate::Model<T>,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -503,9 +503,9 @@ pub enum CharKind {
 
 impl Buffer {
     /// Create a new buffer with the given base text.
-    pub fn new<T: Into<String>>(replica_id: ReplicaId, id: BufferId, base_text: T) -> Self {
+    pub fn local<T: Into<String>>(base_text: T, cx: &mut ModelContext<Self>) -> Self {
         Self::build(
-            TextBuffer::new(replica_id, id, base_text.into()),
+            TextBuffer::new(0, cx.entity_id().as_non_zero_u64().into(), base_text.into()),
             None,
             None,
             Capability::ReadWrite,
@@ -517,10 +517,10 @@ impl Buffer {
         remote_id: BufferId,
         replica_id: ReplicaId,
         capability: Capability,
-        base_text: String,
+        base_text: impl Into<String>,
     ) -> Self {
         Self::build(
-            TextBuffer::new(replica_id, remote_id, base_text),
+            TextBuffer::new(replica_id, remote_id, base_text.into()),
             None,
             None,
             capability,

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -297,7 +297,6 @@ mod tests {
     use language::{language_settings::AllLanguageSettings, AutoindentMode, Buffer};
     use settings::SettingsStore;
     use std::num::NonZeroU32;
-    use text::BufferId;
 
     #[gpui::test]
     async fn test_c_autoindent(cx: &mut TestAppContext) {
@@ -315,8 +314,7 @@ mod tests {
         let language = crate::language("c", tree_sitter_c::language());
 
         cx.new_model(|cx| {
-            let mut buffer = Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "")
-                .with_language(language, cx);
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
 
             // empty function
             buffer.edit([(0..0, "int main() {}")], None, cx);

--- a/crates/languages/src/css.rs
+++ b/crates/languages/src/css.rs
@@ -136,7 +136,6 @@ async fn get_cached_server_binary(
 #[cfg(test)]
 mod tests {
     use gpui::{Context, TestAppContext};
-    use text::BufferId;
     use unindent::Unindent;
 
     #[gpui::test]
@@ -168,10 +167,8 @@ mod tests {
         "#
         .unindent();
 
-        let buffer = cx.new_model(|cx| {
-            language::Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-                .with_language(language, cx)
-        });
+        let buffer =
+            cx.new_model(|cx| language::Buffer::local(text, cx).with_language(language, cx));
         let outline = buffer.update(cx, |buffer, _| buffer.snapshot().outline(None).unwrap());
         assert_eq!(
             outline

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -186,7 +186,6 @@ mod tests {
     use language::{language_settings::AllLanguageSettings, AutoindentMode, Buffer};
     use settings::SettingsStore;
     use std::num::NonZeroU32;
-    use text::BufferId;
 
     #[gpui::test]
     async fn test_python_autoindent(cx: &mut TestAppContext) {
@@ -204,8 +203,7 @@ mod tests {
         });
 
         cx.new_model(|cx| {
-            let mut buffer = Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "")
-                .with_language(language, cx);
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
             let append = |buffer: &mut Buffer, text: &str, cx: &mut ModelContext<Buffer>| {
                 let ix = buffer.len();
                 buffer.edit([(ix..ix, text)], Some(AutoindentMode::EachLine), cx);

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -435,7 +435,6 @@ mod tests {
     use gpui::{BorrowAppContext, Context, Hsla, TestAppContext};
     use language::language_settings::AllLanguageSettings;
     use settings::SettingsStore;
-    use text::BufferId;
     use theme::SyntaxTheme;
 
     #[gpui::test]
@@ -652,8 +651,7 @@ mod tests {
         let language = crate::language("rust", tree_sitter_rust::language());
 
         cx.new_model(|cx| {
-            let mut buffer = Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), "")
-                .with_language(language, cx);
+            let mut buffer = Buffer::local("", cx).with_language(language, cx);
 
             // indent between braces
             buffer.set_text("fn a() {}", cx);

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -413,7 +413,6 @@ async fn get_cached_eslint_server_binary(
 #[cfg(test)]
 mod tests {
     use gpui::{Context, TestAppContext};
-    use text::BufferId;
     use unindent::Unindent;
 
     #[gpui::test]
@@ -435,10 +434,8 @@ mod tests {
         "#
         .unindent();
 
-        let buffer = cx.new_model(|cx| {
-            language::Buffer::new(0, BufferId::new(cx.entity_id().as_u64()).unwrap(), text)
-                .with_language(language, cx)
-        });
+        let buffer =
+            cx.new_model(|cx| language::Buffer::local(text, cx).with_language(language, cx));
         let outline = buffer.update(cx, |buffer, _| buffer.snapshot().outline(None).unwrap());
         assert_eq!(
             outline

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1141,7 +1141,7 @@ mod tests {
     use super::*;
     use editor::{DisplayPoint, Editor};
     use gpui::{Context, Hsla, TestAppContext, VisualTestContext};
-    use language::{Buffer, BufferId};
+    use language::Buffer;
     use smol::stream::StreamExt as _;
     use unindent::Unindent as _;
 
@@ -1161,9 +1161,7 @@ mod tests {
     ) -> (View<Editor>, View<BufferSearchBar>, &mut VisualTestContext) {
         init_globals(cx);
         let buffer = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
+            Buffer::local(
                 r#"
                 A regular expression (shortened as regex or regexp;[1] also referred to as
                 rational expression[2][3]) is a sequence of characters that specifies a search
@@ -1171,6 +1169,7 @@ mod tests {
                 for "find" or "find and replace" operations on strings, or for input validation.
                 "#
                 .unindent(),
+                cx,
             )
         });
         let cx = cx.add_empty_window();
@@ -1519,13 +1518,7 @@ mod tests {
             expected_query_matches_count > 1,
             "Should pick a query with multiple results"
         );
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                buffer_text,
-            )
-        });
+        let buffer = cx.new_model(|cx| Buffer::local(buffer_text, cx));
         let window = cx.add_window(|_| gpui::Empty);
 
         let editor = window.build_view(cx, |cx| Editor::for_buffer(buffer.clone(), None, cx));
@@ -1721,13 +1714,7 @@ mod tests {
         for "find" or "find and replace" operations on strings, or for input validation.
         "#
         .unindent();
-        let buffer = cx.new_model(|cx| {
-            Buffer::new(
-                0,
-                BufferId::new(cx.entity_id().as_u64()).unwrap(),
-                buffer_text,
-            )
-        });
+        let buffer = cx.new_model(|cx| Buffer::local(buffer_text, cx));
         let cx = cx.add_empty_window();
 
         let editor = cx.new_view(|cx| Editor::for_buffer(buffer.clone(), None, cx));

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -71,12 +71,19 @@ impl Display for BufferId {
     }
 }
 
+impl From<NonZeroU64> for BufferId {
+    fn from(id: NonZeroU64) -> Self {
+        BufferId(id)
+    }
+}
+
 impl BufferId {
     /// Returns Err if `id` is outside of BufferId domain.
     pub fn new(id: u64) -> anyhow::Result<Self> {
         let id = NonZeroU64::new(id).context("Buffer id cannot be 0.")?;
         Ok(Self(id))
     }
+
     /// Increments this buffer id, returning the old value.
     /// So that's a post-increment operator in disguise.
     pub fn next(&mut self) -> Self {

--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -73,14 +73,14 @@ mod test {
     use crate::{test::VimTestContext, Vim};
     use editor::Editor;
     use gpui::{Context, Entity, VisualTestContext};
-    use language::{Buffer, BufferId};
+    use language::Buffer;
 
     // regression test for blur called with a different active editor
     #[gpui::test]
     async fn test_blur_focus(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
 
-        let buffer = cx.new_model(|_| Buffer::new(0, BufferId::new(1).unwrap(), "a = 1\nb = 2\n"));
+        let buffer = cx.new_model(|cx| Buffer::local("a = 1\nb = 2\n", cx));
         let window2 = cx.add_window(|cx| Editor::for_buffer(buffer, None, cx));
         let editor2 = cx
             .update(|cx| {
@@ -115,7 +115,7 @@ mod test {
         let mut cx1 = VisualTestContext::from_window(cx.window, &cx);
         let editor1 = cx.editor.clone();
 
-        let buffer = cx.new_model(|_| Buffer::new(0, BufferId::new(1).unwrap(), "a = 1\nb = 2\n"));
+        let buffer = cx.new_model(|cx| Buffer::local("a = 1\nb = 2\n", cx));
         let (editor2, cx2) = cx.add_window_view(|cx| Editor::for_buffer(buffer, None, cx));
 
         editor2.update(cx2, |_, cx| {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -751,20 +751,21 @@ impl LocalWorktree {
 
     pub fn load_buffer(
         &mut self,
-        id: BufferId,
         path: &Path,
         cx: &mut ModelContext<Worktree>,
     ) -> Task<Result<Model<Buffer>>> {
         let path = Arc::from(path);
+        let reservation = cx.reserve_model();
+        let buffer_id = BufferId::from(reservation.entity_id().as_non_zero_u64());
         cx.spawn(move |this, mut cx| async move {
             let (file, contents, diff_base) = this
                 .update(&mut cx, |t, cx| t.as_local().unwrap().load(&path, cx))?
                 .await?;
             let text_buffer = cx
                 .background_executor()
-                .spawn(async move { text::Buffer::new(0, id, contents) })
+                .spawn(async move { text::Buffer::new(0, buffer_id, contents) })
                 .await;
-            cx.new_model(|_| {
+            cx.insert_model(reservation, |_| {
                 Buffer::build(
                     text_buffer,
                     diff_base,
@@ -777,13 +778,13 @@ impl LocalWorktree {
 
     pub fn new_buffer(
         &mut self,
-        buffer_id: BufferId,
         path: Arc<Path>,
         cx: &mut ModelContext<Worktree>,
     ) -> Model<Buffer> {
-        let text_buffer = text::Buffer::new(0, buffer_id, "".into());
         let worktree = cx.handle();
-        cx.new_model(|_| {
+        cx.new_model(|cx| {
+            let buffer_id = BufferId::from(cx.entity_id().as_non_zero_u64());
+            let text_buffer = text::Buffer::new(0, buffer_id, "".into());
             Buffer::build(
                 text_buffer,
                 None,

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -21,7 +21,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use text::BufferId;
 use util::{http::FakeHttpClient, test::temp_tree, ResultExt};
 
 #[gpui::test]
@@ -577,11 +576,9 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     let prev_read_dir_count = fs.read_dir_call_count();
     let buffer = tree
         .update(cx, |tree, cx| {
-            tree.as_local_mut().unwrap().load_buffer(
-                BufferId::new(1).unwrap(),
-                "one/node_modules/b/b1.js".as_ref(),
-                cx,
-            )
+            tree.as_local_mut()
+                .unwrap()
+                .load_buffer("one/node_modules/b/b1.js".as_ref(), cx)
         })
         .await
         .unwrap();
@@ -621,11 +618,9 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     let prev_read_dir_count = fs.read_dir_call_count();
     let buffer = tree
         .update(cx, |tree, cx| {
-            tree.as_local_mut().unwrap().load_buffer(
-                BufferId::new(1).unwrap(),
-                "one/node_modules/a/a2.js".as_ref(),
-                cx,
-            )
+            tree.as_local_mut()
+                .unwrap()
+                .load_buffer("one/node_modules/a/a2.js".as_ref(), cx)
         })
         .await
         .unwrap();


### PR DESCRIPTION
This PR renames `language::Buffer::new` to `language::Buffer::local` and simplifies its interface. Instead of taking a replica id (which should always be 0 for the local case) and a `BufferId`, which was awkward and verbose to construct, it simply takes text and a `cx`.

It uses the `cx` to derive a `BufferId` from the `EntityId` associated with the `cx`, which should always be positive based on the following analysis...

We convert the entity id to a u64 using this method on `EntityId`, which is defined by macros in the `slotmap` crate:

```rust
    pub fn as_ffi(self) -> u64 {
        (u64::from(self.version.get()) << 32) | u64::from(self.idx)
    }
```

If you look at the type of `version` in `KeyData`, it is non-zero:

```rust
#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
pub struct KeyData {
    idx: u32,
    version: NonZeroU32,
}
```

This commit also adds `Context::reserve_model` and `Context::insert_model` to determine a model's entity ID before it is created, which we need in order to assign a `BufferId` in the background when loading a buffer asynchronously.

Release Notes:

- N/A
