### PR TITLE
Remove unread notes indicator for now

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1,4 +1,4 @@
-mdod channel_modal;
+mod channel_modal;
 mod contact_finder;
 
 use self::channel_modal::ChannelModal;

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2970,6 +2970,7 @@ impl Render for DraggedChannelView {
 struct JoinChannelTooltip {
     channel_store: Model<ChannelStore>,
     channel_id: ChannelId,
+    #[allow(unused)]
     has_notes_notification: bool,
 }
 

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1,4 +1,4 @@
-mod channel_modal;
+mdod channel_modal;
 mod contact_finder;
 
 use self::channel_modal::ChannelModal;
@@ -2983,12 +2983,6 @@ impl Render for JoinChannelTooltip {
 
             container
                 .child(Label::new("Join channel"))
-                .children(self.has_notes_notification.then(|| {
-                    h_flex()
-                        .gap_2()
-                        .child(Indicator::dot().color(Color::Info))
-                        .child(Label::new("Unread notes"))
-                }))
                 .children(participants.iter().map(|participant| {
                     h_flex()
                         .gap_2()


### PR DESCRIPTION
I'd like to add something back here, but it's more distracting than
helpful today.

Fixes: #10887

Release Notes:

- Removed channel notes unread indicator
