### PR TITLE
inline blame: Match icon size to font size in buffer

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3388,7 +3388,11 @@ fn render_inline_blame_entry(
         .font_family(style.text.font().family)
         .text_color(cx.theme().status().hint)
         .line_height(style.text.line_height)
-        .child(Icon::new(IconName::FileGit).color(Color::Hint))
+        .child(
+            Icon::new(IconName::FileGit)
+                .color(Color::Hint)
+                .font_size(style.text.font_size),
+        )
         .child(text)
         .gap_2()
         .hoverable_tooltip(move |_| tooltip.clone().into())

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -344,6 +344,14 @@ impl Icon {
         self
     }
 
+    pub fn font_size(self, font_size: AbsoluteLength) -> Self {
+        let rems = match font_size {
+            AbsoluteLength::Pixels(pixels) => rems_from_px(pixels.into()),
+            AbsoluteLength::Rems(rems) => rems,
+        };
+        self.custom_size(rems)
+    }
+
     pub fn transform(mut self, transformation: Transformation) -> Self {
         self.transformation = transformation;
         self


### PR DESCRIPTION
This fixes #11311.


Release Notes:

- Fixed icon in inline git blame entry not changing with the buffer font size. ([#11311](https://github.com/zed-industries/zed/issues/11311)).

Before:

![screenshot-2024-05-14-10 48 49@2x](https://github.com/zed-industries/zed/assets/1185253/4a288cae-a52b-4bee-8681-f1d9ba3b57f3)

After:

![screenshot-2024-05-14-10 50 06@2x](https://github.com/zed-industries/zed/assets/1185253/f7a6a608-8ecc-4642-adbd-80858dea75e9)
