### PR TITLE
gleam: Add runnable tests

### DIFF
--- a/extensions/gleam/languages/gleam/runnables.scm
+++ b/extensions/gleam/languages/gleam/runnables.scm
@@ -1,0 +1,6 @@
+; Functions with names ending in `_test`.
+; This matches the standalone test style used by Startest and Gleeunit.
+(
+    (function name: (_) @run
+        (#match? @run ".*_test$"))
+) @gleam-test

--- a/extensions/gleam/languages/gleam/tasks.json
+++ b/extensions/gleam/languages/gleam/tasks.json
@@ -1,0 +1,8 @@
+[
+  {
+    "label": "gleam test $ZED_SYMBOL",
+    "command": "gleam",
+    "args": ["test", "--", "--test-name-filter=$ZED_SYMBOL"],
+    "tags": ["gleam-test"]
+  }
+]


### PR DESCRIPTION
This PR adds basic runnable tests for Gleam.

Functions with names ending in `_test` will be available for running:

https://github.com/zed-industries/zed/assets/1486634/9f3f81e5-a7fa-425c-a5a2-d615062486bb

Release Notes:

- N/A
