### PR TITLE
Allow users to configure ESLint's `rulesCustomizations` settings

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -278,6 +278,11 @@ impl LspAdapter for EsLintLspAdapter {
             .cloned()
             .unwrap_or_else(|| json!({}));
 
+        let rules_customizations = eslint_user_settings
+            .get("rulesCustomizations")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+
         let node_path = eslint_user_settings.get("nodePath").unwrap_or(&Value::Null);
         let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
             .iter()
@@ -286,7 +291,7 @@ impl LspAdapter for EsLintLspAdapter {
         json!({
             "": {
                 "validate": "on",
-                "rulesCustomizations": [],
+                "rulesCustomizations": rules_customizations,
                 "run": "onType",
                 "nodePath": node_path,
                 "workingDirectory": {"mode": "auto"},

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -104,3 +104,22 @@ For example, here's how to set `problems.shortenToSingleLine`:
   }
 }
 ```
+
+#### Configure ESLint's `rulesCustomizations`:
+
+You can configure ESLint's `rulesCustomizations` setting (requires Zed `0.134.x`):
+
+```json
+{
+  "lsp": {
+    "eslint": {
+      "settings": {
+        "rulesCustomizations": [
+          // set all eslint errors/warnings to show as warnings
+          { "rule": "*", "severity": "warn" }
+        ]
+      }
+    }
+  }
+}
+```

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -107,7 +107,7 @@ For example, here's how to set `problems.shortenToSingleLine`:
 
 #### Configure ESLint's `rulesCustomizations`:
 
-You can configure ESLint's `rulesCustomizations` setting (requires Zed `0.134.x`):
+You can configure ESLint's `rulesCustomizations` setting:
 
 ```json
 {


### PR DESCRIPTION
`rulesCustomizations` is an array of rule severity overrides. Globs can be used to apply default severities for multiple rules. See [docs](https://github.com/microsoft/vscode-eslint/blob/553e632fb4cf073fce1549fb6c3c1b5140a52ebb/README.md?plain=1#L312-L333) & [type definitions](https://github.com/microsoft/vscode-eslint/blob/553e632fb4cf073fce1549fb6c3c1b5140a52ebb/%24shared/settings.ts#L168)

Example Zed `settings.json` to override all eslint errors to warnings:
```jsonc
{
    "lsp": {
        "eslint": {
            "settings": {
                "rulesCustomizations": [
                    // set all eslint errors/warnings to show as warnings
                    { "rule": "*", "severity": "warn" }
                ]
            }
        }
    }
}
```


Release Notes:

- Added support for configuring ESLint's `rulesCustomizations` settings, ie. `{"lsp": {"eslint": {"settings": {"rulesCustomizations": [{"rule": "*", "severity": "warn"}]}}}}`

Demo:

https://github.com/zed-industries/zed/assets/2072378/18f0bb28-0546-4234-a11f-39af6c9fcc12

