### PR TITLE
Add an `explore extensions` button to welcome screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11795,6 +11795,7 @@ dependencies = [
  "copilot_ui",
  "db",
  "editor",
+ "extensions_ui",
  "fuzzy",
  "gpui",
  "install_cli",

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 client.workspace = true
 copilot_ui.workspace = true
 db.workspace = true
+extensions_ui.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 install_cli.workspace = true

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -145,6 +145,16 @@ impl Render for WelcomePage {
                                         );
                                         copilot_ui::initiate_sign_in(cx);
                                     })),
+                            )
+                            .child(
+                                Button::new("explore extensions", "Explore extensions")
+                                    .full_width()
+                                    .on_click(cx.listener(|this, _, cx| {
+                                        this.telemetry.report_app_event(
+                                            "welcome page: open extensions".to_string(),
+                                        );
+                                        cx.dispatch_action(Box::new(extensions_ui::Extensions));
+                                    })),
                             ),
                     )
                     .child(


### PR DESCRIPTION
We are still getting comments from users saying they didn't know we had extensions until just now. This doesn't fix anything for existing users, but it helps make new users more aware, earlier on. There's probably more we need to do for discoverability, but this feels like it should help.

Release Notes:

- N/A