### PR TITLE
lsp: More information in error if server fails to start

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -262,7 +262,7 @@ impl LanguageServer {
         let mut command = process::Command::new(&binary.path);
         command
             .current_dir(working_dir)
-            .args(binary.arguments)
+            .args(&binary.arguments)
             .envs(binary.env.unwrap_or_default())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -270,7 +270,12 @@ impl LanguageServer {
             .kill_on_drop(true);
         #[cfg(windows)]
         command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
-        let mut server = command.spawn()?;
+        let mut server = command.spawn().with_context(|| {
+            format!(
+                "failed to spawn command. path: {:?}, working directory: {:?}, args: {:?}",
+                binary.path, working_dir, &binary.arguments
+            )
+        })?;
 
         let stdin = server.stdin.take().unwrap();
         let stdout = server.stdout.take().unwrap();


### PR DESCRIPTION
We do log that information, but we don't put it in the error message where it's really useful.



Release Notes:

- N/A
