### PR TITLE
dart: Fix `final`, `const`, `this` highlights inside class definitions

### DIFF
--- a/extensions/dart/languages/dart/highlights.scm
+++ b/extensions/dart/languages/dart/highlights.scm
@@ -82,7 +82,6 @@
 
 (getter_signature
  (identifier) @function.method)
-
 (setter_signature
  name: (identifier) @function.method)
 (enum_declaration
@@ -110,6 +109,9 @@
  (#match? @type "^_?[A-Z].*[a-z]"))
 
 ("Function" @type)
+
+(const_builtin) @constant.builtin
+(final_builtin) @constant.builtin
 
 ; properties
 (unconditional_assignable_selector
@@ -180,6 +182,7 @@
  "is"
  "new"
  "super"
+ "this"
  "with"
  ] @keyword
 
@@ -210,17 +213,14 @@
 ] @keyword.coroutine
 
 [
- (const_builtin)
- (final_builtin)
  "abstract"
-  "covariant"
+ "covariant"
  "dynamic"
  "external"
  "static"
- "final"
-  "base"
-  "sealed"
- ] @type.qualifier
+ "base"
+ "sealed"
+] @type.qualifier
 
 ; when used as an identifier:
 ((identifier) @variable.builtin


### PR DESCRIPTION

Release Notes:

- Fixed final, const, this highlight inside class definition

Before:
![Screenshot 2024-04-11 at 19 08 06](https://github.com/zed-industries/zed/assets/6732968/b060e80f-2ace-4947-ab7f-566423b02fb4)

After:
![Screenshot 2024-04-11 at 19 07 45](https://github.com/zed-industries/zed/assets/6732968/853ea400-4316-41be-b39f-67c80b25105f)

