### PR TITLE
chore: replace usages of `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,7 +2163,6 @@ dependencies = [
  "gpui",
  "lazy_static",
  "log",
- "once_cell",
  "parking_lot",
  "postage",
  "rand 0.8.5",
@@ -7986,7 +7985,7 @@ name = "release_channel"
 version = "0.1.0"
 dependencies = [
  "gpui",
- "once_cell",
+ "lazy_static",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -33,7 +33,6 @@ async-tungstenite = { version = "0.16", features = ["async-std", "async-native-t
 futures.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-once_cell = "1.19.0"
 parking_lot.workspace = true
 postage.workspace = true
 rand.workspace = true

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use clock::SystemClock;
 use futures::Future;
 use gpui::{AppContext, AppMetadata, BackgroundExecutor, Task};
-use once_cell::sync::Lazy;
+use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use release_channel::ReleaseChannel;
 use settings::{Settings, SettingsStore};
@@ -61,15 +61,18 @@ const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 
 #[cfg(not(debug_assertions))]
 const FLUSH_INTERVAL: Duration = Duration::from_secs(60 * 5);
-static ZED_CLIENT_CHECKSUM_SEED: Lazy<Option<Vec<u8>>> = Lazy::new(|| {
-    option_env!("ZED_CLIENT_CHECKSUM_SEED")
-        .map(|s| s.as_bytes().into())
-        .or_else(|| {
-            env::var("ZED_CLIENT_CHECKSUM_SEED")
-                .ok()
-                .map(|s| s.as_bytes().into())
-        })
-});
+
+lazy_static! {
+    static ref ZED_CLIENT_CHECKSUM_SEED: Option<Vec<u8>> = {
+        option_env!("ZED_CLIENT_CHECKSUM_SEED")
+            .map(|s| s.as_bytes().into())
+            .or_else(|| {
+                env::var("ZED_CLIENT_CHECKSUM_SEED")
+                    .ok()
+                    .map(|s| s.as_bytes().into())
+            })
+    };
+}
 
 impl Telemetry {
     pub fn new(

--- a/crates/release_channel/Cargo.toml
+++ b/crates/release_channel/Cargo.toml
@@ -10,4 +10,4 @@ workspace = true
 
 [dependencies]
 gpui.workspace = true
-once_cell = "1.19.0"
+lazy_static.workspace = true

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -5,23 +5,23 @@
 use std::{env, str::FromStr};
 
 use gpui::{AppContext, Global, SemanticVersion};
-use once_cell::sync::Lazy;
+use lazy_static::lazy_static;
 
-static RELEASE_CHANNEL_NAME: Lazy<String> = if cfg!(debug_assertions) {
-    Lazy::new(|| {
+lazy_static! {
+    static ref RELEASE_CHANNEL_NAME: String = if cfg!(debug_assertions) {
         env::var("ZED_RELEASE_CHANNEL")
             .unwrap_or_else(|_| include_str!("../../zed/RELEASE_CHANNEL").trim().to_string())
-    })
-} else {
-    Lazy::new(|| include_str!("../../zed/RELEASE_CHANNEL").trim().to_string())
-};
+    } else {
+        include_str!("../../zed/RELEASE_CHANNEL").trim().to_string()
+    };
 
-#[doc(hidden)]
-pub static RELEASE_CHANNEL: Lazy<ReleaseChannel> =
-    Lazy::new(|| match ReleaseChannel::from_str(&RELEASE_CHANNEL_NAME) {
-        Ok(channel) => channel,
-        _ => panic!("invalid release channel {}", *RELEASE_CHANNEL_NAME),
-    });
+    #[doc(hidden)]
+    pub static ref RELEASE_CHANNEL: ReleaseChannel =
+        match ReleaseChannel::from_str(&RELEASE_CHANNEL_NAME) {
+            Ok(channel) => channel,
+            _ => panic!("invalid release channel {}", *RELEASE_CHANNEL_NAME),
+        };
+}
 
 /// The Git commit SHA that Zed was built at.
 #[derive(Clone)]


### PR DESCRIPTION
Replace all usages of `once_cell` with `lazy_static`.
`lazy_static` is used a lot while `once_cell` is only used in 2 files.
Because they provide the same functionality it makes sense to decide on one of the two. 

Release Notes:

- N/A
