### PR TITLE
Update reference to keymap.json in tasks docs

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -73,7 +73,7 @@ The intended use of ephemeral tasks is to stay in the flow with continuous `task
 
 ## Custom keybindings for tasks
 
-You can define your own keybindings for your tasks via additional argument to `task::Spawn`. If you wanted to bind the aforementioned `echo current file's path` task to `alt-g`, you would add the following snippet in your `keybindings.json` file:
+You can define your own keybindings for your tasks via additional argument to `task::Spawn`. If you wanted to bind the aforementioned `echo current file's path` task to `alt-g`, you would add the following snippet in your [`keymap.json`](./key-bindings/) file:
 
 ```json
 {


### PR DESCRIPTION
I assume this was an older file name or just a typo as I can't find any other references to a `keybindings.json` file. Either way it was confusing for a bit :) 

Release Notes:

- N/A
