### PR TITLE
Use lowercased language name as language id fallback

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -948,12 +948,9 @@ impl Copilot {
 }
 
 fn id_for_language(language: Option<&Arc<Language>>) -> String {
-    let language_name = language.map(|language| language.name());
-    match language_name.as_deref() {
-        Some("Plain Text") => "plaintext".to_string(),
-        Some(language_name) => language_name.to_lowercase(),
-        None => "plaintext".to_string(),
-    }
+    language
+        .map(|language| language.lsp_id())
+        .unwrap_or_else(|| "plaintext".to_string())
 }
 
 fn uri_for_buffer(buffer: &Model<Buffer>, cx: &AppContext) -> lsp::Url {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -249,11 +249,10 @@ impl CachedLspAdapter {
     }
 
     pub fn language_id(&self, language: &Language) -> String {
-        let language_name = language.name();
         self.language_ids
-            .get(language_name.as_ref())
+            .get(language.name().as_ref())
             .cloned()
-            .unwrap_or_else(|| language_name.to_lowercase())
+            .unwrap_or_else(|| language.lsp_id())
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -1380,6 +1379,13 @@ impl Language {
 
     pub fn prettier_plugins(&self) -> &Vec<Arc<str>> {
         &self.config.prettier_plugins
+    }
+
+    pub fn lsp_id(&self) -> String {
+        match self.config.name.as_ref() {
+            "Plain Text" => "plaintext".to_string(),
+            language_name => language_name.to_lowercase(),
+        }
     }
 }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -152,7 +152,7 @@ pub struct CachedLspAdapter {
     pub name: LanguageServerName,
     pub disk_based_diagnostic_sources: Vec<String>,
     pub disk_based_diagnostics_progress_token: Option<String>,
-    pub language_ids: HashMap<String, String>,
+    language_ids: HashMap<String, String>,
     pub adapter: Arc<dyn LspAdapter>,
     pub reinstall_attempt_count: AtomicU64,
     /// Indicates whether this language server is the primary language server
@@ -246,6 +246,14 @@ impl CachedLspAdapter {
             .clone()
             .labels_for_symbols(symbols, language)
             .await
+    }
+
+    pub fn language_id(&self, language: &Language) -> String {
+        let language_name = language.name();
+        self.language_ids
+            .get(language_name.as_ref())
+            .cloned()
+            .unwrap_or_else(|| language_name.to_lowercase())
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2386,7 +2386,6 @@ impl Project {
 
             if let Some(language) = language {
                 for adapter in self.languages.lsp_adapters(&language) {
-                    let language_id = adapter.language_ids.get(language.name().as_ref()).cloned();
                     let server = self
                         .language_server_ids
                         .get(&(worktree_id, adapter.name.clone()))
@@ -2403,12 +2402,13 @@ impl Project {
                         None => continue,
                     };
 
+                    let language_id = adapter.language_id(&language);
                     server
                         .notify::<lsp::notification::DidOpenTextDocument>(
                             lsp::DidOpenTextDocumentParams {
                                 text_document: lsp::TextDocumentItem::new(
                                     uri.clone(),
-                                    language_id.unwrap_or_default(),
+                                    language_id,
                                     0,
                                     initial_snapshot.text(),
                                 ),
@@ -3741,11 +3741,7 @@ impl Project {
                     lsp::DidOpenTextDocumentParams {
                         text_document: lsp::TextDocumentItem::new(
                             uri,
-                            adapter
-                                .language_ids
-                                .get(language.name().as_ref())
-                                .cloned()
-                                .unwrap_or_default(),
+                            adapter.language_id(&language),
                             version,
                             initial_snapshot.text(),
                         ),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2402,13 +2402,12 @@ impl Project {
                         None => continue,
                     };
 
-                    let language_id = adapter.language_id(&language);
                     server
                         .notify::<lsp::notification::DidOpenTextDocument>(
                             lsp::DidOpenTextDocumentParams {
                                 text_document: lsp::TextDocumentItem::new(
                                     uri.clone(),
-                                    language_id,
+                                    adapter.language_id(&language),
                                     0,
                                     initial_snapshot.text(),
                                 ),

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -397,7 +397,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             uri: lsp::Url::from_file_path("/the-root/test.rs").unwrap(),
             version: 0,
             text: "const A: i32 = 1;".to_string(),
-            language_id: Default::default()
+            language_id: "rust".to_string(),
         }
     );
 
@@ -444,7 +444,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             uri: lsp::Url::from_file_path("/the-root/package.json").unwrap(),
             version: 0,
             text: "{\"a\": 1}".to_string(),
-            language_id: Default::default()
+            language_id: "json".to_string(),
         }
     );
 
@@ -529,7 +529,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             uri: lsp::Url::from_file_path("/the-root/test3.rs").unwrap(),
             version: 0,
             text: rust_buffer2.update(cx, |buffer, _| buffer.text()),
-            language_id: Default::default()
+            language_id: "rust".to_string(),
         },
     );
 
@@ -579,7 +579,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             uri: lsp::Url::from_file_path("/the-root/test3.json").unwrap(),
             version: 0,
             text: rust_buffer2.update(cx, |buffer, _| buffer.text()),
-            language_id: Default::default()
+            language_id: "json".to_string(),
         },
     );
 
@@ -634,7 +634,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             uri: lsp::Url::from_file_path("/the-root/test.rs").unwrap(),
             version: 0,
             text: rust_buffer.update(cx, |buffer, _| buffer.text()),
-            language_id: Default::default()
+            language_id: "rust".to_string(),
         }
     );
 
@@ -655,13 +655,13 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
                 uri: lsp::Url::from_file_path("/the-root/package.json").unwrap(),
                 version: 0,
                 text: json_buffer.update(cx, |buffer, _| buffer.text()),
-                language_id: Default::default()
+                language_id: "json".to_string(),
             },
             lsp::TextDocumentItem {
                 uri: lsp::Url::from_file_path("/the-root/test3.json").unwrap(),
                 version: 0,
                 text: rust_buffer2.update(cx, |buffer, _| buffer.text()),
-                language_id: Default::default()
+                language_id: "json".to_string(),
             }
         ]
     );


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/11399 

Release Notes:

- Fixed empty language name in `textDocument/didOpen` LSP requests ([11399](https://github.com/zed-industries/zed/issues/11399))