### PR TITLE
wayland: Window controls and drag

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -73,7 +73,8 @@ impl Render for CollabTitlebarItem {
                     .gap_1()
                     .children(self.render_project_host(cx))
                     .child(self.render_project_name(cx))
-                    .children(self.render_project_branch(cx)),
+                    .children(self.render_project_branch(cx))
+                    .on_mouse_move(|_, cx| cx.stop_propagation()),
             )
             .child(
                 h_flex()
@@ -105,6 +106,7 @@ impl Render for CollabTitlebarItem {
 
                             this.children(current_user_face_pile.map(|face_pile| {
                                 v_flex()
+                                    .on_mouse_move(|_, cx| cx.stop_propagation())
                                     .child(face_pile)
                                     .child(render_color_ribbon(player_colors.local().cursor))
                             }))
@@ -167,6 +169,7 @@ impl Render for CollabTitlebarItem {
                 h_flex()
                     .gap_1()
                     .pr_1()
+                    .on_mouse_move(|_, cx| cx.stop_propagation())
                     .when_some(room, |this, room| {
                         let room = room.read(cx);
                         let project = self.project.read(cx);

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -58,7 +58,7 @@ impl Render for CollabTitlebarItem {
         let project_id = self.project.read(cx).remote_id();
         let workspace = self.workspace.upgrade();
 
-        TitleBar::new("collab-titlebar")
+        TitleBar::new("collab-titlebar", Box::new(workspace::CloseWindow))
             // note: on windows titlebar behaviour is handled by the platform implementation
             .when(cfg!(not(windows)), |this| {
                 this.on_click(|event, cx| {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -226,13 +226,8 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     #[cfg(target_os = "windows")]
     fn get_raw_handle(&self) -> windows::HWND;
 
-    #[cfg(target_os = "linux")]
     fn show_window_menu(&self, position: Point<Pixels>);
-
-    #[cfg(target_os = "linux")]
     fn start_system_move(&self);
-
-    #[cfg(target_os = "linux")]
     fn should_render_window_controls(&self) -> bool;
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -227,7 +227,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn get_raw_handle(&self) -> windows::HWND;
 
     #[cfg(target_os = "linux")]
-    fn mark_window_move(&self, move_state: WindowMoveState);
+    fn start_system_move(&self);
 
     #[cfg(target_os = "linux")]
     fn should_render_window_controls(&self) -> bool;
@@ -236,17 +236,6 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn as_test(&mut self) -> Option<&mut TestWindow> {
         None
     }
-}
-
-/// All the window move states needed for CSD based window move.
-#[cfg(target_os = "linux")]
-pub enum WindowMoveState {
-    /// Start marks the probable start of the move event
-    Start,
-    /// Moving marks the actual start of the drag event
-    Moving,
-    /// Stop marks the end of the drag event
-    Stop
 }
 
 /// This type is public so that our test macro can generate and use it, but it should not

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -227,6 +227,9 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn get_raw_handle(&self) -> windows::HWND;
 
     #[cfg(target_os = "linux")]
+    fn show_window_menu(&self, position: Point<Pixels>);
+
+    #[cfg(target_os = "linux")]
     fn start_system_move(&self);
 
     #[cfg(target_os = "linux")]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -226,10 +226,27 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     #[cfg(target_os = "windows")]
     fn get_raw_handle(&self) -> windows::HWND;
 
+    #[cfg(target_os = "linux")]
+    fn mark_window_move(&self, move_state: WindowMoveState);
+
+    #[cfg(target_os = "linux")]
+    fn should_render_window_controls(&self) -> bool;
+
     #[cfg(any(test, feature = "test-support"))]
     fn as_test(&mut self) -> Option<&mut TestWindow> {
         None
     }
+}
+
+/// All the window move states needed for CSD based window move.
+#[cfg(target_os = "linux")]
+pub enum WindowMoveState {
+    /// Start marks the probable start of the move event
+    Start,
+    /// Moving marks the actual start of the drag event
+    Moving,
+    /// Stop marks the end of the drag event
+    Stop
 }
 
 /// This type is public so that our test macro can generate and use it, but it should not

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -197,7 +197,7 @@ impl WaylandClientStatePtr {
             .expect("The pointer should always be valid when dispatching in wayland")
     }
 
-    pub fn get_event_serial(&self) -> u32 {
+    pub fn get_latest_serial(&self) -> u32 {
         self.0.upgrade().unwrap().borrow().serial
     }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -197,8 +197,8 @@ impl WaylandClientStatePtr {
             .expect("The pointer should always be valid when dispatching in wayland")
     }
 
-    pub fn get_latest_serial(&self) -> u32 {
-        self.0.upgrade().unwrap().borrow().serial
+    pub fn get_serial(&self, kind: SerialKind) -> u32 {
+        self.0.upgrade().unwrap().borrow().serial_tracker.get(kind)
     }
 
     pub fn drop_window(&self, surface_id: &ObjectId) {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -116,7 +116,7 @@ impl Globals {
                 )
                 .ok(),
             shm: globals.bind(&qh, 1..=1, ()).unwrap(),
-            seat: seat,
+            seat,
             wm_base: globals.bind(&qh, 1..=1, ()).unwrap(),
             viewporter: globals.bind(&qh, 1..=1, ()).ok(),
             fractional_scale_manager: globals.bind(&qh, 1..=1, ()).ok(),

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -23,6 +23,7 @@ use wayland_client::globals::{registry_queue_init, GlobalList, GlobalListContent
 use wayland_client::protocol::wl_callback::{self, WlCallback};
 use wayland_client::protocol::wl_data_device_manager::DndAction;
 use wayland_client::protocol::wl_pointer::{AxisRelativeDirection, AxisSource};
+use wayland_client::protocol::wl_seat::WlSeat;
 use wayland_client::protocol::{
     wl_data_device, wl_data_device_manager, wl_data_offer, wl_data_source, wl_output, wl_region,
 };
@@ -80,6 +81,7 @@ pub struct Globals {
     pub data_device_manager: Option<wl_data_device_manager::WlDataDeviceManager>,
     pub wm_base: xdg_wm_base::XdgWmBase,
     pub shm: wl_shm::WlShm,
+    pub seat: wl_seat::WlSeat,
     pub viewporter: Option<wp_viewporter::WpViewporter>,
     pub fractional_scale_manager:
         Option<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
@@ -93,6 +95,7 @@ impl Globals {
         globals: GlobalList,
         executor: ForegroundExecutor,
         qh: QueueHandle<WaylandClientStatePtr>,
+        seat: wl_seat::WlSeat,
     ) -> Self {
         Globals {
             activation: globals.bind(&qh, 1..=1, ()).ok(),
@@ -113,6 +116,7 @@ impl Globals {
                 )
                 .ok(),
             shm: globals.bind(&qh, 1..=1, ()).unwrap(),
+            seat: seat,
             wm_base: globals.bind(&qh, 1..=1, ()).unwrap(),
             viewporter: globals.bind(&qh, 1..=1, ()).ok(),
             fractional_scale_manager: globals.bind(&qh, 1..=1, ()).ok(),
@@ -191,6 +195,10 @@ impl WaylandClientStatePtr {
         self.0
             .upgrade()
             .expect("The pointer should always be valid when dispatching in wayland")
+    }
+
+    pub fn get_event_serial(&self) -> u32 {
+        return self.0.upgrade().unwrap().borrow_mut().serial
     }
 
     pub fn drop_window(&self, surface_id: &ObjectId) {
@@ -303,7 +311,7 @@ impl WaylandClient {
         });
 
         let seat = seat.unwrap();
-        let globals = Globals::new(globals, common.foreground_executor.clone(), qh.clone());
+        let globals = Globals::new(globals, common.foreground_executor.clone(), qh.clone(), seat.clone());
 
         let data_device = globals
             .data_device_manager

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -198,7 +198,7 @@ impl WaylandClientStatePtr {
     }
 
     pub fn get_event_serial(&self) -> u32 {
-        return self.0.upgrade().unwrap().borrow_mut().serial
+        self.0.upgrade().unwrap().borrow().serial
     }
 
     pub fn drop_window(&self, surface_id: &ObjectId) {
@@ -311,7 +311,12 @@ impl WaylandClient {
         });
 
         let seat = seat.unwrap();
-        let globals = Globals::new(globals, common.foreground_executor.clone(), qh.clone(), seat.clone());
+        let globals = Globals::new(
+            globals,
+            common.foreground_executor.clone(),
+            qh.clone(),
+            seat.clone(),
+        );
 
         let data_device = globals
             .data_device_manager
@@ -970,6 +975,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
             } => {
                 state.serial_tracker.update(SerialKind::MouseEnter, serial);
                 state.mouse_location = Some(point(px(surface_x as f32), px(surface_y as f32)));
+                state.button_pressed = None;
 
                 if let Some(window) = get_window(&mut state, &surface.id()) {
                     state.mouse_focused_window = Some(window.clone());
@@ -998,6 +1004,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                     });
                     state.mouse_focused_window = None;
                     state.mouse_location = None;
+                    state.button_pressed = None;
 
                     drop(state);
                     focused_window.handle_input(input);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -27,8 +27,8 @@ use crate::platform::{PlatformAtlas, PlatformInputHandler, PlatformWindow};
 use crate::scene::Scene;
 use crate::{
     px, size, Bounds, DevicePixels, Globals, Modifiers, Pixels, PlatformDisplay, PlatformInput,
-    Point, PromptLevel, Size, WaylandClientState, WaylandClientStatePtr, WindowAppearance,
-    WindowBackgroundAppearance, WindowBounds, WindowMoveState, WindowParams,
+    Point, PromptLevel, Size, WaylandClientStatePtr, WindowAppearance, WindowBackgroundAppearance,
+    WindowBounds, WindowParams,
 };
 
 #[derive(Default)]
@@ -81,7 +81,6 @@ pub struct WaylandWindowState {
     fullscreen: bool,
     restore_bounds: Bounds<DevicePixels>,
     maximized: bool,
-    window_move_event_serial: u32,
     client: WaylandClientStatePtr,
     callbacks: Callbacks,
 }
@@ -155,7 +154,6 @@ impl WaylandWindowState {
             fullscreen: false,
             restore_bounds: Bounds::default(),
             maximized: false,
-            window_move_event_serial: 0,
             callbacks: Callbacks::default(),
             client,
         }
@@ -756,21 +754,10 @@ impl PlatformWindow for WaylandWindow {
         state.renderer.sprite_atlas().clone()
     }
 
-    fn mark_window_move(&self, move_state: WindowMoveState) {
+    fn start_system_move(&self) {
         let mut state = self.borrow_mut();
-        match move_state {
-            WindowMoveState::Start => {
-                state.window_move_event_serial = state.client.get_event_serial();
-            }
-            WindowMoveState::Moving => {
-                state
-                    .toplevel
-                    ._move(&state.globals.seat, state.window_move_event_serial);
-            }
-            WindowMoveState::Stop => {
-                state.window_move_event_serial = 0;
-            }
-        }
+        let serial = state.client.get_latest_serial();
+        state.toplevel._move(&state.globals.seat, serial);
     }
 
     fn should_render_window_controls(&self) -> bool {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -23,6 +23,7 @@ use wayland_protocols_plasma::blur::client::{org_kde_kwin_blur, org_kde_kwin_blu
 
 use crate::platform::blade::{BladeRenderer, BladeSurfaceConfig};
 use crate::platform::linux::wayland::display::WaylandDisplay;
+use crate::platform::linux::wayland::serial::SerialKind;
 use crate::platform::{PlatformAtlas, PlatformInputHandler, PlatformWindow};
 use crate::scene::Scene;
 use crate::{
@@ -755,8 +756,8 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn start_system_move(&self) {
-        let mut state = self.borrow_mut();
-        let serial = state.client.get_latest_serial();
+        let state = self.borrow();
+        let serial = state.client.get_serial(SerialKind::MousePress);
         state.toplevel._move(&state.globals.seat, serial);
     }
 

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -755,6 +755,17 @@ impl PlatformWindow for WaylandWindow {
         state.renderer.sprite_atlas().clone()
     }
 
+    fn show_window_menu(&self, position: Point<Pixels>) {
+        let state = self.borrow();
+        let serial = state.client.get_serial(SerialKind::MousePress);
+        state.toplevel.show_window_menu(
+            &state.globals.seat,
+            serial,
+            position.x.0 as i32,
+            position.y.0 as i32,
+        );
+    }
+
     fn start_system_move(&self) {
         let state = self.borrow();
         let serial = state.client.get_serial(SerialKind::MousePress);

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -721,7 +721,8 @@ impl PlatformWindow for X11Window {
         inner.renderer.sprite_atlas().clone()
     }
 
-    fn mark_window_move(&self, _: WindowMoveState) {}
+    // todo(linux)
+    fn start_system_move(&self) {}
 
     fn should_render_window_controls(&self) -> bool {
         false

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -722,6 +722,9 @@ impl PlatformWindow for X11Window {
     }
 
     // todo(linux)
+    fn show_window_menu(&self, _position: Point<Pixels>) {}
+
+    // todo(linux)
     fn start_system_move(&self) {}
 
     fn should_render_window_controls(&self) -> bool {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -8,6 +8,7 @@ use crate::{
     Scene, Size, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowOptions,
     WindowParams, X11Client, X11ClientState, X11ClientStatePtr,
 };
+
 use blade_graphics as gpu;
 use parking_lot::Mutex;
 use raw_window_handle as rwh;
@@ -718,5 +719,11 @@ impl PlatformWindow for X11Window {
     fn sprite_atlas(&self) -> sync::Arc<dyn PlatformAtlas> {
         let inner = self.0.state.borrow();
         inner.renderer.sprite_atlas().clone()
+    }
+
+    fn mark_window_move(&self, _: WindowMoveState) {}
+
+    fn should_render_window_controls(&self) -> bool {
+        false
     }
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1100,6 +1100,14 @@ impl PlatformWindow for MacWindow {
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         self.0.lock().renderer.sprite_atlas().clone()
     }
+
+    fn show_window_menu(&self, _position: Point<Pixels>) {}
+
+    fn start_system_move(&self) {}
+
+    fn should_render_window_controls(&self) -> bool {
+        false
+    }
 }
 
 impl rwh::HasWindowHandle for MacWindow {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -258,12 +258,14 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
-    #[cfg(target_os = "linux")]
+    fn show_window_menu(&self, _position: Point<Pixels>) {
+        unimplemented!()
+    }
+
     fn start_system_move(&self) {
         unimplemented!()
     }
 
-    #[cfg(target_os = "linux")]
     fn should_render_window_controls(&self) -> bool {
         false
     }

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -4,7 +4,6 @@ use crate::{
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowParams,
 };
-use crate::WindowMoveState;
 use collections::HashMap;
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
@@ -260,10 +259,10 @@ impl PlatformWindow for TestWindow {
     }
 
     #[cfg(target_os = "linux")]
-    fn mark_window_move(&self, _: WindowMoveState) {
-        unimplemented!()   
+    fn start_system_move(&self) {
+        unimplemented!()
     }
-    
+
     #[cfg(target_os = "linux")]
     fn should_render_window_controls(&self) -> bool {
         false

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -4,6 +4,7 @@ use crate::{
     PlatformInputHandler, PlatformWindow, Point, Size, TestPlatform, TileId, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowParams,
 };
+use crate::WindowMoveState;
 use collections::HashMap;
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
@@ -256,6 +257,16 @@ impl PlatformWindow for TestWindow {
     #[cfg(target_os = "windows")]
     fn get_raw_handle(&self) -> windows::Win32::Foundation::HWND {
         unimplemented!()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn mark_window_move(&self, _: WindowMoveState) {
+        unimplemented!()   
+    }
+    
+    #[cfg(target_os = "linux")]
+    fn should_render_window_controls(&self) -> bool {
+        false
     }
 }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -628,6 +628,14 @@ impl PlatformWindow for WindowsWindow {
     fn get_raw_handle(&self) -> HWND {
         self.0.hwnd
     }
+
+    fn show_window_menu(&self, _position: Point<Pixels>) {}
+
+    fn start_system_move(&self) {}
+
+    fn should_render_window_controls(&self) -> bool {
+        false
+    }
 }
 
 #[implement(IDropTarget)]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -12,8 +12,8 @@ use crate::{
     RenderSvgParams, ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle, Style,
     SubscriberSet, Subscription, TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement,
     TransformationMatrix, Underline, UnderlineStyle, View, VisualContext, WeakView,
-    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowMoveState, WindowOptions,
-    WindowParams, WindowTextSystem, SUBPIXEL_VARIANTS,
+    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowOptions, WindowParams,
+    WindowTextSystem, SUBPIXEL_VARIANTS,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::{FxHashMap, FxHashSet};
@@ -1131,31 +1131,15 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.zoom();
     }
 
-    /// Mark the start of window move when using client side decorations in linux (only wayland)
-    pub fn mark_moving(&self) {
+    /// Tells the compositor to take control of window movement (Wayland only)
+    ///
+    /// Events may not be received during a move operation.
+    pub fn start_system_move(&self) {
         #[cfg(target_os = "linux")]
-        self.window
-            .platform_window
-            .mark_window_move(WindowMoveState::Start)
+        self.window.platform_window.start_system_move()
     }
 
-    /// Mark the start of window move when using client side decorations in linux (only wayland)
-    pub fn start_moving(&self) {
-        #[cfg(target_os = "linux")]
-        self.window
-            .platform_window
-            .mark_window_move(WindowMoveState::Moving)
-    }
-
-    /// Mark the stop of window move when using client side decorations in linux (only wayland)
-    pub fn stop_moving(&self) {
-        #[cfg(target_os = "linux")]
-        self.window
-            .platform_window
-            .mark_window_move(WindowMoveState::Stop)
-    }
-
-    /// Specifies if the title bar window controls need to be rendered in linux (wayland and x11)
+    /// Returns whether the title bar window controls need to be rendered by the application (Wayland and X11)
     pub fn should_render_window_controls(&self) -> bool {
         #[cfg(target_os = "linux")]
         self.window.platform_window.should_render_window_controls()

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -12,8 +12,8 @@ use crate::{
     RenderSvgParams, ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle, Style,
     SubscriberSet, Subscription, TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement,
     TransformationMatrix, Underline, UnderlineStyle, View, VisualContext, WeakView,
-    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowOptions, WindowParams,
-    WindowTextSystem, SUBPIXEL_VARIANTS,
+    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowMoveState, WindowOptions,
+    WindowParams, WindowTextSystem, SUBPIXEL_VARIANTS,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::{FxHashMap, FxHashSet};
@@ -1129,6 +1129,36 @@ impl<'a> WindowContext<'a> {
     /// Toggle zoom on the window.
     pub fn zoom_window(&self) {
         self.window.platform_window.zoom();
+    }
+
+    /// Mark the start of window move when using client side decorations in linux (only wayland)
+    pub fn mark_moving(&self) {
+        #[cfg(target_os = "linux")]
+        self.window
+            .platform_window
+            .mark_window_move(WindowMoveState::Start)
+    }
+
+    /// Mark the start of window move when using client side decorations in linux (only wayland)
+    pub fn start_moving(&self) {
+        #[cfg(target_os = "linux")]
+        self.window
+            .platform_window
+            .mark_window_move(WindowMoveState::Moving)
+    }
+
+    /// Mark the stop of window move when using client side decorations in linux (only wayland)
+    pub fn stop_moving(&self) {
+        #[cfg(target_os = "linux")]
+        self.window
+            .platform_window
+            .mark_window_move(WindowMoveState::Stop)
+    }
+
+    /// Specifies if the title bar window controls need to be rendered in linux (wayland and x11)
+    pub fn should_render_window_controls(&self) -> bool {
+        #[cfg(target_os = "linux")]
+        self.window.platform_window.should_render_window_controls()
     }
 
     /// Updates the window's title at the platform level.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1133,7 +1133,6 @@ impl<'a> WindowContext<'a> {
 
     /// Opens the native title bar context menu, useful when implementing client side decorations (Wayland only)
     pub fn show_window_menu(&self, position: Point<Pixels>) {
-        #[cfg(target_os = "linux")]
         self.window.platform_window.show_window_menu(position)
     }
 
@@ -1141,13 +1140,11 @@ impl<'a> WindowContext<'a> {
     ///
     /// Events may not be received during a move operation.
     pub fn start_system_move(&self) {
-        #[cfg(target_os = "linux")]
         self.window.platform_window.start_system_move()
     }
 
     /// Returns whether the title bar window controls need to be rendered by the application (Wayland and X11)
     pub fn should_render_window_controls(&self) -> bool {
-        #[cfg(target_os = "linux")]
         self.window.platform_window.should_render_window_controls()
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1131,6 +1131,12 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.zoom();
     }
 
+    /// Opens the native title bar context menu, useful when implementing client side decorations (Wayland only)
+    pub fn show_window_menu(&self, position: Point<Pixels>) {
+        #[cfg(target_os = "linux")]
+        self.window.platform_window.show_window_menu(position)
+    }
+
     /// Tells the compositor to take control of window movement (Wayland only)
     ///
     /// Events may not be received during a move operation.

--- a/crates/ui/src/components/stories/title_bar.rs
+++ b/crates/ui/src/components/stories/title_bar.rs
@@ -1,4 +1,4 @@
-use gpui::Render;
+use gpui::{NoAction, Render};
 use story::{StoryContainer, StoryItem, StorySection};
 
 use crate::{prelude::*, PlatformStyle, TitleBar};
@@ -19,7 +19,7 @@ impl Render for TitleBarStory {
                 StorySection::new().child(
                     StoryItem::new(
                         "Default (macOS)",
-                        TitleBar::new("macos")
+                        TitleBar::new("macos", Box::new(NoAction))
                             .platform_style(PlatformStyle::Mac)
                             .map(add_sample_children),
                     )
@@ -31,7 +31,7 @@ impl Render for TitleBarStory {
                 StorySection::new().child(
                     StoryItem::new(
                         "Default (Linux)",
-                        TitleBar::new("linux")
+                        TitleBar::new("linux", Box::new(NoAction))
                             .platform_style(PlatformStyle::Linux)
                             .map(add_sample_children),
                     )
@@ -43,7 +43,7 @@ impl Render for TitleBarStory {
                 StorySection::new().child(
                     StoryItem::new(
                         "Default (Windows)",
-                        TitleBar::new("windows")
+                        TitleBar::new("windows", Box::new(NoAction))
                             .platform_style(PlatformStyle::Windows)
                             .map(add_sample_children),
                     )

--- a/crates/ui/src/components/title_bar.rs
+++ b/crates/ui/src/components/title_bar.rs
@@ -1,4 +1,5 @@
 mod title_bar;
 mod windows_window_controls;
+mod linux_window_controls;
 
 pub use title_bar::*;

--- a/crates/ui/src/components/title_bar.rs
+++ b/crates/ui/src/components/title_bar.rs
@@ -1,5 +1,5 @@
+mod linux_window_controls;
 mod title_bar;
 mod windows_window_controls;
-mod linux_window_controls;
 
 pub use title_bar::*;

--- a/crates/ui/src/components/title_bar/linux_window_controls.rs
+++ b/crates/ui/src/components/title_bar/linux_window_controls.rs
@@ -1,0 +1,132 @@
+use gpui::{prelude::*, Rgba, WindowAppearance};
+
+use crate::prelude::*;
+
+#[derive(IntoElement)]
+pub struct LinuxWindowControls {
+    button_height: Pixels,
+}
+
+impl LinuxWindowControls {
+    pub fn new(button_height: Pixels) -> Self {
+        Self { button_height }
+    }
+}
+
+impl RenderOnce for LinuxWindowControls {
+    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+        let close_button_hover_color = Rgba {
+            r: 232.0 / 255.0,
+            g: 17.0 / 255.0,
+            b: 32.0 / 255.0,
+            a: 1.0,
+        };
+
+        let button_hover_color = match cx.appearance() {
+            WindowAppearance::Light | WindowAppearance::VibrantLight => Rgba {
+                r: 0.1,
+                g: 0.1,
+                b: 0.1,
+                a: 0.2,
+            },
+            WindowAppearance::Dark | WindowAppearance::VibrantDark => Rgba {
+                r: 0.9,
+                g: 0.9,
+                b: 0.9,
+                a: 0.1,
+            },
+        };
+
+        div()
+            .id("linux-window-controls")
+            .flex()
+            .flex_row()
+            .justify_center()
+            .content_stretch()
+            .max_h(self.button_height)
+            .min_h(self.button_height)
+            .child(TitlebarButton::new(
+                "minimize",
+                TitlebarButtonType::Minimize,
+                button_hover_color,
+            ))
+            .child(TitlebarButton::new(
+                "maximize-or-restore",
+                if cx.is_maximized() {
+                    TitlebarButtonType::Restore
+                } else {
+                    TitlebarButtonType::Maximize
+                },
+                button_hover_color,
+            ))
+            .child(TitlebarButton::new(
+                "close",
+                TitlebarButtonType::Close,
+                close_button_hover_color,
+            ))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+enum TitlebarButtonType {
+    Minimize,
+    Restore,
+    Maximize,
+    Close,
+}
+
+#[derive(IntoElement)]
+struct TitlebarButton {
+    id: ElementId,
+    icon: TitlebarButtonType,
+    hover_background_color: Rgba,
+}
+
+impl TitlebarButton {
+    pub fn new(
+        id: impl Into<ElementId>,
+        icon: TitlebarButtonType,
+        hover_background_color: Rgba,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            icon,
+            hover_background_color,
+        }
+    }
+}
+
+impl RenderOnce for TitlebarButton {
+    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
+        let width = px(36.);
+
+        h_flex()
+            .id(self.id)
+            .justify_center()
+            .content_center()
+            .w(width)
+            .h_full()
+            .hover(|style| style.bg(self.hover_background_color))
+            .active(|style| {
+                let mut active_color = self.hover_background_color;
+                active_color.a *= 0.2;
+
+                style.bg(active_color)
+            })
+            .child(Icon::new(match self.icon {
+                TitlebarButtonType::Minimize => IconName::Dash,
+                TitlebarButtonType::Restore => IconName::Minimize,
+                TitlebarButtonType::Maximize => IconName::Maximize,
+                TitlebarButtonType::Close => IconName::Close,
+            }))
+            .on_click(move |_, cx| {
+                cx.stop_propagation();
+                match self.icon {
+                    TitlebarButtonType::Minimize => cx.minimize_window(),
+                    TitlebarButtonType::Restore => cx.zoom_window(),
+                    TitlebarButtonType::Maximize => cx.zoom_window(),
+                    TitlebarButtonType::Close => cx.quit(),
+                }
+            })
+    }
+}

--- a/crates/ui/src/components/title_bar/linux_window_controls.rs
+++ b/crates/ui/src/components/title_bar/linux_window_controls.rs
@@ -129,6 +129,7 @@ impl RenderOnce for TitlebarButton {
                 TitlebarButtonType::Maximize => IconName::Maximize,
                 TitlebarButtonType::Close => IconName::Close,
             }))
+            .on_mouse_move(|_, cx| cx.stop_propagation())
             .on_click(move |_, cx| {
                 cx.stop_propagation();
                 match self.icon {

--- a/crates/ui/src/components/title_bar/linux_window_controls.rs
+++ b/crates/ui/src/components/title_bar/linux_window_controls.rs
@@ -125,7 +125,8 @@ impl RenderOnce for TitlebarButton {
                     TitlebarButtonType::Minimize => cx.minimize_window(),
                     TitlebarButtonType::Restore => cx.zoom_window(),
                     TitlebarButtonType::Maximize => cx.zoom_window(),
-                    TitlebarButtonType::Close => cx.quit(),
+                    // TODO: trigger unsaved changes dialog
+                    TitlebarButtonType::Close => cx.remove_window(),
                 }
             })
     }

--- a/crates/ui/src/components/title_bar/title_bar.rs
+++ b/crates/ui/src/components/title_bar/title_bar.rs
@@ -1,6 +1,7 @@
 use gpui::{AnyElement, Interactivity, Stateful};
 use smallvec::SmallVec;
 
+use crate::components::title_bar::linux_window_controls::LinuxWindowControls;
 use crate::components::title_bar::windows_window_controls::WindowsWindowControls;
 use crate::prelude::*;
 
@@ -110,6 +111,20 @@ impl RenderOnce for TitleBar {
             .when(
                 self.platform_style == PlatformStyle::Windows && !cx.is_fullscreen(),
                 |title_bar| title_bar.child(WindowsWindowControls::new(height)),
+            )
+            .when(
+                self.platform_style == PlatformStyle::Linux && !cx.is_fullscreen() && cx.should_render_window_controls(),
+                |title_bar| {
+                    title_bar
+                        .child(LinuxWindowControls::new(height))
+                        .on_mouse_down(gpui::MouseButton::Left, move |_, cx| cx.mark_moving())
+                        .on_mouse_move(move |ev, cx| {
+                            if ev.dragging() {
+                                cx.start_moving();
+                            }
+                        })
+                        .on_mouse_up(gpui::MouseButton::Left, move |_, cx| cx.stop_moving())
+                },
             )
     }
 }

--- a/crates/ui/src/components/title_bar/title_bar.rs
+++ b/crates/ui/src/components/title_bar/title_bar.rs
@@ -119,6 +119,9 @@ impl RenderOnce for TitleBar {
                 |title_bar| {
                     title_bar
                         .child(LinuxWindowControls::new(height))
+                        .on_mouse_down(gpui::MouseButton::Right, move |ev, cx| {
+                            cx.show_window_menu(ev.position)
+                        })
                         .on_mouse_move(move |ev, cx| {
                             if ev.dragging() {
                                 cx.start_system_move();

--- a/crates/ui/src/components/title_bar/title_bar.rs
+++ b/crates/ui/src/components/title_bar/title_bar.rs
@@ -1,4 +1,4 @@
-use gpui::{AnyElement, Interactivity, Stateful};
+use gpui::{Action, AnyElement, Interactivity, Stateful};
 use smallvec::SmallVec;
 
 use crate::components::title_bar::linux_window_controls::LinuxWindowControls;
@@ -10,6 +10,7 @@ pub struct TitleBar {
     platform_style: PlatformStyle,
     content: Stateful<Div>,
     children: SmallVec<[AnyElement; 2]>,
+    close_window_action: Box<dyn Action>,
 }
 
 impl TitleBar {
@@ -46,11 +47,12 @@ impl TitleBar {
         }
     }
 
-    pub fn new(id: impl Into<ElementId>) -> Self {
+    pub fn new(id: impl Into<ElementId>, close_window_action: Box<dyn Action>) -> Self {
         Self {
             platform_style: PlatformStyle::platform(),
             content: div().id(id.into()),
             children: SmallVec::new(),
+            close_window_action,
         }
     }
 
@@ -118,7 +120,7 @@ impl RenderOnce for TitleBar {
                     && cx.should_render_window_controls(),
                 |title_bar| {
                     title_bar
-                        .child(LinuxWindowControls::new(height))
+                        .child(LinuxWindowControls::new(height, self.close_window_action))
                         .on_mouse_down(gpui::MouseButton::Right, move |ev, cx| {
                             cx.show_window_menu(ev.position)
                         })

--- a/crates/ui/src/components/title_bar/title_bar.rs
+++ b/crates/ui/src/components/title_bar/title_bar.rs
@@ -113,17 +113,17 @@ impl RenderOnce for TitleBar {
                 |title_bar| title_bar.child(WindowsWindowControls::new(height)),
             )
             .when(
-                self.platform_style == PlatformStyle::Linux && !cx.is_fullscreen() && cx.should_render_window_controls(),
+                self.platform_style == PlatformStyle::Linux
+                    && !cx.is_fullscreen()
+                    && cx.should_render_window_controls(),
                 |title_bar| {
                     title_bar
                         .child(LinuxWindowControls::new(height))
-                        .on_mouse_down(gpui::MouseButton::Left, move |_, cx| cx.mark_moving())
                         .on_mouse_move(move |ev, cx| {
                             if ev.dragging() {
-                                cx.start_moving();
+                                cx.start_system_move();
                             }
                         })
-                        .on_mouse_up(gpui::MouseButton::Left, move |_, cx| cx.stop_moving())
                 },
             )
     }


### PR DESCRIPTION
Based on https://github.com/zed-industries/zed/pull/11046

- Partially fixes #10346 
- Fixes https://github.com/zed-industries/zed/issues/9964

## Features
Window buttons
![image](https://github.com/zed-industries/zed/assets/71973804/1b7e0504-3925-45ba-90b5-5adb55e0d739)

Window drag
![image](https://github.com/zed-industries/zed/assets/71973804/9c509a37-e5a5-484c-9f80-c722aeee4380)

Native window context menu
![image](https://github.com/zed-industries/zed/assets/71973804/048ecf52-e277-49bb-a106-91cad226fd8a)

### Limitations

- No resizing
- Wayland only (though X11 always has window decorations)

### Technical

This PR adds three APIs to gpui.

1. `show_window_menu`: Triggers the native title bar context menu.
2.  `start_system_move`: Tells the compositor to start dragging the window.
3. `should_render_window_controls`: Whether the compositor doesn't support server side decorations.

These APIs have only been implemented for Wayland, but they should be portable to other platforms.

Release Notes:

- N/A
