### PR TITLE
Defer first update active buffer for conversation

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2065,7 +2065,7 @@ impl ConversationEditor {
             workspace: workspace.downgrade(),
             _subscriptions,
         };
-        this.update_active_buffer(workspace, cx);
+        cx.defer(|this, cx| this.update_active_buffer(workspace, cx));
         this.update_message_headers(cx);
         this
     }


### PR DESCRIPTION
This fixes when the workspace is not actually available for a `.read(cx)`.

Release Notes:

- Fix a panic when quoting a selection before the assistant panel has been started
