### PR TITLE
Remove bincode from workspace serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12265,7 +12265,6 @@ dependencies = [
  "any_vec",
  "anyhow",
  "async-recursion 1.0.5",
- "bincode",
  "call",
  "client",
  "clock",

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -79,6 +79,7 @@ pub async fn open_db<M: Migrator + 'static>(
 }
 
 async fn open_main_db<M: Migrator>(db_path: &PathBuf) -> Option<ThreadSafeConnection<M>> {
+    dbg!(&db_path);
     log::info!("Opening main db");
     ThreadSafeConnection::<M>::builder(db_path.to_string_lossy().as_ref(), true)
         .with_db_initialization_query(DB_INITIALIZE_QUERY)

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -27,7 +27,6 @@ test-support = [
 anyhow.workspace = true
 any_vec.workspace = true
 async-recursion.workspace = true
-bincode = "1.2.1"
 call.workspace = true
 client.workspace = true
 clock.workspace = true


### PR DESCRIPTION
Using bincode makes it quite tricky to debug the workspaces table, as it
contains leading null bytes (which sqlite doesn't handle well).

JSON is much easier to use, and more space-efficient to boot.

The primary downside is that the foreign keys we have set up mean
that running this migration causes your panes/items to be lost.

Release Notes:

- N/A
