### PR TITLE
More vim-like regexes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Zed
 
-Thanks for your interest in contributing to Zed, the collaborative platform that is also a code editor!
+Thanks for your interest in contributing to onetothree Zed, the collaborative platform that is also a code editor!
 
 All activity in Zed forums is subject to our [Code of Conduct](https://zed.dev/docs/code-of-conduct). Additionally, contributors must sign our [Contributor License Agreement](https://zed.dev/cla) before their contributions can be merged.
 

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -239,7 +239,7 @@ pub fn move_to_internal(
                     };
                     let mut query = regex::escape(&query);
                     if whole_word {
-                        query = format!(r"\b{}\b", query);
+                        query = format!(r"\<{}\>", query);
                     }
                     Some(search_bar.search(&query, Some(options), cx))
                 });


### PR DESCRIPTION
Fixes:  #10539

Release Notes:

- vim: Use `\<` `\>` instead of `\b`

