### PR TITLE
glsl: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12701,7 +12701,7 @@ dependencies = [
 
 [[package]]
 name = "zed_glsl"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/glsl/Cargo.toml
+++ b/extensions/glsl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_glsl"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/glsl/extension.toml
+++ b/extensions/glsl/extension.toml
@@ -1,7 +1,7 @@
 id = "glsl"
 name = "GLSL"
 description = "GLSL support."
-version = "0.0.1"
+version = "0.1.0"
 schema_version = 1
 authors = ["Mikayla Maki <mikayla@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the GLSL extension to v0.1.0.

Changes:

- #10694

Release Notes:

- N/A
