### PR TITLE
Fix Wayland keyrepeat getting cancelled by unrelated keyup

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -843,7 +843,9 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                             keystroke: Keystroke::from_xkb(keymap_state, state.modifiers, keycode),
                         });
 
-                        state.repeat.current_keysym = None;
+                        if state.repeat.current_keysym == Some(keysym) {
+                            state.repeat.current_keysym = None;
+                        }
 
                         drop(state);
                         focused_window.handle_input(input);


### PR DESCRIPTION
fixes #11048

## Problem
in the situation `press right`, `press left`, `release right` the following happens right now:

- `keypressed right`, `current_keysym` is set to `right`
- `keypressed left`, `current_keysym` is set to `left`

the repeat timer runs asynchronously and emits keyrepeats since `current_keysym.is_some()`

- `keyreleased right`, `current_keysym` is set to None

the repeat timer no longer emits keyrepeats

- `keyreleased left`, this is where `current_keysym` should actually be set to None.

## Solution
Only reset `current_keysym` if the released key matches the last pressed key.

Release Notes:

- N/A
