### PR TITLE
Alternate files with ctrl-6

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,5 +1,11 @@
 [
   {
+    "context": "ProjectPanel || Editor",
+    "bindings": {
+      "ctrl-6": "workspace::AlternateFile"
+    }
+  },
+  {
     "context": "Editor && VimControl && !VimWaiting && !menu",
     "bindings": {
       "i": [

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -2,7 +2,7 @@
   {
     "context": "ProjectPanel || Editor",
     "bindings": {
-      "ctrl-6": "workspace::AlternateFile"
+      "ctrl-6": "pane::AlternateFile"
     }
   },
   {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -330,6 +330,7 @@ pub trait ItemHandle: 'static + Send {
     fn serialized_item_kind(&self) -> Option<&'static str>;
     fn show_toolbar(&self, cx: &AppContext) -> bool;
     fn pixel_position_of_cursor(&self, cx: &AppContext) -> Option<Point<Pixels>>;
+    fn downgrade_item(&self) -> Box<dyn WeakItemHandle>;
 }
 
 pub trait WeakItemHandle: Send + Sync {
@@ -701,6 +702,10 @@ impl<T: Item> ItemHandle for View<T> {
 
     fn pixel_position_of_cursor(&self, cx: &AppContext) -> Option<Point<Pixels>> {
         self.read(cx).pixel_position_of_cursor(cx)
+    }
+
+    fn downgrade_item(&self) -> Box<dyn WeakItemHandle> {
+        Box::new(self.downgrade())
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -114,6 +114,7 @@ actions!(
         ActivatePrevItem,
         ActivateNextItem,
         ActivateLastItem,
+        AlternateFile,
         CloseCleanItems,
         CloseItemsToTheLeft,
         CloseItemsToTheRight,
@@ -183,6 +184,7 @@ impl fmt::Debug for Event {
 /// responsible for managing item tabs, focus and zoom states and drag and drop features.
 /// Can be split, see `PaneGroup` for more details.
 pub struct Pane {
+    alternate_file_items: (Option<Box<dyn ItemHandle>>, Option<Box<dyn ItemHandle>>),
     focus_handle: FocusHandle,
     items: Vec<Box<dyn ItemHandle>>,
     activation_history: Vec<EntityId>,
@@ -286,6 +288,7 @@ impl Pane {
 
         let handle = cx.view().downgrade();
         Self {
+            alternate_file_items: (None, None),
             focus_handle,
             items: Vec::new(),
             activation_history: Vec::new(),
@@ -387,6 +390,29 @@ impl Pane {
             ),
             _subscriptions: subscriptions,
             double_click_dispatch_action,
+        }
+    }
+
+    fn alternate_file(&mut self, cx: &mut ViewContext<Pane>) {
+        let (_, alternative) = &self.alternate_file_items;
+        if let Some(alternative) = alternative {
+            self.add_item(alternative.clone(), true, true, None, cx);
+        }
+    }
+
+    pub fn track_alternate_file_items(&mut self) {
+        if let Some(item) = self.active_item() {
+            let (current, _) = &self.alternate_file_items;
+            match current {
+                Some(current) => {
+                    if current.item_id() != item.item_id() {
+                        self.alternate_file_items = (Some(item), Some(current.clone()));
+                    }
+                }
+                None => {
+                    self.alternate_file_items = (Some(item), None);
+                }
+            }
         }
     }
 
@@ -1981,6 +2007,9 @@ impl Render for Pane {
             .size_full()
             .flex_none()
             .overflow_hidden()
+            .on_action(cx.listener(|pane, _: &AlternateFile, cx| {
+                pane.alternate_file(cx);
+            }))
             .on_action(cx.listener(|pane, _: &SplitLeft, cx| pane.split(SplitDirection::Left, cx)))
             .on_action(cx.listener(|pane, _: &SplitUp, cx| pane.split(SplitDirection::Up, cx)))
             .on_action(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -18,6 +18,7 @@ use gpui::{
     MouseDownEvent, NavigationDirection, Pixels, Point, PromptLevel, Render, ScrollHandle,
     Subscription, Task, View, ViewContext, VisualContext, WeakFocusHandle, WeakView, WindowContext,
 };
+use itertools::Itertools;
 use parking_lot::Mutex;
 use project::{Project, ProjectEntryId, ProjectPath};
 use serde::Deserialize;
@@ -396,7 +397,14 @@ impl Pane {
     fn alternate_file(&mut self, cx: &mut ViewContext<Pane>) {
         let (_, alternative) = &self.alternate_file_items;
         if let Some(alternative) = alternative {
-            self.add_item(alternative.clone(), true, true, None, cx);
+            let existing = self
+                .items()
+                .find_position(|item| item.item_id() == alternative.item_id());
+            if let Some((ix, _)) = existing {
+                self.activate_item(ix, true, true, cx);
+            } else {
+                self.add_item(alternative.clone(), true, true, None, cx);
+            }
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -113,6 +113,7 @@ pub struct RemoveWorktreeFromProject(pub WorktreeId);
 actions!(
     workspace,
     [
+        AlternateFile,
         Open,
         OpenInTerminal,
         NewFile,
@@ -597,6 +598,7 @@ pub struct Workspace {
     centered_layout: bool,
     bounds_save_task_queued: Option<Task<()>>,
     on_prompt_for_new_path: Option<PromptForNewPath>,
+    alternate_file_paths: (Option<ProjectPath>, Option<ProjectPath>),
 }
 
 impl EventEmitter<Event> for Workspace {}
@@ -874,6 +876,7 @@ impl Workspace {
             centered_layout: false,
             bounds_save_task_queued: None,
             on_prompt_for_new_path: None,
+            alternate_file_paths: (None, None),
         }
     }
 
@@ -2499,8 +2502,27 @@ impl Workspace {
         self.zoomed_position = None;
         cx.emit(Event::ZoomChanged);
         self.update_active_view_for_followers(cx);
+        self.track_alternate_files(cx);
 
         cx.notify();
+    }
+
+    fn track_alternate_files(&mut self, cx: &mut ViewContext<Self>) {
+        if let Some(item) = self.active_item(cx) {
+            if let Some(project_path) = item.project_path(cx) {
+                let (current, alternative) = self.alternate_file_paths.clone();
+                match current {
+                    Some(current) => {
+                        if current != project_path {
+                            self.alternate_file_paths = (Some(project_path), Some(current.clone()));
+                        }
+                    }
+                    None => {
+                        self.alternate_file_paths = (Some(project_path), None);
+                    }
+                }
+            }
+        }
     }
 
     fn handle_pane_event(
@@ -2516,6 +2538,7 @@ impl Workspace {
             }
             pane::Event::Remove => self.remove_pane(pane, cx),
             pane::Event::ActivateItem { local } => {
+                self.track_alternate_files(cx);
                 if *local {
                     self.unfollow(&pane, cx);
                 }
@@ -3769,6 +3792,17 @@ impl Workspace {
             .on_action(cx.listener(Self::send_keystrokes))
             .on_action(cx.listener(Self::add_folder_to_project))
             .on_action(cx.listener(Self::follow_next_collaborator))
+            .on_action(cx.listener(|workspace, _: &AlternateFile, cx| {
+                let app_state = AppState::global(cx);
+                if let Some(app_state) = app_state.upgrade() {
+                    let (_, alternative) = &workspace.alternate_file_paths;
+                    if let Some(alternative) = alternative {
+                        let pane = workspace.active_pane().downgrade();
+                        let path = alternative.to_owned();
+                        let task = workspace.open_path(path, Some(pane), true, cx).detach();
+                    }
+                }
+            }))
             .on_action(cx.listener(|workspace, _: &Unfollow, cx| {
                 let pane = workspace.active_pane().clone();
                 workspace.unfollow(&pane, cx);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2510,10 +2510,10 @@ impl Workspace {
     fn track_alternate_files(&mut self, cx: &mut ViewContext<Self>) {
         if let Some(item) = self.active_item(cx) {
             if let Some(project_path) = item.project_path(cx) {
-                let (current, alternative) = self.alternate_file_paths.clone();
+                let (current, alternative) = &self.alternate_file_paths;
                 match current {
                     Some(current) => {
-                        if current != project_path {
+                        if *current != project_path {
                             self.alternate_file_paths = (Some(project_path), Some(current.clone()));
                         }
                     }


### PR DESCRIPTION
This is my stab at #7709 

I realize the code is flawed. There's no test coverage, I'm using `clone()` and there are probably better ways to hook into the events. Also, I didn't know what context to use for the keybinding. But maybe with some pointers from someone who actually know what they're doing, I can get this shippable.

Release Notes:

- vim: Added ctrl-6 for [alternate-file](https://vimhelp.org/editing.txt.html#CTRL-%5E) to navigate back and forth between two buffers.


https://github.com/zed-industries/zed/assets/261929/2d10494e-5668-4988-b7b4-417c922d6c61



