### PR TITLE
add a setting to control show/hide terminal button for status bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -490,6 +490,8 @@
     // Whether or not selecting text in the terminal will automatically
     // copy to the system clipboard.
     "copy_on_select": false,
+    // Whether to show the terminal button in the status bar
+    "button": true,
     // Any key-value pairs added to this list will be added to the terminal's
     // environment. Use `:` to separate multiple values.
     "env": {

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -36,6 +36,7 @@ pub struct TerminalSettings {
     pub alternate_scroll: AlternateScroll,
     pub option_as_meta: bool,
     pub copy_on_select: bool,
+    pub button: bool,
     pub dock: TerminalDockPosition,
     pub default_width: Pixels,
     pub default_height: Pixels,
@@ -138,6 +139,10 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: false
     pub copy_on_select: Option<bool>,
+    /// Whether to show the terminal button in the status bar.
+    ///
+    /// Default: true
+    pub button: Option<bool>,
     pub dock: Option<TerminalDockPosition>,
     /// Default width when the terminal is docked to the left or right.
     ///

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -727,7 +727,9 @@ impl Panel for TerminalPanel {
     }
 
     fn icon(&self, _cx: &WindowContext) -> Option<IconName> {
-        Some(IconName::Terminal)
+        TerminalSettings::get_global(_cx)
+            .button
+            .then(|| IconName::Terminal)
     }
 
     fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -726,8 +726,8 @@ impl Panel for TerminalPanel {
         "TerminalPanel"
     }
 
-    fn icon(&self, _cx: &WindowContext) -> Option<IconName> {
-        TerminalSettings::get_global(_cx)
+    fn icon(&self, cx: &WindowContext) -> Option<IconName> {
+        TerminalSettings::get_global(cx)
             .button
             .then(|| IconName::Terminal)
     }

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -812,6 +812,7 @@ These values take in the same options as the root-level settings with the same n
   "font_features": null,
   "font_size": null,
   "option_as_meta": false,
+  "button": false
   "shell": {},
   "toolbar": {
     "title": true
@@ -989,6 +990,16 @@ See Buffer Font Features
 **Options**
 
 At the moment, only the `title` option is available, it controls displaying of the terminal title that can be changed via `PROMPT_COMMAND`. If the title is hidden, the terminal toolbar is not displayed.
+
+### Terminal Button
+
+- Description: Control to show or hide the terminal button in the status bar
+- Setting: `button`
+- Default: `true`
+
+**Options**
+
+`boolean` values
 
 ### Working Directory
 


### PR DESCRIPTION
Release Notes:

- Added a setting to show/hide the terminal button in the status bar: `{"terminal": {"button": false}}` to hide it. (#10513)