### PR TITLE
Add "Open in Terminal" context menu entries for project panel, editor and tab context menus

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -131,10 +131,10 @@ use ui::{
 use util::{defer, maybe, post_inc, RangeExt, ResultExt, TryFutureExt};
 use workspace::item::ItemHandle;
 use workspace::notifications::NotificationId;
-use workspace::Toast;
 use workspace::{
     searchable::SearchEvent, ItemNavHistory, SplitDirection, ViewId, Workspace, WorkspaceId,
 };
+use workspace::{OpenInTerminal, OpenTerminal, Toast};
 
 use crate::hover_links::find_url;
 
@@ -4917,6 +4917,25 @@ impl Editor {
                 });
                 editor.change_selections(None, cx, |selections| selections.refresh());
             });
+        }
+    }
+
+    pub fn open_active_item_in_terminal(&mut self, _: &OpenInTerminal, cx: &mut ViewContext<Self>) {
+        if let Some(working_directory) = self.active_excerpt(cx).and_then(|(_, buffer, _)| {
+            let project_path = buffer.read(cx).project_path(cx)?;
+            let project = self.project.as_ref()?.read(cx);
+            let entry = project.entry_for_path(&project_path, cx)?;
+            let abs_path = project.absolute_path(&project_path, cx)?;
+            let parent = if entry.is_symlink {
+                abs_path.canonicalize().ok()?
+            } else {
+                abs_path
+            }
+            .parent()?
+            .to_path_buf();
+            Some(parent)
+        }) {
+            cx.dispatch_action(OpenTerminal { working_directory }.boxed_clone());
         }
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -363,6 +363,7 @@ impl EditorElement {
         register_action(view, cx, Editor::unique_lines_case_sensitive);
         register_action(view, cx, Editor::accept_partial_inline_completion);
         register_action(view, cx, Editor::revert_selected_hunks);
+        register_action(view, cx, Editor::open_active_item_in_terminal)
     }
 
     fn register_key_listeners(&self, cx: &mut ElementContext, layout: &EditorLayout) {

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -3,6 +3,7 @@ use crate::{
     GoToTypeDefinition, Rename, RevealInFinder, SelectMode, ToggleCodeActions,
 };
 use gpui::{DismissEvent, Pixels, Point, Subscription, View, ViewContext};
+use workspace::OpenInTerminal;
 
 pub struct MouseContextMenu {
     pub(crate) position: Point<Pixels>,
@@ -83,6 +84,7 @@ pub fn deploy_context_menu(
                 )
                 .separator()
                 .action("Reveal in Finder", Box::new(RevealInFinder))
+                .action("Open in Terminal…", Box::new(OpenInTerminal))
         })
     };
     let mouse_context_menu = MouseContextMenu::new(position, context_menu, cx);

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -84,7 +84,7 @@ pub fn deploy_context_menu(
                 )
                 .separator()
                 .action("Reveal in Finder", Box::new(RevealInFinder))
