### PR TITLE
preview tabs: Allow replacing preview tab when using code navigation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -323,8 +323,10 @@
     // when you switch to another file unless you explicitly pin them.
     // This is useful for quickly viewing files without cluttering your workspace.
     "enabled": true,
-    // Whether to open files in preview mode when selected from the file finder.
-    "enable_preview_from_file_finder": false
+    // Whether to open tabs in preview mode when selected from the file finder.
+    "enable_preview_from_file_finder": false,
+    // Whether a preview tab remains in preview mode when code navigation is used to navigate away from the tab.
+    "enable_preview_from_code_navigation": false
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -325,7 +325,7 @@
     "enabled": true,
     // Whether to open tabs in preview mode when selected from the file finder.
     "enable_preview_from_file_finder": false,
-    // Whether a preview tab remains in preview mode when code navigation is used to navigate away from the tab.
+    // Whether a preview tab gets replaced when code navigation is used to navigate away from the tab.
     "enable_preview_from_code_navigation": false
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -99,6 +99,7 @@ impl ActivityIndicator {
                         Box::new(
                             cx.new_view(|cx| Editor::for_buffer(buffer, Some(project.clone()), cx)),
                         ),
+                        None,
                         cx,
                     );
                 }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -243,7 +243,7 @@ fn view_release_notes_locally(workspace: &mut Workspace, cx: &mut ViewContext<Wo
                                 Some(tab_description),
                                 cx,
                             );
-                            workspace.add_item_to_active_pane(Box::new(view.clone()), cx);
+                            workspace.add_item_to_active_pane(Box::new(view.clone()), None, cx);
                             cx.notify();
                         })
                         .log_err();

--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -310,7 +310,7 @@ async fn test_basic_following(
     let multibuffer_editor_a = workspace_a.update(cx_a, |workspace, cx| {
         let editor =
             cx.new_view(|cx| Editor::for_multibuffer(multibuffer_a, Some(project_a.clone()), cx));
-        workspace.add_item_to_active_pane(Box::new(editor.clone()), cx);
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, cx);
         editor
     });
     executor.run_until_parked();

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -477,7 +477,7 @@ mod tests {
         });
 
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(editor.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(editor.clone()), None, cx);
             editor.update(cx, |editor, cx| editor.focus(cx))
         });
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -222,7 +222,7 @@ impl ProjectDiagnosticsEditor {
             let diagnostics = cx.new_view(|cx| {
                 ProjectDiagnosticsEditor::new(workspace.project().clone(), workspace_handle, cx)
             });
-            workspace.add_item_to_active_pane(Box::new(diagnostics), cx);
+            workspace.add_item_to_active_pane(Box::new(diagnostics), None, cx);
         }
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8035,19 +8035,22 @@ impl Editor {
 
         let item = Box::new(editor);
         let item_id = item.item_id();
-        let mut destination_index = None;
-        workspace.active_pane().update(cx, |pane, cx| {
-            if PreviewTabsSettings::get_global(cx).enable_preview_from_code_navigation {
-                destination_index = pane.close_current_preview_item(cx);
-            }
-            pane.set_preview_item_id(Some(item_id), cx);
-        });
 
         if split {
             workspace.split_item(SplitDirection::Right, item.clone(), cx);
         } else {
+            let destination_index = workspace.active_pane().update(cx, |pane, cx| {
+                if PreviewTabsSettings::get_global(cx).enable_preview_from_code_navigation {
+                    pane.close_current_preview_item(cx)
+                } else {
+                    None
+                }
+            });
             workspace.add_item_to_active_pane(item.clone(), destination_index, cx);
         }
+        workspace.active_pane().update(cx, |pane, cx| {
+            pane.set_preview_item_id(Some(item_id), cx);
+        });
     }
 
     pub fn rename(&mut self, _: &Rename, cx: &mut ViewContext<Self>) -> Option<Task<Result<()>>> {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9161,7 +9161,7 @@ async fn test_mutlibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
                 workspace.active_item(cx).is_none(),
                 "active item should be None before the first item is added"
             );
