### PR TITLE
Take local project settings into account when launching terminals

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -31,25 +31,18 @@ impl Project {
             "creating terminals as a guest is not supported yet"
         );
 
-        let cwd = working_directory
-            .as_deref()
-            .or_else(|| {
-                spawn_task
-                    .as_ref()
-                    .and_then(|spawn_task| spawn_task.cwd.as_deref())
-            });
+        let cwd = working_directory.as_deref().or_else(|| {
+            spawn_task
+                .as_ref()
+                .and_then(|spawn_task| spawn_task.cwd.as_deref())
+        });
 
-        let worktree = cwd
-            .and_then(|cwd| {
-                self.find_local_worktree(cwd, cx)
-            });
+        let worktree = cwd.and_then(|cwd| self.find_local_worktree(cwd, cx));
 
-        let settings_location = worktree
-            .as_ref()
-            .map(|(worktree, path)| SettingsLocation {
-                worktree_id: worktree.read(cx).id().to_usize(),
-                path
-            });
+        let settings_location = worktree.as_ref().map(|(worktree, path)| SettingsLocation {
+            worktree_id: worktree.read(cx).id().to_usize(),
+            path,
+        });
 
         let is_terminal = spawn_task.is_none();
         let settings = TerminalSettings::get(settings_location, cx);

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -31,20 +31,24 @@ impl Project {
             "creating terminals as a guest is not supported yet"
         );
 
-        let working_directory = working_directory
-            .or_else(|| spawn_task.as_ref().and_then(|spawn_task| spawn_task.cwd.clone()));
+        let cwd = working_directory
+            .as_deref()
+            .or_else(|| {
+                spawn_task
+                    .as_ref()
+                    .and_then(|spawn_task| spawn_task.cwd.as_deref())
+            });
 
