### PR TITLE
php: Add runnable tests

### DIFF
--- a/extensions/php/languages/php/highlights.scm
+++ b/extensions/php/languages/php/highlights.scm
@@ -122,3 +122,4 @@
 "try" @keyword
 "use" @keyword
 "while" @keyword
+"yield" @keyword

--- a/extensions/php/languages/php/outline.scm
+++ b/extensions/php/languages/php/outline.scm
@@ -28,7 +28,7 @@
     name: (_) @name
     ) @item
 
-; Add support for Pest runnable (non chainable method)
+; Add support for Pest runnable (non chainable methods)
 (expression_statement
     (function_call_expression
         function: (_) @context
@@ -41,16 +41,14 @@
     )
 ) @item
 
-; Add support for Pest runnable (chainable method)
-(expression_statement
-    (member_call_expression
-        object: (function_call_expression
-            function: (_) @context
-            (#any-of? @context "it" "test" "describe")
-            arguments: (arguments
-                (argument
-                    (encapsed_string (string_value) @name)
-                )
+; Add support for Pest runnable (chainable methods)
+(_
+    object: (function_call_expression
+        function: (_) @context
+        (#any-of? @context "it" "test" "describe")
+        arguments: (arguments
+            (argument
+                (encapsed_string (string_value) @name)
             )
         )
     )

--- a/extensions/php/languages/php/outline.scm
+++ b/extensions/php/languages/php/outline.scm
@@ -28,28 +28,13 @@
     name: (_) @name
     ) @item
 
-; Add support for Pest runnable (non chainable methods)
-(expression_statement
-    (function_call_expression
-        function: (_) @context
-        (#any-of? @context "it" "test" "describe")
-        arguments: (arguments
-            (argument
-                (encapsed_string (string_value) @name)
-            )
-        )
-    )
-) @item
-
-; Add support for Pest runnable (chainable methods)
-(_
-    object: (function_call_expression
-        function: (_) @context
-        (#any-of? @context "it" "test" "describe")
-        arguments: (arguments
-            (argument
-                (encapsed_string (string_value) @name)
-            )
+; Add support for Pest runnable
+(function_call_expression
+    function: (_) @context
+    (#any-of? @context "it" "test" "describe")
+    arguments: (arguments
+        (argument
+            (encapsed_string (string_value) @name)
         )
     )
 ) @item

--- a/extensions/php/languages/php/outline.scm
+++ b/extensions/php/languages/php/outline.scm
@@ -33,6 +33,7 @@
     function: (_) @context
     (#any-of? @context "it" "test" "describe")
     arguments: (arguments
+        .
         (argument
             (encapsed_string (string_value) @name)
         )

--- a/extensions/php/languages/php/outline.scm
+++ b/extensions/php/languages/php/outline.scm
@@ -27,3 +27,31 @@
     "trait" @context
     name: (_) @name
     ) @item
+
+; Add support for Pest runnable (non chainable method)
+(expression_statement
+    (function_call_expression
+        function: (_) @context
+        (#any-of? @context "it" "test" "describe")
+        arguments: (arguments
+            (argument
+                (encapsed_string (string_value) @name)
+            )
+        )
+    )
+) @item
+
+; Add support for Pest runnable (chainable method)
+(expression_statement
+    (member_call_expression
+        object: (function_call_expression
+            function: (_) @context
+            (#any-of? @context "it" "test" "describe")
+            arguments: (arguments
+                (argument
+                    (encapsed_string (string_value) @name)
+                )
+            )
+        )
+    )
+) @item

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -3,14 +3,14 @@
 ; and have a method that follow the naming convention of PHPUnit test methods
 ; and the method is public
 (class_declaration
-    modifier: (_)? @modifier
-    (#not-eq? @modifier "abstract")
-    name: (_) @name
-    (#match? @name ".*Test$")
+    modifier: (_)? @_modifier
+    (#not-eq? @_modifier "abstract")
+    name: (_) @_name
+    (#match? @_name ".*Test$")
     body: (declaration_list
         (method_declaration
-            (visibility_modifier)? @visibility
-            (#eq? @visibility "public")
+            (visibility_modifier)? @_visibility
+            (#eq? @_visibility "public")
             name: (_) @run
             (#match? @run "^test.*")
         )
@@ -22,17 +22,17 @@
 ; and have a method that has the @test annotation
 ; and the method is public
 (class_declaration
-    modifier: (_)? @modifier
-    (#not-eq? @modifier "abstract")
-    name: (_) @name
-    (#match? @name ".*Test$")
+    modifier: (_)? @_modifier
+    (#not-eq? @_modifier "abstract")
+    name: (_) @_name
+    (#match? @_name ".*Test$")
     body: (declaration_list
-        ((comment) @comment
-            (#match? @comment ".*@test\\b.*")
+        ((comment) @_comment
+            (#match? @_comment ".*@test\\b.*")
         .
         (method_declaration
-            (visibility_modifier)? @visibility
-            (#eq? @visibility "public")
+            (visibility_modifier)? @_visibility
+            (#eq? @_visibility "public")
             name: (_) @run
             (#not-match? @run "^test.*")
         ))
@@ -45,20 +45,20 @@
 ; and have a method that has the #[Test] attribute
 ; and the method is public
 (class_declaration
-    modifier: (_)? @modifier
-    (#not-eq? @modifier "abstract")
-    name: (_) @name
-    (#match? @name ".*Test$")
+    modifier: (_)? @_modifier
+    (#not-eq? @_modifier "abstract")
+    name: (_) @_name
+    (#match? @_name ".*Test$")
     body: (declaration_list
         (method_declaration
             (attribute_list
                 (attribute_group
-                    (attribute (name) @attribute)
+                    (attribute (name) @_attribute)
                 )
             )
-            (#eq? @attribute "Test")
-            (visibility_modifier)? @visibility
-            (#eq? @visibility "public")
+            (#eq? @_attribute "Test")
+            (visibility_modifier)? @_visibility
+            (#eq? @_visibility "public")
             name: (_) @run
             (#not-match? @run "^test.*")
         )
@@ -68,8 +68,8 @@
 ; Class that follow the naming convention of PHPUnit test classes
 ; and that doesn't have the abstract modifier
 (class_declaration
-    modifier: (_)? @modifier
-    (#not-eq? @modifier "abstract")
+    modifier: (_)? @_modifier
+    (#not-eq? @_modifier "abstract")
     name: (_) @run
     (#match? @run ".*Test$")
 ) @phpunit-test
@@ -77,8 +77,8 @@
 ; Add support for Pest runnable
 ; Function expression that has `it`, `test` or `describe` as the function name
 (function_call_expression
-    function: (_) @name
-    (#any-of? @name "it" "test" "describe")
+    function: (_) @_name
+    (#any-of? @_name "it" "test" "describe")
     arguments: (arguments
         (argument
             (encapsed_string (string_value) @run)

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -7,13 +7,13 @@
         modifier: (_)? @modifier
         (#not-eq? @modifier "abstract")
         name: (_) @name
-        (#match? @name ".*Test")
+        (#match? @name ".*Test$")
         body: (declaration_list
             (method_declaration
                 (visibility_modifier)? @visibility
                 (#eq? @visibility "public")
                 name: (_) @run
-                (#match? @run "test.*")
+                (#match? @run "^test.*")
             )
         )
     )
@@ -28,7 +28,7 @@
         modifier: (_)? @modifier
         (#not-eq? @modifier "abstract")
         name: (_) @name
-        (#match? @name ".*Test")
+        (#match? @name ".*Test$")
         body: (declaration_list
             ((comment) @comment
                 (#match? @comment ".*@test.*")
@@ -49,6 +49,6 @@
         modifier: (_)? @modifier
         (#not-eq? @modifier "abstract")
         name: (_) @run
-        (#match? @run ".*Test")
+        (#match? @run ".*Test$")
     )
 ) @phpunit-test

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -39,6 +39,32 @@
     )
 ) @phpunit-test
 
+
+; Class that follow the naming convention of PHPUnit test classes
+; and that doesn't have the abstract modifier
+; and have a method that has the #[Test] attribute
+; and the method is public
+(class_declaration
+    modifier: (_)? @modifier
+    (#not-eq? @modifier "abstract")
+    name: (_) @name
+    (#match? @name ".*Test$")
+    body: (declaration_list
+        (method_declaration
+            (attribute_list
+                (attribute_group
+                    (attribute (name) @attribute)
+                )
+            )
+            (#eq? @attribute "Test")
+            (visibility_modifier)? @visibility
+            (#eq? @visibility "public")
+            name: (_) @run
+            (#not-match? @run "^test.*")
+        )
+    )
+) @phpunit-test
+
 ; Class that follow the naming convention of PHPUnit test classes
 ; and that doesn't have the abstract modifier
 (class_declaration

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -80,6 +80,7 @@
     function: (_) @_name
     (#any-of? @_name "it" "test" "describe")
     arguments: (arguments
+        .
         (argument
             (encapsed_string (string_value) @run)
         )

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -1,20 +1,18 @@
-(
-    ; Class that follow the naming convention of PHPUnit test classes
-    ; and that doesn't have the abstract modifier
-    ; and have a method that follow the naming convention of PHPUnit test methods
-    ; and the method is public
-    (class_declaration
-        modifier: (_)? @modifier
-        (#not-eq? @modifier "abstract")
-        name: (_) @name
-        (#match? @name ".*Test$")
-        body: (declaration_list
-            (method_declaration
-                (visibility_modifier)? @visibility
-                (#eq? @visibility "public")
-                name: (_) @run
-                (#match? @run "^test.*")
-            )
+; Class that follow the naming convention of PHPUnit test classes
+; and that doesn't have the abstract modifier
+; and have a method that follow the naming convention of PHPUnit test methods
+; and the method is public
+(class_declaration
+    modifier: (_)? @modifier
+    (#not-eq? @modifier "abstract")
+    name: (_) @name
+    (#match? @name ".*Test$")
+    body: (declaration_list
+        (method_declaration
+            (visibility_modifier)? @visibility
+            (#eq? @visibility "public")
+            name: (_) @run
+            (#match? @run "^test.*")
         )
     )
 ) @phpunit-test
@@ -23,35 +21,31 @@
 ; and that doesn't have the abstract modifier
 ; and have a method that has the @test annotation
 ; and the method is public
-(
-    (class_declaration
-        modifier: (_)? @modifier
-        (#not-eq? @modifier "abstract")
-        name: (_) @name
-        (#match? @name ".*Test$")
-        body: (declaration_list
-            ((comment) @comment
-                (#match? @comment ".*@test\\b.*")
-            .
-            (method_declaration
-                (visibility_modifier)? @visibility
-                (#eq? @visibility "public")
-                name: (_) @run
-                (#not-match? @run "^test.*")
-            ))
-        )
+(class_declaration
+    modifier: (_)? @modifier
+    (#not-eq? @modifier "abstract")
+    name: (_) @name
+    (#match? @name ".*Test$")
+    body: (declaration_list
+        ((comment) @comment
+            (#match? @comment ".*@test\\b.*")
+        .
+        (method_declaration
+            (visibility_modifier)? @visibility
+            (#eq? @visibility "public")
+            name: (_) @run
+            (#not-match? @run "^test.*")
+        ))
     )
 ) @phpunit-test
 
 ; Class that follow the naming convention of PHPUnit test classes
 ; and that doesn't have the abstract modifier
-(
-    (class_declaration
-        modifier: (_)? @modifier
-        (#not-eq? @modifier "abstract")
-        name: (_) @run
-        (#match? @run ".*Test$")
-    )
+(class_declaration
+    modifier: (_)? @modifier
+    (#not-eq? @modifier "abstract")
+    name: (_) @run
+    (#match? @run ".*Test$")
 ) @phpunit-test
 
 ; Add support for Pest runnable (non chainable method)

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -53,3 +53,39 @@
         (#match? @run ".*Test$")
     )
 ) @phpunit-test
+
+; Add support for Pest runnable (non chainable method)
+; Function expression that has `it`, `test` or `describe` as the function name
+; And does not have chained methods
+(
+    (expression_statement
+        (function_call_expression
+            function: (_) @name
+            (#any-of? @name "it" "test" "describe")
+            arguments: (arguments
+                (argument
+                    (encapsed_string (string_value) @run)
+                )
+            )
+        )
+    )
+) @pest-test
+
+; Add support for Pest runnable (chainable method)
+; Function expression that has `it`, `test` or `describe` as the function name
+; And has chained methods
+(
+    (expression_statement
+        (member_call_expression
+            object: (function_call_expression
+                function: (_) @name
+                (#any-of? @name "it" "test" "describe")
+                arguments: (arguments
+                    (argument
+                        (encapsed_string (string_value) @run)
+                    )
+                )
+            )
+        )
+    )
+) @pest-test

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -21,6 +21,29 @@
 
 ; Class that follow the naming convention of PHPUnit test classes
 ; and that doesn't have the abstract modifier
+; and have a method that has the @test annotation
+; and the method is public
+(
+    (class_declaration
+        modifier: (_)? @modifier
+        (#not-eq? @modifier "abstract")
+        name: (_) @name
+        (#match? @name ".*Test")
+        body: (declaration_list
+            ((comment) @comment
+                (#match? @comment ".*@test.*")
+            .
+            (method_declaration
+                (visibility_modifier)? @visibility
+                (#eq? @visibility "public")
+                name: (_) @run
+            ))
+        )
+    )
+) @phpunit-test
+
+; Class that follow the naming convention of PHPUnit test classes
+; and that doesn't have the abstract modifier
 (
     (class_declaration
         modifier: (_)? @modifier

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -75,15 +75,13 @@
 ; Function expression that has `it`, `test` or `describe` as the function name
 ; And has chained methods
 (
-    (expression_statement
-        (member_call_expression
-            object: (function_call_expression
-                function: (_) @name
-                (#any-of? @name "it" "test" "describe")
-                arguments: (arguments
-                    (argument
-                        (encapsed_string (string_value) @run)
-                    )
+    (_
+        object: (function_call_expression
+            function: (_) @name
+            (#any-of? @name "it" "test" "describe")
+            arguments: (arguments
+                (argument
+                    (encapsed_string (string_value) @run)
                 )
             )
         )

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -48,36 +48,14 @@
     (#match? @run ".*Test$")
 ) @phpunit-test
 
-; Add support for Pest runnable (non chainable method)
+; Add support for Pest runnable
 ; Function expression that has `it`, `test` or `describe` as the function name
-; And does not have chained methods
-(
-    (expression_statement
-        (function_call_expression
-            function: (_) @name
-            (#any-of? @name "it" "test" "describe")
-            arguments: (arguments
-                (argument
-                    (encapsed_string (string_value) @run)
-                )
-            )
-        )
-    )
-) @pest-test
-
-; Add support for Pest runnable (chainable method)
-; Function expression that has `it`, `test` or `describe` as the function name
-; And has chained methods
-(
-    (_
-        object: (function_call_expression
-            function: (_) @name
-            (#any-of? @name "it" "test" "describe")
-            arguments: (arguments
-                (argument
-                    (encapsed_string (string_value) @run)
-                )
-            )
+(function_call_expression
+    function: (_) @name
+    (#any-of? @name "it" "test" "describe")
+    arguments: (arguments
+        (argument
+            (encapsed_string (string_value) @run)
         )
     )
 ) @pest-test

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -31,7 +31,7 @@
         (#match? @name ".*Test$")
         body: (declaration_list
             ((comment) @comment
-                (#match? @comment ".*@test.*")
+                (#match? @comment ".*@test\\b.*")
             .
             (method_declaration
                 (visibility_modifier)? @visibility

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -1,0 +1,31 @@
+(
+    ; Class that follow the naming convention of PHPUnit test classes
+    ; and that doesn't have the abstract modifier
+    ; and have a method that follow the naming convention of PHPUnit test methods
+    ; and the method is public
+    (class_declaration
+        modifier: (_)? @modifier
+        (#not-eq? @modifier "abstract")
+        name: (_) @name
+        (#match? @name ".*Test")
+        body: (declaration_list
+            (method_declaration
+                (visibility_modifier)? @visibility
+                (#eq? @visibility "public")
+                name: (_) @run
+                (#match? @run "test.*")
+            )
+        )
+    )
+) @php-test
+
+; Class that follow the naming convention of PHPUnit test classes
+; and that doesn't have the abstract modifier
+(
+    (class_declaration
+        modifier: (_)? @modifier
+        (#not-eq? @modifier "abstract")
+        name: (_) @run
+        (#match? @run ".*Test")
+    )
+) @php-test

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -17,7 +17,7 @@
             )
         )
     )
-) @php-test
+) @phpunit-test
 
 ; Class that follow the naming convention of PHPUnit test classes
 ; and that doesn't have the abstract modifier
@@ -28,4 +28,4 @@
         name: (_) @run
         (#match? @run ".*Test")
     )
-) @php-test
+) @phpunit-test

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -37,6 +37,7 @@
                 (visibility_modifier)? @visibility
                 (#eq? @visibility "public")
                 name: (_) @run
+                (#not-match? @run "^test.*")
             ))
         )
     )

--- a/extensions/php/languages/php/tasks.json
+++ b/extensions/php/languages/php/tasks.json
@@ -4,5 +4,11 @@
     "command": "./vendor/bin/phpunit",
     "args": ["--filter=$ZED_SYMBOL $ZED_FILE"],
     "tags": ["phpunit-test"]
+  },
+  {
+    "label": "pest test $ZED_SYMBOL",
+    "command": "./vendor/bin/pest",
+    "args": ["--filter=$ZED_SYMBOL $ZED_FILE"],
+    "tags": ["pest-test"]
   }
 ]

--- a/extensions/php/languages/php/tasks.json
+++ b/extensions/php/languages/php/tasks.json
@@ -1,8 +1,8 @@
 [
   {
     "label": "phpunit test $ZED_SYMBOL",
-    "command": "vendor/bin/phpunit",
     "args": ["--filter=$ZED_SYMBOL"],
+    "command": "./vendor/bin/phpunit",
     "tags": ["phpunit-test"]
   }
 ]

--- a/extensions/php/languages/php/tasks.json
+++ b/extensions/php/languages/php/tasks.json
@@ -1,0 +1,8 @@
+[
+  {
+    "label": "php test $ZED_SYMBOL",
+    "command": "vendor/bin/phpunit",
+    "args": ["--filter=$ZED_SYMBOL"],
+    "tags": ["php-test"]
+  }
+]

--- a/extensions/php/languages/php/tasks.json
+++ b/extensions/php/languages/php/tasks.json
@@ -1,8 +1,8 @@
 [
   {
     "label": "phpunit test $ZED_SYMBOL",
-    "args": ["--filter=$ZED_SYMBOL"],
     "command": "./vendor/bin/phpunit",
+    "args": ["--filter=$ZED_SYMBOL $ZED_FILE"],
     "tags": ["phpunit-test"]
   }
 ]

--- a/extensions/php/languages/php/tasks.json
+++ b/extensions/php/languages/php/tasks.json
@@ -2,13 +2,13 @@
   {
     "label": "phpunit test $ZED_SYMBOL",
     "command": "./vendor/bin/phpunit",
-    "args": ["--filter=$ZED_SYMBOL $ZED_FILE"],
+    "args": ["--filter $ZED_SYMBOL $ZED_FILE"],
     "tags": ["phpunit-test"]
   },
   {
     "label": "pest test $ZED_SYMBOL",
     "command": "./vendor/bin/pest",
-    "args": ["--filter=$ZED_SYMBOL $ZED_FILE"],
+    "args": ["--filter \"$ZED_SYMBOL\" $ZED_FILE"],
     "tags": ["pest-test"]
   }
 ]

--- a/extensions/php/languages/php/tasks.json
+++ b/extensions/php/languages/php/tasks.json
@@ -1,8 +1,8 @@
 [
   {
-    "label": "php test $ZED_SYMBOL",
+    "label": "phpunit test $ZED_SYMBOL",
     "command": "vendor/bin/phpunit",
     "args": ["--filter=$ZED_SYMBOL"],
-    "tags": ["php-test"]
+    "tags": ["phpunit-test"]
   }
 ]

--- a/extensions/php/languages/php/tasks.json
+++ b/extensions/php/languages/php/tasks.json
@@ -10,5 +10,10 @@
     "command": "./vendor/bin/pest",
     "args": ["--filter \"$ZED_SYMBOL\" $ZED_FILE"],
     "tags": ["pest-test"]
+  },
+  {
+    "label": "execute selection $ZED_SELECTED_TEXT",
+    "command": "php",
+    "args": ["-r", "$ZED_SELECTED_TEXT"]
   }
 ]


### PR DESCRIPTION
### This pull request adds the following:
- Missing mapping for the `yield` keyword.
- Outline scheme for `describe`, `it` and `test` function_call_expressions (to support Pest runnable)
- Pest runnable support
- PHPUnit runnable support
- Task for running selected PHP code.


## Queries explanations

#### Query 1 (PHPUnit: Run specific method test):
1. Class is not abstract (because you cannot run tests from an abstract class)
2. Class has `Test` suffix
3. Method has public modifier(or no modifiers, default is public)
4. Method has `test` prefix

#### Query 2 (PHPUnit: Run specific method test with `@test` annotation):
1. Class is not abstract (because you cannot run tests from an abstract class)
2. Class has `Test` suffix
3. Method has public modifier(or no modifiers, default is public)
4. Method has `@test` annotation

#### Query 3 (PHPUnit: Run specific method test with `#[Test]` attribute):
1. Class is not abstract (because you cannot run tests from an abstract class)
2. Class has `Test` suffix
3. Method has public modifier(or no modifiers, default is public)
4. Method has `#[Test]` attribute

#### Query 4 (PHPUnit: Run all tests inside the class):
1. Class is not abstract (because you cannot run tests from an abstract class)
2. Class has `Test` suffix

#### Query 5 (Pest: Run function test)
1. Function expression has one of the following names: `describe`, `it` or `test`
2. Function expression first argument is a string

### **PHPUnit: Example for valid test class**
<img width="549" alt="Screenshot 2024-05-08 at 10 41 34" src="https://github.com/zed-industries/zed/assets/62463826/e84269de-4f53-410b-b93b-713f9448dc79">


### **PHPUnit: Example for invalid test class**
All the methods should be ignored because you cannot run tests on an abstract class.
<img width="608" alt="Screenshot 2024-05-07 at 22 28 57" src="https://github.com/zed-industries/zed/assets/62463826/8c6b3921-5266-4d88-ada5-5cd827bcf242">

### **Pest: Example**
https://github.com/zed-industries/zed/assets/62463826/bce133eb-0a6f-4ca2-9739-12d9169bb9d6

You should now see all your **Pest** tests inside the buffer symbols modal.
![Screenshot 2024-05-08 at 22 51 25](https://github.com/zed-industries/zed/assets/62463826/9c818b74-383c-45e5-9b41-8dec92759a14)

Release Notes:

- Added test runnable detection for PHP (PHPUnit & Pest).
- Added task for running selected PHP code.
- Added `describe`, `test` and `it` functions to buffer symbols, to support Pest runnable.
- Added `yield` keyword to PHP keyword mapping.
