### PR TITLE
Fix suffix match filename

### DIFF
--- a/crates/file_icons/src/file_icons.rs
+++ b/crates/file_icons/src/file_icons.rs
@@ -51,6 +51,10 @@ impl FileIcons {
         // FIXME: Associate a type with the languages and have the file's language
         //        override these associations
         maybe!({
+            // If `filename`` can be found directly in `suffixes`
+            if let Some(type_str) = this.suffixes.get(path.file_name()?.to_str()?) {
+                return this.get_type_icon(type_str);
+            }
             let suffix = path.icon_stem_or_suffix()?;
 
             if let Some(type_str) = this.stems.get(suffix) {


### PR DESCRIPTION
This PR hopes that the suffixes in file_type.json can match filename first

Before:

<img width="215" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/0aa5bc69-493c-4b31-970e-c0c2ad702056">

After:

<img width="259" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/9a75992f-6601-4270-83a9-49bb849ed821">

Release Notes:

- Fixed suffix match filename
