### PR TITLE
Add feature to display  commands for vim mode

### DIFF
--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -31,10 +31,19 @@ impl ModeIndicator {
 
         if vim.enabled {
             self.mode = Some(vim.state().mode);
-            self.operators = vim.state().current_operators_description();
+            self.operators = self.current_operators_description(&vim);
         } else {
             self.mode = None;
         }
+    }
+
+    fn current_operators_description(&self, vim: &Vim) -> String {
+        vim.state()
+            .operator_stack
+            .iter()
+            .map(|item| item.id())
+            .collect::<Vec<_>>()
+            .join("")
     }
 }
 

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -6,6 +6,7 @@ use crate::{state::Mode, Vim};
 /// The ModeIndicator displays the current mode in the status bar.
 pub struct ModeIndicator {
     pub(crate) mode: Option<Mode>,
+    pub(crate) operators: String,
     _subscription: Subscription,
 }
 
@@ -15,6 +16,7 @@ impl ModeIndicator {
         let _subscription = cx.observe_global::<Vim>(|this, cx| this.update_mode(cx));
         let mut this = Self {
             mode: None,
+            operators: "".to_string(),
             _subscription,
         };
         this.update_mode(cx);
@@ -29,6 +31,7 @@ impl ModeIndicator {
 
         if vim.enabled {
             self.mode = Some(vim.state().mode);
+            self.operators = vim.state().current_operators_description();
         } else {
             self.mode = None;
         }
@@ -41,7 +44,7 @@ impl Render for ModeIndicator {
             return div().into_any();
         };
 
-        Label::new(format!("-- {} --", mode))
+        Label::new(format!("{} -- {} --", self.operators, mode))
             .size(LabelSize::Small)
             .into_any_element()
     }

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -193,6 +193,14 @@ impl EditorState {
         self.operator_stack.last().cloned()
     }
 
+    pub fn current_operators_description(&self) -> String {
+        self.operator_stack
+            .iter()
+            .map(|item| item.id())
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
     pub fn keymap_context_layer(&self) -> KeyContext {
         let mut context = KeyContext::default();
         context.set(

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -193,14 +193,6 @@ impl EditorState {
         self.operator_stack.last().cloned()
     }
 
-    pub fn current_operators_description(&self) -> String {
-        self.operator_stack
-            .iter()
-            .map(|item| item.id())
-            .collect::<Vec<_>>()
-            .join("")
-    }
-
     pub fn keymap_context_layer(&self) -> KeyContext {
         let mut context = KeyContext::default();
         context.set(

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -501,6 +501,17 @@ impl Vim {
         ) {
             self.start_recording(cx)
         };
+        // Since these operations can only be entered with pre-operators,
+        // we need to clear the previous operators when pushing,
+        // so that the current stack is the most correct
+        if matches!(
+            operator,
+            Operator::AddSurrounds { .. }
+                | Operator::ChangeSurrounds { .. }
+                | Operator::DeleteSurrounds
+        ) {
+            self.clear_operator(cx);
+        };
         self.update_state(|state| state.operator_stack.push(operator));
         self.sync_vim_settings(cx);
     }


### PR DESCRIPTION
Release Notes:

- Added the current operator stack to the Vim status bar at the bottom of the editor. #4447

This commit introduces a new feature that displays the current partial command in the vim mode, similar to the behavior in Vim plugin. This helps users keep track of the commands they're entering.

