### PR TITLE
Add git blame error reporting with notification

### DIFF
--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -408,7 +408,7 @@ mod tests {
         assert_eq!(
             message.as_str(),
             // we want the notification to be from the git blame
-            "failed to get blame for \"file.txt\""
+            "Failed to blame \"file.txt\": failed to get blame for \"file.txt\""
         );
         drop(blame); // the blame has to live long enough
     }

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -253,7 +253,7 @@ impl GitBlame {
     fn generate(&mut self, cx: &mut ModelContext<Self>) {
         let buffer_edits = self.buffer.update(cx, |buffer, _| buffer.subscribe());
         let snapshot = self.buffer.read(cx).snapshot();
-        let blame = self.project.read(cx).blame_buffer(&self.buffer, None, cx);
+        let blame = Project::blame_buffer(&self.project, &self.buffer, None, cx);
 
         self.task = cx.spawn(|this, mut cx| async move {
             let (entries, permalinks, messages) = cx

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -253,7 +253,7 @@ impl GitBlame {
     fn generate(&mut self, cx: &mut ModelContext<Self>) {
         let buffer_edits = self.buffer.update(cx, |buffer, _| buffer.subscribe());
         let snapshot = self.buffer.read(cx).snapshot();
-        let blame = Project::blame_buffer(&self.project, &self.buffer, None, cx);
+        let blame = self.project.read(cx).blame_buffer(&self.buffer, None, cx);
 
         self.task = cx.spawn(|this, mut cx| async move {
             let result = cx
@@ -318,7 +318,10 @@ impl GitBlame {
                 }),
                 Err(error) => this.update(&mut cx, |this, cx| {
                     this.project.update(cx, |_, cx| {
-                        cx.emit(project::Event::Notification(format!("{:#}", error)));
+                        log::error!("{error:?}");
+                        cx.emit(project::Event::Notification(
+                            (&format!("{:#}", error)).trim().to_string(),
+                        ));
                     })
                 }),
             }

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -78,6 +78,7 @@ fn run_git_blame(
         .arg(path.as_os_str())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| anyhow!("Failed to start git blame process: {}", e))?;
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7773,10 +7773,8 @@ impl Project {
             })?
             .await?;
 
-        let blame = this
-            .update(&mut cx, |_, cx| {
-                Self::blame_buffer(&this, &buffer, Some(version), cx)
-            })?
+        let blame = cx
+            .update(|cx| Self::blame_buffer(&this, &buffer, Some(version), &cx))?
             .await?;
 
         Ok(serialize_blame_buffer_response(blame))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7712,6 +7712,7 @@ impl Project {
                 let (repo, relative_path, content) = blame_params?;
                 let lock = repo.lock();
                 lock.blame(&relative_path, content)
+                    .with_context(|| format!("Failed to blame {relative_path:?}"))
             })
         } else {
             let project_id = self.remote_id();


### PR DESCRIPTION
<img width="1035" alt="Screenshot 2024-04-11 at 13 13 44" src="https://github.com/zed-industries/zed/assets/13402668/cd0e96a0-41c6-4757-8840-97d15a75c511">

Release Notes:

- Added a notification to show git blame errors.

Caveats:
- ~git blame now executes in foreground
executor  (required since the Fut is !Send)~

TODOs:
- After a failed toggle, the app thinks the blame
is shown. This means toggling again will do nothing
instead of retrying. (Caused by editor.show_git_blame
being set to true before the git blame is generated)
- ~(Maybe) Trim error?~ Done

