### PR TITLE
Move constraints to query parameters for `GET /extensions/:extension_id/download`

### DIFF
--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -106,8 +106,12 @@ async fn get_extension_versions(
 }
 
 #[derive(Debug, Deserialize)]
-struct DownloadLatestExtensionParams {
+struct DownloadLatestExtensionPathParams {
     extension_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DownloadLatestExtensionQueryParams {
     min_schema_version: Option<i32>,
     max_schema_version: Option<i32>,
     min_wasm_api_version: Option<SemanticVersion>,
@@ -116,13 +120,14 @@ struct DownloadLatestExtensionParams {
 
 async fn download_latest_extension(
     Extension(app): Extension<Arc<AppState>>,
-    Path(params): Path<DownloadLatestExtensionParams>,
+    Path(params): Path<DownloadLatestExtensionPathParams>,
+    Query(query): Query<DownloadLatestExtensionQueryParams>,
 ) -> Result<Redirect> {
     let constraints = maybe!({
-        let min_schema_version = params.min_schema_version?;
-        let max_schema_version = params.max_schema_version?;
-        let min_wasm_api_version = params.min_wasm_api_version?;
-        let max_wasm_api_version = params.max_wasm_api_version?;
+        let min_schema_version = query.min_schema_version?;
+        let max_schema_version = query.max_schema_version?;
+        let min_wasm_api_version = query.min_wasm_api_version?;
+        let max_wasm_api_version = query.max_wasm_api_version?;
 
         Some(ExtensionVersionConstraints {
             schema_versions: min_schema_version..=max_schema_version,

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -672,8 +672,6 @@ impl ExtensionStore {
             return;
         };
 
-        dbg!(&url);
-
         self.install_or_upgrade_extension_at_endpoint(
             extension_id,
             url,

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -672,6 +672,8 @@ impl ExtensionStore {
             return;
         };
 
+        dbg!(&url);
+
         self.install_or_upgrade_extension_at_endpoint(
             extension_id,
             url,


### PR DESCRIPTION
This PR fixes a bug where the constraints provided when downloading the latest version of an extension were not being read properly.

These constraints are passed in the query string, but `collab` was attempting to read them from the path.

This should fix https://github.com/zed-industries/zed/issues/10484, once it is deployed.


Release Notes:

- N/A
