### PR TITLE
Fix Collab context menu dismissal

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1408,6 +1408,11 @@ impl CollabPanel {
             });
         }
 
+        if self.context_menu.is_some() {
+            self.context_menu.take();
+            cx.notify();
+        }
+
         self.update_entries(false, cx);
     }
 


### PR DESCRIPTION
Closes: #11413

Release Notes:

- Fixed Collab panel context menu dismissal with `Escape` key ([#11413](https://github.com/zed-industries/zed/issues/11413)).
