### PR TITLE
assistant2: Add the ability to collapse chat messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "assets",
  "assistant_tooling",
  "client",
+ "collections",
  "editor",
  "env_logger",
  "feature_flags",

--- a/crates/assistant2/Cargo.toml
+++ b/crates/assistant2/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/assistant2.rs"
 anyhow.workspace = true
 assistant_tooling.workspace = true
 client.workspace = true
+collections.workspace = true
 editor.workspace = true
 feature_flags.workspace = true
 fs.workspace = true

--- a/crates/assistant2/src/ui/chat_message.rs
+++ b/crates/assistant2/src/ui/chat_message.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use client::User;
-use gpui::AnyElement;
+use gpui::{AnyElement, ClickEvent};
 use ui::{prelude::*, Avatar};
 
 use crate::MessageId;
@@ -17,7 +17,7 @@ pub struct ChatMessage {
     player: UserOrAssistant,
     message: AnyElement,
     collapsed: bool,
-    on_collapse: Box<dyn Fn(bool, &mut WindowContext) + 'static>,
+    on_collapse_handle_click: Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>,
 }
 
 impl ChatMessage {
@@ -26,14 +26,14 @@ impl ChatMessage {
         player: UserOrAssistant,
         message: AnyElement,
         collapsed: bool,
-        on_collapse: Box<dyn Fn(bool, &mut WindowContext) + 'static>,
+        on_collapse_handle_click: Box<dyn Fn(&ClickEvent, &mut WindowContext) + 'static>,
     ) -> Self {
         Self {
             id,
             player,
             message,
             collapsed,
-            on_collapse,
+            on_collapse_handle_click,
         }
     }
 }
@@ -53,7 +53,7 @@ impl RenderOnce for ChatMessage {
             .w_1()
             .mx_2()
             .h_full()
-            .on_click(move |_event, cx| (self.on_collapse)(!self.collapsed, cx))
+            .on_click(self.on_collapse_handle_click)
             .child(
                 div()
                     .w_px()


### PR DESCRIPTION
This PR adds the ability to collapse/uncollapse chat messages.

I think the spacing might be a little off with the collapsed calculations, so we'll need to look into that.

https://github.com/zed-industries/zed/assets/1486634/4009c831-b44e-4b30-85ed-0266cb5b8a26

Release Notes:

- N/A
