### PR TITLE
Update `GITHUB_TOKEN` environment variable for Danger

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run Danger
         run: pnpm run --dir script/danger danger ci
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}


### PR DESCRIPTION
This PR updates the `GITHUB_TOKEN` environment variable that we use for Danger so that it should (hopefully) be able to run for PRs of external contributors.

Followed the instructions outlined [here](https://danger.systems/js/guides/getting_started#setting-up-danger-to-run-on-your-ci).

Danger comments will now by left by the @zed-industries-bot:

<img width="951" alt="Screenshot 2024-04-10 at 1 07 15 PM" src="https://github.com/zed-industries/zed/assets/1486634/d28cd537-9626-47df-8878-75a778824ef4">

Release Notes:

- N/A
