### PR TITLE
Add traits in Rust highlights

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -5,6 +5,8 @@
 
 (trait_item name: (type_identifier) @type.interface)
 (impl_item trait: (type_identifier) @type.interface)
+(abstract_type trait: (type_identifier) @type.interface)
+(dynamic_type trait: (type_identifier) @type.interface)
 (trait_bounds (type_identifier) @type.interface)
 
 (call_expression

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -3,9 +3,9 @@
 (self) @variable.special
 (field_identifier) @property
 
-(trait_item name: (type_identifier) @type.super)
-(impl_item trait: (type_identifier) @type.super)
-(trait_bounds (type_identifier) @type.super)
+(trait_item name: (type_identifier) @type.interface)
+(impl_item trait: (type_identifier) @type.interface)
+(trait_bounds (type_identifier) @type.interface)
 
 (call_expression
   function: [

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -3,6 +3,10 @@
 (self) @variable.special
 (field_identifier) @property
 
+(trait_item name: (type_identifier) @type.super)
+(impl_item trait: (type_identifier) @type.super)
+(trait_bounds (type_identifier) @type.super)
+
 (call_expression
   function: [
     (identifier) @function


### PR DESCRIPTION
Question: I use type.super here because I made a similar change to the ruby syntax to apply the same style to superclasses.
With this in mind, should this change be renamed to type.trait or should it be renamed to something like type.italic so the ruby syntax or any other language can all use type.italic? or maybe something else altogether.

<img width="597" alt="image" src="https://github.com/zed-industries/zed/assets/7274458/9d02dba0-75a4-4439-9f31-fd8aa0873075">

Release Notes:

- Exposed Rust traits as `type.interface` for individual syntax theming.

