### PR TITLE
Fix reveal_path blocks on linux

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -305,12 +305,12 @@ impl<P: LinuxClient + 'static> Platform for P {
 
     fn reveal_path(&self, path: &Path) {
         if path.is_dir() {
-            open::that(path);
+            open::that_detached(path);
             return;
         }
         // If `path` is a file, the system may try to open it in a text editor
         let dir = path.parent().unwrap_or(Path::new(""));
-        open::that(dir);
+        open::that_detached(dir);
     }
 
     fn on_quit(&self, callback: Box<dyn FnMut()>) {


### PR DESCRIPTION
If you go to the file tree and press "x" (which is "project_panel::RevealInFinder"). It will open the default file manager(in my case nautilus). But on Linux it makes Zed unresponsive. This fixes that.

Release Notes:

- N/A