### PR TITLE
project panel: Fix alignment of entries overflowing the panel.

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1642,7 +1642,10 @@ impl ProjectPanel {
                     .child(if let Some(icon) = &icon {
                         h_flex().child(Icon::from_path(icon.to_string()).color(filename_text_color))
                     } else {
-                        h_flex().size(IconSize::default().rems()).invisible()
+                        h_flex()
+                            .size(IconSize::default().rems())
+                            .invisible()
+                            .flex_none()
                     })
                     .child(
                         if let (Some(editor), true) = (Some(&self.filename_editor), show_editor) {


### PR DESCRIPTION
With file icons turned off, we still reserve space for an icon and make it invisible. However, that space was marked as flex, which made it shrink in case subsequent file name could not fit in the current width of the project panel. Fixes #10622


https://github.com/zed-industries/zed/assets/24362066/d565a03a-3712-49d1-bf52-407e4508a8cf


Release Notes:


- Fixed project panel entries misalignment with narrow panel & file icons turned off.
