### PR TITLE
Fix stutter while dragging something over an element that stops event propagation

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -603,6 +603,9 @@ impl EditorElement {
         } else {
             editor.hide_hovered_link(cx);
             hover_at(editor, None, cx);
+            if gutter_hovered {
+                cx.stop_propagation();
+            }
         }
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -603,9 +603,6 @@ impl EditorElement {
         } else {
             editor.hide_hovered_link(cx);
             hover_at(editor, None, cx);
-            if gutter_hovered {
-                cx.stop_propagation();
-            }
         }
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1299,7 +1299,7 @@ impl<'a> WindowContext<'a> {
         });
         self.window.rendered_frame.mouse_listeners = mouse_listeners;
 
-        if self.app.propagate_event && self.has_active_drag() {
+        if self.has_active_drag() {
             if event.is::<MouseMoveEvent>() {
                 // If this was a mouse move event, redraw the window so that the
                 // active drag can follow the mouse cursor.


### PR DESCRIPTION
~~This is extracted from #10643.~~

~~It looks like the editor had a small optimization to drop events when hovering the gutter. This also happens while dragging a tab over the gutter, and causes some stuttering. Please correct me if this wasn't just a small optimization, but I could not derive a different reason for this code to exist.~~

The window was waiting for event propagation to update any drag. This change makes sure the drag always gets updated, which makes sure it will always be fluid, no matter if any element stops event propagation. Ty @as-cii for pointing me to a better solution!

Release Notes:

- Fixed issue where dragging tab over any element that stops event propagation would stutter