### PR TITLE
Rectify broken JS language link

### DIFF
--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -5,7 +5,7 @@
 
 ### Code formatting
 
-Formatting on save is enabled by default for JavaScript, using TypeScript's built-in code formatting. But many JavaScript projects use other command-line code-formatting tools, such as [Prettier](https://prettier.io/). You can use one of these tools by specifying an _external_ code formatter for JavaScript in your settings. See the [configuration](../configuration/configuring-zed.md) documentation for more information.
+Formatting on save is enabled by default for JavaScript, using TypeScript's built-in code formatting. But many JavaScript projects use other command-line code-formatting tools, such as [Prettier](https://prettier.io/). You can use one of these tools by specifying an _external_ code formatter for JavaScript in your settings. See the [configuration](../configuring-zed.md) documentation for more information.
 
 For example, if you have Prettier installed and on your `PATH`, you can use it to format JavaScript files by adding the following to your `settings.json`:
 


### PR DESCRIPTION

Release Notes:

- Fixed [#11690](https://github.com/zed-industries/zed/issues/11690).

