### PR TITLE
git: Do not log error if repository has no commits

### DIFF
--- a/crates/git/src/commit.rs
+++ b/crates/git/src/commit.rs
@@ -8,6 +8,10 @@ use std::process::Command;
 use std::os::windows::process::CommandExt;
 
 pub fn get_messages(working_directory: &Path, shas: &[Oid]) -> Result<HashMap<Oid, String>> {
+    if shas.is_empty() {
+        return Ok(HashMap::default());
+    }
+
     const MARKER: &'static str = "<MARKER>";
 
     let mut command = Command::new("git");


### PR DESCRIPTION
This is a follow-up to #10685 which started to hide these errors instead of displaying them to the user.

But the errors are still noisy and not actionable, so we hide them instead.

Release Notes:

- Removed error message being logged when `git blame` is run in a repository without commits.