### PR TITLE
docs: Add linux build command explanation

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -56,6 +56,14 @@ For a release build:
 cargo run --release
 ```
 
+For a release package:
+
+```
+cargo build --release
+```
+
+the binary can be found in `target/release` folder.
+
 And to run the tests:
 
 ```


### PR DESCRIPTION
Just adding a short note about `cargo build --release` and the location of the compiled binary. It helps a lot to streamline usage of Zed day to day on Linux.

Release Notes:

- N/A
