### PR TITLE
./script/trigger-release

### DIFF
--- a/.github/workflows/bump_patch_version.yml
+++ b/.github/workflows/bump_patch_version.yml
@@ -1,0 +1,48 @@
+name: Bump Patch Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name to run on"
+        required: true
+
+concurrency:
+  # Allow only one workflow per any non-`main` branch.
+  group: ${{ github.workflow }}-${{ github.event.input.branch }}
+  cancel-in-progress: true
+
+jobs:
+  bump_patch_version:
+    runs-on:
+      - self-hosted
+      - test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Bump Patch Version
+        run: |
+          set -eu
+          channel=$(cat crates/zed/RELEASE_CHANNEL)
+
+          tag_suffix=""
+          case $channel in
+            stable)
+              ;;
+            preview)
+              tag_suffix="-pre"
+              ;;
+            *)
+              echo "this must be run on either of stable|preview release branches" >&2
+              exit 1
+              ;;
+          esac
+          which cargo-set-version > /dev/null || cargo install cargo-edit
+          output=$(cargo set-version -p zed --bump patch 2>&1 | sed 's/.* //')
+          cargo check --quiet
+          git commit -am "Bump to $output for $GITHUB_ACTOR"
+          git tag v${output}${suffix}
+          git push origin HEAD v${output}${suffix}

--- a/.github/workflows/bump_patch_version.yml
+++ b/.github/workflows/bump_patch_version.yml
@@ -1,4 +1,4 @@
-name: Bump Patch Version
+name: bump_patch_version
 
 on:
   workflow_dispatch:
@@ -22,10 +22,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.branch }}
+          ssh-key: ${{ secrets.ZED_BOT_DEPLOY_KEY }}
 
       - name: Bump Patch Version
         run: |
-          set -eu
+          set -eux
           channel=$(cat crates/zed/RELEASE_CHANNEL)
 
           tag_suffix=""
@@ -40,9 +41,8 @@ jobs:
               exit 1
               ;;
           esac
-          which cargo-set-version > /dev/null || cargo install cargo-edit
+          which cargo-set-version > /dev/null || cargo install cargo-edit --features vendored-openssl
           output=$(cargo set-version -p zed --bump patch 2>&1 | sed 's/.* //')
-          cargo check --quiet
-          git commit -am "Bump to $output for $GITHUB_ACTOR"
-          git tag v${output}${suffix}
-          git push origin HEAD v${output}${suffix}
+          git commit -am "Bump to $output for @$GITHUB_ACTOR" --author "Zed Bot <hi@zed.dev>"
+          git tag v${output}${tag_suffix}
+          git push origin HEAD v${output}${tag_suffix}

--- a/docs/src/developing_zed__releases.md
+++ b/docs/src/developing_zed__releases.md
@@ -1,0 +1,41 @@
+# Zed Releases
+
+Zed currently maintains two public releases for macOS:
+
+- [Stable](https://zed.dev/download). This is the primary version that people download and use.
+- [Preview](https://zed.dev/releases/preview), which receives updates a week ahead of stable for early adopters.
+
+Typically we cut a new minor release every Wednesday. The current Preview becomes Stable, and the new Preview contains everything on main up until that point.
+
+If bugs are found and fixed during the week, they may be cherry-picked into the release branches and so new patch versions for preview and stable can become available throughout the week.
+
+## Wednesday release process
+
+You will need write access to the Zed repository to do this:
+
+- Checkout `main` and ensure your working copy is clean.
+- Run `./script/bump-zed-minor-versions` and push the tags
+  and branches as instructed.
+- Wait for the builds to appear at https://github.com/zed-industries/zed/releases (typically takes around 30 minutes)
+- Copy the release notes from the previous Preview release(s) to the current Stable release.
+- Write new release notes for Preview. `/script/get-preview-channel-changes` can help with this, but you'll need to edit and format the output to make it good.
+- Download the artifacts for each release and test that you can run them locally.
+- Publish the releases.
+
+## Patch release process
+
+If your PR fixes a panic or a crash, you should cherry-pick it to the current stable and preview branches. If your PR fixes a regression in recently released code, you should cherry-pick it to the appropriate branch.
+
+You will need write access to the Zed repository to do this:
+
+- Cherry pick them onto the correct branch. You can either do this manually, or leave a comment of the form `/cherry-pick v0.XXX.x` on the PR, and the GitHub bot should do it for you.
+- Run `./script/trigger-release {preview|stable}`
+- Wait for the builds to appear at https://github.com/zed-industries/zed/releases (typically takes around 30 minutes)
+- Add release notes using the `Release notes:` section of each cherry-picked PR.
+- Download the artifacts for each release and test that you can run them locally.
+- Publish the release.
+
+## Nightly release process
+
+- Merge your changes to main
+- Run `./script/bump-nightly`

--- a/docs/src/developing_zed__releases.md
+++ b/docs/src/developing_zed__releases.md
@@ -38,4 +38,4 @@ You will need write access to the Zed repository to do this:
 ## Nightly release process
 
 - Merge your changes to main
-- Run `./script/bump-nightly`
+- Run `./script/trigger-release {nightly}`

--- a/script/bump-nightly
+++ b/script/bump-nightly
@@ -2,12 +2,6 @@
 
 set -e
 
-branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$branch" != "main" ]; then
-  echo "You must be on main to run this script"
-  exit 1
-fi
-
-git pull --ff-only origin main
-git tag -f nightly
+git fetch origin main:tags/nightly -f
+git log --oneline -1 nightly
 git push -f origin nightly

--- a/script/get-released-version
+++ b/script/get-released-version
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+channel="$1"
+
+query=""
+case $channel in
+  stable)
+    ;;
+  preview)
+    query="&preview=1"
+    ;;
+  nightly)
+    query="&nightly=1"
+    ;;
+  *)
+    echo "this must be run on either of stable|preview|nightly release branches" >&2
+    exit 1
+    ;;
+esac
+
+curl -s https://zed.dev/api/releases/latest?asset=Zed.dmg$query | jq -r .version

--- a/script/trigger-release
+++ b/script/trigger-release
@@ -3,6 +3,11 @@ set -euo pipefail
 
 which gh >/dev/null || brew install gh
 
+if [ "$1" == "nightly" ]; then
+  ./script/bump-nightly
+  exit
+fi
+
 version=$(./script/get-released-version "$1" | sed 's/\.[^\.]*$/.x/')
 echo "Bumping $1 (v$version)"
 

--- a/script/trigger-release
+++ b/script/trigger-release
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+which gh >/dev/null || brew install gh
+
+version=$(./script/get-released-version "$1" | sed 's/\.[^\.]*$/.x/')
+echo "Bumping $1 (v$version)"
+
+gh workflow run "bump_patch_version.yml" -f branch="v$version"
+echo "Follow along at: https://github.com/zed-industries/zed/actions"


### PR DESCRIPTION
Add `./script/trigger-release {nightly|stable|preview}`

This command can be run regardless of the state of your local git repository, and it
either triggers a workflow run of `bump_patch_version.yml` (for stable/preview) or
it force pushes the nightly tag.

Also add some docs on releases to explain all of this.

Release Notes:

- N/A
