### PR TITLE
Tighten up KeyBinding

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -78,16 +78,11 @@ impl RenderOnce for KeyBinding {
                 )
             })
             .flex_none()
-            .gap_2()
             .children(self.key_binding.keystrokes().iter().map(|keystroke| {
                 let key_icon = Self::icon_for_key(keystroke);
 
                 h_flex()
                     .flex_none()
-                    .map(|el| match self.platform_style {
-                        PlatformStyle::Mac => el.gap_0p5(),
-                        PlatformStyle::Linux | PlatformStyle::Windows => el,
-                    })
                     .p_0p5()
                     .rounded_sm()
                     .text_color(cx.theme().colors().text_muted)
@@ -180,11 +175,9 @@ pub struct KeyIcon {
 
 impl RenderOnce for KeyIcon {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
-        div().w(rems_from_px(14.)).child(
-            Icon::new(self.icon)
-                .size(IconSize::Small)
-                .color(Color::Muted),
-        )
+        Icon::new(self.icon)
+            .size(IconSize::Small)
+            .color(Color::Muted)
     }
 }
 


### PR DESCRIPTION
After #11795, the context menu was looking a little ridiculous on Mac in vim mode (and the command palette has for a while).

<img width="258" alt="Screenshot 2024-05-14 at 20 35 50" src="https://github.com/zed-industries/zed/assets/94272/cb0ec8b9-4da6-4ab4-9eec-c60d62f79eff">
<img width="581" alt="Screenshot 2024-05-14 at 20 56 28" src="https://github.com/zed-industries/zed/assets/94272/d8fec440-17cc-4c20-80d9-c1d7f2f18315">

A future change would be to have a platform style for vim keybindings so we can render `g A`, but for now this just removes a bunch of (to my eyes at least) unnecessary space:

 
<img width="576" alt="Screenshot 2024-05-14 at 21 01 55" src="https://github.com/zed-industries/zed/assets/94272/a39f4123-dc3b-4bb5-bb8d-5de6b37552e7">

cc @iamnbutler 


Release Notes:

- N/A
