### PR TITLE
Fix scrollbar auto-show for cursors out of sight

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -920,9 +920,8 @@ impl EditorElement {
         em_width: Pixels,
         autoscroll_containing_element: bool,
         cx: &mut WindowContext,
-    ) -> (Vec<CursorLayout>, bool) {
+    ) -> Vec<CursorLayout> {
         let mut autoscroll_bounds = None;
-        let mut non_visible_cursors = false;
         let cursor_layouts = self.editor.update(cx, |editor, cx| {
             let mut cursors = Vec::new();
             for (player_color, selections) in selections {
@@ -930,10 +929,6 @@ impl EditorElement {
                     let cursor_position = selection.head;
 
                     let in_range = visible_display_row_range.contains(&cursor_position.row());
-                    if !in_range {
-                        non_visible_cursors |= true;
-                    }
-
                     if (selection.is_local && !editor.show_local_cursors(cx)) || !in_range {
                         continue;
                     }
@@ -1041,7 +1036,7 @@ impl EditorElement {
             cx.request_autoscroll(bounds);
         }
 
-        (cursor_layouts, non_visible_cursors)
+        cursor_layouts
     }
 
     fn layout_scrollbar(
@@ -3770,7 +3765,7 @@ impl Element for EditorElement {
 
                 let cursors = self.collect_cursors(&snapshot, cx);
 
-                let (visible_cursors, non_visible_cursors) = self.layout_visible_cursors(
+                let visible_cursors = self.layout_visible_cursors(
                     &snapshot,
                     &selections,
                     start_row..end_row,
@@ -3790,7 +3785,7 @@ impl Element for EditorElement {
                     bounds,
                     scroll_position,
                     height_in_lines,
-                    non_visible_cursors,
+                    cursors.len() > visible_cursors.len(),
                     cx,
                 );
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2679,10 +2679,10 @@ impl EditorElement {
         let cursor_ranges = layout
             .cursors
             .iter()
-            .map(|cursor| ColoredRange {
-                start: cursor.0.row(),
-                end: cursor.0.row(),
-                color: cursor.1,
+            .map(|(point, color)| ColoredRange {
+                start: point.row(),
+                end: point.row(),
+                color: *color,
             })
             .collect_vec();
         scrollbar_layout.marker_quads_for_ranges(cursor_ranges, None)


### PR DESCRIPTION
This PR fixes scrollbar auto-show feature when there're not visible cursors. The intial behavior was broken in #11147.

The problem is that `selections` only contains visible selections, so the `if` with `non_visible_cursors |= true` is only visited in rare edge cases when we have at least part of the selection still visible on the screen. But when we scroll far enough from the cursor, `non_visible_cursors` keeps its default `false` value, which is incorrect.

Release Notes:

- N/A

/cc @mikayla-maki 