### PR TITLE
extensions: Select language extension based on longest matching path extension

### DIFF
--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -1,6 +1,6 @@
 name = "TypeScript"
 grammar = "typescript"
-path_suffixes = ["ts", "cts", "d.cts", "d.mts", "mts"]
+path_suffixes = ["ts", "cts", "mts"]
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
This is a "let's see if I can get it to work" (aka hack) to try address #8408 and #10997. In short: the [current language extension matcher](https://github.com/zed-industries/zed/blob/main/crates/language/src/language_registry.rs#L511-L520) is only considering the "final extension" of a file when seeing which language extensions would apply to the file. (This is because that's how Rust's `path.extension()` works.) This works fine for most cases, but there are some cases where a language extension may want to match on a "compound file extension", and this is currently not supported at all. 

**Example:**
- Laravel Blade templates use the `blade.php` "extension"
- So a Blade file may be named `index.blade.php`
- [A hypothetical](https://github.com/claytonrcarter/zed-language-laravel-blade) lang extension for Blade will specify `path_suffixes = ["blade.php"]`
- Zed will look at `index.blade.php`, and then try to match a lang ext based on any of the `path_suffixes` exactly matching [either `"php"` or `"index.blade.php"`](https://github.com/zed-industries/zed/blob/main/crates/language/src/language_registry.rs#L511-L513)
- The Blade ext will not match because `"blade.php" != "php"` nor `"index.blade.php"`

**Proposed Solution**
Basically, instead of doing an exact match on the suffix and either the file extension or filename, this change:
- finds the longest suffix that matches the end of the filename
- returns the suffix string length as the matching "score"

**Languages that may use this**
- Laravel Blade templates use the `blade.php` "extension"
- I'm not familiar with Angular, but apparently it [uses `component.html`](https://github.com/zed-industries/zed/issues/10765#issuecomment-2091293304)
- *others?*

**Open questions**
- perf: I'm assuming that `filename.ends_with(&ext) || filename == suffix` is slower than `path_suffixes.contains(&Some(suffix.as_str()))`? If so, how bad is it?
  - alternate option: separate `path_suffixes` in the ext API into `path_suffixes` and `filenames`, and then we could preprocess these when the language ext is first loaded to reduce overhead
- ~~unintended matches: I realized while writing this that it may introduce behavior where (eg) a lang ext for D (suffix `d`) may be matched to Markdown (`md`). In that case, Markdown would still win, though (because of length) ... so may that's not an issue?~~ **edit** I resolved this when I found the tests that cover this change and go this to pass.
- alternate approach: perhaps declare within an extension that it may "compete" with other extensions and provide some way to disambiguate which should apply?
- prior art: #10960 is related to this, but I believe that it is addressing a different problem

Release Notes:

- Added support for "compound" file extensions in language extensions. Fixes #8408 and #10997.