### PR TITLE
wayland: Implement xdg-activation when opening urls

### DIFF
--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -76,8 +76,9 @@ impl LinuxClient for HeadlessClient {
         unimplemented!()
     }
 
-    //todo(linux)
     fn set_cursor_style(&self, _style: CursorStyle) {}
+
+    fn open_uri(&self, _uri: &str) {}
 
     fn write_to_primary(&self, item: crate::ClipboardItem) {}
 

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -61,6 +61,7 @@ pub trait LinuxClient {
         options: WindowParams,
     ) -> Box<dyn PlatformWindow>;
     fn set_cursor_style(&self, style: CursorStyle);
+    fn open_uri(&self, uri: &str);
     fn write_to_primary(&self, item: ClipboardItem);
     fn write_to_clipboard(&self, item: ClipboardItem);
     fn read_from_primary(&self) -> Option<ClipboardItem>;
@@ -216,7 +217,7 @@ impl<P: LinuxClient + 'static> Platform for P {
     }
 
     fn open_url(&self, url: &str) {
-        open::that(url);
+        self.open_uri(url);
     }
 
     fn on_open_urls(&self, callback: Box<dyn FnMut(Vec<String>)>) {
@@ -482,6 +483,20 @@ impl<P: LinuxClient + 'static> Platform for P {
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
         self.read_from_clipboard()
     }
+}
+
+pub(super) fn open_uri_impl(uri: &str, activation_token: Option<&str>) {
+    let mut last_err = None;
+    for mut command in open::commands(uri) {
+        if let Some(token) = activation_token {
+            command.env("XDG_ACTIVATION_TOKEN", token);
+        }
+        match command.status() {
+            Ok(_) => return,
+            Err(err) => last_err = Some(err),
+        }
+    }
+    log::error!("failed to open uri: {uri:?}, last error: {last_err:?}");
 }
 
 pub(super) fn is_within_click_distance(a: Point<Pixels>, b: Point<Pixels>) -> bool {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -485,7 +485,7 @@ impl<P: LinuxClient + 'static> Platform for P {
     }
 }
 
