### PR TITLE
Fix bug with keymaps flickering in mouse menu

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1713,7 +1713,7 @@ impl Editor {
         this
     }
 
-    fn key_context(&self, cx: &AppContext) -> KeyContext {
+    pub fn key_context(&self, cx: &AppContext) -> KeyContext {
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add("Editor");
         let mode = match self.mode {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1713,7 +1713,13 @@ impl Editor {
         this
     }
 
-    pub fn key_context(&self, cx: &AppContext) -> KeyContext {
+    pub fn mouse_menu_is_focused(&self, cx: &mut WindowContext) -> bool {
+        self.mouse_context_menu
+            .as_ref()
+            .is_some_and(|menu| menu.context_menu.focus_handle(cx).is_focused(cx))
+    }
+
+    fn key_context(&self, cx: &AppContext) -> KeyContext {
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add("Editor");
         let mode = match self.mode {

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -70,8 +70,10 @@ pub fn deploy_context_menu(
             s.set_pending_display_range(point..point, SelectMode::Character);
         });
 
+        let focus = cx.focused();
         ui::ContextMenu::build(cx, |menu, _cx| {
-            menu.action("Rename Symbol", Box::new(Rename))
+            let builder = menu
+                .action("Rename Symbol", Box::new(Rename))
                 .action("Go to Definition", Box::new(GoToDefinition))
                 .action("Go to Type Definition", Box::new(GoToTypeDefinition))
                 .action("Go to Implementation", Box::new(GoToImplementation))
@@ -84,7 +86,11 @@ pub fn deploy_context_menu(
                 )
                 .separator()
                 .action("Reveal in Finder", Box::new(RevealInFinder))
-                .action("Open in Terminal", Box::new(OpenInTerminal))
+                .action("Open in Terminal", Box::new(OpenInTerminal));
+            match focus {
+                Some(focus) => builder.context(focus),
+                None => builder,
+            }
         })
     };
     let mouse_context_menu = MouseContextMenu::new(position, context_menu, cx);

--- a/crates/fuzzy/src/char_bag.rs
+++ b/crates/fuzzy/src/char_bag.rs
@@ -5,6 +5,7 @@ pub struct CharBag(u64);
 
 impl CharBag {
     pub fn is_superset(self, other: CharBag) -> bool {
+
         self.0 & other.0 == other.0
     }
 

--- a/crates/fuzzy/src/char_bag.rs
+++ b/crates/fuzzy/src/char_bag.rs
@@ -5,7 +5,6 @@ pub struct CharBag(u64);
 
 impl CharBag {
     pub fn is_superset(self, other: CharBag) -> bool {
-
         self.0 & other.0 == other.0
     }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -818,7 +818,11 @@ impl Vim {
             // disables vim if the rename editor is focused,
             // but not if the command palette is open.
             } else if editor.focus_handle(cx).contains_focused(cx) {
-                editor.remove_keymap_context_layer::<Self>(cx)
+                if editor.key_context(cx).contains("renaming") {
+                    editor.remove_keymap_context_layer::<Self>(cx);
+                } else {
+                    editor.set_keymap_context_layer::<Self>(state.keymap_context_layer(), cx);
+                }
             }
         });
     }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -813,16 +813,11 @@ impl Vim {
             editor.set_input_enabled(!state.vim_controlled());
             editor.set_autoindent(state.should_autoindent());
             editor.selections.line_mode = matches!(state.mode, Mode::VisualLine);
-            if editor.is_focused(cx) {
+            if editor.is_focused(cx) || editor.mouse_menu_is_focused(cx) {
                 editor.set_keymap_context_layer::<Self>(state.keymap_context_layer(), cx);
-            // disables vim if the rename editor is focused,
-            // but not if the command palette is open.
+                // disable vim mode if a sub-editor (inline assist, rename, etc.) is focused
             } else if editor.focus_handle(cx).contains_focused(cx) {
-                if editor.key_context(cx).contains("renaming") {
-                    editor.remove_keymap_context_layer::<Self>(cx);
-                } else {
-                    editor.set_keymap_context_layer::<Self>(state.keymap_context_layer(), cx);
-                }
+                editor.remove_keymap_context_layer::<Self>(cx);
             }
         });
     }


### PR DESCRIPTION
Fixes a bug where Vim bindings would flash in the mouse context menu and then be replaced by the default keybindings. Also fixes those bindings not being usable while the mouse context menu was open.

Release Notes:

- Fixed bug where Vim bindings were not available when mouse context menu was open