### PR TITLE
Add Min column option in git inline blame Enhancement

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1147,8 +1147,6 @@ impl EditorElement {
             content_origin.x
                 + max(line_width, min as f32 * em_width)
                 + (em_width * INLINE_BLAME_PADDING_EM_WIDTHS)
-
-            //  + line_width + (em_width * INLINE_BLAME_PADDING_EM_WIDTHS)
         };
 
         let absolute_offset = point(start_x, start_y);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -45,7 +45,7 @@ use smallvec::SmallVec;
 use std::{
     any::TypeId,
     borrow::Cow,
-    cmp::{self, Ordering},
+    cmp::{self, max, Ordering},
     fmt::Write,
     iter, mem,
     ops::Range,
@@ -1138,7 +1138,17 @@ impl EditorElement {
             let line_layout = &line_layouts[(row - start_row) as usize];
             let line_width = line_layout.line.width;
 
-            content_origin.x + line_width + (em_width * INLINE_BLAME_PADDING_EM_WIDTHS)
+            let project_settings = ProjectSettings::get_global(cx);
+            let inline_blame = project_settings.git.inline_blame;
+            let mut min = 0;
+            if inline_blame.is_some() && inline_blame.unwrap().min_column.is_some() {
+                min = inline_blame.unwrap().min_column.unwrap();
+            }
+            content_origin.x
+                + max(line_width, min as f32 * em_width)
+                + (em_width * INLINE_BLAME_PADDING_EM_WIDTHS)
+
+            //  + line_width + (em_width * INLINE_BLAME_PADDING_EM_WIDTHS)
         };
 
         let absolute_offset = point(start_x, start_y);

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -78,6 +78,8 @@ pub struct InlineBlameSettings {
     ///
     /// Default: 0
     pub delay_ms: Option<u64>,
+
+    pub min_column: Option<u32>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -78,7 +78,9 @@ pub struct InlineBlameSettings {
     ///
     /// Default: 0
     pub delay_ms: Option<u64>,
-
+    /// The minimum column number to show the inline blame information at
+    ///
+    /// Default: 0
     pub min_column: Option<u32>,
 }
 


### PR DESCRIPTION

Release Notes:

Added an option to set the minimum column position to show git inline blame info. 

Set git.inline_blame.min_column in settings.json to use it.