### PR TITLE
workspace: Add restore_on_startup setting that allows always opening an empty Zed instance

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -58,6 +58,8 @@
   "hover_popover_enabled": true,
   // Whether to confirm before quitting Zed.
   "confirm_quit": false,
+  // Whether to restore last closed project when fresh Zed instance is opened.
+  "restore_on_startup": "last_workspace",
   // Whether the cursor blinks in the editor.
   "cursor_blink": true,
   // Whether to pop the completions menu while typing in an editor without

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -81,7 +81,9 @@ use ui::{
 };
 use util::ResultExt;
 use uuid::Uuid;
-pub use workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings};
+pub use workspace_settings::{
+    AutosaveSetting, RestoreOnStartupBehaviour, TabBarSettings, WorkspaceSettings,
+};
 
 use crate::persistence::{
     model::{DockData, DockStructure, SerializedItem, SerializedPane, SerializedPaneGroup},

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -10,6 +10,17 @@ pub struct WorkspaceSettings {
     pub confirm_quit: bool,
     pub show_call_status_icon: bool,
     pub autosave: AutosaveSetting,
+    pub restore_on_startup: RestoreOnStartupBehaviour,
+}
+
+#[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RestoreOnStartupBehaviour {
+    /// Always start with an empty editor
+    None,
+    /// Restore the workspace that was closed last.
+    #[default]
+    LastWorkspace,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -32,6 +43,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: off
     pub autosave: Option<AutosaveSetting>,
+    /// Controls previous session restoration in freshly launched Zed instance.
+    /// Values: none, last_workspace
+    /// Default: last_workspace
+    pub restore_on_startup: Option<RestoreOnStartupBehaviour>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Fixes #7694
The new setting accepts "last_workspace" (default) and "none" as options.

In a follow-up PR I'll add a new option that re-launches all of the Zed windows and not just the last one.

Release Notes:

- Added `restore_on_startup` option, accepting `last_workspace` (default) and `none` options. With `none`, new Zed instances will not restore workspaces that were open last.
