### PR TITLE
elixir: Check for next-ls and lexical in path first

### DIFF
--- a/extensions/elixir/src/language_servers/lexical.rs
+++ b/extensions/elixir/src/language_servers/lexical.rs
@@ -20,8 +20,12 @@ impl Lexical {
     pub fn language_server_binary_path(
         &mut self,
         language_server_id: &LanguageServerId,
-        _worktree: &zed::Worktree,
+        worktree: &zed::Worktree,
     ) -> Result<String> {
+        if let Some(path) = worktree.which("lexical") {
+            return Ok(path);
+        }
+
         if let Some(path) = &self.cached_binary_path {
             if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
                 return Ok(path.clone());

--- a/extensions/elixir/src/language_servers/next_ls.rs
+++ b/extensions/elixir/src/language_servers/next_ls.rs
@@ -20,8 +20,12 @@ impl NextLs {
     pub fn language_server_binary_path(
         &mut self,
         language_server_id: &LanguageServerId,
-        _worktree: &zed::Worktree,
+        worktree: &zed::Worktree,
     ) -> Result<String> {
+        if let Some(path) = worktree.which("next-ls") {
+            return Ok(path);
+        }
+
         if let Some(path) = &self.cached_binary_path {
             if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
                 return Ok(path.clone());


### PR DESCRIPTION
Since it's not longer possible to setup a local elixir LSP, @maxdeviant proposed to look for `next-ls` and `lexical` in path first, just like it's already done for `elixir_ls`.

For context take a look at #11297 (starting from [this comment](https://github.com/zed-industries/zed/issues/11297#issuecomment-2091095537)).

Release Notes:

- N/A
