### PR TITLE
ruby: Fix solargraph completion highlighting

### DIFF
--- a/extensions/ruby/src/language_servers/solargraph.rs
+++ b/extensions/ruby/src/language_servers/solargraph.rs
@@ -20,49 +20,43 @@ impl Solargraph {
     }
 
     pub fn label_for_completion(&self, completion: Completion) -> Option<CodeLabel> {
-        match completion.kind? {
-            CompletionKind::Method => {
-                let highlight_name = match completion.kind? {
-                    CompletionKind::Class | CompletionKind::Module => "type",
-                    CompletionKind::Constant => "constant",
-                    CompletionKind::Method => "function.method",
-                    CompletionKind::Keyword => {
-                        if completion.label.starts_with(':') {
-                            "string.special.symbol"
-                        } else {
-                            "keyword"
-                        }
-                    }
-                    CompletionKind::Variable => {
-                        if completion.label.starts_with('@') {
-                            "property"
-                        } else {
-                            return None;
-                        }
-                    }
-                    _ => return None,
-                };
-
-                let len = completion.label.len();
-                let name_span =
-                    CodeLabelSpan::literal(completion.label, Some(highlight_name.to_string()));
-
-                Some(CodeLabel {
-                    code: Default::default(),
-                    spans: if let Some(detail) = completion.detail {
-                        vec![
-                            name_span,
-                            CodeLabelSpan::literal(" ", None),
-                            CodeLabelSpan::literal(detail, None),
-                        ]
-                    } else {
-                        vec![name_span]
-                    },
-                    filter_range: (0..len).into(),
-                })
+        let highlight_name = match completion.kind? {
+            CompletionKind::Class | CompletionKind::Module => "type",
+            CompletionKind::Constant => "constant",
+            CompletionKind::Method => "function.method",
+            CompletionKind::Keyword => {
+                if completion.label.starts_with(':') {
+                    "string.special.symbol"
+                } else {
+                    "keyword"
+                }
             }
-            _ => None,
-        }
+            CompletionKind::Variable => {
+                if completion.label.starts_with('@') {
+                    "property"
+                } else {
+                    return None;
+                }
+            }
+            _ => return None,
+        };
+
+        let len = completion.label.len();
+        let name_span = CodeLabelSpan::literal(completion.label, Some(highlight_name.to_string()));
+
+        Some(CodeLabel {
+            code: Default::default(),
+            spans: if let Some(detail) = completion.detail {
+                vec![
+                    name_span,
+                    CodeLabelSpan::literal(" ", None),
+                    CodeLabelSpan::literal(detail, None),
+                ]
+            } else {
+                vec![name_span]
+            },
+            filter_range: (0..len).into(),
+        })
     }
 
     pub fn label_for_symbol(&self, symbol: Symbol) -> Option<CodeLabel> {


### PR DESCRIPTION
Hi. This pull request fixes a small error with `solargraph` completions to make them more detailed. It removes the nested match expression to resolve the problem with highlighting the completion items and their signatures with the return type as well. Thanks.

See screenshots below.

Release Notes:

- N/A

| Before  | After |
| ------------- | ------------- |
|  ![CleanShot 2024-05-14 at 23 23 00@2x](https://github.com/zed-industries/zed/assets/1894248/4ea1fa41-1189-4607-8aea-547c27229a18) | ![CleanShot 2024-05-14 at 23 29 30@2x](https://github.com/zed-industries/zed/assets/1894248/3c7be39a-2c7b-4662-8519-8c258c049cfa) |

