### PR TITLE
assistant: Restructure ambient context in preparation for adding more

### DIFF
--- a/crates/assistant/src/ambient_context.rs
+++ b/crates/assistant/src/ambient_context.rs
@@ -1,0 +1,8 @@
+mod recent_buffers;
+
+pub use recent_buffers::*;
+
+#[derive(Default)]
+pub struct AmbientContext {
+    pub recent_buffers: RecentBuffersContext,
+}

--- a/crates/assistant/src/ambient_context/recent_buffers.rs
+++ b/crates/assistant/src/ambient_context/recent_buffers.rs
@@ -1,0 +1,25 @@
+use gpui::{Subscription, Task, WeakModel};
+use language::Buffer;
+
+pub struct RecentBuffersContext {
+    pub enabled: bool,
+    pub buffers: Vec<RecentBuffer>,
+    pub message: String,
+    pub pending_message: Option<Task<()>>,
+}
+
+pub struct RecentBuffer {
+    pub buffer: WeakModel<Buffer>,
+    pub _subscription: Subscription,
+}
+
+impl Default for RecentBuffersContext {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            buffers: Vec::new(),
+            message: String::new(),
+            pending_message: None,
+        }
+    }
+}

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -1,3 +1,4 @@
+mod ambient_context;
 pub mod assistant_panel;
 pub mod assistant_settings;
 mod codegen;

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,3 +1,4 @@
+use crate::ambient_context::{AmbientContext, RecentBuffer};
 use crate::{
     assistant_settings::{AssistantDockPosition, AssistantSettings, ZedDotDevModel},
     codegen::{self, Codegen, CodegenKind},
@@ -1365,34 +1366,6 @@ pub struct Conversation {
     path: Option<PathBuf>,
     _subscriptions: Vec<Subscription>,
     telemetry: Option<Arc<Telemetry>>,
-}
-
-#[derive(Default)]
-struct AmbientContext {
-    recent_buffers: RecentBuffersContext,
-}
-
-struct RecentBuffersContext {
-    enabled: bool,
-    buffers: Vec<RecentBuffer>,
-    message: String,
-    pending_message: Option<Task<()>>,
-}
-
-struct RecentBuffer {
-    buffer: WeakModel<Buffer>,
-    _subscription: Subscription,
-}
-
-impl Default for RecentBuffersContext {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            buffers: Vec::new(),
-            message: String::new(),
-            pending_message: None,
-        }
-    }
 }
 
 impl EventEmitter<ConversationEvent> for Conversation {}


### PR DESCRIPTION
This PR restructures the ambient context in the `assistant` crate to make it more amenable to adding more kinds of ambient context.

Release Notes:

- N/A
