### PR TITLE
Indicate which extension version is installed when on an older version

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -421,7 +421,13 @@ impl ExtensionsPage {
         let extension_id = extension.id.clone();
         let (install_or_uninstall_button, upgrade_button) =
             self.buttons_for_entry(extension, &status, cx);
+        let version = extension.manifest.version.clone();
         let repository_url = extension.manifest.repository.clone();
+
+        let installed_version = match status {
+            ExtensionStatus::Installed(installed_version) => Some(installed_version),
+            _ => None,
+        };
 
         ExtensionCard::new()
             .child(
@@ -435,9 +441,14 @@ impl ExtensionsPage {
                                 Headline::new(extension.manifest.name.clone())
                                     .size(HeadlineSize::Medium),
                             )
-                            .child(
-                                Headline::new(format!("v{}", extension.manifest.version))
-                                    .size(HeadlineSize::XSmall),
+                            .child(Headline::new(format!("v{version}")).size(HeadlineSize::XSmall))
+                            .children(
+                                installed_version
+                                    .filter(|installed_version| *installed_version != version)
+                                    .map(|installed_version| {
+                                        Headline::new(format!("(v{installed_version} installed)",))
+                                            .size(HeadlineSize::XSmall)
+                                    }),
                             ),
                     )
                     .child(


### PR DESCRIPTION
This PR adds an indicator to show what extension version is currently installed when on an extension version that is not the latest.

<img width="1156" alt="Screenshot 2024-04-15 at 2 10 33 PM" src="https://github.com/zed-industries/zed/assets/1486634/61c5e4cf-a0b8-48fc-8e52-f04f1c351794">

Release Notes:

- Added an indicator to show the currently-installed extension version when not on the latest version.
