### PR TITLE
Fix reading workspace-level LSP settings in extensions

### DIFF
--- a/crates/extension/src/wasm_host/wit/since_v0_0_6.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_0_6.rs
@@ -227,7 +227,7 @@ impl ExtensionImports for WasmState {
                     "lsp" => {
                         let settings = key
                             .and_then(|key| {
-                                ProjectSettings::get_global(cx)
+                                ProjectSettings::get(location, cx)
                                     .lsp
                                     .get(&Arc::<str>::from(key))
                             })


### PR DESCRIPTION
This PR fixes an issue where workspace-level LSP settings could be not read using `LspSettings::for_worktree` in extensions.

We we erroneously always reading the global settings instead of respecting the passed-in location.

Release Notes:

- Fixed a bug where workspace LSP settings could not be read by extensions.