### PR TITLE
vim: Add shift-k as alias for g h

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -128,6 +128,7 @@
       "shift-v": "vim::ToggleVisualLine",
       "ctrl-v": "vim::ToggleVisualBlock",
       "ctrl-q": "vim::ToggleVisualBlock",
+      "shift-k": "editor::Hover",
       "shift-r": "vim::ToggleReplace",
       "0": "vim::StartOfLine", // When no number operator present, use start of line motion
       "ctrl-f": "vim::PageDown",


### PR DESCRIPTION
Co-Authored-By: Zachiah Sawyer <zachiah@proton.me>

Release Notes:

- vim: Added `shift-k` to show the hover tooltip
