### PR TITLE
windows: Support multi-monitor

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -169,7 +169,7 @@ pub trait PlatformDisplay: Send + Sync + Debug {
     /// Get the bounds for this display
     fn bounds(&self) -> Bounds<DevicePixels>;
 
-    /// Get the default bounds for this display
+    /// Get the default bounds for this display to place a window
     fn default_bounds(&self) -> Bounds<DevicePixels> {
         let center = self.bounds().center();
         let offset = DEFAULT_WINDOW_SIZE / 2;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -25,10 +25,11 @@ mod test;
 mod windows;
 
 use crate::{
-    Action, AnyWindowHandle, AsyncWindowContext, BackgroundExecutor, Bounds, DevicePixels,
+    point, Action, AnyWindowHandle, AsyncWindowContext, BackgroundExecutor, Bounds, DevicePixels,
     DispatchEventResult, Font, FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, Keymap,
     LineLayout, Pixels, PlatformInput, Point, RenderGlyphParams, RenderImageParams,
     RenderSvgParams, Scene, SharedString, Size, Task, TaskLabel, WindowContext,
+    DEFAULT_WINDOW_SIZE,
 };
 use anyhow::Result;
 use async_task::Runnable;
@@ -167,6 +168,14 @@ pub trait PlatformDisplay: Send + Sync + Debug {
 
     /// Get the bounds for this display
     fn bounds(&self) -> Bounds<DevicePixels>;
+
+    /// Get the default bounds for this display
+    fn default_bounds(&self) -> Bounds<DevicePixels> {
+        let center = self.bounds().center();
+        let offset = DEFAULT_WINDOW_SIZE / 2;
+        let origin = point(center.x - offset.width, center.y - offset.height);
+        Bounds::new(origin, DEFAULT_WINDOW_SIZE)
+    }
 }
 
 /// An opaque identifier for a hardware display

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -143,6 +143,10 @@ impl WindowsDisplay {
             .then(|| devmode.dmDisplayFrequency)
         })
     }
