### PR TITLE
Use project search action with the default keybinding in app menus

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -68,7 +68,7 @@ pub fn app_menus() -> Vec<Menu<'static>> {
                 MenuItem::os_action("Paste", editor::actions::Paste, OsAction::Paste),
                 MenuItem::separator(),
                 MenuItem::action("Find", search::buffer_search::Deploy::find()),
-                MenuItem::action("Find In Project", workspace::NewSearch),
+                MenuItem::action("Find In Project", workspace::DeploySearch::find()),
                 MenuItem::separator(),
                 MenuItem::action(
                     "Toggle Line Comment",


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/10611 

Zed has `workspace::NewSearch` (without a default keybinding) and `workspace::DeploySearch` (with the default keybinding for its `DeploySearch::find()` form).

Use the one with the keybinding, as it's the whole point of the menu.

Release Notes:

- Fixed "Find In Project" app menu item having no keybinding ([10611](https://github.com/zed-industries/zed/issues/10611))
