### PR TITLE
Remove references to submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
           fetch-depth: 0
 
       - name: Remove untracked files
@@ -87,7 +86,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: cargo clippy
         run: cargo xtask clippy
@@ -115,7 +113,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: cargo clippy
         run: cargo xtask clippy
@@ -132,7 +129,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Cache dependencies
         uses: swatinem/rust-cache@v2
@@ -175,7 +171,6 @@ jobs:
           # 25 was chosen arbitrarily.
           fetch-depth: 25
           clean: false
-          submodules: "recursive"
 
       - name: Limit target directory size
         run: script/clear-target-dir-if-larger-than 100
@@ -273,7 +268,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Limit target directory size
         run: script/clear-target-dir-if-larger-than 100

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
           fetch-depth: 0
 
       - name: Run style checks
@@ -41,7 +40,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
           fetch-depth: 0
 
       - name: Install cargo nextest
@@ -76,7 +74,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Build docker image
         run: docker build . --build-arg GITHUB_SHA=$GITHUB_SHA --tag registry.digitalocean.com/zed/collab:$GITHUB_SHA

--- a/.github/workflows/publish_extension_cli.yml
+++ b/.github/workflows/publish_extension_cli.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Cache dependencies
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Run randomized tests
         run: script/randomized-test-ci

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
           fetch-depth: 0
 
       - name: Run style checks
@@ -45,7 +44,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Run tests
         uses: ./.github/actions/run_tests
@@ -75,7 +73,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Set release channel to nightly
         run: |
@@ -109,7 +106,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
 
       - name: Add Rust to the PATH
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -2,11 +2,7 @@
 
 ## Repository
 
-After cloning the repository, ensure all git submodules are initialized:
-
-```shell
-git submodule update --init --recursive
-```
+Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -2,11 +2,7 @@
 
 ## Repository
 
-After cloning the repository, ensure all git submodules are initialized:
-
-```shell
-git submodule update --init --recursive
-```
+Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -5,11 +5,7 @@
 
 ## Repository
 
-After cloning the repository, ensure all git submodules are initialized:
-
-```shell
-git submodule update --init --recursive
-```
+Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 

--- a/script/linux
+++ b/script/linux
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Install our submodule dependencies
-git submodule update --init --recursive
-
 # install the wasm toolchain
 which rustup > /dev/null 2>&1 || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
This PR removes the references to initializing Git submodules as part of building Zed.

These are no longer needed, as our only submodule was removed in #11672.

Release Notes:

- N/A
