### PR TITLE
Recognize `PKGBUILD` as bash script

### DIFF
--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -1,7 +1,7 @@
 name = "Shell Script"
 code_fence_block_name = "bash"
 grammar = "bash"
-path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env"]
+path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD"]
 line_comments = ["# "]
 first_line_pattern = "^#!.*\\b(?:ba|z)?sh\\b"
 brackets = [


### PR DESCRIPTION
[PKGBUILD] is a file used in the build system of arch linux, and it is basically just a bash script with special functions.


Release Notes:

- Changed `PKGBUILD` files to be recognized as bash.
