### PR TITLE
docs: Update system requirements to note Linux and Windows can be built from source.

### DIFF
--- a/docs/src/system-requirements.md
+++ b/docs/src/system-requirements.md
@@ -6,6 +6,14 @@ Supported versions: Catalina (10.15) - Sonoma (14.x).
 
 > The implementation of our screen sharing feature makes use of [LiveKit](https://livekit.io). The LiveKit SDK requires macOS Catalina (10.15); consequently, in v0.62.4, we dropped support for earlier macOS versions that we were initially supporting.
 
-## Linux, Windows, and Web
+## Linux
 
-_Not supported at this time. See our_ [_Platform Support_](https://github.com/zed-industries/zed/issues/5391) _issue._
+Not yet available as an official download. Can be built [from source](./development/linux.md).
+
+## Windows
+
+Not yet available as an official download. Can be built [from source](./development/windows.md).
+
+## Web
+
+Not supported at this time. See our [Platform Support issue](https://github.com/zed-industries/zed/issues/5391).


### PR DESCRIPTION
This PR updates the system requirements in the docs to note that Linux and Windows can be built from source.

This matches the messaging we have in place on the [download page](https://zed.dev/download).

Release Notes:

- N/A
