### PR TITLE
Allow git blame tooltip emails to open mail client

### DIFF
--- a/crates/editor/src/blame_entry_tooltip.rs
+++ b/crates/editor/src/blame_entry_tooltip.rs
@@ -171,9 +171,13 @@ impl Render for BlameEntryTooltip {
                                 .child(author)
                                 .when_some(author_email, |this, author_email| {
                                     this.child(
-                                        div()
-                                            .text_color(cx.theme().colors().text_muted)
-                                            .child(author_email),
+                                        Button::new("author-email", author_email.clone())
+                                            .color(Color::Muted)
+                                            .style(ButtonStyle::Transparent)
+                                            .on_click(move |_, cx| {
+                                                cx.stop_propagation();
+                                                cx.open_url(&format!("mailto:{}", author_email))
+                                            }),
                                     )
                                 })
                                 .border_b_1()


### PR DESCRIPTION
https://github.com/zed-industries/zed/assets/19867440/fe5025cd-6cbd-4c40-b8a0-8f548f3221a1

This matches what GitLense offers in VS Code.

Release Notes:

- Added clickable links to git blame tooltip to open system email client.