### PR TITLE
windows: Let IME early return in vim mode

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -585,7 +585,10 @@ fn handle_ime_position(handle: HWND, state_ptr: Rc<WindowsWindowStatePtr>) -> Op
         let scale_factor = lock.scale_factor;
         drop(lock);
 
-        let caret_range = input_handler.selected_text_range().unwrap_or_default();
+        let Some(caret_range) = input_handler.selected_text_range() else {
+            state_ptr.state.borrow_mut().input_handler = Some(input_handler);
+            return Some(0);
+        };
         let caret_position = input_handler.bounds_for_range(caret_range).unwrap();
         state_ptr.state.borrow_mut().input_handler = Some(input_handler);
         let config = CANDIDATEFORM {


### PR DESCRIPTION
This PR follows up #11387 , slightly changes the IME window behavior to match macOS implementation.

Release Notes:

- N/A
