### PR TITLE
Fix issues with drafting release notes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          # We need to fetch more than one commit so that `script/draft-release-notes`
+          # is able to diff between the current and previous tag.
+          #
+          # 25 was chosen arbitrarily.
+          fetch-depth: 25
           clean: false
           submodules: "recursive"
 
@@ -206,7 +211,8 @@ jobs:
             exit 1
           fi
           mkdir -p target/
-          script/draft-release-notes "$version" "$channel" > target/release-notes.md
+          # Ignore any errors that occur while drafting release notes to not fail the build.
+          script/draft-release-notes "$version" "$channel" > target/release-notes.md || true
 
       - name: Generate license file
         run: script/generate-licenses


### PR DESCRIPTION
This PR addresses some issues I ran into with the way we draft release notes in CI when doing builds.

The first issue I encountered was that `script/draft-release-notes` was failing, seemingly due to CI doing a shallow Git checkout and not having all of the tags available in order to compare then. This was addressed by setting the `fetch-depth` during the Git checkout.

The second issue is that (in my opinion) we shouldn't fail the build if drafting release notes fails. After well, we're doing it as a convenience to ourselves, and it isn't a mandatory part of the build. This was addressed by making any failures in `script/draft-release-notes` not fail the CI step as a whole.

These changes were already applied to the `v0.133.x` branch.

Release Notes:

- N/A
