### PR TITLE
Enable random_channel_buffer_tests to run on Linux

### DIFF
--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -271,6 +271,12 @@ impl TestServer {
             node_runtime: FakeNodeRuntime::new(),
         });
 
+        let os_keymap = if cfg!(target_os = "linux") {
+            "keymaps/default-linux.json"
+        } else {
+            "keymaps/default-macos.json" // Default case if none of the above
+        };
+
         cx.update(|cx| {
             theme::init(theme::LoadThemes::JustBase, cx);
             Project::init(&client, cx);
@@ -285,7 +291,7 @@ impl TestServer {
             file_finder::init(cx);
             menu::init();
             remote_projects::init(client.clone(), cx);
-            settings::KeymapFile::load_asset("keymaps/default-macos.json", cx).unwrap();
+            settings::KeymapFile::load_asset(os_keymap, cx).unwrap();
         });
 
         client

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -274,7 +274,7 @@ impl TestServer {
         let os_keymap = if cfg!(target_os = "linux") {
             "keymaps/default-linux.json"
         } else {
-            "keymaps/default-macos.json" // Default case if none of the above
+            "keymaps/default-macos.json"
         };
 
         cx.update(|cx| {


### PR DESCRIPTION
With this patch applied I can see the following line in the test output:

   test tests::random_channel_buffer_tests::test_random_channel_buffers has been running for over 60 seconds

Without it I run in a failure with 'Invalid keystroke `cmk-,`



Release Notes:

- N/A