### PR TITLE
Add path option to Deno configuration

### DIFF
--- a/crates/languages/src/deno.rs
+++ b/crates/languages/src/deno.rs
@@ -20,7 +20,7 @@ use util::{
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DenoSettings {
     pub enable: bool,
-    pub path: Option<String>
+    pub path: Option<String>,
 }
 
 #[derive(Clone, Serialize, Default, Deserialize, JsonSchema)]
@@ -44,14 +44,12 @@ fn deno_server_binary_arguments() -> Vec<OsString> {
 }
 
 pub struct DenoLspAdapter {
-    path: Option<String>
+    path: Option<String>,
 }
 
 impl DenoLspAdapter {
     pub fn new(path: Option<String>) -> Self {
-        DenoLspAdapter {
-            path
-        }
+        DenoLspAdapter { path }
     }
 }
 

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -207,22 +207,23 @@ pub fn init(
     );
     match &DenoSettings::get(None, cx).enable {
         true => {
+            let deno_path = &DenoSettings::get(None, cx).path;
             language!(
                 "tsx",
                 vec![
-                    Arc::new(deno::DenoLspAdapter::new()),
+                    Arc::new(deno::DenoLspAdapter::new(deno_path.clone())),
                     Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
                 ]
             );
-            language!("typescript", vec![Arc::new(deno::DenoLspAdapter::new())]);
+            language!("typescript", vec![Arc::new(deno::DenoLspAdapter::new(deno_path.clone()))]);
             language!(
                 "javascript",
                 vec![
-                    Arc::new(deno::DenoLspAdapter::new()),
+                    Arc::new(deno::DenoLspAdapter::new(deno_path.clone())),
                     Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
                 ]
             );
-            language!("jsdoc", vec![Arc::new(deno::DenoLspAdapter::new())]);
+            language!("jsdoc", vec![Arc::new(deno::DenoLspAdapter::new(deno_path.clone()))]);
         }
         false => {
             language!(

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -215,7 +215,10 @@ pub fn init(
                     Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
                 ]
             );
-            language!("typescript", vec![Arc::new(deno::DenoLspAdapter::new(deno_path.clone()))]);
+            language!(
+                "typescript",
+                vec![Arc::new(deno::DenoLspAdapter::new(deno_path.clone()))]
+            );
             language!(
                 "javascript",
                 vec![
@@ -223,7 +226,10 @@ pub fn init(
                     Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
                 ]
             );
-            language!("jsdoc", vec![Arc::new(deno::DenoLspAdapter::new(deno_path.clone()))]);
+            language!(
+                "jsdoc",
+                vec![Arc::new(deno::DenoLspAdapter::new(deno_path.clone()))]
+            );
         }
         false => {
             language!(


### PR DESCRIPTION
Something that has been a little frustrating to me is that Zed isn't using the `deno` in my `$PATH` for the lsp. My understanding is that this is frowned upon in general, so instead of just using `deno` in the path, I have added a path configuration for the deno lsp so the user is able to specify which deno binary to use.

This is quite useful when switching between deno stable and deno canary.

Release Notes:

- Fixed ([#10585](https://github.com/zed-industries/zed/issues/10585)).

