### PR TITLE
Adjust names of negated style methods

### DIFF
--- a/crates/assistant2/src/assistant2.rs
+++ b/crates/assistant2/src/assistant2.rs
@@ -620,7 +620,7 @@ impl AssistantChat {
             div()
                 .py_1()
                 .px_2()
-                .neg_mx_1()
+                .mx_neg_1()
                 .rounded_md()
                 .border_1()
                 .border_color(theme.status().error_border)

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -572,7 +572,7 @@ impl ChatPanel {
             )
             .child(
                 self.render_popover_buttons(&cx, message_id, can_delete_message, can_edit_message)
-                    .neg_mt_2p5(),
+                    .mt_neg_2p5(),
             )
     }
 

--- a/crates/collab_ui/src/face_pile.rs
+++ b/crates/collab_ui/src/face_pile.rs
@@ -31,7 +31,7 @@ impl RenderOnce for FacePile {
                     .into_iter()
                     .enumerate()
                     .rev()
-                    .map(|(ix, player)| div().when(ix > 0, |div| div.neg_ml_1()).child(player)),
+                    .map(|(ix, player)| div().when(ix > 0, |div| div.ml_neg_1()).child(player)),
             )
     }
 }

--- a/crates/gpui_macros/src/style_helpers.rs
+++ b/crates/gpui_macros/src/style_helpers.rs
@@ -114,16 +114,16 @@ fn generate_predefined_setter(
     negate: bool,
     doc_string: &str,
 ) -> TokenStream2 {
-    let (negation_prefix, negation_token) = if negate {
-        ("neg_", quote! { - })
+    let (negation_qualifier, negation_token) = if negate {
+        ("_neg", quote! { - })
     } else {
         ("", quote! {})
     };
 
     let method_name = if length.is_empty() {
-        format_ident!("{}{}", negation_prefix, name)
+        format_ident!("{name}{negation_qualifier}")
     } else {
-        format_ident!("{}{}_{}", negation_prefix, name, length)
+        format_ident!("{name}{negation_qualifier}_{length}")
     };
 
     let field_assignments = fields

--- a/crates/theme/src/styles/stories/players.rs
+++ b/crates/theme/src/styles/stories/players.rs
@@ -75,7 +75,7 @@ impl Render for PlayerStory {
                             .child(
                                 div()
                                     .relative()
-                                    .neg_mx_1()
+                                    .mx_neg_1()
                                     .rounded_full()
                                     .border_2()
                                     .border_color(player.background)
@@ -90,7 +90,7 @@ impl Render for PlayerStory {
                             .child(
                                 div()
                                     .relative()
-                                    .neg_mx_1()
+                                    .mx_neg_1()
                                     .rounded_full()
                                     .border_2()
                                     .border_color(player.background)
@@ -105,7 +105,7 @@ impl Render for PlayerStory {
                             .child(
                                 div()
                                     .relative()
-                                    .neg_mx_1()
+                                    .mx_neg_1()
                                     .rounded_full()
                                     .border_2()
                                     .border_color(player.background)

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -396,8 +396,8 @@ impl RenderOnce for IconWithIndicator {
                         .border_1()
                         .border_color(indicator_border_color)
                         .rounded_full()
-                        .neg_bottom_0p5()
-                        .neg_right_1()
+                        .bottom_neg_0p5()
+                        .right_neg_1()
                         .child(indicator),
                 )
             })


### PR DESCRIPTION
This PR adjusts the names of the negated style methods by moving the `neg_` to after the property name instead of before.

This will help keep related style methods grouped together in completions.

It also makes it a bit clearer that the negation applies to the value.

### Before

```rs
div()
    .neg_mx_1()
    .neg_mt_2()
```

### After

```rs
div()
    .mx_neg_1()
    .mt_neg_2()
```

Release Notes:

- N/A
