### PR TITLE
lua: Fix broken LuaLS download on x64

### DIFF
--- a/extensions/lua/src/lua.rs
+++ b/extensions/lua/src/lua.rs
@@ -47,7 +47,7 @@ impl LuaExtension {
             },
             arch = match arch {
                 zed::Architecture::Aarch64 => "arm64",
-                zed::Architecture::X8664 => "x86_64",
+                zed::Architecture::X8664 => "x64",
                 zed::Architecture::X86 => return Err("unsupported platform x86".into()),
             },
         );


### PR DESCRIPTION
The changes in #10437 accidentally switched 'x64' to 'x86_64' which breaks installs on linux x64, macos x64 and windows x64. This yields the following error:

```
[2024-04-16T12:58:01-04:00 ERROR project] failed to start language server "lua-language-server": no asset found matching "lua-language-server-3.7.4-darwin-x86_64.tar.gz"
[2024-04-16T12:58:01-04:00 ERROR project] server stderr: Some("")
```

It's trying to download: 
`lua-language-server-3.7.4-darwin-x86_64.tar.gz`
which should be
`lua-language-server-3.7.4-darwin-x64.tar.gz`

See [LuaLS release page](https://github.com/LuaLS/lua-language-server/releases/tag/3.6.25).

CC: @maxbrunsfeld

lua.rs before ef4c70c:
https://github.com/zed-industries/zed/blob/c6028f665182403a035af193a3f27021f6e57c67/crates/languages/src/lua.rs#L35

lua.rs after:
https://github.com/zed-industries/zed/blob/5d7148bde108bd59ca20f297fcebbcb9b8c27452/extensions/lua/src/lua.rs#L49

Release Notes:

- N/A
