### PR TITLE
Extend Vim default keybindings

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -234,6 +234,8 @@
           "displayLines": true
         }
       ],
+      "g ]": "editor::GoToDiagnostic",
+      "g [": "editor::GoToPrevDiagnostic",
       "shift-h": "vim::WindowTop",
       "shift-m": "vim::WindowMiddle",
       "shift-l": "vim::WindowBottom",
@@ -257,6 +259,9 @@
           "saveIntent": "saveAll"
         }
       ],
+      // tree-sitter related commands
+      "[ x": "editor::SelectLargerSyntaxNode",
+      "] x": "editor::SelectSmallerSyntaxNode",
       // Count support
       "1": ["vim::Number", 1],
       "2": ["vim::Number", 2],
@@ -366,9 +371,7 @@
       "> >": "vim::Indent",
       "< <": "vim::Outdent",
       "ctrl-pagedown": "pane::ActivateNextItem",
-      "ctrl-pageup": "pane::ActivatePrevItem",
-      "[ x": "editor::SelectLargerSyntaxNode",
-      "] x": "editor::SelectSmallerSyntaxNode"
+      "ctrl-pageup": "pane::ActivatePrevItem"
     }
   },
   {
@@ -530,6 +533,19 @@
           }
         }
       ]
+    }
+  },
+
+  {
+    "context": "Editor && vim_mode == normal",
+    "bindings": {
+      "g c c": "editor::ToggleComments"
+    }
+  },
+  {
+    "context": "Editor && vim_mode == visual",
+    "bindings": {
+      "g c": "editor::ToggleComments"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -259,9 +259,6 @@
           "saveIntent": "saveAll"
         }
       ],
-      // tree-sitter related commands
-      "[ x": "editor::SelectLargerSyntaxNode",
-      "] x": "editor::SelectSmallerSyntaxNode",
       // Count support
       "1": ["vim::Number", 1],
       "2": ["vim::Number", 2],
@@ -371,7 +368,18 @@
       "> >": "vim::Indent",
       "< <": "vim::Outdent",
       "ctrl-pagedown": "pane::ActivateNextItem",
-      "ctrl-pageup": "pane::ActivatePrevItem"
+      "ctrl-pageup": "pane::ActivatePrevItem",
+      // tree-sitter related commands
+      "[ x": "editor::SelectLargerSyntaxNode",
+      "] x": "editor::SelectSmallerSyntaxNode"
+    }
+  },
+  {
+    "context": "Editor && vim_mode == visual && vim_operator == none && !VimWaiting",
+    "bindings": {
+      // tree-sitter related commands
+      "[ x": "editor::SelectLargerSyntaxNode",
+      "] x": "editor::SelectSmallerSyntaxNode"
     }
   },
   {
@@ -535,7 +543,6 @@
       ]
     }
   },
-
   {
     "context": "Editor && vim_mode == normal",
     "bindings": {


### PR DESCRIPTION
This implements some of #10457.

Release notes:

- Added `g c c` and `g c` to Vim keybindings to toggle comments in normal and visual mode respectively.
- Added `g ]` and `g [` to Vim keybindings to go to next and previous diagnostic error.
- Changed `[ x` and `] x` (which select larger/smaller syntax node) in Vim mode to also work in visual mode.