-        let worktree = working_directory
-            .as_ref()
-            .and_then(|working_directory| {
-                self.find_local_worktree(working_directory, cx)
+        let worktree = cwd
+            .and_then(|cwd| {
+                self.find_local_worktree(cwd, cx)
             });
 
         let settings_location = worktree
             .as_ref()
             .map(|(worktree, path)| SettingsLocation {
                 worktree_id: worktree.read(cx).id().to_usize(),
-                path: &path
+                path
             });
 
         let is_terminal = spawn_task.is_none();

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -1,7 +1,7 @@
 use crate::Project;
 use collections::HashMap;
 use gpui::{AnyWindowHandle, Context, Entity, Model, ModelContext, WeakModel};
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use smol::channel::bounded;
 use std::path::{Path, PathBuf};
 use task::SpawnInTerminal;
@@ -21,6 +21,7 @@ pub struct Terminals {
 impl Project {
     pub fn create_terminal(
         &mut self,
+        settings_location: Option<SettingsLocation>,
         working_directory: Option<PathBuf>,
         spawn_task: Option<SpawnInTerminal>,
         window: AnyWindowHandle,
@@ -32,7 +33,7 @@ impl Project {
         );
 
         let is_terminal = spawn_task.is_none();
-        let settings = TerminalSettings::get_global(cx);
+        let settings = TerminalSettings::get(settings_location, cx);
         let python_settings = settings.detect_venv.clone();
         let (completion_tx, completion_rx) = bounded(1);
 

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use project::{Fs, ProjectEntryId};
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
 use serde::{Deserialize, Serialize};
-use settings::{Settings, SettingsLocation};
+use settings::Settings;
 use task::{RevealStrategy, SpawnInTerminal, TaskId};
 use terminal::terminal_settings::{Shell, TerminalDockPosition, TerminalSettings};
 use ui::{
@@ -508,25 +508,10 @@ impl TerminalPanel {
                     crate::get_working_directory(workspace, cx, working_directory_strategy)
                 };
 
-                let found_local_worktree = if let Some(working_directory) = working_directory.as_ref() {
-                    workspace.project().read(cx).find_local_worktree(working_directory, cx)
-                } else {
-                    None
-                };
-
-                let settings_location = if let Some((worktree, path)) = found_local_worktree.as_ref() {
-                    Some(SettingsLocation {
-                        worktree_id: worktree.read_with(cx, |worktree, _| worktree.id().to_usize()),
-                        path
-                    })
-                } else {
-                    None
-                };
-
                 let window = cx.window_handle();
                 if let Some(terminal) = workspace.project().update(cx, |project, cx| {
                     project
-                        .create_terminal(settings_location, working_directory, spawn_task, window, cx)
+                        .create_terminal(working_directory, spawn_task, window, cx)
                         .log_err()
                 }) {
                     let terminal = Box::new(cx.new_view(|cx| {
@@ -612,26 +597,11 @@ impl TerminalPanel {
             .update(cx, |workspace, _| workspace.project().clone())
             .ok()?;
 
-        let found_local_worktree = if let Some(working_directory) = working_directory.as_ref() {
-            project.read(cx).find_local_worktree(working_directory, cx)
-        } else {
-            None
-        };
-
-        let settings_location = if let Some((worktree, path)) = found_local_worktree.as_ref() {
-            Some(SettingsLocation {
-                worktree_id: worktree.read_with(cx, |worktree, _| worktree.id().to_usize()),
-                path
-            })
-        } else {
-            None
-        };
-
         let reveal = spawn_task.reveal;
         let window = cx.window_handle();
         let new_terminal = project.update(cx, |project, cx| {
             project
-                .create_terminal(settings_location, working_directory, Some(spawn_task), window, cx)
+                .create_terminal(working_directory, Some(spawn_task), window, cx)
                 .log_err()
         })?;
         terminal_to_replace.update(cx, |terminal_to_replace, cx| {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use project::{Fs, ProjectEntryId};
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
 use serde::{Deserialize, Serialize};
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use task::{RevealStrategy, SpawnInTerminal, TaskId};
 use terminal::terminal_settings::{Shell, TerminalDockPosition, TerminalSettings};
 use ui::{
@@ -508,10 +508,25 @@ impl TerminalPanel {
                     crate::get_working_directory(workspace, cx, working_directory_strategy)
                 };
 
+                let found_local_worktree = if let Some(working_directory) = working_directory.as_ref() {
+                    workspace.project().read(cx).find_local_worktree(working_directory, cx)
+                } else {
+                    None
+                };
+
+                let settings_location = if let Some((worktree, path)) = found_local_worktree.as_ref() {
+                    Some(SettingsLocation {
+                        worktree_id: worktree.read_with(cx, |worktree, _| worktree.id().to_usize()),
+                        path
+                    })
+                } else {
+                    None
+                };
+
                 let window = cx.window_handle();
                 if let Some(terminal) = workspace.project().update(cx, |project, cx| {
                     project
-                        .create_terminal(working_directory, spawn_task, window, cx)
+                        .create_terminal(settings_location, working_directory, spawn_task, window, cx)
                         .log_err()
                 }) {
                     let terminal = Box::new(cx.new_view(|cx| {
@@ -596,11 +611,27 @@ impl TerminalPanel {
             .workspace
             .update(cx, |workspace, _| workspace.project().clone())
             .ok()?;
+
+        let found_local_worktree = if let Some(working_directory) = working_directory.as_ref() {
+            project.read(cx).find_local_worktree(working_directory, cx)
+        } else {
+            None
+        };
+
+        let settings_location = if let Some((worktree, path)) = found_local_worktree.as_ref() {
+            Some(SettingsLocation {
+                worktree_id: worktree.read_with(cx, |worktree, _| worktree.id().to_usize()),
+                path
+            })
+        } else {
+            None
+        };
+
         let reveal = spawn_task.reveal;
         let window = cx.window_handle();
         let new_terminal = project.update(cx, |project, cx| {
             project
-                .create_terminal(working_directory, Some(spawn_task), window, cx)
+                .create_terminal(settings_location, working_directory, Some(spawn_task), window, cx)
                 .log_err()
         })?;
         terminal_to_replace.update(cx, |terminal_to_replace, cx| {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -13,7 +13,7 @@ use gpui::{
 use language::Bias;
 use persistence::TERMINAL_DB;
 use project::{search::SearchQuery, Fs, LocalWorktree, Metadata, Project};
-use settings::{SettingsLocation, SettingsStore};
+use settings::SettingsStore;
 use terminal::{
     alacritty_terminal::{
         index::Point,
@@ -117,26 +117,11 @@ impl TerminalView {
         let working_directory =
             get_working_directory(workspace, cx, strategy.working_directory.clone());
 
-        let found_local_worktree = if let Some(working_directory) = working_directory.as_ref() {
-            workspace.project().read(cx).find_local_worktree(working_directory, cx)
-        } else {
-            None
-        };
-
-        let settings_location = if let Some((worktree, path)) = found_local_worktree.as_ref() {
-            Some(SettingsLocation {
-                worktree_id: worktree.read_with(cx, |worktree, _| worktree.id().to_usize()),
-                path
-            })
-        } else {
-            None
-        };
-
         let window = cx.window_handle();
         let terminal = workspace
             .project()
             .update(cx, |project, cx| {
-                project.create_terminal(settings_location, working_directory, None, window, cx)
+                project.create_terminal(working_directory, None, window, cx)
             })
             .notify_err(workspace, cx);
 
@@ -909,25 +894,8 @@ impl Item for TerminalView {
                 })
                 .filter(|cwd| !cwd.as_os_str().is_empty());
 
-            let found_local_worktree = if let Some(working_directory) = cwd.as_ref() {
-                cx.update(|cx| {
-                    project.read(cx).find_local_worktree(working_directory, cx)
-                        .map(|(worktree, path)| (worktree.read_with(cx, |worktree, _| worktree.id().to_usize()), path))
-                })
-                    .ok()
-                    .flatten()
-            } else {
-                None
-            };
-
-            let settings_location = if let Some(&(worktree_id, ref path)) = found_local_worktree.as_ref() {
-                Some(SettingsLocation { worktree_id, path })
-            } else {
-                None
-            };
-
             let terminal = project.update(&mut cx, |project, cx| {
-                project.create_terminal(settings_location, cwd, None, window, cx)
+                project.create_terminal(cwd, None, window, cx)
             })??;
             pane.update(&mut cx, |_, cx| {
                 cx.new_view(|cx| TerminalView::new(terminal, workspace, workspace_id, cx))


### PR DESCRIPTION
Allows you to define per-project shells, for example.

Fixes #7599

Release Notes:

- Fixed terminals always using the global shell even when local settings specified a different shell.