### PR TITLE
lua: Bump to v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12715,7 +12715,7 @@ dependencies = [
 
 [[package]]
 name = "zed_lua"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/lua/Cargo.toml
+++ b/extensions/lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_lua"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/lua/extension.toml
+++ b/extensions/lua/extension.toml
@@ -1,7 +1,7 @@
 id = "lua"
 name = "Lua"
 description = "Lua support."
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = [
   "Max Brunsfeld <max@zed.dev>",


### PR DESCRIPTION
This PR bumps the Lua extension to v0.0.3.

Changes:

- #10639
- #10642

Release Notes:

- N/A
