### PR TITLE
docs: use_autoclose

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -92,8 +92,9 @@
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
-  // Whether to automatically type closing characters for you. For example,
-  // when you type (, Zed will automatically add a closing ) at the correct position.
+  // Whether to automatically add matching closing characters when typing
+  // opening parenthesis, bracket, brace, single or double quote characters.
+  // For example, when you type (, Zed will add a closing ) at the correct position.
   "use_autoclose": true,
   // Controls how the editor handles the autoclosed characters.
   // When set to `false`(default), skipping over and auto-removing of the closing characters

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -387,7 +387,7 @@ To override settings for a language, add an entry for that language server's nam
 
 ## Auto close
 
-- Description: Whether or not to automatically type closing characters for you.
+- Description: Whether to automatically add matching closing characters when typing opening parenthesis, bracket, brace, single or double quote characters.
 - Setting: `use_autoclose`
 - Default: `true`
 


### PR DESCRIPTION
Add some keywords (bracket, quote, etc)to the comments describing `use_autoclose` preference in the settings json.

This setting took me a while to find -- so now it'll be more easily searchable for others.

Release Notes:

- N/A
