### PR TITLE
linux: Set StartupWMClass in .desktop file

### DIFF
--- a/crates/zed/resources/zed.desktop
+++ b/crates/zed/resources/zed.desktop
@@ -11,3 +11,4 @@ Icon=zed
 Categories=TextEditor;Development;IDE;
 Keywords=zed;
 MimeType=text/plain;inode/directory;
+StartupWMClass=dev.zed.Zed


### PR DESCRIPTION
This has to match the WMClass/AppID, which was added here: #10909

Release Notes:

- N/A
