### PR TITLE
Windows: Fix crash when trying to copy nothing to clipboard

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -687,8 +687,10 @@ impl Platform for WindowsPlatform {
     }
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
-        let mut ctx = ClipboardContext::new().unwrap();
-        ctx.set_contents(item.text().to_owned()).unwrap();
+        if item.text.len() > 0 {
+            let mut ctx = ClipboardContext::new().unwrap();
+            ctx.set_contents(item.text().to_owned()).unwrap();
+        }
     }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {


### PR DESCRIPTION
Release Notes:

- N/A