### PR TITLE
Show Zoom In/Out shortcuts in the labels

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -26,7 +26,7 @@ use workspace::{
     item::Item,
     pane,
     ui::IconName,
-    DraggedTab, NewTerminal, Pane, Workspace,
+    DraggedTab, NewTerminal, Pane, ToggleZoom, Workspace,
 };
 
 use anyhow::Result;
@@ -98,8 +98,13 @@ impl TerminalPanel {
                             .on_click(cx.listener(|pane, _, cx| {
                                 pane.toggle_zoom(&workspace::ToggleZoom, cx);
                             }))
+                            // TODO kb
                             .tooltip(move |cx| {
-                                Tooltip::text(if zoomed { "Zoom Out" } else { "Zoom In" }, cx)
+                                Tooltip::for_action(
+                                    if zoomed { "Zoom Out" } else { "Zoom In" },
+                                    &ToggleZoom,
+                                    cx,
+                                )
                             })
                     })
                     .into_any_element()

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -365,7 +365,11 @@ impl Pane {
                                 pane.toggle_zoom(&crate::ToggleZoom, cx);
                             }))
                             .tooltip(move |cx| {
-                                Tooltip::text(if zoomed { "Zoom Out" } else { "Zoom In" }, cx)
+                                Tooltip::for_action(
+                                    if zoomed { "Zoom Out" } else { "Zoom In" },
+                                    &ToggleZoom,
+                                    cx,
+                                )
                             })
                     })
                     .when_some(pane.split_item_menu.as_ref(), |el, split_item_menu| {


### PR DESCRIPTION
Based on https://github.com/zed-industries/zed/discussions/10599 
Does the same as the assistant tab with the Zoom In/Out labels.

![image](https://github.com/zed-industries/zed/assets/2690773/afc59a3e-c3df-4fc8-bcaf-1d45a21aecf7)

Release Notes:

- Adjusted Zoom In/Out for Pane and Terminal Pane to show keybinding labels