### PR TITLE
blade: Fix display of straight underlines

### DIFF
--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -483,7 +483,7 @@ fn fs_underline(input: UnderlineVarying) -> @location(0) vec4<f32> {
     let underline = b_underlines[input.underline_id];
     if ((underline.wavy & 0xFFu) == 0u)
     {
-        return vec4<f32>(0.0);
+        return blend_color(input.color, input.color.a);
     }
 
     let half_thickness = underline.thickness * 0.5;
@@ -497,7 +497,7 @@ fn fs_underline(input: UnderlineVarying) -> @location(0) vec4<f32> {
     let distance_from_top_border = distance_in_pixels - half_thickness;
     let distance_from_bottom_border = distance_in_pixels + half_thickness;
     let alpha = saturate(0.5 - max(-distance_from_bottom_border, distance_from_top_border));
-    return blend_color(input.color, alpha);
+    return blend_color(input.color, alpha * input.color.a);
 }
 
 // --- monochrome sprites --- //


### PR DESCRIPTION
Fixes: #11715

(also apply alpha of the color to wavy ones while we're at it)

Release Notes:

- Fixed display of straight underlines when using the blade renderer (#11715)