### PR TITLE
copilot: Update root path on Windows

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -429,11 +429,17 @@ impl Copilot {
                     env: None,
                 };
 
+                let root_path = if cfg!(target_os = "windows") {
+                    Path::new("C:/")
+                } else {
+                    Path::new("/")
+                };
+
                 let server = LanguageServer::new(
                     Arc::new(Mutex::new(None)),
                     new_server_id,
                     binary,
-                    Path::new("/"),
+                    root_path,
                     None,
                     cx.clone(),
                 )?;


### PR DESCRIPTION
This PR updates the root path used by Copilot to be a validate path when running on Windows.

Release Notes:

- N/A
