### PR TITLE
gpui: Improve the image example

### DIFF
--- a/crates/gpui/examples/image/image.rs
+++ b/crates/gpui/examples/image/image.rs
@@ -58,11 +58,36 @@ impl Render for ImageShowcase {
     }
 }
 
+actions!(image, [Quit]);
+
 fn main() {
     env_logger::init();
 
     App::new().run(|cx: &mut AppContext| {
-        cx.open_window(WindowOptions::default(), |cx| {
+        cx.activate(true);
+        cx.on_action(|_: &Quit, cx| cx.quit());
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        cx.set_menus(vec![Menu {
+            name: "Image",
+            items: vec![MenuItem::action("Quit", Quit)],
+        }]);
+
+        let window_options = WindowOptions {
+            titlebar: Some(TitlebarOptions {
+                title: Some(SharedString::from("Image Example")),
+                appears_transparent: false,
+                ..Default::default()
+            }),
+
+            bounds: Some(Bounds {
+                size: size(px(1100.), px(600.)).into(),
+                origin: Point::new(DevicePixels::from(200), DevicePixels::from(200)),
+            }),
+
+            ..Default::default()
+        };
+
+        cx.open_window(window_options, |cx| {
             cx.new_view(|_cx| ImageShowcase {
                 // Relative path to your root project path
                 local_resource: Arc::new(PathBuf::from_str("examples/image/app-icon.png").unwrap()),


### PR DESCRIPTION

### fix cropping problem

Prior to these changes the images were being cropped so you never actually saw
the full image but you had to use your mouse to make the window bigger to see
both the text and the images...

### activate
 
```rust
cx.activate(true);
```
was not in place so the window did not appear when you ran the example

### No longer need to Ctrl-c to quit the example

Now you can hit *Cmd-q* to quit out of the example instead of having to *Ctrl-c* in your
terminal where you fired off the example

Release Notes:

- N/A
