### PR TITLE
windows: Remove using `DCompositionWaitForCompositorClock`

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -827,14 +827,14 @@ fn end_vsync_timer(timer_stop_event: HANDLE) {
 }
 
 fn select_vsync_fn() -> Box<dyn Fn(HANDLE) -> bool + Send> {
-    if let Some(dcomp_fn) = load_dcomp_vsync_fn() {
-        log::info!("use DCompositionWaitForCompositorClock for vsync");
-        return Box::new(move |timer_stop_event| {
-            // will be 0 if woken up by timer_stop_event or 1 if the compositor clock ticked
-            // SEE: https://learn.microsoft.com/en-us/windows/win32/directcomp/compositor-clock/compositor-clock
-            (unsafe { dcomp_fn(1, &timer_stop_event, INFINITE) }) == 1
-        });
-    }
+    // if let Some(dcomp_fn) = load_dcomp_vsync_fn() {
+    //     log::info!("use DCompositionWaitForCompositorClock for vsync");
+    //     return Box::new(move |timer_stop_event| {
+    //         // will be 0 if woken up by timer_stop_event or 1 if the compositor clock ticked
+    //         // SEE: https://learn.microsoft.com/en-us/windows/win32/directcomp/compositor-clock/compositor-clock
+    //         (unsafe { dcomp_fn(1, &timer_stop_event, INFINITE) }) == 1
+    //     });
+    // }
     log::info!("use fallback vsync function");
     Box::new(fallback_vsync_fn())
 }


### PR DESCRIPTION
1. Zed unreponse after every time windows wake up from sleep, I must closed then reopen.
2.  I have debug origin implement before #9351, in win11 Zed work well.
3. If i remove using `DCompositionWaitForCompositorClock`, everything work well.
4. I don't known what happened, wake up from sleep this [thread](https://github.com/zed-industries/zed/blob/ca680f07f7e48e75dd5d88fafd96b492bde201f8/crates/gpui/src/platform/windows/platform.rs#L817) not workding. If someone have experience? Or, remove using `DCompositionWaitForCompositorClock`?


Release Notes:

- N/A
