### PR TITLE
gpui/mac: Disable shadows on non-opaque windows

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -995,6 +995,8 @@ impl PlatformWindow for MacWindow {
         };
         unsafe {
             this.native_window.setOpaque_(opaque);
+            // Shadows for transparent windows cause artifacts and performance issues
+            this.native_window.setHasShadow_(opaque);
             let clear_color = if opaque == YES {
                 NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0f64, 0f64, 0f64, 1f64)
             } else {


### PR DESCRIPTION
The culprit behind ghost images in transparent windows and bad performance with blurred windows turns out to be one and the same: window shadows. The simplest and most popular fix appears to be to simply disable shadows on non-opaque windows so let's just do that.

Disabling shadows on a window that is already visible however leaves the shadow on screen, detached from the window, until a full screen effect such as exposé or a virtual desktop switch wipes it clean. There does not seem to be any known solution to this, and it does not affect windows created after switching to a transparent theme so this is a good enough compromise for now.



Release Notes:

- Fixed ghostly artifacts in transparent window backgrounds.
- Fixed sluggishness with blurred window backgrounds. 

