### PR TITLE
Allow hiding title and status bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -317,6 +317,15 @@
     // Whether or not to show the navigation history buttons.
     "show_nav_history_buttons": true
   },
+  // Settings related to the editor's title bar.
+  "title_bar": {
+    // Whether or not to show the title bar.
+    "show": true
+  },
+  "status_bar": {
+    // Whether or not to show the status bar.
+    "show": true
+  },
   // Settings related to the editor's tabs
   "tabs": {
     // Show git status colors in the editor tabs.

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -69,6 +69,36 @@ pub struct TabBarSettingsContent {
     ///
     /// Default: true
     pub show_nav_history_buttons: Option<bool>,
+    /// Whether or not to show the tab bar.
+    ///
+    /// Default: true
+    pub show: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub struct TitleBarSettings {
+    pub show: bool,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct TitleBarSettingsContent {
+    /// Whether or not to show the title bar.
+    ///
+    /// Default: true
+    pub show: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub struct StatusBarSettings {
+    pub show: bool,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct StatusBarSettingsContent {
+    /// Whether or not to show the status bar.
+    ///
+    /// Default: true
+    pub show: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -113,6 +143,26 @@ impl Settings for TabBarSettings {
     const KEY: Option<&'static str> = Some("tab_bar");
 
     type FileContent = TabBarSettingsContent;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
+    }
+}
+
+impl Settings for TitleBarSettings {
+    const KEY: Option<&'static str> = Some("title_bar");
+
+    type FileContent = TitleBarSettingsContent;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
+    }
+}
+
+impl Settings for StatusBarSettings {
+    const KEY: Option<&'static str> = Some("status_bar");
+
+    type FileContent = StatusBarSettingsContent;
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
         sources.json_merge()

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -69,10 +69,6 @@ pub struct TabBarSettingsContent {
     ///
     /// Default: true
     pub show_nav_history_buttons: Option<bool>,
-    /// Whether or not to show the tab bar.
-    ///
-    /// Default: true
-    pub show: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/docs/src/configuring_zed.md
+++ b/docs/src/configuring_zed.md
@@ -315,6 +315,52 @@ List of `string` values
 
 `boolean` values
 
+## Title Bar
+
+- Description: Settings related to the editor's title bar.
+- Setting: `title_bar`
+- Default:
+
+```json
+"title_bar": {
+  "show": true
+}
+```
+
+### Show
+
+- Description: Whether or not to show the title bar.
+- Setting: `show`
+- Default: `true`
+
+This only configures the visibility of zed's title bar. The visibility of the system's title bar is depending on the platform and gpuis according settings.
+
+**Options**
+
+`boolean` values
+
+## Status Bar
+
+- Description: Settings related to the editor's status bar.
+- Setting: `status_bar`
+- Default:
+
+```json
+"status_bar": {
+  "show": true
+}
+```
+
+### Show
+
+- Description: Whether or not to show the status bar.
+- Setting: `show`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## Editor Toolbar
 
 - Description: Whether or not to show various elements in the editor toolbar.


### PR DESCRIPTION
This Pr tries to satisfy two of the requests in https://github.com/zed-industries/zed/issues/4382 and allows hiding the title and status bars.

I tried to adhere to the approach used for `tab_bar` settings (which is also being extended right now [here](https://github.com/zed-industries/zed/pull/7356)) to allow extending more fine grained configuration for both elements in the future (e.g only hide project or branch name, user settings, etc.).

```json
...
"title_bar": {
  "show": true
},
"status_bar": {
  "show": true
}
...
```
 
<img width="1680" alt="Screenshot 2024-04-28 at 19 29 53" src="https://github.com/zed-industries/zed/assets/1132937/dc8b720b-f925-442c-b3ca-ea8f8e15b56b">

 This works really well on a full screen setup on Mac, but i can't say much about other Os's rn, would need to test further.
 When not in fullscreen, there is this odd behavior of the titlebar hanging inside the file explorer, which also blocks interacting with tabs (e.g moving them):
 
 <img width="231" alt="Screenshot 2024-04-28 at 17 11 44" src="https://github.com/zed-industries/zed/assets/1132937/96034c2a-2fca-412e-b267-81ebddedc410">
 
I think a behavior like Iterm2 offers on Mac would be nice here, but that would mean that the Titlebar needs to be in a `NsSplitView` of some kind. Before further investigation i would like to know if these kind of changes go into the direction you folks intend as well. Based on https://github.com/zed-industries/zed/pull/7356#pullrequestreview-2025914678 you might not want to hide ui elements without the possibility of showing them easily if needed rather than needing to change configuration. Alternatively these settings could be part of the `View` Menu and mapped to keyboard shortcuts (?).

> in iterm2 (when configured acordingly) the titelbar is only visible if you hover the top left area of the window. This is also the only area that allows dragging the window, and would prevent the issue not being able to interact with tabs.   
<img width="263" alt="Screenshot 2024-04-28 at 18 25 12" src="https://github.com/zed-industries/zed/assets/1132937/bebd6fa2-3e84-4cd5-93be-8146b3c0f667">


How it looks:

<img width="1136" alt="Screenshot 2024-04-28 at 18 52 45" src="https://github.com/zed-industries/zed/assets/1132937/22d771db-2dfb-48b6-9f1b-81f36d982bc3">
<img width="1136" alt="Screenshot 2024-04-28 at 18 52 53" src="https://github.com/zed-industries/zed/assets/1132937/c7a7d6ee-de9e-4fb2-bd03-a5c5094f0c5d">
<img width="1136" alt="Screenshot 2024-04-28 at 18 53 02" src="https://github.com/zed-industries/zed/assets/1132937/3f71a716-fc6d-4ad9-bb8d-8bccfa2b16c2">


Release Notes:

- Added support to hide title and status bars (part of https://github.com/zed-industries/zed/issues/4382)

