### PR TITLE
Remove selection highlights from deleted diff editors on blur

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1943,13 +1943,8 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn set_current_line_highlight(
-        &mut self,
-        current_line_highlight: CurrentLineHighlight,
-        cx: &mut ViewContext<Self>,
-    ) {
+    pub fn set_current_line_highlight(&mut self, current_line_highlight: CurrentLineHighlight) {
         self.current_line_highlight = current_line_highlight;
-        cx.notify();
     }
 
     pub fn set_collapse_matches(&mut self, collapse_matches: bool) {


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/11710

Release Notes:

- Removed extra line highlights when deleted diff editors loose focus