### PR TITLE
fix: set openai url endpoint via environment variables

### DIFF
--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use gpui::Pixels;
+use open_ai::open_ai_api_url;
 pub use open_ai::Model as OpenAiModel;
 use schemars::{
     schema::{InstanceType, Metadata, Schema, SchemaObject},
@@ -167,7 +168,7 @@ impl Default for AssistantProvider {
 }
 
 fn open_ai_url() -> String {
-    "https://api.openai.com/v1".into()
+    open_ai_api_url().into()
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -168,7 +168,7 @@ impl Default for AssistantProvider {
 }
 
 fn open_ai_url() -> String {
-    open_ai_api_url().into()
+    open_ai_api_url()
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -4662,7 +4662,7 @@ async fn compute_embeddings(
         "openai/text-embedding-3-small" => {
             open_ai::embed(
                 session.http_client.as_ref(),
-                open_ai_api_url(),
+                open_ai_api_url().as_str(),
                 &api_key,
                 OpenAiEmbeddingModel::TextEmbedding3Small,
                 request.texts.iter().map(|text| text.as_str()),

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -32,7 +32,7 @@ use axum::{
 use collections::{HashMap, HashSet};
 pub use connection_pool::{ConnectionPool, ZedVersion};
 use core::fmt::{self, Debug, Formatter};
-use open_ai::{OpenAiEmbeddingModel, OPEN_AI_API_URL};
+use open_ai::{OpenAiEmbeddingModel, open_ai_api_url};
 use sha2::Digest;
 use supermaven_api::{CreateExternalUserRequest, SupermavenAdminApi};
 
@@ -4341,7 +4341,7 @@ async fn complete_with_open_ai(
 ) -> Result<()> {
     let mut completion_stream = open_ai::stream_completion(
         session.http_client.as_ref(),
-        OPEN_AI_API_URL,
+        open_ai_api_url(),
         &api_key,
         crate::ai::language_model_request_to_open_ai(request)?,
         None,
@@ -4662,7 +4662,7 @@ async fn compute_embeddings(
         "openai/text-embedding-3-small" => {
             open_ai::embed(
                 session.http_client.as_ref(),
-                OPEN_AI_API_URL,
+                open_ai_api_url(),
                 &api_key,
                 OpenAiEmbeddingModel::TextEmbedding3Small,
                 request.texts.iter().map(|text| text.as_str()),

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -4341,7 +4341,7 @@ async fn complete_with_open_ai(
 ) -> Result<()> {
     let mut completion_stream = open_ai::stream_completion(
         session.http_client.as_ref(),
-        open_ai_api_url(),
+        open_ai_api_url().as_str(),
         &api_key,
         crate::ai::language_model_request_to_open_ai(request)?,
         None,

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -32,7 +32,7 @@ use axum::{
 use collections::{HashMap, HashSet};
 pub use connection_pool::{ConnectionPool, ZedVersion};
 use core::fmt::{self, Debug, Formatter};
-use open_ai::{OpenAiEmbeddingModel, open_ai_api_url};
+use open_ai::{open_ai_api_url, OpenAiEmbeddingModel};
 use sha2::Digest;
 use supermaven_api::{CreateExternalUserRequest, SupermavenAdminApi};
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -5,9 +5,12 @@ use isahc::config::Configurable;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::time::Duration;
+use std::env;
 use std::{convert::TryFrom, future::Future};
 
-pub const OPEN_AI_API_URL: &str = "https://api.openai.com/v1";
+pub fn open_ai_api_url() -> String {
+    env::var("OPENAI_API_END_POINT").unwrap_or_else(|_| String::from("https://api.open.com/v1"))
+}
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -4,12 +4,12 @@ use http::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use isahc::config::Configurable;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::time::Duration;
 use std::env;
+use std::time::Duration;
 use std::{convert::TryFrom, future::Future};
 
 pub fn open_ai_api_url() -> String {
-    env::var("OPENAI_API_END_POINT").unwrap_or_else(|_| String::from("https://api.open.com/v1"))
+    env::var("OPENAI_API_END_POINT").unwrap_or_else(|_| String::from("https://api.openai.com/v1"))
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]

--- a/crates/semantic_index/examples/index.rs
+++ b/crates/semantic_index/examples/index.rs
@@ -45,7 +45,7 @@ fn main() {
         let embedding_provider = Arc::new(OpenAiEmbeddingProvider::new(
             http.clone(),
             OpenAiEmbeddingModel::TextEmbedding3Small,
-            open_ai::OPEN_AI_API_URL.to_string(),
+            open_ai::open_ai_api_url(),
             api_key,
         ));
 

--- a/docs/src/assistant-panel.md
+++ b/docs/src/assistant-panel.md
@@ -18,7 +18,7 @@ The assistant panel provides you with a way to interact with OpenAI's large lang
 
 The OpenAI API key will be saved in your keychain.
 
-Zed will also use the `OPENAI_API_KEY` environment variable if it's defined. If you need to reset your OpenAI API key, focus on the assistant panel and run the command palette action `assistant: reset key`.
+Zed will also use the `OPENAI_API_KEY` and `OPENAI_API_END_POINT` environment variable if it's defined. If you need to reset your OpenAI API key, focus on the assistant panel and run the command palette action `assistant: reset key`.
 
 ## Having a conversation
 


### PR DESCRIPTION
Sometimes we need to use custom openai endpoint instead of default url (https://api.open.com/v1)

Release Notes:

- Set openai url endpoint via environment variables

