### PR TITLE
Update Preview release installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ brew install --cask zed
 Alternatively, to install the Preview release:
 
 ```sh
-brew tap homebrew/cask-versions
-brew install zed-preview
+brew install --cask zed@preview
 ```
 
 ## Developing Zed


### PR DESCRIPTION
This PR updates the Homebrew installation instructions for the Preview release, which has been migrated to ```homebrew/cask``` as ```zed@preview``` (see [Commit](https://github.com/Homebrew/homebrew-cask/commit/bad25d79e13ca41b492c976ef70b72117c402d20)).

Release Notes:

- N/A
