### PR TITLE
windows: Fix panic with some unicode characters

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -928,8 +928,11 @@ impl IDWriteTextRenderer_Impl for TextRenderer {
     ) -> windows::core::Result<()> {
         unsafe {
             let glyphrun = &*glyphrun;
-            let desc = &*glyphrundescription;
             let glyph_count = glyphrun.glyphCount as usize;
+            if glyph_count == 0 {
+                return Ok(());
+            }
+            let desc = &*glyphrundescription;
             let utf16_length_per_glyph = desc.stringLength as usize / glyph_count;
             let context =
                 &mut *(clientdrawingcontext as *const RendererContext as *mut RendererContext);


### PR DESCRIPTION
Fix #10749 

Release Notes:

- N/A
