### PR TITLE
elixir: Fix next-ls binary name

### DIFF
--- a/extensions/elixir/src/language_servers/next_ls.rs
+++ b/extensions/elixir/src/language_servers/next_ls.rs
@@ -22,7 +22,7 @@ impl NextLs {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<String> {
-        if let Some(path) = worktree.which("next-ls") {
+        if let Some(path) = worktree.which("nextls") {
             return Ok(path);
         }
 


### PR DESCRIPTION
This is to followup #11318, and the comment from @mhanberg.

Release Notes:

- N/A