### PR TITLE
Clarify `CodeLabel.filter_range` doc

### DIFF
--- a/crates/extension_api/wit/since_v0.0.6/extension.wit
+++ b/crates/extension_api/wit/since_v0.0.6/extension.wit
@@ -97,7 +97,7 @@ world extension {
         code: string,
         /// The spans to display in the label.
         spans: list<code-label-span>,
-        /// The range of the code to include when filtering.
+        /// The range of the displayed label to include when filtering.
         filter-range: range,
     }
 


### PR DESCRIPTION
Improves documentation for `CodeLabel.filter_range` in `zed_extension_api` by clarifying that it's a range of only the text displayed in the label, *not* the `code` field.

Release Notes:

- N/A