### PR TITLE
project panel: Adjust formatting of trash/delete action

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -907,7 +907,7 @@ impl ProjectPanel {
                     PromptLevel::Destructive,
                     &format!("{operation} {file_name:?}?",),
                     None,
-                    &["Delete", "Cancel"],
+                    &[operation, "Cancel"],
                 )
             });
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -905,7 +905,7 @@ impl ProjectPanel {
             let answer = (!skip_prompt).then(|| {
                 cx.prompt(
                     PromptLevel::Destructive,
-                    &format!("{operation:?} {file_name:?}?",),
+                    &format!("{operation} {file_name:?}?",),
                     None,
                     &["Delete", "Cancel"],
                 )


### PR DESCRIPTION
This PR removes a confusing quotation mark when trashing/deleting a file, introduced in #10875.
Also makes it clear that the file is actually going into trash instead of being deleted permanently

Before (trash):
<img width="266" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/f94a6257-62d0-4a3f-bc44-19e36bb28f67">

After (trash):
<img width="285" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/becb8143-06cf-4b5e-a52e-be2726df5955">

Before (delete):
<img width="263" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/e109a127-5f9c-4eeb-950e-4c4d5157061b">


After (delete):
<img width="260" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/246d0d94-e3d2-4279-84e2-74b313fe00a7">



Release Notes:

- Fixed formatting of prompt action when trashing/deleting a file