### PR TITLE
gleam: Add `gleam test` task

### DIFF
--- a/extensions/gleam/languages/gleam/tasks.json
+++ b/extensions/gleam/languages/gleam/tasks.json
@@ -1,5 +1,10 @@
 [
   {
+    "label": "gleam test",
+    "command": "gleam",
+    "args": ["test"]
+  },
+  {
     "label": "gleam test $ZED_SYMBOL",
     "command": "gleam",
     "args": ["test", "--", "--test-name-filter=$ZED_SYMBOL"],


### PR DESCRIPTION
This PR adds a task for running `gleam test`.

Release Notes:

- N/A
