### PR TITLE
project panel: do not expand collapsed worktrees on "collapse all entries"

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -599,7 +599,7 @@ impl ProjectPanel {
     }
 
     pub fn collapse_all_entries(&mut self, _: &CollapseAllEntries, cx: &mut ViewContext<Self>) {
-        self.expanded_dir_ids.clear();
+        self.expanded_dir_ids.values_mut().for_each(Vec::clear);
         self.update_visible_entries(None, cx);
         cx.notify();
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -599,7 +599,10 @@ impl ProjectPanel {
     }
 
     pub fn collapse_all_entries(&mut self, _: &CollapseAllEntries, cx: &mut ViewContext<Self>) {
-        self.expanded_dir_ids.values_mut().for_each(Vec::clear);
+        // By keeping entries for fully collapsed worktrees, we avoid expanding them within update_visible_entries
+        // (which is it's default behaviour when there's no entry for a worktree in expanded_dir_ids).
+        self.expanded_dir_ids
+            .retain(|_, expanded_entries| expanded_entries.is_empty());
         self.update_visible_entries(None, cx);
         cx.notify();
     }


### PR DESCRIPTION
Fixes #10597

Release Notes:

- Fixed "project panel: collapse all entries" expanding collapsed worktrees.