-            workspace.add_item_to_active_pane(Box::new(multi_buffer_editor.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(multi_buffer_editor.clone()), None, cx);
             let active_item = workspace
                 .active_item(cx)
                 .expect("should have an active item after adding the multi buffer");

--- a/crates/editor/src/rust_analyzer_ext.rs
+++ b/crates/editor/src/rust_analyzer_ext.rs
@@ -106,6 +106,7 @@ pub fn expand_macro_recursively(
             });
             workspace.add_item_to_active_pane(
                 Box::new(cx.new_view(|cx| Editor::for_multibuffer(buffer, Some(project), cx))),
+                None,
                 cx,
             );
         })

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -45,7 +45,7 @@ pub fn init(cx: &mut AppContext) {
                     workspace.activate_item(&existing, cx);
                 } else {
                     let extensions_page = ExtensionsPage::new(workspace, cx);
-                    workspace.add_item_to_active_pane(Box::new(extensions_page), cx)
+                    workspace.add_item_to_active_pane(Box::new(extensions_page), None, cx)
                 }
             })
             .register_action(move |_, _: &InstallDevExtension, cx| {

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -97,6 +97,7 @@ pub fn init(cx: &mut AppContext) {
                     Box::new(cx.new_view(|cx| {
                         LspLogView::new(workspace.project().clone(), log_store.clone(), cx)
                     })),
+                    None,
                     cx,
                 );
             }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -738,7 +738,7 @@ impl ProjectSearchView {
 
         let model = cx.new_model(|cx| ProjectSearch::new(workspace.project().clone(), cx));
         let search = cx.new_view(|cx| ProjectSearchView::new(model, cx, None));
-        workspace.add_item_to_active_pane(Box::new(search.clone()), cx);
+        workspace.add_item_to_active_pane(Box::new(search.clone()), None, cx);
         search.update(cx, |search, cx| {
             search
                 .included_files_editor
@@ -789,6 +789,7 @@ impl ProjectSearchView {
                 });
                 workspace.add_item_to_active_pane(
                     Box::new(cx.new_view(|cx| ProjectSearchView::new(model, cx, None))),
+                    None,
                     cx,
                 );
             }
@@ -838,7 +839,7 @@ impl ProjectSearchView {
             let model = cx.new_model(|cx| ProjectSearch::new(workspace.project().clone(), cx));
             let view = cx.new_view(|cx| ProjectSearchView::new(model, cx, settings));
 
-            workspace.add_item_to_active_pane(Box::new(view.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(view.clone()), None, cx);
             view
         };
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -134,7 +134,7 @@ impl TerminalView {
                     cx,
                 )
             });
-            workspace.add_item_to_active_pane(Box::new(view), cx)
+            workspace.add_item_to_active_pane(Box::new(view), None, cx)
         }
     }
 

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -29,7 +29,7 @@ pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(|workspace: &mut Workspace, _cx| {
         workspace.register_action(|workspace, _: &Welcome, cx| {
             let welcome_page = WelcomePage::new(workspace, cx);
-            workspace.add_item_to_active_pane(Box::new(welcome_page), cx)
+            workspace.add_item_to_active_pane(Box::new(welcome_page), None, cx)
         });
     })
     .detach();

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -46,6 +46,7 @@ pub struct ItemSettings {
 pub struct PreviewTabsSettings {
     pub enabled: bool,
     pub enable_preview_from_file_finder: bool,
+    pub enable_preview_from_code_navigation: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -79,15 +80,19 @@ pub struct ItemSettingsContent {
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct PreviewTabsSettingsContent {
-    /// Whether to show opened editors as preview editors.
-    /// Preview editors do not stay open, are reused until explicitly set to be kept open opened (via double-click or editing) and show file names in italic.
+    /// Whether to show opened editors as preview tabs.
+    /// Preview tabs do not stay open, are reused until explicitly set to be kept open opened (via double-click or editing) and show file names in italic.
     ///
     /// Default: true
     enabled: Option<bool>,
-    /// Whether to open a preview editor when opening a file using the file finder.
+    /// Whether to open tabs in preview mode when selected from the file finder.
     ///
     /// Default: false
     enable_preview_from_file_finder: Option<bool>,
+    /// Whether a preview tab remains in preview mode when code navigation is used to navigate away from the tab.
+    ///
+    /// Default: false
+    enable_preview_from_code_navigation: Option<bool>,
 }
 
 impl Settings for ItemSettings {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -89,7 +89,7 @@ pub struct PreviewTabsSettingsContent {
     ///
     /// Default: false
     enable_preview_from_file_finder: Option<bool>,
-    /// Whether a preview tab remains in preview mode when code navigation is used to navigate away from the tab.
+    /// Whether a preview tab gets replaced when code navigation is used to navigate away from the tab.
     ///
     /// Default: false
     enable_preview_from_code_navigation: Option<bool>,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -617,21 +617,13 @@ impl Pane {
             self.activate_item(index, focus_item, focus_item, cx);
             existing_item
         } else {
-            let mut destination_index = None;
-            if allow_preview {
-                // If we are opening a new item as preview and we have an existing preview tab, remove it.
-                if let Some(item_idx) = self.preview_item_idx() {
-                    let prev_active_item_index = self.active_item_index;
-                    self.remove_item(item_idx, false, false, cx);
-                    self.active_item_index = prev_active_item_index;
-
-                    // If the item is being opened as preview and we have an existing preview tab,
-                    // open the new item in the position of the existing preview tab.
-                    if item_idx < self.items.len() {
-                        destination_index = Some(item_idx);
-                    }
-                }
-            }
+            // If the item is being opened as preview and we have an existing preview tab,
+            // open the new item in the position of the existing preview tab.
+            let destination_index = if allow_preview {
+                self.close_current_preview_item(cx)
+            } else {
+                None
+            };
 
             let new_item = build_item(cx);
 
@@ -642,6 +634,22 @@ impl Pane {
             self.add_item(new_item.clone(), true, focus_item, destination_index, cx);
 
             new_item
+        }
+    }
+
+    pub fn close_current_preview_item(&mut self, cx: &mut ViewContext<Self>) -> Option<usize> {
+        let Some(item_idx) = self.preview_item_idx() else {
+            return None;
+        };
+
+        let prev_active_item_index = self.active_item_index;
+        self.remove_item(item_idx, false, false, cx);
+        self.active_item_index = prev_active_item_index;
+
+        if item_idx < self.items.len() {
+            Some(item_idx)
+        } else {
+            None
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2000,8 +2000,13 @@ impl Workspace {
         }
     }
 
-    pub fn add_item_to_active_pane(&mut self, item: Box<dyn ItemHandle>, cx: &mut WindowContext) {
-        self.add_item(self.active_pane.clone(), item, None, cx)
+    pub fn add_item_to_active_pane(
+        &mut self,
+        item: Box<dyn ItemHandle>,
+        destination_index: Option<usize>,
+        cx: &mut WindowContext,
+    ) {
+        self.add_item(self.active_pane.clone(), item, destination_index, cx)
     }
 
     pub fn add_item(
@@ -5073,7 +5078,7 @@ mod tests {
             item
         });
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item1.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item1.clone()), None, cx);
         });
         item1.update(cx, |item, _| assert_eq!(item.tab_detail.get(), Some(0)));
 
@@ -5085,7 +5090,7 @@ mod tests {
             item
         });
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item2.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item2.clone()), None, cx);
         });
         item1.update(cx, |item, _| assert_eq!(item.tab_detail.get(), Some(1)));
         item2.update(cx, |item, _| assert_eq!(item.tab_detail.get(), Some(1)));
