### PR TITLE
Remove extra space in completion popup

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1040,9 +1040,9 @@ impl CompletionsMenu {
         .with_width_from_item(widest_completion_ix);
 
         let mut menu = vec![v_flex().elevation_2(cx).px_1().child(list)];
-        multiline_docs.map(|doc| {
-            menu.push(v_flex().elevation_2(cx).px_1().child(doc));
-        });
+        if let Some(multiline_docs) = multiline_docs {
+            menu.push(v_flex().elevation_2(cx).px_1().child(multiline_docs));
+        }
 
         h_flex()
             .items_start()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -125,8 +125,7 @@ use theme::{
     ThemeColors, ThemeSettings,
 };
 use ui::{
-    h_flex, prelude::*, ButtonSize, ButtonStyle, IconButton, IconName, IconSize, ListItem, Popover,
-    Tooltip,
+    h_flex, prelude::*, ButtonSize, ButtonStyle, IconButton, IconName, IconSize, ListItem, Tooltip,
 };
 use util::{defer, maybe, post_inc, RangeExt, ResultExt, TryFutureExt};
 use workspace::item::ItemHandle;
@@ -1040,11 +1039,15 @@ impl CompletionsMenu {
         .track_scroll(self.scroll_handle.clone())
         .with_width_from_item(widest_completion_ix);
 
-        Popover::new()
-            .child(list)
-            .when_some(multiline_docs, |popover, multiline_docs| {
-                popover.aside(multiline_docs)
-            })
+        let mut menu = vec![v_flex().elevation_2(cx).px_1().child(list)];
+        multiline_docs.map(|doc| {
+            menu.push(v_flex().elevation_2(cx).px_1().child(doc));
+        });
+
+        h_flex()
+            .items_start()
+            .gap_1()
+            .children(menu)
             .into_any_element()
     }
 


### PR DESCRIPTION

Release Notes:
- Removed extra space in completion popup

Fixed #8523 

Before:

https://github.com/zed-industries/zed/assets/66138117/9c400d74-b1a0-4fb2-bd40-8bb9d1dceccd

After:

https://github.com/zed-industries/zed/assets/66138117/89f46708-8051-477b-bbb8-e066ea59c561

