### PR TITLE
remote projects: Allow reusing window

### DIFF
--- a/crates/collab/src/tests/dev_server_tests.rs
+++ b/crates/collab/src/tests/dev_server_tests.rs
@@ -70,6 +70,7 @@ async fn test_dev_server(cx: &mut gpui::TestAppContext, cx2: &mut gpui::TestAppC
             workspace::join_remote_project(
                 projects[0].project_id.unwrap(),
                 client.app_state.clone(),
+                None,
                 cx,
             )
         })
@@ -205,7 +206,12 @@ async fn create_remote_project(
             let projects = store.remote_projects();
             assert_eq!(projects.len(), 1);
             assert_eq!(projects[0].path, "/remote");
-            workspace::join_remote_project(projects[0].project_id.unwrap(), client_app_state, cx)
+            workspace::join_remote_project(
+                projects[0].project_id.unwrap(),
+                client_app_state,
+                None,
+                cx,
+            )
         })
         .await
         .unwrap();
@@ -301,6 +307,7 @@ async fn test_dev_server_reconnect(
             workspace::join_remote_project(
                 projects[0].project_id.unwrap(),
                 client2.app_state.clone(),
+                None,
                 cx,
             )
         })

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1834,6 +1834,21 @@ impl Project {
         }
     }
 
+    pub fn leave_remote_project(&mut self) {
+        if self.is_shared() {
+            return;
+        }
+        if let Some(project_id) = self.remote_id() {
+            self.collaborators.clear();
+            self.shared_buffers.clear();
+            self.client_subscriptions.clear();
+
+            self.client
+                .send(proto::LeaveProject { project_id })
+                .log_err();
+        }
+    }
+
     pub fn disconnected_from_host(&mut self, cx: &mut ModelContext<Self>) {
         self.disconnected_from_host_internal(cx);
         cx.emit(Event::DisconnectedFromHost);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1834,21 +1834,6 @@ impl Project {
         }
     }
 
