### PR TITLE
Properly calculate expanded git diff hunk highlight ranges

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -2136,7 +2136,7 @@ struct Row10;"#};
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![1..3, 8..9],
+            vec![1..=3, 8..=9],
         );
         assert_eq!(
             all_hunks,

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -2110,10 +2110,7 @@ struct Row10;"#};
         let snapshot = editor.snapshot(cx);
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
-        assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new(),
-        );
+        assert_eq!(expanded_hunks_background_highlights(editor, cx), Vec::new());
         assert_eq!(
             all_hunks,
             vec![
@@ -2135,8 +2132,8 @@ struct Row10;"#};
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            vec![1..=3, 8..=9],
+            expanded_hunks_background_highlights(editor, cx),
+            vec![1..=2, 8..=8],
         );
         assert_eq!(
             all_hunks,
@@ -2170,10 +2167,7 @@ struct Row10;"#};
         let snapshot = editor.snapshot(cx);
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
-        assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new(),
-        );
+        assert_eq!(expanded_hunks_background_highlights(editor, cx), Vec::new());
         assert_eq!(
             all_hunks,
             vec![(
@@ -2189,8 +2183,8 @@ struct Row10;"#};
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new(),
+            expanded_hunks_background_highlights(editor, cx),
+            vec![5..=5]
         );
         assert_eq!(
             all_hunks,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9543,7 +9543,7 @@ async fn test_toggle_hunk_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![1..=1, 7..=7, 9..=9],
             "After expanding, all git additions should be highlighted for Modified (split into added and removed) and Added hunks"
         );
@@ -9571,7 +9571,7 @@ async fn test_toggle_hunk_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             Vec::new(),
             "After cancelling in editor, no git highlights should be left"
         );
@@ -9684,7 +9684,7 @@ async fn test_toggled_diff_base_change(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![9..=10, 13..=14],
             "After expanding, all git additions should be highlighted for Modified (split into added and removed) and Added hunks"
         );
@@ -9713,7 +9713,7 @@ async fn test_toggled_diff_base_change(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             Vec::new(),
             "After diff base is changed, old git highlights should be removed"
         );
@@ -9858,7 +9858,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![9..=10, 13..=14, 19..=19]
         );
         assert_eq!(
@@ -9923,7 +9923,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![0..=0, 5..=5],
             "Only one hunk is left not folded, its highlight should be visible"
         );
@@ -10004,7 +10004,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![9..=10, 13..=14, 19..=19],
             "After unfolding, all hunk diffs should be visible again"
         );
@@ -10172,10 +10172,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let snapshot = editor.snapshot(cx);
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
-        assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new(),
-        );
+        assert_eq!(expanded_hunks_background_highlights(editor, cx), Vec::new());
         assert_eq!(all_hunks, expected_all_hunks);
         assert_eq!(all_expanded_hunks, Vec::new());
     });
@@ -10190,7 +10187,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![18..=18, 33..=33],
         );
         assert_eq!(all_hunks, expected_all_hunks_shifted);
@@ -10205,10 +10202,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let snapshot = editor.snapshot(cx);
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
-        assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new(),
-        );
+        assert_eq!(expanded_hunks_background_highlights(editor, cx), Vec::new());
         assert_eq!(all_hunks, expected_all_hunks);
         assert_eq!(all_expanded_hunks, Vec::new());
     });
@@ -10222,7 +10216,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![18..=18, 33..=33],
         );
         assert_eq!(all_hunks, expected_all_hunks_shifted);
@@ -10237,10 +10231,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let snapshot = editor.snapshot(cx);
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
-        assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new(),
-        );
+        assert_eq!(expanded_hunks_background_highlights(editor, cx), Vec::new());
         assert_eq!(all_hunks, expected_all_hunks);
         assert_eq!(all_expanded_hunks, Vec::new());
     });
