### PR TITLE
vim: set cursor to hollow-block if editor loses focus

### DIFF
--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -51,6 +51,9 @@ fn blurred(editor: View<Editor>, cx: &mut WindowContext) {
                 vim.clear_operator(cx);
             }
         }
+        editor.update(cx, |editor, cx| {
+            editor.set_cursor_shape(language::CursorShape::Hollow, cx);
+        });
     });
 }
 


### PR DESCRIPTION
This has been bugging me for a while now. Finally figured out how to do it.

Release Notes:

- Fixed cursor in Vim mode not changing into a hollow block when editor loses focus.


Demo: 

https://github.com/zed-industries/zed/assets/1185253/c7585282-156d-4ab2-b516-eb1940d6d0d3

