### PR TITLE
vue: Fix Vue.js language server not starting

### DIFF
--- a/extensions/vue/extension.toml
+++ b/extensions/vue/extension.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/zed-industries/zed"
 [language_servers.vue-language-server]
 name = "Vue Language Server"
 language = "Vue.js"
+language_ids = { "Vue.js" = "vue" }
 # REFACTOR is explicitly disabled, as vue-lsp does not adhere to LSP protocol for code actions with these - it
 # sends back a CodeAction with neither `command` nor `edits` fields set, which is against the spec.
 code_action_kinds = ["", "quickfix", "refactor.rewrite"]


### PR DESCRIPTION
This fixes #10871.

The introduction of #11412 broke Vue.js language support, since it made Zed rely more heavily on correct language name -> language ID mappings, which the Vue.js extension didn't have.

Release Notes:

- N/A

