### PR TITLE
Don't allow dropping files on remote projects

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -8525,11 +8525,13 @@ impl Project {
                     OpenBuffer::Weak(_) => {}
                 },
                 hash_map::Entry::Vacant(e) => {
-                    assert!(
-                        is_remote,
-                        "received buffer update from {:?}",
-                        envelope.original_sender_id
-                    );
+                    if !is_remote {
+                        debug_panic!(
+                            "received buffer update from {:?}",
+                            envelope.original_sender_id
+                        );
+                        return Err(anyhow!("received buffer update for non-remote project"));
+                    }
                     e.insert(OpenBuffer::Operations(ops));
                 }
             }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1891,6 +1891,24 @@ impl Pane {
         let mut to_pane = cx.view().clone();
         let mut split_direction = self.drag_split_direction;
         let paths = paths.paths().to_vec();
+        let is_remote = self
+            .workspace
+            .update(cx, |workspace, cx| {
+                if workspace.project().read(cx).is_remote() {
+                    workspace.show_error(
+                        &anyhow::anyhow!("Cannot drop files on a remote project"),
+                        cx,
+                    );
+                    true
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(true);
+        if is_remote {
+            return;
+        }
+
         self.workspace
             .update(cx, |workspace, cx| {
                 let fs = Arc::clone(workspace.project().read(cx).fs());


### PR DESCRIPTION
Release Notes:

- Fixed a panic when a remote participant dropped a local file on your project
