### PR TITLE
zig: Bump to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12998,7 +12998,7 @@ dependencies = [
 
 [[package]]
 name = "zed_zig"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_zig"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -1,7 +1,7 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Zig extension to v0.1.2.

Changes:

- https://github.com/zed-industries/zed/pull/11409

Release Notes:

- N/A
