### PR TITLE
task: use full task label to distinguish a terminal

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -52,6 +52,7 @@ impl Project {
             (
                 Some(TaskState {
                     id: spawn_task.id,
+                    full_label: spawn_task.full_label,
                     label: spawn_task.label,
                     status: TaskStatus::Running,
                     completion_rx,

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -25,6 +25,8 @@ pub struct TaskId(pub String);
 pub struct SpawnInTerminal {
     /// Id of the task to use when determining task tab affinity.
     pub id: TaskId,
+    /// Full unshortened form of `label` field.
+    pub full_label: String,
     /// Human readable name of the terminal tab.
     pub label: String,
     /// Executable command to spawn.

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -115,10 +115,11 @@ impl TaskTemplate {
         Some(ResolvedTask {
             id: id.clone(),
             original_task: self.clone(),
-            resolved_label: full_label,
+            resolved_label: full_label.clone(),
             resolved: Some(SpawnInTerminal {
                 id,
                 cwd,
+                full_label,
                 label: shortened_label,
                 command,
                 args,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -288,6 +288,7 @@ impl Display for TerminalError {
 
 pub struct SpawnTask {
     pub id: TaskId,
+    pub full_label: String,
     pub label: String,
     pub command: String,
     pub args: Vec<String>,
@@ -594,6 +595,7 @@ pub struct Terminal {
 
 pub struct TaskState {
     pub id: TaskId,
+    pub full_label: String,
     pub label: String,
     pub status: TaskStatus,
     pub completion_rx: Receiver<()>,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1365,7 +1365,7 @@ impl Terminal {
                 if truncate {
                     truncate_and_trailoff(&task_state.label, MAX_CHARS)
                 } else {
-                    task_state.label.clone()
+                    task_state.full_label.clone()
                 }
             }
             None => self

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -296,9 +296,10 @@ impl TerminalPanel {
         })
     }
 
-    pub fn spawn_task(&mut self, spawn_in_terminal: &SpawnInTerminal, cx: &mut ViewContext<Self>) {
+    fn spawn_task(&mut self, spawn_in_terminal: &SpawnInTerminal, cx: &mut ViewContext<Self>) {
         let mut spawn_task = SpawnTask {
             id: spawn_in_terminal.id.clone(),
+            full_label: spawn_in_terminal.full_label.clone(),
             label: spawn_in_terminal.label.clone(),
             command: spawn_in_terminal.command.clone(),
             args: spawn_in_terminal.args.clone(),
@@ -334,7 +335,7 @@ impl TerminalPanel {
             return;
         }
 
-        let terminals_for_task = self.terminals_for_task(&spawn_in_terminal.label, cx);
+        let terminals_for_task = self.terminals_for_task(&spawn_in_terminal.full_label, cx);
         if terminals_for_task.is_empty() {
             self.spawn_in_new_terminal(spawn_task, working_directory, cx);
             return;
@@ -445,7 +446,7 @@ impl TerminalPanel {
             .filter_map(|(index, item)| Some((index, item.act_as::<TerminalView>(cx)?)))
             .filter_map(|(index, terminal_view)| {
                 let task_state = terminal_view.read(cx).terminal().read(cx).task()?;
-                if &task_state.label == label {
+                if &task_state.full_label == label {
                     Some((index, terminal_view))
                 } else {
                     None


### PR DESCRIPTION
Spotted by @SomeoneToIgnore, in #10468 I've used a shortened task label, which might lead to collisions.

Release Notes:

- N/A
