### PR TITLE
windows: Update `WindowsDisplay::frequency()`

### DIFF
--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -121,21 +121,18 @@ impl WindowsDisplay {
     }
 
     pub(crate) fn frequency(&self) -> Option<u32> {
-        available_monitors()
-            .get(self.display_id.0 as usize)
-            .and_then(|hmonitor| get_monitor_info(*hmonitor).ok())
-            .and_then(|info| {
-                let mut devmode = DEVMODEW::default();
-                unsafe {
-                    EnumDisplaySettingsW(
-                        PCWSTR(info.szDevice.as_ptr()),
-                        ENUM_CURRENT_SETTINGS,
-                        &mut devmode,
-                    )
-                }
-                .as_bool()
-                .then(|| devmode.dmDisplayFrequency)
-            })
+        get_monitor_info(self.handle).ok().and_then(|info| {
+            let mut devmode = DEVMODEW::default();
+            unsafe {
+                EnumDisplaySettingsW(
+                    PCWSTR(info.szDevice.as_ptr()),
+                    ENUM_CURRENT_SETTINGS,
+                    &mut devmode,
+                )
+            }
+            .as_bool()
+            .then(|| devmode.dmDisplayFrequency)
+        })
     }
 }
 


### PR DESCRIPTION
A subsequent update introduced the `HMONITOR` value to the `WindowsDisplay` struct, eliminating the need for polling to retrieve this value.

Release Notes:

- N/A
