### PR TITLE
Support Tree Sitter Repos That Do Not Check in Generated Code

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -205,6 +205,22 @@ impl ExtensionBuilder {
         let parser_path = src_path.join("parser.c");
         let scanner_path = src_path.join("scanner.c");
 
+        if !parser_path.exists() {
+            log::info!("generating {grammar_name} parser");
+            let generate_output = Command::new("tree-sitter")
+                .args(["generate", "--no-bindings"])
+                .current_dir(&base_grammar_path)
+                .output()
+                .context("failed to run `tree-sitter generate`")?;
+
+            if !generate_output.status.success() {
+                bail!(
+                    "No parser checked in and tree-sitter generate failed for {grammar_name} parser: {}",
+                    String::from_utf8_lossy(&generate_output.stderr),
+                );
+            }
+        }
+
         log::info!("compiling {grammar_name} parser");
         let clang_output = Command::new(&clang_path)
             .args(["-fPIC", "-shared", "-Os"])


### PR DESCRIPTION

Release Notes:

- Adds support for tree sitter repos that choose not to check in generated code (such as [swift tree sitter](https://github.com/alex-pinkus/tree-sitter-swift))
- NOTE: Running this from CLI or 'install dev extension' requires node & tree-sitter CLI be installed (if attempting to build language extensions with no checked in parser). Is this a reasonable requirement? Do CI or docs need an update?
