### PR TITLE
Add woff(2) to file type icon list

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -161,6 +161,8 @@
     "webp": "image",
     "wma": "audio",
     "wmv": "video",
+    "woff": "font",
+    "woff2": "font",
     "wv": "audio",
     "xls": "document",
     "xlsx": "document",


### PR DESCRIPTION
I noticed the sidebar was using the fallback icons for woff/woff2 webfont files, instead of the font icon:

<img width="195" alt="CleanShot 2024-04-22 at 03 01 18@2x" src="https://github.com/zed-industries/zed/assets/5074763/2e925c33-0be5-4ed9-ae87-ce72f95f8416">

With this PR, I'm hoping all those font files would use the A icon instead.

Release Notes:

- Updated`.woff` & `.woff2` file types in the sidebar to display the font icon.
