### PR TITLE
Add ReScript suggested extension for res and resi files

### DIFF
--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -56,6 +56,7 @@ const SUGGESTIONS_BY_EXTENSION_ID: &[(&str, &[&str])] = &[
     ("purescript", &["purs"]),
     ("r", &["r", "R"]),
     ("racket", &["rkt"]),
+    ("rescript", &["res", "resi"]),
     ("sql", &["sql"]),
     ("scheme", &["scm"]),
     ("svelte", &["svelte"]),


### PR DESCRIPTION
Release Notes:

- Added ReScript as a suggested extension for `.res` and `.resi` files.
