### PR TITLE
blade: Switch to linear color space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "blade-graphics"
 version = "0.4.0"
-source = "git+https://github.com/kvark/blade?rev=f5766863de9dcc092e90fdbbc5e0007a99e7f9bf#f5766863de9dcc092e90fdbbc5e0007a99e7f9bf"
+source = "git+https://github.com/kvark/blade?rev=e35b2d41f221a48b75f7cf2e78a81e7ecb7a383c#e35b2d41f221a48b75f7cf2e78a81e7ecb7a383c"
 dependencies = [
  "ash",
  "ash-window",
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "blade-macros"
 version = "0.2.1"
-source = "git+https://github.com/kvark/blade?rev=f5766863de9dcc092e90fdbbc5e0007a99e7f9bf#f5766863de9dcc092e90fdbbc5e0007a99e7f9bf"
+source = "git+https://github.com/kvark/blade?rev=e35b2d41f221a48b75f7cf2e78a81e7ecb7a383c#e35b2d41f221a48b75f7cf2e78a81e7ecb7a383c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,8 +256,8 @@ async-recursion = "1.0.0"
 async-tar = "0.4.2"
 async-trait = "0.1"
 bitflags = "2.4.2"
-blade-graphics = { git = "https://github.com/kvark/blade", rev = "f5766863de9dcc092e90fdbbc5e0007a99e7f9bf" }
-blade-macros = { git = "https://github.com/kvark/blade", rev = "f5766863de9dcc092e90fdbbc5e0007a99e7f9bf" }
+blade-graphics = { git = "https://github.com/kvark/blade", rev = "e35b2d41f221a48b75f7cf2e78a81e7ecb7a383c" }
+blade-macros = { git = "https://github.com/kvark/blade", rev = "e35b2d41f221a48b75f7cf2e78a81e7ecb7a383c" }
 cap-std = "3.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -162,7 +162,7 @@ impl BladeAtlasState {
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
             }
             AtlasTextureKind::Polychrome => {
-                format = gpu::TextureFormat::Bgra8Unorm;
+                format = gpu::TextureFormat::Bgra8UnormSrgb;
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
             }
             AtlasTextureKind::Path => {

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -360,9 +360,7 @@ impl BladeRenderer {
             size: config.size,
             usage: gpu::TextureUsage::TARGET,
             display_sync: gpu::DisplaySync::Recent,
-            //Note: this matches the original logic of the Metal backend,
-            // but ultimaterly we need to switch to `Linear`.
-            color_space: gpu::ColorSpace::Srgb,
+            color_space: gpu::ColorSpace::Linear,
             allow_exclusive_full_screen: false,
             transparent: config.transparent,
         };


### PR DESCRIPTION
Release Notes:

- N/A

## What

Addresses a long-standing issue of doing the blending operations in sRGB space. Currently, the input HSL colors are provided in sRGB space and converted to linear in the vertex shader. Conversion back to sRGB, which is required on most platforms today, happens at the very end of the pipeline when writing into sRGB render target.

Note-1: in the future we may consider doing HSL -> sRGB -> Linear transform on CPU before feeding into shaders. However, I don't expect any significant difference here given that we are likely bound by fill rate and pixel shaders, anyway.

Note-2: the graphics stack is programmed to detect if the platform supports presenting in linear color space and avoids converting to sRGB at the end in this case. However, on my Z13 laptop this isn't supported by the RADV driver.

Closes #7684 
Closes #11462
@jansol please confirm if you can!

## Comparison

Screenshot of the Glazier theme before the change:
![glazier-old](https://github.com/zed-industries/zed/assets/107301/6a9552e1-0819-4a4e-8121-8d62ec012bf4)
Same theme after the change:
![glazier-new](https://github.com/zed-industries/zed/assets/107301/4e61c422-4a4b-4c4b-84a3-55680626d681)
