### PR TITLE
docs: Standardize "Note" blockquote usage

### DIFF
--- a/docs/src/assistant-panel.md
+++ b/docs/src/assistant-panel.md
@@ -2,7 +2,7 @@
 
 The assistant panel provides you with a way to interact with OpenAI's large language models. The assistant is good for various tasks, such as generating code, asking questions about existing code, and even writing plaintext, such as emails and documentation. To open the assistant panel, toggle the right dock by using the `workspace: toggle right dock` action in the command palette (`cmd-shift-p`).
 
-_Note: A default binding can be set to toggle the right dock via the settings._
+> **Note**: A default binding can be set to toggle the right dock via the settings.
 
 ## Setup
 

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -64,10 +64,10 @@ You can also only execute a single ESLint rule when using `fixAll`:
 }
 ```
 
-**Note:** the other formatter you have configured will still run, after ESLint.
-So if your language server or prettier configuration don't format according to
-ESLint's rules, then they will overwrite what ESLint fixed and you end up with
-errors.
+> **Note:** the other formatter you have configured will still run, after ESLint.
+> So if your language server or prettier configuration don't format according to
+> ESLint's rules, then they will overwrite what ESLint fixed and you end up with
+> errors.
 
 If you **only** want to run ESLint on save, you can configure code actions as
 the formatter (requires Zed `0.130.x`):

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -12,7 +12,7 @@ Currently the two instances connect via Zed's servers, but we intend to build pe
 
 ## Setup
 
-> NOTE: You must be in the alpha program to see this UI. The instructions will likely change as the feature gets closer to launch.
+> **Note**: You must be in the alpha program to see this UI. The instructions will likely change as the feature gets closer to launch.
 
 1. Open the projects dialog with `cmd-option-o` and then click "Connect…".
 2. Click "Add Server"
@@ -23,11 +23,11 @@ Currently the two instances connect via Zed's servers, but we intend to build pe
    ```
 5. On the remote machine, paste the instructions from step 3.
 
-   > NOTE: Currently you must keep this process open. We are working on making it background itself.
+   > **Note**: Currently you must keep this process open. We are working on making it background itself.
    > In the meantime, you can run `nohup zed --dev-server-token YY.XXX >~/.zed-log 2>&1 &`
 
 6. On your laptop you can now open folders on the remote machine.
-   > NOTE: Zed does not currently handle opening very large directories (e.g. `/` or `~` that may have >100,000 files) very well. We are working on improving this, but suggest in the meantime opening only specific projects, or subfolders of very large mono-repos.
+   > **Note**: Zed does not currently handle opening very large directories (e.g. `/` or `~` that may have >100,000 files) very well. We are working on improving this, but suggest in the meantime opening only specific projects, or subfolders of very large mono-repos.
 
 ## Known Limitations
 


### PR DESCRIPTION
Standardize the blockquote "Notes" usage, so all places are using the `>` blockquote notation, as well as a consistent style for the "Note" word.

PS: Thought that bolding the word "**Note**" would make for a higher visual distinction, so went for it in all existing cases! No strong feelings, though; happy to roll back to just "Note:" if that's preferrable!

Release Notes:

- N/A