### PR TITLE
Windows: Fix canonicalize return UNC path

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -673,7 +673,11 @@ fn start_background_scan_tasks(
 ) -> Vec<Task<()>> {
     let (scan_states_tx, mut scan_states_rx) = mpsc::unbounded();
     let background_scanner = cx.background_executor().spawn({
-        let abs_path = abs_path.canonicalize().expect("start background scan tasks failed for canonicalize path {abs_path}");
+        let abs_path = if cfg!(target_os = "windows") {
+            abs_path.canonicalize().expect("start background scan tasks failed for canonicalize path {abs_path}")
+        } else {
+            abs_path.to_path_buf()
+        };
         let background = cx.background_executor().clone();
         async move {
             let events = fs.watch(&abs_path, FS_WATCH_LATENCY).await;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3589,7 +3589,8 @@ impl BackgroundScanner {
                 let abs_path = if let Ok(path) = abs_path.canonicalize() {
                     path
                 } else {
-                    log::error!("abs_path {abs_path:?} cannot canonicalize");
+                    // many intermediate file will hit here, currently not logger
+                    // log::error!("abs_path {abs_path:?} cannot canonicalize");
                     return false;
                 };
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3590,8 +3590,8 @@ impl BackgroundScanner {
                 let abs_path = if let Ok(path) = abs_path.canonicalize() {
                     path
                 } else {
-                    // many intermediate file will hit here, currently not logger
-                    // log::error!("abs_path {abs_path:?} cannot canonicalize");
+                    // compile intermediate file will hit here, generated and then disappear;
+                    // so fs cannot find them after disappear.
                     return false;
                 };
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -673,7 +673,7 @@ fn start_background_scan_tasks(
 ) -> Vec<Task<()>> {
     let (scan_states_tx, mut scan_states_rx) = mpsc::unbounded();
     let background_scanner = cx.background_executor().spawn({
-        let abs_path = abs_path.canonicalize().expect("start backgroud scan tasks failed for canonicalize path {abs_path}");
+        let abs_path = abs_path.canonicalize().expect("start background scan tasks failed for canonicalize path {abs_path}");
         let background = cx.background_executor().clone();
         async move {
             let events = fs.watch(&abs_path, FS_WATCH_LATENCY).await;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3586,6 +3586,13 @@ impl BackgroundScanner {
                     is_git_related = true;
                 }
 
+                let abs_path = if let Ok(path) = abs_path.canonicalize() {
+                    path
+                } else {
+                    log::error!("abs_path {abs_path:?} cannot canonicalize");
+                    return false;
+                };
+
                 let relative_path: Arc<Path> =
                     if let Ok(path) = abs_path.strip_prefix(&root_canonical_path) {
                         path.into()

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3586,6 +3586,7 @@ impl BackgroundScanner {
                     is_git_related = true;
                 }
 
+                #[cfg(target_os = "windows")]
                 let abs_path = if let Ok(path) = abs_path.canonicalize() {
                     path
                 } else {


### PR DESCRIPTION
In Windows platform, using notify to watch file events. 
1. in [notify windows implement](https://github.com/notify-rs/notify/blob/3df0f65152c8585cfb29d231c880b86b9164dcfd/notify/src/windows.rs#L344), we get the full file path, just with `path.join(file_path)`.  
2. In [zed worktree start_backgroud_scan_tasks](https://github.com/zed-industries/zed/blob/d2569afe662be93c926eed1aeb2b17d050ba90b0/crates/worktree/src/worktree.rs#L679), `abs_path` is not unc path, so we get all file events with not unc path. 
3. but in [zed worktree process_event](https://github.com/zed-industries/zed/blob/d2569afe662be93c926eed1aeb2b17d050ba90b0/crates/worktree/src/worktree.rs#L3619), we `strip_prefix` unc path all times, it will always print annoy error.

@mikayla-maki I can't reopen pre closed pr #10501 .

Release Notes:

- N/A
