### PR TITLE
Log which language servers will be started

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3068,12 +3068,21 @@ impl Project {
 
         let enabled_language_servers =
             settings.customized_language_servers(&available_language_servers);
+        let enabled_lsp_adapters = available_lsp_adapters
+            .into_iter()
+            .filter(|adapter| enabled_language_servers.contains(&adapter.name))
+            .collect::<Vec<_>>();
 
-        for adapter in available_lsp_adapters {
-            if !enabled_language_servers.contains(&adapter.name) {
-                continue;
-            }
+        log::info!(
+            "starting language servers for {language}: {adapters}",
+            language = language.name(),
+            adapters = enabled_lsp_adapters
+                .iter()
+                .map(|adapter| adapter.name.0.as_ref())
+                .join(", ")
+        );
 
+        for adapter in enabled_lsp_adapters {
             self.start_language_server(worktree, adapter.clone(), language.clone(), cx);
         }
     }


### PR DESCRIPTION
This PR adds a new log message indicating which language servers will be started for a given language.

The aim is to make debugging the usage of the new `language_servers` setting (#10911) easier.

Release Notes:

- N/A
