### PR TITLE
chore: Fix main CI after upgrade to Rust 1.78

### DIFF
--- a/crates/assistant2/src/attachments.rs
+++ b/crates/assistant2/src/attachments.rs
@@ -117,7 +117,6 @@ impl UserAttachmentStore {
     }
 }
 
-///
 pub trait AttachmentTool {
     type Output: 'static;
     type View: Render;


### PR DESCRIPTION
The CI was green at the time I've merged Rust 1.78, but a change that violated clippy::empty_doc has slipped through into main in the meantime. Mea culpa, I should've reran the CI.



Release Notes:

- N/A
