### PR TITLE
Add copy path and copy relative path to context click menu

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -1,6 +1,7 @@
 use crate::{
-    DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition, GoToImplementation,
-    GoToTypeDefinition, Rename, RevealInFinder, SelectMode, ToggleCodeActions,
+    CopyPath, CopyRelativePath, DisplayPoint, Editor, EditorMode, FindAllReferences,
+    GoToDefinition, GoToImplementation, GoToTypeDefinition, Rename, RevealInFinder, SelectMode,
+    ToggleCodeActions,
 };
 use gpui::{DismissEvent, Pixels, Point, Subscription, View, ViewContext};
 use workspace::OpenInTerminal;
@@ -85,6 +86,9 @@ pub fn deploy_context_menu(
                 .separator()
                 .action("Reveal in Finder", Box::new(RevealInFinder))
                 .action("Open in Terminal", Box::new(OpenInTerminal))
+                .separator()
+                .action("Copy Path", Box::new(CopyPath))
+                .action("Copy Relative Path", Box::new(CopyRelativePath))
         })
     };
     let mouse_context_menu = MouseContextMenu::new(position, context_menu, cx);


### PR DESCRIPTION
Release Notes:

- Added "Copy path" and "Copy relative path" to the file right click context menu

Related to https://github.com/zed-industries/zed/issues/4474

This replicates the tab behavior that exists on vscode
![image](https://github.com/zed-industries/zed/assets/7784660/5620d76e-5efb-4971-908d-ca76108db36b)

Tasks:
- [x] Check that it works on context menu in file
![image](https://github.com/zed-industries/zed/assets/7784660/dcf0d345-ddb0-433a-b1cf-687c06222a72)
~~- [ ] Check that it works on a tab (does nothing)~~