### PR TITLE
Return an error from project index tool when embedding query fails

### DIFF
--- a/crates/assistant2/src/tools/project_index.rs
+++ b/crates/assistant2/src/tools/project_index.rs
@@ -140,10 +140,9 @@ impl LanguageModelTool for ProjectIndexTool {
 
     fn execute(&self, query: &Self::Input, cx: &mut WindowContext) -> Task<Result<Self::Output>> {
         let project_index = self.project_index.read(cx);
-
         let status = project_index.status();
         let results = project_index.search(
-            query.query.as_str(),
+            query.query.clone(),
             query.limit.unwrap_or(DEFAULT_SEARCH_LIMIT),
             cx,
         );
@@ -151,7 +150,7 @@ impl LanguageModelTool for ProjectIndexTool {
         let fs = self.fs.clone();
 
         cx.spawn(|cx| async move {
-            let results = results.await;
+            let results = results.await?;
 
             let excerpts = results.into_iter().map(|result| {
                 let abs_path = result

--- a/crates/semantic_index/examples/index.rs
+++ b/crates/semantic_index/examples/index.rs
@@ -92,10 +92,11 @@ fn main() {
                 .update(|cx| {
                     let project_index = project_index.read(cx);
                     let query = "converting an anchor to a point";
-                    project_index.search(query, 4, cx)
+                    project_index.search(query.into(), 4, cx)
                 })
                 .unwrap()
-                .await;
+                .await
+                .unwrap();
 
             for search_result in results {
                 let path = search_result.path.clone();

--- a/crates/semantic_index/src/chunking.rs
+++ b/crates/semantic_index/src/chunking.rs
@@ -98,12 +98,9 @@ fn chunk_lines(text: &str) -> Vec<Chunk> {
 
     chunk_ranges
         .into_iter()
-        .map(|range| {
-            let mut hasher = Sha256::new();
-            hasher.update(&text[range.clone()]);
-            let mut digest = [0u8; 32];
-            digest.copy_from_slice(hasher.finalize().as_slice());
-            Chunk { range, digest }
+        .map(|range| Chunk {
+            digest: Sha256::digest(&text[range.clone()]).into(),
+            range,
         })
         .collect()
 }


### PR DESCRIPTION
Previously, a failure to embed the search query (due to a rate limit error) would appear the same as if there were no results.

* Avoid repeatedly embedding the search query for each worktree
* Unify tasks for searching all worktree

Release Notes:

- N/A
