### PR TITLE
Trim index output

### DIFF
--- a/crates/assistant2/src/assistant2.rs
+++ b/crates/assistant2/src/assistant2.rs
@@ -724,21 +724,7 @@ impl AssistantChat {
 
                 let tools = tool_calls
                     .iter()
-                    .map(|tool_call| {
-                        let result = &tool_call.result;
-                        let name = tool_call.name.clone();
-                        match result {
-                            Some(result) => div()
-                                .p_2()
-                                .child(result.into_any_element(&name))
-                                .into_any_element(),
-                            None => div()
-                                .p_2()
-                                .child(Label::new(name).color(Color::Modified))
-                                .child("Running...")
-                                .into_any_element(),
-                        }
-                    })
+                    .map(|tool_call| self.tool_registry.render_tool_call(tool_call, cx))
                     .collect::<Vec<AnyElement>>();
 
                 let tools_body = if tools.is_empty() {

--- a/crates/assistant2/src/tools/project_index.rs
+++ b/crates/assistant2/src/tools/project_index.rs
@@ -216,7 +216,7 @@ impl LanguageModelTool for ProjectIndexTool {
         cx.new_view(|_cx| ProjectIndexView::new(input, output))
     }
 
-    fn render_running(cx: &mut WindowContext) -> impl IntoElement {
+    fn render_running(_: &mut WindowContext) -> impl IntoElement {
         CollapsibleContainer::new(ElementId::Name(nanoid::nanoid!().into()), false)
             .start_slot("Searching code base")
     }

--- a/crates/assistant2/src/tools/project_index.rs
+++ b/crates/assistant2/src/tools/project_index.rs
@@ -71,29 +71,51 @@ impl Render for ProjectIndexView {
             Ok(output) => output,
         };
 
+        let num_files_searched = output.files_searched.len();
+        let num_excerpts = output.excerpts.len();
+
+        let files_searched = if num_files_searched == 1 {
+            "file"
+        } else {
+            "files"
+        };
+        let excerpts = if num_excerpts == 1 {
+            "excerpt"
+        } else {
+            "excerpts"
+        };
+
         v_flex()
             .gap_3()
             .child(
-                Label::new(format!("Reviewed {} files", output.files_searched.len()))
-                    .color(Color::Accent),
+                Label::new(format!(
+                    "Found {} {} in {} {}",
+                    num_excerpts, excerpts, num_files_searched, files_searched
+                ))
+                .color(Color::Accent),
             )
             .child(
                 CollapsibleContainer::new(self.element_id.clone(), self.expanded_header)
                     .start_slot(Label::new("Query Details".to_string()).color(Color::Muted))
-                    .child(Label::new(format!("Searched for `{}`", query)).color(Color::Muted))
                     .on_click(cx.listener(move |this, _, cx| {
                         this.toggle_header(cx);
-                    })),
-            )
-            .child(
-                v_flex()
-                    .gap_2()
-                    .children(output.files_searched.iter().map(|path| {
-                        h_flex()
-                            .gap_2()
-                            .child(Icon::new(IconName::File).color(Color::Muted))
-                            .child(Label::new(path.clone()).color(Color::Muted))
-                    })),
+                    }))
+                    .child(
+                        v_flex()
+                            .gap_3()
+                            .p_3()
+                            .child(
+                                Label::new(format!("Searched for `{}`", query)).color(Color::Muted),
+                            )
+                            .child(v_flex().gap_2().children(output.files_searched.iter().map(
+                                |path| {
+                                    h_flex()
+                                        .gap_2()
+                                        .child(Icon::new(IconName::File).color(Color::Muted))
+                                        .child(Label::new(path.clone()).color(Color::Muted))
+                                },
+                            ))),
+                    ),
             )
     }
 }

--- a/crates/assistant2/src/tools/project_index.rs
+++ b/crates/assistant2/src/tools/project_index.rs
@@ -72,51 +72,46 @@ impl Render for ProjectIndexView {
         };
 
         let num_files_searched = output.files_searched.len();
-        let num_excerpts = output.excerpts.len();
 
-        let files_searched = if num_files_searched == 1 {
-            "file"
-        } else {
-            "files"
-        };
-        let excerpts = if num_excerpts == 1 {
-            "excerpt"
-        } else {
-            "excerpts"
-        };
+        let header = h_flex()
+            .gap_2()
+            .child(Icon::new(IconName::File))
+            .child(format!(
+                "Read {} {}",
+                num_files_searched,
+                if num_files_searched == 1 {
+                    "file"
+                } else {
+                    "files"
+                }
+            ));
 
