### PR TITLE
Use winresource instead of embed-manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3388,12 +3388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embed-manifest"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cd446c890d6bed1d8b53acef5f240069ebef91d6fae7c5f52efe61fe8b5eae"
-
-[[package]]
 name = "emojis"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9410,7 +9404,6 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "editor",
- "embed-manifest",
  "fuzzy",
  "gpui",
  "indoc",
@@ -9425,6 +9418,7 @@ dependencies = [
  "strum",
  "theme",
  "ui",
+ "winresource",
 ]
 
 [[package]]
@@ -12552,7 +12546,6 @@ dependencies = [
  "db",
  "diagnostics",
  "editor",
- "embed-manifest",
  "env_logger",
  "extension",
  "extensions_ui",

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -35,7 +35,7 @@ theme.workspace = true
 ui = { workspace = true, features = ["stories"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-embed-manifest = "1.4.0"
+winresource = "0.1"
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/storybook/build.rs
+++ b/crates/storybook/build.rs
@@ -12,7 +12,13 @@ fn main() {
 
         let manifest = std::path::Path::new("../zed/resources/windows/manifest.xml");
         println!("cargo:rerun-if-changed={}", manifest.display());
-        embed_manifest::embed_manifest(embed_manifest::new_manifest(manifest.to_str().unwrap()))
-            .unwrap();
+
+        let mut res = winresource::WindowsResource::new();
+        res.set_manifest_file(manifest.to_str().unwrap());
+
+        if let Err(e) = res.compile() {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
     }
 }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -94,7 +94,6 @@ workspace.workspace = true
 zed_actions.workspace = true
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-embed-manifest = "1.4.0"
 winresource = "0.1"
 
 [dev-dependencies]

--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -57,11 +57,10 @@ fn main() {
         println!("cargo:rerun-if-changed={}", manifest.display());
         println!("cargo:rerun-if-changed={}", icon.display());
 
-        embed_manifest::embed_manifest(embed_manifest::new_manifest(manifest.to_str().unwrap()))
-            .unwrap();
-
         let mut res = winresource::WindowsResource::new();
         res.set_icon(icon.to_str().unwrap());
+        res.set_manifest_file(manifest.to_str().unwrap());
+
         if let Err(e) = res.compile() {
             eprintln!("{}", e);
             std::process::exit(1);


### PR DESCRIPTION
use winresource for crates/zed and crates/storybook. tested on `x86_64-pc-windows-gnu`. on `x86_64-pc-windows-msvc` I receive a error message, that looks like a problem with my machine
 
Release Notes:

- N/A
