### PR TITLE
Use HIGH priority to wake blocked timers

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -264,7 +264,7 @@ pub async fn post_hang(
         Error::Internal(anyhow!(err))
     })?;
 
-    let mut backtrace = "Possible hang detected on main threadL".to_string();
+    let mut backtrace = "Possible hang detected on main thread:".to_string();
     let unknown = "<unknown>".to_string();
     for frame in report.backtrace.iter() {
         backtrace.push_str(&format!("\n{}", frame.symbols.first().unwrap_or(&unknown)));

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -47,7 +47,6 @@ mod macos {
             .header("src/platform/mac/dispatch.h")
             .allowlist_var("_dispatch_main_q")
             .allowlist_var("_dispatch_source_type_data_add")
-            .allowlist_var("DISPATCH_QUEUE_PRIORITY_DEFAULT")
             .allowlist_var("DISPATCH_QUEUE_PRIORITY_HIGH")
             .allowlist_var("DISPATCH_TIME_NOW")
             .allowlist_function("dispatch_get_global_queue")

--- a/crates/gpui/src/platform/mac/dispatcher.rs
+++ b/crates/gpui/src/platform/mac/dispatcher.rs
@@ -76,7 +76,7 @@ impl PlatformDispatcher for MacDispatcher {
     fn dispatch_after(&self, duration: Duration, runnable: Runnable) {
         unsafe {
             let queue =
-                dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.try_into().unwrap(), 0);
+                dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH.try_into().unwrap(), 0);
             let when = dispatch_time(DISPATCH_TIME_NOW as u64, duration.as_nanos() as i64);
             dispatch_after_f(
                 when,


### PR DESCRIPTION
One contributor to some beach-balls was that the main thread was calling
block_with_timeout, but the timeout never fired.

Release Notes:

- Reduced main thread hangs under very high system load
