### PR TITLE
Add Windows specific path parsing

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -252,7 +252,7 @@ impl<P> PathLikeWithPosition<P> {
         }
     }
 
-    /// This helper function is used for parsing absolute paths on Windows. It exists because absolute paths on Windows are quite different from other platforms. The way they are currently
+    /// This helper function is used for parsing absolute paths on Windows. It exists because absolute paths on Windows are quite different from other platforms. See [this page](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths) for more information.
     #[cfg(target_os = "windows")]
     fn parse_absolute_path<E>(
         s: &str,

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -188,15 +188,17 @@ impl<P> PathLikeWithPosition<P> {
             })
         };
 
+        let trimmed = s.trim();
+
         #[cfg(target_os = "windows")]
         {
-            let is_absolute = s.starts_with("\\\\?\\");
+            let is_absolute = trimmed.starts_with(r"\\?\");
             if is_absolute {
-                return Self::parse_absolute_path(s, parse_path_like_str);
+                return Self::parse_absolute_path(trimmed, parse_path_like_str);
             }
         }
 
-        match s.trim().split_once(FILE_ROW_COLUMN_DELIMITER) {
+        match trimmed.split_once(FILE_ROW_COLUMN_DELIMITER) {
             Some((path_like_str, maybe_row_and_col_str)) => {
                 let path_like_str = path_like_str.trim();
                 let maybe_row_and_col_str = maybe_row_and_col_str.trim();
@@ -264,7 +266,7 @@ impl<P> PathLikeWithPosition<P> {
             })
         };
 
-        let mut iterator = s.trim().split(FILE_ROW_COLUMN_DELIMITER);
+        let mut iterator = s.split(FILE_ROW_COLUMN_DELIMITER);
 
         let drive_prefix = iterator.next().unwrap_or_default();
         let file_path = iterator.next().unwrap_or_default();

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -264,8 +264,6 @@ impl<P> PathLikeWithPosition<P> {
             })
         };
 
-        println!("{s}");
-
         let mut iterator = s.trim().split(FILE_ROW_COLUMN_DELIMITER);
 
         let drive_prefix = iterator.next().unwrap_or_default();
@@ -273,8 +271,6 @@ impl<P> PathLikeWithPosition<P> {
 
         // TODO: How to handle drives without a letter? UNC paths?
         let complete_path = drive_prefix.replace("\\\\?\\", "") + ":" + &file_path;
-
-        println!("{complete_path}");
 
         if let Some(row_str) = iterator.next() {
             if let Some(column_str) = iterator.next() {


### PR DESCRIPTION
Since Windows paths are known to be weird and currently not handled at all (outside of relative paths that just happen to work), I figured I would add a windows specific implementation for parsing absolute paths. It should be functionally the same, of course there's always a chance I missed an edge case though. 

This should fix
- #10849

Note that there are still some cases that will probably break the current implementation, namely local drives that do not have a drive letter assigned (not sure how to handle those). There's also UNC paths but I don't know how important those are at the moment (I'll allow myself to assume not at all)

Release Notes:

- N/A