### PR TITLE
Do not show tooltip for editor controls if clicked

### DIFF
--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -180,7 +180,9 @@ impl Render for QuickActionBar {
                         quick_action_bar.toggle_settings_menu = Some(menu);
                     })
                 })
-                .tooltip(|cx| Tooltip::text("Editor Controls", cx));
+                .when(self.toggle_settings_menu.is_none(), |this| {
+                    this.tooltip(|cx| Tooltip::text("Editor Controls", cx))
+                });
 
         h_flex()
             .id("quick action bar")


### PR DESCRIPTION
This avoids the tooltip showing up when the context menu is visible.

It fixes this:

![screenshot-2024-04-17-13 17 41@2x](https://github.com/zed-industries/zed/assets/1185253/373bb70e-9c7f-4b9f-a928-8206697c6039)


Release Notes:

- N/A
