### PR TITLE
cli: Treat first argument as name of release channel to use for the cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,6 +2047,7 @@ dependencies = [
  "core-services",
  "ipc-channel",
  "plist",
+ "release_channel",
  "serde",
  "util",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 ipc-channel = "0.18"
+release_channel.workspace = true
 serde.workspace = true
 util.workspace = true
 


### PR DESCRIPTION
With this commit, it is now possible to invoke cli with a release channel of bundle as an argument. E.g: `zed stable some_arguments` will find CLI binary of Stable channel installed on your machine and invoke it with `some_arguments` (so the first argument is essentially omitted).

Fixes #10851

Release Notes:

- CLI now accepts an optional name of release channel as it's first argument. For example, `zed stable` will always use your Stable installation's CLI. Trailing args are passed along.