### PR TITLE
docs: Fix installation command via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Support for additional platforms is on our [roadmap](https://zed.dev/roadmap):
 For macOS users, you can also install Zed using [Homebrew](https://brew.sh/):
 
 ```sh
-brew install zed
+brew install --cask zed
 ```
 
 Alternatively, to install the Preview release:


### PR DESCRIPTION
When I installed zed by running `brew install zed` following `README.md`, [brimdata/zed](https://github.com/brimdata/zed) was installed.
By running `brew install --cask zed`, zed was installed properly.
It seems like `--cask` option is needed.

### Environments:
- OS:
    - macOS 13.4
- Homebrew version: 
    ```sh
    Homebrew 4.2.17-40-gef1c54e
    Homebrew/homebrew-core (git revision 0f61f2950ec; last commit 2024-04-03)
    Homebrew/homebrew-cask (git revision 40c0a17ee0; last commit 2024-04-03)
    ```

Release Notes:

- N/A