### PR TITLE
Fix zig syntax and file types

### DIFF
--- a/extensions/zig/languages/zig/config.toml
+++ b/extensions/zig/languages/zig/config.toml
@@ -1,11 +1,12 @@
 name = "Zig"
 grammar = "zig"
-path_suffixes = ["zig", "zig.zon"]
+path_suffixes = ["zig", "zon"]
 line_comments = ["// "]
-autoclose_before = ";:.,=}])>"
+autoclose_before = ";:.,=}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "<", end = ">", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]


### PR DESCRIPTION
Fixed autoclosing and made it recognize all ZON (Zig Object Notation) files.