### PR TITLE
linux: Simplify scrolling implementation

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -267,8 +267,8 @@ impl WaylandClient {
             mouse_location: None,
             continuous_scroll_delta: None,
             discrete_scroll_delta: None,
-            vertical_modifier: 1.0,
-            horizontal_modifier: 1.0,
+            vertical_modifier: -1.0,
+            horizontal_modifier: -1.0,
             button_pressed: None,
             mouse_focused_window: None,
             keyboard_focused_window: None,
@@ -921,13 +921,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                 let scroll_delta = state
                     .continuous_scroll_delta
                     .get_or_insert(point(px(0.0), px(0.0)));
-                let modifier = match axis_source {
-                    // TODO: Make nice feeling kinetic scrolling instead of '2'
-                    AxisSource::Finger if supports_relative_direction => 2.0,
-                    AxisSource::Finger => -2.0,
-
-                    _ => 1.0,
-                };
+                // TODO: Make nice feeling kinetic scrolling instead of '2'
+                let modifier = 3.0;
                 match axis {
                     wl_pointer::Axis::VerticalScroll => {
                         scroll_delta.y += px(value as f32 * modifier * axis_modifier);
@@ -949,13 +944,16 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                     _ => 1.0,
                 };
 
+                // TODO: Make nice feeling kinetic scrolling instead of '2'
+                let modifier = 3.0;
+
                 let scroll_delta = state.discrete_scroll_delta.get_or_insert(point(0.0, 0.0));
                 match axis {
                     wl_pointer::Axis::VerticalScroll => {
-                        scroll_delta.y += discrete as f32 * axis_modifier;
+                        scroll_delta.y += discrete as f32 * axis_modifier * modifier;
                     }
                     wl_pointer::Axis::HorizontalScroll => {
-                        scroll_delta.x += discrete as f32 * axis_modifier;
+                        scroll_delta.x += discrete as f32 * axis_modifier * modifier;
                     }
                     _ => unreachable!(),
                 }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -921,7 +921,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                 let scroll_delta = state
                     .continuous_scroll_delta
                     .get_or_insert(point(px(0.0), px(0.0)));
-                // TODO: Make nice feeling kinetic scrolling instead of '2'
+                // TODO: Make nice feeling kinetic scrolling that integrates with the platform's scroll settings
                 let modifier = 3.0;
                 match axis {
                     wl_pointer::Axis::VerticalScroll => {
@@ -944,7 +944,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                     _ => 1.0,
                 };
 
-                // TODO: Make nice feeling kinetic scrolling instead of '2'
+                // TODO: Make nice feeling kinetic scrolling that integrates with the platform's scroll settings
                 let modifier = 3.0;
 
                 let scroll_delta = state.discrete_scroll_delta.get_or_insert(point(0.0, 0.0));


### PR DESCRIPTION
This PR adjusts our scrolling implementation to delay the generation of ScrollWheel events until we receive a complete frame. 

Note that our implementation is still a bit off-spec, as we don't delay any other kind of events. But it's been working so far on a variety of compositors and the other events contain complete data; so I'll hold off on that refactor for now. 

Release Notes:

- N/A
