### PR TITLE
Fixy

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1713,7 +1713,7 @@ impl Editor {
         this
     }
 
-    fn key_context(&self, cx: &AppContext) -> KeyContext {
+    pub fn key_context(&self, cx: &AppContext) -> KeyContext {
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add("Editor");
         let mode = match self.mode {

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -70,8 +70,10 @@ pub fn deploy_context_menu(
             s.set_pending_display_range(point..point, SelectMode::Character);
         });
 
+        let focus = cx.focused();
         ui::ContextMenu::build(cx, |menu, _cx| {
-            menu.action("Rename Symbol", Box::new(Rename))
+            let builder = menu
+                .action("Rename Symbol", Box::new(Rename))
                 .action("Go to Definition", Box::new(GoToDefinition))
                 .action("Go to Type Definition", Box::new(GoToTypeDefinition))
                 .action("Go to Implementation", Box::new(GoToImplementation))
@@ -84,7 +86,11 @@ pub fn deploy_context_menu(
                 )
                 .separator()
                 .action("Reveal in Finder", Box::new(RevealInFinder))
-                .action("Open in Terminal", Box::new(OpenInTerminal))
+                .action("Open in Terminal", Box::new(OpenInTerminal));
+            match focus {
+                Some(focus) => builder.context(focus),
+                None => builder,
+            }
         })
     };
     let mouse_context_menu = MouseContextMenu::new(position, context_menu, cx);

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -818,7 +818,11 @@ impl Vim {
             // disables vim if the rename editor is focused,
             // but not if the command palette is open.
             } else if editor.focus_handle(cx).contains_focused(cx) {
-                editor.remove_keymap_context_layer::<Self>(cx)
+                if editor.key_context(cx).contains("renaming") {
+                    editor.remove_keymap_context_layer::<Self>(cx);
+                } else {
+                    editor.set_keymap_context_layer::<Self>(state.keymap_context_layer(), cx);
+                }
             }
         });
     }


### PR DESCRIPTION
Fixes a bug where Vim bindings would flash in the mouse context menu and then be replaced by the default keybindings. Also fixes those bindings not being usable while the mouse context menu was open.

Release Notes:

- Fixed bug where Vim bindings were not available when mouse context menu was open