### PR TITLE
haskell: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12706,7 +12706,7 @@ dependencies = [
 
 [[package]]
 name = "zed_haskell"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_haskell"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/haskell/extension.toml
+++ b/extensions/haskell/extension.toml
@@ -1,7 +1,7 @@
 id = "haskell"
 name = "Haskell"
 description = "Haskell support."
-version = "0.0.1"
+version = "0.1.0"
 schema_version = 1
 authors = [
     "Pseudomata <pseudomata@proton.me>",


### PR DESCRIPTION
This PR bumps the Haskell extension to v0.1.0.

This version of the Haskell extension brings improved labels for symbols:

<img width="569" alt="Screenshot 2024-04-10 at 3 38 01 PM" src="https://github.com/zed-industries/zed/assets/1486634/759fa52f-7b85-4395-abfd-070138201162">

Release Notes:

- N/A
