### PR TITLE
vim: Add basic mark support

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -117,6 +117,9 @@
           }
         }
       ],
+      "m": ["vim::PushOperator", "Mark"],
+      "'": ["vim::PushOperator", { "Jump": { "line": true } }],
+      "`": ["vim::PushOperator", { "Jump": { "line": false } }],
       ";": "vim::RepeatFind",
       ",": "vim::RepeatFindReversed",
       "ctrl-o": "pane::GoBack",

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -13,7 +13,7 @@ use std::ops::Range;
 use workspace::Workspace;
 
 use crate::{
-    normal::normal_motion,
+    normal::{mark, normal_motion},
     state::{Mode, Operator},
     surrounds::SurroundsType,
     utils::coerce_punctuation,
@@ -104,6 +104,10 @@ pub enum Motion {
     ZedSearchResult {
         prior_selections: Vec<Range<Anchor>>,
         new_selections: Vec<Range<Anchor>>,
+    },
+    Jump {
+        anchor: Anchor,
+        line: bool,
     },
 }
 
@@ -492,6 +496,7 @@ impl Motion {
             | FindBackward { .. }
             | RepeatFind { .. }
             | RepeatFindReversed { .. }
+            | Jump { .. }
             | ZedSearchResult { .. } => false,
         }
     }
@@ -531,7 +536,8 @@ impl Motion {
             | WindowMiddle
             | WindowBottom
             | NextLineStart
-            | ZedSearchResult { .. } => false,
+            | ZedSearchResult { .. }
+            | Jump { .. } => false,
         }
     }
 
@@ -570,6 +576,7 @@ impl Motion {
             | PreviousSubwordStart { .. }
             | FirstNonWhitespace { .. }
             | FindBackward { .. }
+            | Jump { .. }
             | ZedSearchResult { .. } => false,
             RepeatFind { last_find: motion } | RepeatFindReversed { last_find: motion } => {
                 motion.inclusive()
@@ -761,6 +768,7 @@ impl Motion {
             WindowTop => window_top(map, point, &text_layout_details, times - 1),
             WindowMiddle => window_middle(map, point, &text_layout_details),
             WindowBottom => window_bottom(map, point, &text_layout_details, times - 1),
+            Jump { line, anchor } => mark::jump_motion(map, *anchor, *line),
             ZedSearchResult { new_selections, .. } => {
                 // There will be only one selection, as
                 // Search::SelectNextMatch selects a single match.

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -473,6 +473,7 @@ impl Motion {
             | WindowTop
             | WindowMiddle
             | WindowBottom
+            | Jump { line: true, .. }
             | EndOfParagraph => true,
             EndOfLine { .. }
             | Matching
@@ -496,7 +497,7 @@ impl Motion {
             | FindBackward { .. }
             | RepeatFind { .. }
             | RepeatFindReversed { .. }
-            | Jump { .. }
+            | Jump { line: false, .. }
             | ZedSearchResult { .. } => false,
         }
     }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -2,6 +2,7 @@ mod case;
 mod change;
 mod delete;
 mod increment;
+pub(crate) mod mark;
 mod paste;
 pub(crate) mod repeat;
 mod scroll;

--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -3,7 +3,9 @@ use std::{ops::Range, sync::Arc};
 use collections::HashSet;
 use editor::{
     display_map::{DisplaySnapshot, ToDisplayPoint},
-    movement, Anchor, Bias, DisplayPoint,
+    movement,
+    scroll::Autoscroll,
+    Anchor, Bias, DisplayPoint,
 };
 use gpui::WindowContext;
 use language::SelectionGoal;
@@ -24,7 +26,6 @@ pub fn create_mark(vim: &mut Vim, text: Arc<str>, tail: bool, cx: &mut WindowCon
     }) else {
         return;
     };
-
     vim.update_state(|state| state.marks.insert(text.to_string(), anchors));
     vim.clear_operator(cx);
 }
@@ -123,7 +124,9 @@ pub fn jump(text: Arc<str>, line: bool, cx: &mut WindowContext) {
                     }
                     ranges.insert(anchor..anchor);
                 }
-                editor.change_selections(None, cx, |s| s.select_anchor_ranges(ranges))
+                editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
+                    s.select_anchor_ranges(ranges)
+                })
             });
         })
     }

--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -1,6 +1,5 @@
 use std::{ops::Range, sync::Arc};
 
