### PR TITLE
Register ESLint as an available language server

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -165,10 +165,10 @@ pub fn init(
     );
     language!("proto");
 
-    // Register Tailwind globally as an available language server.
+    // Register globally available language servers.
     //
-    // This will allow users to add Tailwind support for a given language via
-    // the `language_servers` setting:
+    // This will allow users to add support for a built-in language server (e.g., Tailwind)
+    // for a given language via the `language_servers` setting:
     //
     // ```json
     // {
@@ -186,6 +186,10 @@ pub fn init(
             move || Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone()))
         },
     );
+    languages.register_available_lsp_adapter(LanguageServerName("eslint".into()), {
+        let node_runtime = node_runtime.clone();
+        move || Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone()))
+    });
 
     // Register Tailwind for the existing languages that should have it by default.
     //


### PR DESCRIPTION
This PR adds the ability for the ESLint language server (`eslint`) to be controlled by the `language_servers` setting.

Now in your settings you can indicate that the ESLint language server should be used for a given language, even if that language does not have the ESLint language server registered for it already:

```json
{
  "languages": {
    "My Language": {
      "language_servers": ["eslint", "..."]
    }
  }
}
```

Release Notes:

- N/A
