### PR TITLE
Fix runnable, code_actions button can not trigger when editor not focused

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4509,6 +4509,7 @@ impl Editor {
                     .icon_color(Color::Muted)
                     .selected(is_active)
                     .on_click(cx.listener(move |editor, _e, cx| {
+                        editor.focus(cx);
                         editor.toggle_code_actions(
                             &ToggleCodeActions {
                                 deployed_from_indicator: Some(row),
@@ -4540,12 +4541,13 @@ impl Editor {
         row: DisplayRow,
         cx: &mut ViewContext<Self>,
     ) -> IconButton {
-        IconButton::new("code_actions_indicator", ui::IconName::Play)
+        IconButton::new("run_indicator", ui::IconName::Play)
             .icon_size(IconSize::XSmall)
             .size(ui::ButtonSize::None)
             .icon_color(Color::Muted)
             .selected(is_active)
             .on_click(cx.listener(move |editor, _e, cx| {
+                editor.focus(cx);
                 editor.toggle_code_actions(
                     &ToggleCodeActions {
                         deployed_from_indicator: Some(row),


### PR DESCRIPTION
Release Notes:

- Fixed runnable and code_actions buttons can not trigger when editor not focused.
  - Fixed runnable button id, avoid pressed state confusion.


## Before

https://github.com/zed-industries/zed/assets/5518/546450fc-ad2c-45d0-8bdb-7b15cfebe235

## After

https://github.com/zed-industries/zed/assets/5518/efc4f863-9db1-4846-83ae-c99ae4dcb3ed

