### PR TITLE
wayland: Fix crash on wayfire

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -227,8 +227,6 @@ impl WaylandWindow {
             .as_ref()
             .map(|viewporter| viewporter.get_viewport(&surface, &globals.qh, ()));
 
-        surface.frame(&globals.qh, surface.id());
-
         let this = Self(WaylandWindowStatePtr {
             state: Rc::new(RefCell::new(WaylandWindowState::new(
                 surface.clone(),
@@ -255,8 +253,8 @@ impl WaylandWindowStatePtr {
         Rc::ptr_eq(&self.state, &other.state)
     }
 
-    pub fn frame(&self, from_frame_callback: bool) {
-        if from_frame_callback {
+    pub fn frame(&self, request_frame_callback: bool) {
+        if request_frame_callback {
             let state = self.state.borrow_mut();
             state.surface.frame(&state.globals.qh, state.surface.id());
             drop(state);
@@ -273,7 +271,7 @@ impl WaylandWindowStatePtr {
                 let state = self.state.borrow();
                 state.xdg_surface.ack_configure(serial);
                 drop(state);
-                self.frame(false);
+                self.frame(true);
             }
             _ => {}
         }

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -273,7 +273,7 @@ impl WaylandWindowStatePtr {
                 let mut state = self.state.borrow_mut();
                 state.xdg_surface.ack_configure(serial);
                 let request_frame_callback = !state.acknowledged_first_configure;
-                state.acknowledged_first_configure |= !state.acknowledged_first_configure;
+                state.acknowledged_first_configure = true;
                 drop(state);
                 self.frame(request_frame_callback);
             }


### PR DESCRIPTION
It is a protocol violation to attach a buffer before acknowledging in xdg_surface::configure.

Release Notes:

- N/A
