### PR TITLE
terminal: Fix Alacritty key bindings

### DIFF
--- a/crates/terminal/src/mappings/keys.rs
+++ b/crates/terminal/src/mappings/keys.rs
@@ -56,6 +56,7 @@ pub fn to_esc_str(keystroke: &Keystroke, mode: &TermMode, alt_is_meta: bool) -> 
         ("tab", AlacModifiers::Shift) => Some("\x1b[Z".to_string()),
         ("backspace", AlacModifiers::Alt) => Some("\x1b\x7f".to_string()),
         ("backspace", AlacModifiers::Shift) => Some("\x7f".to_string()),
+        ("space", AlacModifiers::Ctrl) => Some("\x00".to_string()),
         ("home", AlacModifiers::Shift) if mode.contains(TermMode::ALT_SCREEN) => {
             Some("\x1b[1;2H".to_string())
         }


### PR DESCRIPTION
Close #10502 

Release Notes:

- Fixed `ctrl-space` not being forwarded correctly in the terminal view. ([#10502](https://github.com/zed-industries/zed/issues/10502))
