### PR TITLE
linux: wayland: fix cursor set_icon

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -701,6 +701,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClient {
         qh: &QueueHandle<Self>,
     ) {
         let mut state = client.0.borrow_mut();
+        let cursor_icon_name = state.cursor_icon_name.clone();
 
         match event {
             wl_pointer::Event::Enter {
@@ -716,7 +717,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClient {
                     state.enter_token = Some(());
                     state.mouse_focused_window = Some(window.clone());
                     state.cursor.set_serial_id(serial);
-                    state.cursor.set_icon(&wl_pointer, None);
+                    state.cursor.set_icon(&wl_pointer, Some(cursor_icon_name.as_str()));
                     drop(state);
                     window.set_focused(true);
                 }
@@ -747,7 +748,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClient {
                     return;
                 }
                 state.mouse_location = Some(point(px(surface_x as f32), px(surface_y as f32)));
-                state.cursor.set_icon(&wl_pointer, None);
+                state.cursor.set_icon(&wl_pointer, Some(cursor_icon_name.as_str()));
 
                 if let Some(window) = state.mouse_focused_window.clone() {
                     let input = PlatformInput::MouseMove(MouseMoveEvent {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -717,7 +717,9 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClient {
                     state.enter_token = Some(());
                     state.mouse_focused_window = Some(window.clone());
                     state.cursor.set_serial_id(serial);
-                    state.cursor.set_icon(&wl_pointer, Some(cursor_icon_name.as_str()));
+                    state
+                        .cursor
+                        .set_icon(&wl_pointer, Some(cursor_icon_name.as_str()));
                     drop(state);
                     window.set_focused(true);
                 }
@@ -748,7 +750,9 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClient {
                     return;
                 }
                 state.mouse_location = Some(point(px(surface_x as f32), px(surface_y as f32)));
-                state.cursor.set_icon(&wl_pointer, Some(cursor_icon_name.as_str()));
+                state
+                    .cursor
+                    .set_icon(&wl_pointer, Some(cursor_icon_name.as_str()));
 
                 if let Some(window) = state.mouse_focused_window.clone() {
                     let input = PlatformInput::MouseMove(MouseMoveEvent {


### PR DESCRIPTION

Release Notes:

- Partially (Wayland implementation) Fixed [#10124](https://github.com/zed-industries/zed/issues/10124)).

The recent refactor of the linux gpui implementation (https://github.com/zed-industries/zed/pull/10227) broke the wayland cursor update logic by setting the cursor icon as `None`. Fix it by setting the `cursor_icon_name`.
