### PR TITLE
Rename label to toggle inline git blame on/off

### DIFF
--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -155,7 +155,7 @@ impl Render for QuickActionBar {
                             }
 
                             menu = menu.toggleable_entry(
-                                "Show Git Blame",
+                                "Show Git Blame Inline",
                                 git_blame_inline_enabled,
                                 Some(editor::actions::ToggleGitBlameInline.boxed_clone()),
                                 {


### PR DESCRIPTION
cc @iamnbutler I think we should differentiate between inline blame and the gutter blame.

Release Notes:

- N/A
