### PR TITLE
Display more specific tasks above in the modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12565,15 +12565,6 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f4ae4e302a80591635ef9a236b35fde6fcc26cfd060e66fde4ba9f9fd394a1"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "zed_extension_api"
 version = "0.0.6"
 dependencies = [
  "serde",

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -426,7 +426,7 @@ mod test_inventory {
             );
             used.into_iter()
                 .chain(current)
-                .map(|(_, task)| task.original_task.label)
+                .map(|(_, task)| task.original_task().label.clone())
                 .collect()
         })
     }

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -198,7 +198,7 @@ impl Inventory {
         &self,
         language: Option<Arc<Language>>,
         worktree: Option<WorktreeId>,
-        task_context: TaskContext,
+        task_context: &TaskContext,
         cx: &mut AppContext,
     ) -> (
         Vec<(TaskSourceKind, ResolvedTask)>,
@@ -242,7 +242,7 @@ impl Inventory {
             .chain(language_tasks)
             .filter_map(|(kind, task)| {
                 let id_base = kind.to_id_base();
-                Some((kind, task.resolve_task(&id_base, task_context.clone())?))
+                Some((kind, task.resolve_task(&id_base, task_context)?))
             })
             .map(|(kind, task)| {
                 let lru_score = task_usage
@@ -421,7 +421,7 @@ mod test_inventory {
             let (used, current) = inventory.used_and_current_resolved_tasks(
                 None,
                 worktree,
-                TaskContext::default(),
+                &TaskContext::default(),
                 cx,
             );
             used.into_iter()
@@ -445,7 +445,7 @@ mod test_inventory {
             let id_base = task_source_kind.to_id_base();
             inventory.task_scheduled(
                 task_source_kind.clone(),
-                task.resolve_task(&id_base, TaskContext::default())
+                task.resolve_task(&id_base, &TaskContext::default())
                     .unwrap_or_else(|| panic!("Failed to resolve task with name {task_name}")),
             );
         });
@@ -460,7 +460,7 @@ mod test_inventory {
             let (used, current) = inventory.used_and_current_resolved_tasks(
                 None,
                 worktree,
-                TaskContext::default(),
+                &TaskContext::default(),
                 cx,
             );
             let mut all = used;

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -55,14 +55,21 @@ pub struct ResolvedTask {
     /// so it's impossible to determine the id equality without more context in a generic case.
     pub id: TaskId,
     /// A template the task got resolved from.
-    pub original_task: TaskTemplate,
+    original_task: TaskTemplate,
     /// Full, unshortened label of the task after all resolutions are made.
     pub resolved_label: String,
     /// Variables that were substituted during the task template resolution.
-    pub substituted_variables: HashSet<VariableName>,
+    substituted_variables: HashSet<VariableName>,
     /// Further actions that need to take place after the resolved task is spawned,
     /// with all task variables resolved.
     pub resolved: Option<SpawnInTerminal>,
+}
+
+impl ResolvedTask {
+    /// A task template before the resolution.
+    pub fn original_task(&self) -> &TaskTemplate {
+        &self.original_task
+    }
 }
 
 /// Variables, available for use in [`TaskContext`] when a Zed's [`TaskTemplate`] gets resolved into a [`ResolvedTask`].

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -58,6 +58,8 @@ pub struct ResolvedTask {
     pub original_task: TaskTemplate,
     /// Full, unshortened label of the task after all resolutions are made.
     pub resolved_label: String,
+    /// Whether the task template contained a substitution dependency for the [`VariableName::Symbol`] Zed task variable.
+    pub depends_on_symbol: bool,
     /// Further actions that need to take place after the resolved task is spawned,
     /// with all task variables resolved.
     pub resolved: Option<SpawnInTerminal>,

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -118,10 +118,10 @@ pub struct TaskVariables(HashMap<VariableName, String>);
 
 impl TaskVariables {
     /// Converts the container into a map of environment variables and their values.
-    fn into_env_variables(self) -> HashMap<String, String> {
+    fn to_env_variables(&self) -> HashMap<String, &str> {
         self.0
-            .into_iter()
-            .map(|(name, value)| (name.to_string(), value))
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.as_str()))
             .collect()
     }
 

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -70,6 +70,11 @@ impl ResolvedTask {
     pub fn original_task(&self) -> &TaskTemplate {
         &self.original_task
     }
+
+    /// Variables that were substituted during the task template resolution.
+    pub fn substituted_variables(&self) -> &HashSet<VariableName> {
+        &self.substituted_variables
+    }
 }
 
 /// Variables, available for use in [`TaskContext`] when a Zed's [`TaskTemplate`] gets resolved into a [`ResolvedTask`].

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -5,7 +5,7 @@ pub mod static_source;
 mod task_template;
 mod vscode_format;
 
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use gpui::ModelContext;
 use serde::Serialize;
 use std::any::Any;
@@ -58,8 +58,8 @@ pub struct ResolvedTask {
     pub original_task: TaskTemplate,
     /// Full, unshortened label of the task after all resolutions are made.
     pub resolved_label: String,
-    /// Whether the task template contained a substitution dependency for the [`VariableName::Symbol`] Zed task variable.
-    pub depends_on_symbol: bool,
+    /// Variables that were substituted during the task template resolution.
+    pub substituted_variables: HashSet<VariableName>,
     /// Further actions that need to take place after the resolved task is spawned,
     /// with all task variables resolved.
     pub resolved: Option<SpawnInTerminal>,
@@ -119,14 +119,6 @@ impl std::fmt::Display for VariableName {
 pub struct TaskVariables(HashMap<VariableName, String>);
 
 impl TaskVariables {
-    /// Converts the container into a map of environment variables and their values.
-    fn to_env_variables(&self) -> HashMap<String, &str> {
-        self.0
-            .iter()
-            .map(|(name, value)| (name.to_string(), value.as_str()))
-            .collect()
-    }
-
     /// Inserts another variable into the container, overwriting the existing one if it already exists — in this case, the old value is returned.
     pub fn insert(&mut self, variable: VariableName, value: String) -> Option<String> {
         self.0.insert(variable, value)

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use util::{truncate_and_remove_front, ResultExt};
 
-use crate::{ResolvedTask, SpawnInTerminal, TaskContext, TaskId, ZED_VARIABLE_NAME_PREFIX};
+use crate::{
+    ResolvedTask, SpawnInTerminal, TaskContext, TaskId, VariableName, ZED_VARIABLE_NAME_PREFIX,
+};
 
 /// A template definition of a Zed task to run.
 /// May use the [`VariableName`] to get the corresponding substitutions into its fields.
@@ -83,22 +85,31 @@ impl TaskTemplate {
             return None;
         }
 
+        let mut depends_on_symbol = false;
         let task_variables = cx.task_variables.to_env_variables();
         let truncated_variables = truncate_variables(&task_variables);
         let cwd = match self.cwd.as_deref() {
-            Some(cwd) => Some(substitute_all_template_variables_in_str(
-                cwd,
-                &task_variables,
-            )?),
+            Some(cwd) => {
+                let (cwd_depends_on_symbol, substitured_cwd) =
+                    substitute_all_template_variables_in_str(cwd, &task_variables)?;
+                depends_on_symbol |= cwd_depends_on_symbol;
+                Some(substitured_cwd)
+            }
             None => None,
         }
         .map(PathBuf::from)
         .or(cx.cwd.clone());
-        let shortened_label =
+        let (_, shortened_label) =
             substitute_all_template_variables_in_str(&self.label, &truncated_variables)?;
-        let full_label = substitute_all_template_variables_in_str(&self.label, &task_variables)?;
-        let command = substitute_all_template_variables_in_str(&self.command, &task_variables)?;
-        let args = substitute_all_template_variables_in_vec(self.args.clone(), &task_variables)?;
+        let (label_depends_on_symbol, full_label) =
+            substitute_all_template_variables_in_str(&self.label, &task_variables)?;
+        depends_on_symbol |= label_depends_on_symbol;
+        let (command_depends_on_symbol, command) =
+            substitute_all_template_variables_in_str(&self.command, &task_variables)?;
+        depends_on_symbol |= command_depends_on_symbol;
+        let (args_depends_on_symbol, args) =
+            substitute_all_template_variables_in_vec(self.args.clone(), &task_variables)?;
+        depends_on_symbol |= args_depends_on_symbol;
 
         let task_hash = to_hex_hash(&self)
             .context("hashing task template")
@@ -107,10 +118,13 @@ impl TaskTemplate {
             .context("hashing task variables")
             .log_err()?;
         let id = TaskId(format!("{id_base}_{task_hash}_{variables_hash}"));
-        let mut env = substitute_all_template_variables_in_map(self.env.clone(), &task_variables)?;
+        let (env_depends_on_symbol, mut env) =
+            substitute_all_template_variables_in_map(self.env.clone(), &task_variables)?;
+        depends_on_symbol |= env_depends_on_symbol;
         env.extend(task_variables.into_iter().map(|(k, v)| (k, v.to_owned())));
         Some(ResolvedTask {
             id: id.clone(),
+            depends_on_symbol,
             original_task: self.clone(),
             resolved_label: full_label.clone(),
             resolved: Some(SpawnInTerminal {
@@ -153,12 +167,14 @@ fn to_hex_hash(object: impl Serialize) -> anyhow::Result<String> {
 fn substitute_all_template_variables_in_str<A: AsRef<str>>(
     template_str: &str,
     task_variables: &HashMap<String, A>,
-) -> Option<String> {
+) -> Option<(bool, String)> {
+    let mut depends_on_symbol = false;
     let substituted_string = shellexpand::env_with_context(template_str, |var| {
         // Colons denote a default value in case the variable is not set. We want to preserve that default, as otherwise shellexpand will substitute it for us.
         let colon_position = var.find(':').unwrap_or(var.len());
         let (variable_name, default) = var.split_at(colon_position);
         if let Some(name) = task_variables.get(variable_name) {
+            depends_on_symbol = variable_name == VariableName::Symbol.to_string();
             let mut name = name.as_ref().to_owned();
             // Got a task variable hit
             if !default.is_empty() {
@@ -178,31 +194,39 @@ fn substitute_all_template_variables_in_str<A: AsRef<str>>(
         Ok(None)
     })
     .ok()?;
-    Some(substituted_string.into_owned())
+    Some((depends_on_symbol, substituted_string.into_owned()))
 }
 
 fn substitute_all_template_variables_in_vec(
     mut template_strs: Vec<String>,
     task_variables: &HashMap<String, &str>,
-) -> Option<Vec<String>> {
+) -> Option<(bool, Vec<String>)> {
+    let mut depends_on_symbol = false;
     for variable in template_strs.iter_mut() {
-        let new_value = substitute_all_template_variables_in_str(&variable, task_variables)?;
+        let (new_depends_on_symbol, new_value) =
+            substitute_all_template_variables_in_str(&variable, task_variables)?;
+        depends_on_symbol |= new_depends_on_symbol;
         *variable = new_value;
     }
-    Some(template_strs)
+    Some((depends_on_symbol, template_strs))
 }
 
 fn substitute_all_template_variables_in_map(
     keys_and_values: HashMap<String, String>,
     task_variables: &HashMap<String, &str>,
-) -> Option<HashMap<String, String>> {
+) -> Option<(bool, HashMap<String, String>)> {
+    let mut depends_on_symbol = false;
     let mut new_map: HashMap<String, String> = Default::default();
     for (key, value) in keys_and_values {
-        let new_value = substitute_all_template_variables_in_str(&value, task_variables)?;
-        let new_key = substitute_all_template_variables_in_str(&key, task_variables)?;
+        let (var_depends_on_symbol, new_value) =
+            substitute_all_template_variables_in_str(&value, task_variables)?;
+        depends_on_symbol |= var_depends_on_symbol;
+        let (key_depends_on_symbol, new_key) =
+            substitute_all_template_variables_in_str(&key, task_variables)?;
+        depends_on_symbol |= key_depends_on_symbol;
         new_map.insert(new_key, new_value);
     }
-    Some(new_map)
+    Some((depends_on_symbol, new_map))
 }
 
 #[cfg(test)]
@@ -387,7 +411,7 @@ mod tests {
             ).unwrap_or_else(|| panic!("Should successfully resolve task {task_with_all_variables:?} with variables {all_variables:?}"));
 
             match &first_resolved_id {
-                None => first_resolved_id = Some(resolved_task.id),
+                None => first_resolved_id = Some(resolved_task.id.clone()),
                 Some(first_id) => assert_eq!(
                     &resolved_task.id, first_id,
                     "Step {i}, for the same task template and context, there should be the same resolved task id"
@@ -402,6 +426,10 @@ mod tests {
                 resolved_task.resolved_label,
                 format!("test label for 1234 and {long_value}"),
                 "Resolved task label should be substituted with variables and those should not be shortened"
+            );
+            assert!(
+                resolved_task.depends_on_symbol,
+                "Task that depends on all vars, should depend on the Symbol one too, but got: {resolved_task:?}"
             );
 
             let spawn_in_terminal = resolved_task
@@ -496,5 +524,59 @@ mod tests {
         assert!(task
             .resolve_task(TEST_ID_BASE, &TaskContext::default())
             .is_none());
+    }
+
+    #[test]
+    fn test_symbol_dependent_tasks() {
+        let task_with_all_properties = TaskTemplate {
+            label: "test_label".to_string(),
+            command: "test_command".to_string(),
+            args: vec!["test_arg".to_string()],
+            env: HashMap::from_iter([("test_env_key".to_string(), "test_env_var".to_string())]),
+            ..TaskTemplate::default()
+        };
+        let cx = TaskContext {
+            cwd: None,
+            task_variables: TaskVariables::from_iter(Some((
+                VariableName::Symbol,
+                "test_symbol".to_string(),
+            ))),
+        };
+
+        for (i, symbol_dependent_task) in [
+            TaskTemplate {
+                label: format!("test_label_{}", VariableName::Symbol.template_value()),
+                ..task_with_all_properties.clone()
+            },
+            TaskTemplate {
+                command: format!("test_command_{}", VariableName::Symbol.template_value()),
+                ..task_with_all_properties.clone()
+            },
+            TaskTemplate {
+                args: vec![format!(
+                    "test_arg_{}",
+                    VariableName::Symbol.template_value()
+                )],
+                ..task_with_all_properties.clone()
+            },
+            TaskTemplate {
+                env: HashMap::from_iter([(
+                    "test_env_key".to_string(),
+                    format!("test_env_var_{}", VariableName::Symbol.template_value()),
+                )]),
+                ..task_with_all_properties.clone()
+            },
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let resolved = symbol_dependent_task
+                .resolve_task(TEST_ID_BASE, &cx)
+                .unwrap_or_else(|| panic!("Failed to resolve task {symbol_dependent_task:?}"));
+            assert!(
+                resolved.depends_on_symbol,
+                "(index {i}) Expected the task to depend on symbol task variable: {resolved:?}"
+            )
+        }
     }
 }

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -29,7 +29,7 @@ pub fn init(cx: &mut AppContext) {
                         })
                     {
                         if action.reevaluate_context {
-                            let mut original_task = last_scheduled_task.original_task;
+                            let mut original_task = last_scheduled_task.original_task();
                             if let Some(allow_concurrent_runs) = action.allow_concurrent_runs {
                                 original_task.allow_concurrent_runs = allow_concurrent_runs;
                             }
@@ -40,7 +40,7 @@ pub fn init(cx: &mut AppContext) {
                             schedule_task(
                                 workspace,
                                 task_source_kind,
-                                &original_task,
+                                original_task,
                                 &task_context,
                                 false,
                                 cx,

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -29,7 +29,7 @@ pub fn init(cx: &mut AppContext) {
                         })
                     {
                         if action.reevaluate_context {
-                            let mut original_task = last_scheduled_task.original_task();
+                            let mut original_task = last_scheduled_task.original_task().clone();
                             if let Some(allow_concurrent_runs) = action.allow_concurrent_runs {
                                 original_task.allow_concurrent_runs = allow_concurrent_runs;
                             }
@@ -40,7 +40,7 @@ pub fn init(cx: &mut AppContext) {
                             schedule_task(
                                 workspace,
                                 task_source_kind,
-                                original_task,
+                                &original_task,
                                 &task_context,
                                 false,
                                 cx,

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -42,7 +42,7 @@ pub fn init(cx: &mut AppContext) {
                                 workspace,
                                 task_source_kind,
                                 &original_task,
-                                task_context,
+                                &task_context,
                                 false,
                                 cx,
                             )
@@ -104,7 +104,7 @@ fn spawn_task_with_name(name: String, cx: &mut ViewContext<Workspace>) {
                     workspace,
                     task_source_kind,
                     &target_task,
-                    task_context,
+                    &task_context,
                     false,
                     cx,
                 );
@@ -253,7 +253,7 @@ fn schedule_task(
     workspace: &Workspace,
     task_source_kind: TaskSourceKind,
     task_to_resolve: &TaskTemplate,
-    task_cx: TaskContext,
+    task_cx: &TaskContext,
     omit_history: bool,
     cx: &mut ViewContext<'_, Workspace>,
 ) {

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -102,7 +102,7 @@ impl TasksModalDelegate {
         };
         Some((
             source_kind,
-            new_oneshot.resolve_task(&id_base, self.task_context.clone())?,
+            new_oneshot.resolve_task(&id_base, &self.task_context)?,
         ))
     }
 
@@ -212,7 +212,7 @@ impl PickerDelegate for TasksModalDelegate {
                                     inventory.used_and_current_resolved_tasks(
                                         language,
                                         worktree,
-                                        picker.delegate.task_context.clone(),
+                                        &picker.delegate.task_context,
                                         cx,
                                     )
                                 });
@@ -403,7 +403,6 @@ impl PickerDelegate for TasksModalDelegate {
     }
 }
 
-// TODO kb more tests on recent tasks from language templates
 #[cfg(test)]
 mod tests {
     use gpui::{TestAppContext, VisualTestContext};


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/10341

Uses more heuristics to bump certain tasks up in the modals list:
* tasks with more template variables than the others (as more specific)
* tasks with symbol template variable also get more points as more specific

Before:
<img width="578" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/f1687d2b-1028-421c-a356-07d3b5c96812">

After:
<img width="566" alt="image" src="https://github.com/zed-industries/zed/assets/2690773/63a6f07b-527e-4bc9-b798-8bebb9206491">


Release Notes:

- N/A
