### PR TITLE
gpui: Fix incorrect colorspace

### DIFF
--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -1,6 +1,6 @@
 use crate::{size, DevicePixels, Result, SharedString, Size};
 use anyhow::anyhow;
-use image::{Bgra, ImageBuffer};
+use image::{ImageBuffer, Rgba};
 use std::{
     borrow::Cow,
     fmt,
@@ -43,12 +43,12 @@ pub(crate) struct RenderImageParams {
 pub struct ImageData {
     /// The ID associated with this image
     pub id: ImageId,
-    data: ImageBuffer<Bgra<u8>, Vec<u8>>,
+    data: ImageBuffer<Rgba<u8>, Vec<u8>>,
 }
 
 impl ImageData {
     /// Create a new image from the given data.
-    pub fn new(data: ImageBuffer<Bgra<u8>, Vec<u8>>) -> Self {
+    pub fn new(data: ImageBuffer<Rgba<u8>, Vec<u8>>) -> Self {
         static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
         Self {

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -370,7 +370,7 @@ impl Asset for Image {
             };
 
             let data = if let Ok(format) = image::guess_format(&bytes) {
-                let data = image::load_from_memory_with_format(&bytes, format)?.into_bgra8();
+                let data = image::load_from_memory_with_format(&bytes, format)?.into_rgba8();
                 ImageData::new(data)
             } else {
                 let pixmap =


### PR DESCRIPTION

Release Notes:

- Fixed incorrect colorspace

I believe the wrong colorspace was used, at least when i tried it on my linux machine, images were displayed incorrectly.

Zed: v1.0.0 (Zed Dev 3289188e0adaa6c6e73836f8beef5abad3982376)
OS: Linux 1.0.0
Memory: 23.4 GiB
Architecture: x86_64

before:
![image](https://github.com/zed-industries/zed/assets/68782699/500ce970-1bb8-4a20-8d97-59f5dcf4a8ec)

after:
![image](https://github.com/zed-industries/zed/assets/68782699/07d8326a-e2f4-4fb5-921e-cc608e7ded58)
