### PR TITLE
Clean up `Indicator`

### DIFF
--- a/crates/ui/src/components/indicator.rs
+++ b/crates/ui/src/components/indicator.rs
@@ -1,9 +1,7 @@
-use gpui::Transformation;
-
 use crate::{prelude::*, AnyIcon};
 
 #[derive(Default)]
-pub enum IndicatorStyle {
+enum IndicatorKind {
     #[default]
     Dot,
     Bar,
@@ -12,28 +10,28 @@ pub enum IndicatorStyle {
 
 #[derive(IntoElement)]
 pub struct Indicator {
-    style: IndicatorStyle,
+    kind: IndicatorKind,
     pub color: Color,
 }
 
 impl Indicator {
     pub fn dot() -> Self {
         Self {
-            style: IndicatorStyle::Dot,
+            kind: IndicatorKind::Dot,
             color: Color::Default,
         }
     }
 
     pub fn bar() -> Self {
         Self {
-            style: IndicatorStyle::Dot,
+            kind: IndicatorKind::Bar,
             color: Color::Default,
         }
     }
 
     pub fn icon(icon: impl Into<AnyIcon>) -> Self {
         Self {
-            style: IndicatorStyle::Icon(icon.into()),
+            kind: IndicatorKind::Icon(icon.into()),
             color: Color::Default,
         }
     }
@@ -48,49 +46,19 @@ impl RenderOnce for Indicator {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         let container = div().flex_none();
 
-        match self.style {
-            IndicatorStyle::Icon(icon) => container
+        match self.kind {
+            IndicatorKind::Icon(icon) => container
                 .child(icon.map(|icon| icon.custom_size(rems_from_px(8.)).color(self.color))),
-            IndicatorStyle::Dot => container
+            IndicatorKind::Dot => container
                 .w_1p5()
                 .h_1p5()
                 .rounded_full()
                 .bg(self.color.color(cx)),
-            IndicatorStyle::Bar => container
+            IndicatorKind::Bar => container
                 .w_full()
                 .h_1p5()
                 .rounded_t_md()
                 .bg(self.color.color(cx)),
         }
-    }
-}
-
-#[derive(IntoElement)]
-pub struct IndicatorIcon {
-    icon: Icon,
-    transformation: Option<Transformation>,
-}
-
-impl IndicatorIcon {
-    pub fn new(icon: Icon) -> Self {
-        Self {
-            icon,
-            transformation: None,
-        }
-    }
-
-    pub fn transformation(mut self, transformation: Transformation) -> Self {
-        self.transformation = Some(transformation);
-        self
-    }
-}
-
-impl RenderOnce for IndicatorIcon {
-    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
-        self.icon
-            .custom_size(rems_from_px(8.))
-            .when_some(self.transformation, |this, transformation| {
-                this.transform(transformation)
-            })
     }
 }


### PR DESCRIPTION
This PR cleans up the `Indicator` component:

- Renamed `IndicatorStyle` to `IndicatorKind` and made it private.
- Fixed `Indicator::bar()` to construct an indicator using the right `IndicatorKind`.
- Removed the `IndicatorIcon`, since we didn't actually end up using it.

Release Notes:

- N/A
