### PR TITLE
editor: Add scroll_beyond_last_line setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -255,6 +255,8 @@
     /// 2. "indent_aware"
     "background_coloring": "disabled"
   },
+  // Whether the editor will scroll beyond the last line.
+  "scroll_beyond_last_line": "one_page",
   // The number of lines to keep above/below the cursor when scrolling.
   "vertical_scroll_margin": 3,
   // Scroll sensitivity multiplier. This multiplier is applied

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -15,6 +15,7 @@ pub struct EditorSettings {
     pub toolbar: Toolbar,
     pub scrollbar: Scrollbar,
     pub gutter: Gutter,
+    pub scroll_beyond_last_line: ScrollBeyondLastLine,
     pub vertical_scroll_margin: f32,
     pub scroll_sensitivity: f32,
     pub relative_line_numbers: bool,
@@ -116,6 +117,22 @@ pub enum MultiCursorModifier {
     CmdOrCtrl,
 }
 
+/// Whether the editor will scroll beyond the last line.
+///
+/// Default: one_page
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ScrollBeyondLastLine {
+    /// The editor will not scroll beyond the last line.
+    Off,
+
+    /// The editor will scroll beyond the last line by one page.
+    OnePage,
+
+    /// The editor will scroll beyond the last line by the same number of lines as vertical_scroll_margin.
+    VerticalScrollMargin,
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
     /// Whether the cursor blinks in the editor.
@@ -158,6 +175,10 @@ pub struct EditorSettingsContent {
     pub scrollbar: Option<ScrollbarContent>,
     /// Gutter related settings
     pub gutter: Option<GutterContent>,
+    /// Whether the editor will scroll beyond the last line.
+    ///
+    /// Default: one_page
+    pub scroll_beyond_last_line: Option<ScrollBeyondLastLine>,
     /// The number of lines to keep above/below the cursor when auto-scrolling.
     ///
     /// Default: 3.

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -2,6 +2,7 @@ mod actions;
 pub(crate) mod autoscroll;
 pub(crate) mod scroll_amount;
 
+use crate::editor_settings::ScrollBeyondLastLine;
 use crate::{
     display_map::{DisplaySnapshot, ToDisplayPoint},
     hover_popover::hide_hover,
@@ -199,8 +200,20 @@ impl ScrollManager {
                 0,
             )
         } else {
+            let scroll_top = scroll_position.y;
+            let scroll_top = match EditorSettings::get_global(cx).scroll_beyond_last_line {
+                ScrollBeyondLastLine::OnePage => scroll_top,
+                ScrollBeyondLastLine::Off => scroll_top
+                    .min((map.max_buffer_row().as_f32()) - self.visible_line_count.unwrap() + 1.0),
+                ScrollBeyondLastLine::VerticalScrollMargin => scroll_top.min(
+                    (map.max_buffer_row().as_f32()) - self.visible_line_count.unwrap()
+                        + 1.0
+                        + self.vertical_scroll_margin,
+                ),
+            };
+
             let scroll_top_buffer_point =
-                DisplayPoint::new(DisplayRow(scroll_position.y as u32), 0).to_point(&map);
+                DisplayPoint::new(DisplayRow(scroll_top as u32), 0).to_point(&map);
             let top_anchor = map
                 .buffer_snapshot
                 .anchor_at(scroll_top_buffer_point, Bias::Right);
@@ -210,7 +223,7 @@ impl ScrollManager {
                     anchor: top_anchor,
                     offset: point(
                         scroll_position.x.max(0.),
-                        scroll_position.y - top_anchor.to_display_point(&map).row().as_f32(),
+                        scroll_top - top_anchor.to_display_point(&map).row().as_f32(),
                     ),
                 },
                 scroll_top_buffer_point.row,


### PR DESCRIPTION
Add `scroll_beyond_last_line` setting with 3 options: 

- `one_page`: The default (current) behaviour of scrolling one more page beyond the last line. 
<img width="568" alt="SCR-20240429-sxry" src="https://github.com/zed-industries/zed/assets/126383/1effbee9-759f-4858-9022-83bbb208ef82">

- `off`: No scrolling beyond the last line. 
<img width="568" alt="SCR-20240429-syhv" src="https://github.com/zed-industries/zed/assets/126383/5391b1d7-918d-43f3-8a6f-7642ef32d174">

- `vertical_scroll_margin`: Scroll beyond the last line by the same number of lines as `vertical_scroll_margin`. Matches the behaviour of keyboard scrolling. 
<img width="568" alt="SCR-20240429-sypc" src="https://github.com/zed-industries/zed/assets/126383/bb9cc928-e515-4503-88f7-e434c45d742f">

Release Notes:

- Added `scroll_beyond_last_line` setting ([#4962](https://github.com/zed-industries/zed/issues/4962)).

