### PR TITLE
Image viewer: Fix the scaling and offset of images

### DIFF
--- a/crates/gpui/src/platform/linux/x11/display.rs
+++ b/crates/gpui/src/platform/linux/x11/display.rs
@@ -15,7 +15,7 @@ impl X11Display {
     pub(crate) fn new(xc: &XCBConnection, x_screen_index: usize) -> Option<Self> {
         let screen = xc.setup().roots.get(x_screen_index).unwrap();
         Some(Self {
-            x_screen_index: x_screen_index,
+            x_screen_index,
             bounds: Bounds {
                 origin: Default::default(),
                 size: Size {

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -212,9 +212,8 @@ impl Render for ImageView {
                     .h_full()
                     .child(
                         img(self.path.clone())
-                            .object_fit(ObjectFit::ScaleDown)
-                            .max_w_full()
-                            .max_h_full(),
+                            .object_fit(ObjectFit::Contain)
+                            .size_full(),
                     ),
             )
     }


### PR DESCRIPTION
Small fix to the image viewer and used shorthand struct initialization to get rid of an annoying warning.
This would go great with https://github.com/zed-industries/zed/pull/10016 so once it gets merged this should also be merged 

before:
![image](https://github.com/zed-industries/zed/assets/68782699/ada72787-8e4e-4ce2-97c2-feaa0a1addf5)

after:
![image](https://github.com/zed-industries/zed/assets/68782699/830ea3a7-4c03-4b6d-adc5-254fd5131981)
Release Notes:

- N/A

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.
