### PR TITLE
Make primary clipboard Linux only

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -530,6 +530,7 @@ impl EditorElement {
         cx.stop_propagation();
     }
 
+    #[cfg(target_os = "linux")]
     fn mouse_middle_down(
         editor: &mut Editor,
         event: &MouseDownEvent,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3241,6 +3241,7 @@ impl EditorElement {
                         MouseButton::Right => editor.update(cx, |editor, cx| {
                             Self::mouse_right_down(editor, event, &position_map, &text_hitbox, cx);
                         }),
+                        #[cfg(target_os = "linux")]
                         MouseButton::Middle => editor.update(cx, |editor, cx| {
                             Self::mouse_middle_down(editor, event, &position_map, &text_hitbox, cx);
                         }),

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -547,6 +547,7 @@ impl AppContext {
 
     /// Writes data to the primary selection buffer.
     /// Only available on Linux.
+    #[cfg(target_os = "linux")]
     pub fn write_to_primary(&self, item: ClipboardItem) {
         self.platform.write_to_primary(item)
     }
@@ -558,6 +559,7 @@ impl AppContext {
 
     /// Reads data from the primary selection buffer.
     /// Only available on Linux.
+    #[cfg(target_os = "linux")]
     pub fn read_from_primary(&self) -> Option<ClipboardItem> {
         self.platform.read_from_primary()
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -147,8 +147,10 @@ pub(crate) trait Platform: 'static {
     fn set_cursor_style(&self, style: CursorStyle);
     fn should_auto_hide_scrollbars(&self) -> bool;
 
+    #[cfg(target_os = "linux")]
     fn write_to_primary(&self, item: ClipboardItem);
     fn write_to_clipboard(&self, item: ClipboardItem);
+    #[cfg(target_os = "linux")]
     fn read_from_primary(&self) -> Option<ClipboardItem>;
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -817,8 +817,6 @@ impl Platform for MacPlatform {
         }
     }
 
-    fn write_to_primary(&self, _item: ClipboardItem) {}
-
     fn write_to_clipboard(&self, item: ClipboardItem) {
         let state = self.0.lock();
         unsafe {
@@ -854,10 +852,6 @@ impl Platform for MacPlatform {
                     .setData_forType(metadata_bytes, state.metadata_pasteboard_type);
             }
         }
-    }
-
-    fn read_from_primary(&self) -> Option<ClipboardItem> {
-        None
     }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -23,6 +23,7 @@ pub(crate) struct TestPlatform {
     active_display: Rc<dyn PlatformDisplay>,
     active_cursor: Mutex<CursorStyle>,
     current_clipboard_item: Mutex<Option<ClipboardItem>>,
+    #[cfg(target_os = "linux")]
     current_primary_item: Mutex<Option<ClipboardItem>>,
     pub(crate) prompts: RefCell<TestPrompts>,
     pub opened_url: RefCell<Option<String>>,
@@ -45,6 +46,7 @@ impl TestPlatform {
             active_display: Rc::new(TestDisplay::new()),
             active_window: Default::default(),
             current_clipboard_item: Mutex::new(None),
+            #[cfg(target_os = "linux")]
             current_primary_item: Mutex::new(None),
             weak: weak.clone(),
             opened_url: Default::default(),
@@ -272,6 +274,7 @@ impl Platform for TestPlatform {
         false
     }
 
+    #[cfg(target_os = "linux")]
     fn write_to_primary(&self, item: ClipboardItem) {
         *self.current_primary_item.lock() = Some(item);
     }
@@ -280,6 +283,7 @@ impl Platform for TestPlatform {
         *self.current_clipboard_item.lock() = Some(item);
     }
 
+    #[cfg(target_os = "linux")]
     fn read_from_primary(&self) -> Option<ClipboardItem> {
         self.current_primary_item.lock().clone()
     }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -625,17 +625,11 @@ impl Platform for WindowsPlatform {
         false
     }
 
-    fn write_to_primary(&self, _item: ClipboardItem) {}
-
     fn write_to_clipboard(&self, item: ClipboardItem) {
         if item.text.len() > 0 {
             let mut ctx = ClipboardContext::new().unwrap();
             ctx.set_contents(item.text().to_owned()).unwrap();
         }
-    }
-
-    fn read_from_primary(&self) -> Option<ClipboardItem> {
-        None
     }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1210,34 +1210,40 @@ impl Terminal {
             {
                 self.pty_tx.notify(bytes);
             }
-        } else if e.button == MouseButton::Left {
-            let position = e.position - origin;
-            let (point, side) = grid_point_and_side(
-                position,
-                self.last_content.size,
-                self.last_content.display_offset,
-            );
+        } else {
+            match e.button {
+                MouseButton::Left => {
+                    let position = e.position - origin;
+                    let (point, side) = grid_point_and_side(
+                        position,
+                        self.last_content.size,
+                        self.last_content.display_offset,
+                    );
 
-            let selection_type = match e.click_count {
-                0 => return, //This is a release
-                1 => Some(SelectionType::Simple),
-                2 => Some(SelectionType::Semantic),
-                3 => Some(SelectionType::Lines),
-                _ => None,
-            };
+                    let selection_type = match e.click_count {
+                        0 => return, //This is a release
+                        1 => Some(SelectionType::Simple),
+                        2 => Some(SelectionType::Semantic),
+                        3 => Some(SelectionType::Lines),
+                        _ => None,
+                    };
 
-            let selection =
-                selection_type.map(|selection_type| Selection::new(selection_type, point, side));
+                    let selection = selection_type
+                        .map(|selection_type| Selection::new(selection_type, point, side));
 
-            if let Some(sel) = selection {
-                self.events
-                    .push_back(InternalEvent::SetSelection(Some((sel, point))));
-            }
-        } else if e.button == MouseButton::Middle {
-            #[cfg(target_os = "linux")]
-            if let Some(item) = _cx.read_from_primary() {
-                let text = item.text().to_string();
-                self.input(text);
+                    if let Some(sel) = selection {
+                        self.events
+                            .push_back(InternalEvent::SetSelection(Some((sel, point))));
+                    }
+                }
+                #[cfg(target_os = "linux")]
+                MouseButton::Middle => {
+                    if let Some(item) = _cx.read_from_primary() {
+                        let text = item.text().to_string();
+                        self.input(text);
+                    }
+                }
+                _ => {}
             }
         }
     }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1234,6 +1234,7 @@ impl Terminal {
                     .push_back(InternalEvent::SetSelection(Some((sel, point))));
             }
         } else if e.button == MouseButton::Middle {
+            #[cfg(target_os = "linux")]
             if let Some(item) = cx.read_from_primary() {
                 let text = item.text().to_string();
                 self.input(text);

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1195,7 +1195,7 @@ impl Terminal {
         &mut self,
         e: &MouseDownEvent,
         origin: Point<Pixels>,
-        cx: &mut ModelContext<Self>,
+        _cx: &mut ModelContext<Self>,
     ) {
         let position = e.position - origin;
         let point = grid_point(
@@ -1235,7 +1235,7 @@ impl Terminal {
             }
         } else if e.button == MouseButton::Middle {
             #[cfg(target_os = "linux")]
-            if let Some(item) = cx.read_from_primary() {
+            if let Some(item) = _cx.read_from_primary() {
                 let text = item.text().to_string();
                 self.input(text);
             }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -349,6 +349,7 @@ fn main() {
         let languages = Arc::new(languages);
         let node_runtime = RealNodeRuntime::new(client.http_client());
 
+        //
         language::init(cx);
         languages::init(languages.clone(), node_runtime.clone(), cx);
         let user_store = cx.new_model(|cx| UserStore::new(client.clone(), cx));

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -349,7 +349,6 @@ fn main() {
         let languages = Arc::new(languages);
         let node_runtime = RealNodeRuntime::new(client.http_client());
 
-        //
         language::init(cx);
         languages::init(languages.clone(), node_runtime.clone(), cx);
         let user_store = cx.new_model(|cx| UserStore::new(client.clone(), cx));


### PR DESCRIPTION
I guess only Linux supports the primary clipboard.

Release Notes:

- N/A
