### PR TITLE
clojure: Don't cache user-installed `clojure-lsp`

### DIFF
--- a/extensions/clojure/src/clojure.rs
+++ b/extensions/clojure/src/clojure.rs
@@ -11,15 +11,14 @@ impl ClojureExtension {
         config: zed::LanguageServerConfig,
         worktree: &zed::Worktree,
     ) -> Result<String> {
+        if let Some(path) = worktree.which("clojure-lsp") {
+            return Ok(path);
+        }
+
         if let Some(path) = &self.cached_binary_path {
             if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
                 return Ok(path.clone());
             }
-        }
-
-        if let Some(path) = worktree.which("clojure-lsp") {
-            self.cached_binary_path = Some(path.clone());
-            return Ok(path);
         }
 
         zed::set_language_server_installation_status(


### PR DESCRIPTION
This PR updates the Clojure extension to not cache the binary when it is using the one on the $PATH.

Release Notes:

- N/A
