### PR TITLE
project panel: Allow confirming prompt with keyboard

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -907,7 +907,7 @@ impl ProjectPanel {
             let operation = if trash { "Trash" } else { "Delete" };
             let answer = (!skip_prompt).then(|| {
                 cx.prompt(
-                    PromptLevel::Destructive,
+                    PromptLevel::Info,
                     &format!("{operation} {file_name:?}?",),
                     None,
                     &[operation, "Cancel"],


### PR DESCRIPTION
The ability to confirm the file deletion prompt by pressing "Enter" was broken in #11015

Release Notes:

- Restored the ability to confirm a prompt by pressing "Enter" when deleting/trashing files
