### PR TITLE
Compile and instantiate wasm modules on a background thread

### DIFF
--- a/crates/extension/src/wasm_host.rs
+++ b/crates/extension/src/wasm_host.rs
@@ -106,9 +106,9 @@ impl WasmHost {
         wasm_bytes: Vec<u8>,
         manifest: Arc<ExtensionManifest>,
         executor: BackgroundExecutor,
-    ) -> impl 'static + Future<Output = Result<WasmExtension>> {
+    ) -> Task<Result<WasmExtension>> {
         let this = self.clone();
-        async move {
+        executor.clone().spawn(async move {
             let zed_api_version = parse_wasm_extension_version(&manifest.id, &wasm_bytes)?;
 
             let component = Component::from_binary(&this.engine, &wasm_bytes)
@@ -147,7 +147,7 @@ impl WasmHost {
                 tx,
                 zed_api_version,
             })
-        }
+        })
     }
 
     async fn build_wasi_ctx(&self, manifest: &Arc<ExtensionManifest>) -> Result<wasi::WasiCtx> {


### PR DESCRIPTION
Release Notes:

- Fixed a hang that could occur when loading some extensions, by loading extensions on a background thread.