### PR TITLE
Revert "Changed cmd+w with no open tabs to close window (#10740)"

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     toolbar::Toolbar,
     workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings},
-    CloseWindow, NewCenterTerminal, NewFile, NewSearch, OpenInTerminal, OpenTerminal, OpenVisible,
+    NewCenterTerminal, NewFile, NewSearch, OpenInTerminal, OpenTerminal, OpenVisible,
     SplitDirection, ToggleZoom, Workspace,
 };
 use anyhow::Result;
@@ -879,8 +879,6 @@ impl Pane {
         cx: &mut ViewContext<Self>,
     ) -> Option<Task<Result<()>>> {
         if self.items.is_empty() {
-            // Close the window when there's no active items to close.
-            cx.dispatch_action(Box::new(CloseWindow));
             return None;
         }
         let active_item_id = self.items[self.active_item_index].item_id();


### PR DESCRIPTION
This PR reverts #10740, as it makes it too easy to close Zed accidentally.

Quitting Zed when you don't mean to is disruptive and can break your flow. This is even more the case when you're collaborating.

Therefore, we shouldn't make it easy to quit Zed when you don't mean to. 

If we want to bring back this behavior it needs to have a corresponding setting that should, in my opinion, be **off** by default. Additionally, someone made the good point that this behavior should not be present on Linux or Windows.

This reverts commit 5102e37a5bc344cb1f5f2a4116b55d4d3afafbb0.

Release Notes:

- Changed `cmd-w` with no open tabs to no longer close the window (preview-only).
