### PR TITLE
Add missing block.copy()

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -570,6 +570,7 @@ impl Platform for MacPlatform {
                     let _ = done_tx.send(result);
                 }
             });
+            let block = block.copy();
             let _: () = msg_send![workspace, setDefaultApplicationAtURL: app toOpenURLsWithScheme: scheme completionHandler: block];
         }
 


### PR DESCRIPTION
https://crates.io/crates/block implies this is necessary, and we're
still seeing segfaults in this method, so...

Release Notes:

- Fixed a panic when installing the CLI / registering for the zed:// protocol
