### PR TITLE
editor: Do not show test indicators if a line is folded

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1407,7 +1407,10 @@ impl EditorElement {
             editor
                 .tasks
                 .keys()
-                .map(|row| {
+                .filter_map(|row| {
+                    if snapshot.is_line_folded(*row) {
+                        return None;
+                    }
                     let button = editor.render_run_indicator(
                         &self.style,
                         Some(*row) == active_task_indicator_row,
@@ -1426,7 +1429,7 @@ impl EditorElement {
                         gutter_hitbox,
                         cx,
                     );
-                    button
+                    Some(button)
                 })
                 .collect_vec()
         })


### PR DESCRIPTION
Originally reported by @RemcoSmitsDev



Release Notes:

- N/A
