### PR TITLE
Fix misalignment of vim mode indicator

### DIFF
--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -55,6 +55,7 @@ impl Render for ModeIndicator {
 
         Label::new(format!("{} -- {} --", self.operators, mode))
             .size(LabelSize::Small)
+            .line_height_style(LineHeightStyle::UiLabel)
             .into_any_element()
     }
 }


### PR DESCRIPTION
Credit-to: @elkowar

New is the top
<img width="220" alt="Screenshot 2024-04-24 at 19 00 48" src="https://github.com/zed-industries/zed/assets/94272/9d917bf1-e175-494d-9653-757d15584921">

Release Notes:

- N/A
