### PR TITLE
Add autosave with delay

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -300,6 +300,8 @@
   // when saving it.
   "ensure_final_newline_on_save": true,
   // Whether or not to perform a buffer format before saving
+  //
+  // Keep in mind, if the autosave with delay is enabled, format_on_save will be ignored
   "format_on_save": "on",
   // How to perform a buffer format. This setting can take 4 values:
   //

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1231,8 +1231,15 @@ impl Pane {
         project: Model<Project>,
         cx: &mut WindowContext,
     ) -> Task<Result<()>> {
+        let format = if let AutosaveSetting::AfterDelay { .. } =
+            WorkspaceSettings::get_global(cx).autosave
+        {
+            false
+        } else {
+            true
+        }
         if Self::can_autosave_item(item, cx) {
-            item.save(true, project, cx)
+            item.save(format, project, cx)
         } else {
             Task::ready(Ok(()))
         }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1237,7 +1237,7 @@ impl Pane {
             false
         } else {
             true
-        }
+        };
         if Self::can_autosave_item(item, cx) {
             item.save(format, project, cx)
         } else {


### PR DESCRIPTION
Implemented autosave functionality with a delay, which now refrains from formatting the code upon triggering unless the user manually saves it. Additionally, enhanced documentation for the `format_on_save` setting has been added. This resolves the issue where autosave with delay would inadvertently format the code, disrupting the user experience, as reported in the corresponding issue.

Release Notes:

- Fixed a bug where autosave after_delay would auto-format the buffer ([#9787](https://github.com/zed-industries/zed/issues/9787)).
