### PR TITLE
Fix horizontal scrolling direction on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -547,7 +547,7 @@ fn handle_mouse_horizontal_wheel_msg(
         let wheel_scroll_chars = lock.mouse_wheel_settings.wheel_scroll_chars;
         drop(lock);
         let wheel_distance =
-            (wparam.signed_hiword() as f32 / WHEEL_DELTA as f32) * wheel_scroll_chars as f32;
+            (-wparam.signed_hiword() as f32 / WHEEL_DELTA as f32) * wheel_scroll_chars as f32;
         let mut cursor_point = POINT {
             x: lparam.signed_loword().into(),
             y: lparam.signed_hiword().into(),


### PR DESCRIPTION
As per Microsoft documentation, positive values scroll right, not left. GPUI was incorrectly assuming it perfectly mirrored vertical scrolling.

Fixes #11515

Release Notes:

- N/A
