### PR TITLE
chat panel: Add timestamp in tooltip to edited message

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -532,6 +532,7 @@ impl ChatPanel {
                                 self.client.id(),
                                 &message,
                                 self.local_timezone,
+                                cx,
                             )
                         });
                         el.child(
@@ -746,6 +747,7 @@ impl ChatPanel {
         current_user_id: u64,
         message: &channel::ChannelMessage,
         local_timezone: UtcOffset,
+        cx: &AppContext,
     ) -> RichText {
         let mentions = message
             .mentions
@@ -771,7 +773,7 @@ impl ChatPanel {
             rich_text.highlights.push((
                 range.clone(),
                 Highlight::Highlight(HighlightStyle {
-                    fade_out: Some(0.8),
+                    color: Some(cx.theme().colors().text_muted),
                     ..Default::default()
                 }),
             ));
@@ -1198,6 +1200,7 @@ mod tests {
             102,
             &message,
             UtcOffset::UTC,
+            cx,
         );
 
         // Note that the "'" was replaced with ’ due to smart punctuation.
@@ -1251,6 +1254,7 @@ mod tests {
             102,
             &message,
             UtcOffset::UTC,
+            cx,
         );
 
         // Note that the "'" was replaced with ’ due to smart punctuation.
@@ -1297,6 +1301,7 @@ mod tests {
             102,
             &message,
             UtcOffset::UTC,
+            cx,
         );
 
         // Note that the "'" was replaced with ’ due to smart punctuation.


### PR DESCRIPTION
Hovering over the `(edited)` text inside a message displays a tooltip with the timestamp of when the message was last edited:

![image](https://github.com/zed-industries/zed/assets/53836821/be6d68c2-7447-42bc-bd5e-7a9053b3c980)

---

Also removed the `fade_out` style for the `(edited)` text, as this was causing tooltips to fade out as well:

![image](https://github.com/zed-industries/zed/assets/53836821/91d3cf6a-db58-4e1d-b257-663b2ce1aca4)

Instead it uses `theme().text_muted` now.


Release Notes:

- Hovering over an edited message now displays a tooltip revealing the timestamp of the last edit.