### PR TITLE
Don't log JSON parse errors with no settings

### DIFF
--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -47,6 +47,9 @@ impl KeymapFile {
     }
 
     pub fn parse(content: &str) -> Result<Self> {
+        if content.is_empty() {
+            return Ok(Self::default());
+        }
         parse_json_with_comments::<Self>(content)
     }
 

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -430,7 +430,11 @@ impl SettingsStore {
         user_settings_content: &str,
         cx: &mut AppContext,
     ) -> Result<()> {
-        let settings: serde_json::Value = parse_json_with_comments(user_settings_content)?;
+        let settings: serde_json::Value = if user_settings_content.is_empty() {
+            parse_json_with_comments("{}")?
+        } else {
+            parse_json_with_comments(user_settings_content)?
+        };
         if settings.is_object() {
             self.raw_user_settings = settings;
             self.recompute_values(None, cx)?;
@@ -448,9 +452,11 @@ impl SettingsStore {
         settings_content: Option<&str>,
         cx: &mut AppContext,
     ) -> Result<()> {
-        if let Some(content) = settings_content {
-            self.raw_local_settings
-                .insert((root_id, path.clone()), parse_json_with_comments(content)?);
+        if settings_content.is_some_and(|content| !content.is_empty()) {
+            self.raw_local_settings.insert(
+                (root_id, path.clone()),
+                parse_json_with_comments(settings_content.unwrap())?,
+            );
         } else {
             self.raw_local_settings.remove(&(root_id, path.clone()));
         }


### PR DESCRIPTION
Release Notes:

- Silenced error messages on startup when no settings/keymap files exist.
