### PR TITLE
Allow arrow keys to be used in tab switcher

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -608,6 +608,8 @@
   {
     "context": "TabSwitcher",
     "bindings": {
+      "ctrl-up": "menu::SelectPrev",
+      "ctrl-down": "menu::SelectNext",
       "ctrl-shift-tab": "menu::SelectPrev",
       "ctrl-backspace": "tab_switcher::CloseSelectedItem"
     }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -617,6 +617,8 @@
   {
     "context": "TabSwitcher",
     "bindings": {
+      "ctrl-up": "menu::SelectPrev",
+      "ctrl-down": "menu::SelectNext",
       "ctrl-shift-tab": "menu::SelectPrev",
       "ctrl-backspace": "tab_switcher::CloseSelectedItem"
     }


### PR DESCRIPTION
In addition to `ctrl-tab` and `ctrl-shift-tab`, VS Code allows changing the selection in the tab switcher via the up and down arrow keys.

Release Notes:

- Added bindings to allow `up` and `down` arrow keys to be used while the tab switcher is open.