### PR TITLE
Fix project-panel double click file support on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -698,12 +698,13 @@ impl WindowsWindowInner {
         if let Some(callback) = callbacks.input.as_mut() {
             let x = lparam.signed_loword() as f32;
             let y = lparam.signed_hiword() as f32;
+            let click_count = self.click_state.borrow().current_count;
             let scale_factor = self.scale_factor.get();
             let event = MouseUpEvent {
                 button,
                 position: logical_point(x, y, scale_factor),
                 modifiers: self.current_modifiers(),
-                click_count: 1,
+                click_count,
             };
             if callback(PlatformInput::MouseUp(event)).default_prevented {
                 return Some(0);

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1675,7 +1675,7 @@ impl ProjectPanel {
                                 if event.down.modifiers.secondary() {
                                     this.split_entry(entry_id, cx);
                                 } else {
-                                    let click_count = event.up.click_count;
+                                    let click_count = event.down.click_count;
                                     this.open_entry(
                                         entry_id,
                                         click_count > 1,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1675,7 +1675,7 @@ impl ProjectPanel {
                                 if event.down.modifiers.secondary() {
                                     this.split_entry(entry_id, cx);
                                 } else {
-                                    let click_count = event.down.click_count;
+                                    let click_count = event.up.click_count;
                                     this.open_entry(
                                         entry_id,
                                         click_count > 1,


### PR DESCRIPTION

Release Notes:

- Fixed project panel double click to force open file on Windows.

Ref issue: #10898 

@bennetbo 

I saw you was also used `event.down.click_count` in Markdown Preview.

https://github.com/zed-industries/zed/commit/7dccbd8e3b61c48ae174807a4023332b7c1df06a#diff-c8d1735cb347ea08d03198df112343ec50a74de8d50414a6f3be6c6d674c6d19R161

And this also used in other place:

<img width="870" alt="image" src="https://github.com/zed-industries/zed/assets/5518/b844e700-b95f-4cd2-987f-9e4305ebdd7c">

## Test demo after updated

Looks like it is no side effect

![2024-04-24 10 17 45](https://github.com/zed-industries/zed/assets/5518/0df4cf06-7448-4014-9df2-f2608a5f5314)

