### PR TITLE
Add `reevaluate_context` option to each individual task

### DIFF
--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -294,6 +294,7 @@ impl Inventory {
                         let (previous_task, _) = o.get();
                         let new_template = task.original_task();
                         if new_template.ignore_previously_resolved
+                            || new_template.reevaluate_context
                             || new_template != previous_task.original_task()
                         {
                             o.insert((task, lru_score));

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -40,6 +40,8 @@ pub struct SpawnInTerminal {
     pub cwd: Option<PathBuf>,
     /// Env overrides for the command, will be appended to the terminal's environment from the settings.
     pub env: HashMap<String, String>,
+    /// Whether to reevaluate context when rerunning the task.
+    pub reevaluate_context: bool,
     /// Whether to use a new terminal tab or reuse the existing one to spawn the process.
     pub use_new_terminal: bool,
     /// Whether to allow multiple instances of the same task to be run, or rather wait for the existing ones to finish.

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -33,6 +33,11 @@ pub struct TaskTemplate {
     /// Current working directory to spawn the command into, defaults to current project root.
     #[serde(default)]
     pub cwd: Option<String>,
+    /// Controls whether the task context is reevaluated prior to execution of a task.
+    /// If it is not, environment variables such as ZED_COLUMN, ZED_FILE will be the same as in the last execution of a task
+    /// If it is, these variables will be updated to reflect current state of editor at the time task::Rerun is executed.
+    #[serde(default)]
+    pub reevaluate_context: bool,
     /// Whether to use a new terminal tab or reuse the existing one to spawn the process.
     #[serde(default)]
     pub use_new_terminal: bool,
@@ -198,6 +203,7 @@ impl TaskTemplate {
                 command,
                 args: self.args.clone(),
                 env,
+                reevaluate_context: self.reevaluate_context,
                 use_new_terminal: self.use_new_terminal,
                 allow_concurrent_runs: self.allow_concurrent_runs,
                 reveal: self.reveal,

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -31,8 +31,11 @@ pub fn init(cx: &mut AppContext) {
                             project.task_inventory().read(cx).last_scheduled_task()
                         })
                     {
-                        if action.reevaluate_context {
-                            let mut original_task = last_scheduled_task.original_task().clone();
+                        let mut original_task = last_scheduled_task.original_task().clone();
+                        if let Some(reevaluate_context) = action.reevaluate_context {
+                            original_task.reevaluate_context = reevaluate_context;
+                        }
+                        if original_task.reevaluate_context {
                             if let Some(allow_concurrent_runs) = action.allow_concurrent_runs {
                                 original_task.allow_concurrent_runs = allow_concurrent_runs;
                             }

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -39,12 +39,10 @@ impl Spawn {
 /// Rerun last task
 #[derive(PartialEq, Clone, Deserialize, Default)]
 pub struct Rerun {
-    /// Controls whether the task context is reevaluated prior to execution of a task.
-    /// If it is not, environment variables such as ZED_COLUMN, ZED_FILE are gonna be the same as in the last execution of a task
-    /// If it is, these variables will be updated to reflect current state of editor at the time task::Rerun is executed.
-    /// default: false
+    /// Overrides `reevaluate_context` property of the task being reran.
+    /// Default: null
     #[serde(default)]
-    pub reevaluate_context: bool,
+    pub reevaluate_context: Option<bool>,
     /// Overrides `allow_concurrent_runs` property of the task being reran.
     /// Default: null
     #[serde(default)]


### PR DESCRIPTION
Since `allow_concurrent_runs` and `use_new_terminal` are both able to be specified in both `Task::Rerun` options as well as the task itself, I figured it would make sense to add the `reevaluate_context` option on a per-task basis as well.

Release Notes:

- Allows `reevaluate_context` to be specified on a task-by-task basis, like so:
```json
[
  {
    "label": "Example task",
    "command": "echo $ZED_FILE",
    "reevaluate_context": true
  }
]
```
