### PR TITLE
Remember window restore size

### DIFF
--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -14,7 +14,7 @@ pub use collab_panel::CollabPanel;
 pub use collab_titlebar_item::CollabTitlebarItem;
 use gpui::{
     actions, point, AppContext, DevicePixels, Pixels, PlatformDisplay, Size, Task,
-    WindowBackgroundAppearance, WindowContext, WindowKind, WindowOptions,
+    WindowBackgroundAppearance, WindowContext, WindowKind, WindowOpenStatus, WindowOptions,
 };
 use panel_settings::MessageEditorSettings;
 pub use panel_settings::{
@@ -117,14 +117,13 @@ fn notification_window_options(
     let app_id = ReleaseChannel::global(cx).app_id();
 
     WindowOptions {
-        open_status: Some(bounds),
+        open_status: WindowOpenStatus::Windowed(Some(bounds)),
         titlebar: None,
         focus: false,
         show: true,
         kind: WindowKind::PopUp,
         is_movable: false,
         display_id: Some(screen.id()),
-        fullscreen: false,
         window_background: WindowBackgroundAppearance::default(),
         app_id: Some(app_id.to_owned()),
     }

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -14,7 +14,7 @@ pub use collab_panel::CollabPanel;
 pub use collab_titlebar_item::CollabTitlebarItem;
 use gpui::{
     actions, point, AppContext, DevicePixels, Pixels, PlatformDisplay, Size, Task,
-    WindowBackgroundAppearance, WindowContext, WindowKind, WindowOpenStatus, WindowOptions,
+    WindowBackgroundAppearance, WindowBounds, WindowContext, WindowKind, WindowOptions,
 };
 use panel_settings::MessageEditorSettings;
 pub use panel_settings::{
@@ -117,7 +117,7 @@ fn notification_window_options(
     let app_id = ReleaseChannel::global(cx).app_id();
 
     WindowOptions {
-        open_status: WindowOpenStatus::Windowed(Some(bounds)),
+        window_bounds: WindowBounds::Windowed(Some(bounds)),
         titlebar: None,
         focus: false,
         show: true,

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -117,7 +117,7 @@ fn notification_window_options(
     let app_id = ReleaseChannel::global(cx).app_id();
 
     WindowOptions {
-        window_bounds: WindowBounds::Windowed(bounds),
+        window_bounds: Some(WindowBounds::Windowed(bounds)),
         titlebar: None,
         focus: false,
         show: true,

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -117,7 +117,7 @@ fn notification_window_options(
     let app_id = ReleaseChannel::global(cx).app_id();
 
     WindowOptions {
-        bounds: Some(bounds),
+        open_status: Some(bounds),
         titlebar: None,
         focus: false,
         show: true,

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -117,7 +117,7 @@ fn notification_window_options(
     let app_id = ReleaseChannel::global(cx).app_id();
 
     WindowOptions {
-        window_bounds: WindowBounds::Windowed(Some(bounds)),
+        window_bounds: WindowBounds::Windowed(bounds),
         titlebar: None,
         focus: false,
         show: true,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9,7 +9,7 @@ use crate::{
     JoinLines,
 };
 use futures::StreamExt;
-use gpui::{div, TestAppContext, VisualTestContext, WindowOptions};
+use gpui::{div, TestAppContext, VisualTestContext, WindowOpenStatus, WindowOptions};
 use indoc::indoc;
 use language::{
     language_settings::{AllLanguageSettings, AllLanguageSettingsContent, LanguageSettingsContent},
@@ -7493,10 +7493,10 @@ async fn test_following(cx: &mut gpui::TestAppContext) {
     let follower = cx.update(|cx| {
         cx.open_window(
             WindowOptions {
-                open_status: Some(Bounds::from_corners(
+                open_status: WindowOpenStatus::Windowed(Some(Bounds::from_corners(
                     gpui::Point::new(0.into(), 0.into()),
                     gpui::Point::new(10.into(), 80.into()),
-                )),
+                ))),
                 ..Default::default()
             },
             |cx| cx.new_view(|cx| build_editor(buffer.clone(), cx)),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7493,7 +7493,7 @@ async fn test_following(cx: &mut gpui::TestAppContext) {
     let follower = cx.update(|cx| {
         cx.open_window(
             WindowOptions {
-                bounds: Some(Bounds::from_corners(
+                open_status: Some(Bounds::from_corners(
                     gpui::Point::new(0.into(), 0.into()),
                     gpui::Point::new(10.into(), 80.into()),
                 )),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7493,7 +7493,7 @@ async fn test_following(cx: &mut gpui::TestAppContext) {
     let follower = cx.update(|cx| {
         cx.open_window(
             WindowOptions {
-                window_bounds: WindowBounds::Windowed(Some(Bounds::from_corners(
+                window_bounds: Some(WindowBounds::Windowed(Bounds::from_corners(
                     gpui::Point::new(0.into(), 0.into()),
                     gpui::Point::new(10.into(), 80.into()),
                 ))),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9,7 +9,7 @@ use crate::{
     JoinLines,
 };
 use futures::StreamExt;
-use gpui::{div, TestAppContext, VisualTestContext, WindowOpenStatus, WindowOptions};
+use gpui::{div, TestAppContext, VisualTestContext, WindowBounds, WindowOptions};
 use indoc::indoc;
 use language::{
     language_settings::{AllLanguageSettings, AllLanguageSettingsContent, LanguageSettingsContent},
@@ -7493,7 +7493,7 @@ async fn test_following(cx: &mut gpui::TestAppContext) {
     let follower = cx.update(|cx| {
         cx.open_window(
             WindowOptions {
-                open_status: WindowOpenStatus::Windowed(Some(Bounds::from_corners(
+                window_bounds: WindowBounds::Windowed(Some(Bounds::from_corners(
                     gpui::Point::new(0.into(), 0.into()),
                     gpui::Point::new(10.into(), 80.into()),
                 ))),

--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -63,7 +63,7 @@ fn main() {
         .with_assets(Assets {})
         .run(|cx: &mut AppContext| {
             let options = WindowOptions {
-                open_status: WindowOpenStatus::Windowed(Some(Bounds::centered(
+                window_bounds: WindowBounds::Windowed(Some(Bounds::centered(
                     None,
                     size(px(300.), px(300.)),
                     cx,

--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -63,7 +63,11 @@ fn main() {
         .with_assets(Assets {})
         .run(|cx: &mut AppContext| {
             let options = WindowOptions {
-                open_status: Some(Bounds::centered(None, size(px(300.), px(300.)), cx)),
+                open_status: WindowOpenStatus::Windowed(Some(Bounds::centered(
+                    None,
+                    size(px(300.), px(300.)),
+                    cx,
+                ))),
                 ..Default::default()
             };
             cx.open_window(options, |cx| {

--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -63,7 +63,7 @@ fn main() {
         .with_assets(Assets {})
         .run(|cx: &mut AppContext| {
             let options = WindowOptions {
-                bounds: Some(Bounds::centered(None, size(px(300.), px(300.)), cx)),
+                open_status: Some(Bounds::centered(None, size(px(300.), px(300.)), cx)),
                 ..Default::default()
             };
             cx.open_window(options, |cx| {

--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -63,7 +63,7 @@ fn main() {
         .with_assets(Assets {})
         .run(|cx: &mut AppContext| {
             let options = WindowOptions {
-                window_bounds: WindowBounds::Windowed(Some(Bounds::centered(
+                window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
                     None,
                     size(px(300.), px(300.)),
                     cx,

--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -26,7 +26,7 @@ fn main() {
         let bounds = Bounds::centered(None, size(px(600.0), px(600.0)), cx);
         cx.open_window(
             WindowOptions {
-                open_status: Some(bounds),
+                open_status: WindowOpenStatus::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| {

--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -26,7 +26,7 @@ fn main() {
         let bounds = Bounds::centered(None, size(px(600.0), px(600.0)), cx);
         cx.open_window(
             WindowOptions {
-                bounds: Some(bounds),
+                open_status: Some(bounds),
                 ..Default::default()
             },
             |cx| {

--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -26,7 +26,7 @@ fn main() {
         let bounds = Bounds::centered(None, size(px(600.0), px(600.0)), cx);
         cx.open_window(
             WindowOptions {
-                open_status: WindowOpenStatus::Windowed(Some(bounds)),
+                window_bounds: WindowBounds::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| {

--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -26,7 +26,7 @@ fn main() {
         let bounds = Bounds::centered(None, size(px(600.0), px(600.0)), cx);
         cx.open_window(
             WindowOptions {
-                window_bounds: WindowBounds::Windowed(Some(bounds)),
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
             |cx| {

--- a/crates/gpui/examples/image/image.rs
+++ b/crates/gpui/examples/image/image.rs
@@ -79,10 +79,10 @@ fn main() {
                 ..Default::default()
             }),
 
-            bounds: Some(Bounds {
+            window_bounds: Some(WindowBounds::Windowed(Bounds {
                 size: size(px(1100.), px(600.)).into(),
                 origin: Point::new(DevicePixels::from(200), DevicePixels::from(200)),
-            }),
+            })),
 
             ..Default::default()
         };

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -43,7 +43,7 @@ fn main() {
 
                 WindowOptions {
                     // Set the bounds of the window in screen coordinates
-                    bounds: Some(bounds),
+                    open_status: Some(bounds),
                     // Specify the display_id to ensure the window is created on the correct screen
                     display_id: Some(screen.id()),
 

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -43,7 +43,7 @@ fn main() {
 
                 WindowOptions {
                     // Set the bounds of the window in screen coordinates
-                    window_bounds: WindowBounds::Windowed(Some(bounds)),
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
                     // Specify the display_id to ensure the window is created on the correct screen
                     display_id: Some(screen.id()),
 

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -43,7 +43,7 @@ fn main() {
 
                 WindowOptions {
                     // Set the bounds of the window in screen coordinates
-                    open_status: Some(bounds),
+                    open_status: WindowOpenStatus::Windowed(Some(bounds)),
                     // Specify the display_id to ensure the window is created on the correct screen
                     display_id: Some(screen.id()),
 
@@ -53,7 +53,6 @@ fn main() {
                     show: true,
                     kind: WindowKind::PopUp,
                     is_movable: false,
-                    fullscreen: false,
                     app_id: None,
                 }
             };

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -43,7 +43,7 @@ fn main() {
 
                 WindowOptions {
                     // Set the bounds of the window in screen coordinates
-                    open_status: WindowOpenStatus::Windowed(Some(bounds)),
+                    window_bounds: WindowBounds::Windowed(Some(bounds)),
                     // Specify the display_id to ensure the window is created on the correct screen
                     display_id: Some(screen.id()),
 

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -4,9 +4,8 @@ use crate::{
     Element, Empty, Entity, EventEmitter, ForegroundExecutor, Global, InputEvent, Keystroke, Model,
     ModelContext, Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
     MouseUpEvent, Pixels, Platform, Point, Render, Result, Size, Task, TestDispatcher,
-    TestPlatform, TestWindow, TextSystem, View, ViewContext, VisualContext, WindowContext,
-    WindowHandle, WindowOpenStatus,
-    WindowOptions,
+    TestPlatform, TestWindow, TextSystem, View, ViewContext, VisualContext, WindowBounds,
+    WindowContext, WindowHandle, WindowOptions,
 };
 use anyhow::{anyhow, bail};
 use futures::{channel::oneshot, Stream, StreamExt};
@@ -189,7 +188,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         cx.open_window(
             WindowOptions {
-                open_status: WindowOpenStatus::Windowed(Some(bounds)),
+                window_bounds: WindowBounds::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(build_window),
@@ -202,7 +201,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                open_status: WindowOpenStatus::Windowed(Some(bounds)),
+                window_bounds: WindowBounds::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(|_| Empty),
@@ -225,7 +224,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                open_status: WindowOpenStatus::Windowed(Some(bounds)),
+                window_bounds: WindowBounds::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(build_root_view),

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -188,7 +188,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         cx.open_window(
             WindowOptions {
-                bounds: Some(bounds),
+                open_status: Some(bounds),
                 ..Default::default()
             },
             |cx| cx.new_view(build_window),
@@ -201,7 +201,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                bounds: Some(bounds),
+                open_status: Some(bounds),
                 ..Default::default()
             },
             |cx| cx.new_view(|_| Empty),
@@ -224,7 +224,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                bounds: Some(bounds),
+                open_status: Some(bounds),
                 ..Default::default()
             },
             |cx| cx.new_view(build_root_view),

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -5,7 +5,8 @@ use crate::{
     ModelContext, Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
     MouseUpEvent, Pixels, Platform, Point, Render, Result, Size, Task, TestDispatcher,
     TestPlatform, TestWindow, TextSystem, View, ViewContext, VisualContext, WindowContext,
-    WindowHandle, WindowOptions,
+    WindowHandle, WindowOpenStatus,
+    WindowOptions,
 };
 use anyhow::{anyhow, bail};
 use futures::{channel::oneshot, Stream, StreamExt};
@@ -188,7 +189,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         cx.open_window(
             WindowOptions {
-                open_status: Some(bounds),
+                open_status: WindowOpenStatus::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(build_window),
@@ -201,7 +202,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                open_status: Some(bounds),
+                open_status: WindowOpenStatus::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(|_| Empty),
@@ -224,7 +225,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                open_status: Some(bounds),
+                open_status: WindowOpenStatus::Windowed(Some(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(build_root_view),

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -188,7 +188,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         cx.open_window(
             WindowOptions {
-                window_bounds: WindowBounds::Windowed(Some(bounds)),
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(build_window),
@@ -201,7 +201,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                window_bounds: WindowBounds::Windowed(Some(bounds)),
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(|_| Empty),
@@ -224,7 +224,7 @@ impl TestAppContext {
         let bounds = Bounds::maximized(None, &mut cx);
         let window = cx.open_window(
             WindowOptions {
-                window_bounds: WindowBounds::Windowed(Some(bounds)),
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
             |cx| cx.new_view(build_root_view),

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -515,9 +515,8 @@ pub trait InputHandler: 'static {
 /// The variables that can be configured when creating a new window
 #[derive(Debug)]
 pub struct WindowOptions {
-    /// The bounds of the window in screen coordinates.
-    /// None -> inherit, Some(bounds) -> set bounds
-    pub bounds: Option<Bounds<DevicePixels>>,
+    /// TODO:
+    pub open_status: WindowOpenStatus,
 
     /// The titlebar configuration of the window
     pub titlebar: Option<TitlebarOptions>,
@@ -527,9 +526,6 @@ pub struct WindowOptions {
 
     /// Whether the window should be shown when created
     pub show: bool,
-
-    /// Whether the window should be fullscreen when created
-    pub fullscreen: bool,
 
     /// The kind of window to create
     pub kind: WindowKind,
@@ -551,7 +547,7 @@ pub struct WindowOptions {
 /// The variables that can be configured when creating a new window
 #[derive(Debug)]
 pub(crate) struct WindowParams {
-    pub bounds: Bounds<DevicePixels>,
+    pub open_status: WindowOpenStatus,
 
     /// The titlebar configuration of the window
     pub titlebar: Option<TitlebarOptions>,
@@ -573,8 +569,9 @@ pub(crate) struct WindowParams {
 
 /// TODO:
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum WindowOpenState {
-    /// windowed
+pub enum WindowOpenStatus {
+    /// The bounds of the window in screen coordinates.
+    /// None -> inherit, Some(bounds) -> set bounds
     Windowed(Option<Bounds<DevicePixels>>),
     /// maximized
     Maximized,
@@ -585,7 +582,7 @@ pub enum WindowOpenState {
 impl Default for WindowOptions {
     fn default() -> Self {
         Self {
-            bounds: None,
+            open_status: WindowOpenStatus::Windowed(None),
             titlebar: Some(TitlebarOptions {
                 title: Default::default(),
                 appears_transparent: Default::default(),
@@ -596,7 +593,6 @@ impl Default for WindowOptions {
             kind: WindowKind::Normal,
             is_movable: true,
             display_id: None,
-            fullscreen: false,
             window_background: WindowBackgroundAppearance::default(),
             app_id: None,
         }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -184,7 +184,8 @@ unsafe impl Send for DisplayId {}
 pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn bounds(&self) -> Bounds<DevicePixels>;
     fn is_maximized(&self) -> bool;
-    fn next_open_status(&self) -> WindowOpenStatus;
+    fn is_minimized(&self) -> bool;
+    fn restore_size(&self) -> Bounds<DevicePixels>;
     fn content_size(&self) -> Size<Pixels>;
     fn scale_factor(&self) -> f32;
     fn appearance(&self) -> WindowAppearance;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -184,7 +184,7 @@ unsafe impl Send for DisplayId {}
 pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn bounds(&self) -> Bounds<DevicePixels>;
     fn is_maximized(&self) -> bool;
-    fn restore_status(&self) -> WindowBounds;
+    fn window_bounds(&self) -> WindowBounds;
     fn content_size(&self) -> Size<Pixels>;
     fn scale_factor(&self) -> f32;
     fn appearance(&self) -> WindowAppearance;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -589,6 +589,17 @@ impl Default for WindowOpenStatus {
     }
 }
 
+impl WindowOpenStatus {
+    /// Retrieve the inner bounds
+    pub fn get_bounds(&self) -> Option<Bounds<DevicePixels>> {
+        match self {
+            WindowOpenStatus::Windowed(bounds) => *bounds,
+            WindowOpenStatus::Maximized(bounds) => Some(*bounds),
+            WindowOpenStatus::FullScreen(bounds) => Some(*bounds),
+        }
+    }
+}
+
 impl Default for WindowOptions {
     fn default() -> Self {
         Self {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -567,16 +567,25 @@ pub(crate) struct WindowParams {
     pub window_background: WindowBackgroundAppearance,
 }
 
-/// TODO:
+/// Represents the status of how a window should be opened.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum WindowOpenStatus {
-    /// The bounds of the window in screen coordinates.
-    /// None -> inherit, Some(bounds) -> set bounds
+    /// Specifies the bounds of the window in screen coordinates.
+    /// - `None`: Inherit the bounds.
+    /// - `Some(bounds)`: Set the bounds to the specified value.
     Windowed(Option<Bounds<DevicePixels>>),
-    /// maximized
-    Maximized,
-    /// fullscreen
-    FullScreen,
+    /// Indicates that the window should open in a maximized state.
+    /// The bounds provided here represent the restore size of the window.
+    Maximized(Bounds<DevicePixels>),
+    /// Indicates that the window should open in fullscreen mode.
+    /// The bounds provided here represent the restore size of the window.
+    FullScreen(Bounds<DevicePixels>),
+}
+
+impl Default for WindowOpenStatus {
+    fn default() -> Self {
+        WindowOpenStatus::Windowed(None)
+    }
 }
 
 impl Default for WindowOptions {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -548,7 +548,7 @@ pub struct WindowOptions {
 /// The variables that can be configured when creating a new window
 #[derive(Debug)]
 pub(crate) struct WindowParams {
-    pub open_status: WindowOpenStatus,
+    pub bounds: Bounds<DevicePixels>,
 
     /// The titlebar configuration of the window
     pub titlebar: Option<TitlebarOptions>,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -580,7 +580,7 @@ pub enum WindowOpenStatus {
     Maximized(Bounds<DevicePixels>),
     /// Indicates that the window should open in fullscreen mode.
     /// The bounds provided here represent the restore size of the window.
-    FullScreen(Bounds<DevicePixels>),
+    Fullscreen(Bounds<DevicePixels>),
 }
 
 impl Default for WindowOpenStatus {
@@ -595,7 +595,7 @@ impl WindowOpenStatus {
         match self {
             WindowOpenStatus::Windowed(bounds) => *bounds,
             WindowOpenStatus::Maximized(bounds) => Some(*bounds),
-            WindowOpenStatus::FullScreen(bounds) => Some(*bounds),
+            WindowOpenStatus::Fullscreen(bounds) => Some(*bounds),
         }
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -185,7 +185,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn bounds(&self) -> Bounds<DevicePixels>;
     fn is_maximized(&self) -> bool;
     fn is_minimized(&self) -> bool;
-    fn restore_size(&self) -> Bounds<DevicePixels>;
+    fn restore_status(&self) -> WindowOpenStatus;
     fn content_size(&self) -> Size<Pixels>;
     fn scale_factor(&self) -> f32;
     fn appearance(&self) -> WindowAppearance;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -571,6 +571,17 @@ pub(crate) struct WindowParams {
     pub window_background: WindowBackgroundAppearance,
 }
 
+/// TODO:
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum WindowOpenState {
+    /// windowed
+    Windowed(Option<Bounds<DevicePixels>>),
+    /// maximized
+    Maximized,
+    /// fullscreen
+    FullScreen,
+}
+
 impl Default for WindowOptions {
     fn default() -> Self {
         Self {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -184,7 +184,7 @@ unsafe impl Send for DisplayId {}
 pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn bounds(&self) -> Bounds<DevicePixels>;
     fn is_maximized(&self) -> bool;
-    fn is_minimized(&self) -> bool;
+    fn next_open_status(&self) -> WindowOpenStatus;
     fn content_size(&self) -> Size<Pixels>;
     fn scale_factor(&self) -> f32;
     fn appearance(&self) -> WindowAppearance;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -184,7 +184,6 @@ unsafe impl Send for DisplayId {}
 pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn bounds(&self) -> Bounds<DevicePixels>;
     fn is_maximized(&self) -> bool;
-    fn is_minimized(&self) -> bool;
     fn restore_status(&self) -> WindowOpenStatus;
     fn content_size(&self) -> Size<Pixels>;
     fn scale_factor(&self) -> f32;

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -28,7 +28,7 @@ use crate::scene::Scene;
 use crate::{
     px, size, Bounds, DevicePixels, Globals, Modifiers, Pixels, PlatformDisplay, PlatformInput,
     Point, PromptLevel, Size, WaylandClientState, WaylandClientStatePtr, WindowAppearance,
-    WindowBackgroundAppearance, WindowParams,
+    WindowBackgroundAppearance, WindowOpenStatus, WindowParams,
 };
 
 #[derive(Default)]
@@ -548,6 +548,17 @@ impl PlatformWindow for WaylandWindow {
     fn is_minimized(&self) -> bool {
         // This cannot be determined by the client
         false
+    }
+
+    fn restore_status(&self) -> WindowOpenStatus {
+        let state = self.borrow();
+        if state.fullscreen {
+            WindowOpenStatus::FullScreen(state.bounds.map(|p| DevicePixels(p as i32)))
+        } else if state.maximized {
+            WindowOpenStatus::Maximized(state.bounds.map(|p| DevicePixels(p as i32)))
+        } else {
+            WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p as i32))))
+        }
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -694,7 +694,7 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn toggle_fullscreen(&self) {
-        let mut state = self.borrow();
+        let mut state = self.borrow_mut();
         state.restore_bounds = state.bounds.map(|p| DevicePixels(p as i32));
         if !state.fullscreen {
             state.toplevel.set_fullscreen(None);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -561,7 +561,7 @@ impl PlatformWindow for WaylandWindow {
     fn restore_status(&self) -> WindowOpenStatus {
         let state = self.borrow();
         if state.fullscreen {
-            WindowOpenStatus::FullScreen(state.restore_bounds)
+            WindowOpenStatus::Fullscreen(state.restore_bounds)
         } else if state.maximized {
             WindowOpenStatus::Maximized(state.restore_bounds)
         } else {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -556,11 +556,11 @@ impl PlatformWindow for WaylandWindow {
     fn window_bounds(&self) -> WindowBounds {
         let state = self.borrow();
         if state.fullscreen {
-            WindowOpenStatus::Fullscreen(state.restore_bounds)
+            WindowBounds::Fullscreen(state.restore_bounds)
         } else if state.maximized {
-            WindowOpenStatus::Maximized(state.restore_bounds)
+            WindowBounds::Maximized(state.restore_bounds)
         } else {
-            WindowOpenStatus::Windowed(state.bounds.map(|p| DevicePixels(p as i32)))
+            WindowBounds::Windowed(state.bounds.map(|p| DevicePixels(p as i32)))
         }
     }
 

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -79,6 +79,7 @@ pub struct WaylandWindowState {
     input_handler: Option<PlatformInputHandler>,
     decoration_state: WaylandDecorationState,
     fullscreen: bool,
+    restore_bounds: Bounds<DevicePixels>,
     maximized: bool,
     client: WaylandClientStatePtr,
     callbacks: Callbacks,
@@ -151,6 +152,7 @@ impl WaylandWindowState {
             input_handler: None,
             decoration_state: WaylandDecorationState::Client,
             fullscreen: false,
+            restore_bounds: Bounds::default(),
             maximized: false,
             callbacks: Callbacks::default(),
             client,
@@ -550,12 +552,12 @@ impl PlatformWindow for WaylandWindow {
         false
     }
 
-    // todo(linux)
     fn restore_status(&self) -> WindowOpenStatus {
         let state = self.borrow();
         if state.fullscreen {
-            WindowOpenStatus::FullScreen(state.bounds.map(|p| DevicePixels(p as i32)))
+            WindowOpenStatus::FullScreen(state.restore_bounds)
         } else if state.maximized {
+            // todo(linux)
             WindowOpenStatus::Maximized(state.bounds.map(|p| DevicePixels(p as i32)))
         } else {
             WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p as i32))))
@@ -692,6 +694,7 @@ impl PlatformWindow for WaylandWindow {
 
     fn toggle_fullscreen(&self) {
         let state = self.borrow();
+        state.restore_bounds = state.bounds.map(|p| DevicePixels(p as i32));
         if !state.fullscreen {
             state.toplevel.set_fullscreen(None);
         } else {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -551,11 +551,6 @@ impl PlatformWindow for WaylandWindow {
         self.borrow().maximized
     }
 
-    fn is_minimized(&self) -> bool {
-        // This cannot be determined by the client
-        false
-    }
-
     // todo(linux)
     // check if it is right
     fn restore_status(&self) -> WindowOpenStatus {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -335,9 +335,9 @@ impl WaylandWindowStatePtr {
                 let fullscreen = states.contains(&(xdg_toplevel::State::Fullscreen as u8));
                 let maximized = states.contains(&(xdg_toplevel::State::Maximized as u8));
                 let mut state = self.state.borrow_mut();
-                state.maximized = true;
+                state.maximized = maximized;
                 state.fullscreen = fullscreen;
-                if fullscreen || state.maximized {
+                if fullscreen || maximized {
                     state.restore_bounds = state.bounds.map(|p| DevicePixels(p as i32));
                 }
                 self.resize(width, height);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -550,6 +550,7 @@ impl PlatformWindow for WaylandWindow {
         false
     }
 
+    // todo(linux)
     fn restore_status(&self) -> WindowOpenStatus {
         let state = self.borrow();
         if state.fullscreen {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -335,9 +335,9 @@ impl WaylandWindowStatePtr {
                 let fullscreen = states.contains(&(xdg_toplevel::State::Fullscreen as u8));
                 let maximized = states.contains(&(xdg_toplevel::State::Maximized as u8));
                 let mut state = self.state.borrow_mut();
-                state.maximized = maximized;
+                state.maximized = true;
                 state.fullscreen = fullscreen;
-                if fullscreen || maximized {
+                if fullscreen || state.maximized {
                     state.restore_bounds = state.bounds.map(|p| DevicePixels(p as i32));
                 }
                 self.resize(width, height);
@@ -698,7 +698,7 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn toggle_fullscreen(&self) {
-        let state = self.borrow();
+        let mut state = self.borrow();
         state.restore_bounds = state.bounds.map(|p| DevicePixels(p as i32));
         if !state.fullscreen {
             state.toplevel.set_fullscreen(None);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -28,7 +28,7 @@ use crate::scene::Scene;
 use crate::{
     px, size, Bounds, DevicePixels, Globals, Modifiers, Pixels, PlatformDisplay, PlatformInput,
     Point, PromptLevel, Size, WaylandClientState, WaylandClientStatePtr, WindowAppearance,
-    WindowBackgroundAppearance, WindowOpenStatus, WindowParams,
+    WindowBackgroundAppearance, WindowBounds, WindowParams,
 };
 
 #[derive(Default)]
@@ -553,14 +553,14 @@ impl PlatformWindow for WaylandWindow {
 
     // todo(linux)
     // check if it is right
-    fn restore_status(&self) -> WindowOpenStatus {
+    fn window_bounds(&self) -> WindowBounds {
         let state = self.borrow();
         if state.fullscreen {
             WindowOpenStatus::Fullscreen(state.restore_bounds)
         } else if state.maximized {
             WindowOpenStatus::Maximized(state.restore_bounds)
         } else {
-            WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p as i32))))
+            WindowOpenStatus::Windowed(state.bounds.map(|p| DevicePixels(p as i32)))
         }
     }
 

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -340,6 +340,7 @@ impl WaylandWindowStatePtr {
                 if fullscreen || maximized {
                     state.restore_bounds = state.bounds.map(|p| DevicePixels(p as i32));
                 }
+                drop(state);
                 self.resize(width, height);
                 self.set_fullscreen(fullscreen);
 

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -526,11 +526,6 @@ impl PlatformWindow for X11Window {
     }
 
     // todo(linux)
-    fn is_minimized(&self) -> bool {
-        false
-    }
-
-    // todo(linux)
     fn restore_status(&self) -> WindowOpenStatus {
         let state = self.state.borrow();
         WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p))))

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -526,9 +526,9 @@ impl PlatformWindow for X11Window {
     }
 
     // todo(linux)
-    fn restore_status(&self) -> WindowOpenStatus {
+    fn window_bounds(&self) -> WindowOpenStatus {
         let state = self.state.borrow();
-        WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p))))
+        WindowOpenStatus::Windowed(state.bounds.map(|p| DevicePixels(p)))
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -532,7 +532,7 @@ impl PlatformWindow for X11Window {
 
     // todo(linux)
     fn restore_status(&self) -> WindowOpenStatus {
-        let state = self.borrow();
+        let state = self.state.borrow();
         WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p as i32))))
     }
 

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -5,7 +5,7 @@ use crate::{
     platform::blade::{BladeRenderer, BladeSurfaceConfig},
     size, Bounds, DevicePixels, ForegroundExecutor, Modifiers, Pixels, Platform, PlatformAtlas,
     PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptLevel,
-    Scene, Size, WindowAppearance, WindowBackgroundAppearance, WindowOpenStatus, WindowOptions,
+    Scene, Size, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowOptions,
     WindowParams, X11Client, X11ClientState, X11ClientStatePtr,
 };
 use blade_graphics as gpu;

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -526,9 +526,9 @@ impl PlatformWindow for X11Window {
     }
 
     // todo(linux)
-    fn window_bounds(&self) -> WindowOpenStatus {
-        let state = self.state.borrow();
-        WindowOpenStatus::Windowed(state.bounds.map(|p| DevicePixels(p)))
+    fn window_bounds(&self) -> WindowBounds {
+        let state = self.0.state.borrow();
+        WindowBounds::Windowed(state.bounds.map(|p| DevicePixels(p)))
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -533,7 +533,13 @@ impl PlatformWindow for X11Window {
     // todo(linux)
     fn restore_status(&self) -> WindowOpenStatus {
         let state = self.state.borrow();
-        WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p as i32))))
+        if state.fullscreen {
+            WindowOpenStatus::FullScreen(state.bounds.map(|p| DevicePixels(p)))
+        } else if state.maximized {
+            WindowOpenStatus::Maximized(state.bounds.map(|p| DevicePixels(p)))
+        } else {
+            WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p))))
+        }
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -533,13 +533,7 @@ impl PlatformWindow for X11Window {
     // todo(linux)
     fn restore_status(&self) -> WindowOpenStatus {
         let state = self.state.borrow();
-        if state.fullscreen {
-            WindowOpenStatus::FullScreen(state.bounds.map(|p| DevicePixels(p)))
-        } else if state.maximized {
-            WindowOpenStatus::Maximized(state.bounds.map(|p| DevicePixels(p)))
-        } else {
-            WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p))))
-        }
+        WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p))))
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -5,8 +5,8 @@ use crate::{
     platform::blade::{BladeRenderer, BladeSurfaceConfig},
     size, Bounds, DevicePixels, ForegroundExecutor, Modifiers, Pixels, Platform, PlatformAtlas,
     PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptLevel,
-    Scene, Size, WindowAppearance, WindowBackgroundAppearance, WindowOptions, WindowParams,
-    X11Client, X11ClientState, X11ClientStatePtr,
+    Scene, Size, WindowAppearance, WindowBackgroundAppearance, WindowOpenStatus, WindowOptions,
+    WindowParams, X11Client, X11ClientState, X11ClientStatePtr,
 };
 use blade_graphics as gpu;
 use parking_lot::Mutex;
@@ -528,6 +528,12 @@ impl PlatformWindow for X11Window {
     // todo(linux)
     fn is_minimized(&self) -> bool {
         false
+    }
+
+    // todo(linux)
+    fn restore_status(&self) -> WindowOpenStatus {
+        let state = self.borrow();
+        WindowOpenStatus::Windowed(Some(state.bounds.map(|p| DevicePixels(p as i32))))
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -501,7 +501,7 @@ impl MacWindowState {
 
     fn restore_status(&self) -> WindowOpenStatus {
         if self.is_fullscreen() {
-            WindowOpenStatus::FullScreen(self.fullscreen_restore_bounds)
+            WindowOpenStatus::Fullscreen(self.fullscreen_restore_bounds)
         } else if self.is_maximized() {
             WindowOpenStatus::Maximized(self.maximized_restore_bounds)
         } else {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -353,7 +353,6 @@ struct MacWindowState {
     external_files_dragged: bool,
     // Whether the next left-mouse click is also the focusing click.
     first_mouse: bool,
-    minimized: bool,
     maximized: bool,
     maximized_restore_bounds: Bounds<DevicePixels>,
     fullscreen_restore_bounds: Bounds<DevicePixels>,
@@ -437,10 +436,6 @@ impl MacWindowState {
 
     fn is_maximized(&self) -> bool {
         self.maximized
-    }
-
-    fn is_minimized(&self) -> bool {
-        self.minimized
     }
 
     fn is_fullscreen(&self) -> bool {
@@ -653,7 +648,6 @@ impl MacWindow {
                 previous_keydown_inserted_text: None,
                 external_files_dragged: false,
                 first_mouse: false,
-                minimized: false,
                 maximized: false,
                 maximized_restore_bounds: Bounds::default(),
                 fullscreen_restore_bounds: Bounds::default(),
@@ -799,10 +793,6 @@ impl PlatformWindow for MacWindow {
 
     fn is_maximized(&self) -> bool {
         self.0.as_ref().lock().is_maximized()
-    }
-
-    fn is_minimized(&self) -> bool {
-        self.0.as_ref().lock().is_minimized()
     }
 
     fn content_size(&self) -> Size<Pixels> {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -499,7 +499,13 @@ impl MacWindowState {
     }
 
     fn restore_status(&self) -> WindowOpenStatus {
-        WindowOpenStatus::Windowed(None)
+        if self.is_fullscreen() {
+            WindowOpenStatus::FullScreen(self.bounds())
+        } else if self.is_maximized() {
+            WindowOpenStatus::Maximized(self.maximized_restore_bounds)
+        } else {
+            WindowOpenStatus::Windowed(Some(self.bounds()))
+        }
     }
 }
 
@@ -512,7 +518,7 @@ impl MacWindow {
         handle: AnyWindowHandle,
         WindowParams {
             window_background,
-            bounds,
+            open_status,
             titlebar,
             kind,
             is_movable,
@@ -574,6 +580,7 @@ impl MacWindow {
                 NSScreen::visibleFrame(screen)
             });
 
+            let bounds = open_status.get_bounds().unwrap();
             let window_rect = NSRect::new(
                 NSPoint::new(
                     screen_frame.origin.x + bounds.origin.x.0 as f64,
@@ -613,6 +620,22 @@ impl MacWindow {
                 )
             };
 
+            let mut maximized = false;
+            let mut maximized_restore_bounds = Bounds::default();
+            match open_status {
+                WindowOpenStatus::Windowed(_) => {}
+                WindowOpenStatus::Maximized(_) => {
+                    maximized = true;
+                    maximized_restore_bounds = bounds;
+                    native_window.setFrame_display_animate_(
+                        native_window.screen().visibleFrame(),
+                        1,
+                        0,
+                    );
+                }
+                WindowOpenStatus::FullScreen(_) => {}
+            }
+
             let mut window = Self(Arc::new(Mutex::new(MacWindowState {
                 handle,
                 executor,
@@ -647,8 +670,8 @@ impl MacWindow {
                 external_files_dragged: false,
                 first_mouse: false,
                 minimized: false,
-                maximized: false,
-                maximized_restore_bounds: Bounds::default(),
+                maximized,
+                maximized_restore_bounds,
             })));
 
             (*native_window).set_ivar(

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -759,8 +759,8 @@ impl MacWindow {
             if maximized {
                 native_window.setFrame_display_animate_(
                     native_window.screen().visibleFrame(),
-                    1,
-                    0,
+                    YES,
+                    NO,
                 );
             }
 

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1477,11 +1477,6 @@ fn window_fullscreen_changed(this: &Object, is_fullscreen: bool) {
     if is_fullscreen {
         lock.fullscreen_restore_bounds = lock.bounds();
     }
-    if let Some(mut callback) = lock.fullscreen_callback.take() {
-        drop(lock);
-        callback(is_fullscreen);
-        window_state.lock().fullscreen_callback = Some(callback);
-    }
 }
 
 extern "C" fn window_did_move(this: &Object, _: Sel, _: id) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -627,11 +627,6 @@ impl MacWindow {
                 WindowOpenStatus::Maximized(_) => {
                     maximized = true;
                     maximized_restore_bounds = bounds;
-                    native_window.setFrame_display_animate_(
-                        native_window.screen().visibleFrame(),
-                        1,
-                        0,
-                    );
                 }
                 WindowOpenStatus::FullScreen(_) => {}
             }
@@ -760,6 +755,15 @@ impl MacWindow {
             // the window position might be incorrect if the main screen (the screen that contains the window that has focus)
             //  is different from the primary screen.
             NSWindow::setFrameTopLeftPoint_(native_window, window_rect.origin);
+
+            if maximized {
+                native_window.setFrame_display_animate_(
+                    native_window.screen().visibleFrame(),
+                    1,
+                    0,
+                );
+            }
+
             window.0.lock().move_traffic_light();
 
             pool.drain();

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -261,6 +261,10 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
         window_did_change_occlusion_state as extern "C" fn(&Object, Sel, id),
     );
     decl.add_method(
+        sel!(windowWillEnterFullScreen:),
+        window_will_enter_fullscreen as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
         sel!(windowDidMove:),
         window_did_move as extern "C" fn(&Object, Sel, id),
     );
@@ -1464,19 +1468,9 @@ extern "C" fn window_did_resize(this: &Object, _: Sel, _: id) {
 }
 
 extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
-    window_fullscreen_changed(this, true);
-}
-
-extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
-    window_fullscreen_changed(this, false);
-}
-
-fn window_fullscreen_changed(this: &Object, is_fullscreen: bool) {
     let window_state = unsafe { get_window_state(this) };
     let mut lock = window_state.as_ref().lock();
-    if is_fullscreen {
-        lock.fullscreen_restore_bounds = lock.bounds();
-    }
+    lock.fullscreen_restore_bounds = lock.bounds();
 }
 
 extern "C" fn window_did_move(this: &Object, _: Sel, _: id) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -4,7 +4,7 @@ use crate::{
     DisplayLink, ExternalPaths, FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke,
     Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
     Pixels, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformWindow, Point, PromptLevel,
-    Size, Timer, WindowAppearance, WindowBackgroundAppearance, WindowKind, WindowOpenStatus,
+    Size, Timer, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowKind,
     WindowParams,
 };
 use block::ConcreteBlock;
@@ -486,13 +486,13 @@ impl MacWindowState {
         }
     }
 
-    fn restore_status(&self) -> WindowOpenStatus {
+    fn window_bounds(&self) -> WindowBounds {
         if self.is_fullscreen() {
-            WindowOpenStatus::Fullscreen(self.fullscreen_restore_bounds)
+            WindowBoundss::Fullscreen(self.fullscreen_restore_bounds)
         } else if self.is_maximized() {
-            WindowOpenStatus::Maximized(self.maximized_restore_bounds)
+            WindowBoundss::Maximized(self.maximized_restore_bounds)
         } else {
-            WindowOpenStatus::Windowed(Some(self.bounds()))
+            WindowBoundss::Windowed(self.bounds())
         }
     }
 }
@@ -779,8 +779,8 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().bounds()
     }
 
-    fn restore_status(&self) -> WindowOpenStatus {
-        self.0.as_ref().lock().restore_status()
+    fn window_bounds(&self) -> WindowOpenStatus {
+        self.0.as_ref().lock().window_bounds()
     }
 
     fn is_maximized(&self) -> bool {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -307,14 +307,6 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
         sel!(concludeDragOperation:),
         conclude_drag_operation as extern "C" fn(&Object, Sel, id),
     );
-    decl.add_method(
-        sel!(windowDidMiniaturize:),
-        window_did_miniaturize as extern "C" fn(&Object, Sel, id),
-    );
-    decl.add_method(
-        sel!(windowDidDeminiaturize:),
-        window_did_deminiaturize as extern "C" fn(&Object, Sel, id),
-    );
 
     decl.register()
 }
@@ -1904,18 +1896,6 @@ extern "C" fn conclude_drag_operation(this: &Object, _: Sel, _: id) {
         &window_state,
         PlatformInput::FileDrop(FileDropEvent::Exited),
     );
-}
-
-extern "C" fn window_did_miniaturize(this: &Object, _: Sel, _: id) {
-    let window_state = unsafe { get_window_state(this) };
-
-    window_state.lock().minimized = true;
-}
-
-extern "C" fn window_did_deminiaturize(this: &Object, _: Sel, _: id) {
-    let window_state = unsafe { get_window_state(this) };
-
-    window_state.lock().minimized = false;
 }
 
 async fn synthetic_drag(

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1528,7 +1528,6 @@ fn window_fullscreen_changed(this: &Object, is_fullscreen: bool) {
     let mut lock = window_state.as_ref().lock();
     if is_fullscreen {
         lock.fullscreen_restore_bounds = lock.bounds();
-        println!("F bounds: {:#?}", lock.bounds());
     }
     if let Some(mut callback) = lock.fullscreen_callback.take() {
         drop(lock);

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -519,7 +519,7 @@ impl MacWindow {
         handle: AnyWindowHandle,
         WindowParams {
             window_background,
-            open_status,
+            bounds,
             titlebar,
             kind,
             is_movable,
@@ -581,7 +581,6 @@ impl MacWindow {
                 NSScreen::visibleFrame(screen)
             });
 
-            let bounds = open_status.get_bounds().unwrap();
             let window_rect = NSRect::new(
                 NSPoint::new(
                     screen_frame.origin.x + bounds.origin.x.0 as f64,
@@ -621,22 +620,6 @@ impl MacWindow {
                 )
             };
 
-            let mut maximized = false;
-            let mut fullscreen = false;
-            let mut maximized_restore_bounds = Bounds::default();
-            let mut fullscreen_restore_bounds = Bounds::default();
-            match open_status {
-                WindowOpenStatus::Windowed(_) => {}
-                WindowOpenStatus::Maximized(_) => {
-                    maximized = true;
-                    maximized_restore_bounds = bounds;
-                }
-                WindowOpenStatus::FullScreen(bounds) => {
-                    fullscreen = true;
-                    fullscreen_restore_bounds = bounds;
-                }
-            }
-
             let mut window = Self(Arc::new(Mutex::new(MacWindowState {
                 handle,
                 executor,
@@ -672,8 +655,8 @@ impl MacWindow {
                 first_mouse: false,
                 minimized: false,
                 maximized,
-                maximized_restore_bounds,
-                fullscreen_restore_bounds,
+                maximized_restore_bounds: Bounds::default(),
+                fullscreen_restore_bounds: Bounds::default(),
             })));
 
             (*native_window).set_ivar(

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -4,7 +4,8 @@ use crate::{
     DisplayLink, ExternalPaths, FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke,
     Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
     Pixels, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformWindow, Point, PromptLevel,
-    Size, Timer, WindowAppearance, WindowBackgroundAppearance, WindowKind, WindowParams,
+    Size, Timer, WindowAppearance, WindowBackgroundAppearance, WindowKind, WindowOpenStatus,
+    WindowParams,
 };
 use block::ConcreteBlock;
 use cocoa::{
@@ -279,6 +280,10 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
         sel!(windowShouldClose:),
         window_should_close as extern "C" fn(&Object, Sel, id) -> BOOL,
     );
+    decl.add_method(
+        sel!(windowShouldZoom:toFrame:),
+        window_should_zoom as extern "C" fn(&Object, Sel, id, NSRect) -> BOOL,
+    );
 
     decl.add_method(sel!(close), close_window as extern "C" fn(&Object, Sel));
 
@@ -349,6 +354,7 @@ struct MacWindowState {
     // Whether the next left-mouse click is also the focusing click.
     first_mouse: bool,
     minimized: bool,
+    maximized_restore_bounds: Bounds<DevicePixels>,
 }
 
 impl MacWindowState {
@@ -640,6 +646,7 @@ impl MacWindow {
                 external_files_dragged: false,
                 first_mouse: false,
                 minimized: false,
+                maximized_restore_bounds: Bounds::default(),
             })));
 
             (*native_window).set_ivar(
@@ -773,6 +780,10 @@ impl Drop for MacWindow {
 impl PlatformWindow for MacWindow {
     fn bounds(&self) -> Bounds<DevicePixels> {
         self.0.as_ref().lock().bounds()
+    }
+
+    fn restore_status(&self) -> WindowOpenStatus {
+        WindowOpenStatus::Windowed(None)
     }
 
     fn is_maximized(&self) -> bool {
@@ -1528,6 +1539,14 @@ extern "C" fn window_should_close(this: &Object, _: Sel, _: id) -> BOOL {
     } else {
         YES
     }
+}
+
+extern "C" fn window_should_zoom(this: &Object, _: Sel, _: id, _: NSRect) -> BOOL {
+    let window_state = unsafe { get_window_state(this) };
+    let mut lock = window_state.as_ref().lock();
+    let bounds = lock.bounds();
+    println!("======>\n    Zoom bounds: {:#?}", bounds);
+    YES
 }
 
 extern "C" fn close_window(this: &Object, _: Sel) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -488,11 +488,11 @@ impl MacWindowState {
 
     fn window_bounds(&self) -> WindowBounds {
         if self.is_fullscreen() {
-            WindowBoundss::Fullscreen(self.fullscreen_restore_bounds)
+            WindowBounds::Fullscreen(self.fullscreen_restore_bounds)
         } else if self.is_maximized() {
-            WindowBoundss::Maximized(self.maximized_restore_bounds)
+            WindowBounds::Maximized(self.maximized_restore_bounds)
         } else {
-            WindowBoundss::Windowed(self.bounds())
+            WindowBounds::Windowed(self.bounds())
         }
     }
 }
@@ -779,7 +779,7 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().bounds()
     }
 
-    fn window_bounds(&self) -> WindowOpenStatus {
+    fn window_bounds(&self) -> WindowBounds {
         self.0.as_ref().lock().window_bounds()
     }
 

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -654,7 +654,7 @@ impl MacWindow {
                 external_files_dragged: false,
                 first_mouse: false,
                 minimized: false,
-                maximized,
+                maximized: false,
                 maximized_restore_bounds: Bounds::default(),
                 fullscreen_restore_bounds: Bounds::default(),
             })));
@@ -745,16 +745,6 @@ impl MacWindow {
             // the window position might be incorrect if the main screen (the screen that contains the window that has focus)
             //  is different from the primary screen.
             NSWindow::setFrameTopLeftPoint_(native_window, window_rect.origin);
-
-            if maximized {
-                native_window.setFrame_display_animate_(
-                    native_window.screen().visibleFrame(),
-                    YES,
-                    NO,
-                );
-            } else if fullscreen {
-                window.toggle_fullscreen();
-            }
 
             window.0.lock().move_traffic_light();
 

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -354,6 +354,7 @@ struct MacWindowState {
     // Whether the next left-mouse click is also the focusing click.
     first_mouse: bool,
     minimized: bool,
+    maximized: bool,
     maximized_restore_bounds: Bounds<DevicePixels>,
 }
 
@@ -434,11 +435,7 @@ impl MacWindowState {
     }
 
     fn is_maximized(&self) -> bool {
-        unsafe {
-            let bounds = self.bounds();
-            let screen_size = self.native_window.screen().visibleFrame().into();
-            bounds.size == screen_size
-        }
+        self.maximized
     }
 
     fn is_minimized(&self) -> bool {
@@ -499,6 +496,10 @@ impl MacWindowState {
             let content_layout_rect: CGRect = msg_send![self.native_window, contentLayoutRect];
             px((frame.size.height - content_layout_rect.size.height) as f32)
         }
+    }
+
+    fn restore_status(&self) -> WindowOpenStatus {
+        WindowOpenStatus::Windowed(None)
     }
 }
 
@@ -646,6 +647,7 @@ impl MacWindow {
                 external_files_dragged: false,
                 first_mouse: false,
                 minimized: false,
+                maximized: false,
                 maximized_restore_bounds: Bounds::default(),
             })));
 
@@ -783,7 +785,7 @@ impl PlatformWindow for MacWindow {
     }
 
     fn restore_status(&self) -> WindowOpenStatus {
-        WindowOpenStatus::Windowed(None)
+        self.0.as_ref().lock().restore_status()
     }
 
     fn is_maximized(&self) -> bool {
@@ -1545,7 +1547,9 @@ extern "C" fn window_should_zoom(this: &Object, _: Sel, _: id, _: NSRect) -> BOO
     let window_state = unsafe { get_window_state(this) };
     let mut lock = window_state.as_ref().lock();
     let bounds = lock.bounds();
-    println!("======>\n    Zoom bounds: {:#?}", bounds);
+    lock.maximized_restore_bounds = bounds;
+    lock.maximized = !lock.maximized;
+
     YES
 }
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -2,7 +2,7 @@ use crate::{
     AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, DevicePixels,
     DispatchEventResult, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
-    WindowBackgroundAppearance, WindowParams,
+    WindowBackgroundAppearance, WindowParams, WindowOpenStatus
 };
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -56,7 +56,7 @@ impl TestWindow {
         display: Rc<dyn PlatformDisplay>,
     ) -> Self {
         Self(Arc::new(Mutex::new(TestWindowState {
-            bounds: params.open_status.get_bounds(),
+            bounds: params.open_status.get_bounds().unwrap(),
             display,
             platform,
             handle,
@@ -110,6 +110,10 @@ impl TestWindow {
 impl PlatformWindow for TestWindow {
     fn bounds(&self) -> Bounds<DevicePixels> {
         self.0.lock().bounds
+    }
+
+    fn restore_status(&self) -> WindowOpenStatus {
+        WindowOpenStatus::Windowed(Some(self.bounds()))
     }
 
     fn is_maximized(&self) -> bool {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -2,7 +2,7 @@ use crate::{
     AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, DevicePixels,
     DispatchEventResult, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
-    WindowBackgroundAppearance, WindowOpenStatus, WindowParams,
+    WindowBackgroundAppearance, WindowBounds, WindowParams,
 };
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -112,8 +112,8 @@ impl PlatformWindow for TestWindow {
         self.0.lock().bounds
     }
 
-    fn restore_status(&self) -> WindowOpenStatus {
-        WindowOpenStatus::Windowed(Some(self.bounds()))
+    fn restore_status(&self) -> WindowBounds {
+        WindowBounds::Windowed(Some(self.bounds()))
     }
 
     fn is_maximized(&self) -> bool {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -56,7 +56,7 @@ impl TestWindow {
         display: Rc<dyn PlatformDisplay>,
     ) -> Self {
         Self(Arc::new(Mutex::new(TestWindowState {
-            bounds: params.open_status.get_bounds().unwrap(),
+            bounds: params.bounds,
             display,
             platform,
             handle,

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -2,7 +2,7 @@ use crate::{
     AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, DevicePixels,
     DispatchEventResult, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
-    WindowBackgroundAppearance, WindowParams, WindowOpenStatus
+    WindowBackgroundAppearance, WindowOpenStatus, WindowParams,
 };
 use collections::HashMap;
 use parking_lot::Mutex;

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -113,7 +113,7 @@ impl PlatformWindow for TestWindow {
     }
 
     fn restore_status(&self) -> WindowBounds {
-        WindowBounds::Windowed(Some(self.bounds()))
+        WindowBounds::Windowed(self.bounds())
     }
 
     fn is_maximized(&self) -> bool {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -120,10 +120,6 @@ impl PlatformWindow for TestWindow {
         false
     }
 
-    fn is_minimized(&self) -> bool {
-        false
-    }
-
     fn content_size(&self) -> Size<Pixels> {
         self.bounds().size.into()
     }

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -112,7 +112,7 @@ impl PlatformWindow for TestWindow {
         self.0.lock().bounds
     }
 
-    fn restore_status(&self) -> WindowBounds {
+    fn window_bounds(&self) -> WindowBounds {
         WindowBounds::Windowed(self.bounds())
     }
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -56,7 +56,7 @@ impl TestWindow {
         display: Rc<dyn PlatformDisplay>,
     ) -> Self {
         Self(Arc::new(Mutex::new(TestWindowState {
-            bounds: params.bounds,
+            bounds: params.open_status,
             display,
             platform,
             handle,

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -56,7 +56,7 @@ impl TestWindow {
         display: Rc<dyn PlatformDisplay>,
     ) -> Self {
         Self(Arc::new(Mutex::new(TestWindowState {
-            bounds: params.open_status,
+            bounds: params.open_status.get_bounds(),
             display,
             platform,
             handle,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -109,7 +109,7 @@ impl WindowsWindowState {
         !self.is_fullscreen() && unsafe { IsZoomed(self.hwnd) }.as_bool()
     }
 
-    fn restore_status(&self) -> WindowOpenStatus {
+    fn restore_status(&self) -> WindowBounds {
         self.restore_size.get()
     }
 
@@ -134,11 +134,11 @@ impl WindowsWindowState {
         };
 
         if self.is_fullscreen() {
-            WindowOpenStatus::Fullscreen(self.fullscreen_restore_bounds.get())
+            WindowBounds::Fullscreen(self.fullscreen_restore_bounds.get())
         } else if placement.showCmd == SW_SHOWMAXIMIZED.0 as u32 {
-            WindowOpenStatus::Maximized(bounds)
+            WindowBounds::Maximized(bounds)
         } else {
-            WindowOpenStatus::Windowed(Some(bounds))
+            WindowBounds::Windowed(bounds)
         }
     }
 
@@ -360,7 +360,7 @@ impl PlatformWindow for WindowsWindow {
         self.0.is_minimized()
     }
 
-    fn restore_status(&self) -> WindowOpenStatus {
+    fn restore_status(&self) -> WindowBounds {
         self.inner.restore_status()
     }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -84,8 +84,6 @@ impl WindowsWindowState {
         Self {
             origin,
             physical_size,
-            restore_origin,
-            restore_size,
             scale_factor,
             callbacks,
             input_handler,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -82,21 +82,16 @@ impl WindowsWindowState {
         let click_state = ClickState::new();
         let fullscreen = None;
 
-        let fullscreen_restore_origin;
-        let fullscreen_restore_size;
-        if let Some(bounds) = fullscreen_restore_bounds {
-            fullscreen_restore_origin = Cell::new(bounds.origin);
-            fullscreen_restore_size = Cell::new(bounds.size);
+        let fullscreen_restore_bounds = if let Some(bounds) = fullscreen_restore_bounds {
+            Cell::new(bounds)
         } else {
-            fullscreen_restore_origin = Cell::new(Point::default());
-            fullscreen_restore_size = Cell::new(Size::default());
-        }
+            Cell::new(Bounds::default())
+        };
 
         Self {
             origin,
             physical_size,
-            fullscreen_restore_origin,
-            fullscreen_restore_size,
+            fullscreen_restore_bounds,
             scale_factor,
             callbacks,
             input_handler,
@@ -144,10 +139,7 @@ impl WindowsWindowState {
         };
 
         if self.is_fullscreen() {
-            WindowOpenStatus::FullScreen(Bounds {
-                origin: self.fullscreen_restore_origin.get(),
-                size: self.fullscreen_restore_size.get(),
-            })
+            WindowOpenStatus::FullScreen(self.fullscreen_restore_bounds.get())
         } else if placement.showCmd == SW_SHOWMAXIMIZED.0 as u32 {
             WindowOpenStatus::Maximized(bounds)
         } else {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -283,9 +283,6 @@ impl WindowsWindow {
             WindowOpenStatus::FullScreen => SW_SHOW,
         };
         unsafe { ShowWindow(raw_hwnd, show_cmd) };
-        if !params.focus {
-            unsafe { ShowWindow(wnd.inner.hwnd, SW_SHOWNOACTIVATE) };
-        }
         if params.open_status == WindowOpenStatus::FullScreen {
             wnd.toggle_fullscreen();
         }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -113,6 +113,10 @@ impl WindowsWindowState {
     }
 
     fn bounds(&self) -> Bounds<DevicePixels> {
+        unsafe {
+            let mut placement = WINDOWPLACEMENT::default();
+            let x = GetWindowPlacement();
+        }
         let bounds = Bounds {
             origin: self.origin,
             size: self.physical_size,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -211,10 +211,6 @@ impl WindowsWindowStatePtr {
             main_receiver: context.main_receiver.clone(),
         })
     }
-
-    fn is_minimized(&self) -> bool {
-        unsafe { IsIconic(self.hwnd) }.as_bool()
-    }
 }
 
 #[derive(Default)]

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -231,10 +231,10 @@ impl WindowsWindow {
                 .unwrap_or(""),
         );
         let dwstyle = WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
-        let x = options.bounds.origin.x.0;
-        let y = options.bounds.origin.y.0;
-        let nwidth = options.bounds.size.width.0;
-        let nheight = options.bounds.size.height.0;
+        let x = options.open_status.origin.x.0;
+        let y = options.open_status.origin.y.0;
+        let nwidth = options.open_status.size.width.0;
+        let nheight = options.open_status.size.height.0;
         let hwndparent = HWND::default();
         let hmenu = HMENU::default();
         let hinstance = get_module_handle();

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -231,14 +231,39 @@ impl WindowsWindow {
                 .unwrap_or(""),
         );
         let dwstyle = WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
-        let (x, y, nwidth, nheight) = match params.open_status {
+        let (x, y, nwidth, nheight, show_cmd, fullscreen) = match params.open_status {
             WindowOpenStatus::Windowed(Some(bounds)) => (
                 bounds.origin.x.0,
                 bounds.origin.y.0,
                 bounds.size.width.0,
                 bounds.size.height.0,
+                SW_SHOW,
+                false,
             ),
-            _ => (CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT),
+            WindowOpenStatus::Maximized(bounds) => (
+                bounds.origin.x.0,
+                bounds.origin.y.0,
+                bounds.size.width.0,
+                bounds.size.height.0,
+                SW_SHOWMAXIMIZED,
+                false,
+            ),
+            WindowOpenStatus::FullScreen(bounds) => (
+                bounds.origin.x.0,
+                bounds.origin.y.0,
+                bounds.size.width.0,
+                bounds.size.height.0,
+                SW_SHOW,
+                true,
+            ),
+            _ => (
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                SW_SHOW,
+                false,
+            ),
         };
         let hwndparent = HWND::default();
         let hmenu = HMENU::default();
@@ -277,13 +302,8 @@ impl WindowsWindow {
         register_drag_drop(state_ptr.clone());
         let wnd = Self(state_ptr);
 
-        let show_cmd = match params.open_status {
-            WindowOpenStatus::Windowed(_) => SW_SHOW,
-            WindowOpenStatus::Maximized => SW_SHOWMAXIMIZED,
-            WindowOpenStatus::FullScreen => SW_SHOW,
-        };
         unsafe { ShowWindow(raw_hwnd, show_cmd) };
-        if params.open_status == WindowOpenStatus::FullScreen {
+        if fullscreen {
             wnd.toggle_fullscreen();
         }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -113,18 +113,30 @@ impl WindowsWindowState {
     }
 
     fn bounds(&self) -> Bounds<DevicePixels> {
-        unsafe {
-            let mut placement = WINDOWPLACEMENT::default();
-            let x = GetWindowPlacement();
-        }
-        let bounds = Bounds {
-            origin: self.origin,
-            size: self.physical_size,
+        let placement = unsafe {
+            let mut placement = WINDOWPLACEMENT {
+                length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
+                ..Default::default()
+            };
+            GetWindowPlacement(self.hwnd, &mut placement).log_err();
+            placement
         };
-        if self.is_fullscreen() {
-            WindowOpenStatus::FullScreen(bounds)
-        } else if self.is_maximized() {
-            WindowOpenStatus::Maximized(bounds)
+        let bounds = Bounds {
+            origin: point(
+                DevicePixels(placement.rcNormalPosition.left),
+                DevicePixels(placement.rcNormalPosition.top),
+            ),
+            size: size(
+                DevicePixels(placement.rcNormalPosition.right - placement.rcNormalPosition.left),
+                DevicePixels(placement.rcNormalPosition.bottom - placement.rcNormalPosition.top),
+            ),
+        };
+        if placement.showCmd == SW_SHOWMAXIMIZED.0 as u32 {
+            if self.is_fullscreen() {
+                WindowOpenStatus::FullScreen(bounds)
+            } else {
+                WindowOpenStatus::Maximized(bounds)
+            }
         } else {
             WindowOpenStatus::Windowed(Some(bounds))
         }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -134,7 +134,7 @@ impl WindowsWindowState {
         };
 
         if self.is_fullscreen() {
-            WindowOpenStatus::FullScreen(self.fullscreen_restore_bounds.get())
+            WindowOpenStatus::Fullscreen(self.fullscreen_restore_bounds.get())
         } else if placement.showCmd == SW_SHOWMAXIMIZED.0 as u32 {
             WindowOpenStatus::Maximized(bounds)
         } else {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -82,10 +82,10 @@ impl WindowsWindowState {
         let fullscreen = None;
 
         Self {
-            origin: origin.clone(),
-            physical_size: physical_size.clone(),
-            restore_origin: origin,
-            restore_size: physical_size,
+            origin,
+            physical_size,
+            restore_origin,
+            restore_size,
             scale_factor,
             callbacks,
             input_handler,
@@ -108,14 +108,21 @@ impl WindowsWindowState {
         !self.is_fullscreen() && unsafe { IsZoomed(self.hwnd) }.as_bool()
     }
 
-    fn restore_size(&self) -> Bounds<DevicePixels> {
+    fn restore_status(&self) -> WindowOpenStatus {
         self.restore_size.get()
     }
 
     fn bounds(&self) -> Bounds<DevicePixels> {
-        Bounds {
+        let bounds = Bounds {
             origin: self.origin,
             size: self.physical_size,
+        };
+        if self.is_fullscreen() {
+            WindowOpenStatus::FullScreen(bounds)
+        } else if self.is_maximized() {
+            WindowOpenStatus::Maximized(bounds)
+        } else {
+            WindowOpenStatus::Windowed(Some(bounds))
         }
     }
 
@@ -364,12 +371,8 @@ impl PlatformWindow for WindowsWindow {
         self.0.is_minimized()
     }
 
-    fn restore_size(&self) -> Bounds<DevicePixels> {
-        self.inner.restore_size()
-    }
-
-    fn restore_size(&self) -> Bounds<DevicePixels> {
-        self.inner.restore_size()
+    fn restore_status(&self) -> WindowOpenStatus {
+        self.inner.restore_status()
     }
 
     /// get the logical size of the app's drawable area.

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -109,7 +109,7 @@ impl WindowsWindowState {
         !self.is_fullscreen() && unsafe { IsZoomed(self.hwnd) }.as_bool()
     }
 
-    fn restore_status(&self) -> WindowBounds {
+    fn window_bounds(&self) -> WindowBounds {
         self.restore_size.get()
     }
 
@@ -356,12 +356,8 @@ impl PlatformWindow for WindowsWindow {
         self.0.state.borrow().is_maximized()
     }
 
-    fn is_minimized(&self) -> bool {
-        self.0.is_minimized()
-    }
-
-    fn restore_status(&self) -> WindowBounds {
-        self.inner.restore_status()
+    fn window_bounds(&self) -> WindowBounds {
+        self.inner.window_bounds()
     }
 
     /// get the logical size of the app's drawable area.

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -71,10 +71,6 @@ impl WindowsWindowState {
     ) -> Self {
         let origin = point(cs.x.into(), cs.y.into());
         let physical_size = size(cs.cx.into(), cs.cy.into());
-        let restore_size = Cell::new(Bounds {
-            origin: point(DevicePixels(cs.x), DevicePixels(cs.y)),
-            size: size(DevicePixels(cs.cx), DevicePixels(cs.cy)),
-        });
         let scale_factor = {
             let monitor_dpi = unsafe { GetDpiForWindow(hwnd) } as f32;
             monitor_dpi / USER_DEFAULT_SCREEN_DPI as f32
@@ -86,9 +82,10 @@ impl WindowsWindowState {
         let fullscreen = None;
 
         Self {
-            origin,
-            physical_size,
-            restore_size,
+            origin: origin.clone(),
+            physical_size: physical_size.clone(),
+            restore_origin: origin,
+            restore_size: physical_size,
             scale_factor,
             callbacks,
             input_handler,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -333,7 +333,6 @@ impl WindowsWindow {
         }
         unsafe { ShowWindow(raw_hwnd, show_cmd) };
         if fullscreen {
-            println!("Toggle fullscreen");
             wnd.toggle_fullscreen();
         }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -71,6 +71,10 @@ impl WindowsWindowState {
     ) -> Self {
         let origin = point(cs.x.into(), cs.y.into());
         let physical_size = size(cs.cx.into(), cs.cy.into());
+        let restore_size = Cell::new(Bounds {
+            origin: point(DevicePixels(cs.x), DevicePixels(cs.y)),
+            size: size(DevicePixels(cs.cx), DevicePixels(cs.cy)),
+        });
         let scale_factor = {
             let monitor_dpi = unsafe { GetDpiForWindow(hwnd) } as f32;
             monitor_dpi / USER_DEFAULT_SCREEN_DPI as f32
@@ -84,6 +88,7 @@ impl WindowsWindowState {
         Self {
             origin,
             physical_size,
+            restore_size,
             scale_factor,
             callbacks,
             input_handler,
@@ -104,6 +109,10 @@ impl WindowsWindowState {
 
     pub(crate) fn is_maximized(&self) -> bool {
         !self.is_fullscreen() && unsafe { IsZoomed(self.hwnd) }.as_bool()
+    }
+
+    fn restore_size(&self) -> Bounds<DevicePixels> {
+        self.restore_size.get()
     }
 
     fn bounds(&self) -> Bounds<DevicePixels> {
@@ -356,6 +365,14 @@ impl PlatformWindow for WindowsWindow {
 
     fn is_minimized(&self) -> bool {
         self.0.is_minimized()
+    }
+
+    fn restore_size(&self) -> Bounds<DevicePixels> {
+        self.inner.restore_size()
+    }
+
+    fn restore_size(&self) -> Bounds<DevicePixels> {
+        self.inner.restore_size()
     }
 
     /// get the logical size of the app's drawable area.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -592,7 +592,7 @@ impl Window {
         cx: &mut AppContext,
     ) -> Self {
         let WindowOptions {
-            bounds,
+            open_status: bounds,
             titlebar,
             focus,
             show,
@@ -608,7 +608,7 @@ impl Window {
         let mut platform_window = cx.platform.open_window(
             handle,
             WindowParams {
-                bounds,
+                open_status: bounds,
                 titlebar,
                 kind,
                 is_movable,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -639,7 +639,7 @@ impl Window {
         let last_input_timestamp = Rc::new(Cell::new(Instant::now()));
 
         match open_status {
-            WindowOpenStatus::FullScreen(_) => platform_window.toggle_fullscreen(),
+            WindowOpenStatus::Fullscreen(_) => platform_window.toggle_fullscreen(),
             WindowOpenStatus::Maximized(_) => platform_window.zoom(),
             WindowOpenStatus::Windowed(_) => {}
         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -951,7 +951,7 @@ impl<'a> WindowContext<'a> {
     /// Return the restore size to indicate that how a window should be opened
     /// after it has been closed
     pub fn restore_status(&self) -> WindowBounds {
-        self.window.platform_window.restore_status()
+        self.window.platform_window.window_bounds()
     }
 
     /// Dispatch the given action on the currently focused element.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -950,8 +950,8 @@ impl<'a> WindowContext<'a> {
 
     /// Return the restore size to indicate that how a window should be opened
     /// after it has been closed
-    pub fn restore_size(&self) -> Bounds<DevicePixels> {
-        self.window.platform_window.restore_size()
+    pub fn restore_status(&self) -> WindowOpenStatus {
+        self.window.platform_window.restore_status()
     }
 
     /// Dispatch the given action on the currently focused element.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -948,6 +948,12 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.is_minimized()
     }
 
+    /// Return the restore size to indicate that how a window should be opened
+    /// after it has been closed
+    pub fn restore_size(&self) -> Bounds<DevicePixels> {
+        self.window.platform_window.restore_size()
+    }
+
     /// Dispatch the given action on the currently focused element.
     pub fn dispatch_action(&mut self, action: Box<dyn Action>) {
         let focus_handle = self.focused();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -565,7 +565,7 @@ fn default_bounds(display_id: Option<DisplayId>, cx: &mut AppContext) -> Bounds<
     const DEFAULT_WINDOW_OFFSET: Point<DevicePixels> = point(DevicePixels(0), DevicePixels(35));
 
     cx.active_window()
-        .and_then(|w| w.update(cx, |_, cx| cx.window_bounds()).ok())
+        .and_then(|w| w.update(cx, |_, cx| cx.bounds()).ok())
         .map(|bounds| bounds.map_origin(|origin| origin + DEFAULT_WINDOW_OFFSET))
         .unwrap_or_else(|| {
             let display = display_id
@@ -696,7 +696,7 @@ impl Window {
             let mut cx = cx.to_async();
             move |_, _| {
                 handle
-                    .update(&mut cx, |_, cx| cx.window_bounds_changed())
+                    .update(&mut cx, |_, cx| cx.bounds_changed())
                     .log_err();
             }
         }));
@@ -704,7 +704,7 @@ impl Window {
             let mut cx = cx.to_async();
             move || {
                 handle
-                    .update(&mut cx, |_, cx| cx.window_bounds_changed())
+                    .update(&mut cx, |_, cx| cx.bounds_changed())
                     .log_err();
             }
         }));
@@ -948,9 +948,9 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.is_maximized()
     }
 
-    /// Return the restore size to indicate that how a window should be opened
+    /// Return the `WindowBounds` to indicate that how a window should be opened
     /// after it has been closed
-    pub fn restore_status(&self) -> WindowBounds {
+    pub fn window_bounds(&self) -> WindowBounds {
         self.window.platform_window.window_bounds()
     }
 
@@ -1080,7 +1080,7 @@ impl<'a> WindowContext<'a> {
             .spawn(|app| f(AsyncWindowContext::new(app, self.window.handle)))
     }
 
-    fn window_bounds_changed(&mut self) {
+    fn bounds_changed(&mut self) {
         self.window.scale_factor = self.window.platform_window.scale_factor();
         self.window.viewport_size = self.window.platform_window.content_size();
         self.window.display_id = self.window.platform_window.display().id();
@@ -1093,7 +1093,7 @@ impl<'a> WindowContext<'a> {
     }
 
     /// Returns the bounds of the current window in the global coordinate space, which could span across multiple displays.
-    pub fn window_bounds(&self) -> Bounds<DevicePixels> {
+    pub fn bounds(&self) -> Bounds<DevicePixels> {
         self.window.platform_window.bounds()
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -951,12 +951,6 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.is_maximized()
     }
 
-    /// Check if the platform window is minimized
-    /// On some platforms (namely Windows) the position is incorrect when minimized
-    pub fn is_minimized(&self) -> bool {
-        self.window.platform_window.is_minimized()
-    }
-
     /// Return the restore size to indicate that how a window should be opened
     /// after it has been closed
     pub fn restore_status(&self) -> WindowOpenStatus {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -603,11 +603,6 @@ impl Window {
             app_id,
         } = options;
 
-        // let open_status = if open_status == WindowOpenStatus::Windowed(None) {
-        //     WindowOpenStatus::Windowed(Some(default_bounds(display_id, cx)))
-        // } else {
-        //     open_status
-        // };
         let bounds = open_status
             .get_bounds()
             .unwrap_or_else(|| default_bounds(display_id, cx));

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -86,7 +86,7 @@ fn main() {
         let bounds = Bounds::centered(None, size, cx);
         let _window = cx.open_window(
             WindowOptions {
-                window_bounds: WindowBounds::Windowed(Some(bounds)),
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
             move |cx| {

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -7,8 +7,8 @@ mod story_selector;
 use clap::Parser;
 use dialoguer::FuzzySelect;
 use gpui::{
-    div, px, size, AnyView, AppContext, Bounds, Render, ViewContext, VisualContext,
-    WindowOpenStatus, WindowOptions,
+    div, px, size, AnyView, AppContext, Bounds, Render, ViewContext, VisualContext, WindowBounds,
+    WindowOptions,
 };
 use log::LevelFilter;
 use project::Project;
@@ -86,7 +86,7 @@ fn main() {
         let bounds = Bounds::centered(None, size, cx);
         let _window = cx.open_window(
             WindowOptions {
-                open_status: WindowOpenStatus::Windowed(Some(bounds)),
+                window_bounds: WindowBounds::Windowed(Some(bounds)),
                 ..Default::default()
             },
             move |cx| {

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -7,7 +7,8 @@ mod story_selector;
 use clap::Parser;
 use dialoguer::FuzzySelect;
 use gpui::{
-    div, px, size, AnyView, AppContext, Bounds, Render, ViewContext, VisualContext, WindowOptions,
+    div, px, size, AnyView, AppContext, Bounds, Render, ViewContext, VisualContext,
+    WindowOpenStatus, WindowOptions,
 };
 use log::LevelFilter;
 use project::Project;
@@ -85,7 +86,7 @@ fn main() {
         let bounds = Bounds::centered(None, size, cx);
         let _window = cx.open_window(
             WindowOptions {
-                open_status: Some(bounds),
+                open_status: WindowOpenStatus::Windowed(Some(bounds)),
                 ..Default::default()
             },
             move |cx| {

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -85,7 +85,7 @@ fn main() {
         let bounds = Bounds::centered(None, size, cx);
         let _window = cx.open_window(
             WindowOptions {
-                bounds: Some(bounds),
+                open_status: Some(bounds),
                 ..Default::default()
             },
             move |cx| {

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -396,7 +396,7 @@ impl WorkspaceDb {
             WorkspaceId,
             Option<LocalPaths>,
             Option<u64>,
-            SerializedWindowOpenStatus,
+            Option<SerializedWindowOpenStatus>,
             Option<Uuid>,
             Option<bool>,
             DockStructure,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -59,7 +59,7 @@ impl sqlez::bindable::Column for SerializedAxis {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct SerializedWindowOpenStatus(pub(crate) WindowOpenStatus);
 
 impl StaticColumnCount for SerializedWindowOpenStatus {

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -328,6 +328,8 @@ define_connection! {
         ALTER TABLE pane_groups ADD COLUMN flexes TEXT;
     ),
     // Add fullscreen field to workspace
+    // Deprecated, `WindowBounds` holds the fullscreen state now.
+    // Preserving so users can downgrade Zed.
     sql!(
         ALTER TABLE workspaces ADD COLUMN fullscreen INTEGER; //bool
     ),

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -85,13 +85,29 @@ impl Bind for SerializedWindowOpenStatus {
                     next_index,
                 )
             }
-            WindowOpenStatus::Maximized => {
+            WindowOpenStatus::Maximized(bounds) => {
                 let next_index = statement.bind(&"Maximized", start_index)?;
-                statement.bind(&(0.0, 0.0, 0.0, 0.0), next_index)
+                statement.bind(
+                    &(
+                        SerializedDevicePixels(bounds.origin.x),
+                        SerializedDevicePixels(bounds.origin.y),
+                        SerializedDevicePixels(bounds.size.width),
+                        SerializedDevicePixels(bounds.size.height),
+                    ),
+                    next_index,
+                )
             }
-            WindowOpenStatus::FullScreen => {
+            WindowOpenStatus::FullScreen(bounds) => {
                 let next_index = statement.bind(&"FullScreen", start_index)?;
-                statement.bind(&(0.0, 0.0, 0.0, 0.0), next_index)
+                statement.bind(
+                    &(
+                        SerializedDevicePixels(bounds.origin.x),
+                        SerializedDevicePixels(bounds.origin.y),
+                        SerializedDevicePixels(bounds.size.width),
+                        SerializedDevicePixels(bounds.size.height),
+                    ),
+                    next_index,
+                )
             }
         }
     }
@@ -112,8 +128,28 @@ impl Column for SerializedWindowOpenStatus {
                     size: size(width.into(), height.into()),
                 })))
             }
-            "Maximized" => SerializedWindowOpenStatus(WindowOpenStatus::Maximized),
-            "FullScreen" => SerializedWindowOpenStatus(WindowOpenStatus::FullScreen),
+            "Maximized" => {
+                let ((x, y, width, height), _) = Column::column(statement, next_index)?;
+                let x: i32 = x;
+                let y: i32 = y;
+                let width: i32 = width;
+                let height: i32 = height;
+                SerializedWindowOpenStatus(WindowOpenStatus::Maximized(Bounds {
+                    origin: point(x.into(), y.into()),
+                    size: size(width.into(), height.into()),
+                }))
+            }
+            "FullScreen" => {
+                let ((x, y, width, height), _) = Column::column(statement, next_index)?;
+                let x: i32 = x;
+                let y: i32 = y;
+                let width: i32 = width;
+                let height: i32 = height;
+                SerializedWindowOpenStatus(WindowOpenStatus::FullScreen(Bounds {
+                    origin: point(x.into(), y.into()),
+                    size: size(width.into(), height.into()),
+                }))
+            }
             _ => bail!("Window State did not have a valid string"),
         };
 

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -363,7 +363,6 @@ impl WorkspaceDb {
             Option<SerializedWindowOpenStatus>,
             Option<Uuid>,
             Option<bool>,
-            Option<bool>,
             DockStructure,
         ) = self
             .select_row_bound(sql! {
@@ -377,7 +376,6 @@ impl WorkspaceDb {
                     window_width,
                     window_height,
                     display,
-                    fullscreen,
                     centered_layout,
                     left_dock_visible,
                     left_dock_active_panel,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -73,8 +73,6 @@ impl Bind for SerializedWindowOpenStatus {
         match self.0 {
             WindowBounds::Windowed(bounds) => {
                 let next_index = statement.bind(&"Windowed", start_index)?;
-                // this can not be None
-                let bounds = bounds.unwrap();
                 statement.bind(
                     &(
                         SerializedDevicePixels(bounds.origin.x),
@@ -123,10 +121,10 @@ impl Column for SerializedWindowOpenStatus {
                 let y: i32 = y;
                 let width: i32 = width;
                 let height: i32 = height;
-                SerializedWindowOpenStatus(WindowBounds::Windowed(Some(Bounds {
+                SerializedWindowOpenStatus(WindowBounds::Windowed(Bounds {
                     origin: point(x.into(), y.into()),
                     size: size(width.into(), height.into()),
-                })))
+                }))
             }
             "Maximized" => {
                 let ((x, y, width, height), _) = Column::column(statement, next_index)?;

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -97,7 +97,7 @@ impl Bind for SerializedWindowOpenStatus {
                     next_index,
                 )
             }
-            WindowOpenStatus::FullScreen(bounds) => {
+            WindowOpenStatus::Fullscreen(bounds) => {
                 let next_index = statement.bind(&"FullScreen", start_index)?;
                 statement.bind(
                     &(
@@ -145,7 +145,7 @@ impl Column for SerializedWindowOpenStatus {
                 let y: i32 = y;
                 let width: i32 = width;
                 let height: i32 = height;
-                SerializedWindowOpenStatus(WindowOpenStatus::FullScreen(Bounds {
+                SerializedWindowOpenStatus(WindowOpenStatus::Fullscreen(Bounds {
                     origin: point(x.into(), y.into()),
                     size: size(width.into(), height.into()),
                 }))

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -117,7 +117,7 @@ impl Column for SerializedWindowOpenStatus {
     fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
         let (window_state, next_index) = String::column(statement, start_index)?;
         let status = match window_state.as_str() {
-            "Windowed" => {
+            "Windowed" | "Fixed" => {
                 let ((x, y, width, height), _) = Column::column(statement, next_index)?;
                 let x: i32 = x;
                 let y: i32 = y;

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -329,6 +329,10 @@ define_connection! {
     sql!(
         ALTER TABLE pane_groups ADD COLUMN flexes TEXT;
     ),
+    // Add fullscreen field to workspace
+    sql!(
+        ALTER TABLE workspaces ADD COLUMN fullscreen INTEGER; //bool
+    ),
     // Add preview field to items
     sql!(
         ALTER TABLE items ADD COLUMN preview INTEGER; //bool
@@ -603,7 +607,7 @@ impl WorkspaceDb {
         &self,
     ) -> anyhow::Result<(Option<Uuid>, Option<SerializedWindowOpenStatus>, Option<bool>)> {
         let mut prepared_query =
-            self.select::<(Option<Uuid>, Option<SerializedWindowsBounds>, Option<bool>)>(sql!(
+            self.select::<(Option<Uuid>, Option<SerializedWindowOpenStatus>, Option<bool>)>(sql!(
                 SELECT
                 display,
                 window_state, window_x, window_y, window_width, window_height,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -340,14 +340,22 @@ impl WorkspaceDb {
         // Note that we re-assign the workspace_id here in case it's empty
         // and we've grabbed the most recent workspace
         let (
+            
             workspace_id,
+           
             local_paths,
             dev_server_project_id,
-            bounds,
+           
+            open_status,
+           
             display,
+           
             fullscreen,
+           
             centered_layout,
+           
             docks,
+        ,
         ): (
             WorkspaceId,
             Option<LocalPaths>,
@@ -413,8 +421,7 @@ impl WorkspaceDb {
                 .get_center_pane_group(workspace_id)
                 .context("Getting center group")
                 .log_err()?,
-            bounds: bounds.map(|bounds| bounds.0),
-            fullscreen: fullscreen.unwrap_or(false),
+            open_status,
             centered_layout: centered_layout.unwrap_or(false),
             display,
             docks,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -376,22 +376,13 @@ impl WorkspaceDb {
         // Note that we re-assign the workspace_id here in case it's empty
         // and we've grabbed the most recent workspace
         let (
-            
             workspace_id,
-           
             local_paths,
             dev_server_project_id,
-           
             open_status,
-           
             display,
-           
-            fullscreen,
-           
             centered_layout,
-           
             docks,
-        ,
         ): (
             WorkspaceId,
             Option<LocalPaths>,
@@ -605,19 +596,26 @@ impl WorkspaceDb {
 
     pub(crate) fn last_window(
         &self,
-    ) -> anyhow::Result<(Option<Uuid>, Option<SerializedWindowOpenStatus>, Option<bool>)> {
-        let mut prepared_query =
-            self.select::<(Option<Uuid>, Option<SerializedWindowOpenStatus>, Option<bool>)>(sql!(
-                SELECT
-                display,
-                window_state, window_x, window_y, window_width, window_height,
-                fullscreen
-                FROM workspaces
-                WHERE local_paths
-                IS NOT NULL
-                ORDER BY timestamp DESC
-                LIMIT 1
-            ))?;
+    ) -> anyhow::Result<(
+        Option<Uuid>,
+        Option<SerializedWindowOpenStatus>,
+        Option<bool>,
+    )> {
+        let mut prepared_query = self.select::<(
+            Option<Uuid>,
+            Option<SerializedWindowOpenStatus>,
+            Option<bool>,
+        )>(sql!(
+            SELECT
+            display,
+            window_state, window_x, window_y, window_width, window_height,
+            fullscreen
+            FROM workspaces
+            WHERE local_paths
+            IS NOT NULL
+            ORDER BY timestamp DESC
+            LIMIT 1
+        ))?;
         let result = prepared_query()?;
         Ok(result
             .into_iter()

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -960,10 +960,9 @@ mod tests {
             id: WorkspaceId(1),
             location: LocalPaths::new(["/tmp", "/tmp2"]).into(),
             center_group: Default::default(),
-            bounds: Default::default(),
+            open_status: Default::default(),
             display: Default::default(),
             docks: Default::default(),
-            fullscreen: false,
             centered_layout: false,
         };
 
@@ -971,10 +970,9 @@ mod tests {
             id: WorkspaceId(2),
             location: LocalPaths::new(["/tmp"]).into(),
             center_group: Default::default(),
-            bounds: Default::default(),
+            open_status: Default::default(),
             display: Default::default(),
             docks: Default::default(),
-            fullscreen: false,
             centered_layout: false,
         };
 
@@ -1071,10 +1069,9 @@ mod tests {
             id: WorkspaceId(5),
             location: LocalPaths::new(["/tmp", "/tmp2"]).into(),
             center_group,
-            bounds: Default::default(),
+            open_status: Default::default(),
             display: Default::default(),
             docks: Default::default(),
-            fullscreen: false,
             centered_layout: false,
         };
 
@@ -1101,10 +1098,9 @@ mod tests {
             id: WorkspaceId(1),
             location: LocalPaths::new(["/tmp", "/tmp2"]).into(),
             center_group: Default::default(),
-            bounds: Default::default(),
+            open_status: Default::default(),
             display: Default::default(),
             docks: Default::default(),
-            fullscreen: false,
             centered_layout: false,
         };
 
@@ -1112,10 +1108,9 @@ mod tests {
             id: WorkspaceId(2),
             location: LocalPaths::new(["/tmp"]).into(),
             center_group: Default::default(),
-            bounds: Default::default(),
+            open_status: Default::default(),
             display: Default::default(),
             docks: Default::default(),
-            fullscreen: false,
             centered_layout: false,
         };
 
@@ -1150,10 +1145,9 @@ mod tests {
             id: WorkspaceId(3),
             location: LocalPaths::new(&["/tmp", "/tmp2"]).into(),
             center_group: Default::default(),
-            bounds: Default::default(),
+            open_status: Default::default(),
             display: Default::default(),
             docks: Default::default(),
-            fullscreen: false,
             centered_layout: false,
         };
 
@@ -1185,10 +1179,9 @@ mod tests {
             id: WorkspaceId(4),
             location: LocalPaths::new(workspace_id).into(),
             center_group: center_group.clone(),
-            bounds: Default::default(),
+            open_status: Default::default(),
             display: Default::default(),
             docks: Default::default(),
-            fullscreen: false,
             centered_layout: false,
         }
     }

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -379,7 +379,7 @@ impl WorkspaceDb {
             workspace_id,
             local_paths,
             dev_server_project_id,
-            open_status,
+            window_bounds,
             display,
             centered_layout,
             docks,
@@ -446,7 +446,7 @@ impl WorkspaceDb {
                 .get_center_pane_group(workspace_id)
                 .context("Getting center group")
                 .log_err()?,
-            window_bounds: open_status,
+            window_bounds,
             centered_layout: centered_layout.unwrap_or(false),
             display,
             docks,
@@ -596,13 +596,12 @@ impl WorkspaceDb {
 
     pub(crate) fn last_window(
         &self,
-    ) -> anyhow::Result<(Option<Uuid>, Option<SerializedWindowBounds>, Option<bool>)> {
+    ) -> anyhow::Result<(Option<Uuid>, Option<SerializedWindowBounds>)> {
         let mut prepared_query =
-            self.select::<(Option<Uuid>, Option<SerializedWindowBounds>, Option<bool>)>(sql!(
+            self.select::<(Option<Uuid>, Option<SerializedWindowBounds>)>(sql!(
                 SELECT
                 display,
-                window_state, window_x, window_y, window_width, window_height,
-                fullscreen
+                window_state, window_x, window_y, window_width, window_height
                 FROM workspaces
                 WHERE local_paths
                 IS NOT NULL
@@ -610,10 +609,7 @@ impl WorkspaceDb {
                 LIMIT 1
             ))?;
         let result = prepared_query()?;
-        Ok(result
-            .into_iter()
-            .next()
-            .unwrap_or_else(|| (None, None, None)))
+        Ok(result.into_iter().next().unwrap_or_else(|| (None, None)))
     }
 
     query! {

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -59,7 +59,7 @@ impl sqlez::bindable::Column for SerializedAxis {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
 pub(crate) struct SerializedWindowOpenStatus(pub(crate) WindowOpenStatus);
 
 impl StaticColumnCount for SerializedWindowOpenStatus {
@@ -396,7 +396,7 @@ impl WorkspaceDb {
             WorkspaceId,
             Option<LocalPaths>,
             Option<u64>,
-            Option<SerializedWindowOpenStatus>,
+            SerializedWindowOpenStatus,
             Option<Uuid>,
             Option<bool>,
             DockStructure,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::{anyhow, bail, Context, Result};
 use client::DevServerProjectId;
 use db::{define_connection, query, sqlez::connection::Connection, sqlez_macros::sql};
-use gpui::{point, size, Axis, Bounds, WindowOpenStatus};
+use gpui::{point, size, Axis, Bounds, WindowBounds};
 
 use sqlez::{
     bindable::{Bind, Column, StaticColumnCount},
@@ -60,7 +60,7 @@ impl sqlez::bindable::Column for SerializedAxis {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
-pub(crate) struct SerializedWindowOpenStatus(pub(crate) WindowOpenStatus);
+pub(crate) struct SerializedWindowOpenStatus(pub(crate) WindowBounds);
 
 impl StaticColumnCount for SerializedWindowOpenStatus {
     fn column_count() -> usize {
@@ -71,7 +71,7 @@ impl StaticColumnCount for SerializedWindowOpenStatus {
 impl Bind for SerializedWindowOpenStatus {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         match self.0 {
-            WindowOpenStatus::Windowed(bounds) => {
+            WindowBounds::Windowed(bounds) => {
                 let next_index = statement.bind(&"Windowed", start_index)?;
                 // this can not be None
                 let bounds = bounds.unwrap();
@@ -85,7 +85,7 @@ impl Bind for SerializedWindowOpenStatus {
                     next_index,
                 )
             }
-            WindowOpenStatus::Maximized(bounds) => {
+            WindowBounds::Maximized(bounds) => {
                 let next_index = statement.bind(&"Maximized", start_index)?;
                 statement.bind(
                     &(
@@ -97,7 +97,7 @@ impl Bind for SerializedWindowOpenStatus {
                     next_index,
                 )
             }
-            WindowOpenStatus::Fullscreen(bounds) => {
+            WindowBounds::Fullscreen(bounds) => {
                 let next_index = statement.bind(&"FullScreen", start_index)?;
                 statement.bind(
                     &(
@@ -123,7 +123,7 @@ impl Column for SerializedWindowOpenStatus {
                 let y: i32 = y;
                 let width: i32 = width;
                 let height: i32 = height;
-                SerializedWindowOpenStatus(WindowOpenStatus::Windowed(Some(Bounds {
+                SerializedWindowOpenStatus(WindowBounds::Windowed(Some(Bounds {
                     origin: point(x.into(), y.into()),
                     size: size(width.into(), height.into()),
                 })))
@@ -134,7 +134,7 @@ impl Column for SerializedWindowOpenStatus {
                 let y: i32 = y;
                 let width: i32 = width;
                 let height: i32 = height;
-                SerializedWindowOpenStatus(WindowOpenStatus::Maximized(Bounds {
+                SerializedWindowOpenStatus(WindowBounds::Maximized(Bounds {
                     origin: point(x.into(), y.into()),
                     size: size(width.into(), height.into()),
                 }))
@@ -145,7 +145,7 @@ impl Column for SerializedWindowOpenStatus {
                 let y: i32 = y;
                 let width: i32 = width;
                 let height: i32 = height;
-                SerializedWindowOpenStatus(WindowOpenStatus::Fullscreen(Bounds {
+                SerializedWindowOpenStatus(WindowBounds::Fullscreen(Bounds {
                     origin: point(x.into(), y.into()),
                     size: size(width.into(), height.into()),
                 }))

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -293,10 +293,6 @@ define_connection! {
     sql!(
         ALTER TABLE pane_groups ADD COLUMN flexes TEXT;
     ),
-    // Add fullscreen field to workspace
-    sql!(
-        ALTER TABLE workspaces ADD COLUMN fullscreen INTEGER; //bool
-    ),
     // Add preview field to items
     sql!(
         ALTER TABLE items ADD COLUMN preview INTEGER; //bool
@@ -849,7 +845,7 @@ impl WorkspaceDb {
     }
 
     query! {
-        pub(crate) async fn set_window_bounds(workspace_id: WorkspaceId, bounds: SerializedWindowOpenStatus, display: Uuid) -> Result<()> {
+        pub(crate) async fn set_window_open_status(workspace_id: WorkspaceId, bounds: SerializedWindowOpenStatus, display: Uuid) -> Result<()> {
             UPDATE workspaces
             SET window_state = ?2,
                 window_x = ?3,
@@ -857,14 +853,6 @@ impl WorkspaceDb {
                 window_width = ?5,
                 window_height = ?6,
                 display = ?7
-            WHERE workspace_id = ?1
-        }
-    }
-
-    query! {
-        pub(crate) async fn set_fullscreen(workspace_id: WorkspaceId, fullscreen: bool) -> Result<()> {
-            UPDATE workspaces
-            SET fullscreen = ?2
             WHERE workspace_id = ?1
         }
     }

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -110,7 +110,7 @@ pub(crate) struct SerializedWorkspace {
     pub(crate) id: WorkspaceId,
     pub(crate) location: SerializedWorkspaceLocation,
     pub(crate) center_group: SerializedPaneGroup,
-    pub(crate) open_status: Option<SerializedWindowOpenStatus>,
+    pub(crate) open_status: SerializedWindowOpenStatus,
     pub(crate) centered_layout: bool,
     pub(crate) display: Option<Uuid>,
     pub(crate) docks: DockStructure,

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -110,7 +110,7 @@ pub(crate) struct SerializedWorkspace {
     pub(crate) id: WorkspaceId,
     pub(crate) location: SerializedWorkspaceLocation,
     pub(crate) center_group: SerializedPaneGroup,
-    pub(crate) open_status: SerializedWindowOpenStatus,
+    pub(crate) open_status: Option<SerializedWindowOpenStatus>,
     pub(crate) centered_layout: bool,
     pub(crate) display: Option<Uuid>,
     pub(crate) docks: DockStructure,

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -1,4 +1,4 @@
-use super::{SerializedAxis, SerializedWindowOpenStatus};
+use super::{SerializedAxis, SerializedWindowBounds};
 use crate::{item::ItemHandle, ItemDeserializers, Member, Pane, PaneAxis, Workspace, WorkspaceId};
 use anyhow::{Context, Result};
 use async_recursion::async_recursion;
@@ -110,7 +110,7 @@ pub(crate) struct SerializedWorkspace {
     pub(crate) id: WorkspaceId,
     pub(crate) location: SerializedWorkspaceLocation,
     pub(crate) center_group: SerializedPaneGroup,
-    pub(crate) open_status: Option<SerializedWindowOpenStatus>,
+    pub(crate) window_bounds: Option<SerializedWindowBounds>,
     pub(crate) centered_layout: bool,
     pub(crate) display: Option<Uuid>,
     pub(crate) docks: DockStructure,

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -1,4 +1,4 @@
-use super::SerializedAxis;
+use super::{SerializedAxis, SerializedWindowOpenStatus};
 use crate::{item::ItemHandle, ItemDeserializers, Member, Pane, PaneAxis, Workspace, WorkspaceId};
 use anyhow::{Context, Result};
 use async_recursion::async_recursion;
@@ -110,8 +110,7 @@ pub(crate) struct SerializedWorkspace {
     pub(crate) id: WorkspaceId,
     pub(crate) location: SerializedWorkspaceLocation,
     pub(crate) center_group: SerializedPaneGroup,
-    pub(crate) bounds: Option<Bounds<DevicePixels>>,
-    pub(crate) fullscreen: bool,
+    pub(crate) open_status: Option<SerializedWindowOpenStatus>,
     pub(crate) centered_layout: bool,
     pub(crate) display: Option<Uuid>,
     pub(crate) docks: DockStructure,

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -7,7 +7,7 @@ use db::sqlez::{
     bindable::{Bind, Column, StaticColumnCount},
     statement::Statement,
 };
-use gpui::{AsyncWindowContext, Bounds, DevicePixels, Model, Task, View, WeakView};
+use gpui::{AsyncWindowContext, Model, Task, View, WeakView};
 use project::Project;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -786,11 +786,11 @@ impl Workspace {
                     this.update(&mut cx, |this, cx| {
                         if let Some(display) = cx.display() {
                             if let Some(display_uuid) = display.uuid().log_err() {
-                                let restore_bounds = cx.window_bounds();
+                                let window_bounds = cx.window_bounds();
                                 cx.background_executor()
                                     .spawn(DB.set_window_open_status(
                                         workspace_id,
-                                        SerializedWindowBounds(restore_bounds),
+                                        SerializedWindowBounds(window_bounds),
                                         display_uuid,
                                     ))
                                     .detach_and_log_err(cx);
@@ -940,7 +940,7 @@ impl Workspace {
                         .as_ref()
                         .and_then(|workspace| Some((workspace.display?, workspace.window_bounds?)))
                         .or_else(|| {
-                            let (display, window_bounds, _) = DB.last_window().log_err()?;
+                            let (display, window_bounds) = DB.last_window().log_err()?;
                             Some((display?, window_bounds?))
                         });
 
@@ -3650,12 +3650,12 @@ impl Workspace {
         if let Some(location) = location {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
-            let open_status = Some(SerializedWindowBounds(cx.window_bounds()));
+            let window_bounds = Some(SerializedWindowBounds(cx.window_bounds()));
             let serialized_workspace = SerializedWorkspace {
                 id: self.database_id,
                 location,
                 center_group,
-                window_bounds: open_status,
+                window_bounds,
                 display: Default::default(),
                 docks,
                 centered_layout: self.centered_layout,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -933,27 +933,27 @@ impl Workspace {
             } else {
                 let window_bounds_override = window_bounds_env_override();
 
-                let (open_status, display) = if let Some(bounds) = window_bounds_override {
+                let (window_bounds, display) = if let Some(bounds) = window_bounds_override {
                     (Some(WindowBounds::Windowed(bounds)), None)
                 } else {
                     let restorable_bounds = serialized_workspace
                         .as_ref()
                         .and_then(|workspace| Some((workspace.display?, workspace.open_status?)))
                         .or_else(|| {
-                            let (display, open_status, _) = DB.last_window().log_err()?;
-                            Some((display?, open_status?))
+                            let (display, window_bounds, _) = DB.last_window().log_err()?;
+                            Some((display?, window_bounds?))
                         });
 
                     if let Some((serialized_display, serialized_status)) = restorable_bounds {
-                        (serialized_status.0, Some(serialized_display))
+                        (Some(serialized_status.0), Some(serialized_display))
                     } else {
-                        (WindowBounds::Windowed(None), None)
+                        (None, None)
                     }
                 };
 
                 // Use the serialized workspace to construct the new window
                 let mut options = cx.update(|cx| (app_state.build_window_options)(display, cx))?;
-                options.window_bounds = open_status;
+                options.window_bounds = window_bounds;
                 let centered_layout = serialized_workspace
                     .as_ref()
                     .map(|w| w.centered_layout)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3665,11 +3665,9 @@ impl Workspace {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
             let open_status = if cx.is_fullscreen() {
-                WindowOpenStatus::FullScreen
-            } else if cx.is_maximized() {
-                WindowOpenStatus::Maximized
+                Some(SerializedWindowOpenStatus(WindowOpenStatus::FullScreen))
             } else {
-                WindowOpenStatus::Windowed(None)
+                None
             };
             let serialized_workspace = SerializedWorkspace {
                 id: self.database_id,
@@ -3678,7 +3676,6 @@ impl Workspace {
                 open_status,
                 display: Default::default(),
                 docks,
-                fullscreen: cx.is_fullscreen(),
                 centered_layout: self.centered_layout,
             };
             return cx.spawn(|_| persistence::DB.save_workspace(serialized_workspace));

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -969,7 +969,7 @@ impl Workspace {
 
                 // Use the serialized workspace to construct the new window
                 let mut options = cx.update(|cx| (app_state.build_window_options)(display, cx))?;
-                options.bounds = bounds;
+                options.open_status = bounds;
                 options.fullscreen = fullscreen;
                 let centered_layout = serialized_workspace
                     .as_ref()
@@ -4867,7 +4867,7 @@ pub fn join_hosted_project(
             let window_bounds_override = window_bounds_env_override();
             cx.update(|cx| {
                 let mut options = (app_state.build_window_options)(None, cx);
-                options.bounds = window_bounds_override;
+                options.open_status = window_bounds_override;
                 cx.open_window(options, |cx| {
                     cx.new_view(|cx| {
                         Workspace::new(Default::default(), project, app_state.clone(), cx)
@@ -4993,7 +4993,7 @@ pub fn join_in_room_project(
             let window_bounds_override = window_bounds_env_override();
             cx.update(|cx| {
                 let mut options = (app_state.build_window_options)(None, cx);
-                options.bounds = window_bounds_override;
+                options.open_status = window_bounds_override;
                 cx.open_window(options, |cx| {
                     cx.new_view(|cx| {
                         Workspace::new(Default::default(), project, app_state.clone(), cx)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4920,7 +4920,7 @@ pub fn join_dev_server_project(
                 let window_bounds_override = window_bounds_env_override();
                 cx.update(|cx| {
                     let mut options = (app_state.build_window_options)(None, cx);
-                    options.bounds = window_bounds_override;
+                    options.open_status = WindowOpenStatus::Windowed(window_bounds_override);
                     cx.open_window(options, |cx| {
                         cx.new_view(|cx| {
                             Workspace::new(Default::default(), project, app_state.clone(), cx)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -938,7 +938,7 @@ impl Workspace {
                 } else {
                     let restorable_bounds = serialized_workspace
                         .as_ref()
-                        .and_then(|workspace| Some((workspace.display?, workspace.open_status?)))
+                        .and_then(|workspace| Some((workspace.display?, workspace.open_status)))
                         .or_else(|| {
                             let (display, open_status) = DB.last_window().log_err()?;
                             Some((display?, open_status?))
@@ -3650,7 +3650,7 @@ impl Workspace {
         if let Some(location) = location {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
-            let open_status = cx.restore_status();
+            let open_status = SerializedWindowOpenStatus(cx.restore_status());
             let serialized_workspace = SerializedWorkspace {
                 id: self.database_id,
                 location,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -938,7 +938,7 @@ impl Workspace {
                 } else {
                     let restorable_bounds = serialized_workspace
                         .as_ref()
-                        .and_then(|workspace| Some((workspace.display?, workspace.open_status)))
+                        .and_then(|workspace| Some((workspace.display?, workspace.open_status?)))
                         .or_else(|| {
                             let (display, open_status) = DB.last_window().log_err()?;
                             Some((display?, open_status?))
@@ -3650,7 +3650,7 @@ impl Workspace {
         if let Some(location) = location {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
-            let open_status = SerializedWindowOpenStatus(cx.restore_status());
+            let open_status = Some(SerializedWindowOpenStatus(cx.restore_status()));
             let serialized_workspace = SerializedWorkspace {
                 id: self.database_id,
                 location,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3650,13 +3650,7 @@ impl Workspace {
         if let Some(location) = location {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
-            let open_status = if cx.is_fullscreen() {
-                Some(SerializedWindowOpenStatus(WindowOpenStatus::FullScreen(
-                        Bounds::default(),
-                    )))
-            } else {
-                None
-            };
+            let open_status = cx.restore_status();
             let serialized_workspace = SerializedWorkspace {
                 id: self.database_id,
                 location,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -940,7 +940,7 @@ impl Workspace {
                         .as_ref()
                         .and_then(|workspace| Some((workspace.display?, workspace.open_status?)))
                         .or_else(|| {
-                            let (display, open_status, _fullscreen) = DB.last_window().log_err()?;
+                            let (display, open_status) = DB.last_window().log_err()?;
                             Some((display?, open_status?))
                         });
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3665,7 +3665,9 @@ impl Workspace {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
             let open_status = if cx.is_fullscreen() {
-                Some(SerializedWindowOpenStatus(WindowOpenStatus::FullScreen))
+                Some(SerializedWindowOpenStatus(WindowOpenStatus::FullScreen(
+                        Bounds::default(),
+                    )))
             } else {
                 None
             };

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -32,7 +32,7 @@ use gpui::{
     ElementId, Entity as _, EntityId, EventEmitter, FocusHandle, FocusableView, Global,
     GlobalElementId, KeyContext, Keystroke, LayoutId, ManagedView, Model, ModelContext,
     PathPromptOptions, Point, PromptLevel, Render, Size, Subscription, Task, View, WeakView,
-    WindowHandle, WindowOpenStatus, WindowOptions,
+    WindowBounds, WindowHandle, WindowOptions,
 };
 use item::{
     FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, PreviewTabsSettings,
@@ -934,7 +934,7 @@ impl Workspace {
                 let window_bounds_override = window_bounds_env_override();
 
                 let (open_status, display) = if let Some(bounds) = window_bounds_override {
-                    (WindowOpenStatus::Windowed(Some(bounds)), None)
+                    (Some(WindowBounds::Windowed(bounds)), None)
                 } else {
                     let restorable_bounds = serialized_workspace
                         .as_ref()
@@ -947,13 +947,13 @@ impl Workspace {
                     if let Some((serialized_display, serialized_status)) = restorable_bounds {
                         (serialized_status.0, Some(serialized_display))
                     } else {
-                        (WindowOpenStatus::Windowed(None), None)
+                        (WindowBounds::Windowed(None), None)
                     }
                 };
 
                 // Use the serialized workspace to construct the new window
                 let mut options = cx.update(|cx| (app_state.build_window_options)(display, cx))?;
-                options.open_status = open_status;
+                options.window_bounds = open_status;
                 let centered_layout = serialized_workspace
                     .as_ref()
                     .map(|w| w.centered_layout)
@@ -4850,7 +4850,8 @@ pub fn join_hosted_project(
             let window_bounds_override = window_bounds_env_override();
             cx.update(|cx| {
                 let mut options = (app_state.build_window_options)(None, cx);
-                options.open_status = WindowOpenStatus::Windowed(window_bounds_override);
+                options.window_bounds =
+                    window_bounds_override.map(|bounds| WindowBounds::Windowed(bounds));
                 cx.open_window(options, |cx| {
                     cx.new_view(|cx| {
                         Workspace::new(Default::default(), project, app_state.clone(), cx)
@@ -4914,7 +4915,8 @@ pub fn join_dev_server_project(
                 let window_bounds_override = window_bounds_env_override();
                 cx.update(|cx| {
                     let mut options = (app_state.build_window_options)(None, cx);
-                    options.open_status = WindowOpenStatus::Windowed(window_bounds_override);
+                    options.window_bounds =
+                        window_bounds_override.map(|bounds| WindowBounds::Windowed(bounds));
                     cx.open_window(options, |cx| {
                         cx.new_view(|cx| {
                             Workspace::new(Default::default(), project, app_state.clone(), cx)
@@ -4976,7 +4978,8 @@ pub fn join_in_room_project(
             let window_bounds_override = window_bounds_env_override();
             cx.update(|cx| {
                 let mut options = (app_state.build_window_options)(None, cx);
-                options.open_status = WindowOpenStatus::Windowed(window_bounds_override);
+                options.window_bounds =
+                    window_bounds_override.map(|bounds| WindowBounds::Windowed(bounds));
                 cx.open_window(options, |cx| {
                     cx.new_view(|cx| {
                         Workspace::new(Default::default(), project, app_state.clone(), cx)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -786,7 +786,7 @@ impl Workspace {
                     this.update(&mut cx, |this, cx| {
                         if let Some(display) = cx.display() {
                             if let Some(display_uuid) = display.uuid().log_err() {
-                                let restore_bounds = cx.restore_status();
+                                let restore_bounds = cx.window_bounds();
                                 cx.background_executor()
                                     .spawn(DB.set_window_open_status(
                                         workspace_id,
@@ -3650,7 +3650,7 @@ impl Workspace {
         if let Some(location) = location {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
-            let open_status = Some(SerializedWindowBounds(cx.restore_status()));
+            let open_status = Some(SerializedWindowBounds(cx.window_bounds()));
             let serialized_workspace = SerializedWorkspace {
                 id: self.database_id,
                 location,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -955,12 +955,10 @@ impl Workspace {
                         .and_then(|workspace| Some((workspace.display?, workspace.open_status?)))
                         .or_else(|| {
                             let (display, open_status, _fullscreen) = DB.last_window().log_err()?;
-                            Some((display?, open_status?.0))
+                            Some((display?, open_status?))
                         });
 
-                    if let Some((serialized_display, serialized_status, fullscreen)) =
-                        restorable_bounds
-                    {
+                    if let Some((serialized_display, serialized_status)) = restorable_bounds {
                         (serialized_status.0, Some(serialized_display))
                     } else {
                         (WindowOpenStatus::Windowed(None), None)
@@ -3667,11 +3665,11 @@ impl Workspace {
             let center_group = build_serialized_pane_group(&self.center.root, cx);
             let docks = build_serialized_docks(self, cx);
             let open_status = if cx.is_fullscreen() {
-                WindowOpenStauts::FullScreen
+                WindowOpenStatus::FullScreen
             } else if cx.is_maximized() {
                 WindowOpenStatus::Maximized
             } else {
-                WindowOpenStauts::Windowed(None)
+                WindowOpenStatus::Windowed(None)
             };
             let serialized_workspace = SerializedWorkspace {
                 id: self.database_id,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -940,7 +940,7 @@ impl Workspace {
                         .as_ref()
                         .and_then(|workspace| Some((workspace.display?, workspace.open_status?)))
                         .or_else(|| {
-                            let (display, open_status) = DB.last_window().log_err()?;
+                            let (display, open_status, _) = DB.last_window().log_err()?;
                             Some((display?, open_status?))
                         });
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -96,7 +96,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
             appears_transparent: true,
             traffic_light_position: Some(point(px(9.0), px(9.0))),
         }),
-        window_bounds: WindowBounds::Windowed(None),
+        window_bounds: None,
         focus: false,
         show: false,
         kind: WindowKind::Normal,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -10,7 +10,7 @@ use collections::VecDeque;
 use editor::{scroll::Autoscroll, Editor, MultiBuffer};
 use gpui::{
     actions, point, px, AppContext, AsyncAppContext, Context, FocusableView, PromptLevel,
-    TitlebarOptions, View, ViewContext, VisualContext, WindowBounds, WindowKind, WindowOptions,
+    TitlebarOptions, View, ViewContext, VisualContext, WindowKind, WindowOptions,
 };
 pub use only_instance::*;
 pub use open_listener::*;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -10,7 +10,7 @@ use collections::VecDeque;
 use editor::{scroll::Autoscroll, Editor, MultiBuffer};
 use gpui::{
     actions, point, px, AppContext, AsyncAppContext, Context, FocusableView, PromptLevel,
-    TitlebarOptions, View, ViewContext, VisualContext, WindowKind, WindowOpenStatus, WindowOptions,
+    TitlebarOptions, View, ViewContext, VisualContext, WindowBounds, WindowKind, WindowOptions,
 };
 pub use only_instance::*;
 pub use open_listener::*;
@@ -96,7 +96,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
             appears_transparent: true,
             traffic_light_position: Some(point(px(9.0), px(9.0))),
         }),
-        open_status: WindowOpenStatus::Windowed(None),
+        window_bounds: WindowBounds::Windowed(None),
         focus: false,
         show: false,
         kind: WindowKind::Normal,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -10,7 +10,7 @@ use collections::VecDeque;
 use editor::{scroll::Autoscroll, Editor, MultiBuffer};
 use gpui::{
     actions, point, px, AppContext, AsyncAppContext, Context, FocusableView, PromptLevel,
-    TitlebarOptions, View, ViewContext, VisualContext, WindowKind, WindowOptions,
+    TitlebarOptions, View, ViewContext, VisualContext, WindowKind, WindowOpenStatus, WindowOptions,
 };
 pub use only_instance::*;
 pub use open_listener::*;
@@ -96,13 +96,12 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
             appears_transparent: true,
             traffic_light_position: Some(point(px(9.0), px(9.0))),
         }),
-        open_status: None,
+        open_status: WindowOpenStatus::Windowed(None),
         focus: false,
         show: false,
         kind: WindowKind::Normal,
         is_movable: true,
         display_id: display.map(|display| display.id()),
-        fullscreen: false,
         window_background: cx.theme().window_background_appearance(),
         app_id: Some(app_id.to_owned()),
     }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -96,7 +96,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
             appears_transparent: true,
             traffic_light_position: Some(point(px(9.0), px(9.0))),
         }),
-        bounds: None,
+        open_status: None,
         focus: false,
         show: false,
         kind: WindowKind::Normal,


### PR DESCRIPTION
Now, regardless of how the Zed window is closed, Zed can remember the window's restore size.

- [x] Windows implementation
- [x] macOS implementation
- [x] Linux implementation (partial)
- [x] update SQL data base (mark column `fullscreen` as deprecated)

The current implementation on Linux is basic, and I'm not sure if it's correct.

The variable `fullscreen` in SQL can be removed, but I'm unsure how to do it.
edit: mark `fullscreen` as deprecated

### Case 1

When the window is closed as maximized, reopening it will open in the maximized state, and returning from maximized state will restore the position and size it had when it was maximized.


https://github.com/zed-industries/zed/assets/14981363/7207752e-878a-4d43-93a7-41ad1fdb3a06


### Case 2

When the window is closed as fullscreen, reopening it will open in fullscreen mode, and toggling fullscreen will restore the position and size it had when it entered fullscreen (note that the fullscreen application was not recorded in the video, showing a black screen, but it had actually entered fullscreen mode).


https://github.com/zed-industries/zed/assets/14981363/ea5aa70d-b296-462a-afb3-4c3372883ea3

### What's more

- As English is not my native language, some variable and struct names may need to be modified to match their actual meaning.
-  I am not familiar with the APIs related to macOS and Linux, so implementation for these two platforms has not been done for now.
- Any suggestions and ideas are welcome.

Release Notes:

- N/A