-                .action("Open in Terminal…", Box::new(OpenInTerminal))
+                .action("Open in Terminal", Box::new(OpenInTerminal))
         })
     };
     let mouse_context_menu = MouseContextMenu::new(position, context_menu, cx);

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -440,7 +440,7 @@ impl ProjectPanel {
                             .action("New Folder", Box::new(NewDirectory))
                             .separator()
                             .action("Reveal in Finder", Box::new(RevealInFinder))
-                            .action("Open in Terminal…", Box::new(OpenInTerminal))
+                            .action("Open in Terminal", Box::new(OpenInTerminal))
                             .when(is_dir, |menu| {
                                 menu.separator()
                                     .action("Find in Folder…", Box::new(NewSearchInDirectory))

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -37,7 +37,7 @@ use util::{maybe, NumericPrefixWithSuffix, ResultExt, TryFutureExt};
 use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
     notifications::DetachAndPromptErr,
-    Workspace,
+    OpenInTerminal, Workspace,
 };
 
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
@@ -127,7 +127,6 @@ actions!(
         CopyPath,
         CopyRelativePath,
         RevealInFinder,
-        OpenInTerminal,
         Cut,
         Paste,
         Rename,

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -98,7 +98,6 @@ impl TerminalPanel {
                             .on_click(cx.listener(|pane, _, cx| {
                                 pane.toggle_zoom(&workspace::ToggleZoom, cx);
                             }))
-                            // TODO kb
                             .tooltip(move |cx| {
                                 Tooltip::for_action(
                                     if zoomed { "Zoom Out" } else { "Zoom In" },

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -292,13 +292,13 @@ impl TerminalPanel {
         action: &workspace::OpenTerminal,
         cx: &mut ViewContext<Workspace>,
     ) {
-        let Some(this) = workspace.focus_panel::<Self>(cx) else {
+        let Some(terminal_panel) = workspace.panel::<Self>(cx) else {
             return;
         };
-
-        this.update(cx, |this, cx| {
-            this.add_terminal(Some(action.working_directory.clone()), None, cx)
-        })
+        terminal_panel.update(cx, |panel, cx| {
+            panel.add_terminal(Some(action.working_directory.clone()), None, cx)
+        });
+        workspace.focus_panel::<Self>(cx);
     }
 
     fn spawn_task(&mut self, spawn_in_terminal: &SpawnInTerminal, cx: &mut ViewContext<Self>) {
@@ -427,26 +427,17 @@ impl TerminalPanel {
         }
     }
 
-    ///Create a new Terminal in the current working directory or the user's home directory
+    /// Create a new Terminal in the current working directory or the user's home directory
     fn new_terminal(
         workspace: &mut Workspace,
         _: &workspace::NewTerminal,
         cx: &mut ViewContext<Workspace>,
     ) {
-        let has_no_terminals = workspace
-            .panel::<Self>(cx)
-            .map(|terminal_panel| terminal_panel.update(cx, |panel, cx| panel.has_no_terminals(cx)))
-            .unwrap_or(true);
-        let Some(this) = workspace.focus_panel::<Self>(cx) else {
+        let Some(terminal_panel) = workspace.panel::<Self>(cx) else {
             return;
         };
-        if has_no_terminals {
-            // `set_active` on focus, will already add a new terminal
-            // into an empty terminal pane, no need to add another one
-            return;
-        }
-
-        this.update(cx, |this, cx| this.add_terminal(None, None, cx))
+        terminal_panel.update(cx, |this, cx| this.add_terminal(None, None, cx));
+        workspace.focus_panel::<Self>(cx);
     }
 
     fn terminals_for_task(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1624,20 +1624,6 @@ impl Pane {
 
                         menu = menu
                             .separator()
-                            .when_some(parent_abs_path, |menu, abs_path| {
-                                menu.entry(
-                                    "Open in Terminal…",
-                                    Some(Box::new(OpenInTerminal)),
-                                    cx.handler_for(&pane, move |_, cx| {
-                                        cx.dispatch_action(
-                                            OpenTerminal {
-                                                working_directory: abs_path.clone(),
-                                            }
-                                            .boxed_clone(),
-                                        );
-                                    }),
-                                )
-                            })
                             .entry(
                                 "Reveal In Project Panel",
                                 Some(Box::new(RevealInProjectPanel {
@@ -1650,7 +1636,21 @@ impl Pane {
                                         ))
                                     });
                                 }),
-                            );
+                            )
+                            .when_some(parent_abs_path, |menu, abs_path| {
+                                menu.entry(
+                                    "Open in Terminal",
+                                    Some(Box::new(OpenInTerminal)),
+                                    cx.handler_for(&pane, move |_, cx| {
+                                        cx.dispatch_action(
+                                            OpenTerminal {
+                                                working_directory: abs_path.clone(),
+                                            }
+                                            .boxed_clone(),
+                                        );
+                                    }),
+                                )
+                            });
                     }
                 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1621,7 +1621,6 @@ impl Pane {
                             .flatten();
 
                         let entry_id = entry.to_proto();
-
                         menu = menu
                             .separator()
                             .entry(
@@ -2018,27 +2017,6 @@ impl Render for Pane {
                     }
                 }),
             )
-            .on_action(cx.listener(|pane, _: &OpenInTerminal, cx| {
-                if let Some(working_directory) = pane
-                    .active_item()
-                    .and_then(|item| item.project_path(cx))
-                    .and_then(|project_path| {
-                        let project = pane.project.read(cx);
-                        let entry = project.entry_for_path(&project_path, cx)?;
-                        let abs_path = project.absolute_path(&project_path, cx)?;
-                        let parent = if entry.is_symlink {
-                            abs_path.canonicalize().ok()?
-                        } else {
-                            abs_path
-                        }
-                        .parent()?
-                        .to_path_buf();
-                        Some(parent)
-                    })
-                {
-                    cx.dispatch_action(OpenTerminal { working_directory }.boxed_clone())
-                }
-            }))
             .when(self.active_item().is_some(), |pane| {
                 pane.child(self.render_tab_bar(cx))
             })

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -112,6 +112,7 @@ actions!(
     workspace,
     [
         Open,
+        OpenInTerminal,
         NewFile,
         NewWindow,
         CloseWindow,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/4566

Pane tabs (does not exist for multibuffer tabs):
<img width="439" alt="Screenshot 2024-04-18 at 23 01 08" src="https://github.com/zed-industries/zed/assets/2690773/3af79ed8-07ea-4cf2-bcf9-735b1b3be8c4">

Editor context menu:
<img width="404" alt="Screenshot 2024-04-18 at 23 01 14" src="https://github.com/zed-industries/zed/assets/2690773/38ea7afc-df2b-45ef-8331-eb6a4588af9f">

Project panel context menu (was not shown for file entries before this):
<img width="408" alt="Screenshot 2024-04-18 at 23 01 18" src="https://github.com/zed-industries/zed/assets/2690773/e336fce1-7da0-4671-b8d2-8d3409c23eb6">

Release Notes:

- (breaking change) Moved `project_panel::OpenInTerminal` into `workspace::OpenInTerminal` action and add it in editors, tab context menus and proper panel file entries ([4566](https://github.com/zed-industries/zed/issues/4566))