-        v_flex()
-            .gap_3()
-            .child(
-                Label::new(format!(
-                    "Found {} {} in {} {}",
-                    num_excerpts, excerpts, num_files_searched, files_searched
-                ))
-                .color(Color::Accent),
-            )
-            .child(
-                CollapsibleContainer::new(self.element_id.clone(), self.expanded_header)
-                    .start_slot(Label::new("Query Details".to_string()).color(Color::Muted))
-                    .on_click(cx.listener(move |this, _, cx| {
-                        this.toggle_header(cx);
-                    }))
-                    .child(
-                        v_flex()
-                            .gap_3()
-                            .p_3()
-                            .child(
-                                Label::new(format!("Searched for `{}`", query)).color(Color::Muted),
-                            )
-                            .child(v_flex().gap_2().children(output.files_searched.iter().map(
-                                |path| {
-                                    h_flex()
-                                        .gap_2()
-                                        .child(Icon::new(IconName::File).color(Color::Muted))
-                                        .child(Label::new(path.clone()).color(Color::Muted))
-                                },
-                            ))),
-                    ),
-            )
+        v_flex().gap_3().child(
+            CollapsibleContainer::new(self.element_id.clone(), self.expanded_header)
+                .start_slot(header)
+                .on_click(cx.listener(move |this, _, cx| {
+                    this.toggle_header(cx);
+                }))
+                .child(
+                    v_flex()
+                        .gap_3()
+                        .p_3()
+                        .child(
+                            h_flex()
+                                .gap_2()
+                                .child(Icon::new(IconName::MagnifyingGlass))
+                                .child(Label::new(format!("`{}`", query)).color(Color::Muted)),
+                        )
+                        .child(v_flex().gap_2().children(output.files_searched.iter().map(
+                            |path| {
+                                h_flex()
+                                    .gap_2()
+                                    .child(Icon::new(IconName::File))
+                                    .child(Label::new(path.clone()).color(Color::Muted))
+                            },
+                        ))),
+                ),
+        )
     }
 }
 
@@ -219,6 +214,11 @@ impl LanguageModelTool for ProjectIndexTool {
         cx: &mut WindowContext,
     ) -> gpui::View<Self::View> {
         cx.new_view(|_cx| ProjectIndexView::new(input, output))
+    }
+
+    fn render_running(cx: &mut WindowContext) -> impl IntoElement {
+        CollapsibleContainer::new(ElementId::Name(nanoid::nanoid!().into()), false)
+            .start_slot("Searching code base")
     }
 
     fn format(_input: &Self::Input, output: &Result<Self::Output>) -> String {

--- a/crates/assistant2/src/tools/project_index.rs
+++ b/crates/assistant2/src/tools/project_index.rs
@@ -73,38 +73,8 @@ impl Render for ProjectIndexView {
         div()
             .v_flex()
             .gap_2()
-            .child(
-                div()
-                    .p_2()
-                    .rounded_md()
-                    .bg(cx.theme().colors().editor_background)
-                    .child(
-                        h_flex()
-                            .child(Label::new("Query: ").color(Color::Modified))
-                            .child(Label::new(query).color(Color::Muted)),
-                    ),
-            )
             .children(output.excerpts.iter().map(|excerpt| {
-                let element_id = excerpt.element_id.clone();
-                let expanded = excerpt.expanded;
-
-                CollapsibleContainer::new(element_id.clone(), expanded)
-                    .start_slot(
-                        h_flex()
-                            .gap_1()
-                            .child(Icon::new(IconName::File).color(Color::Muted))
-                            .child(Label::new(excerpt.path.clone()).color(Color::Muted)),
-                    )
-                    .on_click(cx.listener(move |this, _, cx| {
-                        this.toggle_expanded(element_id.clone(), cx);
-                    }))
-                    .child(
-                        div()
-                            .p_2()
-                            .rounded_md()
-                            .bg(cx.theme().colors().editor_background)
-                            .child(excerpt.text.clone()),
-                    )
+                div().child(Label::new(format!("- {}", excerpt.path.as_ref())).color(Color::Muted))
             }))
     }
 }
@@ -138,7 +108,7 @@ impl LanguageModelTool for ProjectIndexTool {
     }
 
     fn description(&self) -> String {
-        "Semantic search against the user's current codebase, returning excerpts related to the query by computing a dot product against embeddings of chunks and an embedding of the query".to_string()
+        "Semantic search against the user's current codebase, returning excerpts related to the query by computing a dot product against embeddings of code chunks in the code base and an embedding of the query.".to_string()
     }
 
     fn execute(&self, query: &Self::Input, cx: &mut WindowContext) -> Task<Result<Self::Output>> {

--- a/crates/assistant_tooling/src/tool.rs
+++ b/crates/assistant_tooling/src/tool.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use gpui::{AnyElement, AnyView, IntoElement as _, Render, Task, View, WindowContext};
+use gpui::{div, AnyElement, AnyView, IntoElement, Render, Task, View, WindowContext};
 use schemars::{schema::RootSchema, schema_for, JsonSchema};
 use serde::Deserialize;
 use std::fmt::Display;
@@ -104,4 +104,8 @@ pub trait LanguageModelTool {
         output: Result<Self::Output>,
         cx: &mut WindowContext,
     ) -> View<Self::View>;
+
+    fn render_running(_cx: &mut WindowContext) -> impl IntoElement {
+        div()
+    }
 }


### PR DESCRIPTION
Trims down the project index output view in assistant2 to just list the filenames and hideaway the query.

<img width="374" alt="image" src="https://github.com/zed-industries/zed/assets/836375/8603e3cf-9fdc-4661-bc45-1d87621a006f">

Introduces a way for tools to render running.

Release Notes:

- N/A
