### PR TITLE
Add brackets and missing operators to Python grammar

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -48,6 +48,15 @@
 (string) @string
 (escape_sequence) @escape
 
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
 (interpolation
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
@@ -96,6 +105,8 @@
   "is"
   "not"
   "or"
+  "is not"
+  "not in"
 ] @operator
 
 [


### PR DESCRIPTION

Release Notes:

- Fixed #4341 

Before:
![before](https://github.com/zed-industries/zed/assets/16101408/34672e47-5131-481a-803e-064db8126cc9)

After:
![after](https://github.com/zed-industries/zed/assets/16101408/7d2405c6-d04f-4738-ad2e-a9424b1c9d19)
