### PR TITLE
markdown preview: Update channel notes when other collaborator changes buffer

### DIFF
--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -305,6 +305,10 @@ impl ChannelView {
                 });
             }
             ChannelBufferEvent::BufferEdited => {
+                // Emit the event to the editor so that other views can update it's state (e.g. markdown preview)
+                self.editor.update(cx, |_, cx| {
+                    cx.emit(EditorEvent::Edited);
+                });
                 if self.editor.read(cx).is_focused(cx) {
                     self.acknowledge_buffer_version(cx);
                 } else {

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -305,7 +305,7 @@ impl ChannelView {
                 });
             }
             ChannelBufferEvent::BufferEdited => {
-                // Emit the event to the editor so that other views can update it's state (e.g. markdown preview)
+                // Emit the edited event on the editor context so that other views can update it's state (e.g. markdown preview)
                 self.editor.update(cx, |_, cx| {
                     cx.emit(EditorEvent::Edited);
                 });


### PR DESCRIPTION


https://github.com/zed-industries/zed/assets/53836821/9a57885e-83b0-49fb-b3a8-0a7868566b85


Release Notes:

- Markdown preview now re-renders when another collaborator changes the content of channel notes
