### PR TITLE
astro: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13030,7 +13030,7 @@ dependencies = [
 
 [[package]]
 name = "zed_astro"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.4",
 ]

--- a/extensions/astro/Cargo.toml
+++ b/extensions/astro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_astro"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/astro/extension.toml
+++ b/extensions/astro/extension.toml
@@ -1,7 +1,7 @@
 id = "astro"
 name = "Astro"
 description = "Astro support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Alvaro Gaona <alvgaona@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Astro extension to v0.0.2.

Changes:

- #11830

Release Notes:

- N/A
