### PR TITLE
util/http: Remove low_speed_timeout, fixes slow ollama

### DIFF
--- a/crates/util/src/http.rs
+++ b/crates/util/src/http.rs
@@ -136,7 +136,6 @@ pub fn client() -> Arc<dyn HttpClient> {
     Arc::new(
         isahc::HttpClient::builder()
             .connect_timeout(Duration::from_secs(5))
-            .low_speed_timeout(100, Duration::from_secs(5))
             .proxy(http_proxy_from_env())
             .build()
             .unwrap(),


### PR DESCRIPTION
I've configured Zed to use a local instance of Ollama:

```toml
  "assistant": {
    "openai_api_url": "http://ollama.local:11434/v1"
  }
```

Unfortunately, my server running ollama is a bit slow.  Especially when testing larger models.

Under these conditions, it can take tens of seconds for ollama to parse a prompt plus context.  This causes Zed to close the connection due to no data transfer.

Fix this so that Zed Assistant2 works even though the server is slow.
