### PR TITLE
Add basic bash and Python tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9842,6 +9842,7 @@ dependencies = [
  "serde_json",
  "settings",
  "shellexpand",
+ "shlex",
  "smol",
  "task",
  "terminal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,6 +298,7 @@ serde_json_lenient = { version = "0.1", features = [
 ] }
 serde_repr = "0.1"
 sha2 = "0.10"
+shlex = "1.3"
 shellexpand = "2.1.0"
 smallvec = { version = "1.6", features = ["union"] }
 smol = "1.2"

--- a/crates/languages/src/bash.rs
+++ b/crates/languages/src/bash.rs
@@ -1,0 +1,17 @@
+use language::ContextProviderWithTasks;
+use task::{TaskTemplate, TaskTemplates, VariableName};
+
+pub(super) fn bash_task_context() -> ContextProviderWithTasks {
+    ContextProviderWithTasks::new(TaskTemplates(vec![
+        TaskTemplate {
+            label: format!("execute '{}'", VariableName::SelectedText.template_value()),
+            command: VariableName::SelectedText.template_value(),
+            ..TaskTemplate::default()
+        },
+        TaskTemplate {
+            label: format!("run '{}'", VariableName::File.template_value()),
+            command: VariableName::File.template_value(),
+            ..TaskTemplate::default()
+        },
+    ]))
+}

