### PR TITLE
Use Rope instead of String for buffer diff base

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -2073,7 +2073,7 @@ struct Row10;"#};
             .as_singleton()
             .unwrap()
             .update(cx, |buffer, cx| {
-                buffer.set_diff_base(Some(base_text.to_string()), cx);
+                buffer.set_diff_base(Some(base_text.into()), cx);
             });
     });
     editor_cx_b.update_editor(|editor, cx| {
@@ -2083,7 +2083,7 @@ struct Row10;"#};
             .as_singleton()
             .unwrap()
             .update(cx, |buffer, cx| {
-                buffer.set_diff_base(Some(base_text.to_string()), cx);
+                buffer.set_diff_base(Some(base_text.into()), cx);
             });
     });
     cx_a.executor().run_until_parked();

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -2570,7 +2570,10 @@ async fn test_git_diff_base_change(
     // Smoke test diffing
 
     buffer_local_a.read_with(cx_a, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(diff_base.as_str())
+        );
         git::diff::assert_hunks(
             buffer.snapshot().git_diff_hunks_in_row_range(0..4),
             &buffer,
@@ -2591,7 +2594,10 @@ async fn test_git_diff_base_change(
     // Smoke test diffing
 
     buffer_remote_a.read_with(cx_b, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(diff_base.as_str())
+        );
         git::diff::assert_hunks(
             buffer.snapshot().git_diff_hunks_in_row_range(0..4),
             &buffer,
@@ -2611,7 +2617,10 @@ async fn test_git_diff_base_change(
     // Smoke test new diffing
 
     buffer_local_a.read_with(cx_a, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(new_diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(new_diff_base.as_str())
+        );
 
         git::diff::assert_hunks(
             buffer.snapshot().git_diff_hunks_in_row_range(0..4),
@@ -2624,7 +2633,10 @@ async fn test_git_diff_base_change(
     // Smoke test B
 
     buffer_remote_a.read_with(cx_b, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(new_diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(new_diff_base.as_str())
+        );
         git::diff::assert_hunks(
             buffer.snapshot().git_diff_hunks_in_row_range(0..4),
             &buffer,
@@ -2664,7 +2676,10 @@ async fn test_git_diff_base_change(
     // Smoke test diffing
 
     buffer_local_b.read_with(cx_a, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(diff_base.as_str())
+        );
         git::diff::assert_hunks(
             buffer.snapshot().git_diff_hunks_in_row_range(0..4),
             &buffer,
@@ -2685,7 +2700,10 @@ async fn test_git_diff_base_change(
     // Smoke test diffing
 
     buffer_remote_b.read_with(cx_b, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(diff_base.as_str())
+        );
         git::diff::assert_hunks(
             buffer.snapshot().git_diff_hunks_in_row_range(0..4),
             &buffer,
@@ -2705,7 +2723,10 @@ async fn test_git_diff_base_change(
     // Smoke test new diffing
 
     buffer_local_b.read_with(cx_a, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(new_diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(new_diff_base.as_str())
+        );
         println!("{:?}", buffer.as_rope().to_string());
         println!("{:?}", buffer.diff_base());
         println!(
@@ -2727,7 +2748,10 @@ async fn test_git_diff_base_change(
     // Smoke test B
 
     buffer_remote_b.read_with(cx_b, |buffer, _| {
-        assert_eq!(buffer.diff_base(), Some(new_diff_base.as_ref()));
+        assert_eq!(
+            buffer.diff_base().map(|rope| rope.to_string()).as_deref(),
+            Some(new_diff_base.as_str())
+        );
         git::diff::assert_hunks(
             buffer.snapshot().git_diff_hunks_in_row_range(0..4),
             &buffer,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9026,7 +9026,7 @@ async fn test_multibuffer_reverts(cx: &mut gpui::TestAppContext) {
                     .collect::<String>(),
                 cx,
             );
-            buffer.set_diff_base(Some(sample_text), cx);
+            buffer.set_diff_base(Some(sample_text.into()), cx);
         });
         cx.executor().run_until_parked();
     }
@@ -10041,17 +10041,17 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         "vvvv\nwwww\nxxxx\nyyyy\nzzzz\n@@@@\n{{{{\n||||\n}}}}\n~~~~\n\u{7f}\u{7f}\u{7f}\u{7f}";
     let buffer_1 = cx.new_model(|cx| {
         let mut buffer = Buffer::local(modified_sample_text_1.to_string(), cx);
-        buffer.set_diff_base(Some(sample_text_1.clone()), cx);
+        buffer.set_diff_base(Some(sample_text_1.clone().into()), cx);
         buffer
     });
     let buffer_2 = cx.new_model(|cx| {
         let mut buffer = Buffer::local(modified_sample_text_2.to_string(), cx);
-        buffer.set_diff_base(Some(sample_text_2.clone()), cx);
+        buffer.set_diff_base(Some(sample_text_2.clone().into()), cx);
         buffer
     });
     let buffer_3 = cx.new_model(|cx| {
         let mut buffer = Buffer::local(modified_sample_text_3.to_string(), cx);
-        buffer.set_diff_base(Some(sample_text_3.clone()), cx);
+        buffer.set_diff_base(Some(sample_text_3.clone().into()), cx);
         buffer
     });
 
@@ -11351,7 +11351,7 @@ fn assert_hunk_revert(
             .as_singleton()
             .unwrap()
             .update(cx, |buffer, cx| {
-                buffer.set_diff_base(Some(base_text.to_string()), cx);
+                buffer.set_diff_base(Some(base_text.into()), cx);
             });
     });
     cx.executor().run_until_parked();

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -145,7 +145,8 @@ mod tests {
                         1.five
                         1.six
                     "
-                    .unindent(),
+                    .unindent()
+                    .into(),
                 ),
                 cx,
             );
@@ -181,7 +182,8 @@ mod tests {
                         2.four
                         2.six
                     "
-                    .unindent(),
+                    .unindent()
+                    .into(),
                 ),
                 cx,
             );

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -99,12 +99,13 @@ pub fn editor_hunks(
                 .read(cx)
                 .excerpt_containing(Point::new(hunk.associated_range.start, 0), cx)
                 .expect("no excerpt for expanded buffer's hunk start");
-            let diff_base = &buffer
+            let diff_base = buffer
                 .read(cx)
                 .diff_base()
                 .expect("should have a diff base for expanded hunk")
-                [hunk.diff_base_byte_range.clone()];
-            (diff_base.to_owned(), hunk.status(), display_range)
+                .slice(hunk.diff_base_byte_range.clone())
+                .to_string();
+            (diff_base, hunk.status(), display_range)
         })
         .collect()
 }
@@ -134,16 +135,13 @@ pub fn expanded_hunks(
                 .read(cx)
                 .excerpt_containing(expanded_hunk.hunk_range.start, cx)
                 .expect("no excerpt for expanded buffer's hunk start");
-            let diff_base = &buffer
+            let diff_base = buffer
                 .read(cx)
                 .diff_base()
                 .expect("should have a diff base for expanded hunk")
-                [expanded_hunk.diff_base_byte_range.clone()];
-            (
-                diff_base.to_owned(),
-                expanded_hunk.status,
-                hunk_display_range,
-            )
+                .slice(expanded_hunk.diff_base_byte_range.clone())
+                .to_string();
+            (diff_base, expanded_hunk.status, hunk_display_range)
         })
         .collect()
 }

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -21,6 +21,7 @@ use std::{
         Arc,
     },
 };
+use text::Rope;
 use ui::Context;
 use util::{
     assert_set_eq,
@@ -271,7 +272,7 @@ impl EditorTestContext {
     }
 
     pub fn set_diff_base(&mut self, diff_base: Option<&str>) {
-        let diff_base = diff_base.map(String::from);
+        let diff_base = diff_base.map(Rope::from);
         self.update_buffer(|buffer, cx| buffer.set_diff_base(diff_base, cx));
     }
 

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -520,8 +520,16 @@ impl Buffer {
     pub fn new(replica_id: u16, remote_id: BufferId, mut base_text: String) -> Buffer {
         let line_ending = LineEnding::detect(&base_text);
         LineEnding::normalize(&mut base_text);
+        Self::new_normalized(replica_id, remote_id, line_ending, Rope::from(base_text))
+    }
 
-        let history = History::new(Rope::from(base_text.as_ref()));
+    pub fn new_normalized(
+        replica_id: u16,
+        remote_id: BufferId,
+        line_ending: LineEnding,
+        normalized: Rope,
+    ) -> Buffer {
+        let history = History::new(normalized);
         let mut fragments = SumTree::new();
         let mut insertions = SumTree::new();
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1065,7 +1065,7 @@ impl LocalWorktree {
         &self,
         path: &Path,
         cx: &mut ModelContext<Worktree>,
-    ) -> Task<Result<(File, String, Option<String>)>> {
+    ) -> Task<Result<(File, String, Option<Rope>)>> {
         let path = Arc::from(path);
         let abs_path = self.absolutize(&path);
         let fs = self.fs.clone();
@@ -1096,7 +1096,7 @@ impl LocalWorktree {
                                 if abs_path_metadata.is_dir || abs_path_metadata.is_symlink {
                                     None
                                 } else {
-                                    git_repo.lock().load_index_text(&repo_path)
+                                    git_repo.lock().load_index_text(&repo_path).map(Rope::from)
                                 }
                             }
                         }));


### PR DESCRIPTION
As an attempt to do things better when showing diff hunks, store diff base as Rope, not String, to have cheaper clones when the diff base text is reused, e.g. creating another buffer with the diff base text for hunk diff expanding.

Release Notes:

- N/A
