### PR TITLE
lua: Don't cache user-installed `lua-language-server`

### DIFF
--- a/extensions/lua/src/lua.rs
+++ b/extensions/lua/src/lua.rs
@@ -13,15 +13,14 @@ impl LuaExtension {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<String> {
+        if let Some(path) = worktree.which("lua-language-server") {
+            return Ok(path);
+        }
+
         if let Some(path) = &self.cached_binary_path {
             if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
                 return Ok(path.clone());
             }
-        }
-
-        if let Some(path) = worktree.which("lua-language-server") {
-            self.cached_binary_path = Some(path.clone());
-            return Ok(path);
         }
 
         zed::set_language_server_installation_status(


### PR DESCRIPTION
This PR updates the Lua extension to not cache the binary when it is using the one on the $PATH.

Release Notes:

- N/A
