### PR TITLE
assistant2: Use new icon in status bar

### DIFF
--- a/crates/assistant2/src/assistant2.rs
+++ b/crates/assistant2/src/assistant2.rs
@@ -202,7 +202,7 @@ impl Panel for AssistantPanel {
     }
 
     fn icon(&self, _cx: &WindowContext) -> Option<::ui::IconName> {
-        Some(IconName::Ai)
+        Some(IconName::ZedAssistant)
     }
 
     fn icon_tooltip(&self, _: &WindowContext) -> Option<&'static str> {


### PR DESCRIPTION
This PR updates the new assistant to use the new (temporary) icon in the status bar to distinguish it.

We added the icon in #11257, but hadn't wired it up.

Release Notes:

- N/A