@@ -10329,7 +10320,7 @@ async fn test_edits_around_toggled_additions(
             vec![("".to_string(), DiffHunkStatus::Added, 4..7)]
         );
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![4..=6]
         );
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10365,7 +10356,7 @@ async fn test_edits_around_toggled_additions(
             vec![("".to_string(), DiffHunkStatus::Added, 4..8)]
         );
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![4..=6],
             "Edited hunk should have one more line added"
         );
@@ -10406,7 +10397,7 @@ async fn test_edits_around_toggled_additions(
             vec![("".to_string(), DiffHunkStatus::Added, 4..9)]
         );
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![4..=6],
             "Edited hunk should have one more line added"
         );
@@ -10446,7 +10437,7 @@ async fn test_edits_around_toggled_additions(
             vec![("".to_string(), DiffHunkStatus::Added, 4..8)]
         );
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![4..=6],
             "Deleting a line should shrint the hunk"
         );
@@ -10456,7 +10447,6 @@ async fn test_edits_around_toggled_additions(
         );
     });
 
-    dbg!("~~~~~~~~~~~~");
     cx.update_editor(|editor, cx| {
         editor.move_up(&MoveUp, cx);
         editor.delete_line(&DeleteLine, cx);
@@ -10491,7 +10481,7 @@ async fn test_edits_around_toggled_additions(
             vec![("".to_string(), DiffHunkStatus::Added, 5..6)]
         );
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![5..=5]
         );
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10534,7 +10524,7 @@ async fn test_edits_around_toggled_additions(
             ]
         );
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             Vec::new(),
             "Should close all stale expanded addition hunks"
         );
@@ -10633,10 +10623,7 @@ async fn test_edits_around_toggled_deletions(
         let snapshot = editor.snapshot(cx);
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
-        assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new()
-        );
+        assert_eq!(expanded_hunks_background_highlights(editor, cx), Vec::new());
         assert_eq!(
             all_hunks,
             vec![(
@@ -10673,7 +10660,7 @@ async fn test_edits_around_toggled_deletions(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             Vec::new(),
             "Deleted hunks do not highlight current editor's background"
         );
@@ -10711,10 +10698,7 @@ async fn test_edits_around_toggled_deletions(
         let snapshot = editor.snapshot(cx);
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
-        assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
-            Vec::new()
-        );
+        assert_eq!(expanded_hunks_background_highlights(editor, cx), Vec::new());
         assert_eq!(
             all_hunks,
             vec![(
@@ -10758,7 +10742,7 @@ async fn test_edits_around_toggled_deletions(
             )]
         );
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![7..=7],
             "Modified expanded hunks should display additions and highlight their background"
         );
@@ -10852,7 +10836,7 @@ async fn test_edits_around_toggled_modifications(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![6..=6],
         );
         assert_eq!(
@@ -10895,7 +10879,7 @@ async fn test_edits_around_toggled_modifications(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![6..=6],
             "Modified hunk should grow highlighted lines on more text additions"
         );
@@ -10941,9 +10925,8 @@ async fn test_edits_around_toggled_modifications(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![6..=8],
-            "Modified hunk should grow deleted lines on text deletions above"
         );
         assert_eq!(
             all_hunks,
@@ -10951,7 +10934,8 @@ async fn test_edits_around_toggled_modifications(
                 "const B: u32 = 42;\nconst C: u32 = 42;\n".to_string(),
                 DiffHunkStatus::Modified,
                 6..9
-            )]
+            )],
+            "Modified hunk should grow deleted lines on text deletions above"
         );
         assert_eq!(all_hunks, all_expanded_hunks);
     });
@@ -10985,7 +10969,7 @@ async fn test_edits_around_toggled_modifications(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![6..=9],
             "Modified hunk should grow deleted lines on text modifications above"
         );
@@ -11029,7 +11013,7 @@ async fn test_edits_around_toggled_modifications(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![6..=8],
             "Modified hunk should grow shrink lines on modification lines removal"
         );
@@ -11070,7 +11054,7 @@ async fn test_edits_around_toggled_modifications(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             Vec::new(),
             "Modified hunk should turn into a removed one on all modified lines removal"
         );
