### PR TITLE
linux: Use app_id as filepath for desktop file

### DIFF
--- a/crates/zed/resources/zed.desktop
+++ b/crates/zed/resources/zed.desktop
@@ -11,4 +11,3 @@ Icon=zed
 Categories=TextEditor;Development;IDE;
 Keywords=zed;
 MimeType=text/plain;inode/directory;
-StartupWMClass=dev.zed.Zed

--- a/script/install.sh
+++ b/script/install.sh
@@ -51,15 +51,42 @@ linux() {
         suffix="-$channel"
     fi
 
+    appid=""
+    case "$channel" in
+      stable)
+        appid="dev.zed.Zed"
+        ;;
+      nightly)
+        appid="dev.zed.Zed-Nightly"
+        ;;
+      preview)
+        appid="dev.zed.Zed-Preview"
+        ;;
+      dev)
+        appid="dev.zed.Zed-Dev"
+        ;;
+      *)
+        echo "Unknown release channel: ${channel}. Using stable app ID."
+        appid="dev.zed.Zed"
+        ;;
+    esac
+
+    # Unpack
     rm -rf "$HOME/.local/zed$suffix.app"
     mkdir -p "$HOME/.local/zed$suffix.app"
     tar -xzf "$temp/zed-linux-$arch.tar.gz" -C "$HOME/.local/"
 
+    # Setup ~/.local directories
     mkdir -p "$HOME/.local/bin" "$HOME/.local/share/applications"
+
+    # Link the binary
     ln -sf ~/.local/zed$suffix.app/bin/zed ~/.local/bin/
-    cp ~/.local/zed$suffix.app/share/applications/zed$suffix.desktop ~/.local/share/applications/
-    sed -i "s|Icon=zed|Icon=$HOME/.local/zed$suffix.app/share/icons/hicolor/512x512/apps/zed.png|g" ~/.local/share/applications/zed$suffix.desktop
-    sed -i "s|Exec=zed|Exec=$HOME/.local/zed$suffix.app/bin/zed|g" ~/.local/share/applications/zed$suffix.desktop
+
+    # Copy .desktop file
+    desktop_file_path="$HOME/.local/share/applications/${appid}.desktop"
+    cp ~/.local/zed$suffix.app/share/applications/zed$suffix.desktop "${desktop_file_path}"
+    sed -i "s|Icon=zed|Icon=$HOME/.local/zed$suffix.app/share/icons/hicolor/512x512/apps/zed.png|g" "${desktop_file_path}"
+    sed -i "s|Exec=zed|Exec=$HOME/.local/zed$suffix.app/bin/zed|g" "${desktop_file_path}"
 
     if which zed >/dev/null 2>&1; then
         echo "Zed has been installed. Run with 'zed'"


### PR DESCRIPTION
This undoes the changes from #11333 and uses the path of the `.desktop` file instead.

According ot the spec (https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) the filename and path of the `desktop` file are used to determine the desktop file ID.

This is enough to match the windows (which have the same WMClass/app-id) with the desktop entry.

Release Notes:

- N/A
