### PR TITLE
shell: Load SHELL from passwd entry if launched as desktop app

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -306,7 +306,7 @@ fn main() {
         Task::ready(())
     } else {
         app.background_executor().spawn(async {
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(unix))]
             {
                 load_shell_from_passwd().await.log_err();
             }
@@ -683,7 +683,7 @@ fn init_stdout_logger() {
         .init();
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(unix)]
 async fn load_shell_from_passwd() -> Result<()> {
     let bufsize = match unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) } {
         n if n < 0 => 1024,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -306,7 +306,7 @@ fn main() {
         Task::ready(())
     } else {
         app.background_executor().spawn(async {
-            #[cfg(unix))]
+            #[cfg(unix)]
             {
                 load_shell_from_passwd().await.log_err();
             }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -684,6 +684,7 @@ fn init_stdout_logger() {
         .init();
 }
 
+#[cfg(not(target_os = "windows"))]
 async fn load_shell_from_passwd() -> Result<()> {
     let bufsize = match unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) } {
         n if n < 0 => 1024,


### PR DESCRIPTION
This fixes #8794 and other related problems.

The problem, in short, is this: `$SHELL` might be outdated. This code ensures that we update `$SHELL` to what we can deem the newest version, if we're started as a desktop application.

The background is that you can get the user's preferred shell in two ways:

1. Read the `SHELL` env variable
2. Read the `/etc/passwd` file and check which shell is set

Most applications should and do prefer (1) over (2).

Why is it preferred? Reading `SHELL` means that processes can inherit the variable from each other. And you can do something like `SHELL=/bin/cool-shell ./my-cool-app`

But what happens if the application was launched from the desktop? Which SHELL env does it inherit then?

It inherits the env from the process that launched it, which is Finder.app or launchd or GNOME or something else — these are all long-running processes that get their environment when the user logs in.

They do *not* get a new environment unless restarted (either process restarted or computer restarted)

That means the `SHELL` env variable they have might be outdated.

That's a problem if you, for example, change your shell with `chsh` and then launch the app from the desktop.

That change of the default shell is not reflected in the app if the app only reads from SHELL. Because that hasn’t been updated. Instead it should read from passwd file to get the newest value.



Release Notes:

- Fixed SHELL being outdated if Zed was launched via Finder or Raycast or other desktop launchers. ([#8794](https://github.com/zed-industries/zed/issues/8794))