### PR TITLE
remoting: Adjust prompt level for dev server prompts

### DIFF
--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -328,7 +328,7 @@ impl DevServerProjects {
 
     fn delete_dev_server(&mut self, id: DevServerId, cx: &mut ViewContext<Self>) {
         let answer = cx.prompt(
-            gpui::PromptLevel::Destructive,
+            gpui::PromptLevel::Warning,
             "Are you sure?",
             Some("This will delete the dev server and all of its remote projects."),
             &["Delete", "Cancel"],
@@ -375,7 +375,7 @@ impl DevServerProjects {
         cx: &mut ViewContext<Self>,
     ) {
         let answer = cx.prompt(
-            gpui::PromptLevel::Destructive,
+            gpui::PromptLevel::Warning,
             format!("Delete \"{}\"?", path).as_str(),
             Some("This will delete the remote project. You can always re-add it later."),
             &["Delete", "Cancel"],


### PR DESCRIPTION
This changes the remoting prompts to use `PromptLevel::Warning` instead of `PromptLevel::Destructive`.
In #11015 we decided to apply PromptLevel::Destructive to prompts other than the new path picker. However, we did not notice that this breaks confirmation with the keyboard, so it should really only be used in specific situations (e.g. replacing a file with the remote "save as" picker, because it matches the behavior of the macOS file dialog).

Release Notes:

- N/A
