### PR TITLE
Add setting to choose specific language server for formatting

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -365,6 +365,8 @@ pub enum FormatOnSave {
     Off,
     /// Files should be formatted using the current language server.
     LanguageServer,
+    /// Format code using a specific language server.
+    LanguageServerName(Arc<str>),
     /// The external program to use to format the files on save.
     External {
         /// The external program to run.
@@ -398,6 +400,8 @@ pub enum Formatter {
     Auto,
     /// Format code using the current language server.
     LanguageServer,
+    /// Format code using a specific language server.
+    LanguageServerName(Arc<str>),
     /// Format code using Zed's Prettier integration.
     Prettier,
     /// Format code using an external command.

--- a/crates/project/src/prettier_support.rs
+++ b/crates/project/src/prettier_support.rs
@@ -30,7 +30,10 @@ pub fn prettier_plugins_for_language(
 ) -> Option<&HashSet<String>> {
     match &language_settings.formatter {
         Formatter::Prettier { .. } | Formatter::Auto => Some(&language_settings.prettier.plugins),
-        Formatter::LanguageServer | Formatter::External { .. } | Formatter::CodeActions(_) => None,
+        Formatter::LanguageServerName { .. }
+        | Formatter::LanguageServer
+        | Formatter::External { .. }
+        | Formatter::CodeActions(_) => None,
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/11288

Inspired by VSCode, which also lets you choose a specific formatter like this.
I successfully tried this out so may as well make a PR, totally open for discussion tho :).

Example settings:
```json
{
  "languages": {
    "TypeScript": {
      "formatter": {
        "language_server_name": "biome"
      }
    },
  }
}
```

Release Notes:

- N/A