### PR TITLE
Blade window transparency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "blade-graphics"
 version = "0.4.0"
-source = "git+https://github.com/kvark/blade?rev=e82eec97691c3acdb43494484be60d661edfebf3#e82eec97691c3acdb43494484be60d661edfebf3"
+source = "git+https://github.com/kvark/blade?rev=f5766863de9dcc092e90fdbbc5e0007a99e7f9bf#f5766863de9dcc092e90fdbbc5e0007a99e7f9bf"
 dependencies = [
  "ash",
  "ash-window",
@@ -1510,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "blade-macros"
 version = "0.2.1"
-source = "git+https://github.com/kvark/blade?rev=e82eec97691c3acdb43494484be60d661edfebf3#e82eec97691c3acdb43494484be60d661edfebf3"
+source = "git+https://github.com/kvark/blade?rev=f5766863de9dcc092e90fdbbc5e0007a99e7f9bf#f5766863de9dcc092e90fdbbc5e0007a99e7f9bf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
+ "wayland-protocols-plasma",
  "windows 0.53.0",
  "x11rb",
  "xkbcommon",
@@ -11777,6 +11778,19 @@ dependencies = [
  "bitflags 2.4.2",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+dependencies = [
+ "bitflags 2.4.2",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,8 +254,8 @@ async-recursion = "1.0.0"
 async-tar = "0.4.2"
 async-trait = "0.1"
 bitflags = "2.4.2"
-blade-graphics = { git = "https://github.com/kvark/blade", rev = "e82eec97691c3acdb43494484be60d661edfebf3" }
-blade-macros = { git = "https://github.com/kvark/blade", rev = "e82eec97691c3acdb43494484be60d661edfebf3" }
+blade-graphics = { git = "https://github.com/kvark/blade", rev = "f5766863de9dcc092e90fdbbc5e0007a99e7f9bf" }
+blade-macros = { git = "https://github.com/kvark/blade", rev = "f5766863de9dcc092e90fdbbc5e0007a99e7f9bf" }
 cap-std = "3.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -111,6 +111,7 @@ wayland-protocols = { version = "0.31.2", features = [
     "staging",
     "unstable",
 ] }
+wayland-protocols-plasma = { version = "0.2.0", features = ["client"] }
 oo7 = "0.3.0"
 open = "5.1.2"
 filedescriptor = "0.8.2"

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -200,6 +200,16 @@ impl BladePipelines {
         shader.check_struct_size::<MonochromeSprite>();
         shader.check_struct_size::<PolychromeSprite>();
 
+        let color_targets = &[gpu::ColorTargetState {
+            format: surface_info.format,
+            blend: Some(match surface_info.alpha {
+                gpu::AlphaMode::Ignored => gpu::BlendState::ALPHA_BLENDING,
+                gpu::AlphaMode::PreMultiplied => gpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
+                gpu::AlphaMode::PostMultiplied => gpu::BlendState::ALPHA_BLENDING,
+            }),
+            write_mask: gpu::ColorWrites::default(),
+        }];
+
         Self {
             quads: gpu.create_render_pipeline(gpu::RenderPipelineDesc {
                 name: "quads",
@@ -212,11 +222,7 @@ impl BladePipelines {
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_quad"),
-                color_targets: &[gpu::ColorTargetState {
-                    format: surface_info.format,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
-                    write_mask: gpu::ColorWrites::default(),
-                }],
+                color_targets,
             }),
             shadows: gpu.create_render_pipeline(gpu::RenderPipelineDesc {
                 name: "shadows",
@@ -229,11 +235,7 @@ impl BladePipelines {
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_shadow"),
-                color_targets: &[gpu::ColorTargetState {
-                    format: surface_info.format,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
-                    write_mask: gpu::ColorWrites::default(),
-                }],
+                color_targets,
             }),
             path_rasterization: gpu.create_render_pipeline(gpu::RenderPipelineDesc {
                 name: "path_rasterization",
@@ -263,11 +265,7 @@ impl BladePipelines {
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_path"),
-                color_targets: &[gpu::ColorTargetState {
-                    format: surface_info.format,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
-                    write_mask: gpu::ColorWrites::default(),
-                }],
+                color_targets,
             }),
             underlines: gpu.create_render_pipeline(gpu::RenderPipelineDesc {
                 name: "underlines",
@@ -280,11 +278,7 @@ impl BladePipelines {
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_underline"),
-                color_targets: &[gpu::ColorTargetState {
-                    format: surface_info.format,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
-                    write_mask: gpu::ColorWrites::default(),
-                }],
+                color_targets,
             }),
             mono_sprites: gpu.create_render_pipeline(gpu::RenderPipelineDesc {
                 name: "mono-sprites",
@@ -297,11 +291,7 @@ impl BladePipelines {
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_mono_sprite"),
-                color_targets: &[gpu::ColorTargetState {
-                    format: surface_info.format,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
-                    write_mask: gpu::ColorWrites::default(),
-                }],
+                color_targets,
             }),
             poly_sprites: gpu.create_render_pipeline(gpu::RenderPipelineDesc {
                 name: "poly-sprites",
@@ -314,11 +304,7 @@ impl BladePipelines {
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_poly_sprite"),
-                color_targets: &[gpu::ColorTargetState {
-                    format: surface_info.format,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
-                    write_mask: gpu::ColorWrites::default(),
-                }],
+                color_targets,
             }),
             surfaces: gpu.create_render_pipeline(gpu::RenderPipelineDesc {
                 name: "surfaces",
@@ -331,11 +317,7 @@ impl BladePipelines {
                 },
                 depth_stencil: None,
                 fragment: shader.at("fs_surface"),
-                color_targets: &[gpu::ColorTargetState {
-                    format: surface_info.format,
-                    blend: Some(gpu::BlendState::ALPHA_BLENDING),
-                    write_mask: gpu::ColorWrites::default(),
-                }],
+                color_targets,
             }),
         }
     }
@@ -365,7 +347,7 @@ impl BladeRenderer {
             // but ultimaterly we need to switch to `Linear`.
             color_space: gpu::ColorSpace::Srgb,
             allow_exclusive_full_screen: false,
-            transparent: false,
+            transparent: true,
         }
     }
 

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -28,7 +28,7 @@ pub unsafe fn new_renderer(
     _native_window: *mut c_void,
     native_view: *mut c_void,
     bounds: crate::Size<f32>,
-    window_background: crate::WindowBackgroundAppearance,
+    transparent: bool,
 ) -> Renderer {
     use raw_window_handle as rwh;
     struct RawWindow {
@@ -71,7 +71,7 @@ pub unsafe fn new_renderer(
                 height: bounds.height as u32,
                 depth: 1,
             },
-            transparent: window_background == crate::WindowBackgroundAppearance::Transparent,
+            transparent,
         },
     )
 }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -47,6 +47,7 @@ use wayland_protocols::xdg::decoration::zv1::client::{
     zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1,
 };
 use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+use wayland_protocols_plasma::blur::client::{org_kde_kwin_blur, org_kde_kwin_blur_manager};
 use xkbcommon::xkb::ffi::XKB_KEYMAP_FORMAT_TEXT_V1;
 use xkbcommon::xkb::{self, Keycode, KEYMAP_COMPILE_NO_FLAGS};
 
@@ -82,6 +83,7 @@ pub struct Globals {
     pub fractional_scale_manager:
         Option<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
     pub decoration_manager: Option<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1>,
+    pub blur_manager: Option<org_kde_kwin_blur_manager::OrgKdeKwinBlurManager>,
     pub executor: ForegroundExecutor,
 }
 
@@ -114,6 +116,7 @@ impl Globals {
             viewporter: globals.bind(&qh, 1..=1, ()).ok(),
             fractional_scale_manager: globals.bind(&qh, 1..=1, ()).ok(),
             decoration_manager: globals.bind(&qh, 1..=1, ()).ok(),
+            blur_manager: globals.bind(&qh, 1..=1, ()).ok(),
             executor,
             qh,
         }
@@ -560,6 +563,8 @@ delegate_noop!(WaylandClientStatePtr: ignore wl_buffer::WlBuffer);
 delegate_noop!(WaylandClientStatePtr: ignore wl_region::WlRegion);
 delegate_noop!(WaylandClientStatePtr: ignore wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
 delegate_noop!(WaylandClientStatePtr: ignore zxdg_decoration_manager_v1::ZxdgDecorationManagerV1);
+delegate_noop!(WaylandClientStatePtr: ignore org_kde_kwin_blur_manager::OrgKdeKwinBlurManager);
+delegate_noop!(WaylandClientStatePtr: ignore org_kde_kwin_blur::OrgKdeKwinBlur);
 delegate_noop!(WaylandClientStatePtr: ignore wp_viewporter::WpViewporter);
 delegate_noop!(WaylandClientStatePtr: ignore wp_viewport::WpViewport);
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -24,7 +24,7 @@ use wayland_client::protocol::wl_callback::{self, WlCallback};
 use wayland_client::protocol::wl_data_device_manager::DndAction;
 use wayland_client::protocol::wl_pointer::{AxisRelativeDirection, AxisSource};
 use wayland_client::protocol::{
-    wl_data_device, wl_data_device_manager, wl_data_offer, wl_data_source, wl_output,
+    wl_data_device, wl_data_device_manager, wl_data_offer, wl_data_source, wl_output, wl_region,
 };
 use wayland_client::{
     delegate_noop,
@@ -557,6 +557,7 @@ delegate_noop!(WaylandClientStatePtr: ignore wl_data_device_manager::WlDataDevic
 delegate_noop!(WaylandClientStatePtr: ignore wl_shm::WlShm);
 delegate_noop!(WaylandClientStatePtr: ignore wl_shm_pool::WlShmPool);
 delegate_noop!(WaylandClientStatePtr: ignore wl_buffer::WlBuffer);
+delegate_noop!(WaylandClientStatePtr: ignore wl_region::WlRegion);
 delegate_noop!(WaylandClientStatePtr: ignore wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
 delegate_noop!(WaylandClientStatePtr: ignore zxdg_decoration_manager_v1::ZxdgDecorationManagerV1);
 delegate_noop!(WaylandClientStatePtr: ignore wp_viewporter::WpViewporter);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -19,6 +19,7 @@ use wayland_protocols::wp::viewporter::client::wp_viewport;
 use wayland_protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1;
 use wayland_protocols::xdg::shell::client::xdg_surface;
 use wayland_protocols::xdg::shell::client::xdg_toplevel::{self, WmCapabilities};
+use wayland_protocols_plasma::blur::client::{org_kde_kwin_blur, org_kde_kwin_blur_manager};
 
 use crate::platform::blade::{BladeRenderer, BladeSurfaceConfig};
 use crate::platform::linux::wayland::display::WaylandDisplay;
@@ -68,6 +69,7 @@ pub struct WaylandWindowState {
     acknowledged_first_configure: bool,
     pub surface: wl_surface::WlSurface,
     decoration: Option<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1>,
+    blur: Option<org_kde_kwin_blur::OrgKdeKwinBlur>,
     toplevel: xdg_toplevel::XdgToplevel,
     viewport: Option<wp_viewport::WpViewport>,
     outputs: HashSet<ObjectId>,
@@ -139,6 +141,7 @@ impl WaylandWindowState {
             acknowledged_first_configure: false,
             surface,
             decoration,
+            blur: None,
             toplevel,
             viewport,
             globals,
@@ -167,6 +170,9 @@ impl Drop for WaylandWindow {
         state.renderer.destroy();
         if let Some(decoration) = &state.decoration {
             decoration.destroy();
+        }
+        if let Some(blur) = &state.blur {
+            blur.release();
         }
         state.toplevel.destroy();
         if let Some(viewport) = &state.viewport {
@@ -621,20 +627,40 @@ impl PlatformWindow for WaylandWindow {
         let opaque = background_appearance == WindowBackgroundAppearance::Opaque;
         let mut state = self.borrow_mut();
         state.renderer.update_transparency(!opaque);
+
+        let region = state
+            .globals
+            .compositor
+            .create_region(&state.globals.qh, ());
+        region.add(0, 0, i32::MAX, i32::MAX);
+
         if opaque {
             // Promise the compositor that this region of the window surface
             // contains no transparent pixels. This allows the compositor to
             // do skip whatever is behind the surface for better performance.
-            let region = state
-                .globals
-                .compositor
-                .create_region(&state.globals.qh, ());
-            region.add(0, 0, i32::MAX, i32::MAX);
             state.surface.set_opaque_region(Some(&region));
-            region.destroy();
         } else {
             state.surface.set_opaque_region(None);
-        };
+        }
+
+        if let Some(ref blur_manager) = state.globals.blur_manager {
+            if (background_appearance == WindowBackgroundAppearance::Blurred) {
+                if (state.blur.is_none()) {
+                    let blur = blur_manager.create(&state.surface, &state.globals.qh, ());
+                    blur.set_region(Some(&region));
+                    state.blur = Some(blur);
+                }
+                state.blur.as_ref().unwrap().commit();
+            } else {
+                // It probably doesn't hurt to clear the blur for opaque windows
+                blur_manager.unset(&state.surface);
+                if let Some(b) = state.blur.take() {
+                    b.release()
+                }
+            }
+        }
+
+        region.destroy();
     }
 
     fn set_edited(&mut self, edited: bool) {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -130,7 +130,7 @@ impl WaylandWindowState {
                 height: bounds.size.height,
                 depth: 1,
             },
-            transparent: options.window_background == WindowBackgroundAppearance::Transparent,
+            transparent: options.window_background != WindowBackgroundAppearance::Opaque,
         };
 
         Self {
@@ -620,7 +620,7 @@ impl PlatformWindow for WaylandWindow {
         let mut state = self.borrow_mut();
         state
             .renderer
-            .update_transparency(background_appearance == WindowBackgroundAppearance::Transparent);
+            .update_transparency(background_appearance != WindowBackgroundAppearance::Opaque);
     }
 
     fn set_edited(&mut self, edited: bool) {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -19,7 +19,7 @@ use wayland_protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1
 use wayland_protocols::xdg::shell::client::xdg_surface;
 use wayland_protocols::xdg::shell::client::xdg_toplevel::{self, WmCapabilities};
 
-use crate::platform::blade::BladeRenderer;
+use crate::platform::blade::{BladeRenderer, BladeSurfaceConfig};
 use crate::platform::linux::wayland::display::WaylandDisplay;
 use crate::platform::{PlatformAtlas, PlatformInputHandler, PlatformWindow};
 use crate::scene::Scene;
@@ -124,10 +124,13 @@ impl WaylandWindowState {
             }
             .unwrap(),
         );
-        let extent = gpu::Extent {
-            width: bounds.size.width,
-            height: bounds.size.height,
-            depth: 1,
+        let config = BladeSurfaceConfig {
+            size: gpu::Extent {
+                width: bounds.size.width,
+                height: bounds.size.height,
+                depth: 1,
+            },
+            transparent: options.window_background == WindowBackgroundAppearance::Transparent,
         };
 
         Self {
@@ -138,10 +141,8 @@ impl WaylandWindowState {
             toplevel,
             viewport,
             globals,
-
             outputs: HashSet::default(),
-
-            renderer: BladeRenderer::new(gpu, extent),
+            renderer: BladeRenderer::new(gpu, config),
             bounds,
             scale: 1.0,
             input_handler: None,
@@ -615,8 +616,11 @@ impl PlatformWindow for WaylandWindow {
         self.borrow_mut().toplevel.set_app_id(app_id.to_owned());
     }
 
-    fn set_background_appearance(&mut self, _background_appearance: WindowBackgroundAppearance) {
-        // todo(linux)
+    fn set_background_appearance(&mut self, background_appearance: WindowBackgroundAppearance) {
+        let mut state = self.borrow_mut();
+        state
+            .renderer
+            .update_transparency(background_appearance == WindowBackgroundAppearance::Transparent);
     }
 
     fn set_edited(&mut self, edited: bool) {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -2,10 +2,11 @@
 #![allow(unused)]
 
 use crate::{
-    platform::blade::{BladeRenderer, BladeSurfaceConfig}, size, Bounds, DevicePixels, ForegroundExecutor, Modifiers,
-    Pixels, Platform, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler,
-    PlatformWindow, Point, PromptLevel, Scene, Size, WindowAppearance, WindowBackgroundAppearance,
-    WindowOptions, WindowParams, X11Client, X11ClientState, X11ClientStatePtr,
+    platform::blade::{BladeRenderer, BladeSurfaceConfig},
+    size, Bounds, DevicePixels, ForegroundExecutor, Modifiers, Pixels, Platform, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptLevel,
+    Scene, Size, WindowAppearance, WindowBackgroundAppearance, WindowOptions, WindowParams,
+    X11Client, X11ClientState, X11ClientStatePtr,
 };
 use blade_graphics as gpu;
 use parking_lot::Mutex;
@@ -215,7 +216,7 @@ impl X11WindowState {
                 &[atoms.WM_DELETE_WINDOW],
             )
             .unwrap();
-        let transparent = params.window_background == WindowBackgroundAppearance::Transparent;
+        let transparent = params.window_background != WindowBackgroundAppearance::Opaque;
         if transparent {
             xcb_connection
                 .change_property32(
@@ -549,19 +550,20 @@ impl PlatformWindow for X11Window {
     fn set_edited(&mut self, edited: bool) {}
 
     fn set_background_appearance(&mut self, background_appearance: WindowBackgroundAppearance) {
-        let mut state = self.0.state.borrow_mut();
-        let transparent = background_appearance == WindowBackgroundAppearance::Transparent;
-        self.0.xcb_connection
+        let mut inner = self.0.state.borrow_mut();
+        let transparent = background_appearance != WindowBackgroundAppearance::Opaque;
+        self.0
+            .xcb_connection
             .change_property32(
                 xproto::PropMode::REPLACE,
                 self.0.x_window,
-                state.atoms._NET_WM_WINDOW_OPACITY,
+                inner.atoms._NET_WM_WINDOW_OPACITY,
                 xproto::AtomEnum::CARDINAL,
                 &[if transparent { 0 } else { !0 }],
             )
             .unwrap();
 
-        state.renderer.update_transparency(transparent);
+        inner.renderer.update_transparency(transparent);
     }
 
     // todo(linux), this corresponds to `orderFrontCharacterPalette` on macOS,

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -2,7 +2,7 @@ use super::metal_atlas::MetalAtlas;
 use crate::{
     point, size, AtlasTextureId, AtlasTextureKind, AtlasTile, Bounds, ContentMask, DevicePixels,
     Hsla, MonochromeSprite, Path, PathId, PathVertex, PolychromeSprite, PrimitiveBatch, Quad,
-    ScaledPixels, Scene, Shadow, Size, Surface, Underline,
+    ScaledPixels, Scene, Shadow, Size, Surface, Underline, WindowBackgroundAppearance,
 };
 use block::ConcreteBlock;
 use cocoa::{
@@ -37,6 +37,7 @@ pub unsafe fn new_renderer(
     _native_window: *mut c_void,
     _native_view: *mut c_void,
     _bounds: crate::Size<f32>,
+    _window_background: WindowBackgroundAppearance,
 ) -> Renderer {
     MetalRenderer::new(context)
 }
@@ -229,6 +230,10 @@ impl MetalRenderer {
                 setDrawableSize: size
             ];
         }
+    }
+
+    pub fn update_transparency(&mut self, _transparent: bool) {
+        // todo(mac)?
     }
 
     pub fn destroy(&mut self) {

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -2,7 +2,7 @@ use super::metal_atlas::MetalAtlas;
 use crate::{
     point, size, AtlasTextureId, AtlasTextureKind, AtlasTile, Bounds, ContentMask, DevicePixels,
     Hsla, MonochromeSprite, Path, PathId, PathVertex, PolychromeSprite, PrimitiveBatch, Quad,
-    ScaledPixels, Scene, Shadow, Size, Surface, Underline, WindowBackgroundAppearance,
+    ScaledPixels, Scene, Shadow, Size, Surface, Underline,
 };
 use block::ConcreteBlock;
 use cocoa::{
@@ -37,7 +37,7 @@ pub unsafe fn new_renderer(
     _native_window: *mut c_void,
     _native_view: *mut c_void,
     _bounds: crate::Size<f32>,
-    _window_background: WindowBackgroundAppearance,
+    _transparent: bool,
 ) -> Renderer {
     MetalRenderer::new(context)
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -626,7 +626,7 @@ impl MacWindow {
                     native_window as *mut _,
                     native_view as *mut _,
                     window_size,
-                    window_background,
+                    window_background != WindowBackgroundAppearance::Opaque,
                 ),
                 request_frame_callback: None,
                 event_callback: None,
@@ -982,7 +982,7 @@ impl PlatformWindow for MacWindow {
     fn set_background_appearance(&mut self, background_appearance: WindowBackgroundAppearance) {
         let mut this = self.0.as_ref().lock();
         this.renderer
-            .update_transparency(background_appearance == WindowBackgroundAppearance::Transparent);
+            .update_transparency(background_appearance != WindowBackgroundAppearance::Opaque);
 
         let blur_radius = if background_appearance == WindowBackgroundAppearance::Blurred {
             80

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -626,6 +626,7 @@ impl MacWindow {
                     native_window as *mut _,
                     native_view as *mut _,
                     window_size,
+                    window_background,
                 ),
                 request_frame_callback: None,
                 event_callback: None,
@@ -979,7 +980,10 @@ impl PlatformWindow for MacWindow {
     fn set_app_id(&mut self, _app_id: &str) {}
 
     fn set_background_appearance(&mut self, background_appearance: WindowBackgroundAppearance) {
-        let this = self.0.as_ref().lock();
+        let mut this = self.0.as_ref().lock();
+        this.renderer
+            .update_transparency(background_appearance == WindowBackgroundAppearance::Transparent);
+
         let blur_radius = if background_appearance == WindowBackgroundAppearance::Blurred {
             80
         } else {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1280,7 +1280,7 @@ impl WindowsWindow {
             // todo(windows) move window to target monitor
             // options.display_id
             display: Rc::new(WindowsDisplay::primary_monitor().unwrap()),
-            transparent: options.window_background == WindowBackgroundAppearance::Transparent,
+            transparent: options.window_background != WindowBackgroundAppearance::Opaque,
         };
         let lpparam = Some(&context as *const _ as *const _);
         unsafe {
@@ -1517,7 +1517,7 @@ impl PlatformWindow for WindowsWindow {
         self.inner
             .renderer
             .borrow_mut()
-            .update_transparency(background_appearance == WindowBackgroundAppearance::Transparent);
+            .update_transparency(background_appearance != WindowBackgroundAppearance::Opaque);
     }
 
     // todo(windows)

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -35,7 +35,7 @@ use windows::{
     },
 };
 
-use crate::platform::blade::BladeRenderer;
+use crate::platform::blade::{BladeRenderer, BladeSurfaceConfig};
 use crate::*;
 
 pub(crate) struct WindowsWindowInner {
@@ -62,6 +62,7 @@ impl WindowsWindowInner {
         handle: AnyWindowHandle,
         hide_title_bar: bool,
         display: Rc<WindowsDisplay>,
+        transparent: bool,
     ) -> Self {
         let monitor_dpi = unsafe { GetDpiForWindow(hwnd) } as f32;
         let origin = Cell::new(Point {
@@ -95,7 +96,7 @@ impl WindowsWindowInner {
             }
         }
 
-        let raw = RawWindow { hwnd: hwnd.0 as _ };
+        let raw = RawWindow { hwnd: hwnd.0 };
         let gpu = Arc::new(
             unsafe {
                 gpu::Context::init_windowed(
@@ -109,12 +110,11 @@ impl WindowsWindowInner {
             }
             .unwrap(),
         );
-        let extent = gpu::Extent {
-            width: 1,
-            height: 1,
-            depth: 1,
+        let config = BladeSurfaceConfig {
+            size: gpu::Extent::default(),
+            transparent,
         };
-        let renderer = RefCell::new(BladeRenderer::new(gpu, extent));
+        let renderer = RefCell::new(BladeRenderer::new(gpu, config));
         let callbacks = RefCell::new(Callbacks::default());
         let display = RefCell::new(display);
         let click_state = RefCell::new(ClickState::new());
@@ -1241,6 +1241,7 @@ struct WindowCreateContext {
     handle: AnyWindowHandle,
     hide_title_bar: bool,
     display: Rc<WindowsDisplay>,
+    transparent: bool,
 }
 
 impl WindowsWindow {
@@ -1279,6 +1280,7 @@ impl WindowsWindow {
             // todo(windows) move window to target monitor
             // options.display_id
             display: Rc::new(WindowsDisplay::primary_monitor().unwrap()),
+            transparent: options.window_background == WindowBackgroundAppearance::Transparent,
         };
         let lpparam = Some(&context as *const _ as *const _);
         unsafe {
@@ -1511,8 +1513,11 @@ impl PlatformWindow for WindowsWindow {
 
     fn set_app_id(&mut self, _app_id: &str) {}
 
-    fn set_background_appearance(&mut self, _background_appearance: WindowBackgroundAppearance) {
-        // todo(windows)
+    fn set_background_appearance(&mut self, background_appearance: WindowBackgroundAppearance) {
+        self.inner
+            .renderer
+            .borrow_mut()
+            .update_transparency(background_appearance == WindowBackgroundAppearance::Transparent);
     }
 
     // todo(windows)
@@ -1783,6 +1788,7 @@ unsafe extern "system" fn wnd_proc(
             ctx.handle,
             ctx.hide_title_bar,
             ctx.display.clone(),
+            ctx.transparent,
         ));
         let weak = Box::new(Rc::downgrade(&inner));
         unsafe { set_window_long(hwnd, GWLP_USERDATA, Box::into_raw(weak) as isize) };


### PR DESCRIPTION
Release Notes:

- N/A

Following up to #10880
TODO:
- [x] create window as transparent
  - [x] X11
  - [x] Wayland
  - [ ] Windows
  - [x] MacOS (when used with Blade)  
- [x] enable GPU surface transparency
- [x] adjust the pipeline blend modes
- [x] adjust shader outputs

![transparency2](https://github.com/zed-industries/zed/assets/107301/d554a41b-5d3f-4420-a857-c64c1747c2d5)

Blurred results from @jansol (on Wayland), who contributed to this work:

![zed-blur](https://github.com/zed-industries/zed/assets/107301/a6822171-2dcf-4109-be55-b75557c586de)

