### PR TITLE
Increase short SHA length to 7 characters

### DIFF
--- a/crates/editor/src/blame_entry_tooltip.rs
+++ b/crates/editor/src/blame_entry_tooltip.rs
@@ -128,8 +128,7 @@ impl Render for BlameEntryTooltip {
 
         let author_email = self.blame_entry.author_mail.clone();
 
-        let pretty_commit_id = format!("{}", self.blame_entry.sha);
-        let short_commit_id = pretty_commit_id.chars().take(6).collect::<String>();
+        let short_commit_id = self.blame_entry.sha.display_short();
         let absolute_timestamp = blame_entry_absolute_timestamp(&self.blame_entry, cx);
 
         let message = self

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3364,8 +3364,7 @@ fn render_blame_entry(
 
     let relative_timestamp = blame_entry_relative_timestamp(&blame_entry, cx);
 
-    let pretty_commit_id = format!("{}", blame_entry.sha);
-    let short_commit_id = pretty_commit_id.chars().take(6).collect::<String>();
+    let short_commit_id = blame_entry.sha.display_short();
 
     let author_name = blame_entry.author.as_deref().unwrap_or("<no name>");
     let name = util::truncate_and_trailoff(author_name, 20);

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -37,6 +37,11 @@ impl Oid {
     pub(crate) fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
+
+    /// Returns this [`Oid`] as a short SHA.
+    pub fn display_short(&self) -> String {
+        self.to_string().chars().take(7).collect()
+    }
 }
 
 impl FromStr for Oid {


### PR DESCRIPTION
This PR increases the length of a shortened Git SHA from 6 to 7 characters.

This matches what GitHub uses.

I also took the opportunity to factor out a common method for computing a short SHA so that we have a single source of truth for the length that we're using.

Release Notes:

- Increased the short commit SHA length used by git blame from 6 to 7 characters.
