### PR TITLE
diagnostics: Update diagnostics more eagerly

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -136,8 +136,15 @@ impl ProjectDiagnosticsEditor {
                         .entry(*language_server_id)
                         .or_default()
                         .insert(path.clone());
-                    if this.editor.read(cx).selections.all::<usize>(cx).is_empty()
-                        && !this.is_dirty(cx)
+
+                    if this.is_dirty(cx) {
+                        return;
+                    }
+                    let selections = this.editor.read(cx).selections.all::<usize>(cx);
+                    if selections.len() < 2
+                        && selections
+                            .first()
+                            .map_or(true, |selection| selection.end == selection.start)
                     {
                         this.update_excerpts(Some(*language_server_id), cx);
                     }


### PR DESCRIPTION
Here comes a lenghty explanation for a short commit: We've had feedback that our diagnostics tab often mismatches what's shown in the status bar. E.g: https://x.com/fasterthanlime/status/1778764747732594753 Let's dive into the lifetime of diagnostic tab first; it is actually spawned *just once per workspace*, the first time you click on the diagnostics status indicator. Even if you close this tab, we still reuse the same object under the hood later on. This has upsides, as it means that you can close a tab and then reopen it with your selections still in-tact and so on. However, this also leads to the perceived staleness. Crucially, the first time ever in a given session that you spawn the diagnostics tab, the status bar counts match the content of a tab. That is because we always call \`update_excerpts\` when we create diagnostics tab for the first time, but later on we have severe constraints on when we want to update the excerpts in diagnostics tab, mostly centered around presence of selections in an editor... but, since we reuse the diagnostic tab object under the hood, we're always gonna have at least one selection in an editor sans the first time you open it. The end result is that in order for diagnostic tab contents to be updated, we have to get a "on-disk-diagnostics-finished" notification from language server, which can take a long time.
Another example of this property manifesting itself is that if you fix a diagnostic warning/error, it takes a while for diagnostic tab to reflect it.

With this PR, I've afforded a bit of leniency in refreshing the contents of that tab. The old check that discarded updates when diagnostics editor had at least one selection has been updated to instead reject multicursors; this is still overly conservative, as I'm not yet sure how big of an issue is the cursor that's jumping around (as that's what the selections constraint is supposed to prevent).



Release Notes:

- Fixed some cases where diagnostics tab showed outdated entries before the language server is done with it's analysis.
