### PR TITLE
Make the vim mode indicator a button that toggles mode

### DIFF
--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -48,14 +48,24 @@ impl ModeIndicator {
 }
 
 impl Render for ModeIndicator {
-    fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let Some(mode) = self.mode.as_ref() else {
             return div().into_any();
         };
 
-        Label::new(format!("{} -- {} --", self.operators, mode))
-            .size(LabelSize::Small)
-            .into_any_element()
+        Button::new(
+            "vim-mode-indicator-toggle",
+            format!("{} – {} –", self.operators, mode),
+        )
+        .label_size(LabelSize::Small)
+        .on_click(cx.listener(|this, _, cx| {
+            Vim::update(cx, |vim, cx| match this.mode {
+                Some(Mode::Normal) => vim.switch_mode(Mode::Insert, true, cx),
+                _ => vim.switch_mode(Mode::Normal, true, cx),
+            });
+        }))
+        .tooltip(|cx| ui::Tooltip::text("Toggle vim mode", cx))
+        .into_any_element()
     }
 }
 


### PR DESCRIPTION
This PR updates the vim mode indicator status bar element to be a button.
This is primarily done for consistency: previously, all other entries in the status bar where buttons, except the vim mode indicator. This also meant that the mode indicator would appear one pixel higher than the other entries, throwing off visual consistency.

I also replaced the two minuses around the mode indicator with an endash, which makes the status bar appear a lot cleaner.



Release Notes:

- Fixed visual consistency of the vim indicator being one pixel higher than everything else in the status bar
- Turned vim mode indicator into a button that toggles between insert and normal mode