### PR TITLE
chore: Bump taffy version to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4654,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df00eed8d1f0db937f6be10e46e8072b0671accb504cf0f959c5c52c679f5b9"
+checksum = "d196ffc1627db18a531359249b2bf8416178d84b729f3cebeb278f285fb9b58c"
 
 [[package]]
 name = "group"
@@ -9895,12 +9895,14 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.3.11"
-source = "git+https://github.com/DioxusLabs/taffy?rev=1876f72bee5e376023eaa518aa7b8a34c769bd1b#1876f72bee5e376023eaa518aa7b8a34c769bd1b"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2e140b328c6cb5e744bb2c65910b47df86b239afc793ee2c52262569cf9225"
 dependencies = [
  "arrayvec",
  "grid",
  "num-traits",
+ "serde",
  "slotmap",
 ]
 

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -61,7 +61,7 @@ slotmap = "1.0.6"
 smallvec.workspace = true
 smol.workspace = true
 sum_tree.workspace = true
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1876f72bee5e376023eaa518aa7b8a34c769bd1b" }
+taffy = "0.4.3"
 thiserror.workspace = true
 time.workspace = true
 util.workspace = true

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -9,14 +9,14 @@ use taffy::{
     geometry::{Point as TaffyPoint, Rect as TaffyRect, Size as TaffySize},
     style::AvailableSpace as TaffyAvailableSpace,
     tree::NodeId,
-    Taffy,
+    TaffyTree, TraversePartialTree as _,
 };
 
 type NodeMeasureFn =
     Box<dyn FnMut(Size<Option<Pixels>>, Size<AvailableSpace>, &mut WindowContext) -> Size<Pixels>>;
 
 pub struct TaffyLayoutEngine {
-    taffy: Taffy,
+    taffy: TaffyTree<()>,
     styles: FxHashMap<LayoutId, Style>,
     children_to_parents: FxHashMap<LayoutId, LayoutId>,
     absolute_layout_bounds: FxHashMap<LayoutId, Bounds<Pixels>>,
@@ -29,7 +29,7 @@ static EXPECT_MESSAGE: &str = "we should avoid taffy layout errors by constructi
 impl TaffyLayoutEngine {
     pub fn new() -> Self {
         TaffyLayoutEngine {
-            taffy: Taffy::new(),
+            taffy: TaffyTree::new(),
             styles: FxHashMap::default(),
             children_to_parents: FxHashMap::default(),
             absolute_layout_bounds: FxHashMap::default(),
@@ -114,7 +114,7 @@ impl TaffyLayoutEngine {
     fn max_depth(&self, depth: u32, parent: LayoutId) -> anyhow::Result<u32> {
         println!(
             "{parent:?} at depth {depth} has {} children",
-            self.taffy.child_count(parent.0)?
+            self.taffy.child_count(parent.0)
         );
 
         let mut max_child_depth = 0;


### PR DESCRIPTION
Taffy 0.4 has been released 2 months ago. We've been using an older commit from their 0.4 development branch since November.
Compared to the commit we were pinned to, the following relevant changes have been made:
- https://github.com/DioxusLabs/taffy/commit/563d5dcee7b9138b4c3f865155d036a8b7597e65
- https://github.com/DioxusLabs/taffy/commit/64f8aa0fb114d939ca0d53ddc44045a03fde548d
- https://github.com/DioxusLabs/taffy/commit/70b35712a2e79b6fdfef4cff4392ca94287cd0b1
![image](https://github.com/zed-industries/zed/assets/24362066/ffdfae03-2743-496f-bb21-7aa38462178f)

Release Notes:

- N/A