@@ -11173,7 +11157,7 @@ async fn test_multiple_expanded_hunks_merge(
         let all_hunks = editor_hunks(editor, &snapshot, cx);
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
-            expanded_hunks_background_highlights(editor, &snapshot),
+            expanded_hunks_background_highlights(editor, cx),
             vec![6..=6],
         );
         assert_eq!(

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9544,7 +9544,7 @@ async fn test_toggle_hunk_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![1..2, 7..8, 9..10],
+            vec![1..1, 7..7, 9..9],
             "After expanding, all git additions should be highlighted for Modified (split into added and removed) and Added hunks"
         );
         assert_eq!(
@@ -9685,7 +9685,7 @@ async fn test_toggled_diff_base_change(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![9..11, 13..15],
+            vec![9..10, 13..14],
             "After expanding, all git additions should be highlighted for Modified (split into added and removed) and Added hunks"
         );
         assert_eq!(
@@ -9859,7 +9859,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![9..11, 13..15, 19..20]
+            vec![9..10, 13..14, 19..19]
         );
         assert_eq!(
             all_hunks,
@@ -9924,7 +9924,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![5..6],
+            vec![0..0, 5..5],
             "Only one hunk is left not folded, its highlight should be visible"
         );
         assert_eq!(
@@ -10005,7 +10005,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![9..11, 13..15, 19..20],
+            vec![9..10, 13..14, 19..19],
             "After unfolding, all hunk diffs should be visible again"
         );
         assert_eq!(
@@ -10191,7 +10191,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![18..19, 33..34],
+            vec![18..18, 33..33],
         );
         assert_eq!(all_hunks, expected_all_hunks_shifted);
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10223,7 +10223,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![18..19, 33..34],
+            vec![18..18, 33..33],
         );
         assert_eq!(all_hunks, expected_all_hunks_shifted);
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10330,7 +10330,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..7]
+            vec![4..6]
         );
         assert_eq!(all_hunks, all_expanded_hunks);
     });
@@ -10366,7 +10366,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..8],
+            vec![4..6],
             "Edited hunk should have one more line added"
         );
         assert_eq!(
@@ -10407,7 +10407,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..9],
+            vec![4..6],
             "Edited hunk should have one more line added"
         );
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10447,7 +10447,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..8],
+            vec![4..6],
             "Deleting a line should shrint the hunk"
         );
         assert_eq!(
@@ -10491,7 +10491,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![5..6]
+            vec![5..5]
         );
         assert_eq!(all_hunks, all_expanded_hunks);
     });
