### PR TITLE
task: Allow Rerun action to override properties of task being reran

### DIFF
--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use collections::HashMap;
 use schemars::{gen::SchemaSettings, JsonSchema};
 use serde::{Deserialize, Serialize};
@@ -102,9 +102,8 @@ impl TaskTemplate {
         let full_label = substitute_all_template_variables_in_str(&self.label, &task_variables)?;
         let command = substitute_all_template_variables_in_str(&self.command, &task_variables)?;
         let args = substitute_all_template_variables_in_vec(self.args.clone(), &task_variables)?;
-        let task_hash = to_hex_hash(self)
-            .context("hashing task template")
-            .log_err()?;
+
+        let task_hash = self.task_hash().log_err()?;
         let variables_hash = to_hex_hash(&task_variables)
             .context("hashing task variables")
             .log_err()?;
@@ -127,6 +126,30 @@ impl TaskTemplate {
                 reveal: self.reveal,
             }),
         })
+    }
+
+    fn task_hash(&self) -> Result<String> {
+        /// Parts of TaskTemplate that should be used for identity matching.
+        /// Right now, we omit `allow_concurrent_runs` and `use_new_terminal`
+        #[derive(Serialize)]
+        struct HashableTaskTemplate<'a> {
+            pub label: &'a str,
+            pub command: &'a str,
+            pub args: &'a [String],
+            pub env: &'a HashMap<String, String>,
+            pub cwd: Option<&'a str>,
+            pub reveal: RevealStrategy,
+        }
+
+        let hashable = HashableTaskTemplate {
+            label: &self.label,
+            command: &self.command,
+            args: &self.args,
+            env: &self.env,
+            cwd: self.cwd.as_deref(),
+            reveal: self.reveal,
+        };
+        to_hex_hash(&hashable).context("hashing task template")
     }
 }
 

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -44,6 +44,10 @@ pub struct Rerun {
     /// If it is, these variables will be updated to reflect current state of editor at the time task::Rerun is executed.
     /// default: false
     pub reevaluate_context: bool,
+    #[serde(default)]
+    pub allow_concurrent_runs: Option<bool>,
+    #[serde(default)]
+    pub use_new_terminal: Option<bool>,
 }
 
 impl_actions!(task, [Rerun, Spawn]);

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -38,14 +38,18 @@ impl Spawn {
 /// Rerun last task
 #[derive(PartialEq, Clone, Deserialize, Default)]
 pub struct Rerun {
-    #[serde(default)]
     /// Controls whether the task context is reevaluated prior to execution of a task.
     /// If it is not, environment variables such as ZED_COLUMN, ZED_FILE are gonna be the same as in the last execution of a task
     /// If it is, these variables will be updated to reflect current state of editor at the time task::Rerun is executed.
     /// default: false
+    #[serde(default)]
     pub reevaluate_context: bool,
+    /// Overrides `allow_concurrent_runs` property of the task being reran.
+    /// Default: null
     #[serde(default)]
     pub allow_concurrent_runs: Option<bool>,
+    /// Overrides `use_new_terminal` property of the task being reran.
+    /// Default: null
     #[serde(default)]
     pub use_new_terminal: Option<bool>,
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -334,7 +334,7 @@ impl TerminalPanel {
             return;
         }
 
-        let terminals_for_task = self.terminals_for_task(&spawn_in_terminal.id, cx);
+        let terminals_for_task = self.terminals_for_task(&spawn_in_terminal.label, cx);
         if terminals_for_task.is_empty() {
             self.spawn_in_new_terminal(spawn_task, working_directory, cx);
             return;
@@ -435,7 +435,7 @@ impl TerminalPanel {
 
     fn terminals_for_task(
         &self,
-        id: &TaskId,
+        label: &str,
         cx: &mut AppContext,
     ) -> Vec<(usize, View<TerminalView>)> {
         self.pane
@@ -445,7 +445,7 @@ impl TerminalPanel {
             .filter_map(|(index, item)| Some((index, item.act_as::<TerminalView>(cx)?)))
             .filter_map(|(index, terminal_view)| {
                 let task_state = terminal_view.read(cx).terminal().read(cx).task()?;
-                if &task_state.id == id {
+                if &task_state.label == label {
                     Some((index, terminal_view))
                 } else {
                     None


### PR DESCRIPTION
For example:
```
"alt-t": [
    "task::Rerun",
     { "reevaluate_context": true, "allow_concurrent_runs": true }
],
```
Overriding `allow_concurrent_runs` to `true` by itself should terminate current instance of the task, if there's any.

This PR also fixes task deduplication in terminal panel to use expanded label and not the id, which depends on task context. It kinda aligns with how task rerun worked prior to #10341 . That's omitted in the release notes though, as it's not in Preview yet.

Release Notes:

- `Task::Rerun` action can now override `allow_concurrent_runs` and `use_new_terminal` properties of the task that is being reran.
