### PR TITLE
Rename `chat_with_functions` to use snake_case

### DIFF
--- a/crates/assistant2/examples/chat_with_functions.rs
+++ b/crates/assistant2/examples/chat_with_functions.rs
@@ -1,4 +1,5 @@
-/// This example creates a basic Chat UI with a function for rolling a die.
+//! This example creates a basic Chat UI with a function for rolling a die.
+
 use anyhow::{Context as _, Result};
 use assets::Assets;
 use assistant2::AssistantPanel;


### PR DESCRIPTION
This PR renames the `chat-with-functions.rs` example to use snake_case for the filename, as is convention.

Release Notes:

- N/A
