### PR TITLE
Windows: Temporary comments for dealing with open recently crash

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -952,17 +952,17 @@ impl WindowsWindowInner {
         Some(0)
     }
 
-    fn handle_activate_msg(&self, wparam: WPARAM) -> Option<isize> {
+    fn handle_activate_msg(&self, _wparam: WPARAM) -> Option<isize> {
         if self.hide_title_bar {
             if let Some(titlebar_rect) = self.get_titlebar_rect().log_err() {
                 unsafe { InvalidateRect(self.hwnd, Some(&titlebar_rect), FALSE) };
             }
         }
-        let activated = wparam.loword() > 0;
-        let mut callbacks = self.callbacks.borrow_mut();
-        if let Some(mut cb) = callbacks.active_status_change.as_mut() {
-            cb(activated);
-        }
+        // let activated = wparam.loword() > 0;
+        // let mut callbacks = self.callbacks.borrow_mut();
+        // if let Some(mut cb) = callbacks.active_status_change.as_mut() {
+        //     cb(activated);
+        // }
         None
     }
 


### PR DESCRIPTION
I thought here is the root cause the problem of crash when open recent in zed. relatve issue might be: #11094 , #10884. I don't know how to deal with this problem should we currently comment this line? or some one can deal with this problem.

Release Notes:

- N/A
