### PR TITLE
Always submit function definitions in Simple mode too

### DIFF
--- a/crates/assistant2/src/assistant2.rs
+++ b/crates/assistant2/src/assistant2.rs
@@ -314,7 +314,8 @@ impl AssistantChat {
                 let completion = this.update(cx, |this, cx| {
                     this.push_new_assistant_message(cx);
 
-                    let definitions = if call_count < limit && matches!(mode, SubmitMode::Codebase)
+                    let definitions = if call_count < limit
+                        && matches!(mode, SubmitMode::Codebase | SubmitMode::Simple)
                     {
                         this.tool_registry.definitions()
                     } else {


### PR DESCRIPTION
Switches Assistant2 to always provide functions. It's up to the model to choose to use them. At a later point, the `Submit::Codebase` should change the `tool_choice` to `query_codebase` rather than `auto`. For now, I think this will improve the experience for folks testing.

Release Notes:

- N/A
