### PR TITLE
Suggest the SCSS extension for `.scss` files

### DIFF
--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -59,6 +59,7 @@ const SUGGESTIONS_BY_EXTENSION_ID: &[(&str, &[&str])] = &[
     ("racket", &["rkt"]),
     ("rescript", &["res", "resi"]),
     ("scheme", &["scm"]),
+    ("scss", &["scss"]),
     ("sql", &["sql"]),
     ("svelte", &["svelte"]),
     ("swift", &["swift"]),


### PR DESCRIPTION
This PR adds a suggestion for the new [SCSS extension](https://github.com/bajrangCoder/zed-scss) when `.scss` files are opened.

Release Notes:

- Added a suggestion for the SCSS extension when `.scss` files are opened.
