### PR TITLE
docs: Fix default value for `formatter` setting

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -406,7 +406,7 @@ To override settings for a language, add an entry for that language server's nam
 
 - Description: How to perform a buffer format.
 - Setting: `formatter`
-- Default: `language_server`
+- Default: `auto`
 
 **Options**
 


### PR DESCRIPTION
This PR fixes the default value for the `formatter` setting listed in the docs.

The default value is `"auto"`: https://github.com/zed-industries/zed/blob/194c43b84b4c2b0f2e78d8ef533bb99b6916f38c/assets/settings/default.json#L367

Resolves #11468.

Release Notes:

- N/A
