### PR TITLE
Wayland: Implement text_input_v3 and xkb compose

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -632,6 +632,68 @@ impl Keystroke {
             ime_key,
         }
     }
+
+    /**
+     * Returns which symbol the dead key represents
+     * https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#dead_keycodes_for_linux
+     */
+    pub fn underlying_dead_key(keysym: Keysym) -> Option<String> {
+        match keysym {
+            Keysym::dead_grave => Some("`".to_owned()),
+            Keysym::dead_acute => Some("´".to_owned()),
+            Keysym::dead_circumflex => Some("^".to_owned()),
+            Keysym::dead_tilde => Some("~".to_owned()),
+            Keysym::dead_perispomeni => Some("͂".to_owned()),
+            Keysym::dead_macron => Some("¯".to_owned()),
+            Keysym::dead_breve => Some("˘".to_owned()),
+            Keysym::dead_abovedot => Some("˙".to_owned()),
+            Keysym::dead_diaeresis => Some("¨".to_owned()),
+            Keysym::dead_abovering => Some("˚".to_owned()),
+            Keysym::dead_doubleacute => Some("˝".to_owned()),
+            Keysym::dead_caron => Some("ˇ".to_owned()),
+            Keysym::dead_cedilla => Some("¸".to_owned()),
+            Keysym::dead_ogonek => Some("˛".to_owned()),
+            Keysym::dead_iota => Some("ͅ".to_owned()),
+            Keysym::dead_voiced_sound => Some("゙".to_owned()),
+            Keysym::dead_semivoiced_sound => Some("゚".to_owned()),
+            Keysym::dead_belowdot => Some("̣̣".to_owned()),
+            Keysym::dead_hook => Some("̡".to_owned()),
+            Keysym::dead_horn => Some("̛".to_owned()),
+            Keysym::dead_stroke => Some("̶̶".to_owned()),
+            Keysym::dead_abovecomma => Some("̓̓".to_owned()),
+            Keysym::dead_psili => Some("᾿".to_owned()),
+            Keysym::dead_abovereversedcomma => Some("ʽ".to_owned()),
+            Keysym::dead_dasia => Some("῾".to_owned()),
+            Keysym::dead_doublegrave => Some("̏".to_owned()),
+            Keysym::dead_belowring => Some("˳".to_owned()),
+            Keysym::dead_belowmacron => Some("̱".to_owned()),
+            Keysym::dead_belowcircumflex => Some("ꞈ".to_owned()),
+            Keysym::dead_belowtilde => Some("̰".to_owned()),
+            Keysym::dead_belowbreve => Some("̮".to_owned()),
+            Keysym::dead_belowdiaeresis => Some("̤".to_owned()),
+            Keysym::dead_invertedbreve => Some("̯".to_owned()),
+            Keysym::dead_belowcomma => Some("̦".to_owned()),
+            Keysym::dead_currency => None,
+            Keysym::dead_lowline => None,
+            Keysym::dead_aboveverticalline => None,
+            Keysym::dead_belowverticalline => None,
+            Keysym::dead_longsolidusoverlay => None,
+            Keysym::dead_a => None,
+            Keysym::dead_A => None,
+            Keysym::dead_e => None,
+            Keysym::dead_E => None,
+            Keysym::dead_i => None,
+            Keysym::dead_I => None,
+            Keysym::dead_o => None,
+            Keysym::dead_O => None,
+            Keysym::dead_u => None,
+            Keysym::dead_U => None,
+            Keysym::dead_small_schwa => Some("ə".to_owned()),
+            Keysym::dead_capital_schwa => Some("Ə".to_owned()),
+            Keysym::dead_greek => None,
+            _ => None,
+        }
+    }
 }
 
 impl Modifiers {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -853,7 +853,9 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 state.enter_token.take();
 
                 if let Some(window) = keyboard_focused_window {
+                    state.pre_edit_text.take();
                     drop(state);
+                    window.handle_ime_delete();
                     window.set_focused(false);
                 }
             }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1200,12 +1200,15 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                 }
                 match button_state {
                     wl_pointer::ButtonState::Pressed => {
-                        if let Some(pre_edit) = state.pre_edit_text.take() {
-                            if let Some(window) = state.keyboard_focused_window.clone() {
-                                drop(state);
-                                window.handle_ime_commit(pre_edit);
-                                state = client.borrow_mut();
-                            }
+                        if let (Some(window), Some(pre_edit), Some(compose_state)) = (
+                            state.keyboard_focused_window.clone(),
+                            state.pre_edit_text.take(),
+                            state.compose_state.as_mut(),
+                        ) {
+                            compose_state.reset();
+                            drop(state);
+                            window.handle_ime_commit(pre_edit);
+                            state = client.borrow_mut();
                         }
                         let click_elapsed = state.click.last_click.elapsed();
 

--- a/crates/gpui/src/platform/linux/wayland/serial.rs
+++ b/crates/gpui/src/platform/linux/wayland/serial.rs
@@ -5,6 +5,7 @@ use collections::HashMap;
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub(crate) enum SerialKind {
     DataDevice,
+    InputMethod,
     MouseEnter,
     MousePress,
     KeyPress,

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -417,6 +417,70 @@ impl WaylandWindowStatePtr {
         }
     }
 
+    pub fn handle_ime_commit(&self, text: String) {
+        if let Some(ref mut fun) = self.callbacks.borrow_mut().input {
+            if !fun(PlatformInput::KeyUp(crate::KeyUpEvent {
+                keystroke: crate::Keystroke::default(),
+            }))
+            .propagate
+            {
+                return;
+            }
+        }
+        let mut state = self.state.borrow_mut();
+        if let Some(mut input_handler) = state.input_handler.take() {
+            drop(state);
+            input_handler.replace_text_in_range(None, &text);
+            self.state.borrow_mut().input_handler = Some(input_handler);
+        }
+    }
+
+    pub fn handle_ime_preedit(&self, text: String) {
+        if let Some(ref mut fun) = self.callbacks.borrow_mut().input {
+            if !fun(PlatformInput::KeyUp(crate::KeyUpEvent {
+                keystroke: crate::Keystroke::default(),
+            }))
+            .propagate
+            {
+                return;
+            }
+        }
+        let mut state = self.state.borrow_mut();
+        if let Some(mut input_handler) = state.input_handler.take() {
+            drop(state);
+            input_handler.replace_and_mark_text_in_range(
+                None,
+                &text,
+                Some(0..text.chars().count()),
+            );
+            self.state.borrow_mut().input_handler = Some(input_handler);
+        }
+    }
+
+    pub fn handle_ime_delete(&self) {
+        let mut state = self.state.borrow_mut();
+        if let Some(mut input_handler) = state.input_handler.take() {
+            drop(state);
+            if let Some(marked) = input_handler.marked_text_range() {
+                input_handler.replace_text_in_range(Some(marked), "");
+            };
+            self.state.borrow_mut().input_handler = Some(input_handler);
+        }
+    }
+
+    pub fn get_ime_area(&self) -> Option<Bounds<Pixels>> {
+        let mut state = self.state.borrow_mut();
+        let mut bounds: Option<Bounds<Pixels>> = None;
+        if let Some(mut input_handler) = state.input_handler.take() {
+            drop(state);
+            if let Some(range) = input_handler.marked_text_range() {
+                bounds = input_handler.bounds_for_range(range);
+            }
+            self.state.borrow_mut().input_handler = Some(input_handler);
+        }
+        bounds
+    }
+
     pub fn set_size_and_scale(
         &self,
         width: Option<NonZeroU32>,

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -418,15 +418,6 @@ impl WaylandWindowStatePtr {
     }
 
     pub fn handle_ime_commit(&self, text: String) {
-        if let Some(ref mut fun) = self.callbacks.borrow_mut().input {
-            if !fun(PlatformInput::KeyUp(crate::KeyUpEvent {
-                keystroke: crate::Keystroke::default(),
-            }))
-            .propagate
-            {
-                return;
-            }
-        }
         let mut state = self.state.borrow_mut();
         if let Some(mut input_handler) = state.input_handler.take() {
             drop(state);
@@ -436,15 +427,6 @@ impl WaylandWindowStatePtr {
     }
 
     pub fn handle_ime_preedit(&self, text: String) {
-        if let Some(ref mut fun) = self.callbacks.borrow_mut().input {
-            if !fun(PlatformInput::KeyUp(crate::KeyUpEvent {
-                keystroke: crate::Keystroke::default(),
-            }))
-            .propagate
-            {
-                return;
-            }
-        }
         let mut state = self.state.borrow_mut();
         if let Some(mut input_handler) = state.input_handler.take() {
             drop(state);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -473,7 +473,7 @@ impl WaylandWindowStatePtr {
         let mut bounds: Option<Bounds<Pixels>> = None;
         if let Some(mut input_handler) = state.input_handler.take() {
             drop(state);
-            if let Some(range) = input_handler.marked_text_range() {
+            if let Some(range) = input_handler.selected_text_range() {
                 bounds = input_handler.bounds_for_range(range);
             }
             self.state.borrow_mut().input_handler = Some(input_handler);

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -448,11 +448,7 @@ impl WaylandWindowStatePtr {
         let mut state = self.state.borrow_mut();
         if let Some(mut input_handler) = state.input_handler.take() {
             drop(state);
-            input_handler.replace_and_mark_text_in_range(
-                None,
-                &text,
-                Some(0..text.chars().count()),
-            );
+            input_handler.replace_and_mark_text_in_range(None, &text, None);
             self.state.borrow_mut().input_handler = Some(input_handler);
         }
     }


### PR DESCRIPTION
Release Notes:

- N/A

Fixes #9207 
Known Issues:
- [ ] ~~After launching Zed and immediately trying to change input method, the input panel will appear at Point{0, 0}~~
- [ ] ~~`ime_handle_preedit` should not trigger `write_to_primary`~~ Move to other PR
- [ ] ~~Cursor is visually stuck at the end.~~ Move to other PR
Currently tested with KDE & fcitx5.