### PR TITLE
Allow controlling Tailwind via the `language_servers` setting

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -789,5 +789,24 @@ mod tests {
             ),
             language_server_names(&["deno", "eslint", "tailwind"])
         );
+
+        // Adding a language server not know the list of available languages servers adds it to the list.
+        assert_eq!(
+            LanguageSettings::resolve_language_servers(
+                &[
+                    "my-cool-language-server".into(),
+                    LanguageSettings::REST_OF_LANGUAGE_SERVERS.into()
+                ],
+                &available_language_servers
+            ),
+            language_server_names(&[
+                "my-cool-language-server",
+                "typescript-language-server",
+                "biome",
+                "deno",
+                "eslint",
+                "tailwind",
+            ])
+        );
     }
 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -790,7 +790,7 @@ mod tests {
             language_server_names(&["deno", "eslint", "tailwind"])
         );
 
-        // Adding a language server not know the list of available languages servers adds it to the list.
+        // Adding a language server not in the list of available languages servers adds it to the list.
         assert_eq!(
             LanguageSettings::resolve_language_servers(
                 &[

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -174,7 +174,7 @@ pub fn init(
     // {
     //   "languages": {
     //     "My Language": {
-    //       "language_servers": ["tailwind-css-language-server", "..."]
+    //       "language_servers": ["tailwindcss-language-server", "..."]
     //     }
     //   }
     // }

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -173,7 +173,9 @@ pub fn init(
     // ```json
     // {
     //   "languages": {
-    //     "My Language": ["tailwind-css-language-server", "..."]
+    //     "My Language": {
+    //       "language_servers": ["tailwind-css-language-server", "..."]
+    //     }
     //   }
     // }
     // ```

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -107,10 +107,7 @@ pub fn init(
     language!("cpp", vec![Arc::new(c::CLspAdapter)]);
     language!(
         "css",
-        vec![
-            Arc::new(css::CssLspAdapter::new(node_runtime.clone())),
-            Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
-        ]
+        vec![Arc::new(css::CssLspAdapter::new(node_runtime.clone())),]
     );
     language!("go", vec![Arc::new(go::GoLspAdapter)]);
     language!("gomod");
@@ -160,13 +157,7 @@ pub fn init(
         ))]
     );
     language!("ruby", vec![Arc::new(ruby::RubyLanguageServer)]);
-    language!(
-        "erb",
-        vec![
-            Arc::new(ruby::RubyLanguageServer),
-            Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
-        ]
-    );
+    language!("erb", vec![Arc::new(ruby::RubyLanguageServer),]);
     language!("regex");
     language!(
         "yaml",
@@ -174,14 +165,40 @@ pub fn init(
     );
     language!("proto");
 
+    // Register Tailwind globally as an available language server.
+    //
+    // This will allow users to add Tailwind support for a given language via
+    // the `language_servers` setting:
+    //
+    // ```json
+    // {
+    //   "languages": {
+    //     "My Language": ["tailwind-css-language-server", "..."]
+    //   }
+    // }
+    // ```
+    languages.register_available_lsp_adapter(
+        LanguageServerName("tailwindcss-language-server".into()),
+        {
+            let node_runtime = node_runtime.clone();
+            move || Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone()))
+        },
+    );
+
+    // Register Tailwind for the existing languages that should have it by default.
+    //
+    // This can be driven by the `language_servers` setting once we have a way for
+    // extensions to provide their own default value for that setting.
     let tailwind_languages = [
         "Astro",
+        "CSS",
+        "ERB",
         "HEEX",
         "HTML",
+        "JavaScript",
         "PHP",
         "Svelte",
         "TSX",
-        "JavaScript",
         "Vue.js",
     ];
 


### PR DESCRIPTION
This PR adds the ability for the Tailwind language server (`tailwindcss-language-server`) to be controlled by the `language_servers` setting.

Now in your settings you can indicate that the Tailwind language server should be used for a given language, even if that language does not have the Tailwind language server registered for it already:

```json
{
  "languages": {
    "My Language": {
      "language_servers": ["tailwindcss-language-server", "..."]
    }
  }
}
```

Release Notes:

- N/A
