### PR TITLE
storybook: Fix crash in Picker story

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9418,6 +9418,7 @@ dependencies = [
  "log",
  "menu",
  "picker",
+ "project",
  "rust-embed",
  "settings",
  "simplelog",

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -26,6 +26,7 @@ language.workspace = true
 log.workspace = true
 menu.workspace = true
 picker.workspace = true
+project.workspace = true
 rust-embed.workspace = true
 settings.workspace = true
 simplelog = "0.9"

--- a/crates/storybook/src/stories/picker.rs
+++ b/crates/storybook/src/stories/picker.rs
@@ -1,6 +1,7 @@
 use fuzzy::StringMatchCandidate;
 use gpui::{div, prelude::*, KeyBinding, Render, SharedString, Styled, Task, View, WindowContext};
 use picker::{Picker, PickerDelegate};
+use project::Project;
 use std::sync::Arc;
 use ui::{prelude::*, ListItemSpacing};
 use ui::{Label, ListItem};
@@ -190,6 +191,7 @@ impl PickerStory {
                     ]);
                     delegate.update_matches("".into(), cx).detach();
 
+                    Project::init_settings(cx);
                     let picker = Picker::uniform_list(delegate, cx);
                     picker.focus(cx);
                     picker


### PR DESCRIPTION

@mikayla-maki approved my suggested change as noted in the issue below...

Release Notes:

- Fixed: [#10739 ](https://github.com/zed-industries/zed/issues/10739)
