### PR TITLE
Use buffer font when rendering editor breadcrumbs and diagnostics

### DIFF
--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -52,12 +52,19 @@ impl Render for Breadcrumbs {
                 Some(BreadcrumbText {
                     text: "⋯".into(),
                     highlights: None,
+                    font: None,
                 }),
             );
         }
 
         let highlighted_segments = segments.into_iter().map(|segment| {
             let mut text_style = cx.text_style();
+            if let Some(font) = segment.font {
+                text_style.font_family = font.family;
+                text_style.font_features = font.features;
+                text_style.font_style = font.style;
+                text_style.font_weight = font.weight;
+            }
             text_style.color = Color::Muted.color(cx);
 
             StyledText::new(segment.text.replace('\n', "␤"))

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10593,6 +10593,11 @@ pub fn diagnostic_block_renderer(diagnostic: Diagnostic, _is_valid: bool) -> Ren
 
         let mut text_style = cx.text_style().clone();
         text_style.color = diagnostic_style(diagnostic.severity, true, cx.theme().status());
+        let theme_settings = ThemeSettings::get_global(cx);
+        text_style.font_family = theme_settings.buffer_font.family.clone();
+        text_style.font_style = theme_settings.buffer_font.style;
+        text_style.font_features = theme_settings.buffer_font.features;
+        text_style.font_weight = theme_settings.buffer_font.weight;
 
         let multi_line_diagnostic = diagnostic.message.contains('\n');
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -30,7 +30,7 @@ use std::{
     sync::Arc,
 };
 use text::{BufferId, Selection};
-use theme::Theme;
+use theme::{Theme, ThemeSettings};
 use ui::{h_flex, prelude::*, Label};
 use util::{paths::PathExt, ResultExt, TryFutureExt};
 use workspace::item::{BreadcrumbText, FollowEvent, FollowableItemHandle};
@@ -827,13 +827,18 @@ impl Item for Editor {
             .map(|path| path.to_string_lossy().to_string())
             .unwrap_or_else(|| "untitled".to_string());
 
+        let settings = ThemeSettings::get_global(cx);
+
         let mut breadcrumbs = vec![BreadcrumbText {
             text: filename,
             highlights: None,
+            font: Some(settings.buffer_font.clone()),
         }];
+
         breadcrumbs.extend(symbols.into_iter().map(|symbol| BreadcrumbText {
             text: symbol.text,
             highlights: Some(symbol.highlight_ranges),
+            font: Some(settings.buffer_font.clone()),
         }));
         Some(breadcrumbs)
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -861,6 +861,7 @@ impl Item for TerminalView {
         Some(vec![BreadcrumbText {
             text: self.terminal().read(cx).breadcrumb_text.clone(),
             highlights: None,
+            font: None,
         }])
     }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -14,7 +14,7 @@ use client::{
 use futures::{channel::mpsc, StreamExt};
 use gpui::{
     AnyElement, AnyView, AppContext, Entity, EntityId, EventEmitter, FocusHandle, FocusableView,
-    HighlightStyle, Model, Pixels, Point, SharedString, Task, View, ViewContext, WeakView,
+    Font, HighlightStyle, Model, Pixels, Point, SharedString, Task, View, ViewContext, WeakView,
     WindowContext,
 };
 use project::{Project, ProjectEntryId, ProjectPath};
@@ -122,6 +122,7 @@ pub enum ItemEvent {
 pub struct BreadcrumbText {
     pub text: String,
     pub highlights: Option<Vec<(Range<usize>, HighlightStyle)>>,
+    pub font: Option<Font>,
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Before:

<img width="592" alt="Screenshot 2024-04-12 at 12 00 00 PM" src="https://github.com/zed-industries/zed/assets/2280405/3251743e-4f2c-4ca3-9bc5-88f37660f7b9">

After:

<img width="673" alt="Screenshot 2024-04-12 at 12 11 37 PM" src="https://github.com/zed-industries/zed/assets/2280405/6a8ac597-261a-45d9-bf2a-a673b6f26b0e">


Release Notes:

- N/A