### PR TITLE
windows: Fix `Zed` freezing when resuming from sleep

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -813,8 +813,8 @@ unsafe fn show_savefile_dialog(directory: PathBuf) -> Result<IFileSaveDialog> {
 
 fn begin_vsync_timer(vsync_event: HANDLE, timer_stop_event: OwnedHandle) {
     let vsync_fn = select_vsync_fn();
-    std::thread::spawn(move || {
-        while vsync_fn(timer_stop_event.to_raw()) {
+    std::thread::spawn(move || loop {
+        if vsync_fn(timer_stop_event.to_raw()) {
             if unsafe { SetEvent(vsync_event) }.log_err().is_none() {
                 break;
             }


### PR DESCRIPTION
It seems that on the first frame after the system resumes from sleep, `dcomp_vsync_fn` mistakenly detects the `timer_stop_event` triggering and exits the loop.

Release Notes:

- N/A
