### PR TITLE
vim: Don’t allow edits in the read-only state

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -418,6 +418,9 @@ impl MultiBuffer {
         S: ToOffset,
         T: Into<Arc<str>>,
     {
+        if self.read_only() {
+            return;
+        }
         if self.buffers.borrow().is_empty() {
             return;
         }


### PR DESCRIPTION
Fix #8423 

Release Notes:

- vim: Fixed vim-surround motions editing read-only buffer (preview-only)