### PR TITLE
vim: Increment search right

### DIFF
--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -117,13 +117,16 @@ fn find_number(
 ) -> Option<(Range<Point>, String, u32)> {
     let mut offset = start.to_offset(snapshot);
 
-    // go backwards to the start of any number the selection is within
-    for ch in snapshot.reversed_chars_at(offset) {
-        if ch.is_ascii_digit() || ch == '-' || ch == 'b' || ch == 'x' {
-            offset -= ch.len_utf8();
-            continue;
+    let ch0 = snapshot.chars_at(offset).next();
+    if ch0.as_ref().is_some_and(char::is_ascii_digit) || matches!(ch0, Some('-' | 'b' | 'x')) {
+        // go backwards to the start of any number the selection is within
+        for ch in snapshot.reversed_chars_at(offset) {
+            if ch.is_ascii_digit() || ch == '-' || ch == 'b' || ch == 'x' {
+                offset -= ch.len_utf8();
+                continue;
+            }
+            break;
         }
-        break;
     }
 
     let mut begin = None;

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -252,12 +252,12 @@ mod test {
 
         cx.simulate_shared_keystrokes(["ctrl-a"]).await;
         cx.assert_shared_state(indoc! {"
-            1..ˇ3
+            111..ˇ3
             "})
             .await;
         cx.simulate_shared_keystrokes(["ctrl-x"]).await;
         cx.assert_shared_state(indoc! {"
-            1..ˇ2
+            111..ˇ2
             "})
             .await;
     }

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -218,6 +218,48 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_increment_with_dot(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state(indoc! {"
+            1ˇ.2
+            "})
+            .await;
+
+        cx.simulate_shared_keystrokes(["ctrl-a"]).await;
+        cx.assert_shared_state(indoc! {"
+            1.ˇ3
+            "})
+            .await;
+        cx.simulate_shared_keystrokes(["ctrl-x"]).await;
+        cx.assert_shared_state(indoc! {"
+            1.ˇ2
+            "})
+            .await;
+    }
+
+    #[gpui::test]
+    async fn test_increment_with_two_dots(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state(indoc! {"
+            111.ˇ.2
+            "})
+            .await;
+
+        cx.simulate_shared_keystrokes(["ctrl-a"]).await;
+        cx.assert_shared_state(indoc! {"
+            1..ˇ3
+            "})
+            .await;
+        cx.simulate_shared_keystrokes(["ctrl-x"]).await;
+        cx.assert_shared_state(indoc! {"
+            1..ˇ2
+            "})
+            .await;
+    }
+
+    #[gpui::test]
     async fn test_increment_radix(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
 

--- a/crates/vim/test_data/test_increment_with_dot.json
+++ b/crates/vim/test_data/test_increment_with_dot.json
@@ -1,0 +1,5 @@
+{"Put":{"state":"1ˇ.2\n"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"1.ˇ3\n","mode":"Normal"}}
+{"Key":"ctrl-x"}
+{"Get":{"state":"1.ˇ2\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_with_two_dots.json
+++ b/crates/vim/test_data/test_increment_with_two_dots.json
@@ -1,5 +1,5 @@
-{"Put":{"state":"1.ˇ.2\n"}}
+{"Put":{"state":"111.ˇ.2\n"}}
 {"Key":"ctrl-a"}
-{"Get":{"state":"1..ˇ3\n","mode":"Normal"}}
+{"Get":{"state":"111..ˇ3\n","mode":"Normal"}}
 {"Key":"ctrl-x"}
-{"Get":{"state":"1..ˇ2\n","mode":"Normal"}}
+{"Get":{"state":"111..ˇ2\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_with_two_dots.json
+++ b/crates/vim/test_data/test_increment_with_two_dots.json
@@ -1,0 +1,5 @@
+{"Put":{"state":"1.ˇ.2\n"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"1..ˇ3\n","mode":"Normal"}}
+{"Key":"ctrl-x"}
+{"Get":{"state":"1..ˇ2\n","mode":"Normal"}}


### PR DESCRIPTION
Hi there, nice editor!
Here's my attempt at fixing #10865.

Thanks

Release Notes:

-vim: Fix ctrl+a when cursor is on a decimal point ([#10865](https://github.com/zed-industries/zed/issues/10865)).