### PR TITLE
terminal: hide navigation buttons

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -71,7 +71,7 @@ impl TerminalPanel {
             );
             pane.set_can_split(false, cx);
             pane.set_can_navigate(false, cx);
-            pane.display_nav_history_buttons(false);
+            pane.display_nav_history_buttons(None);
             pane.set_render_tab_bar_buttons(cx, move |pane, cx| {
                 let terminal_panel = terminal_panel.clone();
                 h_flex()


### PR DESCRIPTION
We were effectively discarding value set by display_nav_history_buttons once we've updated settings for a pane. This commit adds another bit of state to display_nav_history_buttons by allowing it to hard-deny setting updates.

Release Notes:

- Fixed a bug that caused disabled navigation buttons to show up in terminal panel.