### PR TITLE
Fix Python venv activation script when Nushell is setup as default shell

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -186,6 +186,7 @@ impl Project {
         }
     }
 
+    // TOFIX: This function does not work properly when Nushell is set as default shell
     fn activate_python_virtual_environment(
         &mut self,
         activate_command: &'static str,

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -186,7 +186,7 @@ impl Project {
         }
     }
 
-    // TOFIX: This function does not work properly when Nushell is set as default shell
+    // TOFIX: This function does not work properly when Nushell is set as default shell (see #8970)
     fn activate_python_virtual_environment(
         &mut self,
         activate_command: &'static str,


### PR DESCRIPTION
**[WIP]**

Release Notes:

- Added/Fixed https://github.com/zed-industries/zed/issues/8970