### PR TITLE
lua: Fix extension version

### DIFF
--- a/extensions/lua/extension.toml
+++ b/extensions/lua/extension.toml
@@ -1,7 +1,7 @@
 id = "lua"
 name = "Lua"
 description = "Lua support."
-version = "0.1.0"
+version = "0.0.1"
 schema_version = 1
 authors = ["Kaylee Simmons <kay@the-simmons.net>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR fixes the Lua extension version to be v0.0.1 instead of v0.1.0 for the initial release.

Release Notes:

- N/A
