### PR TITLE
Fix scroll thumb

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2488,7 +2488,6 @@ impl EditorElement {
                             editor.set_scroll_position(position, cx);
                         }
 
-                        mouse_position = event.position;
                         cx.stop_propagation();
                     } else {
                         editor.scroll_manager.set_is_dragging_scrollbar(false, cx);
@@ -2496,6 +2495,7 @@ impl EditorElement {
                             editor.scroll_manager.show_scrollbar(cx);
                         }
                     }
+                    mouse_position = event.position;
                 })
             }
         });


### PR DESCRIPTION
Editor scrollbar has several issues that show up on large files:

- The thumb scrolls beyond the window.
- When dragged, the thumb goes out of sync with the mouse pointer.
- When the scrollbar trunk is clicked, the thumb jumps incorrectly.

https://github.com/zed-industries/zed/assets/2101250/320dba59-a526-4e68-99b3-1186271ba839

The reason is that the scrollbar now has two modes:
1. The "basic mode" for small files, when the thumb height correctly represents the visible area, i.e. the top of the thumb matches the top visible row (let's call it top-to-top sync), and the bottom of the thumb matches the bottom visible row.
2. The "extended mode" for large files, when thumb becomes too small and we have to impose minimal height to it. In this mode we have a vertical offset of the first row position inside the scrollbar, we try to position the thumb center-to-center with the editor.

...and the second mode is not implemented correctly. Also, mouse event handlers ignore it. It is possible to fix this implementation, but I'm not sure if it worth doing because it a) leads to some confusing cases (for instance, in the extended mode the first row marker is not at the top of the scrollbar), and b) differs from what all other editors do.

Here's a previous mentioning of this problem: https://github.com/zed-industries/zed/pull/9080#pullrequestreview-1927465293

This PR changes the "extended mode", making it synchronize the thumb top-to-top with the editor. It solves all the mentioned problems and makes the scroll thumb work the same whay as in other editors.

But if you want to stick to the idea of the center-to-center sync for large files, I can do that too.

Release Notes:

- Fixed scroll thumb behaviour.

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

- N/A
