### PR TITLE
windows: Fix crash in vim normal mode when IME key is pressed

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -791,8 +791,7 @@ impl WindowsWindowInner {
             let Some(mut input_handler) = self.input_handler.take() else {
                 return Some(1);
             };
-            // we are composing, this should never fail
-            let caret_range = input_handler.selected_text_range().unwrap();
+            let caret_range = input_handler.selected_text_range().unwrap_or_default();
             let caret_position = input_handler.bounds_for_range(caret_range).unwrap();
             self.input_handler.set(Some(input_handler));
             let scale_factor = self.scale_factor.get();


### PR DESCRIPTION
Fixed crash in vim normal mode when ime key press.

Release Notes:

- N/A