-pub(super) fn open_uri_impl(uri: &str, activation_token: Option<&str>) {
+pub(super) fn open_uri_internal(uri: &str, activation_token: Option<&str>) {
     let mut last_err = None;
     for mut command in open::commands(uri) {
         if let Some(token) = activation_token {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -50,7 +50,7 @@ use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_ba
 use xkbcommon::xkb::ffi::XKB_KEYMAP_FORMAT_TEXT_V1;
 use xkbcommon::xkb::{self, Keycode, KEYMAP_COMPILE_NO_FLAGS};
 
-use super::super::{open_uri_impl, read_fd, DOUBLE_CLICK_INTERVAL};
+use super::super::{open_uri_internal, read_fd, DOUBLE_CLICK_INTERVAL};
 use super::window::{WaylandWindowState, WaylandWindowStatePtr};
 use crate::platform::linux::is_within_click_distance;
 use crate::platform::linux::wayland::cursor::Cursor;
@@ -441,7 +441,7 @@ impl LinuxClient for WaylandClient {
             token.set_surface(&window.surface());
             token.commit();
         } else {
-            open_uri_impl(uri, None);
+            open_uri_internal(uri, None);
         }
     }
 
@@ -715,7 +715,7 @@ impl Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ()> for WaylandClie
         let mut state = client.borrow_mut();
         if let xdg_activation_token_v1::Event::Done { token } = event {
             if let Some(uri) = state.pending_open_uri.take() {
-                open_uri_impl(&uri, Some(&token));
+                open_uri_internal(&uri, Some(&token));
             } else {
                 log::error!("called while pending_open_uri is None");
             }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -458,7 +458,7 @@ impl LinuxClient for WaylandClient {
         ) {
             state.pending_open_uri = Some(uri.to_owned());
             let token = activation.get_activation_token(&state.globals.qh, ());
-            token.set_serial(state.pointer_serial, &state.wl_seat);
+            token.set_serial(state.serial, &state.wl_seat);
             token.set_surface(&window.surface());
             token.commit();
         } else {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -42,6 +42,7 @@ use wayland_protocols::wp::fractional_scale::v1::client::{
     wp_fractional_scale_manager_v1, wp_fractional_scale_v1,
 };
 use wayland_protocols::wp::viewporter::client::{wp_viewport, wp_viewporter};
+use wayland_protocols::xdg::activation::v1::client::{xdg_activation_token_v1, xdg_activation_v1};
 use wayland_protocols::xdg::decoration::zv1::client::{
     zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1,
 };
@@ -49,7 +50,7 @@ use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_ba
 use xkbcommon::xkb::ffi::XKB_KEYMAP_FORMAT_TEXT_V1;
 use xkbcommon::xkb::{self, Keycode, KEYMAP_COMPILE_NO_FLAGS};
 
-use super::super::{read_fd, DOUBLE_CLICK_INTERVAL};
+use super::super::{open_uri_impl, read_fd, DOUBLE_CLICK_INTERVAL};
 use super::window::{WaylandWindowState, WaylandWindowStatePtr};
 use crate::platform::linux::is_within_click_distance;
 use crate::platform::linux::wayland::cursor::Cursor;
@@ -71,6 +72,7 @@ const MIN_KEYCODE: u32 = 8;
 #[derive(Clone)]
 pub struct Globals {
     pub qh: QueueHandle<WaylandClientStatePtr>,
+    pub activation: Option<xdg_activation_v1::XdgActivationV1>,
     pub compositor: wl_compositor::WlCompositor,
     pub cursor_shape_manager: Option<wp_cursor_shape_manager_v1::WpCursorShapeManagerV1>,
     pub data_device_manager: Option<wl_data_device_manager::WlDataDeviceManager>,
@@ -90,6 +92,7 @@ impl Globals {
         qh: QueueHandle<WaylandClientStatePtr>,
     ) -> Self {
         Globals {
+            activation: globals.bind(&qh, 1..=1, ()).ok(),
             compositor: globals
                 .bind(
                     &qh,
@@ -117,10 +120,32 @@ impl Globals {
     }
 }
 
+impl Drop for Globals {
+    fn drop(&mut self) {
+        if let Some(activation) = &self.activation {
+            activation.destroy();
+        }
+        if let Some(cursor_shape_manager) = &self.cursor_shape_manager {
+            cursor_shape_manager.destroy();
+        }
+        self.wm_base.destroy();
+        if let Some(viewporter) = &self.viewporter {
+            viewporter.destroy();
+        }
+        if let Some(fractional_scale_manager) = &self.fractional_scale_manager {
+            fractional_scale_manager.destroy();
+        }
+        if let Some(decoration_manager) = &self.decoration_manager {
+            decoration_manager.destroy();
+        }
+    }
+}
+
 pub(crate) struct WaylandClientState {
     serial: u32, // todo(linux): storing a general serial is wrong
     pointer_serial: u32,
     globals: Globals,
+    wl_seat: wl_seat::WlSeat, // todo(linux): multi-seat support
     wl_pointer: Option<wl_pointer::WlPointer>,
     cursor_shape_device: Option<wp_cursor_shape_device_v1::WpCursorShapeDeviceV1>,
     data_device: Option<wl_data_device::WlDataDevice>,
@@ -151,6 +176,8 @@ pub(crate) struct WaylandClientState {
     primary: Option<Primary>,
     event_loop: Option<EventLoop<'static, WaylandClientStatePtr>>,
     common: LinuxCommon,
+
+    pending_open_uri: Option<String>,
 }
 
 pub struct DragState {
@@ -259,7 +286,6 @@ impl WaylandClient {
             for global in list {
                 match &global.interface[..] {
                     "wl_seat" => {
-                        // TODO: multi-seat support
                         seat = Some(globals.registry().bind::<wl_seat::WlSeat, _, _>(
                             global.name,
                             wl_seat_version(global.version),
@@ -310,6 +336,7 @@ impl WaylandClient {
             serial: 0,
             pointer_serial: 0,
             globals,
+            wl_seat: seat,
             wl_pointer: None,
             cursor_shape_device: None,
             data_device,
@@ -357,6 +384,8 @@ impl WaylandClient {
             clipboard: Some(clipboard),
             primary: Some(primary),
             event_loop: Some(event_loop),
+
+            pending_open_uri: None,
         }));
 
         WaylandSource::new(conn, event_queue).insert(handle);
@@ -418,6 +447,22 @@ impl LinuxClient for WaylandClient {
                     .cursor
                     .set_icon(&wl_pointer, serial, &style.to_icon_name());
             }
+        }
+    }
+
+    fn open_uri(&self, uri: &str) {
+        let mut state = self.0.borrow_mut();
+        if let (Some(activation), Some(window)) = (
+            state.globals.activation.clone(),
+            state.mouse_focused_window.clone(),
+        ) {
+            state.pending_open_uri = Some(uri.to_owned());
+            let token = activation.get_activation_token(&state.globals.qh, ());
+            token.set_serial(state.pointer_serial, &state.wl_seat);
+            token.set_surface(&window.surface());
+            token.commit();
+        } else {
+            open_uri_impl(uri, None);
         }
     }
 
@@ -525,6 +570,7 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for WaylandClientStat
     }
 }
 
+delegate_noop!(WaylandClientStatePtr: ignore xdg_activation_v1::XdgActivationV1);
 delegate_noop!(WaylandClientStatePtr: ignore wl_compositor::WlCompositor);
 delegate_noop!(WaylandClientStatePtr: ignore wp_cursor_shape_device_v1::WpCursorShapeDeviceV1);
 delegate_noop!(WaylandClientStatePtr: ignore wp_cursor_shape_manager_v1::WpCursorShapeManagerV1);
@@ -674,6 +720,28 @@ impl Dispatch<xdg_wm_base::XdgWmBase, ()> for WaylandClientStatePtr {
             state.serial = serial;
             wm_base.pong(serial);
         }
+    }
+}
+
+impl Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ()> for WaylandClientStatePtr {
+    fn event(
+        this: &mut Self,
+        token: &xdg_activation_token_v1::XdgActivationTokenV1,
+        event: <xdg_activation_token_v1::XdgActivationTokenV1 as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let client = this.get_client();
+        let mut state = client.borrow_mut();
+        if let xdg_activation_token_v1::Event::Done { token } = event {
+            if let Some(uri) = state.pending_open_uri.take() {
+                open_uri_impl(&uri, Some(&token));
+            } else {
+                log::error!("called while pending_open_uri is None");
+            }
+        }
+        token.destroy();
     }
 }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -120,27 +120,6 @@ impl Globals {
     }
 }
 
-impl Drop for Globals {
-    fn drop(&mut self) {
-        if let Some(activation) = &self.activation {
-            activation.destroy();
-        }
-        if let Some(cursor_shape_manager) = &self.cursor_shape_manager {
-            cursor_shape_manager.destroy();
-        }
-        self.wm_base.destroy();
-        if let Some(viewporter) = &self.viewporter {
-            viewporter.destroy();
-        }
-        if let Some(fractional_scale_manager) = &self.fractional_scale_manager {
-            fractional_scale_manager.destroy();
-        }
-        if let Some(decoration_manager) = &self.decoration_manager {
-            decoration_manager.destroy();
-        }
-    }
-}
-
 pub(crate) struct WaylandClientState {
     serial: u32, // todo(linux): storing a general serial is wrong
     pointer_serial: u32,

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -251,6 +251,10 @@ impl WaylandWindow {
 }
 
 impl WaylandWindowStatePtr {
+    pub fn surface(&self) -> wl_surface::WlSurface {
+        self.state.borrow().surface.clone()
+    }
+
     pub fn ptr_eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.state, &other.state)
     }

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -29,7 +29,10 @@ use crate::{
     Size, TouchPhase, WindowParams, X11Window,
 };
 
-use super::{super::SCROLL_LINES, X11Display, X11WindowStatePtr, XcbAtoms};
+use super::{
+    super::{open_uri_impl, SCROLL_LINES},
+    X11Display, X11WindowStatePtr, XcbAtoms,
+};
 use super::{button_of_key, modifiers_from_state};
 use crate::platform::linux::is_within_click_distance;
 use crate::platform::linux::platform::DOUBLE_CLICK_INTERVAL;
@@ -671,6 +674,10 @@ impl LinuxClient for X11Client {
 
     //todo(linux)
     fn set_cursor_style(&self, _style: CursorStyle) {}
+
+    fn open_uri(&self, uri: &str) {
+        open_uri_impl(uri, None);
+    }
 
     fn write_to_primary(&self, item: crate::ClipboardItem) {
         self.0.borrow_mut().primary.set_contents(item.text);

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 use super::{
-    super::{open_uri_impl, SCROLL_LINES},
+    super::{open_uri_internal, SCROLL_LINES},
     X11Display, X11WindowStatePtr, XcbAtoms,
 };
 use super::{button_of_key, modifiers_from_state};
@@ -676,7 +676,7 @@ impl LinuxClient for X11Client {
     fn set_cursor_style(&self, _style: CursorStyle) {}
 
     fn open_uri(&self, uri: &str) {
-        open_uri_impl(uri, None);
+        open_uri_internal(uri, None);
     }
 
     fn write_to_primary(&self, item: crate::ClipboardItem) {


### PR DESCRIPTION
Since Wayland doesn't have a way for windows to activate themselves, currently, when you click on a link in Zed, the browser window opens in the background.

This PR implements the `xdg-activation` protocol to get an activation token, which the browser can use to raise its window.

https://github.com/zed-industries/zed/assets/71973804/8b3456c0-89f8-4201-b1cb-633a149796b7

Release Notes:

- N/A