@@ -5099,7 +5104,7 @@ mod tests {
             item
         });
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item3.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item3.clone()), None, cx);
         });
         item1.update(cx, |item, _| assert_eq!(item.tab_detail.get(), Some(1)));
         item2.update(cx, |item, _| assert_eq!(item.tab_detail.get(), Some(3)));
@@ -5143,7 +5148,7 @@ mod tests {
 
         // Add an item to an empty pane
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item1), cx)
+            workspace.add_item_to_active_pane(Box::new(item1), None, cx)
         });
         project.update(cx, |project, cx| {
             assert_eq!(
@@ -5157,7 +5162,7 @@ mod tests {
 
         // Add a second item to a non-empty pane
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item2), cx)
+            workspace.add_item_to_active_pane(Box::new(item2), None, cx)
         });
         assert_eq!(cx.window_title().as_deref(), Some("two.txt — root1"));
         project.update(cx, |project, cx| {
@@ -5212,7 +5217,7 @@ mod tests {
         // When there are no dirty items, there's nothing to do.
         let item1 = cx.new_view(|cx| TestItem::new(cx));
         workspace.update(cx, |w, cx| {
-            w.add_item_to_active_pane(Box::new(item1.clone()), cx)
+            w.add_item_to_active_pane(Box::new(item1.clone()), None, cx)
         });
         let task = workspace.update(cx, |w, cx| w.prepare_to_close(false, cx));
         assert!(task.await.unwrap());
@@ -5226,8 +5231,8 @@ mod tests {
                 .with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
         });
         workspace.update(cx, |w, cx| {
-            w.add_item_to_active_pane(Box::new(item2.clone()), cx);
-            w.add_item_to_active_pane(Box::new(item3.clone()), cx);
+            w.add_item_to_active_pane(Box::new(item2.clone()), None, cx);
+            w.add_item_to_active_pane(Box::new(item3.clone()), None, cx);
         });
         let task = workspace.update(cx, |w, cx| w.prepare_to_close(false, cx));
         cx.executor().run_until_parked();
@@ -5271,10 +5276,10 @@ mod tests {
                 .with_project_items(&[TestProjectItem::new_untitled(cx)])
         });
         let pane = workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item1.clone()), cx);
