### PR TITLE
git blame: ignore uncommitted files or repos without commits

### DIFF
--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -63,6 +63,9 @@ impl Blame {
     }
 }
 
+const GIT_BLAME_NO_COMMIT_ERROR: &'static str = "fatal: no such ref: HEAD";
+const GIT_BLAME_NO_PATH: &'static str = "fatal: no such path";
+
 fn run_git_blame(
     git_binary: &Path,
     working_directory: &Path,
@@ -98,6 +101,10 @@ fn run_git_blame(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let trimmed = stderr.trim();
+        if trimmed == GIT_BLAME_NO_COMMIT_ERROR || trimmed.contains(GIT_BLAME_NO_PATH) {
+            return Ok(String::new());
+        }
         return Err(anyhow!("git blame process failed: {}", stderr));
     }
 


### PR DESCRIPTION
This fixes useless error messages popping up in case a file hasn't been committed yet or the repo doesn't have commits yet.

Release Notes:

- Fixed git blame functionality not handling errors correctly when there are no commits yet or when file isn't committed yet.