--- a/crates/languages/src/bash.rs
+++ b/crates/languages/src/bash.rs
@@ -4,8 +4,9 @@ use task::{TaskTemplate, TaskTemplates, VariableName};
 pub(super) fn bash_task_context() -> ContextProviderWithTasks {
     ContextProviderWithTasks::new(TaskTemplates(vec![
         TaskTemplate {
-            label: format!("execute '{}'", VariableName::SelectedText.template_value()),
+            label: "execute selection".to_owned(),
             command: VariableName::SelectedText.template_value(),
+            ignore_previously_resolved: true,
             ..TaskTemplate::default()
         },
         TaskTemplate {

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -8,10 +8,14 @@ use smol::stream::StreamExt;
 use std::{str, sync::Arc};
 use util::{asset_str, ResultExt};
 
-use crate::{elixir::elixir_task_context, rust::RustContextProvider};
+use crate::{
+    bash::bash_task_context, elixir::elixir_task_context, python::python_task_context,
+    rust::RustContextProvider,
+};
 
 use self::{deno::DenoSettings, elixir::ElixirSettings};
 
+mod bash;
 mod c;
 mod css;
 mod deno;
@@ -133,7 +137,7 @@ pub fn init(
             );
         };
     }
-    language!("bash");
+    language!("bash", Vec::new(), bash_task_context());
     language!("c", vec![Arc::new(c::CLspAdapter) as Arc<dyn LspAdapter>]);
     language!("cpp", vec![Arc::new(c::CLspAdapter)]);
     language!(
@@ -195,7 +199,8 @@ pub fn init(
         "python",
         vec![Arc::new(python::PythonLspAdapter::new(
             node_runtime.clone(),
-        ))]
+        ))],
+        python_task_context()
     );
     language!(
         "rust",

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
+use language::{ContextProviderWithTasks, LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::LanguageServerBinary;
 use node_runtime::NodeRuntime;
 use std::{
@@ -9,6 +9,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use task::{TaskTemplate, TaskTemplates, VariableName};
 use util::ResultExt;
 
 const SERVER_PATH: &str = "node_modules/pyright/langserver.index.js";
@@ -178,6 +179,29 @@ async fn get_cached_server_binary(
         log::error!("missing executable in directory {:?}", server_path);
         None
     }
+}
+
+pub(super) fn python_task_context() -> ContextProviderWithTasks {
+    ContextProviderWithTasks::new(TaskTemplates(vec![
+        TaskTemplate {
+            label: format!("execute '{}'", VariableName::SelectedText.template_value()),
+            command: "python3".to_owned(),
+            args: vec![
+                "-c".to_owned(),
+                format!(
+                    "exec(r'''{}''')",
+                    VariableName::SelectedText.template_value()
+                ),
+            ],
+            ..TaskTemplate::default()
+        },
+        TaskTemplate {
+            label: format!("run '{}'", VariableName::File.template_value()),
+            command: "python3".to_owned(),
+            args: vec![VariableName::File.template_value()],
+            ..TaskTemplate::default()
+        },
+    ]))
 }
 
 #[cfg(test)]

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -184,7 +184,7 @@ async fn get_cached_server_binary(
 pub(super) fn python_task_context() -> ContextProviderWithTasks {
     ContextProviderWithTasks::new(TaskTemplates(vec![
         TaskTemplate {
-            label: format!("execute '{}'", VariableName::SelectedText.template_value()),
+            label: "execute selection".to_owned(),
             command: "python3".to_owned(),
             args: vec![
                 "-c".to_owned(),
@@ -193,6 +193,7 @@ pub(super) fn python_task_context() -> ContextProviderWithTasks {
                     VariableName::SelectedText.template_value()
                 ),
             ],
+            ignore_previously_resolved: true,
             ..TaskTemplate::default()
         },
         TaskTemplate {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -44,6 +44,7 @@ impl Project {
             .unwrap_or_else(|| Path::new(""));
 
         let (spawn_task, shell) = if let Some(spawn_task) = spawn_task {
+            log::debug!("Spawning task: {spawn_task:?}");
             env.extend(spawn_task.env);
             // Activate minimal Python virtual environment
             if let Some(python_settings) = &python_settings.as_option() {

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -39,6 +39,15 @@ pub struct TaskTemplate {
     /// Whether to allow multiple instances of the same task to be run, or rather wait for the existing ones to finish.
     #[serde(default)]
     pub allow_concurrent_runs: bool,
+    /// Task templates might produce different tasks with similar properties, e.g. equal labels.
+    /// Certain places in Zed like the task spawn modal, prefer already resolved tasks in such cases,
+    /// to allow rerunning previous tasks with previous contexts later.
+    ///
+    /// This property changes the behavior in such situations, ignoring the already resolved tasks instead.
+    /// It's useful for tasks where labels are constant, but the actual command always needs the freshmost context,
+    /// for instance, "run this selection" tasks.
+    #[serde(default)]
+    pub ignore_previously_resolved: bool,
     /// What to do with the terminal pane and tab, after the command was started:
     /// * `always` — always show the terminal pane, add and focus the corresponding task's tab in it (default)
     /// * `never` — avoid changing current terminal pane focus, but still add/reuse the task's tab there

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -114,12 +114,22 @@ impl TaskTemplate {
         }
         .map(PathBuf::from)
         .or(cx.cwd.clone());
-        let shortened_label = substitute_all_template_variables_in_str(
+        let human_readable_label = substitute_all_template_variables_in_str(
             &self.label,
             &truncated_variables,
             &variable_names,
             &mut substituted_variables,
-        )?;
+        )?
+        .lines()
+        .fold(String::new(), |mut string, line| {
+            if string.is_empty() {
+                string.push_str(line);
+            } else {
+                string.push_str("\\n");
+                string.push_str(line);
+            }
+            string
+        });
         let full_label = substitute_all_template_variables_in_str(
             &self.label,
             &task_variables,
@@ -162,7 +172,7 @@ impl TaskTemplate {
                 id,
                 cwd,
                 full_label,
-                label: shortened_label,
+                label: human_readable_label,
                 command,
                 args,
                 env,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -286,6 +286,7 @@ impl Display for TerminalError {
     }
 }
 
+#[derive(Debug)]
 pub struct SpawnTask {
     pub id: TaskId,
     pub full_label: String,

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -28,6 +28,7 @@ search.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
+shlex.workspace = true
 shellexpand.workspace = true
 smol.workspace = true
 terminal.workspace = true

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1,4 +1,4 @@
-use std::{ops::ControlFlow, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, ops::ControlFlow, path::PathBuf, sync::Arc};
 
 use crate::TerminalView;
 use collections::{HashMap, HashSet};
@@ -315,10 +315,14 @@ impl TerminalPanel {
             return;
         };
 
-        let mut command = std::mem::take(&mut spawn_task.command);
+        let old_command = std::mem::take(&mut spawn_task.command);
+        let mut command = shlex::try_quote(&old_command)
+            .map(|quoted| quoted.into_owned())
+            .unwrap_or(old_command);
         let args = std::mem::take(&mut spawn_task.args);
         for arg in args {
             command.push(' ');
+            let arg = shlex::try_quote(&arg).unwrap_or(Cow::Borrowed(&arg));
             command.push_str(&arg);
         }
         spawn_task.command = shell;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -315,10 +315,7 @@ impl TerminalPanel {
             return;
         };
 
-        let old_command = std::mem::take(&mut spawn_task.command);
-        let mut command = shlex::try_quote(&old_command)
-            .map(|quoted| quoted.into_owned())
-            .unwrap_or(old_command);
+        let mut command = std::mem::take(&mut spawn_task.command);
         let args = std::mem::take(&mut spawn_task.args);
         for arg in args {
             command.push(' ');


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/5141

* adds "run selection" and "run file" tasks for bash and Python.
* replaces newlines with `\n` symbols in the human-readable task labels
* properly escapes task command arguments when spawning the task in terminal

Caveats:

* bash tasks will always use user's default shell to spawn the selections, but they should rather respect the shebang line even if it's not selected
* Python tasks will always use `python3` to spawn its tasks now, as there's no proper mechanism in Zed to deal with different Python executables

Release Notes:

- Added tasks for bash and Python to execute selections and open files in terminal