### PR TITLE
csharp: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12630,7 +12630,7 @@ dependencies = [
 
 [[package]]
 name = "zed_csharp"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.4",
 ]

--- a/extensions/csharp/Cargo.toml
+++ b/extensions/csharp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_csharp"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/csharp/extension.toml
+++ b/extensions/csharp/extension.toml
@@ -1,7 +1,7 @@
 id = "csharp"
 name = "C#"
 description = "C# support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["fminkowski <fminkowski@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the C# extension to v0.0.2.

Changes:

- #10638

Release Notes:

- N/A