### PR TITLE
windows: Fix node_runtime to support proxy by keep system env

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -247,7 +247,6 @@ impl NodeRuntime for RealNodeRuntime {
             }
 
             let mut command = Command::new(node_binary);
-            command.env_clear();
             command.env("PATH", env_path);
             command.arg(npm_file).arg(subcommand);
             command.args(["--cache".into(), installation_path.join("cache")]);


### PR DESCRIPTION
Release Notes:

- Fixed node runtime install npm on Windows by using system proxy.

----

NPM is installed in some regions (such as mainland China) and accessing npmjs.org must go through a proxy. 

```
[2024-05-14T22:31:02+08:00 ERROR project] failed to start language server "json-language-server": failed to execute npm info subcommand:
stdout: "{\n  \"error\": {\n    \"code\": \"EAI_FAIL\",\n    \"summary\": \"request to https://registry.npmjs.org/vscode-json-languageserver failed, reason: getaddrinfo EAI_FAIL registry.npmjs.org\",\n    
\"detail\": \"This is a problem related to network connectivity.\\nIn most cases you are behind a proxy or have bad network settings.\\n\\nIf you are behind a proxy, please make sure that the\\n'proxy' config is set properly.  See: 'npm help config'\"\n  }\n}\n"
```

However, when NPM install was executed in node_runtime before, the `env_clear` action was performed. This will lose the `http_proxy` environment variable set by the operating system.

I have done a lot of testing on Windows in the past few days:

   - Set `http_proxy`, `https_proxy` envs directly by use `envs` method for command.
   - Set `--proxy` argument.

But it still not work, the localhost proxy server `127.0.1` can't connect.

```
[2024-05-14T22:34:47+08:00 ERROR project] failed to start language server "json-language-server": failed to execute npm info subcommand:
stdout: "{\n  \"error\": {\n    \"code\": \"UNKNOWN\",\n    \"summary\": \"request to https://registry.npmjs.org/vscode-json-languageserver failed, reason: connect UNKNOWN 127.0.0.1:7897 - Local (undefined:undefined)\",\n    \"detail\": \"\"\n  }\n}\n"
stderr: "npm ERR! code UNKNOWN\nnpm ERR! syscall connect\nnpm ERR! errno UNKNOWN\nnpm ERR! request to https://registry.npmjs.org/vscode-json-languageserver failed, reason: connect UNKNOWN 127.0.0.1:7897 - Local (undefined:undefined)\n\nnpm ERR! A complete log of this run can be found in:\nnpm ERR!     C:\\Users\\jason\\AppData\\Local\\Zed\\node\\node-v18.15.0-win-x64\\cache\\_logs\\2024-05-14T14_34_39_920Z-debug-0.log\n"
```

> In this log, `127.0.0.1:7897` is my local proxy server, it is readed from `http_proxy` env.

I haven't found out why this happens on Windows. I have executed the same command on CMD, and it all works.

> The above issue not happened on macOS, it works fine.

Today, I have tried to remove the `env_clear`, then the proxy works. I don't why, why I set `envs` not work (I am sure the env and value is correct), but it actually works now.

So, I give up, to just removed `env_clear` let it just work.

**The Node runtime already uses absolute paths and additionally sets PATH, cache, --prefix, so there seems to be no need to clear the system ENVs?**


