### PR TITLE
Backport documentation for inline git blame

### DIFF
--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -555,9 +555,14 @@ To interpret all `.c` files as C++, and files called `MyLockFile` as TOML:
 - Default:
 
 ```json
-"git": {
-  "git_gutter": "tracked_files"
-},
+{
+  "git": {
+    "git_gutter": "tracked_files",
+    "inline_blame": {
+      "enabled": true
+    }
+  }
+}
 ```
 
 ### Git Gutter


### PR DESCRIPTION
Only noticed this when editing zed.dev.

Release Notes:

- N/A
