### PR TITLE
Add avatar support for codeberg in git blame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11095,6 +11095,7 @@ dependencies = [
  "futures 0.3.28",
  "gpui",
  "indoc",
+ "itertools 0.11.0",
  "language",
  "log",
  "lsp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11095,7 +11095,6 @@ dependencies = [
  "futures 0.3.28",
  "gpui",
  "indoc",
- "itertools 0.11.0",
  "language",
  "log",
  "lsp",

--- a/crates/git/src/hosting_provider.rs
+++ b/crates/git/src/hosting_provider.rs
@@ -71,37 +71,25 @@ impl HostingProvider {
         commit: Oid,
         client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
-        match self {
+        let author = match self {
             HostingProvider::Github => {
                 let commit = commit.to_string();
-
-                let author =
-                    github::fetch_github_commit_author(repo_owner, repo, &commit, &client).await?;
-
-                Ok(author
-                    .map(|author| -> Result<Url, url::ParseError> {
-                        let mut url = Url::parse(&author.avatar_url)?;
-                        url.set_query(Some("size=128"));
-                        Ok(url)
-                    })
-                    .transpose()?)
+                github::fetch_github_commit_author(repo_owner, repo, &commit, &client).await?
             }
             HostingProvider::Codeberg => {
                 let commit = commit.to_string();
-
-                let author =
-                    codeberg::fetch_codeberg_commit_author(repo_owner, repo, &commit, &client)
-                        .await?;
-                Ok(author
-                    .map(|author| -> Result<Url, url::ParseError> {
-                        let mut url = Url::parse(&author.avatar_url)?;
-                        url.set_query(Some("size=128"));
-                        Ok(url)
-                    })
-                    .transpose()?)
+                codeberg::fetch_codeberg_commit_author(repo_owner, repo, &commit, &client).await?
             }
-            _ => Ok(None),
-        }
+            _ => None,
+        };
+
+        Ok(author
+            .map(|author| -> Result<Url, url::ParseError> {
+                let mut url = Url::parse(&author.avatar_url)?;
+                url.set_query(Some("size=128"));
+                Ok(url)
+            })
+            .transpose()?)
     }
 }
 

