### PR TITLE
dart: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12724,7 +12724,7 @@ dependencies = [
 
 [[package]]
 name = "zed_dart"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/dart/Cargo.toml
+++ b/extensions/dart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_dart"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/dart/extension.toml
+++ b/extensions/dart/extension.toml
@@ -1,7 +1,7 @@
 id = "dart"
 name = "Dart"
 description = "Dart support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Abdullah Alsigar <abdullah.alsigar@gmail.com>", "Flo <flo80@users.noreply.github.com>"]
 repository = "https://github.com/zed-industries/zed"
@@ -9,6 +9,7 @@ repository = "https://github.com/zed-industries/zed"
 [language_servers.dart]
 name = "Dart LSP"
 language = "Dart"
+languages = ["Dart"]
 
 [grammars.dart]
 repository = "https://github.com/UserNobody14/tree-sitter-dart"


### PR DESCRIPTION
This PR bumps the Dart extension to v0.0.2.

Changes:

- https://github.com/zed-industries/zed/pull/8347
- https://github.com/zed-industries/zed/pull/10552

Release Notes:

- N/A