-    pub fn leave_remote_project(&mut self) {
-        if self.is_shared() {
-            return;
-        }
-        if let Some(project_id) = self.remote_id() {
-            self.collaborators.clear();
-            self.shared_buffers.clear();
-            self.client_subscriptions.clear();
-
-            self.client
-                .send(proto::LeaveProject { project_id })
-                .log_err();
-        }
-    }
-
     pub fn disconnected_from_host(&mut self, cx: &mut ModelContext<Self>) {
         self.disconnected_from_host_internal(cx);
         cx.emit(Event::DisconnectedFromHost);

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -338,8 +338,14 @@ impl PickerDelegate for RecentProjectsDelegate {
                                     })
                                 };
                                 if let Some(app_state) = AppState::global(cx).upgrade() {
+                                    let window_to_replace = if replace_current_window {
+                                       cx.window_handle().downcast::<Workspace>()
+                                    } else {
+                                        None
+                                    };
+
                                     let task =
-                                        workspace::join_remote_project(project_id, app_state, cx);
+                                        workspace::join_remote_project(project_id, app_state, window_to_replace, cx);
                                     cx.spawn(|_, _| async move {
                                         task.await?;
                                         Ok(())

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -310,7 +310,6 @@ impl PickerDelegate for RecentProjectsDelegate {
                                     workspace.open_workspace_for_paths(false, paths, cx)
                                 }
                             }
-                            //TODO support opening remote projects in the same window
                             SerializedWorkspaceLocation::Remote(remote_project) => {
                                 let store = ::remote_projects::Store::global(cx).read(cx);
                                 let Some(project_id) = store

--- a/crates/recent_projects/src/remote_projects.rs
+++ b/crates/recent_projects/src/remote_projects.rs
@@ -386,7 +386,7 @@ impl RemoteProjects {
             .on_click(cx.listener(move |_, _, cx| {
                 if let Some(project_id) = project_id {
                     if let Some(app_state) = AppState::global(cx).upgrade() {
-                        workspace::join_remote_project(project_id, app_state, cx)
+                        workspace::join_remote_project(project_id, app_state, None, cx)
                             .detach_and_prompt_err("Could not join project", cx, |_, _| None)
                     }
                 } else {

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -9,8 +9,8 @@ use fs::Fs;
 use futures::stream::StreamExt;
 use futures_batch::ChunksTimeoutStreamExt;
 use gpui::{
-    AppContext, AsyncAppContext, Context, EntityId, EventEmitter, Global, Model, ModelContext,
-    Subscription, Task, WeakModel,
+    AppContext, AsyncAppContext, BorrowAppContext, Context, Entity, EntityId, EventEmitter, Global,
+    Model, ModelContext, Subscription, Task, WeakModel,
 };
 use heed::types::{SerdeBincode, Str};
 use language::LanguageRegistry;
@@ -68,6 +68,16 @@ impl SemanticIndex {
         project: Model<Project>,
         cx: &mut AppContext,
     ) -> Model<ProjectIndex> {
+        let project_weak = project.downgrade();
+        project.update(cx, move |_, cx| {
+            cx.on_release(move |_, cx| {
+                cx.update_global::<SemanticIndex, _>(|this, _| {
+                    this.project_indices.remove(&project_weak);
+                })
+            })
+            .detach();
+        });
+
         self.project_indices
             .entry(project.downgrade())
             .or_insert_with(|| {
@@ -86,7 +96,7 @@ impl SemanticIndex {
 
 pub struct ProjectIndex {
     db_connection: heed::Env,
-    project: Model<Project>,
+    project: WeakModel<Project>,
     worktree_indices: HashMap<EntityId, WorktreeIndexHandle>,
     language_registry: Arc<LanguageRegistry>,
     fs: Arc<dyn Fs>,
@@ -116,7 +126,7 @@ impl ProjectIndex {
         let fs = project.read(cx).fs().clone();
         let mut this = ProjectIndex {
             db_connection,
-            project: project.clone(),
+            project: project.downgrade(),
             worktree_indices: HashMap::default(),
             language_registry,
             fs,
@@ -143,8 +153,11 @@ impl ProjectIndex {
     }
 
     fn update_worktree_indices(&mut self, cx: &mut ModelContext<Self>) {
-        let worktrees = self
-            .project
+        let Some(project) = self.project.upgrade() else {
+            return;
+        };
+
+        let worktrees = project
             .read(cx)
             .visible_worktrees(cx)
             .filter_map(|worktree| {

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -71,9 +71,11 @@ impl SemanticIndex {
         let project_weak = project.downgrade();
         project.update(cx, move |_, cx| {
             cx.on_release(move |_, cx| {
-                cx.update_global::<SemanticIndex, _>(|this, _| {
-                    this.project_indices.remove(&project_weak);
-                })
+                if cx.has_global::<SemanticIndex>() {
+                    cx.update_global::<SemanticIndex, _>(|this, _| {
+                        this.project_indices.remove(&project_weak);
+                    })
+                }
             })
             .detach();
         });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1313,12 +1313,6 @@ impl Workspace {
         quitting: bool,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<bool>> {
-        self.project().update(cx, |project, _| {
-            if project.remote_project_id().is_some() {
-                project.leave_remote_project();
-            }
-        });
-
         let active_call = self.active_call().cloned();
         let window = cx.window_handle();
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1313,6 +1313,12 @@ impl Workspace {
         quitting: bool,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<bool>> {
+        self.project().update(cx, |project, _| {
+            if project.remote_project_id().is_some() {
+                project.leave_remote_project();
+            }
+        });
+
         let active_call = self.active_call().cloned();
         let window = cx.window_handle();
 


### PR DESCRIPTION
Release Notes:

- Allow reusing the window when opening a remote project from the recent projects picker
- Fixed an issue, which would not let you rejoin a remote project after disconnecting from it for the first time
