### PR TITLE
zig: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12696,9 +12696,9 @@ dependencies = [
 
 [[package]]
 name = "zed_zig"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
- "zed_extension_api 0.0.5",
+ "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_zig"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"
@@ -13,4 +13,4 @@ path = "src/zig.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.5"
+zed_extension_api = "0.0.6"

--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -1,7 +1,7 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.0.1"
+version = "0.1.0"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/zig/src/zig.rs
+++ b/extensions/zig/src/zig.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use zed::LanguageServerId;
 use zed_extension_api::{self as zed, Result};
 
 struct ZigExtension {
@@ -8,7 +9,7 @@ struct ZigExtension {
 impl ZigExtension {
     fn language_server_binary_path(
         &mut self,
-        config: zed::LanguageServerConfig,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<String> {
         if let Some(path) = &self.cached_binary_path {
@@ -23,7 +24,7 @@ impl ZigExtension {
         }
 
         zed::set_language_server_installation_status(
-            &config.name,
+            &language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
         let release = zed::latest_github_release(
@@ -64,7 +65,7 @@ impl ZigExtension {
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             zed::set_language_server_installation_status(
-                &config.name,
+                &language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
 
@@ -104,11 +105,11 @@ impl zed::Extension for ZigExtension {
 
     fn language_server_command(
         &mut self,
-        config: zed::LanguageServerConfig,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         Ok(zed::Command {
-            command: self.language_server_binary_path(config, worktree)?,
+            command: self.language_server_binary_path(language_server_id, worktree)?,
             args: vec![],
             env: Default::default(),
         })


### PR DESCRIPTION
This PR bumps the Zig extension to v0.1.0.

This version of the extension has been updated to use v0.0.6 of the `zed_extension_api`.

It also adds support for treating `.zig.zon` files as Zig files (#10012).

Release Notes:

- N/A
