### PR TITLE
Render messages as early as possible to show progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "serde_json",
  "settings",
  "sum_tree",
+ "ui",
  "unindent",
  "util",
 ]

--- a/crates/assistant2/src/assistant2.rs
+++ b/crates/assistant2/src/assistant2.rs
@@ -16,7 +16,8 @@ use crate::{
 use ::ui::{div, prelude::*, Color, Tooltip, ViewContext};
 use anyhow::{Context, Result};
 use assistant_tooling::{
-    AttachmentRegistry, ProjectContext, ToolFunctionCall, ToolRegistry, UserAttachment,
+    tool_running_placeholder, AttachmentRegistry, ProjectContext, ToolFunctionCall, ToolRegistry,
+    UserAttachment,
 };
 use client::{proto, Client, UserStore};
 use collections::HashMap;
@@ -862,6 +863,10 @@ impl AssistantChat {
                     if !tools.is_empty() {
                         message_elements.push(div().children(tools).into_any_element())
                     }
+                }
+
+                if message_elements.is_empty() {
+                    message_elements.push(tool_running_placeholder());
                 }
 
                 div()

--- a/crates/assistant2/src/tools/project_index.rs
+++ b/crates/assistant2/src/tools/project_index.rs
@@ -6,6 +6,7 @@ use project::ProjectPath;
 use schemars::JsonSchema;
 use semantic_index::{ProjectIndex, Status};
 use serde::Deserialize;
+use serde_json::Value;
 use std::{fmt::Write as _, ops::Range};
 use ui::{div, prelude::*, CollapsibleContainer, Color, Icon, IconName, Label, WindowContext};
 
@@ -202,8 +203,14 @@ impl LanguageModelTool for ProjectIndexTool {
         cx.new_view(|_cx| ProjectIndexView::new(input, output))
     }
 
-    fn render_running(_: &mut WindowContext) -> impl IntoElement {
-        CollapsibleContainer::new(ElementId::Name(nanoid::nanoid!().into()), false)
-            .start_slot("Searching code base")
+    fn render_running(arguments: &Option<Value>, _: &mut WindowContext) -> impl IntoElement {
+        let text: String = arguments
+            .as_ref()
+            .and_then(|arguments| arguments.get("query"))
+            .and_then(|query| query.as_str())
+            .map(|query| format!("Searching for: {}", query))
+            .unwrap_or_else(|| "Preparing search...".to_string());
+
+        CollapsibleContainer::new(ElementId::Name(nanoid::nanoid!().into()), false).start_slot(text)
     }
 }

--- a/crates/assistant_tooling/Cargo.toml
+++ b/crates/assistant_tooling/Cargo.toml
@@ -21,6 +21,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sum_tree.workspace = true
+ui.workspace = true
 util.workspace = true
 
 [dev-dependencies]

--- a/crates/assistant_tooling/src/assistant_tooling.rs
+++ b/crates/assistant_tooling/src/assistant_tooling.rs
@@ -5,5 +5,6 @@ mod tool_registry;
 pub use attachment_registry::{AttachmentRegistry, LanguageModelAttachment, UserAttachment};
 pub use project_context::ProjectContext;
 pub use tool_registry::{
-    LanguageModelTool, ToolFunctionCall, ToolFunctionDefinition, ToolOutput, ToolRegistry,
+    tool_running_placeholder, LanguageModelTool, ToolFunctionCall, ToolFunctionDefinition,
+    ToolOutput, ToolRegistry,
 };


### PR DESCRIPTION
This shows "Researching..." as placeholder text as early as possible so that the user can see the model is working on reading/researching/etc.

This also adds on an `Option<Value>` to the `render_running` function so that tools can hopefully render based on partially completed JSON (still to come).

Release Notes:

- N/A
