### PR TITLE
Use document window animation for “normal” windows

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -73,6 +73,8 @@ const NSTrackingActiveAlways: NSUInteger = 0x80;
 #[allow(non_upper_case_globals)]
 const NSTrackingInVisibleRect: NSUInteger = 0x200;
 #[allow(non_upper_case_globals)]
+const NSWindowAnimationBehaviorDocumentWindow: NSInteger = 3;
+#[allow(non_upper_case_globals)]
 const NSWindowAnimationBehaviorUtilityWindow: NSInteger = 4;
 #[allow(non_upper_case_globals)]
 const NSViewLayerContentsRedrawDuringViewResize: NSInteger = 2;
@@ -703,6 +705,13 @@ impl MacWindow {
                 WindowKind::Normal => {
                     native_window.setLevel_(NSNormalWindowLevel);
                     native_window.setAcceptsMouseMovedEvents_(YES);
+
+                    // Use the same animation when opening new windows as document windows do,
+                    // e.g. ⌘N in TextEdit or Xcode.
+                    let _: () = msg_send![
+                        native_window,
+                        setAnimationBehavior: NSWindowAnimationBehaviorDocumentWindow
+                    ];
                 }
                 WindowKind::PopUp => {
                     // Use a tracking area to allow receiving MouseMoved events even when


### PR DESCRIPTION
Release Notes:

- Added animation when opening new editor windows to match document windows on macOS, e.g. File > New in TextEdit or File > New > File… in Xcode.

https://github.com/zed-industries/zed/assets/31783266/91ff12e2-585d-46bd-9c3e-d71bc9a2c45a

https://github.com/zed-industries/zed/assets/31783266/cefc890d-35bb-4a8d-a64a-85c7a556c9d7