### PR TITLE
Set destructive action only when prompt level is set to `Destructive`

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -926,7 +926,6 @@ impl PlatformWindow for MacWindow {
             if let Some((ix, answer)) = latest_non_cancel_label {
                 let button: id = msg_send![alert, addButtonWithTitle: ns_string(answer)];
                 let _: () = msg_send![button, setTag: ix as NSInteger];
-                let _: () = msg_send![button, setHasDestructiveAction: YES];
                 if level == PromptLevel::Destructive {
                     let _: () = msg_send![button, setHasDestructiveAction: YES];
                 }


### PR DESCRIPTION
Oversight from #11015, where we added `PromptLevel::Destructive`, which should be used when a prompt performs a "destructive" action (e.g. deleting a file). However, we accidentally set `setHasDestructiveAction` to `true` regardless of which prompt level would be specified

Release Notes:

- N/A
