### PR TITLE
Fix primary language server selection for formatting

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4676,12 +4676,21 @@ impl Project {
 
         let mut project_transaction = ProjectTransaction::default();
         for (buffer, buffer_abs_path) in &buffers_with_paths {
-            let adapters_and_servers: Vec<_> = project.update(&mut cx, |project, cx| {
-                project
-                    .language_servers_for_buffer(&buffer.read(cx), cx)
-                    .map(|(adapter, lsp)| (adapter.clone(), lsp.clone()))
-                    .collect()
-            })?;
+            let (primary_adapter_and_server, adapters_and_servers) =
+                project.update(&mut cx, |project, cx| {
+                    let buffer = buffer.read(cx);
+
+                    let adapters_and_servers = project
+                        .language_servers_for_buffer(buffer, cx)
+                        .map(|(adapter, lsp)| (adapter.clone(), lsp.clone()))
+                        .collect::<Vec<_>>();
+
+                    let primary_adapter = project
+                        .primary_language_server_for_buffer(buffer, cx)
+                        .map(|(adapter, lsp)| (adapter.clone(), lsp.clone()));
+
+                    (primary_adapter, adapters_and_servers)
+                })?;
 
             let settings = buffer.update(&mut cx, |buffer, cx| {
                 language_settings(buffer.language(), buffer.file(), cx).clone()
@@ -4734,10 +4743,8 @@ impl Project {
             // Apply language-specific formatting using either the primary language server
             // or external command.
             // Except for code actions, which are applied with all connected language servers.
-            let primary_language_server = adapters_and_servers
-                .first()
-                .cloned()
-                .map(|(_, lsp)| lsp.clone());
+            let primary_language_server =
+                primary_adapter_and_server.map(|(_adapter, server)| server.clone());
             let server_and_buffer = primary_language_server
                 .as_ref()
                 .zip(buffer_abs_path.as_ref());


### PR DESCRIPTION
This PR fixes the way we select the primary language server for use with formatting.

Previously we were just taking the first one in the list, but this could be the wrong one in cases where a language server was provided by an extension in conjunction with a built-in language server (e.g., Tailwind).

We now use the `primary_language_server_for_buffer` method to more accurately identify the primary one.

Fixes https://github.com/zed-industries/zed/issues/10902.

Release Notes:

- Fixed an issue where the wrong language server could be used for formatting.
