### PR TITLE
docs: Install Windows 10/11 SDK with VS installation

### DIFF
--- a/docs/src/developing_zed__building_zed_windows.md
+++ b/docs/src/developing_zed__building_zed_windows.md
@@ -25,7 +25,7 @@ git submodule update --init --recursive
   rustup target add wasm32-wasi
   ```
 
-- Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with optional component `MSVC v*** - VS YYYY C++ x64/x86 build tools`. 
+- Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with optional component `MSVC v*** - VS YYYY C++ x64/x86 build tools` and install WINDOWS 11 or 10 SDK depending on your system
 
 > [!NOTE]
 > `v***` is your VS version and `YYYY` is year when your VS was released.

--- a/docs/src/developing_zed__building_zed_windows.md
+++ b/docs/src/developing_zed__building_zed_windows.md
@@ -25,7 +25,7 @@ git submodule update --init --recursive
   rustup target add wasm32-wasi
   ```
 
-- Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with optional component `MSVC v*** - VS YYYY C++ x64/x86 build tools` and install WINDOWS 11 or 10 SDK depending on your system
+- Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with optional component `MSVC v*** - VS YYYY C++ x64/x86 build tools` and install Windows 11 or 10 SDK depending on your system
 
 > [!NOTE]
 > `v***` is your VS version and `YYYY` is year when your VS was released.


### PR DESCRIPTION
This installation is also needed with VS installation. Only then they would be able to target the WINDOWS SDK

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

I was getting link.exe error before this stating that my MSVC was not installed properly. But MSVC was perfectly installed. I went on stackoverflow and checked for similar instances with `cargo run` on windows and found this

https://stackoverflow.com/a/55603112/12859779

where in comment Fasis states that we need to install WINDOWS 10 SDK. I had Windos 11 so Installed that and it worked :)

Release Notes:

- N/A