### PR TITLE
Use the default option shift arrow key selection for the TextMate keymap

### DIFF
--- a/assets/keymaps/textmate.json
+++ b/assets/keymaps/textmate.json
@@ -39,13 +39,13 @@
       "cmd-shift-left": "editor::SelectToBeginningOfLine",
       "cmd-shift-right": "editor::SelectToEndOfLine",
       "alt-shift-left": [
-        "editor::SelectToPreviousSubwordStart",
+        "editor::SelectToPreviousWordStart",
         {
           "stop_at_soft_wraps": true
         }
       ],
       "alt-shift-right": [
-        "editor::SelectToNextSubwordEnd",
+        "editor::SelectToNextWordEnd",
         {
           "stop_at_soft_wraps": true
         }

--- a/assets/keymaps/textmate.json
+++ b/assets/keymaps/textmate.json
@@ -39,13 +39,13 @@
       "cmd-shift-left": "editor::SelectToBeginningOfLine",
       "cmd-shift-right": "editor::SelectToEndOfLine",
       "alt-shift-left": [
-        "editor::SelectToBeginningOfLine",
+        "editor::SelectToPreviousSubwordStart",
         {
           "stop_at_soft_wraps": true
         }
       ],
       "alt-shift-right": [
-        "editor::SelectToEndOfLine",
+        "editor::SelectToNextSubwordEnd",
         {
           "stop_at_soft_wraps": true
         }


### PR DESCRIPTION
By default when pressing the option+shift+arrow keys selection should jump to words along the way rather than selecting the entire line.

https://github.com/zed-industries/zed/issues/10242


Release Notes:

- Fixed ([#10242](https://github.com/zed-industries/zed/issues/10242)).

TextMate keymap uses default option shift arrow selection
