### PR TITLE
Update default implementation of `LspAdapter::check_if_user_installed(...)` with generic functionality that can be overridden if needed

### DIFF
--- a/crates/languages/src/lua.rs
+++ b/crates/languages/src/lua.rs
@@ -15,10 +15,14 @@ use util::{
 #[derive(Copy, Clone)]
 pub struct LuaLspAdapter;
 
+impl LuaLspAdapter {
+    const SERVER_NAME: &'static str = "lua-language-server";
+}
+
 #[async_trait(?Send)]
 impl super::LspAdapter for LuaLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName("lua-language-server".into())
+        LanguageServerName(Self::SERVER_NAME.into())
     }
 
     async fn fetch_latest_server_version(
@@ -65,7 +69,7 @@ impl super::LspAdapter for LuaLspAdapter {
     ) -> Result<LanguageServerBinary> {
         let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
 
-        let binary_path = container_dir.join("bin/lua-language-server");
+        let binary_path = container_dir.join("bin/").join(Self::SERVER_NAME);
 
         if fs::metadata(&binary_path).await.is_err() {
             let mut response = delegate
@@ -125,7 +129,7 @@ async fn get_cached_server_binary(container_dir: PathBuf) -> Option<LanguageServ
                 && entry
                     .file_name()
                     .to_str()
-                    .map_or(false, |name| name == "lua-language-server")
+                    .map_or(false, |name| name == LuaLspAdapter::SERVER_NAME)
             {
                 last_binary_path = Some(entry.path());
             }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1,5 +1,6 @@
 use collections::HashMap;
 use gpui::AppContext;
+use language::LspBinaryConfigProvider;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
@@ -45,6 +46,16 @@ pub enum GitGutterSetting {
 pub struct BinarySettings {
     pub path: Option<String>,
     pub arguments: Option<Vec<String>>,
+}
+
+impl LspBinaryConfigProvider for BinarySettings {
+    fn path(&self) -> Option<String> {
+        self.path.clone()
+    }
+
+    fn arguments(&self) -> Option<Vec<String>> {
+        self.arguments.clone()
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]


### PR DESCRIPTION
The previous default implementation for the trait method was a no-op (it always returned `None`), but the concrete implementations for the few languages that supported it were more or less copy/paste boilerplate.

To avoid a circular dependency between the `language` and `project` crates, this PR introduces the `LspBinaryConfigProvider` trait that allows for a DI-like approach to getting the user's LSP override configs out of the LSP Adapter Delegate.

Through this approach, we can make the default implementation of the trait method apply to all LSP Adapters by using the `LspAdapter::name(...)` method to provide the key in to the config map.

LSP Adapter implementations still have the ability to implement the trait method explicitly in the event that the generalized logic is not sufficient for detecting and bootstrapping the LSP binary. An example could be cases where the `PATH` fallback still needs specific CLI flags/options, as the default logic passes no arguments. The `gopls` adapter is one such case where the concrete implementation is more-or-less the same but needs flags for the CLI.

The small number of existing explicit implementations have not been changed. This should make it easier to use local installs of LSPs for users with constrained connectivity without needing to wait for all of the various language adapters already in place to support overrides explicitly.

I think in practice the primary entry point here is going to be using the config file overrides; I feel like the automagic `PATH` overrides could lead to a lot of unexpected behavior for users, especially when CLI args are involved, and so it might be prudent to have the generalized version only provide an override from the config file. Adapter implementations can then choose to implement the `PATH` fallback logic if they want. Another option would be adding another trait method to `LspAdapter` such as `default_args()` akin to `name()` that would be used with the `PATH` fallback.

Probably worth discussing, and I can revise the PR easily.

Related Issues:
- https://github.com/zed-industries/zed/issues/10170
- https://github.com/zed-industries/zed/issues/4978
- https://github.com/zed-industries/zed/issues/5135
- https://github.com/zed-industries/zed/issues/6767

Release Notes:

- Added a default/generic implementation for `LspAdapter::check_if_user_installed(...)` to enable detecting local LSP binaries for all LspAdapter implementations