-use collections::HashSet;
 use editor::{
     display_map::{DisplaySnapshot, ToDisplayPoint},
     movement,
@@ -112,7 +111,7 @@ pub fn jump(text: Arc<str>, line: bool, cx: &mut WindowContext) {
         Vim::update(cx, |vim, cx| {
             vim.update_active_editor(cx, |_, editor, cx| {
                 let map = editor.snapshot(cx);
-                let mut ranges: HashSet<Range<Anchor>> = HashSet::default();
+                let mut ranges: Vec<Range<Anchor>> = Vec::new();
                 for mut anchor in anchors {
                     if line {
                         let mut point = anchor.to_display_point(&map.display_snapshot);
@@ -122,7 +121,9 @@ pub fn jump(text: Arc<str>, line: bool, cx: &mut WindowContext) {
                             .buffer_snapshot
                             .anchor_before(point.to_point(&map.display_snapshot));
                     }
-                    ranges.insert(anchor..anchor);
+                    if ranges.last() != Some(&(anchor..anchor)) {
+                        ranges.push(anchor..anchor);
+                    }
                 }
                 editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.select_anchor_ranges(ranges)

--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -1,0 +1,86 @@
+use std::{ops::Range, sync::Arc};
+
+use collections::HashSet;
+use editor::{
+    display_map::{DisplaySnapshot, ToDisplayPoint},
+    Anchor, DisplayPoint,
+};
+use gpui::WindowContext;
+use language::SelectionGoal;
+
+use crate::{
+    motion::{self, Motion},
+    Vim,
+};
+
+pub fn create_mark(vim: &mut Vim, text: Arc<str>, cx: &mut WindowContext) {
+    let Some(anchors) = vim.update_active_editor(cx, |_, editor, _| {
+        editor
+            .selections
+            .disjoint_anchors()
+            .iter()
+            .map(|s| s.head().clone())
+            .collect::<Vec<_>>()
+    }) else {
+        return;
+    };
+
+    vim.update_state(|state| state.marks.insert(text.to_string(), anchors));
+    vim.clear_operator(cx);
+}
+
+pub fn jump(text: Arc<str>, line: bool, cx: &mut WindowContext) {
+    let Some(anchors) = Vim::read(cx).state().marks.get(&*text).cloned() else {
+        return;
+    };
+
+    Vim::update(cx, |vim, cx| {
+        vim.pop_operator(cx);
+    });
+
+    let is_active_operator = Vim::read(cx).state().active_operator().is_some();
+    if is_active_operator {
+        if let Some(anchor) = anchors.last() {
+            motion::motion(
+                Motion::Jump {
+                    anchor: *anchor,
+                    line,
+                },
+                cx,
+            )
+        }
+        return;
+    } else {
+        Vim::update(cx, |vim, cx| {
+            vim.update_active_editor(cx, |_, editor, cx| {
+                let map = editor.snapshot(cx);
+                let mut ranges: HashSet<Range<Anchor>> = HashSet::default();
+                for mut anchor in anchors {
+                    if line {
+                        let mut point = anchor.to_display_point(&map.display_snapshot);
+                        point = motion::first_non_whitespace(&map.display_snapshot, false, point);
+                        anchor = map
+                            .display_snapshot
+                            .buffer_snapshot
+                            .anchor_before(point.to_point(&map.display_snapshot));
+                    }
+                    ranges.insert(anchor..anchor);
+                }
+                editor.change_selections(None, cx, |s| s.select_anchor_ranges(ranges))
+            });
+        })
+    }
+}
+
+pub fn jump_motion(
+    map: &DisplaySnapshot,
+    anchor: Anchor,
+    line: bool,
+) -> (DisplayPoint, SelectionGoal) {
+    let mut point = anchor.to_display_point(map);
+    if line {
+        point = motion::first_non_whitespace(map, false, point)
+    }
+
+    (point, SelectionGoal::None)
+}

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1073,3 +1073,20 @@ async fn test_mouse_selection(cx: &mut TestAppContext) {
 
     cx.assert_state("one «ˇtwo» three", Mode::Visual)
 }
+
+#[gpui::test]
+async fn test_marks(cx: &mut TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state("line one\nline ˇtwo\nline three").await;
+    cx.simulate_shared_keystrokes(["m", "a", "l", "'", "a"])
+        .await;
+    cx.assert_shared_state("line one\nˇline two\nline three")
+        .await;
+    cx.simulate_shared_keystrokes(["`", "a"]).await;
+    cx.assert_shared_state("line one\nline ˇtwo\nline three")
+        .await;
+
+    cx.simulate_shared_keystrokes(["^", "d", "`", "a"]).await;
+    cx.assert_shared_state("line one\nˇtwo\nline three").await;
+}

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1075,7 +1075,7 @@ async fn test_mouse_selection(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_marks(cx: &mut TestAppContext) {
+async fn test_lowercase_marks(cx: &mut TestAppContext) {
     let mut cx = NeovimBackedTestContext::new(cx).await;
 
     cx.set_shared_state("line one\nline ˇtwo\nline three").await;
@@ -1089,4 +1089,117 @@ async fn test_marks(cx: &mut TestAppContext) {
 
     cx.simulate_shared_keystrokes(["^", "d", "`", "a"]).await;
     cx.assert_shared_state("line one\nˇtwo\nline three").await;
+}
+
+#[gpui::test]
+async fn test_lt_gt_marks(cx: &mut TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        Line ˇthree
+        Line four
+        Line five
+    "
+    ))
+    .await;
+
+    cx.simulate_shared_keystrokes(["v", "j", "escape", "k", "k"])
+        .await;
+
+    cx.simulate_shared_keystrokes(["'", "<"]).await;
+    cx.assert_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        ˇLine three
+        Line four
+        Line five
+    "
+    ))
+    .await;
+
+    cx.simulate_shared_keystrokes(["`", "<"]).await;
+    cx.assert_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        Line ˇthree
+        Line four
+        Line five
+    "
+    ))
+    .await;
+
+    cx.simulate_shared_keystrokes(["'", ">"]).await;
+    cx.assert_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        Line three
+        ˇLine four
+        Line five
+    "
+    ))
+    .await;
+
+    cx.simulate_shared_keystrokes(["`", ">"]).await;
+    cx.assert_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        Line three
+        Line ˇfour
+        Line five
+    "
+    ))
+    .await;
+}
+
+#[gpui::test]
+async fn test_caret_mark(cx: &mut TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        Line three
+        ˇLine four
+        Line five
+    "
+    ))
+    .await;
+
+    cx.simulate_shared_keystrokes([
+        "c", "w", "shift-s", "t", "r", "a", "i", "g", "h", "t", " ", "t", "h", "i", "n", "g",
+        "escape", "j", "j",
+    ])
+    .await;
+
+    cx.simulate_shared_keystrokes(["'", "^"]).await;
+    cx.assert_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        Line three
+        ˇStraight thing four
+        Line five
+    "
+    ))
+    .await;
+
+    cx.simulate_shared_keystrokes(["`", "^"]).await;
+    cx.assert_shared_state(indoc!(
+        "
+        Line one
+        Line two
+        Line three
+        Straight thingˇ four
+        Line five
+    "
+    ))
+    .await;
 }

