### PR TITLE
vim:  Fix hollow cursor being offset when selecting text

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -89,7 +89,10 @@ impl SelectionLayout {
         }
 
         // any vim visual mode (including line mode)
-        if cursor_shape == CursorShape::Block && !range.is_empty() && !selection.reversed {
+        if (cursor_shape == CursorShape::Block || cursor_shape == CursorShape::Hollow)
+            && !range.is_empty()
+            && !selection.reversed
+        {
             if head.column() > 0 {
                 head = map.clip_point(DisplayPoint::new(head.row(), head.column() - 1), Bias::Left)
             } else if head.row() > 0 && head != map.max_point() {


### PR DESCRIPTION
Fixed the cursor selection being offset, the hollow cursor was being displayed fine when not having text selected that's why it might not have been noticed at first.

Release Notes:
- N/A

Improved: https://github.com/zed-industries/zed/commit/0d6fb08b67e26f5e6abd14ff51b3a9ba1d89b9c0
