### PR TITLE
Fix Markdown code rendering in tooltips ignoring languages

### DIFF
--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -252,7 +252,7 @@ pub async fn parse_markdown_block(
                     new_paragraph(text, &mut list_stack);
                     current_language = if let CodeBlockKind::Fenced(language) = kind {
                         language_registry
-                            .language_for_name(language.as_ref())
+                            .language_for_name_or_extension(language.as_ref())
                             .await
                             .ok()
                     } else {
@@ -358,5 +358,37 @@ pub fn new_paragraph(text: &mut String, list_stack: &mut Vec<(Option<u64>, bool)
     }
     if is_subsequent_paragraph_of_list {
         text.push_str("  ");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_dividers() {
+        let input = r#"
+### instance-method `format`
+
+---
+→ `void`
+Parameters:
+- `const int &`
+- `const std::tm &`
+- `int & dest`
+
+---
+```cpp
+// In my_formatter_flag
+public: void format(const int &, const std::tm &, int &dest)
+```
+"#;
+
+        let mut options = pulldown_cmark::Options::all();
+        options.remove(pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+
+        let parser = pulldown_cmark::Parser::new_ext(input, options);
+        for event in parser.into_iter() {
+            println!("{:?}", event);
+        }
     }
 }


### PR DESCRIPTION
Some code blocks that are returned in tooltips (returned by language servers, for example) use the language file extension as the language in the the triple-backtick code blocks.

Example:

    ```rs
    fn rust_code() {}
    ```

    ```cpp
    fn rust_code() {}
    ```

Before this change we only looked up the language with the `rs`/`cpp`/... being interpreted as the language name. Now we also treat it as a possible file extension.



Release Notes:

- Fixed Markdown code blocks in tooltips not having correct language highlighting.

Before:

![image](https://github.com/zed-industries/zed/assets/1185253/1f3870a6-467c-4e5f-9e49-1ff32240d10f)

After:

![screenshot-2024-04-16-12 43 39@2x](https://github.com/zed-industries/zed/assets/1185253/21a45ed5-825a-412d-9dc0-35a444fc64ba)

