### PR TITLE
Show buffer_search on vim::MoveToNextMatch

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -840,6 +840,10 @@ impl BufferSearchBar {
         }
     }
 
+    pub fn has_active_match(&self) -> bool {
+        self.active_match_index.is_some()
+    }
+
     fn clear_matches(&mut self, cx: &mut ViewContext<Self>) {
         let mut active_item_matches = None;
         for (searchable_item, matches) in self.searchable_items_with_matches.drain() {

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -218,6 +218,9 @@ pub fn move_to_match_internal(
         pane.update(cx, |pane, cx| {
             if let Some(search_bar) = pane.toolbar().read(cx).item_of_type::<BufferSearchBar>() {
                 search_bar.update(cx, |search_bar, cx| {
+                    if !search_bar.has_active_match() || !search_bar.show(cx) {
+                        return;
+                    }
                     search_bar.select_match(direction, count, cx);
 
                     let new_selections = vim.editor_selections(cx);

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -516,6 +516,9 @@ pub fn select_match(
         pane.update(cx, |pane, cx| {
             if let Some(search_bar) = pane.toolbar().read(cx).item_of_type::<BufferSearchBar>() {
                 search_bar.update(cx, |search_bar, cx| {
+                    if !search_bar.has_active_match() || !search_bar.show(cx) {
+                        return;
+                    }
                     // without update_match_index there is a bug when the cursor is before the first match
                     search_bar.update_match_index(cx);
                     search_bar.select_match(direction.opposite(), 1, cx);


### PR DESCRIPTION
This changes the vim::MoveToNextMatch event callback to open the buffer_search toolbar. This fixes an issue where highlights would appear which were only cancellable by opening then closing the toolbar.

Release Notes:

- vim: ensure buffer search toolbar now opens on `n` and `gn` so that the highlights can be cleared