### PR TITLE
Use default allocator as a default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,9 +5678,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+checksum = "81eb4061c0582dedea1cbc7aff2240300dd6982e0239d1c99e65c1dbf4a30ba7"
 dependencies = [
  "cc",
  "libc",
@@ -6045,9 +6045,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+checksum = "9f41a2280ded0da56c8cf898babb86e8f10651a34adcfff190ae9a1159c6908d"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -61,7 +61,7 @@ languages.workspace = true
 log.workspace = true
 markdown_preview.workspace = true
 menu.workspace = true
-mimalloc = "0.1"
+mimalloc = { version = "0.1", optional = true }
 nix = {workspace = true, features = ["pthread"] }
 node_runtime.workspace = true
 notifications.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -24,7 +24,6 @@ use language::LanguageRegistry;
 use log::LevelFilter;
 
 use assets::Assets;
-use mimalloc::MiMalloc;
 use node_runtime::RealNodeRuntime;
 use parking_lot::Mutex;
 use release_channel::AppCommitSha;
@@ -56,8 +55,9 @@ use zed::{
     OpenListener, OpenRequest,
 };
 
+#[cfg(feature = "mimalloc")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn fail_to_launch(e: anyhow::Error) {
     App::new().run(move |cx| {


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/10525

Move `mimalloc` under the feature flag, `cargo build --features mimalloc` could be used to restore the old behavior.


Release Notes:

- Switched back to system allocator, keeping mimalloc as a compilation option