### PR TITLE
vim: Support paste with count

### DIFF
--- a/crates/vim/test_data/test_paste_count.json
+++ b/crates/vim/test_data/test_paste_count.json
@@ -1,0 +1,13 @@
+{"Put":{"state":"onˇe\ntwo\nthree\n"}}
+{"Key":"y"}
+{"Key":"y"}
+{"Key":"3"}
+{"Key":"p"}
+{"Get":{"state":"one\nˇone\none\none\ntwo\nthree\n","mode":"Normal"}}
+{"Put":{"state":"one\nˇtwo\nthree\n"}}
+{"Key":"y"}
+{"Key":"$"}
+{"Key":"$"}
+{"Key":"3"}
+{"Key":"p"}
+{"Get":{"state":"one\ntwotwotwotwˇo\nthree\n","mode":"Normal"}}


### PR DESCRIPTION
Fixes: #10842



Release Notes:

- vim: Fix pasting with a count (#10842)
