### PR TITLE
docs: Change path from `/docs2` to `/docs`

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p target/deploy
-          mdbook build ./docs --dest-dir=../target/deploy/docs2/
+          mdbook build ./docs --dest-dir=../target/deploy/docs/
 
       - name: Deploy
         uses: cloudflare/wrangler-action@v3

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,7 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Zed"
-site-url = "/docs2/"
+site-url = "/docs/"
 
 [output.html]
 no-section-label = true
@@ -14,7 +14,7 @@ preferred-dark-theme = "light"
 enable = false
 
 [output.html.redirect]
-"/elixir.html" = "/docs2/languages/elixir.html"
-"/javascript.html" = "/docs2/languages/javascript.html"
-"/ruby.html" = "/docs2/languages/ruby.html"
-"/python.html" = "/docs2/languages/python.html"
+"/elixir.html" = "/docs/languages/elixir.html"
+"/javascript.html" = "/docs/languages/javascript.html"
+"/ruby.html" = "/docs/languages/ruby.html"
+"/python.html" = "/docs/languages/python.html"


### PR DESCRIPTION
This PR changes the docs path from `/docs2` to just `/docs` in preparation for release.

Release Notes:

- N/A
