### PR TITLE
git: Fix inline blame moving on horizontal scroll

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1200,7 +1200,7 @@ impl EditorElement {
                 .map(|col| self.column_pixels(col as usize, cx))
                 .unwrap_or(px(0.));
 
-            content_origin.x + max(padded_line_width, min_column)
+            (content_origin.x - scroll_pixel_position.x) + max(padded_line_width, min_column)
         };
 
         let absolute_offset = point(start_x, start_y);


### PR DESCRIPTION
This fixes the behaviour reported by @mikayla-maki.

## Before

https://github.com/zed-industries/zed/assets/1185253/35aa4e6d-295b-4050-b5cc-cab0f91b27e1


## After

https://github.com/zed-industries/zed/assets/1185253/a17cbc9c-fc2c-43d6-918b-1205b327507b

## Release notes

Release Notes:

- Fixed inline git blame information moving when horizontally scrolling.