### PR TITLE
Use Elixir LS as the default language server for Elixir

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -588,6 +588,9 @@
     "C": {
       "format_on_save": "off"
     },
+    "Elixir": {
+      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
+    },
     "Gleam": {
       "tab_size": 2
     },
@@ -595,6 +598,9 @@
       "code_actions_on_format": {
         "source.organizeImports": true
       }
+    },
+    "HEEX": {
+      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
     "Make": {
       "hard_tabs": true


### PR DESCRIPTION
This PR adds `language_servers` settings for Elixir and HEEX to ensure they both only use Elixir LS by default.

Eventually we'd like to have these provided by the Elixir extension, but there are some outstanding questions on the design.

For now we can just use the built-in default settings to ensure a good out-of-the-box experience for Elixir users.

Release Notes:

- N/A
