### PR TITLE
elixir: Respect LSP settings for `elixir-ls`

### DIFF
--- a/extensions/elixir/src/elixir.rs
+++ b/extensions/elixir/src/elixir.rs
@@ -102,6 +102,23 @@ impl zed::Extension for ElixirExtension {
             _ => Ok(None),
         }
     }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        match language_server_id.as_ref() {
+            ElixirLs::LANGUAGE_SERVER_ID => {
+                if let Some(elixir_ls) = self.elixir_ls.as_mut() {
+                    return elixir_ls.language_server_workspace_configuration(worktree);
+                }
+            }
+            _ => (),
+        }
+
+        Ok(None)
+    }
 }
 
 zed::register_extension!(ElixirExtension);

--- a/extensions/elixir/src/language_servers/elixir_ls.rs
+++ b/extensions/elixir/src/language_servers/elixir_ls.rs
@@ -1,7 +1,8 @@
 use std::fs;
 
 use zed::lsp::{Completion, CompletionKind, Symbol, SymbolKind};
-use zed::{CodeLabel, CodeLabelSpan, LanguageServerId};
+use zed::settings::LspSettings;
+use zed::{serde_json, CodeLabel, CodeLabelSpan, LanguageServerId};
 use zed_extension_api::{self as zed, Result};
 
 pub struct ElixirLs {
@@ -87,6 +88,20 @@ impl ElixirLs {
 
         self.cached_binary_path = Some(binary_path.clone());
         Ok(binary_path)
+    }
+
+    pub fn language_server_workspace_configuration(
+        &mut self,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree("elixir-ls", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+
+        Ok(Some(serde_json::json!({
+            "elixirLS": settings
+        })))
     }
 
     pub fn label_for_completion(&self, completion: Completion) -> Option<CodeLabel> {


### PR DESCRIPTION
This PR updates the Elixir extension to respect the LSP settings for `elixir-ls`:

```json
"lsp": {
  "elixir-ls": {
    "settings": {
      "dialyzerEnabled": false
    }
  }
}
```

```
Received workspace/didChangeConfiguration
Received client configuration via workspace/didChangeConfiguration
%{"dialyzerEnabled" => false}
Loaded DETS databases in 33ms
Loaded DETS databases in 10ms
Compiling 65 files (.ex)
```

Release Notes:

- N/A
