### PR TITLE
Add pkgconf to arch linux required dependencies

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -81,6 +81,7 @@ if [[ -n $pacman ]]; then
     libxkbcommon-x11
     openssl
     zstd
+    pkgconf
   )
   $maysudo "$pacman" -S --needed --noconfirm "${deps[@]}"
   exit 0


### PR DESCRIPTION
It's needed to build openssl crate

Fixes: #11448

Release Notes:

- N/A