### PR TITLE
Improve logic for obtaining surrounds range in Vim mode

### DIFF
--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -23,6 +23,7 @@ collections.workspace = true
 command_palette_hooks.workspace = true
 editor.workspace = true
 gpui.workspace = true
+itertools.workspace = true
 language.workspace = true
 log.workspace = true
 nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = [

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -806,7 +806,7 @@ fn surrounding_markers(
     if let Some((ch, range)) = movement::chars_after(map, point).next() {
         if ch == open_marker {
             match movement::chars_before(map, point).next() {
-                Some((before_ch, _)) if before_ch == '\\' => {}
+                Some(('\\', _)) => {}
                 _ => {
                     if open_marker == close_marker {
                         let mut total = 0;

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -9,6 +9,7 @@ use editor::{
     movement::{self, FindRange},
     Bias, DisplayPoint,
 };
+
 use itertools::Itertools;
 
 use gpui::{actions, impl_actions, ViewContext, WindowContext};
@@ -875,10 +876,7 @@ fn surrounding_markers(
         Some((ch, _)) => ch,
         _ => '\0',
     };
-    println!("before ch close {:?}", before_ch);
     for (ch, range) in movement::chars_after(map, opening.end) {
-        println!("after, ch is {:?}, before {:?}", ch, before_ch);
-
         if ch == '\n' && !search_across_lines {
             break;
         }

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -880,6 +880,7 @@ fn surrounding_markers(
         if ch == '\n' && !search_across_lines {
             break;
         }
+
         if before_ch != '\\' {
             if ch == close_marker {
                 if matched_opens == 0 {

--- a/crates/vim/test_data/test_singleline_surrounding_character_objects_with_escape.json
+++ b/crates/vim/test_data/test_singleline_surrounding_character_objects_with_escape.json
@@ -1,0 +1,10 @@
+{"Put":{"state":"h\"e\\\"lˇlo \\\"world\"!"}}
+{"Key":"v"}
+{"Key":"i"}
+{"Key":"\""}
+{"Get":{"state":"h\"«e\\\"llo \\\"worldˇ»\"!","mode":"Visual"}}
+{"Put":{"state":"hello \"teˇst \\\"inside\\\" world\""}}
+{"Key":"v"}
+{"Key":"i"}
+{"Key":"\""}
+{"Get":{"state":"hello \"«test \\\"inside\\\" worldˇ»\"","mode":"Visual"}}


### PR DESCRIPTION
now correctly retrieves range in cases where escape characters are present. Fixed #10827


Release Notes:

- vim: Fix logic for finding surrounding quotes to ignore escaped characters (#10827)
