### PR TITLE
XDG_BASE_DIR support (linux, windows)

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -54,16 +54,12 @@ lazy_static::lazy_static! {
     pub static ref COPILOT_DIR: PathBuf = SUPPORT_DIR.join("copilot");
     pub static ref DEFAULT_PRETTIER_DIR: PathBuf = SUPPORT_DIR.join("prettier");
     pub static ref DB_DIR: PathBuf = SUPPORT_DIR.join("db");
-    pub static ref CRASHES_DIR: PathBuf = if cfg!(target_os = "macos") {
-        HOME.join("Library/Logs/DiagnosticReports")
-    } else {
-        SUPPORT_DIR.join("crashes")
-    };
-    pub static ref CRASHES_RETIRED_DIR: PathBuf = if cfg!(target_os = "macos") {
-        CRASHES_DIR.join("Retired")
-    } else {
-        CRASHES_DIR.join("retired")
-    };
+    pub static ref CRASHES_DIR: Option<PathBuf> = cfg!(target_os = "macos")
+        .then_some(HOME.join("Library/Logs/DiagnosticReports"));
+    pub static ref CRASHES_RETIRED_DIR: Option<PathBuf> = CRASHES_DIR
+        .as_ref()
+        .map(|dir| dir.join("Retired"));
+
     pub static ref SETTINGS: PathBuf = CONFIG_DIR.join("settings.json");
     pub static ref KEYMAP: PathBuf = CONFIG_DIR.join("keymap.json");
     pub static ref TASKS: PathBuf = CONFIG_DIR.join("tasks.json");

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -19,8 +19,16 @@ lazy_static::lazy_static! {
     } else {
         HOME.join(".config").join("zed")
     };
-    pub static ref CONVERSATIONS_DIR: PathBuf = CONFIG_DIR.join("conversations");
-    pub static ref EMBEDDINGS_DIR: PathBuf = CONFIG_DIR.join("embeddings");
+    pub static ref CONVERSATIONS_DIR: PathBuf = if cfg!(target_os = "macos") {
+        CONFIG_DIR.join("conversations")
+    } else {
+        SUPPORT_DIR.join("conversations")
+    };
+    pub static ref EMBEDDINGS_DIR: PathBuf = if cfg!(target_os = "macos") {
+        CONFIG_DIR.join("embeddings")
+    } else {
+        SUPPORT_DIR.join("embeddings")
+    };
     pub static ref THEMES_DIR: PathBuf = CONFIG_DIR.join("themes");
 
     pub static ref SUPPORT_DIR: PathBuf = if cfg!(target_os = "macos") {

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -22,23 +22,24 @@ lazy_static::lazy_static! {
     pub static ref CONVERSATIONS_DIR: PathBuf = CONFIG_DIR.join("conversations");
     pub static ref EMBEDDINGS_DIR: PathBuf = CONFIG_DIR.join("embeddings");
     pub static ref THEMES_DIR: PathBuf = CONFIG_DIR.join("themes");
-    pub static ref LOGS_DIR: PathBuf = if cfg!(target_os = "macos") {
-        HOME.join("Library/Logs/Zed")
-    } else if cfg!(target_os = "windows") {
-        dirs::data_local_dir()
-            .expect("failed to determine LocalAppData directory")
-            .join("Zed/logs")
+
+    pub static ref SUPPORT_DIR: PathBuf = if cfg!(target_os = "macos") {
+        HOME.join("Library/Application Support/Zed")
     } else if cfg!(target_os = "linux") {
         dirs::data_local_dir()
             .expect("failed to determine XDG_DATA_DIR directory")
-            .join("zed/logs")
-    } else {
-        CONFIG_DIR.join("logs")
-    };
-    pub static ref SUPPORT_DIR: PathBuf = if cfg!(target_os = "macos") {
-        HOME.join("Library/Application Support/Zed")
+            .join("zed")
+    } else if cfg!(target_os = "windows") {
+        dirs::data_local_dir()
+            .expect("failed to determine LocalAppData directory")
+            .join("Zed")
     } else {
         CONFIG_DIR.clone()
+    };
+    pub static ref LOGS_DIR: PathBuf = if cfg!(target_os = "macos") {
+        HOME.join("Library/Logs/Zed")
+    } else {
+        SUPPORT_DIR.join("logs")
     };
     pub static ref EXTENSIONS_DIR: PathBuf = SUPPORT_DIR.join("extensions");
     pub static ref LANGUAGES_DIR: PathBuf = SUPPORT_DIR.join("languages");
@@ -47,19 +48,11 @@ lazy_static::lazy_static! {
     pub static ref DB_DIR: PathBuf = SUPPORT_DIR.join("db");
     pub static ref CRASHES_DIR: PathBuf = if cfg!(target_os = "macos") {
         HOME.join("Library/Logs/DiagnosticReports")
-    } else if cfg!(target_os = "windows") {
-        dirs::data_local_dir()
-            .expect("failed to determine LocalAppData directory")
-            .join("Zed/crashes")
-    } else if cfg!(target_os = "linux") {
-        dirs::data_local_dir()
-            .expect("failed to determine XDG_DATA_DIR directory")
-            .join("zed/crashes")
     } else {
-        CONFIG_DIR.join("crashes")
+        SUPPORT_DIR.join("crashes")
     };
     pub static ref CRASHES_RETIRED_DIR: PathBuf = if cfg!(target_os = "macos") {
-        HOME.join("Library/Logs/DiagnosticReports/Retired")
+        CRASHES_DIR.join("Retired")
     } else {
         CRASHES_DIR.join("retired")
     };
@@ -73,13 +66,13 @@ lazy_static::lazy_static! {
     pub static ref LOCAL_TASKS_RELATIVE_PATH: &'static Path = Path::new(".zed/tasks.json");
     pub static ref LOCAL_VSCODE_TASKS_RELATIVE_PATH: &'static Path = Path::new(".vscode/tasks.json");
     pub static ref TEMP_DIR: PathBuf = if cfg!(target_os = "widows") {
-        dirs::data_local_dir()
+        dirs::cache_dir()
             .expect("failed to determine LocalAppData directory")
-            .join("Temp/Zed")
+            .join("Zed")
     } else if cfg!(target_os = "linux") {
-        dirs::data_local_dir()
-            .expect("failed to determine XDG_DATA_DIR directory")
-            .join("tmp/zed")
+        dirs::cache_dir()
+            .expect("failed to determine XDG_CACHE_HOME directory")
+            .join("zed")
     } else {
         HOME.join(".cache").join("zed")
     };

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -12,6 +12,10 @@ lazy_static::lazy_static! {
         dirs::config_dir()
             .expect("failed to determine RoamingAppData directory")
             .join("Zed")
+    } else if cfg!(target_os = "linux") {
+        dirs::config_dir()
+            .expect("failed to determine XDG_CONFIG_HOME directory")
+            .join("zed")
     } else {
         HOME.join(".config").join("zed")
     };
@@ -24,15 +28,15 @@ lazy_static::lazy_static! {
         dirs::data_local_dir()
             .expect("failed to determine LocalAppData directory")
             .join("Zed/logs")
+    } else if cfg!(target_os = "linux") {
+        dirs::data_local_dir()
+            .expect("failed to determine XDG_DATA_DIR directory")
+            .join("zed/logs")
     } else {
         CONFIG_DIR.join("logs")
     };
     pub static ref SUPPORT_DIR: PathBuf = if cfg!(target_os = "macos") {
         HOME.join("Library/Application Support/Zed")
-    } else if cfg!(target_os = "windows") {
-        dirs::config_dir()
-            .expect("failed to determine RoamingAppData directory")
-            .join("Zed")
     } else {
         CONFIG_DIR.clone()
     };
@@ -47,6 +51,10 @@ lazy_static::lazy_static! {
         dirs::data_local_dir()
             .expect("failed to determine LocalAppData directory")
             .join("Zed/crashes")
+    } else if cfg!(target_os = "linux") {
+        dirs::data_local_dir()
+            .expect("failed to determine XDG_DATA_DIR directory")
+            .join("zed/crashes")
     } else {
         CONFIG_DIR.join("crashes")
     };
@@ -68,6 +76,10 @@ lazy_static::lazy_static! {
         dirs::data_local_dir()
             .expect("failed to determine LocalAppData directory")
             .join("Temp/Zed")
+    } else if cfg!(target_os = "linux") {
+        dirs::data_local_dir()
+            .expect("failed to determine XDG_DATA_DIR directory")
+            .join("tmp/zed")
     } else {
         HOME.join(".cache").join("zed")
     };

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -925,7 +925,11 @@ async fn upload_previous_crashes(
 
     let crash_report_url = http.build_zed_api_url("/telemetry/crashes", &[])?;
 
-    for dir in [&*CRASHES_DIR, &*CRASHES_RETIRED_DIR] {
+    // crash directories are only set on MacOS
+    for dir in [&*CRASHES_DIR, &*CRASHES_RETIRED_DIR]
+        .iter()
+        .filter_map(|d| d.as_deref())
+    {
         let mut children = smol::fs::read_dir(&dir).await?;
         while let Some(child) = children.next().await {
             let child = child?;


### PR DESCRIPTION
This PR adds XDG_BASE_DIR support on linux, and cleans up the path declarations slightly. Additionally, we move the embeddings and conversations directly to the SUPPORT_DIR on those platforms.
I _think_ that should also be done on MacOS in the future, but that has been left out here for now to not break existing users setups. 

Additionally, we move the SUPPORT_DIR into LocalAppData on windows for consistency.

fixes https://github.com/zed-industries/zed/issues/9308
fixes https://github.com/zed-industries/zed/issues/7155

Release Notes:

- N/A