### PR TITLE
prisma: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12736,7 +12736,7 @@ dependencies = [
 
 [[package]]
 name = "zed_prisma"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.4",
 ]

--- a/extensions/prisma/Cargo.toml
+++ b/extensions/prisma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_prisma"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/prisma/extension.toml
+++ b/extensions/prisma/extension.toml
@@ -1,7 +1,7 @@
 id = "prisma"
 name = "Prisma"
 description = "Prisma support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Matthew Gramigna <matthewgramigna@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Prisma extension to v0.02.

Changes:

- The Prisma extension now provides its own `tab_size` setting ([#10296](https://github.com/zed-industries/zed/pull/10296))

Release Notes:

- N/A
