### PR TITLE
Add keybindings to jump to first / last file in project panel

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -625,7 +625,9 @@
       "t": "project_panel::OpenPermanent",
       "v": "project_panel::OpenPermanent",
       "p": "project_panel::Open",
-      "x": "project_panel::RevealInFinder"
+      "x": "project_panel::RevealInFinder",
+      "shift-g": "menu::SelectLast",
+      "g g": "menu::SelectFirst"
     }
   }
 ]


### PR DESCRIPTION
Release Notes:
- vim: Support `g g`/`G` to go to top/bottom of the project panel.

In vim type environments i usually expect to be able to jump to the top and bottom and i was confused as to why that wasn't possible in the project panel. So i added it. If anyone using different keymaps also thinks this might be useful i would be happy to add other defaults. I think for vim mode it is the most useful though, because you tend to not use your mouse in vim mode.

This is my first contribution to any rust project, but it seemed like a good starting point.
The function select_last() is inspired by select_first.
I was also thinking about adding a bigger jump keybinding, that would jump for example 5 entries up / down, with vim default keybindings "{" / "}". 
FYI: I tested this on linux only and don't have access to any macos machines.


- N/A
