### PR TITLE
php: Highlight PHPDoc comments

### DIFF
--- a/extensions/php/extension.toml
+++ b/extensions/php/extension.toml
@@ -15,3 +15,7 @@ language_ids = { PHP = "php"}
 repository = "https://github.com/tree-sitter/tree-sitter-php"
 commit = "8ab93274065cbaf529ea15c24360cfa3348ec9e4"
 path = "php"
+
+[grammars.phpdoc]
+repository = "https://github.com/claytonrcarter/tree-sitter-phpdoc"
+commit = "1d0e255b37477d0ca46f1c9e9268c8fa76c0b3fc"

--- a/extensions/php/languages/php/injections.scm
+++ b/extensions/php/languages/php/injections.scm
@@ -1,3 +1,7 @@
 ((text) @content
  (#set! "language" "html")
  (#set! "combined"))
+
+((comment) @content
+  (#match? @content "^/\\*\\*[^*]")
+  (#set! "language" "phpdoc"))

--- a/extensions/php/languages/phpdoc/config.toml
+++ b/extensions/php/languages/phpdoc/config.toml
@@ -1,0 +1,9 @@
+name = "PHPDoc"
+grammar = "phpdoc"
+autoclose_before = "]})>"
+brackets = [
+  { start = "{", end = "}", close = true, newline = false },
+  { start = "[", end = "]", close = true, newline = false },
+  { start = "(", end = ")", close = true, newline = false },
+  { start = "<", end = ">", close = true, newline = false },
+]

--- a/extensions/php/languages/phpdoc/highlights.scm
+++ b/extensions/php/languages/phpdoc/highlights.scm
@@ -1,0 +1,13 @@
+(tag_name) @keyword
+
+(tag (variable_name) @variable)
+(variable_name "$" @operator)
+
+(tag
+  (tag_name) @keyword
+  (#eq? @keyword "@method")
+  (name) @function.method)
+
+(primitive_type) @type.builtin
+(named_type (name) @type) @type
+(named_type (qualified_name) @type) @type


### PR DESCRIPTION
This adds highlighting of phpdoc tags and PHP types to phpdoc comments, using [tree-sitter-phpdoc](https://github.com/claytonrcarter/tree-sitter-phpdoc) (maintained by yours me, and also in use by neovim).

<table>
<tr>
<td>
<strong>Before</strong>
<img src="https://github.com/zed-industries/zed/assets/1420419/bae4c502-8a2c-4399-893f-fcff4e5797b6">
</td>
<td>
<strong>After</strong>
<img src="https://github.com/zed-industries/zed/assets/1420419/8848e9fb-61a0-4938-a118-7041da9589c0">
</td>
</tr>
</table>


Release Notes:

- N/A