### PR TITLE
storybook: Fix Backspace in Auto Height Editor and Picker stories

### DIFF
--- a/assets/keymaps/storybook.json
+++ b/assets/keymaps/storybook.json
@@ -17,7 +17,8 @@
       "cmd-enter": "menu::SecondaryConfirm",
       "escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
-      "cmd-q": "storybook::Quit"
+      "cmd-q": "storybook::Quit",
+      "backspace": "editor::Backspace"
     }
   }
 ]

--- a/assets/keymaps/storybook.json
+++ b/assets/keymaps/storybook.json
@@ -18,7 +18,10 @@
       "escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
       "cmd-q": "storybook::Quit",
-      "backspace": "editor::Backspace"
+      "backspace": "editor::Backspace",
+      "delete": "editor::Delete",
+      "left": "editor::MoveLeft",
+      "right": "editor::MoveRight"
     }
   }
 ]


### PR DESCRIPTION

Currently in the *Auto Height Editor* story the backspace key is not working when you type into the Editor.

The same thing is true for the *Picker* story as one is not able to backspace...

By adding an entry in the keymap file

```rust
assets/keymaps/storybook.json
```

both of these issues are solved...

Release Notes:

- N/A
