### PR TITLE
Add `language_servers` setting for customizing which language servers run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5410,6 +5410,7 @@ dependencies = [
  "globset",
  "gpui",
  "indoc",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "lsp",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -294,6 +294,10 @@
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.
   "enable_language_server": true,
+  // The list of language servers to use (or disable) for all languages.
+  //
+  // This is typically customized on a per-language basis.
+  "language_servers": ["..."],
   // When to automatically save edited buffers. This setting can
   // take four values.
   //

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -34,11 +34,13 @@ fuzzy.workspace = true
 git.workspace = true
 globset.workspace = true
 gpui.workspace = true
+itertools.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 lsp.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
+pulldown-cmark.workspace = true
 rand = { workspace = true, optional = true }
 regex.workspace = true
 rpc.workspace = true
@@ -50,15 +52,14 @@ similar = "1.3"
 smallvec.workspace = true
 smol.workspace = true
 sum_tree.workspace = true
+task.workspace = true
 text.workspace = true
 theme.workspace = true
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
-pulldown-cmark.workspace = true
 tree-sitter.workspace = true
 unicase = "2.6"
 util.workspace = true
-task.workspace = true
 
 [dev-dependencies]
 collections = { workspace = true, features = ["test-support"] }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -144,11 +144,11 @@ impl LanguageSettings {
 
         let rest = available_language_servers
             .into_iter()
-            .cloned()
-            .filter(|available_language_server| {
+            .filter(|&available_language_server| {
                 !disabled_language_servers.contains(&&available_language_server.0)
                     && !enabled_language_servers.contains(&&available_language_server.0)
             })
+            .cloned()
             .collect::<Vec<_>>();
 
         enabled_language_servers
@@ -751,7 +751,7 @@ mod tests {
         // A value of just `["..."]` is the same as taking all of the available language servers.
         assert_eq!(
             LanguageSettings::resolve_language_servers(
-                &vec![LanguageSettings::REST_OF_LANGUAGE_SERVERS.into()],
+                &[LanguageSettings::REST_OF_LANGUAGE_SERVERS.into()],
                 &available_language_servers,
             ),
             available_language_servers
@@ -760,10 +760,10 @@ mod tests {
         // Referencing one of the available language servers will change its order.
         assert_eq!(
             LanguageSettings::resolve_language_servers(
-                &vec![
+                &[
                     "biome".into(),
                     LanguageSettings::REST_OF_LANGUAGE_SERVERS.into(),
-                    "deno".into(),
+                    "deno".into()
                 ],
                 &available_language_servers
             ),
@@ -779,7 +779,7 @@ mod tests {
         // Negating an available language server removes it from the list.
         assert_eq!(
             LanguageSettings::resolve_language_servers(
-                &vec![
+                &[
                     "deno".into(),
                     "!typescript-language-server".into(),
                     "!biome".into(),

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -98,8 +98,7 @@ pub struct LanguageSettings {
     /// special tokens:
     /// - `"!<language_server_id>"` - A language server ID prefixed with a `!` will be disabled.
     /// - `"..."` - A placeholder to refer to the **rest** of the registered language servers for this language.
-    #[serde(default)]
-    pub language_servers: Option<Vec<String>>,
+    pub language_servers: Vec<String>,
     /// Controls whether Copilot provides suggestion immediately (true)
     /// or waits for a `copilot::Toggle` (false).
     pub show_copilot_suggestions: bool,
@@ -127,7 +126,7 @@ pub struct CopilotSettings {
 }
 
 /// The settings for all languages.
-#[derive(Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct AllLanguageSettingsContent {
     /// The settings for enabling/disabling features.
     #[serde(default)]
@@ -148,7 +147,7 @@ pub struct AllLanguageSettingsContent {
 }
 
 /// The settings for a particular language.
-#[derive(Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct LanguageSettingsContent {
     /// How many columns a tab should occupy.
     ///
@@ -275,7 +274,7 @@ pub struct CopilotSettingsContent {
 }
 
 /// The settings for enabling/disabling features.
-#[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct FeaturesContent {
     /// Whether the GitHub Copilot feature is enabled.
@@ -626,6 +625,12 @@ impl settings::Settings for AllLanguageSettings {
 }
 
 fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent) {
+    fn merge<T>(target: &mut T, value: Option<T>) {
+        if let Some(value) = value {
+            *target = value;
+        }
+    }
+
     merge(&mut settings.tab_size, src.tab_size);
     merge(&mut settings.hard_tabs, src.hard_tabs);
     merge(&mut settings.soft_wrap, src.soft_wrap);
@@ -660,6 +665,7 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
         &mut settings.enable_language_server,
         src.enable_language_server,
     );
+    merge(&mut settings.language_servers, src.language_servers.clone());
     merge(
         &mut settings.show_copilot_suggestions,
         src.show_copilot_suggestions,
@@ -670,9 +676,4 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
         src.extend_comment_on_newline,
     );
     merge(&mut settings.inlay_hints, src.inlay_hints);
-    fn merge<T>(target: &mut T, value: Option<T>) {
-        if let Some(value) = value {
-            *target = value;
-        }
-    }
 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -92,6 +92,14 @@ pub struct LanguageSettings {
     pub prettier: HashMap<String, serde_json::Value>,
     /// Whether to use language servers to provide code intelligence.
     pub enable_language_server: bool,
+    /// The list of language servers to use (or disable) for this language.
+    ///
+    /// This array should consist of language server IDs, as well as the following
+    /// special tokens:
+    /// - `"!<language_server_id>"` - A language server ID prefixed with a `!` will be disabled.
+    /// - `"..."` - A placeholder to refer to the **rest** of the registered language servers for this language.
+    #[serde(default)]
+    pub language_servers: Option<Vec<String>>,
     /// Controls whether Copilot provides suggestion immediately (true)
     /// or waits for a `copilot::Toggle` (false).
     pub show_copilot_suggestions: bool,
@@ -211,6 +219,16 @@ pub struct LanguageSettingsContent {
     /// Default: true
     #[serde(default)]
     pub enable_language_server: Option<bool>,
+    /// The list of language servers to use (or disable) for this language.
+    ///
+    /// This array should consist of language server IDs, as well as the following
+    /// special tokens:
+    /// - `"!<language_server_id>"` - A language server ID prefixed with a `!` will be disabled.
+    /// - `"..."` - A placeholder to refer to the **rest** of the registered language servers for this language.
+    ///
+    /// Default: ["..."]
+    #[serde(default)]
+    pub language_servers: Option<Vec<String>>,
     /// Controls whether Copilot provides suggestion immediately (true)
     /// or waits for a `copilot::Toggle` (false).
     ///

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3031,7 +3031,20 @@ impl Project {
             return;
         }
 
-        for adapter in self.languages.clone().lsp_adapters(&language) {
+        let available_lsp_adapters = self.languages.clone().lsp_adapters(&language);
+        let available_language_servers = available_lsp_adapters
+            .iter()
+            .map(|lsp_adapter| lsp_adapter.name.clone())
+            .collect::<Vec<_>>();
+
+        let enabled_language_servers =
+            settings.customized_language_servers(&available_language_servers);
+
+        for adapter in available_lsp_adapters {
+            if !enabled_language_servers.contains(&adapter.name) {
+                continue;
+            }
+
             self.start_language_server(worktree, adapter.clone(), language.clone(), cx);
         }
     }


### PR DESCRIPTION
This PR adds a new `language_servers` setting underneath the language settings.


This setting controls which of the available language servers for a given language will run.

The `language_servers` setting is an array of strings. Each item in the array must be either:

- A language server ID (e.g., `"rust-analyzer"`, `"typescript-language-server"`, `"eslint"`, etc.) denoting a language server that should be enabled.
- A language server ID prefixed with a `!` (e.g., `"!rust-analyzer"`, `"!typescript-language-server"`, `"!eslint"`, etc.) denoting a language server that should be disabled.
- A `"..."` placeholder, which will be replaced by the remaining available language servers that haven't already been mentioned in the array.

For example, to enable the Biome language server in place of the default TypeScript language server, you would add the following to your settings:

```json
{
  "languages": {
    "TypeScript": {
      "language_servers": ["biome", "!typescript-language-server", "..."]
    }
  }
}
```

More details can be found in #10906.

Release Notes:

- Added `language_servers` setting to language settings for customizing which language server(s) run for a given language.
