### PR TITLE
Change `ToolOutput` to `ToolView`

### DIFF
--- a/crates/assistant2/src/tools/annotate_code.rs
+++ b/crates/assistant2/src/tools/annotate_code.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use assistant_tooling::{LanguageModelTool, ProjectContext, ToolOutput};
+use assistant_tooling::{LanguageModelTool, ProjectContext, ToolView};
 use editor::{
     display_map::{BlockContext, BlockDisposition, BlockProperties, BlockStyle},
     Editor, MultiBuffer,
@@ -230,7 +230,7 @@ impl Render for AnnotationResultView {
     }
 }
 
-impl ToolOutput for AnnotationResultView {
+impl ToolView for AnnotationResultView {
     type Input = AnnotationInput;
     type SerializedState = Option<String>;
 

--- a/crates/assistant2/src/tools/create_buffer.rs
+++ b/crates/assistant2/src/tools/create_buffer.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use assistant_tooling::{LanguageModelTool, ProjectContext, ToolOutput};
+use assistant_tooling::{LanguageModelTool, ProjectContext, ToolView};
 use editor::Editor;
 use gpui::{prelude::*, Model, Task, View, WeakView};
 use project::Project;
@@ -65,7 +65,7 @@ impl Render for CreateBufferView {
     }
 }
 
-impl ToolOutput for CreateBufferView {
+impl ToolView for CreateBufferView {
     type Input = CreateBufferInput;
 
     type SerializedState = ();

--- a/crates/assistant2/src/tools/project_index.rs
+++ b/crates/assistant2/src/tools/project_index.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use assistant_tooling::{LanguageModelTool, ToolOutput};
+use assistant_tooling::{LanguageModelTool, ToolView};
 use collections::BTreeMap;
 use file_icons::FileIcons;
 use gpui::{prelude::*, AnyElement, Model, Task};
@@ -232,7 +232,7 @@ impl Render for ProjectIndexView {
     }
 }
 
-impl ToolOutput for ProjectIndexView {
+impl ToolView for ProjectIndexView {
     type Input = CodebaseQuery;
     type SerializedState = SerializedState;
 

--- a/crates/assistant_tooling/src/assistant_tooling.rs
+++ b/crates/assistant_tooling/src/assistant_tooling.rs
@@ -8,6 +8,6 @@ pub use attachment_registry::{
 };
 pub use project_context::ProjectContext;
 pub use tool_registry::{
-    LanguageModelTool, SavedToolFunctionCall, ToolFunctionCall, ToolFunctionDefinition, ToolOutput,
-    ToolRegistry,
+    LanguageModelTool, SavedToolFunctionCall, ToolFunctionCall, ToolFunctionDefinition,
+    ToolRegistry, ToolView,
 };


### PR DESCRIPTION
Additionally, the internal `ToolView` trait used by the registry is now called `InternalToolView`.

This should make it a bit easier to understand that the `ToolView` is intended for a `gpui::View` (implementing `Render`). It does still feel like more could be merged here but I think the built tools are now a bit clearer.

Release Notes:

- N/A
