### PR TITLE
Add a few tests to cover other folder names

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -641,6 +641,30 @@ mod tests {
             NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
             Some(NumericPrefixWithSuffix(1, "_2ab"))
         );
+
+        let target = "1.2";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(1, ".2"))
+        );
+
+        let target = "1.2_a";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(1, ".2_a"))
+        );
+
+        let target = "12.2_a";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(12, ".2_a"))
+        );
+
+        let target = "12a.2_a";
+        assert_eq!(
+            NumericPrefixWithSuffix::from_numeric_prefixed_str(target),
+            Some(NumericPrefixWithSuffix(12, "a.2_a"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Added additional tests to cover other folder names in regards to [#10193](https://github.com/zed-industries/zed/issues/10193) and [#9729](https://github.com/zed-industries/zed/issues/9729).

I had a similar issue but with folder names like '2.5' and '2.5_backup'. I didn't see test coverage for those kinds of file names, so wanted to add them.

![2024-04-10 09 07 03](https://github.com/zed-industries/zed/assets/127535196/eef26ce2-b0c7-4b1f-98ed-426ce1df0af2)

Release Notes:

- N/A
