### PR TITLE
Revert "Use XI2 for Scrolling on X11"

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -115,7 +115,7 @@ wayland-protocols = { version = "0.31.2", features = [
 ] }
 oo7 = "0.3.0"
 open = "5.1.2"
-x11rb = { version = "0.13.0", features = ["allow-unsafe-code", "xkb", "randr", "xinput"] }
+x11rb = { version = "0.13.0", features = ["allow-unsafe-code", "xkb", "randr"] }
 xkbcommon = { version = "0.7", features = ["wayland", "x11"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -13,10 +13,7 @@ use raw_window_handle as rwh;
 use util::ResultExt;
 use x11rb::{
     connection::Connection,
-    protocol::{
-        xinput,
-        xproto::{self, ConnectionExt as _, CreateWindowAux},
-    },
+    protocol::xproto::{self, ConnectionExt as _, CreateWindowAux},
     wrapper::ConnectionExt,
     xcb_ffi::XCBConnection,
 };
@@ -143,7 +140,6 @@ impl X11WindowState {
         x_main_screen_index: usize,
         x_window: xproto::Window,
         atoms: &XcbAtoms,
-        scroll_devices: &Vec<xinput::DeviceInfo>,
     ) -> Self {
         let x_screen_index = params
             .display_id
@@ -164,6 +160,8 @@ impl X11WindowState {
                 | xproto::EventMask::BUTTON1_MOTION
                 | xproto::EventMask::BUTTON2_MOTION
                 | xproto::EventMask::BUTTON3_MOTION
+                | xproto::EventMask::BUTTON4_MOTION
+                | xproto::EventMask::BUTTON5_MOTION
                 | xproto::EventMask::BUTTON_MOTION,
         );
 
@@ -182,20 +180,6 @@ impl X11WindowState {
                 &win_aux,
             )
             .unwrap();
-
-        for device in scroll_devices {
-            xinput::ConnectionExt::xinput_xi_select_events(
-                &xcb_connection,
-                x_window,
-                &[xinput::EventMask {
-                    deviceid: device.device_id as u16,
-                    mask: vec![xinput::XIEventMask::MOTION],
-                }],
-            )
-            .unwrap()
-            .check()
-            .unwrap();
-        }
 
         if let Some(titlebar) = params.titlebar {
             if let Some(title) = titlebar.title {
@@ -278,7 +262,6 @@ impl X11Window {
         x_main_screen_index: usize,
         x_window: xproto::Window,
         atoms: &XcbAtoms,
-        scroll_devices: &Vec<xinput::DeviceInfo>,
     ) -> Self {
         X11Window {
             state: Rc::new(RefCell::new(X11WindowState::new(
@@ -287,7 +270,6 @@ impl X11Window {
                 x_main_screen_index,
                 x_window,
                 atoms,
-                scroll_devices,
             ))),
             callbacks: Rc::new(RefCell::new(Callbacks::default())),
             xcb_connection: xcb_connection.clone(),


### PR DESCRIPTION
Reverts zed-industries/zed#10695

Some users are experiencing broken scrolling due to the changes from this PR, so it should be reverted while I investigate what causes the problems.

Release Notes:

- N/A