### PR TITLE
Make Markdown default to `"format_on_save": "off"`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -628,6 +628,9 @@
     "Make": {
       "hard_tabs": true
     },
+    "Markdown": {
+      "format_on_save": "off"
+    },
     "Prisma": {
       "tab_size": 2
     }


### PR DESCRIPTION
This PR changes the Markdown language defaults to set `format_on_save` to be `off`.

Prettier's Markdown formatting is a bit controversial for some people, so we turn it off by default.

To restore the previous behavior, add the following to your settings:

```json
{
  "languages": {
    "Markdown": {
      "format_on_save": "on"
    }
  }
}
```


Release Notes:

- Changed the default `format_on_save` behavior for Markdown files to be `off`.
