### PR TITLE
go: support highlight regexp

### DIFF
--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -1,0 +1,13 @@
+; Refer to https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/go/injections.scm#L4C1-L16C41
+(call_expression
+  (selector_expression) @_function
+  (#any-of? @_function
+    "regexp.Match" "regexp.MatchReader" "regexp.MatchString" "regexp.Compile" "regexp.CompilePOSIX"
+    "regexp.MustCompile" "regexp.MustCompilePOSIX")
+  (argument_list
+    .
+    [
+      (raw_string_literal)
+      (interpreted_string_literal)
+    ] @content
+    (#set! "language" "regex")))


### PR DESCRIPTION
Before:
<img width="521" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/7b87e552-0cf0-4168-933f-21d1ae84bf64">

After:
<img width="499" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/f1171375-8c22-4186-a5f1-1bdfa56cf01f">

Release Notes:

- Added go regexp highligh
