### PR TITLE
Remove occasionally incorrect expectation

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -453,9 +453,7 @@ impl<T: Item> ItemHandle for View<T> {
                             }
 
                             workspace.update(&mut cx, |workspace, cx| {
-                                let item = item.upgrade().expect(
-                                    "item to be alive, otherwise task would have been dropped",
-                                );
+                                let Some(item) = item.upgrade() else { return };
                                 workspace.update_followers(
                                     is_project_item,
                                     proto::update_followers::Variant::UpdateView(


### PR DESCRIPTION
This panic has occured a handful of times, I think it must be the case
that:

1. Item is dropped outside of an update loop
2. The next update is this one

In that case no flush effects will have called the release observers
yet, but we cannot upgrade the WeakModel because the ref count is 0



Release Notes:

- Fixed a (rare) panic while collaborating