-            workspace.add_item_to_active_pane(Box::new(item2.clone()), cx);
-            workspace.add_item_to_active_pane(Box::new(item3.clone()), cx);
-            workspace.add_item_to_active_pane(Box::new(item4.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item1.clone()), None, cx);
+            workspace.add_item_to_active_pane(Box::new(item2.clone()), None, cx);
+            workspace.add_item_to_active_pane(Box::new(item3.clone()), None, cx);
+            workspace.add_item_to_active_pane(Box::new(item4.clone()), None, cx);
             workspace.active_pane().clone()
         });
 
@@ -5396,9 +5401,9 @@ mod tests {
         //     multi-entry items:   (3, 4)
         let left_pane = workspace.update(cx, |workspace, cx| {
             let left_pane = workspace.active_pane().clone();
-            workspace.add_item_to_active_pane(Box::new(item_2_3.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item_2_3.clone()), None, cx);
             for item in single_entry_items {
-                workspace.add_item_to_active_pane(Box::new(item), cx);
+                workspace.add_item_to_active_pane(Box::new(item), None, cx);
             }
             left_pane.update(cx, |pane, cx| {
                 pane.activate_item(2, true, true, cx);
@@ -5469,7 +5474,7 @@ mod tests {
         });
         let item_id = item.entity_id();
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, cx);
         });
 
         // Autosave on window change.
@@ -5554,7 +5559,7 @@ mod tests {
 
         // Add the item again, ensuring autosave is prevented if the underlying file has been deleted.
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, cx);
         });
         item.update(cx, |item, cx| {
             item.project_items[0].update(cx, |item, _| {
@@ -5592,7 +5597,7 @@ mod tests {
         let toolbar_notify_count = Rc::new(RefCell::new(0));
 
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(Box::new(item.clone()), cx);
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, cx);
             let toolbar_notification_count = toolbar_notify_count.clone();
             cx.observe(&toolbar, move |_, _, _| {
                 *toolbar_notification_count.borrow_mut() += 1

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -593,7 +593,7 @@ fn open_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
                             })
                         });
 
-                        workspace.add_item_to_active_pane(Box::new(editor), cx);
+                        workspace.add_item_to_active_pane(Box::new(editor), None, cx);
                     })
                     .log_err();
             })
@@ -812,7 +812,7 @@ fn open_telemetry_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Works
                 });
                 workspace.add_item_to_active_pane(
                     Box::new(cx.new_view(|cx| Editor::for_multibuffer(buffer, Some(project), cx))),
-                    cx,
+                    None,cx,
                 );
             }).log_err()?;
 
@@ -848,6 +848,7 @@ fn open_bundled_file(
                         Box::new(cx.new_view(|cx| {
                             Editor::for_multibuffer(buffer, Some(project.clone()), cx)
                         })),
+                        None,
                         cx,
                     );
                 })

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -798,7 +798,8 @@ These values take in the same options as the root-level settings with the same n
 ```json
 "preview_tabs": {
   "enabled": true,
-  "enable_preview_from_file_finder": false
+  "enable_preview_from_file_finder": false,
+  "enable_preview_from_code_navigation": false,
 }
 ```
 
@@ -806,6 +807,16 @@ These values take in the same options as the root-level settings with the same n
 
 - Description: Determines whether to open files in preview mode when selected from the file finder.
 - Setting: `enable_preview_from_file_finder`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
+### Enable preview from code navigation
+
+- Description: Determines whether a preview tab gets replaced when code navigation is used to navigate away from the tab (requires Zed `0.134.x`).
+- Setting: `enable_preview_from_code_navigation`
 - Default: `false`
 
 **Options**


### PR DESCRIPTION
This PR adds support for replacing the current preview tab when using GoToDefinition. Previously a tab, that was navigated away from, was converted into a permanent tab and the new tab was opened as preview.

Without `enable_preview_from_code_navigation`:

https://github.com/zed-industries/zed/assets/53836821/99840724-d6ff-4738-a9c4-ee71a0001634

With `enable_preview_from_code_navigation`:

https://github.com/zed-industries/zed/assets/53836821/8c60efcb-d597-40bf-b08b-13faf5a289b6

Note: In the future I would like to improve support for the navigation history, because right now tabs that are not "normal" project items, e.g. FindAllReferences cannot be reopened

Release Notes:

- Added support for replacing the current preview tab when using code navigation (`enable_preview_from_code_navigation`)
