### PR TITLE
ruby: Add `embedded_template` grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5710,7 +5710,6 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-css",
- "tree-sitter-embedded-template",
  "tree-sitter-go",
  "tree-sitter-gomod",
  "tree-sitter-gowork",

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -36,7 +36,6 @@ tree-sitter-bash.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true
 tree-sitter-css.workspace = true
-tree-sitter-embedded-template.workspace = true
 tree-sitter-go.workspace = true
 tree-sitter-gomod.workspace = true
 tree-sitter-gowork.workspace = true

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -36,10 +36,6 @@ pub fn init(
         ("c", tree_sitter_c::language()),
         ("cpp", tree_sitter_cpp::language()),
         ("css", tree_sitter_css::language()),
-        (
-            "embedded_template",
-            tree_sitter_embedded_template::language(),
-        ),
         ("go", tree_sitter_go::language()),
         ("gomod", tree_sitter_gomod::language()),
         ("gowork", tree_sitter_gowork::language()),

--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -13,3 +13,7 @@ language = "Ruby"
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
 commit = "9d86f3761bb30e8dcc81e754b81d3ce91848477e"
+
+[grammars.embedded_template]
+repository = "https://github.com/tree-sitter/tree-sitter-embedded-template"
+commit = "91fc5ae1140d5c9d922312431f7d251a48d7b8ce"


### PR DESCRIPTION
This PR adds the `embedded_template` grammar to the Ruby extension, as we need it present for ERB.

Release Notes:

- N/A
