### PR TITLE
Make `prefer_line` the default soft-wrap behavior.

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -370,11 +370,13 @@
   //
   // 1. Do not soft wrap.
   //      "soft_wrap": "none",
-  // 2. Soft wrap lines that overflow the editor:
+  // 2. Prefer a single line generally, unless an overly long line is encountered.
+  //      "soft_wrap": "prefer_line",
+  // 3. Soft wrap lines that overflow the editor:
   //      "soft_wrap": "editor_width",
-  // 3. Soft wrap lines at the preferred line length
+  // 4. Soft wrap lines at the preferred line length
   //      "soft_wrap": "preferred_line_length",
-  "soft_wrap": "none",
+  "soft_wrap": "prefer_line",
   // The column at which to soft-wrap lines, for buffers where soft-wrap
   // is enabled.
   "preferred_line_length": 80,
@@ -598,7 +600,12 @@
       "format_on_save": "off"
     },
     "Elixir": {
-      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": [
+        "elixir-ls",
+        "!next-ls",
+        "!lexical",
+        "..."
+      ]
     },
     "Gleam": {
       "tab_size": 2
@@ -609,7 +616,12 @@
       }
     },
     "HEEX": {
-      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": [
+        "elixir-ls",
+        "!next-ls",
+        "!lexical",
+        "..."
+      ]
     },
     "Make": {
       "hard_tabs": true


### PR DESCRIPTION
Stops lines from clipping at 1024 by default, returning it to the old default behaviour where it wraps at 512. The `none` mode is only supposed to be used for git hunks. See https://github.com/zed-industries/zed/issues/11518#issuecomment-2099836283.

Release Notes:

- N/A