--- a/crates/vim/src/utils.rs
+++ b/crates/vim/src/utils.rs
@@ -39,6 +39,24 @@ fn copy_selections_content_internal(
     let mut text = String::new();
     let mut clipboard_selections = Vec::with_capacity(selections.len());
     let mut ranges_to_highlight = Vec::new();
+
+    vim.update_state(|state| {
+        state.marks.insert(
+            "[".to_string(),
+            selections
+                .iter()
+                .map(|s| buffer.anchor_before(s.start))
+                .collect(),
+        );
+        state.marks.insert(
+            "]".to_string(),
+            selections
+                .iter()
+                .map(|s| buffer.anchor_after(s.end))
+                .collect(),
+        )
+    });
+
     {
         let mut is_first = true;
         for selection in selections.iter() {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -194,7 +194,9 @@ fn observe_keystrokes(keystroke_event: &KeystrokeEvent, cx: &mut WindowContext) 
             | Operator::Replace
             | Operator::AddSurrounds { .. }
             | Operator::ChangeSurrounds { .. }
-            | Operator::DeleteSurrounds,
+            | Operator::DeleteSurrounds
+            | Operator::Mark
+            | Operator::Jump { .. },
         ) => {}
         Some(_) => {
             vim.clear_operator(cx);
@@ -706,6 +708,10 @@ impl Vim {
                 }
                 _ => Vim::update(cx, |vim, cx| vim.clear_operator(cx)),
             },
+            Some(Operator::Mark) => {
+                Vim::update(cx, |vim, cx| normal::mark::create_mark(vim, text, cx))
+            }
+            Some(Operator::Jump { line }) => normal::mark::jump(text, line, cx),
             _ => match Vim::read(cx).state().mode {
                 Mode::Replace => multi_replace(text, cx),
                 _ => {}

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -30,7 +30,10 @@ use gpui::{
 use language::{CursorShape, Point, SelectionGoal, TransactionId};
 pub use mode_indicator::ModeIndicator;
 use motion::Motion;
-use normal::normal_replace;
+use normal::{
+    mark::{create_mark, create_mark_after, create_mark_before},
+    normal_replace,
+};
 use replace::multi_replace;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -420,6 +423,10 @@ impl Vim {
         // Sync editor settings like clip mode
         self.sync_vim_settings(cx);
 
+        if mode != Mode::Insert && last_mode == Mode::Insert {
+            create_mark_after(self, "^".into(), cx)
+        }
+
         if leave_selections {
             return;
         }
@@ -616,6 +623,7 @@ impl Vim {
         let is_multicursor = editor.read(cx).selections.count() > 1;
 
         let state = self.state();
+        let mut is_visual = state.mode.is_visual();
         if state.mode == Mode::Insert && state.current_tx.is_some() {
             if state.current_anchor.is_none() {
                 self.update_state(|state| state.current_anchor = Some(newest));
@@ -632,11 +640,18 @@ impl Vim {
             } else {
                 self.switch_mode(Mode::Visual, false, cx)
             }
+            is_visual = true;
         } else if newest.start == newest.end
             && !is_multicursor
             && [Mode::Visual, Mode::VisualLine, Mode::VisualBlock].contains(&state.mode)
         {
-            self.switch_mode(Mode::Normal, true, cx)
+            self.switch_mode(Mode::Normal, true, cx);
+            is_visual = false;
+        }
+
+        if is_visual {
+            create_mark_before(self, ">".into(), cx);
+            create_mark(self, "<".into(), true, cx)
         }
     }
 
@@ -708,9 +723,9 @@ impl Vim {
                 }
                 _ => Vim::update(cx, |vim, cx| vim.clear_operator(cx)),
             },
-            Some(Operator::Mark) => {
-                Vim::update(cx, |vim, cx| normal::mark::create_mark(vim, text, cx))
-            }
+            Some(Operator::Mark) => Vim::update(cx, |vim, cx| {
+                normal::mark::create_mark(vim, text, false, cx)
+            }),
             Some(Operator::Jump { line }) => normal::mark::jump(text, line, cx),
             _ => match Vim::read(cx).state().mode {
                 Mode::Replace => multi_replace(text, cx),

--- a/crates/vim/test_data/test_builtin_marks.json
+++ b/crates/vim/test_data/test_builtin_marks.json
@@ -1,0 +1,36 @@
+{"Put":{"state":"Line one\nLine two\nLine ˇthree\nLine four\nLine five\n"}}
+{"Key":"v"}
+{"Key":"j"}
+{"Key":"escape"}
+{"Key":"k"}
+{"Key":"k"}
+{"Key":"'"}
+{"Key":"<"}
+{"Get":{"state":"Line one\nLine two\nˇLine three\nLine four\nLine five\n","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"<"}
+{"Get":{"state":"Line one\nLine two\nLine ˇthree\nLine four\nLine five\n","mode":"Normal"}}
+{"Key":"'"}
+{"Key":">"}
+{"Get":{"state":"Line one\nLine two\nLine three\nˇLine four\nLine five\n","mode":"Normal"}}
+{"Key":"`"}
+{"Key":">"}
+{"Get":{"state":"Line one\nLine two\nLine three\nLine ˇfour\nLine five\n","mode":"Normal"}}
+{"Key":"g"}
+{"Key":"g"}
+{"Key":"^"}
+{"Key":"j"}
+{"Key":"j"}
+{"Key":"l"}
+{"Key":"l"}
+{"Key":"c"}
+{"Key":"e"}
+{"Key":"k"}
+{"Key":"e"}
+{"Key":"escape"}
+{"Key":"'"}
+{"Key":"."}
+{"Get":{"state":"Line one\nLine two\nˇLike three\nLine four\nLine five\n","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"."}
+{"Get":{"state":"Line one\nLine two\nLiˇke three\nLine four\nLine five\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_caret_mark.json
+++ b/crates/vim/test_data/test_caret_mark.json
@@ -1,0 +1,26 @@
+{"Put":{"state":"Line one\nLine two\nLine three\nˇLine four\nLine five\n"}}
+{"Key":"c"}
+{"Key":"w"}
+{"Key":"shift-s"}
+{"Key":"t"}
+{"Key":"r"}
+{"Key":"a"}
+{"Key":"i"}
+{"Key":"g"}
+{"Key":"h"}
+{"Key":"t"}
+{"Key":" "}
+{"Key":"t"}
+{"Key":"h"}
+{"Key":"i"}
+{"Key":"n"}
+{"Key":"g"}
+{"Key":"escape"}
+{"Key":"j"}
+{"Key":"j"}
+{"Key":"'"}
+{"Key":"^"}
+{"Get":{"state":"Line one\nLine two\nLine three\nˇStraight thing four\nLine five\n","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"^"}
+{"Get":{"state":"Line one\nLine two\nLine three\nStraight thingˇ four\nLine five\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_lowercase_marks.json
+++ b/crates/vim/test_data/test_lowercase_marks.json
@@ -1,0 +1,15 @@
+{"Put":{"state":"line one\nline ˇtwo\nline three"}}
+{"Key":"m"}
+{"Key":"a"}
+{"Key":"l"}
+{"Key":"'"}
+{"Key":"a"}
+{"Get":{"state":"line one\nˇline two\nline three","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"a"}
+{"Get":{"state":"line one\nline ˇtwo\nline three","mode":"Normal"}}
+{"Key":"^"}
+{"Key":"d"}
+{"Key":"`"}
+{"Key":"a"}
+{"Get":{"state":"line one\nˇtwo\nline three","mode":"Normal"}}

--- a/crates/vim/test_data/test_lt_gt_marks.json
+++ b/crates/vim/test_data/test_lt_gt_marks.json
@@ -1,0 +1,18 @@
+{"Put":{"state":"Line one\nLine two\nLine ˇthree\nLine four\nLine five\n"}}
+{"Key":"v"}
+{"Key":"j"}
+{"Key":"escape"}
+{"Key":"k"}
+{"Key":"k"}
+{"Key":"'"}
+{"Key":"<"}
+{"Get":{"state":"Line one\nLine two\nˇLine three\nLine four\nLine five\n","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"<"}
+{"Get":{"state":"Line one\nLine two\nLine ˇthree\nLine four\nLine five\n","mode":"Normal"}}
+{"Key":"'"}
+{"Key":">"}
+{"Get":{"state":"Line one\nLine two\nLine three\nˇLine four\nLine five\n","mode":"Normal"}}
+{"Key":"`"}
+{"Key":">"}
+{"Get":{"state":"Line one\nLine two\nLine three\nLine ˇfour\nLine five\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_marks.json
+++ b/crates/vim/test_data/test_marks.json
@@ -1,0 +1,15 @@
+{"Put":{"state":"line one\nline ˇtwo\nline three"}}
+{"Key":"m"}
+{"Key":"a"}
+{"Key":"l"}
+{"Key":"'"}
+{"Key":"a"}
+{"Get":{"state":"line one\nˇline two\nline three","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"a"}
+{"Get":{"state":"line one\nline ˇtwo\nline three","mode":"Normal"}}
+{"Key":"^"}
+{"Key":"d"}
+{"Key":"`"}
+{"Key":"a"}
+{"Get":{"state":"line one\nˇtwo\nline three","mode":"Normal"}}

--- a/crates/vim/test_data/test_period_mark.json
+++ b/crates/vim/test_data/test_period_mark.json
@@ -1,0 +1,14 @@
+{"Put":{"state":"Line one\nLine two\nLiˇne three\nLine four\nLine five\n"}}
+{"Key":"c"}
+{"Key":"e"}
+{"Key":"k"}
+{"Key":"e"}
+{"Key":"escape"}
+{"Key":"j"}
+{"Key":"j"}
+{"Key":"'"}
+{"Key":"."}
+{"Get":{"state":"Line one\nLine two\nˇLike three\nLine four\nLine five\n","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"."}
+{"Get":{"state":"Line one\nLine two\nLiˇke three\nLine four\nLine five\n","mode":"Normal"}}


### PR DESCRIPTION
Release Notes:
- vim: Added support for buffer-local marks (`'a-'z`) and some builtin marks `'<`,`'>`,`'[`,`']`, `'{`, `'}` and `^`. Global marks (`'A-'Z`), and other builtin marks (`'0-'9`, `'(`, `')`, `''`, `'.`, `'"`) are not yet implemented. (#5122)