### PR TITLE
chore: Revert accidental pushes to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4318,9 +4318,7 @@ dependencies = [
  "git2",
  "lazy_static",
  "log",
- "parking_lot",
  "pretty_assertions",
- "rope",
  "serde",
  "serde_json",
  "smol",
@@ -4329,7 +4327,6 @@ dependencies = [
  "time",
  "unindent",
  "url",
- "util",
  "windows 0.53.0",
 ]
 

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -24,9 +24,6 @@ text.workspace = true
 time.workspace = true
 url.workspace = true
 serde.workspace = true
-rope.workspace = true
-util.workspace = true
-parking_lot.workspace = true
 windows.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
This reverts two commits that I've just pushed to main instead of `move-repository-trait-into-git`. Mea culpa.
Release Notes:

- N/A
