### PR TITLE
Fix a link to Zed configuring docs

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -8,7 +8,7 @@ You can obtain the release build via the [download page](https://zed.dev/downloa
 
 ## Configure Zed
 
-Use `⌘` + `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See [Configuring Zed](/configuring-zed.md) for all available settings.
+Use `⌘` + `,` to open your custom settings to set things like fonts, formatting settings, per-language settings and more. You can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See [Configuring Zed](./configuring-zed.md) for all available settings.
 
 ## Set up your key bindings
 


### PR DESCRIPTION
Based on https://github.com/zed-industries/zed/pull/11736 

Release Notes:

- N/A
