### PR TITLE
Fix wayland event loop not stopping

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -365,6 +365,8 @@ impl LinuxClient for WaylandClient {
                 |_| {},
             )
             .log_err();
+
+        self.0.borrow_mut().event_loop = Some(event_loop);
     }
 
     fn write_to_clipboard(&self, item: crate::ClipboardItem) {
@@ -541,10 +543,13 @@ impl Dispatch<xdg_toplevel::XdgToplevel, ObjectId> for WaylandClientStatePtr {
             return;
         };
 
-        drop(state);
         let should_close = window.handle_toplevel_event(event);
 
         if should_close {
+            if state.windows.len() <= 1 {
+                state.common.signal.stop();
+            }
+            drop(state);
             this.drop_window(surface_id);
         }
     }

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -311,13 +311,10 @@ impl WaylandWindowStatePtr {
             xdg_toplevel::Event::Close => {
                 let mut cb = self.callbacks.borrow_mut();
                 if let Some(mut should_close) = cb.should_close.take() {
-                    let result = (should_close)();
                     cb.should_close = Some(should_close);
-                    if result {
-                        drop(cb);
-                        self.close();
-                    }
-                    result
+                    drop(cb);
+                    self.close();
+                    true
                 } else {
                     false
                 }


### PR DESCRIPTION
Fixed #10483

Release Notes:
- Fixed the Wayland event loop not stopping.

1. There was a missing call to `signal.stop()` in the Wayland logic.
2. The callback of `should_close()` apparently always returns false, so even if you close the window, it wouldn't be notified.