### PR TITLE
Add development credentials provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,6 +2154,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion 0.3.2",
+ "async-trait",
  "async-tungstenite",
  "chrono",
  "clock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion 0.3.2",
- "async-trait",
  "async-tungstenite",
  "chrono",
  "clock",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -18,7 +18,6 @@ test-support = ["clock/test-support", "collections/test-support", "gpui/test-sup
 [dependencies]
 anyhow.workspace = true
 async-recursion = "0.3"
-async-trait.workspace = true
 async-tungstenite = { version = "0.16", features = ["async-std", "async-native-tls"] }
 chrono = { workspace = true, features = ["serde"] }
 clock.workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -16,39 +16,39 @@ doctest = false
 test-support = ["clock/test-support", "collections/test-support", "gpui/test-support", "rpc/test-support"]
 
 [dependencies]
+anyhow.workspace = true
+async-recursion = "0.3"
+async-trait.workspace = true
+async-tungstenite = { version = "0.16", features = ["async-std", "async-native-tls"] }
 chrono = { workspace = true, features = ["serde"] }
 clock.workspace = true
 collections.workspace = true
-gpui.workspace = true
-util.workspace = true
-release_channel.workspace = true
-rpc.workspace = true
-text.workspace = true
-settings.workspace = true
 feature_flags.workspace = true
-
-anyhow.workspace = true
-async-recursion = "0.3"
-async-tungstenite = { version = "0.16", features = ["async-std", "async-native-tls"] }
 futures.workspace = true
+gpui.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 once_cell = "1.19.0"
 parking_lot.workspace = true
 postage.workspace = true
 rand.workspace = true
+release_channel.workspace = true
+rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+settings.workspace = true
 sha2.workspace = true
 smol.workspace = true
 sysinfo.workspace = true
 telemetry_events.workspace = true
 tempfile.workspace = true
+text.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tiny_http = "0.8"
 url.workspace = true
+util.workspace = true
 
 [dev-dependencies]
 clock = { workspace = true, features = ["test-support"] }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -478,9 +478,10 @@ impl Client {
         http: Arc<HttpClientWithUrl>,
         cx: &mut AppContext,
     ) -> Arc<Self> {
-        let use_zed_development_auth = match ReleaseChannel::global(cx) {
-            ReleaseChannel::Dev => *ZED_DEVELOPMENT_AUTH,
-            ReleaseChannel::Nightly | ReleaseChannel::Preview | ReleaseChannel::Stable => false,
+        let use_zed_development_auth = match ReleaseChannel::try_global(cx) {
+            Some(ReleaseChannel::Dev) => *ZED_DEVELOPMENT_AUTH,
+            Some(ReleaseChannel::Nightly | ReleaseChannel::Preview | ReleaseChannel::Stable)
+            | None => false,
         };
 
         let credentials_provider: Arc<dyn CredentialsProvider + Send + Sync + 'static> =

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -542,10 +542,12 @@ fn handle_open_request(
 
 async fn authenticate(client: Arc<Client>, cx: &AsyncAppContext) -> Result<()> {
     if stdout_is_a_pty() {
-        if client::IMPERSONATE_LOGIN.is_some() {
+        if *client::ZED_DEVELOPMENT_AUTH {
+            client.authenticate_and_connect(true, &cx).await?;
+        } else if client::IMPERSONATE_LOGIN.is_some() {
             client.authenticate_and_connect(false, &cx).await?;
         }
-    } else if client.has_keychain_credentials(&cx).await {
+    } else if client.has_credentials(&cx).await {
         client.authenticate_and_connect(true, &cx).await?;
     }
     Ok::<_, anyhow::Error>(())


### PR DESCRIPTION
This PR adds a new development credentials provider for the purpose of streamlining local development against production collab.

## Problem

Today if you want to run a development build of Zed against the production collab server, you need to either:

1. Enter your keychain password every time in order to retrieve your saved credentials
2. Re-authenticate with zed.dev every time
    - This can get annoying as you need to pop out into a browser window
    - I've also seen cases where if you re-auth too many times in a row GitHub will make you confirm the authentication, as it looks suspicious

## Solution

This PR decouples the concept of the credentials provider from the keychain, and adds a new development credentials provider to address this specific case.

Now when running a development build of Zed and the `ZED_DEVELOPMENT_AUTH` environment variable is set to a non-empty value, the credentials will be saved to disk instead of the system keychain.

While this is not as secure as storing them in the system keychain, since it is only used for development the tradeoff seems acceptable for the resulting improvement in UX.

Release Notes:

- N/A
