### PR TITLE
Add ability to specify binary path/args for clangd

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -88,7 +88,7 @@ impl super::LspAdapter for GoLspAdapter {
             })
         } else {
             let env = delegate.shell_env().await;
-            let path = delegate.which("gopls".as_ref()).await?;
+            let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
             Some(LanguageServerBinary {
                 path,
                 arguments: server_binary_arguments(),


### PR DESCRIPTION
This uses the language server settings added in #9293 to allow users to specify the binary path and arguments with which to start up `clangd`.

Example user settings for `clangd`:

```json
{
  "lsp": {
    "clangd": {
      "binary": {
        "path": "/usr/bin/clangd",
        "arguments": ["--log=verbose"]
      },
    }
  }
}
```

Constraints:

* Right now this only allows ABSOLUTE paths.

Release Notes:

- Added ability to specify `clangd` binary `path` (must be absolute) and `arguments` in user settings. Example: `{"lsp": {"clangd": {"binary": {"path": "/usr/bin/clangd", "arguments": ["--log=verbose"] }}}}`