### PR TITLE
Fix alt-shift-(left|right) behaviour

### DIFF
--- a/assets/keymaps/textmate.json
+++ b/assets/keymaps/textmate.json
@@ -39,13 +39,13 @@
       "cmd-shift-left": "editor::SelectToBeginningOfLine",
       "cmd-shift-right": "editor::SelectToEndOfLine",
       "alt-shift-left": [
-        "editor::SelectToBeginningOfLine",
+        "editor::SelectToPreviousWordStart",
         {
           "stop_at_soft_wraps": true
         }
       ],
       "alt-shift-right": [
-        "editor::SelectToEndOfLine",
+        "editor::SelectToNextWordEnd",
         {
           "stop_at_soft_wraps": true
         }


### PR DESCRIPTION
Not sure what the etiquette is here, but in the interest of fixing #10242, I've re-implemented @jish's PR https://github.com/zed-industries/zed/pull/10535 and have signed the CLA


Release Notes:

- Fixed `alt-shift-left` and `alt-shift-right` in the Textmate default keybindings. ([#10242](https://github.com/zed-industries/zed/issues/10242))

TextMate keymap uses default option shift arrow selection