### PR TITLE
toml: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12682,9 +12682,9 @@ dependencies = [
 
 [[package]]
 name = "zed_toml"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
- "zed_extension_api 0.0.5",
+ "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/extensions/toml/Cargo.toml
+++ b/extensions/toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_toml"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"
@@ -13,4 +13,4 @@ path = "src/toml.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.5"
+zed_extension_api = "0.0.6"

--- a/extensions/toml/extension.toml
+++ b/extensions/toml/extension.toml
@@ -1,7 +1,7 @@
 id = "toml"
 name = "TOML"
 description = "TOML support."
-version = "0.0.2"
+version = "0.1.0"
 schema_version = 1
 authors = [
     "Max Brunsfeld <max@zed.dev>",


### PR DESCRIPTION
This PR bumps the TOML extension to v0.1.0.

This version of the extension has been updated to use v0.0.6 of the `zed_extension_api`.

Release Notes:

- N/A
