### PR TITLE
Remove 'Destructive' prompts

### DIFF
--- a/crates/file_finder/src/new_path_prompt.rs
+++ b/crates/file_finder/src/new_path_prompt.rs
@@ -334,7 +334,7 @@ impl PickerDelegate for NewPathDelegate {
         if exists {
             self.should_dismiss = false;
             let answer = cx.prompt(
-                gpui::PromptLevel::Destructive,
+                gpui::PromptLevel::Critical,
                 &format!("{} already exists. Do you want to replace it?", m.relative_path()),
                 Some(
                     "A file or folder with the same name already eixsts. Replacing it will overwrite its current contents.",

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -719,10 +719,6 @@ pub enum PromptLevel {
 
     /// A prompt that is shown when a critical problem has occurred
     Critical,
-
-    /// A prompt that is shown when asking the user to confirm a potentially destructive action
-    /// (overwriting a file for example)
-    Destructive,
 }
 
 /// The style of the cursor (pointer)

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -890,7 +890,7 @@ impl PlatformWindow for MacWindow {
             let alert_style = match level {
                 PromptLevel::Info => 1,
                 PromptLevel::Warning => 0,
-                PromptLevel::Critical | PromptLevel::Destructive => 2,
+                PromptLevel::Critical => 2,
             };
             let _: () = msg_send![alert, setAlertStyle: alert_style];
             let _: () = msg_send![alert, setMessageText: ns_string(msg)];
@@ -905,16 +905,10 @@ impl PlatformWindow for MacWindow {
             {
                 let button: id = msg_send![alert, addButtonWithTitle: ns_string(answer)];
                 let _: () = msg_send![button, setTag: ix as NSInteger];
-                if level == PromptLevel::Destructive && answer != &"Cancel" {
-                    let _: () = msg_send![button, setHasDestructiveAction: YES];
-                }
             }
             if let Some((ix, answer)) = latest_non_cancel_label {
                 let button: id = msg_send![alert, addButtonWithTitle: ns_string(answer)];
                 let _: () = msg_send![button, setTag: ix as NSInteger];
-                if level == PromptLevel::Destructive {
-                    let _: () = msg_send![button, setHasDestructiveAction: YES];
-                }
             }
 
             let (done_tx, done_rx) = oneshot::channel();

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -437,7 +437,7 @@ impl PlatformWindow for WindowsWindow {
                             title = windows::core::w!("Warning");
                             main_icon = TD_WARNING_ICON;
                         }
-                        crate::PromptLevel::Critical | crate::PromptLevel::Destructive => {
+                        crate::PromptLevel::Critical => {
                             title = windows::core::w!("Critical");
                             main_icon = TD_ERROR_ICON;
                         }

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -263,7 +263,7 @@ impl Render for LanguageServerPrompt {
                                             PromptLevel::Warning => {
                                                 Some(DiagnosticSeverity::WARNING)
                                             }
-                                            PromptLevel::Critical | PromptLevel::Destructive => {
+                                            PromptLevel::Critical => {
                                                 Some(DiagnosticSeverity::ERROR)
                                             }
                                         }


### PR DESCRIPTION
While these would match how macOS handles this scenario, they crash on
Catalina, and require mouse clicks to interact.

cc @bennetbo



Release Notes:

- N/A
