### PR TITLE
Fix center element wrapper size

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4061,7 +4061,7 @@ impl Render for Workspace {
                                     .overflow_hidden()
                                     .child(
                                         h_flex()
-                                            .h_full()
+                                            .flex_1()
                                             .when_some(paddings.0, |this, p| {
                                                 this.child(p.border_r_1())
                                             })

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -158,7 +158,7 @@ For example, to disable ligatures for a given font you can add the following to 
 **Options**
 
 The `left_padding` and `right_padding` options define the relative width of the
-left and right padding of the central pane from the workspace when the centered layout mode is activated. Valid values range is from `0` to `0.45`.
+left and right padding of the central pane from the workspace when the centered layout mode is activated. Valid values range is from `0` to `0.4`.
 
 ## Copilot
 


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/pull/9754#pullrequestreview-2005401133
Fixes https://github.com/zed-industries/zed/pull/9754#issuecomment-2060536590
Closes https://github.com/zed-industries/zed/pull/10669

* Updates the docs to use a proper max value for the centered layout padding (0.4 instead of 0.45)
* Makes the `center` wrapper (`h_flex`) to be of size of the `center` element always, to ensure terminal lines are displayed correctly

The letter fix is somewhat hacky: while it does the right thing right now, it does not prevent us from future mistakes like these, and does not explain why the bottom dock could be of one, smaller, height, and its contents, the terminal pane/terminal element/something else would think that it has a larger height, thus breaking the scrolling and rendering.
cc @alygin if you're interested to solve another layout-related thing.

Release Notes:

- N/A
