### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ brew install --cask zed@preview
 
 ## Developing Zed
 
-- [Building Zed for macOS](./docs/src/developing_zed__building_zed_macos.md)
-- [Building Zed for Linux](./docs/src/developing_zed__building_zed_linux.md)
-- [Building Zed for Windows](./docs/src/developing_zed__building_zed_windows.md)
-- [Running Collaboration Locally](./docs/src/developing_zed__local_collaboration.md)
+- [Building Zed for macOS](./docs/src/development/macos.md)
+- [Building Zed for Linux](./docs/src/development/linux.md)
+- [Building Zed for Windows](./docs/src/development/windows.md)
+- [Running Collaboration Locally](./docs/src/development/local-collaboration.md)
 
 ## Contributing
 

--- a/docs/src/development/local-collaboration.md
+++ b/docs/src/development/local-collaboration.md
@@ -1,6 +1,6 @@
 # Local Collaboration
 
-First, make sure you've installed Zed's [backend dependencies](./developing_zed__building_zed.md#backend-dependencies).
+First, make sure you've installed Zed's [backend dependencies](../developing-zed.md#backend-dependencies).
 
 ## Database setup
 


### PR DESCRIPTION
This PR fixes the links in the README to account for the changes in the docs structure.

Also, somehow the README had gotten added with `\r\n` newlines, so I changed it back to `\n` newlines.

Release Notes:

- N/A
