### PR TITLE
windows: Update crate `Windows` from `0.53` to `0.56`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,7 +4164,7 @@ dependencies = [
  "text",
  "time",
  "util",
- "windows 0.53.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -4483,7 +4483,7 @@ dependencies = [
  "unindent",
  "url",
  "util",
- "windows 0.53.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -4705,7 +4705,8 @@ dependencies = [
  "wayland-cursor",
  "wayland-protocols",
  "wayland-protocols-plasma",
- "windows 0.53.0",
+ "windows 0.56.0",
+ "windows-core 0.56.0",
  "x11rb",
  "xkbcommon",
 ]
@@ -5972,7 +5973,7 @@ dependencies = [
  "serde_json",
  "smol",
  "util",
- "windows 0.53.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -6440,7 +6441,7 @@ dependencies = [
  "tempfile",
  "util",
  "walkdir",
- "windows 0.53.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -10109,7 +10110,7 @@ dependencies = [
  "theme",
  "thiserror",
  "util",
- "windows 0.53.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -11021,7 +11022,7 @@ dependencies = [
  "story",
  "strum",
  "theme",
- "windows 0.53.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -12161,19 +12162,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "windows"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core 0.53.0",
- "windows-implement",
- "windows-interface",
- "windows-targets 0.52.4",
+ "windows-core 0.56.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -12182,24 +12181,26 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
  "windows-result",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12208,9 +12209,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12219,11 +12220,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -12250,7 +12251,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -12285,17 +12286,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -12312,9 +12314,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -12330,9 +12332,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12348,9 +12350,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -12366,9 +12374,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -12384,9 +12392,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -12402,9 +12410,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -12420,9 +12428,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,7 +388,7 @@ wit-component = "0.201"
 sys-locale = "0.3.1"
 
 [workspace.dependencies.windows]
-version = "0.53.0"
+version = "0.56.0"
 features = [
     "implement",
     "Foundation_Numerics",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -127,6 +127,7 @@ xkbcommon = { version = "0.7", features = ["wayland", "x11"] }
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
+windows-core = "0.56"
 
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "2.4"

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -81,7 +81,7 @@ impl DirectWriteComponent {
             // `DirectWriteTextSystem` to run on `win10 1703`+.
             let in_memory_loader = factory.CreateInMemoryFontFileLoader()?;
             factory.RegisterFontFileLoader(&in_memory_loader)?;
-            let builder = factory.CreateFontSetBuilder2()?;
+            let builder = factory.CreateFontSetBuilder()?;
             let mut locale_vec = vec![0u16; LOCALE_NAME_MAX_LENGTH as usize];
             GetUserDefaultLocaleName(&mut locale_vec);
             let locale = String::from_utf16_lossy(&locale_vec);
@@ -107,7 +107,7 @@ impl DirectWriteTextSystem {
             let mut result = std::mem::zeroed();
             components
                 .factory
-                .GetSystemFontCollection2(false, &mut result, true)?;
+                .GetSystemFontCollection(false, &mut result, true)?;
             result.unwrap()
         };
         let custom_font_set = unsafe { components.builder.CreateFontSet()? };
@@ -303,7 +303,7 @@ impl DirectWriteState {
         let mut collection = std::mem::zeroed();
         self.components
             .factory
-            .GetSystemFontCollection2(false, &mut collection, true)
+            .GetSystemFontCollection(false, &mut collection, true)
             .unwrap();
         self.system_font_collection = collection.unwrap();
     }
@@ -496,7 +496,7 @@ impl DirectWriteState {
         unsafe {
             let font_info = &self.fonts[font_id.0];
             let mut metrics = std::mem::zeroed();
-            font_info.font_face.GetMetrics2(&mut metrics);
+            font_info.font_face.GetMetrics(&mut metrics);
 
             FontMetrics {
                 units_per_em: metrics.Base.designUnitsPerEm as _,
@@ -549,10 +549,11 @@ impl DirectWriteState {
         };
         self.components.factory.CreateGlyphRunAnalysis(
             &glyph_run as _,
-            1.0,
             Some(&transform as _),
-            DWRITE_RENDERING_MODE_NATURAL,
+            DWRITE_RENDERING_MODE1_NATURAL,
             DWRITE_MEASURING_MODE_NATURAL,
+            DWRITE_GRID_FIT_MODE_DEFAULT,
+            DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE,
             0.0,
             0.0,
         )
@@ -707,7 +708,7 @@ impl DirectWriteState {
             render_target.BeginDraw();
             if params.is_emoji {
                 // WARN: only DWRITE_GLYPH_IMAGE_FORMATS_COLR has been tested
-                let enumerator = self.components.factory.TranslateColorGlyphRun2(
+                let enumerator = self.components.factory.TranslateColorGlyphRun(
                     baseline_origin,
                     &glyph_run as _,
                     None,
@@ -721,7 +722,7 @@ impl DirectWriteState {
                     0,
                 )?;
                 while enumerator.MoveNext().is_ok() {
-                    let Ok(color_glyph) = enumerator.GetCurrentRun2() else {
+                    let Ok(color_glyph) = enumerator.GetCurrentRun() else {
                         break;
                     };
                     let color_glyph = &*color_glyph;
@@ -746,7 +747,7 @@ impl DirectWriteState {
                             color_glyph.Base.paletteIndex as u32,
                             color_glyph.measuringMode,
                         ),
-                        _ => render_target.DrawGlyphRun2(
+                        _ => render_target.DrawGlyphRun(
                             baseline_origin,
                             &color_glyph.Base.glyphRun,
                             Some(color_glyph.Base.glyphRunDescription as *const _),
@@ -759,6 +760,7 @@ impl DirectWriteState {
                 render_target.DrawGlyphRun(
                     baseline_origin,
                     &glyph_run,
+                    None,
                     &brush,
                     DWRITE_MEASURING_MODE_NATURAL,
                 );

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use smallvec::SmallVec;
 use std::rc::Rc;
+use util::ResultExt;
 use uuid::Uuid;
 use windows::{
     core::*,
@@ -158,7 +159,9 @@ fn available_monitors() -> SmallVec<[HMONITOR; 4]> {
             None,
             Some(monitor_enum_proc),
             LPARAM(&mut monitors as *mut _ as _),
-        );
+        )
+        .ok()
+        .log_err();
     }
     monitors
 }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -221,7 +221,9 @@ impl Platform for WindowsPlatform {
                                 }
                                 WM_SETTINGCHANGE => self.update_system_settings(),
                                 _ => {
-                                    TranslateMessage(&msg).ok().log_err();
+                                    // todo(windows)
+                                    // crate `windows 0.56` reports true as Err
+                                    TranslateMessage(&msg).as_bool();
                                     DispatchMessageW(&msg);
                                 }
                             }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -114,7 +114,9 @@ impl WindowsPlatform {
                     None,
                     HRGN::default(),
                     RDW_INVALIDATE | RDW_UPDATENOW,
-                );
+                )
+                .ok()
+                .log_err();
             }
         }
     }
@@ -219,7 +221,7 @@ impl Platform for WindowsPlatform {
                                 }
                                 WM_SETTINGCHANGE => self.update_system_settings(),
                                 _ => {
-                                    TranslateMessage(&msg);
+                                    TranslateMessage(&msg).ok().log_err();
                                     DispatchMessageW(&msg);
                                 }
                             }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -303,7 +303,7 @@ impl WindowsWindow {
             placement.rcNormalPosition.bottom = params.bounds.bottom().0;
             SetWindowPlacement(raw_hwnd, &placement).log_err();
         }
-        unsafe { ShowWindow(raw_hwnd, SW_SHOW) };
+        unsafe { ShowWindow(raw_hwnd, SW_SHOW).ok().log_err() };
 
         wnd
     }
@@ -384,7 +384,7 @@ impl PlatformWindow for WindowsWindow {
             GetCursorPos(&mut point)
                 .context("unable to get cursor position")
                 .log_err();
-            ScreenToClient(self.0.hwnd, &mut point);
+            ScreenToClient(self.0.hwnd, &mut point).ok().log_err();
             point
         };
         logical_point(point.x as f32, point.y as f32, scale_factor)
@@ -481,7 +481,7 @@ impl PlatformWindow for WindowsWindow {
         let hwnd = self.0.hwnd;
         unsafe { SetActiveWindow(hwnd) };
         unsafe { SetFocus(hwnd) };
-        unsafe { SetForegroundWindow(hwnd) };
+        unsafe { SetForegroundWindow(hwnd).ok().log_err() };
     }
 
     fn is_active(&self) -> bool {
@@ -511,11 +511,11 @@ impl PlatformWindow for WindowsWindow {
     fn show_character_palette(&self) {}
 
     fn minimize(&self) {
-        unsafe { ShowWindowAsync(self.0.hwnd, SW_MINIMIZE) };
+        unsafe { ShowWindowAsync(self.0.hwnd, SW_MINIMIZE).ok().log_err() };
     }
 
     fn zoom(&self) {
-        unsafe { ShowWindowAsync(self.0.hwnd, SW_MAXIMIZE) };
+        unsafe { ShowWindowAsync(self.0.hwnd, SW_MAXIMIZE).ok().log_err() };
     }
 
     fn toggle_fullscreen(&self) {
@@ -694,7 +694,9 @@ impl IDropTarget_Impl for WindowsDragDropHandler {
                 }
                 ReleaseStgMedium(&mut idata);
                 let mut cursor_position = POINT { x: pt.x, y: pt.y };
-                ScreenToClient(self.0.hwnd, &mut cursor_position);
+                ScreenToClient(self.0.hwnd, &mut cursor_position)
+                    .ok()
+                    .log_err();
                 let scale_factor = self.0.state.borrow().scale_factor;
                 let input = PlatformInput::FileDrop(FileDropEvent::Entered {
                     position: logical_point(
@@ -720,7 +722,9 @@ impl IDropTarget_Impl for WindowsDragDropHandler {
     ) -> windows::core::Result<()> {
         let mut cursor_position = POINT { x: pt.x, y: pt.y };
         unsafe {
-            ScreenToClient(self.0.hwnd, &mut cursor_position);
+            ScreenToClient(self.0.hwnd, &mut cursor_position)
+                .ok()
+                .log_err();
         }
         let scale_factor = self.0.state.borrow().scale_factor;
         let input = PlatformInput::FileDrop(FileDropEvent::Pending {
@@ -751,7 +755,9 @@ impl IDropTarget_Impl for WindowsDragDropHandler {
     ) -> windows::core::Result<()> {
         let mut cursor_position = POINT { x: pt.x, y: pt.y };
         unsafe {
-            ScreenToClient(self.0.hwnd, &mut cursor_position);
+            ScreenToClient(self.0.hwnd, &mut cursor_position)
+                .ok()
+                .log_err();
         }
         let scale_factor = self.0.state.borrow().scale_factor;
         let input = PlatformInput::FileDrop(FileDropEvent::Submit {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -481,7 +481,9 @@ impl PlatformWindow for WindowsWindow {
         let hwnd = self.0.hwnd;
         unsafe { SetActiveWindow(hwnd) };
         unsafe { SetFocus(hwnd) };
-        unsafe { SetForegroundWindow(hwnd).ok().log_err() };
+        // todo(windows)
+        // crate `windows 0.56` reports true as Err
+        unsafe { SetForegroundWindow(hwnd).as_bool() };
     }
 
     fn is_active(&self) -> bool {


### PR DESCRIPTION
Version 0.56 has fixed many of the previous bugs, and one of the bugs prevent me implementing some functions.

Release Notes:

- N/A
