### PR TITLE
Properly extract package name out of cargo pkgid

### DIFF
--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -313,7 +313,9 @@ impl PickerDelegate for TasksModalDelegate {
             String::new()
         };
         if let Some(resolved) = resolved_task.resolved.as_ref() {
-            if display_label != resolved.command_label {
+            if resolved.command_label != display_label
+                && resolved.command_label != resolved_task.resolved_label
+            {
                 if !tooltip_label_text.trim().is_empty() {
                     tooltip_label_text.push('\n');
                 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/10925

Uses correct package name to generate Rust `cargo` tasks.
Also deduplicates lines in task modal item tooltips.

Release Notes:

- Fixed Rust tasks using incorrect package name ([10925](https://github.com/zed-industries/zed/issues/10925))
