### PR TITLE
docs: Fix link to configuring-zed.md on https://zed.dev/docs

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -8,7 +8,7 @@ You can obtain the release build via the [download page](https://zed.dev/downloa
 
 ## Configure Zed
 
-Use `⌘` + `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See [Configuring Zed](/configuring-zed.md) for all available settings.
+Use `⌘` + `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See [Configuring Zed](./configuring-zed.md) for all available settings.
 
 ## Set up your key bindings
 


### PR DESCRIPTION
Problem: mdBook's `site-url` HTML renderer option requires that you use document relative links for assets,
meaning that they should not start with `/`. This meant that `getting-started.md`'s link to `/configuring-zed.md`
incorrectly pointed to `https://zed.dev/configuring-zed.md` instead of `https://zed.dev/docs/configuring-zed.md`.

Solution: Remove the `/` so that the link becomes relative.

Testing: Ran `mdbook serve docs` locally & verified that I was able to click-through
from `http://[::1]:3000/` to `http://[::1]:3000/configuring-zed.html`. This does not cover
the exact production `site-url` case, but I'm not sure how to test that locally.

Reference: https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options