@@ -10758,7 +10758,7 @@ async fn test_edits_around_toggled_deletions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![7..8],
+            vec![7..7],
             "Modified expanded hunks should display additions and highlight their background"
         );
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10852,7 +10852,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..7],
+            vec![6..6],
         );
         assert_eq!(
             all_hunks,
@@ -10895,7 +10895,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..9],
+            vec![6..6],
             "Modified hunk should grow highlighted lines on more text additions"
         );
         assert_eq!(
@@ -10941,7 +10941,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..9],
+            vec![6..8],
             "Modified hunk should grow deleted lines on text deletions above"
         );
         assert_eq!(
@@ -10985,7 +10985,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..10],
+            vec![6..9],
             "Modified hunk should grow deleted lines on text modifications above"
         );
         assert_eq!(
@@ -11029,7 +11029,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..9],
+            vec![6..8],
             "Modified hunk should grow shrink lines on modification lines removal"
         );
         assert_eq!(
@@ -11173,7 +11173,7 @@ async fn test_multiple_expanded_hunks_merge(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..7],
+            vec![6..6],
         );
         assert_eq!(
             all_hunks,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9544,7 +9544,7 @@ async fn test_toggle_hunk_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![1..1, 7..7, 9..9],
+            vec![1..=1, 7..=7, 9..=9],
             "After expanding, all git additions should be highlighted for Modified (split into added and removed) and Added hunks"
         );
         assert_eq!(
@@ -9685,7 +9685,7 @@ async fn test_toggled_diff_base_change(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![9..10, 13..14],
+            vec![9..=10, 13..=14],
             "After expanding, all git additions should be highlighted for Modified (split into added and removed) and Added hunks"
         );
         assert_eq!(
@@ -9859,7 +9859,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![9..10, 13..14, 19..19]
+            vec![9..=10, 13..=14, 19..=19]
         );
         assert_eq!(
             all_hunks,
@@ -9924,7 +9924,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![0..0, 5..5],
+            vec![0..=0, 5..=5],
             "Only one hunk is left not folded, its highlight should be visible"
         );
         assert_eq!(
@@ -10005,7 +10005,7 @@ async fn test_fold_unfold_diff(executor: BackgroundExecutor, cx: &mut gpui::Test
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![9..10, 13..14, 19..19],
+            vec![9..=10, 13..=14, 19..=19],
             "After unfolding, all hunk diffs should be visible again"
         );
         assert_eq!(
@@ -10191,7 +10191,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![18..18, 33..33],
+            vec![18..=18, 33..=33],
         );
         assert_eq!(all_hunks, expected_all_hunks_shifted);
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10223,7 +10223,7 @@ async fn test_toggle_diff_expand_in_multi_buffer(cx: &mut gpui::TestAppContext) 
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![18..18, 33..33],
+            vec![18..=18, 33..=33],
         );
         assert_eq!(all_hunks, expected_all_hunks_shifted);
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10330,7 +10330,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..6]
+            vec![4..=6]
         );
         assert_eq!(all_hunks, all_expanded_hunks);
     });
@@ -10366,7 +10366,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..6],
+            vec![4..=6],
             "Edited hunk should have one more line added"
         );
         assert_eq!(
@@ -10407,7 +10407,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..6],
+            vec![4..=6],
             "Edited hunk should have one more line added"
         );
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10447,7 +10447,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![4..6],
+            vec![4..=6],
             "Deleting a line should shrint the hunk"
         );
         assert_eq!(
@@ -10456,6 +10456,7 @@ async fn test_edits_around_toggled_additions(
         );
     });
 
+    dbg!("~~~~~~~~~~~~");
     cx.update_editor(|editor, cx| {
         editor.move_up(&MoveUp, cx);
         editor.delete_line(&DeleteLine, cx);
@@ -10491,7 +10492,7 @@ async fn test_edits_around_toggled_additions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![5..5]
+            vec![5..=5]
         );
         assert_eq!(all_hunks, all_expanded_hunks);
     });
@@ -10758,7 +10759,7 @@ async fn test_edits_around_toggled_deletions(
         );
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![7..7],
+            vec![7..=7],
             "Modified expanded hunks should display additions and highlight their background"
         );
         assert_eq!(all_hunks, all_expanded_hunks);
