### PR TITLE
gleam: Bump to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12694,7 +12694,7 @@ dependencies = [
 
 [[package]]
 name = "zed_gleam"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_gleam"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/gleam/extension.toml
+++ b/extensions/gleam/extension.toml
@@ -1,7 +1,7 @@
 id = "gleam"
 name = "Gleam"
 description = "Gleam support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Gleam extension to v0.1.1.

Changes:

- #10635

Release Notes:

- N/A