### PR TITLE
vim: Fix e/E with inlay hints

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -721,6 +721,10 @@ impl DisplaySnapshot {
         DisplayPoint(clipped)
     }
 
+    pub fn clip_ignoring_line_ends(&self, point: DisplayPoint, bias: Bias) -> DisplayPoint {
+        DisplayPoint(self.block_snapshot.clip_point(point.0, bias))
+    }
+
     pub fn clip_at_line_end(&self, point: DisplayPoint) -> DisplayPoint {
         let mut point = point.0;
         if point.column == self.line_len(point.row) {

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1094,7 +1094,7 @@ pub(crate) fn next_char(
         *new_point.row_mut() += 1;
         *new_point.column_mut() = 0;
     }
-    new_point
+    map.clip_ignoring_line_ends(new_point, Bias::Right)
 }
 
 pub(crate) fn next_word_start(


### PR DESCRIPTION
Co-Authored-By: Sergey <sergey.b@hey.com>
Fixes: #7046

Release Notes:

- vim: Fixes e/E with inlay hints (#7046)
