### PR TITLE
Add missing LICENSE file to `http` crate

### DIFF
--- a/crates/http/LICENSE-APACHE
+++ b/crates/http/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE


### PR DESCRIPTION
This PR adds a missing LICENSE file to the recently-extracted `http` crate.

Release Notes:

- N/A
