### PR TITLE
Select buffer search query on follow-up cmd-f

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -436,6 +436,7 @@ impl BufferSearchBar {
     pub fn register(registrar: &mut impl SearchActionsRegistrar) {
         registrar.register_handler(ForDeployed(|this, _: &FocusSearch, cx| {
             this.query_editor.focus_handle(cx).focus(cx);
+            this.select_query(cx);
         }));
         registrar.register_handler(ForDeployed(|this, action: &ToggleCaseSensitive, cx| {
             if this.supported_options().case {


### PR DESCRIPTION
https://github.com/zed-industries/zed/assets/2690773/fd754cfc-aca5-4c4d-9b42-53d1c8eca0e9

Unfortunately, the tests did not work for me, as the `FocusSearch` action handlers were never called for me.

Release Notes:

- Improved buffer search workflow: follow-up cmd-f select query string