### PR TITLE
Add missing linux dependencies

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -20,6 +20,7 @@ if [[ -n $apt ]]; then
     libssl-dev
     libzstd-dev
     libvulkan1
+    libgit2-dev
   )
   $maysudo "$apt" install -y "${deps[@]}"
   exit 0


### PR DESCRIPTION
At least one of the dependencies requires cmake to configure the build process.

On ubuntu libgit2-dev was missing. Debian and derivates do not install development headers by default.



Release Notes:

- Improved Linux development setup scripts.


