### PR TITLE
terraform: Sync `Cargo.toml` version with `extension.toml` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12858,7 +12858,7 @@ dependencies = [
 
 [[package]]
 name = "zed_terraform"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/terraform/Cargo.toml
+++ b/extensions/terraform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_terraform"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"


### PR DESCRIPTION
This PR syncs the `Cargo.toml` version with the `extension.toml` version.

We should try to keep these in sync.

Release Notes:

- N/A
