### PR TITLE
Windows: Fix direct_write crash when clicking an empty line

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -367,7 +367,10 @@ impl DirectWriteState {
 
     fn layout_line(&mut self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
         if font_runs.is_empty() {
-            return LineLayout::default();
+            return LineLayout {
+                font_size,
+                ..Default::default()
+            };
         }
         unsafe {
             let text_renderer = self.components.text_renderer.clone();


### PR DESCRIPTION
Windows platform direct_write using `LineLayout::default` indicates `font_size` will be 0. Zed crashed when click empty line.

Release Notes:
- N/A
