### PR TITLE
Prevent command prompt from opening when running git blame on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4327,6 +4327,7 @@ dependencies = [
  "time",
  "unindent",
  "url",
+ "windows 0.53.0",
 ]
 
 [[package]]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -24,6 +24,7 @@ text.workspace = true
 time.workspace = true
 url.workspace = true
 serde.workspace = true
+windows.workspace = true
 
 [dev-dependencies]
 unindent.workspace = true

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -14,6 +14,9 @@ use time::OffsetDateTime;
 use time::UtcOffset;
 use url::Url;
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
 pub use git2 as libgit;
 
 #[derive(Debug, Clone, Default)]
@@ -76,7 +79,9 @@ fn run_git_blame(
     path: &Path,
     contents: &Rope,
 ) -> Result<String> {
-    let child = Command::new(git_binary)
+    let mut child = Command::new(git_binary);
+
+    child
         .current_dir(working_directory)
         .arg("blame")
         .arg("--incremental")
@@ -85,8 +90,12 @@ fn run_git_blame(
         .arg(path.as_os_str())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+        .stderr(Stdio::piped());
+
+    #[cfg(windows)]
+    child.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
+
+    let child = child.spawn()
         .map_err(|e| anyhow!("Failed to start git blame process: {}", e))?;
 
     let mut stdin = child

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -95,7 +95,8 @@ fn run_git_blame(
     #[cfg(windows)]
     child.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
 
-    let child = child.spawn()
+    let child = child
+        .spawn()
         .map_err(|e| anyhow!("Failed to start git blame process: {}", e))?;
 
     let mut stdin = child


### PR DESCRIPTION

Release Notes:

- Fixed issue reported in discord where the git blame feature would open command prompt windows
