### PR TITLE
Don't hide last symbol under the scrollbar

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11082,7 +11082,7 @@ impl Render for Editor {
                 background,
                 local_player: cx.theme().players().local(),
                 text: text_style,
-                scrollbar_width: px(13.),
+                scrollbar_width: EditorElement::SCROLLBAR_WIDTH,
                 syntax: cx.theme().syntax().clone(),
                 status: cx.theme().status().clone(),
                 inlay_hints_style: HighlightStyle {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -136,6 +136,8 @@ pub struct EditorElement {
 type DisplayRowDelta = u32;
 
 impl EditorElement {
+    pub(crate) const SCROLLBAR_WIDTH: Pixels = px(13.);
+
     pub fn new(editor: &View<Editor>, style: EditorStyle) -> Self {
         Self {
             editor: editor.clone(),
@@ -3763,7 +3765,13 @@ impl Element for EditorElement {
                     cx,
                 );
                 let text_width = bounds.size.width - gutter_dimensions.width;
-                let overscroll = size(em_width, px(0.));
+
+                let right_margin = if snapshot.mode == EditorMode::Full {
+                    EditorElement::SCROLLBAR_WIDTH
+                } else {
+                    px(0.)
+                };
+                let overscroll = size(em_width + right_margin, px(0.));
 
                 snapshot = self.editor.update(cx, |editor, cx| {
                     editor.last_bounds = Some(bounds);


### PR DESCRIPTION
This PR adds an extra scrollbar-wide margin to the right side of the editor. This prevents hiding the last character under the scrollbar.

Fixes #7098

Release Notes:

- Fixed hiding of the last character under the scrollbar (#7098).
