### PR TITLE
preview tabs: Support find all references

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9527,7 +9527,7 @@ impl Editor {
         cx.spawn(|_, mut cx| async move {
             let workspace = workspace.ok_or_else(|| anyhow!("cannot jump without workspace"))?;
             let editor = workspace.update(&mut cx, |workspace, cx| {
-                workspace.open_path(path, None, true, cx)
+                workspace.open_path_preview(path, None, true, true, cx)
             })?;
             let editor = editor
                 .await?

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -129,6 +129,7 @@ use ui::{
     Tooltip,
 };
 use util::{defer, maybe, post_inc, RangeExt, ResultExt, TryFutureExt};
+use workspace::item::ItemHandle;
 use workspace::notifications::NotificationId;
 use workspace::Toast;
 use workspace::{
@@ -8002,11 +8003,16 @@ impl Editor {
                 cx,
             );
         });
+        let item = Box::new(editor);
         if split {
-            workspace.split_item(SplitDirection::Right, Box::new(editor), cx);
+            workspace.split_item(SplitDirection::Right, item.clone(), cx);
         } else {
-            workspace.add_item_to_active_pane(Box::new(editor), cx);
+            workspace.add_item_to_active_pane(item.clone(), cx);
         }
+        workspace.active_pane().clone().update(cx, |pane, cx| {
+            let item_id = item.item_id();
+            pane.set_preview_item_id(Some(item_id), cx);
+        });
     }
 
     pub fn rename(&mut self, _: &Rename, cx: &mut ViewContext<Self>) -> Option<Task<Result<()>>> {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9527,6 +9527,10 @@ impl Editor {
         cx.spawn(|_, mut cx| async move {
             let workspace = workspace.ok_or_else(|| anyhow!("cannot jump without workspace"))?;
             let editor = workspace.update(&mut cx, |workspace, cx| {
+                // Reset the preview item id before opening the new item
+                workspace.active_pane().update(cx, |pane, cx| {
+                    pane.set_preview_item_id(None, cx);
+                });
                 workspace.open_path_preview(path, None, true, true, cx)
             })?;
             let editor = editor


### PR DESCRIPTION
`FindAllReferences` will now open a preview tab, jumping to a definition will also open a preview tab.

https://github.com/zed-industries/zed/assets/53836821/fa3db1fd-ccb3-4559-b3d2-b1fe57f86481

Note: One thing I would like to improve here is also adding support for reopening `FindAllReferences` using the navigation history. As of now the navigation history is lacking support for reopening items other then project files, which needs to be implemented first. 

Release Notes:

- N/A
