### PR TITLE
Fix key-bindings.md example

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -61,7 +61,7 @@ A few examples:
 
 ```
  "bindings": {
-   "cmd-k cmd-s": "zed::OpenKeyMap", // matches ⌘-k then ⌘-s
+   "cmd-k cmd-s": "zed::OpenKeymap", // matches ⌘-k then ⌘-s
    "space e": "editor::Complete", // type space then e
    "ç": "editor::Complete", // matches ⌥-c
  }


### PR DESCRIPTION
Fixed obselete command name in keymap example.
From "zed::OpenKeyMap" to "zed::OpenKeymap".



Release Notes:

- N/A
