### PR TITLE
emmet: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12589,7 +12589,7 @@ dependencies = [
 
 [[package]]
 name = "zed_emmet"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.4",
 ]

--- a/extensions/emmet/Cargo.toml
+++ b/extensions/emmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_emmet"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/emmet/extension.toml
+++ b/extensions/emmet/extension.toml
@@ -1,7 +1,7 @@
 id = "emmet"
 name = "Emmet"
 description = "Emmet support"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Emmet extension to v0.0.2.

This version of the Emmet extension adds Emmet support for PHP and ERB files.

Release Notes:

- N/A