@@ -10852,7 +10853,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..6],
+            vec![6..=6],
         );
         assert_eq!(
             all_hunks,
@@ -10895,7 +10896,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..6],
+            vec![6..=6],
             "Modified hunk should grow highlighted lines on more text additions"
         );
         assert_eq!(
@@ -10941,7 +10942,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..8],
+            vec![6..=8],
             "Modified hunk should grow deleted lines on text deletions above"
         );
         assert_eq!(
@@ -10985,7 +10986,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..9],
+            vec![6..=9],
             "Modified hunk should grow deleted lines on text modifications above"
         );
         assert_eq!(
@@ -11029,7 +11030,7 @@ async fn test_edits_around_toggled_modifications(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..8],
+            vec![6..=8],
             "Modified hunk should grow shrink lines on modification lines removal"
         );
         assert_eq!(
@@ -11173,7 +11174,7 @@ async fn test_multiple_expanded_hunks_merge(
         let all_expanded_hunks = expanded_hunks(&editor, &snapshot, cx);
         assert_eq!(
             expanded_hunks_background_highlights(editor, &snapshot),
-            vec![6..6],
+            vec![6..=6],
         );
         assert_eq!(
             all_hunks,

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -14,8 +14,8 @@ use util::{debug_panic, RangeExt};
 use crate::{
     git::{diff_hunk_to_display, DisplayDiffHunk},
     hunks_for_selections, BlockDisposition, BlockId, BlockProperties, BlockStyle, DiffRowHighlight,
-    Editor, ExpandAllHunkDiffs, RangeToAnchorExt, RevertSelectedHunks, ToDisplayPoint,
-    ToggleHunkDiff,
+    Editor, EditorSnapshot, ExpandAllHunkDiffs, RangeToAnchorExt, RevertSelectedHunks,
+    ToDisplayPoint, ToggleHunkDiff,
 };
 
 #[derive(Debug, Clone)]
@@ -184,7 +184,11 @@ impl Editor {
                     }
 
                     for removed_rows in highlights_to_remove {
-                        editor.highlight_rows::<DiffRowHighlight>(removed_rows, None, cx);
+                        editor.highlight_rows::<DiffRowHighlight>(
+                            to_inclusive_row_range(removed_rows, &snapshot),
+                            None,
+                            cx,
+                        );
                     }
                     editor.remove_blocks(blocks_to_remove, None, cx);
                     for hunk in hunks_to_expand {
@@ -216,9 +220,9 @@ impl Editor {
         let hunk_end = hunk.multi_buffer_range.end;
 
         let buffer = self.buffer().clone();
+        let snapshot = self.snapshot(cx);
         let (diff_base_buffer, deleted_text_lines) = buffer.update(cx, |buffer, cx| {
-            let snapshot = buffer.snapshot(cx);
-            let hunk = buffer_diff_hunk(&snapshot, multi_buffer_row_range.clone())?;
+            let hunk = buffer_diff_hunk(&snapshot.buffer_snapshot, multi_buffer_row_range.clone())?;
             let mut buffer_ranges = buffer.range_to_buffer_ranges(multi_buffer_row_range, cx);
             if buffer_ranges.len() == 1 {
                 let (buffer, _, _) = buffer_ranges.pop()?;
@@ -256,7 +260,7 @@ impl Editor {
             }
             DiffHunkStatus::Added => {
                 self.highlight_rows::<DiffRowHighlight>(
-                    hunk_start..hunk_end,
+                    to_inclusive_row_range(hunk_start..hunk_end, &snapshot),
                     Some(added_hunk_color(cx)),
                     cx,
                 );
@@ -264,7 +268,7 @@ impl Editor {
             }
             DiffHunkStatus::Modified => {
                 self.highlight_rows::<DiffRowHighlight>(
-                    hunk_start..hunk_end,
+                    to_inclusive_row_range(hunk_start..hunk_end, &snapshot),
                     Some(added_hunk_color(cx)),
                     cx,
                 );
@@ -461,7 +465,11 @@ impl Editor {
                     });
 
                     for removed_rows in highlights_to_remove {
-                        editor.highlight_rows::<DiffRowHighlight>(removed_rows, None, cx);
+                        editor.highlight_rows::<DiffRowHighlight>(
+                            to_inclusive_row_range(removed_rows, &snapshot),
+                            None,
+                            cx,
+                        );
                     }
                     editor.remove_blocks(blocks_to_remove, None, cx);
 
@@ -618,4 +626,15 @@ fn buffer_diff_hunk(
         return Some(hunk);
     }
     None
+}
+
+fn to_inclusive_row_range(row_range: Range<Anchor>, snapshot: &EditorSnapshot) -> Range<Anchor> {
+    let mut display_row_range =
+        row_range.start.to_display_point(snapshot)..row_range.end.to_display_point(snapshot);
+    if display_row_range.end.row() > display_row_range.start.row() {
+        *display_row_range.end.row_mut() -= 1;
+    }
+    let point_range = display_row_range.start.to_point(&snapshot.display_snapshot)
+        ..display_row_range.end.to_point(&snapshot.display_snapshot);
+    point_range.to_anchors(&snapshot.buffer_snapshot)
 }

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -150,7 +150,7 @@ pub fn expanded_hunks(
 pub fn expanded_hunks_background_highlights(
     editor: &Editor,
     snapshot: &DisplaySnapshot,
-) -> Vec<core::ops::Range<u32>> {
+) -> Vec<std::ops::RangeInclusive<u32>> {
     use itertools::Itertools;
 
     editor
@@ -158,7 +158,8 @@ pub fn expanded_hunks_background_highlights(
         .into_iter()
         .flatten()
         .map(|(range, _)| {
-            range.start.to_display_point(snapshot).row()..range.end.to_display_point(snapshot).row()
+            range.start().to_display_point(snapshot).row()
+                ..=range.end().to_display_point(snapshot).row()
         })
         .unique()
         .collect()

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -148,19 +148,31 @@ pub fn expanded_hunks(
 
 #[cfg(any(test, feature = "test-support"))]
 pub fn expanded_hunks_background_highlights(
-    editor: &Editor,
-    snapshot: &DisplaySnapshot,
+    editor: &mut Editor,
+    cx: &mut gpui::WindowContext,
 ) -> Vec<std::ops::RangeInclusive<u32>> {
-    use itertools::Itertools;
+    let mut highlights = Vec::new();
 
-    editor
-        .highlighted_rows::<crate::DiffRowHighlight>()
-        .into_iter()
-        .flatten()
-        .map(|(range, _)| {
-            range.start().to_display_point(snapshot).row()
-                ..=range.end().to_display_point(snapshot).row()
-        })
-        .unique()
-        .collect()
+    let mut range_start = 0;
+    let mut previous_highlighted_row = None;
+    for (highlighted_row, _) in editor.highlighted_display_rows(collections::HashSet::default(), cx)
+    {
+        match previous_highlighted_row {
+            Some(previous_row) => {
+                if previous_row + 1 != highlighted_row {
+                    highlights.push(range_start..=previous_row);
+                    range_start = highlighted_row;
+                }
+            }
+            None => {
+                range_start = highlighted_row;
+            }
+        }
+        previous_highlighted_row = Some(highlighted_row);
+    }
+    if let Some(previous_row) = previous_highlighted_row {
+        highlights.push(range_start..=previous_row);
+    }
+
+    highlights
 }

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -120,7 +120,7 @@ impl GoToLine {
                 let anchor = snapshot.buffer_snapshot.anchor_before(point);
                 active_editor.clear_row_highlights::<GoToLineRowHighlights>();
                 active_editor.highlight_rows::<GoToLineRowHighlights>(
-                    anchor..anchor,
+                    anchor..=anchor,
                     Some(cx.theme().colors().editor_highlighted_line_background),
                     cx,
                 );

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -142,7 +142,7 @@ impl OutlineViewDelegate {
             self.active_editor.update(cx, |active_editor, cx| {
                 active_editor.clear_row_highlights::<OutlineRowHighlights>();
                 active_editor.highlight_rows::<OutlineRowHighlights>(
-                    outline_item.range.clone(),
+                    outline_item.range.start..=outline_item.range.end,
                     Some(cx.theme().colors().editor_highlighted_line_background),
                     cx,
                 );
@@ -243,7 +243,7 @@ impl PickerDelegate for OutlineViewDelegate {
                 .and_then(|highlights| highlights.into_iter().next().map(|(rows, _)| rows.clone()))
             {
                 active_editor.change_selections(Some(Autoscroll::center()), cx, |s| {
-                    s.select_ranges([rows.start..rows.start])
+                    s.select_ranges([*rows.start()..*rows.start()])
                 });
                 active_editor.clear_row_highlights::<OutlineRowHighlights>();
                 active_editor.focus(cx);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/11576

Release Notes:

- Fixed expanded diff hunks highlighting an extra row as added ([11576](https://github.com/zed-industries/zed/issues/11576))