### PR TITLE
Proxy Danger requests through a proxy service

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run Danger
         run: pnpm run --dir script/danger danger ci
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          DANGER_GITHUB_API_BASE_URL: "https://danger-proxy.fly.dev/github"

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -32,4 +32,5 @@ jobs:
       - name: Run Danger
         run: pnpm run --dir script/danger danger ci
         env:
+          GITHUB_TOKEN: "placeholder"
           DANGER_GITHUB_API_BASE_URL: "https://danger-proxy.fly.dev/github"

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -32,5 +32,10 @@ jobs:
       - name: Run Danger
         run: pnpm run --dir script/danger danger ci
         env:
-          GITHUB_TOKEN: "placeholder"
+          # This GitHub token is not used, but the value needs to be here to avoid
+          # Danger from throwing an error.
+          GITHUB_TOKEN: "not_a_real_token"
+          # All requests are instead proxied through an instance of
+          # https://github.com/maxdeviant/danger-proxy that allows Danger to securely
+          # authenticate with GitHub while still being able to run on PRs from forks.
           DANGER_GITHUB_API_BASE_URL: "https://danger-proxy.fly.dev/github"

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Danger
         run: pnpm run --dir script/danger danger ci
         env:
-          # This GitHub token is not used, but the value needs to be here to avoid
+          # This GitHub token is not used, but the value needs to be here to prevent
           # Danger from throwing an error.
           GITHUB_TOKEN: "not_a_real_token"
           # All requests are instead proxied through an instance of


### PR DESCRIPTION
This PR updates Danger to proxy its requests to GitHub through a proxy service.

## Motivation

Currently Danger is not able to run on PRs opened from forks of Zed.

This is due to GitHub Actions' security policies. Forks are not able to see any of the repository secrets, and the built-in `secrets.GITHUB_TOKEN` has its permissions [restricted](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) to only reads when running on forks.

I asked around on the Danger repo, and some big projects (DefinitelyTyped) are working around this by using a publicly-listed (although slightly obfuscated) token: https://github.com/danger/danger-js/issues/918#issuecomment-2048629487.

While this approach is _probably_ okay given the limited scope and permissions of the GitHub token, I would still prefer a solution that avoids disclosing the token at all.

## Explanation

I ended up writing a small proxy service, [Danger Proxy](https://github.com/maxdeviant/danger-proxy), that can be used to provide Danger with the ability to make authenticated GitHub requests, but without disclosing the token.

From the README:

> Danger Proxy will:
>
> - Proxy all requests to `/github/*` to the GitHub API. The provided GitHub API token will be used for authentication.
> - Restrict requests to the list of repositories specified in the `ALLOWED_REPOS` environment variable.
> - Restrict requests to the subset of the GitHub API that Danger requires.

I have an instance of this service deployed to [danger-proxy.fly.dev](https://danger-proxy.fly.dev/).

Release Notes:

- N/A
