### PR TITLE
editor: Fix menu::Confirm falling through to editor when confirming task entry in code actions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3983,7 +3983,7 @@ impl Editor {
                         cx,
                     );
 
-                    None
+                    Some(Task::ready(Ok(())))
                 })
             }
             CodeActionsItem::CodeAction(action) => {


### PR DESCRIPTION

Release Notes:

- N/A
