### PR TITLE
vue: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13171,7 +13171,7 @@ dependencies = [
 
 [[package]]
 name = "zed_vue"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/vue/Cargo.toml
+++ b/extensions/vue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_vue"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/vue/extension.toml
+++ b/extensions/vue/extension.toml
@@ -1,7 +1,7 @@
 id = "vue"
 name = "Vue"
 description = "Vue support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Vue extension to v0.0.2.

Changes:

- #11743

Release Notes:

- N/A
