### PR TITLE
gpui: Fix `start_display_link` leading to resource leak on hidden windows

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -415,6 +415,15 @@ impl MacWindowState {
 
     fn start_display_link(&mut self) {
         self.stop_display_link();
+        unsafe {
+            if !self
+                .native_window
+                .occlusionState()
+                .contains(NSWindowOcclusionState::NSWindowOcclusionStateVisible)
+            {
+                return;
+            }
+        }
         let display_id = unsafe { display_id_for_screen(self.native_window.screen()) };
         if let Some(mut display_link) =
             DisplayLink::new(display_id, self.native_view.as_ptr() as *mut c_void, step).log_err()


### PR DESCRIPTION
Release Notes:

- N/A

While developing [Loungy](https://loungy.app), I noticed that everytime I wake my laptop, Loungy starts consuming 100% CPU. I traced it down to `start_display_link` as there was this error message at the time of wake up:

```
[2024-05-02T05:02:31Z ERROR util] /Users/matthias/zed/crates/gpui/src/platform/mac/window.rs:420: could not create display link, code: -6661
```

The timeline is this:

1. The application is hidden with `cx.hide()`
2. The system is put to sleep and later woken up
3. `window_did_change_screen` would trigger immediately after wakeup, calling `start_display_link`
4. `start_display_link` fails catastrophically as `DisplayLink::new` starts hogging all the CPU for some reason?
5. throws the error message above
6. Once the window is opened, `window_did_change_occlusion_state` it retriggers `start_display_link` and the CPU issue subsides

