### PR TITLE
Fix default keybinding for ToggleGitBlame

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -159,7 +159,7 @@
       "ctrl-cmd-space": "editor::ShowCharacterPalette",
       "cmd-;": "editor::ToggleLineNumbers",
       "cmd-alt-z": "editor::RevertSelectedHunks",
-      "cmd-alt-g b": "editor::ToggleGitBlame"
+      "cmd-alt-g": "editor::ToggleGitBlame"
     }
   },
   {


### PR DESCRIPTION
- Fixed the keybinding for ToggleGitBlame

https://github.com/zed-industries/zed/pull/9972

@JosephTLyons ToggleGitBlame functionality was not working for me so I changed
the keymap file and removed the extra "b" at the end and its now working...

Release Notes:

- Fixed keybinding for ToggleGitBlame