### PR TITLE
Update documentation and handling to use a `crates/collab/seed.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /plugins/bin
 /script/node_modules
 /crates/theme/schemas/theme.json
-/crates/collab/.admins.json
+/crates/collab/seed.json
 /assets/*licenses.md
 **/venv
 .build

--- a/crates/collab/README.md
+++ b/crates/collab/README.md
@@ -6,7 +6,43 @@ It contains our back-end logic for collaboration, to which we connect from the Z
 
 # Local Development
 
-Detailed instructions on getting started are [here](https://zed.dev/docs/local-collaboration).
+## Database setup
+
+Before you can run the collab server locally, you'll need to set up a zed Postgres database.
+
+```
+script/bootstrap
+```
+
+This script will set up the `zed` Postgres database, and populate it with some users. It requires internet access, because it fetches some users from the GitHub API.
+
+The script will create several _admin_ users, who you'll sign in as by default when developing locally. The GitHub logins for the default users are specified in the `seed.default.json` file.
+
+To use a different set of admin users, create `crates/collab/seed.json`.
+
+```json
+{
+  "admins": ["yourgithubhere"],
+  "channels": ["zed"],
+  "number_of_users": 20
+}
+```
+
+## Testing collaborative features locally
+
+In one terminal, run Zed's collaboration server and the livekit dev server:
+
+```
+foreman start
+```
+
+In a second terminal, run two or more instances of Zed.
+
+```
+script/zed-local -2
+```
+
+This script starts one to four instances of Zed, depending on the `-2`, `-3` or `-4` flags. Each instance will be connected to the local `collab` server, signed in as a different user from `seed.json` or `seed.default.json`.
 
 # Deployment
 

--- a/script/zed-local
+++ b/script/zed-local
@@ -20,9 +20,20 @@ OPTIONS
 const { spawn, execFileSync } = require("child_process");
 const assert = require("assert");
 
-const users = require(
-  process.env.SEED_PATH || "../crates/collab/seed.default.json",
-).admins;
+let users;
+if (process.env.SEED_PATH) {
+  users = require(process.env.SEED_PATH).admins;
+} else {
+  users = require("../crates/collab/seed.default.json").admins;
+  try {
+    const defaultUsers = users;
+    const customUsers = require("../crates/collab/seed.json").admins;
+    assert(customUsers.length > 0);
+    users = customUsers.concat(
+      defaultUsers.filter((user) => !customUsers.includes(user)),
+    );
+  } catch (_) {}
+}
 
 const RESOLUTION_REGEX = /(\d+) x (\d+)/;
 const DIGIT_FLAG_REGEX = /^--?(\d+)$/;


### PR DESCRIPTION
Updates `collab` to accept a `seed.json` file that allows you to override the defaults. Updated the `README` in collab to just have directions inside instead of redirecting the developer to the website.

Release Notes:

- N/A
