### PR TITLE
astro: Fix broken language injections

### DIFF
--- a/extensions/astro/extension.toml
+++ b/extensions/astro/extension.toml
@@ -12,4 +12,4 @@ language = "Astro"
 
 [grammars.astro]
 repository = "https://github.com/virchau13/tree-sitter-astro"
-commit = "dfa0893bdc4bdfada102043404758c66e3580568"
+commit = "4be180759ec13651f72bacee65fa477c64222a1a"

--- a/extensions/astro/languages/astro/injections.scm
+++ b/extensions/astro/languages/astro/injections.scm
@@ -1,16 +1,21 @@
-; inherits: html_tags
 (frontmatter
-  (raw_text) @content
+  (frontmatter_js_block) @content
   (#set! "language" "typescript"))
 
-(interpolation
-  (raw_text) @content
-  (#set! "language" "tsx"))
+(attribute_interpolation
+  (attribute_js_expr) @content
+  (#set! "language" "typescript"))
+
+(html_interpolation
+  (permissible_text) @content
+  (#set! "language" "typescript"))
 
 (script_element
   (raw_text) @content
   (#set! "language" "typescript"))
 
+; TODO: add scss/less or more injections
+; https://github.com/virchau13/tree-sitter-astro/blob/4be180759ec13651f72bacee65fa477c64222a1a/queries/injections.scm#L18-L27
 (style_element
   (raw_text) @content
   (#set! "language" "css"))


### PR DESCRIPTION
Update upstream https://github.com/virchau13/tree-sitter-astro/commit/4be180759ec13651f72bacee65fa477c64222a1a
This will solve #11827

Before:
<img width="644" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/f6b10667-9197-4e5d-8513-78ce3d22f9e7">
After:
<img width="700" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/7bd7b0e6-e73c-4d1d-abd6-d6b2d88e97a6">


Release Notes:

- N/A