### PR TITLE
Adjust project panel delete to send to trash

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -471,7 +471,7 @@ impl ProjectPanel {
                             .separator()
                             .action("Rename", Box::new(Rename))
                             .when(!is_root, |menu| {
-                                menu.action("Delete", Box::new(Delete { skip_prompt: false }))
+                                menu.action("Delete", Box::new(Trash { skip_prompt: false }))
                             })
                             .when(is_local & is_root, |menu| {
                                 menu.separator()


### PR DESCRIPTION
Follow-up to:

- https://github.com/zed-industries/zed/pull/10875

Release Notes:

- Changed the behavior for deleting files from the project panel's context menu. Deleted files will now be sent to the system trash.
