### PR TITLE
Add a setting to show/hide the project panel button in the status bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -212,6 +212,8 @@
     "scroll_debounce_ms": 50
   },
   "project_panel": {
+    // Whether to show the project panel button in the status bar
+    "button": true,
     // Default width of the project panel.
     "default_width": 240,
     // Where to dock the project panel. Can be 'left' or 'right'.

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1899,8 +1899,10 @@ impl Panel for ProjectPanel {
         cx.notify();
     }
 
-    fn icon(&self, _: &WindowContext) -> Option<ui::IconName> {
-        Some(ui::IconName::FileTree)
+    fn icon(&self, cx: &WindowContext) -> Option<IconName> {
+        ProjectPanelSettings::get_global(cx)
+            .button
+            .then(|| IconName::FileTree)
     }
 
     fn icon_tooltip(&self, _cx: &WindowContext) -> Option<&'static str> {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -13,6 +13,7 @@ pub enum ProjectPanelDockPosition {
 
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ProjectPanelSettings {
+    pub button: bool,
     pub default_width: Pixels,
     pub dock: ProjectPanelDockPosition,
     pub file_icons: bool,
@@ -25,6 +26,10 @@ pub struct ProjectPanelSettings {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct ProjectPanelSettingsContent {
+    /// Whether to show the project panel button in the status bar.
+    ///
+    /// Default: true
+    pub button: Option<bool>,
     /// Customise default width (in pixels) taken by project panel
     ///
     /// Default: 240

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -1294,6 +1294,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 
 ```json
 "project_panel": {
+  "button": true,
   "dock": "left",
   "git_status": true,
   "default_width": "N/A - width in pixels"


### PR DESCRIPTION
### What?

A setting has been added to control the visibility of the Project Panel button in the status bar.

### Why?

I don't tend to use the Project Panel, but use a keyboard shortcut to access if needed. Thus, the button in the status bar provides me little more than visual clutter. Additionally, there is precedent for this configurability with other panels  (collaboration, chat, notification, terminal, etc).

Release Notes:

- Added a setting to show/hide the Project Panel button in the status bar. `{"project_panel": {"button": false}}`
