### PR TITLE
Fix scrollbar markers for folded code

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9225,6 +9225,8 @@ impl Editor {
                     self.active_diagnostics = Some(active_diagnostics);
                 }
             }
+
+            self.scrollbar_marker_state.dirty = true;
         }
     }
 
@@ -9258,6 +9260,7 @@ impl Editor {
             }
 
             cx.notify();
+            self.scrollbar_marker_state.dirty = true;
         }
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2866,7 +2866,6 @@ impl EditorElement {
             let snapshot = layout.position_map.snapshot.clone();
             let theme = cx.theme().clone();
             let scrollbar_settings = EditorSettings::get_global(cx).scrollbar;
-            let max_row = layout.max_row;
 
             editor.scrollbar_marker_state.dirty = false;
             editor.scrollbar_marker_state.pending_refresh =
@@ -2875,12 +2874,12 @@ impl EditorElement {
                     let scrollbar_markers = cx
                         .background_executor()
                         .spawn(async move {
+                            let max_point = snapshot.display_snapshot.buffer_snapshot.max_point();
                             let mut marker_quads = Vec::new();
-
                             if scrollbar_settings.git_diff {
                                 let marker_row_ranges = snapshot
                                     .buffer_snapshot
-                                    .git_diff_hunks_in_range(0..max_row)
+                                    .git_diff_hunks_in_range(0..max_point.row)
                                     .map(|hunk| {
                                         let start_display_row =
                                             Point::new(hunk.associated_range.start, 0)
@@ -2949,9 +2948,6 @@ impl EditorElement {
                             }
 
                             if scrollbar_settings.diagnostics {
-                                let max_point =
-                                    snapshot.display_snapshot.buffer_snapshot.max_point();
-
                                 let diagnostics = snapshot
                                     .buffer_snapshot
                                     .diagnostics_in_range::<_, Point>(
@@ -4157,7 +4153,6 @@ impl Element for EditorElement {
                     gutter_dimensions,
                     content_origin,
                     scrollbar_layout,
-                    max_row,
                     active_rows,
                     highlighted_rows,
                     highlighted_ranges,
@@ -4290,7 +4285,6 @@ pub struct EditorLayout {
     cursors: Vec<(DisplayPoint, Hsla)>,
     visible_cursors: Vec<CursorLayout>,
     selections: Vec<(PlayerColor, Vec<SelectionLayout>)>,
-    max_row: u32,
     code_actions_indicator: Option<AnyElement>,
     test_indicators: Vec<AnyElement>,
     fold_indicators: Vec<Option<AnyElement>>,


### PR DESCRIPTION
There're two errors in scrollbar markers in the presence of folded code:

1. Some markers are not displayed (when the marked row numbers are greater than the total displayed rows count after folding).
2. Code folding / unfolding doesn't trigger markers repainting.

This PR fixes both problems.

Release Notes:

- Fixed scrollbar markers for folded code.

The second problem (markers are repainted after I move the cursor, not after folding):

https://github.com/zed-industries/zed/assets/2101250/57ed563d-186d-4497-98ab-d4f946416726