### PR TITLE
eslint: register as language server for Vue.js

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -193,24 +193,21 @@ pub fn init(
     );
     language!(
         "tsx",
-        vec![
-            Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
-            Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
-        ]
+        vec![Arc::new(typescript::TypeScriptLspAdapter::new(
+            node_runtime.clone()
+        ))]
     );
     language!(
         "typescript",
-        vec![
-            Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
-            Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
-        ]
+        vec![Arc::new(typescript::TypeScriptLspAdapter::new(
+            node_runtime.clone()
+        ))]
     );
     language!(
         "javascript",
-        vec![
-            Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
-            Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
-        ]
+        vec![Arc::new(typescript::TypeScriptLspAdapter::new(
+            node_runtime.clone()
+        ))]
     );
     language!(
         "jsdoc",
@@ -247,6 +244,14 @@ pub fn init(
         languages.register_secondary_lsp_adapter(
             language.into(),
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
+        );
+    }
+
+    let eslint_languages = ["TSX", "TypeScript", "JavaScript", "Vue.js"];
+    for language in eslint_languages {
+        languages.register_secondary_lsp_adapter(
+            language.into(),
+            Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
         );
     }
 


### PR DESCRIPTION
This fixes #9934 and does two things:

1. It registers ESLint as a secondary language server for Vue.js files (`.vue`)
2. It registers ESLint as a _secondary_ (instead of primary) language server for TypeScript, JavaScript and TSX.

The second point because I don't see any reason why ESLint should be registered as a primary language server for these languages. I read through the code in `project.rs` that uses the primary language server and I don't think there will be any differences to how it previously worked.

I also manually tested ESLint support in a Vue.js project, a Next.js project and a plain old JS project — still works in all three.

Release Notes:

- Added ESLint support for Vue.js files by starting it as a language server on `.vue` files. ([#9934](https://github.com/zed-industries/zed/issues/9934)).
