### PR TITLE
Do not show image viewer for SVGs

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -37,7 +37,9 @@ impl project::Item for ImageItem {
             .and_then(OsStr::to_str)
             .unwrap_or_default();
 
-        if Img::extensions().contains(&ext) {
+        // Only open the item if it's a binary image (no SVGs, etc.)
+        // Since we do not have a way to toggle to an editor
+        if Img::extensions().contains(&ext) && !ext.contains("svg") {
             Some(cx.spawn(|mut cx| async move {
                 let abs_path = project
                     .read_with(&cx, |project, cx| project.absolute_path(&path, cx))?


### PR DESCRIPTION
Absent some ability to toggle between viewing and editing a file, I think it would be best to get a fix out quick for people to edit SVGs as text files.

Release Notes:

- Fixed editing of SVG images by disabling it from the image viewer ([#10403](https://github.com/zed-industries/zed/issues/10403)). 