### PR TITLE
Use editor's current font size to scale UI elements

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -58,7 +58,7 @@ use std::{
     sync::Arc,
 };
 use sum_tree::Bias;
-use theme::{ActiveTheme, PlayerColor, ThemeSettings};
+use theme::{ActiveTheme, PlayerColor};
 use ui::prelude::*;
 use ui::{h_flex, ButtonLike, ButtonStyle, ContextMenu, Tooltip};
 use util::ResultExt;
@@ -3388,11 +3388,7 @@ fn render_inline_blame_entry(
         .font_family(style.text.font().family)
         .text_color(cx.theme().status().hint)
         .line_height(style.text.line_height)
-        .child(
-            Icon::new(IconName::FileGit)
-                .color(Color::Hint)
-                .font_size(style.text.font_size),
-        )
+        .child(Icon::new(IconName::FileGit).color(Color::Hint))
         .child(text)
         .gap_2()
         .hoverable_tooltip(move |_| tooltip.clone().into())
@@ -3712,22 +3708,30 @@ impl EditorElement {
     fn rem_size(&self, cx: &WindowContext) -> Option<Pixels> {
         match self.editor.read(cx).mode {
             EditorMode::Full => {
-                let buffer_font_size = ThemeSettings::get_global(cx).buffer_font_size;
-                let rem_size_scale = {
-                    // Our default UI font size is 14px on a 16px base scale.
-                    // This means the default UI font size is 0.875rems.
-                    let default_font_size_scale = 14. / ui::BASE_REM_SIZE_IN_PX;
+                let buffer_font_size = self.style.text.font_size;
+                match buffer_font_size {
+                    AbsoluteLength::Pixels(pixels) => {
+                        let rem_size_scale = {
+                            // Our default UI font size is 14px on a 16px base scale.
+                            // This means the default UI font size is 0.875rems.
+                            let default_font_size_scale = 14. / ui::BASE_REM_SIZE_IN_PX;
 
-                    // We then determine the delta between a single rem and the default font
-                    // size scale.
-                    let default_font_size_delta = 1. - default_font_size_scale;
+                            // We then determine the delta between a single rem and the default font
+                            // size scale.
+                            let default_font_size_delta = 1. - default_font_size_scale;
 
-                    // Finally, we add this delta to 1rem to get the scale factor that
-                    // should be used to scale up the UI.
-                    1. + default_font_size_delta
-                };
+                            // Finally, we add this delta to 1rem to get the scale factor that
+                            // should be used to scale up the UI.
+                            1. + default_font_size_delta
+                        };
 
-                Some(buffer_font_size * rem_size_scale)
+                        Some(pixels * rem_size_scale)
+                    }
+                    AbsoluteLength::Rems(rems) => {
+                        println!("here!!!!");
+                        Some(rems.to_pixels(ui::BASE_REM_SIZE_IN_PX.into()))
+                    }
+                }
             }
             // We currently use single-line and auto-height editors in UI contexts,
             // so we don't want to scale everything with the buffer font size, as it

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -348,14 +348,6 @@ impl Icon {
         self
     }
 
-    pub fn font_size(self, font_size: AbsoluteLength) -> Self {
-        let rems = match font_size {
-            AbsoluteLength::Pixels(pixels) => rems_from_px(pixels.into()),
-            AbsoluteLength::Rems(rems) => rems,
-        };
-        self.custom_size(rems)
-    }
-
     pub fn transform(mut self, transformation: Transformation) -> Self {
         self.transformation = transformation;
         self


### PR DESCRIPTION
This is a follow-up to #11817 and fixes the case where the font size has been changed with `cmd +/-` and not through the settings.

It now works with both: when the font size is adjusted in the settings and when changing it via shortcuts.

Release Notes:

- N/A

Demo:

https://github.com/zed-industries/zed/assets/1185253/2e539bd3-f5cc-4aae-9f04-9ae014187959


