### PR TITLE
Highlight reference types directive in TypeScript

### DIFF
--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -1,5 +1,9 @@
 ((comment) @content
   (#set! "language" "jsdoc"))
 
+(((comment) @reference
+  (#match? @reference "^///\\s+<reference\\s+types=\"\\S+\"\\s*/>\\s*$")) @content
+  (#set! "language" "html"))
+
 ((regex) @content
   (#set! "language" "regex"))


### PR DESCRIPTION
Before:

<img width="443" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/a8037edb-ed5b-4b12-92b4-2d409442ad4b">


After:

<img width="429" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/1fd66523-d667-4041-952f-c1125e7feab9">


Release Notes:

- Add typescript reference types directive highlighted(#11001)