### PR TITLE
Restore previous workspace on application resume

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -213,8 +213,9 @@ fn init_ui(args: Args) {
     app.on_reopen(move |cx| {
         if let Some(app_state) = AppState::try_global(cx).and_then(|app_state| app_state.upgrade())
         {
-            workspace::open_new(app_state, cx, |workspace, cx| {
-                Editor::new_file(workspace, &Default::default(), cx)
+            cx.spawn({
+                let app_state = app_state.clone();
+                |cx| async move { restore_or_create_workspace(app_state, cx).await }
             })
             .detach();
         }


### PR DESCRIPTION
Addresses #10812 

Release Notes:

- Launching an empty already-running Zed application now behaves like a regular startup and respects the user `resume_on_startup` setting.
([#10812](https://github.com/zed-industries/zed/issues/10812)).

See attached showcase which highlights how the previous project can now be re-opened through both "quit" and "close window".

This has a noticeable performance benefit on startup/project resume time.

This should also make the behaviour of closing/opening an application consistent between macOS/Linux/Windows.

https://github.com/zed-industries/zed/assets/22855292/9c37ba31-ce0a-4c3d-940d-a56e3347e64a

