### PR TITLE
git blame: Do not try to blame buffer if it has no file

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8982,6 +8982,10 @@ impl Editor {
                 return;
             };
 
+            if buffer.read(cx).file().is_none() {
+                return;
+            }
+
             let project = project.clone();
             let blame = cx.new_model(|cx| GitBlame::new(buffer, project, user_triggered, cx));
             self.blame_subscription = Some(cx.observe(&blame, |_, _, cx| cx.notify()));


### PR DESCRIPTION

Release Notes:

- Fixed error messages being logged due to inline git blame not working on an empty buffer that hasn't been saved yet.