### PR TITLE
Fix panic in rename selections

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8206,9 +8206,13 @@ impl Editor {
                                 cursor_offset_in_rename_range_end..cursor_offset_in_rename_range
                             }
                         };
-                        editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
-                            s.select_ranges([rename_selection_range]);
-                        });
+                        if rename_selection_range.end > old_name.len() {
+                            editor.select_all(&SelectAll, cx);
+                        } else {
+                            editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
+                                s.select_ranges([rename_selection_range]);
+                            });
+                        }
                         editor
                     });
 


### PR DESCRIPTION

cc @someonetoignore

Release Notes:

- Fixed a panic when renaming with a selection (preview only)
