### PR TITLE
Fix `xi_select_events` Bad Window Error

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -179,18 +179,6 @@ impl X11WindowState {
             )
             .unwrap();
 
-        xinput::ConnectionExt::xinput_xi_select_events(
-            &xcb_connection,
-            x_window,
-            &[xinput::EventMask {
-                deviceid: 1,
-                mask: vec![xinput::XIEventMask::MOTION],
-            }],
-        )
-        .unwrap()
-        .check()
-        .unwrap();
-
         if let Some(titlebar) = params.titlebar {
             if let Some(title) = titlebar.title {
                 xcb_connection
@@ -217,6 +205,18 @@ impl X11WindowState {
 
         xcb_connection.map_window(x_window).unwrap();
         xcb_connection.flush().unwrap();
+
+        xinput::ConnectionExt::xinput_xi_select_events(
+            &xcb_connection,
+            x_window,
+            &[xinput::EventMask {
+                deviceid: 1,
+                mask: vec![xinput::XIEventMask::MOTION],
+            }],
+        )
+        .unwrap()
+        .check()
+        .unwrap();
 
         let raw = RawWindow {
             connection: as_raw_xcb_connection::AsRawXcbConnection::as_raw_xcb_connection(


### PR DESCRIPTION
This attempts to fix a crash kvark was having. This might fix it, it might not. I cannot reproduce the problem so I’m waiting to hear back from them.

Release Notes:

- N/A
