### PR TITLE
preview tabs: Fix tab selection getting out of sync

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -818,11 +818,10 @@ impl Pane {
                 if let Some(prev_item) = self.items.get(prev_active_item_ix) {
                     prev_item.deactivated(cx);
                 }
-
-                cx.emit(Event::ActivateItem {
-                    local: activate_pane,
-                });
             }
+            cx.emit(Event::ActivateItem {
+                local: activate_pane,
+            });
 
             if let Some(newly_active_item) = self.items.get(index) {
                 self.activation_history


### PR DESCRIPTION
There was an edge case where the project panel selection would not be updated when opening a lot of tabs quickly using the preview tab feature.
I spent way too long debugging this, thankfully @ConradIrwin spotted it in like 5 minutes 🎉

Release Notes:

- N/A
