### PR TITLE
ruby: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13159,7 +13159,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruby"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/ruby/Cargo.toml
+++ b/extensions/ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Ruby extension to v0.0.2.

Changes:

- #11768

Release Notes:

- N/A
