### PR TITLE
Improve Markdown Highlights

### DIFF
--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -20,5 +20,28 @@
   (info_string
     (language) @text.literal))
 
+; hack to deal with incorrect grammar parsing
+(atx_heading
+  (block_quote_marker) @punctuation.block_quote_marker
+)
+
+; hack to deal with incorrect grammar parsing
+(paragraph
+  (block_quote_marker) @punctuation.block_quote_marker
+)
+
+; hack to deal with incorrect grammar parsing
+(list_item
+  (block_quote_marker) @punctuation.block_quote_marker
+)
+
+(block_quote
+  (block_quote_marker) @punctuation.block_quote_marker
+)
+
+(block_quote
+  (paragraph) @text.block_quote
+)
+
 (link_destination) @link_uri
 (link_text) @link_text


### PR DESCRIPTION
Goals:

- [ ] Improve overall coverage of styleable markdown syntax
- [ ] Specifically add syntax keys for styling block quotes to resolve #10660

As I have time I'll start working through https://www.markdownguide.org/basic-syntax/ and checking we have coverage for as many Commonmark elements as possible.

If someone feels motivated to pick this up and continue it, feel free.

WIP - There are still a number of issues to tackle before merging this

![CleanShot - 2024-04-17 at 11 51 23@2x](https://github.com/zed-industries/zed/assets/1714999/dabff394-44e7-4def-ad38-bf28f08157b3)

Fixes #10660

Release Notes:

- Improved available highlights for Markdown files.
