### PR TITLE
Fix `---` in Markdown docs not rendered correctly

### DIFF
--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -5,7 +5,7 @@ use std::{ops::Range, path::PathBuf};
 
 use crate::{HighlightId, Language, LanguageRegistry};
 use gpui::{px, FontStyle, FontWeight, HighlightStyle, StrikethroughStyle, UnderlineStyle};
-use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag, TagEnd};
 
 /// Parsed Markdown content.
 #[derive(Debug, Clone, Default)]
@@ -165,7 +165,10 @@ pub async fn parse_markdown_block(
     let mut current_language = None;
     let mut list_stack = Vec::new();
 
-    for event in Parser::new_ext(markdown, Options::all()) {
+    let mut options = pulldown_cmark::Options::all();
+    options.remove(pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+
+    for event in Parser::new_ext(markdown, options) {
         let prev_len = text.len();
         match event {
             Event::Text(t) => {


### PR DESCRIPTION
This fixes #10511 by turning off the YAML metadata block rendering in the Markdown parser.

`clangd` uses `---` as dividers, but our parser interpreted it as a YAML metadata block, even though it didn't contain any valid YAML.

Example Markdown from `clangd`:

    ### instance-method `format`

    ---
    → `void`
    Parameters:
    - `const int &`
    - `const std::tm &`
    - `int & dest`

    ---
    ```cpp
    // In my_formatter_flag
    public: void format(const int &, const std::tm &, int &dest)
    ```

What's between the two `---` is *not* valid YAML. Neovim, too, interprets these as dividers and renders them as such.

And since we don't handle any possible metadata anyway, we can turn off the metadata handling, which causes the parser to interpret the `---` as dividers.



Release Notes:

- Fixed Markdown returned by `clangd` being rendered the wrong way. ([#10511](https://github.com/zed-industries/zed/issues/10511)).

Before:

![screenshot-2024-04-16-12 32 15@2x](https://github.com/zed-industries/zed/assets/1185253/a268f106-9504-48aa-9744-42a7521de807)

After:

![screenshot-2024-04-16-12 33 02@2x](https://github.com/zed-industries/zed/assets/1185253/dd178a63-a075-48a9-85d9-565157a5b050)
