### PR TITLE
project: Set completion to undocumented if text empty

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5723,13 +5723,9 @@ impl Project {
             return;
         };
 
-        if response.text.is_empty() {
-            let mut completions = completions.write();
-            let completion = &mut completions[completion_index];
-            completion.documentation = Some(Documentation::Undocumented);
-        }
-
-        let documentation = if response.is_markdown {
+        let documentation = if response.text.is_empty() {
+            Documentation::Undocumented
+        } else if response.is_markdown {
             Documentation::MultiLineMarkdown(
                 markdown::parse_markdown(&response.text, &language_registry, None).await,
             )


### PR DESCRIPTION
I think the previous code was missing a `return` in there because it always overwrote the `completion.documentation` field, even if the `text.is_empty()` is true.

Release Notes:

- N/A
