### PR TITLE
linux: Use optional compile-time RELEASE_VERSION variable

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -348,7 +348,12 @@ impl<P: LinuxClient + 'static> Platform for P {
     }
 
     fn app_version(&self) -> Result<SemanticVersion> {
-        Ok(SemanticVersion::new(1, 0, 0))
+        const VERSION: Option<&str> = option_env!("RELEASE_VERSION");
+        if let Some(version) = VERSION {
+            version.parse()
+        } else {
+            Ok(SemanticVersion::new(1, 0, 0))
+        }
     }
 
     fn app_path(&self) -> Result<PathBuf> {

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -26,7 +26,11 @@ done
 export ZED_BUNDLE=true
 
 channel=$(<crates/zed/RELEASE_CHANNEL)
+
 version="$(cargo metadata --no-deps --manifest-path crates/zed/Cargo.toml --offline --format-version=1 | jq -r '.packages | map(select(.name == "zed"))[0].version')"
+# Set RELEASE_VERSION so it's compiled into GPUI and it knows about the version.
+export RELEASE_VERSION="${version}"
+
 commit=$(git rev-parse HEAD | cut -c 1-7)
 
 version_info=$(rustc --version --verbose)


### PR DESCRIPTION
This implements `app_version` on Linux by using an optional, compile-time `RELEASE_VERSION` env var that can be set.

We settled on the `RELEASE_VERSION` as the name, since it's similar to `RELEASE_CHANNEL` which we use in Zed.

cc @ConradIrwin @mikayla-maki 

Release Notes:

- N/A
