### PR TITLE
Windows: Fix canonicalize return UNC path

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3589,7 +3589,8 @@ impl BackgroundScanner {
                 let abs_path = if let Ok(path) = abs_path.canonicalize() {
                     path
                 } else {
-                    log::error!("abs_path {abs_path:?} cannot canonicalize");
+                    // many intermediate file will hit here, currently not logger
+                    // log::error!("abs_path {abs_path:?} cannot canonicalize");
                     return false;
                 };
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3590,8 +3590,8 @@ impl BackgroundScanner {
                 let abs_path = if let Ok(path) = abs_path.canonicalize() {
                     path
                 } else {
-                    // many intermediate file will hit here, currently not logger
-                    // log::error!("abs_path {abs_path:?} cannot canonicalize");
+                    // compile intermediate file will hit here, generated and then disappear;
+                    // so fs cannot find them after disappear.
                     return false;
                 };
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3586,6 +3586,13 @@ impl BackgroundScanner {
                     is_git_related = true;
                 }
 
+                let abs_path = if let Ok(path) = abs_path.canonicalize() {
+                    path
+                } else {
+                    log::error!("abs_path {abs_path:?} cannot canonicalize");
+                    return false;
+                };
+
                 let relative_path: Arc<Path> =
                     if let Ok(path) = abs_path.strip_prefix(&root_canonical_path) {
                         path.into()

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3586,6 +3586,7 @@ impl BackgroundScanner {
                     is_git_related = true;
                 }
 
+                #[cfg(target_os = "windows")]
                 let abs_path = if let Ok(path) = abs_path.canonicalize() {
                     path
                 } else {


### PR DESCRIPTION
In windows platform, `fs::canonicalize` return unc path, some relative [issue](https://github.com/rust-lang/rust/issues/42869), when strip_prefix with unc path and path in windows, there will not be match, will log many error.

Release Notes:

- N/A
