### PR TITLE
Fix scrollbar marker settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -145,10 +145,10 @@
     "show": "auto",
     // Whether to show git diff indicators in the scrollbar.
     "git_diff": true,
-    // Whether to show selections in the scrollbar.
-    "selections": true,
-    // Whether to show symbols selections in the scrollbar.
-    "symbols_selections": true,
+    // Whether to show buffer search results in the scrollbar.
+    "search_results": true,
+    // Whether to show selected symbol occurences in the scrollbar.
+    "selected_symbol": true,
     // Whether to show diagnostic indicators in the scrollbar.
     "diagnostics": true
   },

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -147,7 +147,7 @@
     "git_diff": true,
     // Whether to show buffer search results in the scrollbar.
     "search_results": true,
-    // Whether to show selected symbol occurences in the scrollbar.
+    // Whether to show selected symbol occurrences in the scrollbar.
     "selected_symbol": true,
     // Whether to show diagnostic indicators in the scrollbar.
     "diagnostics": true

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -57,8 +57,8 @@ pub struct Toolbar {
 pub struct Scrollbar {
     pub show: ShowScrollbar,
     pub git_diff: bool,
-    pub selections: bool,
-    pub symbols_selections: bool,
+    pub selected_symbol: bool,
+    pub search_results: bool,
     pub diagnostics: bool,
 }
 
@@ -188,14 +188,14 @@ pub struct ScrollbarContent {
     ///
     /// Default: true
     pub git_diff: Option<bool>,
-    /// Whether to show buffer search result markers in the scrollbar.
+    /// Whether to show buffer search result indicators in the scrollbar.
     ///
     /// Default: true
-    pub selections: Option<bool>,
-    /// Whether to show symbols highlighted markers in the scrollbar.
+    pub search_results: Option<bool>,
+    /// Whether to show selected symbol occurences in the scrollbar.
     ///
     /// Default: true
-    pub symbols_selections: Option<bool>,
+    pub selected_symbol: Option<bool>,
     /// Whether to show diagnostic indicators in the scrollbar.
     ///
     /// Default: true

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -192,7 +192,7 @@ pub struct ScrollbarContent {
     ///
     /// Default: true
     pub search_results: Option<bool>,
-    /// Whether to show selected symbol occurences in the scrollbar.
+    /// Whether to show selected symbol occurrences in the scrollbar.
     ///
     /// Default: true
     pub selected_symbol: Option<bool>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -962,10 +962,10 @@ impl EditorElement {
                 (is_singleton && scrollbar_settings.git_diff && snapshot.buffer_snapshot.has_git_diffs())
                     ||
                     // Selections
-                    (is_singleton && scrollbar_settings.selections && editor.has_background_highlights::<BufferSearchHighlights>())
+                    (is_singleton && scrollbar_settings.search_results && editor.has_background_highlights::<BufferSearchHighlights>())
                     ||
                     // Symbols Selections
-                    (is_singleton && scrollbar_settings.symbols_selections && (editor.has_background_highlights::<DocumentHighlightRead>() || editor.has_background_highlights::<DocumentHighlightWrite>()))
+                    (is_singleton && scrollbar_settings.selected_symbol && (editor.has_background_highlights::<DocumentHighlightRead>() || editor.has_background_highlights::<DocumentHighlightWrite>()))
                     ||
                     // Diagnostics
                     (is_singleton && scrollbar_settings.diagnostics && snapshot.buffer_snapshot.has_diagnostics())
@@ -2559,10 +2559,14 @@ impl EditorElement {
                             for (background_highlight_id, (_, background_ranges)) in
                                 background_highlights.iter()
                             {
-                                if (*background_highlight_id
-                                    == TypeId::of::<BufferSearchHighlights>()
-                                    && scrollbar_settings.selections)
-                                    || scrollbar_settings.symbols_selections
+                                let is_search_highlights = *background_highlight_id
+                                    == TypeId::of::<BufferSearchHighlights>();
+                                let is_symbol_occurences = *background_highlight_id
+                                    == TypeId::of::<DocumentHighlightRead>()
+                                    || *background_highlight_id
+                                        == TypeId::of::<DocumentHighlightWrite>();
+                                if (is_search_highlights && scrollbar_settings.search_results)
+                                    || (is_symbol_occurences && scrollbar_settings.selected_symbol)
                                 {
                                     let marker_row_ranges =
                                         background_ranges.into_iter().map(|range| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2561,12 +2561,12 @@ impl EditorElement {
                             {
                                 let is_search_highlights = *background_highlight_id
                                     == TypeId::of::<BufferSearchHighlights>();
-                                let is_symbol_occurences = *background_highlight_id
+                                let is_symbol_occurrences = *background_highlight_id
                                     == TypeId::of::<DocumentHighlightRead>()
                                     || *background_highlight_id
                                         == TypeId::of::<DocumentHighlightWrite>();
                                 if (is_search_highlights && scrollbar_settings.search_results)
-                                    || (is_symbol_occurences && scrollbar_settings.selected_symbol)
+                                    || (is_symbol_occurrences && scrollbar_settings.selected_symbol)
                                 {
                                     let marker_row_ranges =
                                         background_ranges.into_iter().map(|range| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -961,10 +961,10 @@ impl EditorElement {
                 // Git
                 (is_singleton && scrollbar_settings.git_diff && snapshot.buffer_snapshot.has_git_diffs())
                     ||
-                    // Selections
+                    // Buffer Search Results
                     (is_singleton && scrollbar_settings.search_results && editor.has_background_highlights::<BufferSearchHighlights>())
                     ||
-                    // Symbols Selections
+                    // Selected Symbol Occurrences
                     (is_singleton && scrollbar_settings.selected_symbol && (editor.has_background_highlights::<DocumentHighlightRead>() || editor.has_background_highlights::<DocumentHighlightWrite>()))
                     ||
                     // Diagnostics

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -190,6 +190,102 @@ List of `string` values
 2. Position the dock to the right of the workspace like a side panel: `right`
 3. Position the dock full screen over the entire workspace: `expanded`
 
+## Editor Scrollbar
+
+- Description: Whether or not to show the editor scrollbar and various elements in it.
+- Setting: `scrollbar`
+- Default:
+
+```json
+"scrollbar": {
+  "show": "auto",
+  "git_diff": true,
+  "search_results": true,
+  "selected_symbol": true,
+  "diagnostics": true
+},
+```
+
+### Show Mode
+
+- Description: When to show the editor scrollbar.
+- Setting: `show`
+- Default: `auto`
+
+**Options**
+
+1. Show the scrollbar if there's important information or follow the system's configured behavior:
+
+```json
+"scrollbar": {
+  "show": "auto"
+}
+```
+
+2. Match the system's configured behavior:
+
+```json
+"scrollbar": {
+  "show": "system"
+}
+```
+
+3. Always show the scrollbar:
+
+```json
+"scrollbar": {
+  "show": "always"
+}
+```
+
+4. Never show the scrollbar:
+
+```json
+"scrollbar": {
+  "show": "never"
+}
+```
+
+### Git Diff Indicators
+
+- Description: Whether to show git diff indicators in the scrollbar.
+- Setting: `git_diff`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+### Search Results Indicators
+
+- Description: Whether to show buffer search results in the scrollbar.
+- Setting: `search_results`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+### Selected Symbols Indicators
+
+- Description: Whether to show selected symbol occurences in the scrollbar.
+- Setting: `selected_symbol`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+### Diagnostics
+
+- Description: Whether to show diagnostic indicators in the scrollbar.
+- Setting: `diagnostics`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## Editor Toolbar
 
 - Description: Whether or not to show various elements in the editor toolbar.

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -268,7 +268,7 @@ List of `string` values
 
 ### Selected Symbols Indicators
 
-- Description: Whether to show selected symbol occurences in the scrollbar.
+- Description: Whether to show selected symbol occurrences in the scrollbar.
 - Setting: `selected_symbol`
 - Default: `true`
 


### PR DESCRIPTION
Zed displays scrollbar markers of three types: git diffs, background highlights and diagnostics. At the moment, the "background highlights" markers are displayed for all the supported highlights:

- Occurences of the symbol under cursor.
- Search results.
- Scope boundaries (only works when a symbol is selected).
- Active hover popover position.

They all use the same color, which leads to confusing results. For instance, in the following case I expect to see markers for the `new_anchor` occurences in lines 43 and 47. But besides them, there're also scope-markers for `ScrollAnchor` initialization block in lines 46 and 49, which makes me think that there're four places where `new_anchor` appears.

<img width="740" alt="zed-scrollbar-markers" src="https://github.com/zed-industries/zed/assets/2101250/78700e6b-fdd1-4c2f-beff-e564d8defc13">

Existing settings `selection` and `symbol_selection` in the `scrollbar` section [don't work as expected](https://github.com/zed-industries/zed/pull/10080#discussion_r1552325493), which increases confusion.

This PR only leaves two types of bg-highlight-markers and provides dedicated settings for them:

- Occurences of the symbol under cursor. Setting: `selected_symbol`, default is `true`.
- Search results. Setting: `search_results`, default is `true`.

The `selection` and `symbol_selection` settings are not used anymore.

Release Notes:

- Breaking changes. Settings `selection` and `symbol_selection` in the `scrollbar` section renamed to `search_results` and `selected_symbol` respectively. Fixed the effect of these settings on which markers are displayed on the scrollbar.

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

- N/A

/cc @mrnugget 