### PR TITLE
markdown preview: Break up list items into individual blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5848,6 +5848,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion 1.0.5",
+ "collections",
  "editor",
  "gpui",
  "language",

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -17,6 +17,7 @@ test-support = []
 [dependencies]
 anyhow.workspace = true
 async-recursion.workspace = true
+collections.workspace = true
 editor.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -9,7 +9,7 @@ use std::{fmt::Display, ops::Range, path::PathBuf};
 pub enum ParsedMarkdownElement {
     Heading(ParsedMarkdownHeading),
     /// An ordered or unordered list of items.
-    List(ParsedMarkdownList),
+    ListItem(ParsedMarkdownListItem),
     Table(ParsedMarkdownTable),
     BlockQuote(ParsedMarkdownBlockQuote),
     CodeBlock(ParsedMarkdownCodeBlock),
@@ -22,7 +22,7 @@ impl ParsedMarkdownElement {
     pub fn source_range(&self) -> Range<usize> {
         match self {
             Self::Heading(heading) => heading.source_range.clone(),
-            Self::List(list) => list.source_range.clone(),
+            Self::ListItem(list_item) => list_item.source_range.clone(),
             Self::Table(table) => table.source_range.clone(),
             Self::BlockQuote(block_quote) => block_quote.source_range.clone(),
             Self::CodeBlock(code_block) => code_block.source_range.clone(),
@@ -40,18 +40,12 @@ pub struct ParsedMarkdown {
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
-pub struct ParsedMarkdownList {
-    pub source_range: Range<usize>,
-    pub children: Vec<ParsedMarkdownListItem>,
-}
-
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
 pub struct ParsedMarkdownListItem {
+    pub source_range: Range<usize>,
     /// How many indentations deep this item is.
     pub depth: u16,
     pub item_type: ParsedMarkdownListItemType,
-    pub contents: Vec<Box<ParsedMarkdownElement>>,
+    pub content: Vec<ParsedMarkdownElement>,
 }
 
 #[derive(Debug)]
@@ -129,7 +123,7 @@ impl ParsedMarkdownTableRow {
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ParsedMarkdownBlockQuote {
     pub source_range: Range<usize>,
-    pub children: Vec<Box<ParsedMarkdownElement>>,
+    pub children: Vec<ParsedMarkdownElement>,
 }
 
 #[derive(Debug)]

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -30,6 +30,10 @@ impl ParsedMarkdownElement {
             Self::HorizontalRule(range) => range.clone(),
         }
     }
+
+    pub fn is_list_item(&self) -> bool {
+        matches!(self, Self::ListItem(_))
+    }
 }
 
 #[derive(Debug)]

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -8,7 +8,6 @@ use std::{fmt::Display, ops::Range, path::PathBuf};
 #[cfg_attr(test, derive(PartialEq))]
 pub enum ParsedMarkdownElement {
     Heading(ParsedMarkdownHeading),
-    /// An ordered or unordered list of items.
     ListItem(ParsedMarkdownListItem),
     Table(ParsedMarkdownTable),
     BlockQuote(ParsedMarkdownBlockQuote),

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -600,6 +600,16 @@ impl<'a> MarkdownParser<'a> {
                     // nested list items have been parsed
                     let block = self.parse_block().await;
                     if let Some(block) = block {
+                        if let Some(items_stack) = items_stack.last_mut() {
+                            // If we did not insert any nested items yet (in this case insertion index is set), we can append the block to the current list item
+                            if !insertion_indices.contains_key(&depth) {
+                                items_stack.extend(block);
+                                continue;
+                            }
+                        }
+
+                        // Othwerwise we need to insert the block after all the nested items
+                        // that have been parsed so far
                         items.extend(block);
                     }
                 }

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -593,11 +593,11 @@ impl<'a> MarkdownParser<'a> {
                     task_item = None;
                 }
                 _ => {
-                    if depth <= 0 {
+                    if depth == 0 {
                         break;
                     }
-                    // This can only happen if a list item contains a block after
-                    // nested list items have been parsed
+                    // This can only happen if a list item starts with more then one paragraph,
+                    // or the list item contains blocks that should be rendered after the nested list items
                     let block = self.parse_block().await;
                     if let Some(block) = block {
                         if let Some(items_stack) = items_stack.last_mut() {

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -608,7 +608,7 @@ impl<'a> MarkdownParser<'a> {
                             }
                         }
 
-                        // Othwerwise we need to insert the block after all the nested items
+                        // Otherwise we need to insert the block after all the nested items
                         // that have been parsed so far
                         items.extend(block);
                     }

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -1,9 +1,10 @@
 use crate::markdown_elements::*;
 use async_recursion::async_recursion;
+use collections::FxHashMap;
 use gpui::FontWeight;
 use language::LanguageRegistry;
 use pulldown_cmark::{Alignment, Event, Options, Parser, Tag, TagEnd};
-use std::{collections::HashMap, ops::Range, path::PathBuf, sync::Arc};
+use std::{ops::Range, path::PathBuf, sync::Arc};
 
 pub async fn parse_markdown(
     markdown_input: &str,
@@ -484,8 +485,9 @@ impl<'a> MarkdownParser<'a> {
         let mut task_item = None;
         let mut order = order;
         let mut order_stack = Vec::new();
-        let mut insertion_indices = HashMap::new();
-        let mut source_ranges = HashMap::new();
+
+        let mut insertion_indices = FxHashMap::default();
+        let mut source_ranges = FxHashMap::default();
         let mut start_item_range = list_source_range.clone();
 
         while !self.eof() {

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -580,6 +580,9 @@ impl<'a> MarkdownParser<'a> {
                         let source_range = source_ranges
                             .remove(&depth)
                             .unwrap_or(start_item_range.clone());
+
+                        // We need to remove the last character of the source range, because it includes the newline character
+                        let source_range = source_range.start..source_range.end - 1;
                         let item = ParsedMarkdownElement::ListItem(ParsedMarkdownListItem {
                             source_range,
                             content,
@@ -932,9 +935,9 @@ Some other content
         assert_eq!(
             parsed.children,
             vec![
-                list_item(0..9, 1, Unordered, vec![p("Item 1", 2..8)]),
-                list_item(9..18, 1, Unordered, vec![p("Item 2", 11..17)]),
-                list_item(18..27, 1, Unordered, vec![p("Item 3", 20..26)]),
+                list_item(0..8, 1, Unordered, vec![p("Item 1", 2..8)]),
+                list_item(9..17, 1, Unordered, vec![p("Item 2", 11..17)]),
+                list_item(18..26, 1, Unordered, vec![p("Item 3", 20..26)]),
             ],
         );
     }
@@ -952,8 +955,8 @@ Some other content
         assert_eq!(
             parsed.children,
             vec![
-                list_item(0..11, 1, Task(false, 2..5), vec![p("TODO", 6..10)]),
-                list_item(11..25, 1, Task(true, 13..16), vec![p("Checked", 17..24)]),
+                list_item(0..10, 1, Task(false, 2..5), vec![p("TODO", 6..10)]),
+                list_item(11..24, 1, Task(true, 13..16), vec![p("Checked", 17..24)]),
             ],
         );
     }
@@ -972,8 +975,8 @@ Some other content
         assert_eq!(
             parsed.children,
             vec![
-                list_item(0..14, 1, Task(false, 2..5), vec![p("Task 1", 6..12)]),
-                list_item(14..27, 1, Task(true, 16..19), vec![p("Task 2", 20..26)]),
+                list_item(0..13, 1, Task(false, 2..5), vec![p("Task 1", 6..12)]),
+                list_item(14..26, 1, Task(true, 16..19), vec![p("Task 2", 20..26)]),
             ],
         );
     }
@@ -1006,21 +1009,21 @@ Some other content
         assert_eq!(
             parsed.children,
             vec![
-                list_item(0..9, 1, Unordered, vec![p("Item 1", 2..8)]),
-                list_item(9..18, 1, Unordered, vec![p("Item 2", 11..17)]),
-                list_item(18..28, 1, Unordered, vec![p("Item 3", 20..26)]),
-                list_item(28..37, 1, Ordered(1), vec![p("Hello", 31..36)]),
-                list_item(37..47, 1, Ordered(2), vec![p("Two", 40..43),]),
-                list_item(47..56, 2, Ordered(1), vec![p("Three", 50..55)]),
-                list_item(56..64, 1, Ordered(3), vec![p("Four", 59..63)]),
-                list_item(64..73, 1, Ordered(4), vec![p("Five", 67..71)]),
-                list_item(73..83, 1, Unordered, vec![p("First", 75..80)]),
-                list_item(83..97, 2, Ordered(1), vec![p("Hello", 86..91)]),
-                list_item(97..117, 3, Ordered(1), vec![p("Goodbyte", 100..108)]),
-                list_item(117..125, 4, Unordered, vec![p("Inner", 119..124)]),
-                list_item(133..141, 4, Unordered, vec![p("Inner", 135..140)]),
-                list_item(143..155, 2, Ordered(2), vec![p("Goodbyte", 146..154)]),
-                list_item(155..162, 1, Unordered, vec![p("Last", 157..161)]),
+                list_item(0..8, 1, Unordered, vec![p("Item 1", 2..8)]),
+                list_item(9..17, 1, Unordered, vec![p("Item 2", 11..17)]),
+                list_item(18..27, 1, Unordered, vec![p("Item 3", 20..26)]),
+                list_item(28..36, 1, Ordered(1), vec![p("Hello", 31..36)]),
+                list_item(37..46, 1, Ordered(2), vec![p("Two", 40..43),]),
+                list_item(47..55, 2, Ordered(1), vec![p("Three", 50..55)]),
+                list_item(56..63, 1, Ordered(3), vec![p("Four", 59..63)]),
+                list_item(64..72, 1, Ordered(4), vec![p("Five", 67..71)]),
+                list_item(73..82, 1, Unordered, vec![p("First", 75..80)]),
+                list_item(83..96, 2, Ordered(1), vec![p("Hello", 86..91)]),
+                list_item(97..116, 3, Ordered(1), vec![p("Goodbyte", 100..108)]),
+                list_item(117..124, 4, Unordered, vec![p("Inner", 119..124)]),
+                list_item(133..140, 4, Unordered, vec![p("Inner", 135..140)]),
+                list_item(143..154, 2, Ordered(2), vec![p("Goodbyte", 146..154)]),
+                list_item(155..161, 1, Unordered, vec![p("Last", 157..161)]),
             ]
         );
     }
@@ -1031,7 +1034,8 @@ Some other content
             "\
 *   This is a list item with two paragraphs.
 
-    This is the second paragraph in the list item.",
+    This is the second paragraph in the list item.
+",
         )
         .await;
 
@@ -1043,7 +1047,7 @@ Some other content
                 Unordered,
                 vec![
                     p("This is a list item with two paragraphs.", 4..44),
-                    p("This is the second paragraph in the list item.", 50..96)
+                    p("This is the second paragraph in the list item.", 50..97)
                 ],
             ),],
         );
@@ -1059,16 +1063,17 @@ Some other content
 
     text
 
-    1. d",
+    1. d
+",
         )
         .await;
 
         assert_eq!(
             parsed.children,
             vec![
-                list_item(0..8, 1, Ordered(1), vec![p("a", 3..4)],),
-                list_item(8..21, 2, Ordered(1), vec![p("b", 12..13),],),
-                list_item(21..28, 3, Ordered(1), vec![p("c", 25..26),],),
+                list_item(0..7, 1, Ordered(1), vec![p("a", 3..4)],),
+                list_item(8..20, 2, Ordered(1), vec![p("b", 12..13),],),
+                list_item(21..27, 3, Ordered(1), vec![p("c", 25..26),],),
                 p("text", 32..37),
                 list_item(41..46, 2, Ordered(1), vec![p("d", 45..46),],),
             ],
@@ -1089,9 +1094,9 @@ Some other content
         assert_eq!(
             parsed.children,
             vec![
-                list_item(0..9, 1, Unordered, vec![p("code", 2..8)]),
-                list_item(9..20, 1, Unordered, vec![p("bold", 11..19)]),
-                list_item(20..50, 1, Unordered, vec![p("link", 22..49)],)
+                list_item(0..8, 1, Unordered, vec![p("code", 2..8)]),
+                list_item(9..19, 1, Unordered, vec![p("bold", 11..19)]),
+                list_item(20..49, 1, Unordered, vec![p("link", 22..49)],)
             ],
         );
     }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -15,6 +15,7 @@ use ui::prelude::*;
 use workspace::item::{Item, ItemHandle, TabContentParams};
 use workspace::{Pane, Workspace};
 
+use crate::markdown_elements::ParsedMarkdownElement;
 use crate::OpenPreviewToTheSide;
 use crate::{
     markdown_elements::ParsedMarkdown,
@@ -180,9 +181,14 @@ impl MarkdownPreviewView {
                             let block = contents.children.get(ix).unwrap();
                             let rendered_block = render_markdown_block(block, &mut render_cx);
 
+                            let should_apply_padding = Self::should_apply_padding_between(
+                                block,
+                                contents.children.get(ix + 1),
+                            );
+
                             div()
                                 .id(ix)
-                                .pb_3()
+                                .when(should_apply_padding, |this| this.pb_3())
                                 .group("markdown-block")
                                 .on_click(cx.listener(move |this, event: &ClickEvent, cx| {
                                     if event.down.click_count == 2 {
@@ -422,6 +428,13 @@ impl MarkdownPreviewView {
         }
 
         block_index.unwrap_or_default()
+    }
+
+    fn should_apply_padding_between(
+        current_block: &ParsedMarkdownElement,
+        next_block: Option<&ParsedMarkdownElement>,
+    ) -> bool {
+        !(current_block.is_list_item() && next_block.map(|b| b.is_list_item()).unwrap_or(false))
     }
 }
 

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -410,7 +410,7 @@ impl MarkdownPreviewView {
                 let Range { start, end } = block.source_range();
 
                 // Check if the cursor is between the last block and the current block
-                if last_end > cursor && cursor < start {
+                if last_end <= cursor && cursor < start {
                     block_index = Some(i.saturating_sub(1));
                     break;
                 }


### PR DESCRIPTION
Fixes a panic related to rendering checkboxes, see #10824.

Currently we are rendering a list into a single block, meaning the whole block has to be rendered when it is visible on screen. This would lead to performance problems when a single list block contained a lot of items (especially if it contained checkboxes). This PR splits up list items into separate blocks, meaning only the actual visible list items on screen get rendered, instead of the whole list.
A nice side effect of the refactoring is, that you can actually click on individual list items now:

https://github.com/zed-industries/zed/assets/53836821/5ef4200c-bd85-4e96-a8bf-e0c8b452f762

Release Notes:

- Improved rendering performance of list elements inside the markdown preview 