--- a/crates/git/src/hosting_provider.rs
+++ b/crates/git/src/hosting_provider.rs
@@ -71,22 +71,29 @@ impl HostingProvider {
         commit: Oid,
         client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
-        let author = match self {
+        let (author, query) = match self {
             HostingProvider::Github => {
                 let commit = commit.to_string();
-                github::fetch_github_commit_author(repo_owner, repo, &commit, &client).await?
+                (
+                    github::fetch_github_commit_author(repo_owner, repo, &commit, &client).await?,
+                    Some("size=128"),
+                )
             }
             HostingProvider::Codeberg => {
                 let commit = commit.to_string();
-                codeberg::fetch_codeberg_commit_author(repo_owner, repo, &commit, &client).await?
+                (
+                    codeberg::fetch_codeberg_commit_author(repo_owner, repo, &commit, &client)
+                        .await?,
+                    None,
+                )
             }
-            _ => None,
+            _ => (None, None),
         };
 
         Ok(author
             .map(|author| -> Result<Url, url::ParseError> {
                 let mut url = Url::parse(&author.avatar_url)?;
-                url.set_query(Some("size=128"));
+                url.set_query(query);
                 Ok(url)
             })
             .transpose()?)

--- a/crates/git/src/hosting_provider.rs
+++ b/crates/git/src/hosting_provider.rs
@@ -3,7 +3,7 @@ use std::{ops::Range, sync::Arc};
 
 use anyhow::Result;
 use url::Url;
-use util::{github, http::HttpClient};
+use util::{codeberg, github, http::HttpClient};
 
 use crate::Oid;
 
@@ -59,7 +59,7 @@ impl HostingProvider {
 
     pub fn supports_avatars(&self) -> bool {
         match self {
-            HostingProvider::Github => true,
+            HostingProvider::Github | HostingProvider::Codeberg => true,
             _ => false,
         }
     }
@@ -78,14 +78,27 @@ impl HostingProvider {
                 let author =
                     github::fetch_github_commit_author(repo_owner, repo, &commit, &client).await?;
 
-                let url = if let Some(author) = author {
-                    let mut url = Url::parse(&author.avatar_url)?;
-                    url.set_query(Some("size=128"));
-                    Some(url)
-                } else {
-                    None
-                };
-                Ok(url)
+                Ok(author
+                    .map(|author| -> Result<Url, url::ParseError> {
+                        let mut url = Url::parse(&author.avatar_url)?;
+                        url.set_query(Some("size=128"));
+                        Ok(url)
+                    })
+                    .transpose()?)
+            }
+            HostingProvider::Codeberg => {
+                let commit = commit.to_string();
+
+                let author =
+                    codeberg::fetch_codeberg_commit_author(repo_owner, repo, &commit, &client)
+                        .await?;
+                Ok(author
+                    .map(|author| -> Result<Url, url::ParseError> {
+                        let mut url = Url::parse(&author.avatar_url)?;
+                        url.set_query(Some("size=128"));
+                        Ok(url)
+                    })
+                    .transpose()?)
             }
             _ => Ok(None),
         }

--- a/crates/util/src/codeberg.rs
+++ b/crates/util/src/codeberg.rs
@@ -1,4 +1,4 @@
-use crate::http::HttpClient;
+use crate::{git_author::GitAuthor, http::HttpClient};
 use anyhow::{bail, Context, Result};
 use futures::AsyncReadExt;
 use isahc::{config::Configurable, AsyncBody, Request};
@@ -23,13 +23,6 @@ struct Author {
     date: String,
 }
 
-#[derive(Debug)]
-pub struct CodebergAuthor {
-    pub id: u64,
-    pub email: String,
-    pub avatar_url: String,
-}
-
 #[derive(Debug, Deserialize)]
 struct User {
     pub login: String,
@@ -42,7 +35,7 @@ pub async fn fetch_codeberg_commit_author(
     repo: &str,
     commit: &str,
     client: &Arc<dyn HttpClient>,
-) -> Result<Option<CodebergAuthor>> {
+) -> Result<Option<GitAuthor>> {
     let url = format!("https://codeberg.org/api/v1/repos/{repo_owner}/{repo}/git/commits/{commit}");
 
     let mut request = Request::get(&url)
@@ -74,7 +67,7 @@ pub async fn fetch_codeberg_commit_author(
     serde_json::from_str::<CommitDetails>(body_str)
         .map(|codeberg_commit| {
             if let Some(author) = codeberg_commit.author {
-                Some(CodebergAuthor {
+                Some(GitAuthor {
                     id: author.id,
                     avatar_url: author.avatar_url,
                     email: codeberg_commit.commit.author.email,

--- a/crates/util/src/codeberg.rs
+++ b/crates/util/src/codeberg.rs
@@ -1,0 +1,87 @@
+use crate::http::HttpClient;
+use anyhow::{bail, Context, Result};
+use futures::AsyncReadExt;
+use isahc::{config::Configurable, AsyncBody, Request};
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize)]
+struct CommitDetails {
+    commit: Commit,
+    author: Option<User>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Commit {
+    author: Author,
+}
+
+#[derive(Debug, Deserialize)]
+struct Author {
+    name: String,
+    email: String,
+    date: String,
+}
+
+#[derive(Debug)]
+pub struct CodebergAuthor {
+    pub id: u64,
+    pub email: String,
+    pub avatar_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct User {
+    pub login: String,
+    pub id: u64,
+    pub avatar_url: String,
+}
+
+pub async fn fetch_codeberg_commit_author(
+    repo_owner: &str,
+    repo: &str,
+    commit: &str,
+    client: &Arc<dyn HttpClient>,
+) -> Result<Option<CodebergAuthor>> {
+    let url = format!("https://codeberg.org/api/v1/repos/{repo_owner}/{repo}/git/commits/{commit}");
+
+    let mut request = Request::get(&url)
+        .redirect_policy(isahc::config::RedirectPolicy::Follow)
+        .header("Content-Type", "application/json");
+
+    if let Ok(codeberg_token) = std::env::var("CODEBERG_TOKEN") {
+        request = request.header("Authorization", format!("Bearer {}", codeberg_token));
+    }
+
+    let mut response = client
+        .send(request.body(AsyncBody::default())?)
+        .await
+        .with_context(|| format!("error fetching Codeberg commit details at {:?}", url))?;
+
+    let mut body = Vec::new();
+    response.body_mut().read_to_end(&mut body).await?;
+
+    if response.status().is_client_error() {
+        let text = String::from_utf8_lossy(body.as_slice());
+        bail!(
+            "status error {}, response: {text:?}",
+            response.status().as_u16()
+        );
+    }
+
+    let body_str = std::str::from_utf8(&body)?;
+
+    serde_json::from_str::<CommitDetails>(body_str)
+        .map(|codeberg_commit| {
+            if let Some(author) = codeberg_commit.author {
+                Some(CodebergAuthor {
+                    id: author.id,
+                    avatar_url: author.avatar_url,
+                    email: codeberg_commit.commit.author.email,
+                })
+            } else {
+                None
+            }
+        })
+        .context("deserializing Codeberg commit details failed")
+}

--- a/crates/util/src/codeberg.rs
+++ b/crates/util/src/codeberg.rs
@@ -68,9 +68,7 @@ pub async fn fetch_codeberg_commit_author(
         .map(|codeberg_commit| {
             if let Some(author) = codeberg_commit.author {
                 Some(GitAuthor {
-                    id: author.id,
                     avatar_url: author.avatar_url,
-                    email: codeberg_commit.commit.author.email,
                 })
             } else {
                 None

--- a/crates/util/src/git_author.rs
+++ b/crates/util/src/git_author.rs
@@ -1,0 +1,7 @@
+/// Represents the common denominator of most git hosting authors
+#[derive(Debug)]
+pub struct GitAuthor {
+    pub id: u64,
+    pub email: String,
+    pub avatar_url: String,
+}

--- a/crates/util/src/git_author.rs
+++ b/crates/util/src/git_author.rs
@@ -1,7 +1,5 @@
 /// Represents the common denominator of most git hosting authors
 #[derive(Debug)]
 pub struct GitAuthor {
-    pub id: u64,
-    pub email: String,
     pub avatar_url: String,
 }

--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -1,4 +1,4 @@
-use crate::http::HttpClient;
+use crate::{git_author::GitAuthor, http::HttpClient};
 use anyhow::{anyhow, bail, Context, Result};
 use futures::AsyncReadExt;
 use isahc::{config::Configurable, AsyncBody, Request};
@@ -54,19 +54,12 @@ struct User {
     pub gravatar_id: String,
 }
 
-#[derive(Debug)]
-pub struct GitHubAuthor {
-    pub id: u64,
-    pub email: String,
-    pub avatar_url: String,
-}
-
 pub async fn fetch_github_commit_author(
     repo_owner: &str,
     repo: &str,
     commit: &str,
     client: &Arc<dyn HttpClient>,
-) -> Result<Option<GitHubAuthor>> {
+) -> Result<Option<GitAuthor>> {
     let url = format!("https://api.github.com/repos/{repo_owner}/{repo}/commits/{commit}");
 
     let mut request = Request::get(&url)
@@ -98,7 +91,7 @@ pub async fn fetch_github_commit_author(
     serde_json::from_str::<CommitDetails>(body_str)
         .map(|github_commit| {
             if let Some(author) = github_commit.author {
-                Some(GitHubAuthor {
+                Some(GitAuthor {
                     id: author.id,
                     avatar_url: author.avatar_url,
                     email: github_commit.commit.author.email,

--- a/crates/util/src/github.rs
+++ b/crates/util/src/github.rs
@@ -92,9 +92,7 @@ pub async fn fetch_github_commit_author(
         .map(|github_commit| {
             if let Some(author) = github_commit.author {
                 Some(GitAuthor {
-                    id: author.id,
                     avatar_url: author.avatar_url,
-                    email: github_commit.commit.author.email,
                 })
             } else {
                 None

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -1,6 +1,7 @@
 pub mod arc_cow;
 pub mod codeberg;
 pub mod fs;
+mod git_author;
 pub mod github;
 pub mod http;
 pub mod paths;

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -1,4 +1,5 @@
 pub mod arc_cow;
+pub mod codeberg;
 pub mod fs;
 pub mod github;
 pub mod http;


### PR DESCRIPTION
Release Notes:

- Added support for avatars in git blame for repositories hosted on codeberg

<img width="1144" alt="Screenshot 2024-04-25 at 16 45 22" src="https://github.com/zed-industries/zed/assets/43210583/d44770d8-44ea-4c6b-a1c0-ac2d1d49408f">

Questions:
- Should we move git stuff like `Commit`, `Author`, etc outside of hosting-specific files (I don't think so, as other hostings can have different stuff)
- Should we also add support for self hosted forgejo instances or should it be a different PR?