+
+    pub fn is_connected(hmonitor: HMONITOR) -> bool {
+        available_monitors().iter().contains(&hmonitor)
+    }
 }
 
 impl PlatformDisplay for WindowsDisplay {

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -113,7 +113,8 @@ impl WindowsDisplay {
             x: center.x.0,
             y: center.y.0,
         };
-        !unsafe { MonitorFromPoint(center, MONITOR_DEFAULTTONULL) }.is_invalid()
+        let monitor = unsafe { MonitorFromPoint(center, MONITOR_DEFAULTTONULL) };
+        !monitor.is_invalid() && monitor == self.handle
     }
 
     pub fn displays() -> Vec<Rc<dyn PlatformDisplay>> {

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -114,7 +114,12 @@ impl WindowsDisplay {
             y: center.y.0,
         };
         let monitor = unsafe { MonitorFromPoint(center, MONITOR_DEFAULTTONULL) };
-        !monitor.is_invalid() && monitor == self.handle
+        if monitor.is_invalid() {
+            false
+        } else {
+            let display = WindowsDisplay::new_with_handle(monitor);
+            display.uuid == self.uuid
+        }
     }
 
     pub fn displays() -> Vec<Rc<dyn PlatformDisplay>> {

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -107,6 +107,15 @@ impl WindowsDisplay {
         Some(WindowsDisplay::new_with_handle(monitor))
     }
 
+    pub fn check_given_origin(&self, bounds: Bounds<DevicePixels>) -> bool {
+        let center = bounds.center();
+        let center = POINT {
+            x: center.x.0,
+            y: center.y.0,
+        };
+        !unsafe { MonitorFromPoint(center, MONITOR_DEFAULTTONULL) }.is_invalid()
+    }
+
     pub fn displays() -> Vec<Rc<dyn PlatformDisplay>> {
         available_monitors()
             .into_iter()

--- a/crates/gpui/src/platform/windows/display.rs
+++ b/crates/gpui/src/platform/windows/display.rs
@@ -107,7 +107,8 @@ impl WindowsDisplay {
         Some(WindowsDisplay::new_with_handle(monitor))
     }
 
-    pub fn check_given_origin(&self, bounds: Bounds<DevicePixels>) -> bool {
+    /// Check if the center point of given bounds is inside this monitor
+    pub fn check_given_bounds(&self, bounds: Bounds<DevicePixels>) -> bool {
         let center = bounds.center();
         let center = POINT {
             x: center.x.0,
@@ -150,6 +151,7 @@ impl WindowsDisplay {
         })
     }
 
+    /// Check if this monitor is still online
     pub fn is_connected(hmonitor: HMONITOR) -> bool {
         available_monitors().iter().contains(&hmonitor)
     }

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -39,6 +39,7 @@ pub(crate) fn handle_msg(
         WM_TIMER => handle_timer_msg(handle, wparam, state_ptr),
         WM_NCCALCSIZE => handle_calc_client_size(handle, wparam, lparam, state_ptr),
         WM_DPICHANGED => handle_dpi_changed_msg(handle, wparam, lparam, state_ptr),
+        WM_DISPLAYCHANGE => handle_display_change_msg(wparam, lparam, state_ptr),
         WM_NCHITTEST => handle_hit_test_msg(handle, msg, wparam, lparam, state_ptr),
         WM_PAINT => handle_paint_msg(handle, state_ptr),
         WM_CLOSE => handle_close_msg(state_ptr),
@@ -768,6 +769,30 @@ fn handle_dpi_changed_msg(
     }
     invalidate_client_area(handle);
 
+    Some(0)
+}
+
+/// The following conditions will trigger this event:
+/// 1. The monitor on which the window is located goes offline or changes resolution.
+/// 2. Another monitor goes offline, is plugged in, or changes resolution.
+///
+/// In either case, the window will only receive information from the monitor on which
+/// it is located.
+///
+/// For example, in the case of condition 2, where the monitor on which the window is
+/// located has actually changed nothing, it will still receive this event.
+fn handle_display_change_msg(
+    wparam: WPARAM,
+    lparam: LPARAM,
+    state_ptr: Rc<WindowsWindowStatePtr>,
+) -> Option<isize> {
+    println!(
+        "display changed: {:?}, {:?}, width: {}, height: {}",
+        wparam,
+        lparam,
+        lparam.loword(),
+        lparam.hiword()
+    );
     Some(0)
 }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -301,7 +301,7 @@ impl WindowsWindow {
                 ..Default::default()
             };
             GetWindowPlacement(raw_hwnd, &mut placement).log_err();
-            // the bounds may be not inside the display, or the display may have been removed
+            // the bounds may be not inside the display
             let bounds = if display.check_given_origin(params.bounds) {
                 params.bounds
             } else {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -258,13 +258,17 @@ impl WindowsWindow {
         );
         let dwstyle = WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
         let hinstance = get_module_handle();
+        let display = if let Some(display_id) = params.display_id {
+            // if we obtain a display_id, then this ID must be valid.
+            WindowsDisplay::new(display_id).unwrap()
+        } else {
+            WindowsDisplay::primary_monitor().unwrap()
+        };
         let mut context = WindowCreateContext {
             inner: None,
             handle,
             hide_title_bar,
-            // todo(windows) move window to target monitor
-            // options.display_id
-            display: WindowsDisplay::primary_monitor().unwrap(),
+            display,
             transparent: params.window_background != WindowBackgroundAppearance::Opaque,
             executor,
             mouse_wheel_settings,
@@ -297,10 +301,17 @@ impl WindowsWindow {
                 ..Default::default()
             };
             GetWindowPlacement(raw_hwnd, &mut placement).log_err();
-            placement.rcNormalPosition.left = params.bounds.left().0;
-            placement.rcNormalPosition.right = params.bounds.right().0;
-            placement.rcNormalPosition.top = params.bounds.top().0;
-            placement.rcNormalPosition.bottom = params.bounds.bottom().0;
+            // the bounds may not inside the display
+            let bounds = if display.check_given_origin(params.bounds) {
+                params.bounds
+            } else {
+                // the display may have been removed
+                display.default_bounds()
+            };
+            placement.rcNormalPosition.left = bounds.left().0;
+            placement.rcNormalPosition.right = bounds.right().0;
+            placement.rcNormalPosition.top = bounds.top().0;
+            placement.rcNormalPosition.bottom = bounds.bottom().0;
             SetWindowPlacement(raw_hwnd, &placement).log_err();
         }
         unsafe { ShowWindow(raw_hwnd, SW_SHOW) };

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -302,7 +302,7 @@ impl WindowsWindow {
             };
             GetWindowPlacement(raw_hwnd, &mut placement).log_err();
             // the bounds may be not inside the display
-            let bounds = if display.check_given_origin(params.bounds) {
+            let bounds = if display.check_given_bounds(params.bounds) {
                 params.bounds
             } else {
                 display.default_bounds()

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -301,11 +301,10 @@ impl WindowsWindow {
                 ..Default::default()
             };
             GetWindowPlacement(raw_hwnd, &mut placement).log_err();
-            // the bounds may not inside the display
+            // the bounds may be not inside the display, or the display may have been removed
             let bounds = if display.check_given_origin(params.bounds) {
                 params.bounds
             } else {
-                // the display may have been removed
                 display.default_bounds()
             };
             placement.rcNormalPosition.left = bounds.left().0;

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -51,6 +51,9 @@ mod prompts;
 
 pub use prompts::*;
 
+pub(crate) const DEFAULT_WINDOW_SIZE: Size<DevicePixels> =
+    size(DevicePixels(1024), DevicePixels(700));
+
 /// Represents the two different phases when dispatching events.
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum DispatchPhase {
@@ -561,7 +564,6 @@ pub(crate) struct ElementStateBox {
 }
 
 fn default_bounds(display_id: Option<DisplayId>, cx: &mut AppContext) -> Bounds<DevicePixels> {
-    const DEFAULT_WINDOW_SIZE: Size<DevicePixels> = size(DevicePixels(1024), DevicePixels(700));
     const DEFAULT_WINDOW_OFFSET: Point<DevicePixels> = point(DevicePixels(0), DevicePixels(35));
 
     cx.active_window()
@@ -573,12 +575,7 @@ fn default_bounds(display_id: Option<DisplayId>, cx: &mut AppContext) -> Bounds<
                 .unwrap_or_else(|| cx.primary_display());
 
             display
-                .map(|display| {
-                    let center = display.bounds().center();
-                    let offset = DEFAULT_WINDOW_SIZE / 2;
-                    let origin = point(center.x - offset.width, center.y - offset.height);
-                    Bounds::new(origin, DEFAULT_WINDOW_SIZE)
-                })
+                .map(|display| display.default_bounds())
                 .unwrap_or_else(|| {
                     Bounds::new(point(DevicePixels(0), DevicePixels(0)), DEFAULT_WINDOW_SIZE)
                 })


### PR DESCRIPTION
Zed can detect changes in monitor connections and disconnections and provide corresponding feedback. For example, if the current window's display monitor is disconnected, the window will be moved to the primary monitor. And now Zed always opens on the monitor specified in `WindowParams`.

Release Notes:

- N/A
