### PR TITLE
Tie the Zed application ID to the release channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "recent_projects",
+ "release_channel",
  "rich_text",
  "rpc",
  "schemars",

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -51,6 +51,7 @@ picker.workspace = true
 project.workspace = true
 recent_projects.workspace = true
 dev_server_projects.workspace = true
+release_channel.workspace = true
 rich_text.workspace = true
 rpc.workspace = true
 schemars.workspace = true

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -20,6 +20,7 @@ use panel_settings::MessageEditorSettings;
 pub use panel_settings::{
     ChatPanelSettings, CollaborationPanelSettings, NotificationPanelSettings,
 };
+use release_channel::ReleaseChannel;
 use settings::Settings;
 use workspace::{notifications::DetachAndPromptErr, AppState};
 
@@ -96,6 +97,7 @@ pub fn toggle_deafen(_: &ToggleDeafen, cx: &mut AppContext) {
 fn notification_window_options(
     screen: Rc<dyn PlatformDisplay>,
     window_size: Size<Pixels>,
+    cx: &AppContext,
 ) -> WindowOptions {
     let notification_margin_width = DevicePixels::from(16);
     let notification_margin_height = DevicePixels::from(-0) - DevicePixels::from(48);
@@ -112,6 +114,8 @@ fn notification_window_options(
         size: window_size.into(),
     };
 
+    let app_id = ReleaseChannel::global(cx).app_id();
+
     WindowOptions {
         bounds: Some(bounds),
         titlebar: None,
@@ -122,6 +126,6 @@ fn notification_window_options(
         display_id: Some(screen.id()),
         fullscreen: false,
         window_background: WindowBackgroundAppearance::default(),
-        app_id: Some("dev.zed.Zed".to_owned()),
+        app_id: Some(app_id.to_owned()),
     }
 }

--- a/crates/collab_ui/src/notifications/incoming_call_notification.rs
+++ b/crates/collab_ui/src/notifications/incoming_call_notification.rs
@@ -32,18 +32,22 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
                 };
 
                 for screen in unique_screens {
-                    let options = notification_window_options(screen, window_size);
-                    let window = cx
-                        .open_window(options, |cx| {
-                            cx.new_view(|_| {
-                                IncomingCallNotification::new(
-                                    incoming_call.clone(),
-                                    app_state.clone(),
-                                )
+                    if let Some(options) = cx
+                        .update(|cx| notification_window_options(screen, window_size, cx))
+                        .log_err()
+                    {
+                        let window = cx
+                            .open_window(options, |cx| {
+                                cx.new_view(|_| {
+                                    IncomingCallNotification::new(
+                                        incoming_call.clone(),
+                                        app_state.clone(),
+                                    )
+                                })
                             })
-                        })
-                        .unwrap();
-                    notification_windows.push(window);
+                            .unwrap();
+                        notification_windows.push(window);
+                    }
                 }
             }
         }

--- a/crates/collab_ui/src/notifications/project_shared_notification.rs
+++ b/crates/collab_ui/src/notifications/project_shared_notification.rs
@@ -26,7 +26,7 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut AppContext) {
             };
 
             for screen in cx.displays() {
-                let options = notification_window_options(screen, window_size);
+                let options = notification_window_options(screen, window_size, cx);
                 let window = cx.open_window(options, |cx| {
                     cx.new_view(|_| {
                         ProjectSharedNotification::new(

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -136,6 +136,18 @@ impl ReleaseChannel {
         }
     }
 
+    /// Returns the application ID that's used by Wayland as application ID
+    /// and WM_CLASS on X11.
+    /// This also has to match the bundle identifier for Zed on macOS.
+    pub fn app_id(&self) -> &'static str {
+        match self {
+            ReleaseChannel::Dev => "dev.zed.Zed-Dev",
+            ReleaseChannel::Nightly => "dev.zed.Zed-Nightly",
+            ReleaseChannel::Preview => "dev.zed.Zed-Preview",
+            ReleaseChannel::Stable => "dev.zed.Zed",
+        }
+    }
+
     /// Returns the query parameter for this [`ReleaseChannel`].
     pub fn release_query_param(&self) -> Option<&'static str> {
         match self {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -87,6 +87,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
             .into_iter()
             .find(|display| display.uuid().ok() == Some(uuid))
     });
+    let app_id = ReleaseChannel::global(cx).app_id();
 
     WindowOptions {
         titlebar: Some(TitlebarOptions {
@@ -102,7 +103,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         display_id: display.map(|display| display.id()),
         fullscreen: false,
         window_background: cx.theme().window_background_appearance(),
-        app_id: Some("dev.zed.Zed".to_owned()),
+        app_id: Some(app_id.to_owned()),
     }
 }
 
@@ -3106,6 +3107,7 @@ mod tests {
             notifications::init(app_state.client.clone(), app_state.user_store.clone(), cx);
             workspace::init(app_state.clone(), cx);
             Project::init_settings(cx);
+            release_channel::init("0.0.0", cx);
             command_palette::init(cx);
             language::init(cx);
             editor::init(cx);


### PR DESCRIPTION
Since we do want to have different versions of Zed running on the same Linux install, we need to give them different application IDs so they're not grouped together as the same application.

This changes the app_id depending on the releaes channel and, crucially, it also matches them up with the bundle identifiers that we use on macOS.

Release Notes:

- N/A
