### PR TITLE
Fix VIM cw on last character of a word doesn't work as expected:

### DIFF
--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -40,7 +40,7 @@ pub fn change_motion(vim: &mut Vim, motion: Motion, times: Option<usize>, cx: &m
                                 times,
                                 ignore_punctuation,
                                 &text_layout_details,
-                                motion == Motion::NextWordStart { ignore_punctuation },
+                                motion == Motion::NextSubwordStart { ignore_punctuation },
                             )
                         }
                         _ => {

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -110,8 +110,8 @@ pub fn change_object(vim: &mut Vim, object: Object, around: bool, cx: &mut Windo
 // Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is
 // on a non-blank.  This is because "cw" is interpreted as change-word, and a
 // word does not include the following white space.  {Vi: "cw" when on a blank
-//     followed by other blanks changes only the first blank; this is probably a
-//     bug, because "dw" deletes all the blanks}
+// followed by other blanks changes only the first blank; this is probably a
+// bug, because "dw" deletes all the blanks}
 fn expand_changed_word_selection(
     map: &DisplaySnapshot,
     selection: &mut Selection<DisplayPoint>,
@@ -206,6 +206,7 @@ mod test {
         cx.assert("Teˇst").await;
         cx.assert("Tˇest test").await;
         cx.assert("Testˇ  test").await;
+        cx.assert("Tesˇt  test").await;
         cx.assert(indoc! {"
                 Test teˇst
                 test"})

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -1,18 +1,7 @@
-use crate::{
-    motion::{self, Motion},
-    object::Object,
-    state::Mode,
-    utils::copy_selections_content,
-    Vim,
-};
-use editor::{
-    display_map::{DisplaySnapshot, ToDisplayPoint},
-    movement::TextLayoutDetails,
-    scroll::Autoscroll,
-    Bias, DisplayPoint,
-};
+use crate::{motion::Motion, object::Object, state::Mode, utils::copy_selections_content, Vim};
+use editor::{display_map::ToDisplayPoint, scroll::Autoscroll, Bias};
 use gpui::WindowContext;
-use language::{char_kind, CharKind, Selection};
+use language::{char_kind, CharKind};
 
 pub fn change_motion(vim: &mut Vim, motion: Motion, times: Option<usize>, cx: &mut WindowContext) {
     // Some motions ignore failure when switching to normal mode

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -31,48 +31,42 @@ pub fn change_motion(vim: &mut Vim, motion: Motion, times: Option<usize>, cx: &m
             editor.set_clip_at_line_ends(false, cx);
             editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
-                    motion_succeeded |= if let Motion::NextWordStart { ignore_punctuation } = motion
-                    {
-                        expand_changed_word_selection(
-                            map,
-                            selection,
-                            times,
-                            ignore_punctuation,
-                            &text_layout_details,
-                            false,
-                        )
-                    } else if let Motion::NextSubwordStart { ignore_punctuation } = motion {
-                        expand_changed_word_selection(
-                            map,
-                            selection,
-                            times,
-                            ignore_punctuation,
-                            &text_layout_details,
-                            true,
-                        )
-                    } else {
-                        let result = motion.expand_selection(
-                            map,
-                            selection,
-                            times,
-                            false,
-                            &text_layout_details,
-                        );
-                        if let Motion::CurrentLine = motion {
-                            let mut start_offset = selection.start.to_offset(map, Bias::Left);
-                            let scope = map
-                                .buffer_snapshot
-                                .language_scope_at(selection.start.to_point(&map));
-                            for (ch, offset) in map.buffer_chars_at(start_offset) {
-                                if ch == '\n' || char_kind(&scope, ch) != CharKind::Whitespace {
-                                    break;
-                                }
-                                start_offset = offset + ch.len_utf8();
-                            }
-                            selection.start = start_offset.to_display_point(map);
+                    motion_succeeded |= match motion {
+                        Motion::NextWordStart { ignore_punctuation }
+                        | Motion::NextSubwordStart { ignore_punctuation } => {
+                            expand_changed_word_selection(
+                                map,
+                                selection,
+                                times,
+                                ignore_punctuation,
+                                &text_layout_details,
+                                motion == Motion::NextWordStart { ignore_punctuation },
+                            )
                         }
-                        result
-                    };
+                        _ => {
+                            let result = motion.expand_selection(
+                                map,
+                                selection,
+                                times,
+                                false,
+                                &text_layout_details,
+                            );
+                            if let Motion::CurrentLine = motion {
+                                let mut start_offset = selection.start.to_offset(map, Bias::Left);
+                                let scope = map
+                                    .buffer_snapshot
+                                    .language_scope_at(selection.start.to_point(&map));
+                                for (ch, offset) in map.buffer_chars_at(start_offset) {
+                                    if ch == '\n' || char_kind(&scope, ch) != CharKind::Whitespace {
+                                        break;
+                                    }
+                                    start_offset = offset + ch.len_utf8();
+                                }
+                                selection.start = start_offset.to_display_point(map);
+                            }
+                            result
+                        }
+                    }
                 });
             });
             copy_selections_content(vim, editor, motion.linewise(), cx);
@@ -126,7 +120,7 @@ fn expand_changed_word_selection(
     text_layout_details: &TextLayoutDetails,
     use_subword: bool,
 ) -> bool {
-    if times.is_none() || times.unwrap() == 1 {
+    let is_not_in_word = || {
         let scope = map
             .buffer_snapshot
             .language_scope_at(selection.start.to_point(map));
@@ -135,25 +129,29 @@ fn expand_changed_word_selection(
             .next()
             .map(|(c, _)| char_kind(&scope, c) != CharKind::Whitespace)
             .unwrap_or_default();
+        return !in_word;
+    };
 
-        if in_word {
-            if use_subword {
-                selection.end =
-                    motion::next_subword_end(map, selection.end, ignore_punctuation, 1, false);
-            } else {
-                selection.end =
-                    motion::next_word_end(map, selection.end, ignore_punctuation, 1, false);
+    if times.is_none() || times.unwrap() == 1 || is_not_in_word() {
+        let next_char = map
+            .buffer_chars_at(
+                motion::next_char(map, selection.end, false).to_offset(map, Bias::Left),
+            )
+            .next();
+        match next_char {
+            Some((' ', _)) => selection.end = motion::next_char(map, selection.end, false),
+            _ => {
+                if use_subword {
+                    selection.end =
+                        motion::next_subword_end(map, selection.end, ignore_punctuation, 1, false);
+                } else {
+                    selection.end =
+                        motion::next_word_end(map, selection.end, ignore_punctuation, 1, false);
+                }
+                selection.end = motion::next_char(map, selection.end, false);
             }
-            selection.end = motion::next_char(map, selection.end, false);
-            true
-        } else {
-            let motion = if use_subword {
-                Motion::NextSubwordStart { ignore_punctuation }
-            } else {
-                Motion::NextWordStart { ignore_punctuation }
-            };
-            motion.expand_selection(map, selection, None, false, &text_layout_details)
         }
+        true
     } else {
         let motion = if use_subword {
             Motion::NextSubwordStart { ignore_punctuation }

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -31,25 +31,16 @@ pub fn change_motion(vim: &mut Vim, motion: Motion, times: Option<usize>, cx: &m
             editor.set_clip_at_line_ends(false, cx);
             editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
-                    motion_succeeded |= if let Motion::NextWordStart { ignore_punctuation } = motion
+                    motion_succeeded |= if let Motion::NextWordStart {
+                        ignore_punctuation: _,
+                    } = motion
                     {
-                        expand_changed_word_selection(
-                            map,
-                            selection,
-                            times,
-                            ignore_punctuation,
-                            &text_layout_details,
-                            false,
-                        )
-                    } else if let Motion::NextSubwordStart { ignore_punctuation } = motion {
-                        expand_changed_word_selection(
-                            map,
-                            selection,
-                            times,
-                            ignore_punctuation,
-                            &text_layout_details,
-                            true,
-                        )
+                        motion.expand_selection(map, selection, times, false, &text_layout_details)
+                    } else if let Motion::NextSubwordStart {
+                        ignore_punctuation: _,
+                    } = motion
+                    {
+                        motion.expand_selection(map, selection, times, false, &text_layout_details)
                     } else {
                         let result = motion.expand_selection(
                             map,
@@ -109,58 +100,6 @@ pub fn change_object(vim: &mut Vim, object: Object, around: bool, cx: &mut Windo
         vim.switch_mode(Mode::Insert, false, cx);
     } else {
         vim.switch_mode(Mode::Normal, false, cx);
-    }
-}
-
-// From the docs https://vimdoc.sourceforge.net/htmldoc/motion.html
-// Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is
-// on a non-blank.  This is because "cw" is interpreted as change-word, and a
-// word does not include the following white space.  {Vi: "cw" when on a blank
-//     followed by other blanks changes only the first blank; this is probably a
-//     bug, because "dw" deletes all the blanks}
-fn expand_changed_word_selection(
-    map: &DisplaySnapshot,
-    selection: &mut Selection<DisplayPoint>,
-    times: Option<usize>,
-    ignore_punctuation: bool,
-    text_layout_details: &TextLayoutDetails,
-    use_subword: bool,
-) -> bool {
-    if times.is_none() || times.unwrap() == 1 {
-        let scope = map
-            .buffer_snapshot
-            .language_scope_at(selection.start.to_point(map));
-        let in_word = map
-            .buffer_chars_at(selection.head().to_offset(map, Bias::Left))
-            .next()
-            .map(|(c, _)| char_kind(&scope, c) != CharKind::Whitespace)
-            .unwrap_or_default();
-
-        if in_word {
-            if use_subword {
-                selection.end =
-                    motion::next_subword_end(map, selection.end, ignore_punctuation, 1, false);
-            } else {
-                selection.end =
-                    motion::next_word_end(map, selection.end, ignore_punctuation, 1, false);
-            }
-            selection.end = motion::next_char(map, selection.end, false);
-            true
-        } else {
-            let motion = if use_subword {
-                Motion::NextSubwordStart { ignore_punctuation }
-            } else {
-                Motion::NextWordStart { ignore_punctuation }
-            };
-            motion.expand_selection(map, selection, None, false, &text_layout_details)
-        }
-    } else {
-        let motion = if use_subword {
-            Motion::NextSubwordStart { ignore_punctuation }
-        } else {
-            Motion::NextWordStart { ignore_punctuation }
-        };
-        motion.expand_selection(map, selection, times, false, &text_layout_details)
     }
 }
 

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -31,16 +31,25 @@ pub fn change_motion(vim: &mut Vim, motion: Motion, times: Option<usize>, cx: &m
             editor.set_clip_at_line_ends(false, cx);
             editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                 s.move_with(|map, selection| {
-                    motion_succeeded |= if let Motion::NextWordStart {
-                        ignore_punctuation: _,
-                    } = motion
+                    motion_succeeded |= if let Motion::NextWordStart { ignore_punctuation } = motion
                     {
-                        motion.expand_selection(map, selection, times, false, &text_layout_details)
-                    } else if let Motion::NextSubwordStart {
-                        ignore_punctuation: _,
-                    } = motion
-                    {
-                        motion.expand_selection(map, selection, times, false, &text_layout_details)
+                        expand_changed_word_selection(
+                            map,
+                            selection,
+                            times,
+                            ignore_punctuation,
+                            &text_layout_details,
+                            false,
+                        )
+                    } else if let Motion::NextSubwordStart { ignore_punctuation } = motion {
+                        expand_changed_word_selection(
+                            map,
+                            selection,
+                            times,
+                            ignore_punctuation,
+                            &text_layout_details,
+                            true,
+                        )
                     } else {
                         let result = motion.expand_selection(
                             map,
@@ -100,6 +109,58 @@ pub fn change_object(vim: &mut Vim, object: Object, around: bool, cx: &mut Windo
         vim.switch_mode(Mode::Insert, false, cx);
     } else {
         vim.switch_mode(Mode::Normal, false, cx);
+    }
+}
+
+// From the docs https://vimdoc.sourceforge.net/htmldoc/motion.html
+// Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is
+// on a non-blank.  This is because "cw" is interpreted as change-word, and a
+// word does not include the following white space.  {Vi: "cw" when on a blank
+//     followed by other blanks changes only the first blank; this is probably a
+//     bug, because "dw" deletes all the blanks}
+fn expand_changed_word_selection(
+    map: &DisplaySnapshot,
+    selection: &mut Selection<DisplayPoint>,
+    times: Option<usize>,
+    ignore_punctuation: bool,
+    text_layout_details: &TextLayoutDetails,
+    use_subword: bool,
+) -> bool {
+    if times.is_none() || times.unwrap() == 1 {
+        let scope = map
+            .buffer_snapshot
+            .language_scope_at(selection.start.to_point(map));
+        let in_word = map
+            .buffer_chars_at(selection.head().to_offset(map, Bias::Left))
+            .next()
+            .map(|(c, _)| char_kind(&scope, c) != CharKind::Whitespace)
+            .unwrap_or_default();
+
+        if in_word {
+            if use_subword {
+                selection.end =
+                    motion::next_subword_end(map, selection.end, ignore_punctuation, 1, false);
+            } else {
+                selection.end =
+                    motion::next_word_end(map, selection.end, ignore_punctuation, 1, false);
+            }
+            selection.end = motion::next_char(map, selection.end, false);
+            true
+        } else {
+            let motion = if use_subword {
+                Motion::NextSubwordStart { ignore_punctuation }
+            } else {
+                Motion::NextWordStart { ignore_punctuation }
+            };
+            motion.expand_selection(map, selection, None, false, &text_layout_details)
+        }
+    } else {
+        let motion = if use_subword {
+            Motion::NextSubwordStart { ignore_punctuation }
+        } else {
+            Motion::NextWordStart { ignore_punctuation }
+        };
+        motion.expand_selection(map, selection, times, false, &text_layout_details)
     }
 }
 

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -120,7 +120,7 @@ fn expand_changed_word_selection(
     text_layout_details: &TextLayoutDetails,
     use_subword: bool,
 ) -> bool {
-    let is_not_in_word = || {
+    let is_in_word = || {
         let scope = map
             .buffer_snapshot
             .language_scope_at(selection.start.to_point(map));
@@ -129,10 +129,9 @@ fn expand_changed_word_selection(
             .next()
             .map(|(c, _)| char_kind(&scope, c) != CharKind::Whitespace)
             .unwrap_or_default();
-        return !in_word;
+        return in_word;
     };
-
-    if times.is_none() || times.unwrap() == 1 || is_not_in_word() {
+    if (times.is_none() || times.unwrap() == 1) && is_in_word() {
         let next_char = map
             .buffer_chars_at(
                 motion::next_char(map, selection.end, false).to_offset(map, Bias::Left),

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -1,7 +1,18 @@
-use crate::{motion::Motion, object::Object, state::Mode, utils::copy_selections_content, Vim};
-use editor::{display_map::ToDisplayPoint, scroll::Autoscroll, Bias};
+use crate::{
+    motion::{self, Motion},
+    object::Object,
+    state::Mode,
+    utils::copy_selections_content,
+    Vim,
+};
+use editor::{
+    display_map::{DisplaySnapshot, ToDisplayPoint},
+    movement::TextLayoutDetails,
+    scroll::Autoscroll,
+    Bias, DisplayPoint,
+};
 use gpui::WindowContext;
-use language::{char_kind, CharKind};
+use language::{char_kind, CharKind, Selection};
 
 pub fn change_motion(vim: &mut Vim, motion: Motion, times: Option<usize>, cx: &mut WindowContext) {
     // Some motions ignore failure when switching to normal mode

--- a/crates/vim/test_data/test_change_w.json
+++ b/crates/vim/test_data/test_change_w.json
@@ -10,6 +10,10 @@
 {"Key":"c"}
 {"Key":"w"}
 {"Get":{"state":"Testˇtest","mode":"Insert"}}
+{"Put":{"state":"Tesˇt  test"}}
+{"Key":"c"}
+{"Key":"w"}
+{"Get":{"state":"Tesˇ  test","mode":"Insert"}}
 {"Put":{"state":"Test teˇst\ntest"}}
 {"Key":"c"}
 {"Key":"w"}


### PR DESCRIPTION
At the moment, using the default expand_selection seems to do the job well, without the need for some additional logic, which may also make the code a little clearer, Fix #10945



Release Notes:


- N/A
