### PR TITLE
Restore the previous styles for single-line editors

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10323,7 +10323,19 @@ impl Render for Editor {
         let settings = ThemeSettings::get_global(cx);
 
         let text_style = match self.mode {
-            EditorMode::SingleLine | EditorMode::AutoHeight { .. } => cx.text_style(),
+            EditorMode::SingleLine | EditorMode::AutoHeight { .. } => TextStyle {
+                color: cx.theme().colors().editor_foreground,
+                font_family: settings.ui_font.family.clone(),
+                font_features: settings.ui_font.features,
+                font_size: rems(0.875).into(),
+                font_weight: FontWeight::NORMAL,
+                font_style: FontStyle::Normal,
+                line_height: relative(settings.buffer_line_height.value()),
+                background_color: None,
+                underline: None,
+                strikethrough: None,
+                white_space: WhiteSpace::Normal,
+            },
             EditorMode::Full => TextStyle {
                 color: cx.theme().colors().editor_foreground,
                 font_family: settings.buffer_font.family.clone(),


### PR DESCRIPTION
This PR fixes a bug introduced in #10870 that caused editors used as single-line inputs to have the wrong text style.

If this change was intentional for something relating to the new Assistant panel, we'll need to figure out a way to change it without breaking these other usages.

### Before

<img width="589" alt="Screenshot 2024-04-24 at 5 35 36 PM" src="https://github.com/zed-industries/zed/assets/1486634/31624cfd-75d1-4771-9402-c14ef9e9483e">

<img width="326" alt="Screenshot 2024-04-24 at 5 35 46 PM" src="https://github.com/zed-industries/zed/assets/1486634/1b76a3ef-7205-49ee-b391-7609f90461bd">

### After

<img width="588" alt="Screenshot 2024-04-24 at 5 36 14 PM" src="https://github.com/zed-industries/zed/assets/1486634/9d550ee2-80c0-4afb-9b45-a2956471c546">

<img width="260" alt="Screenshot 2024-04-24 at 5 36 31 PM" src="https://github.com/zed-industries/zed/assets/1486634/63240f27-1679-45d5-b39c-016860ff9683">

Release Notes:

- Fixed a bug where some inputs were using the wrong font style (preview-only).
