### PR TITLE
rust: reduce false positives in runnables query

### DIFF
--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -1,6 +1,11 @@
 (
-    (attribute_item (attribute) @attribute
-        (#match? @attribute ".*test"))
+    (attribute_item (attribute
+        [((identifier) @_attribute)
+        (scoped_identifier (identifier) @_attribute)
+            ])
+        (#eq? @_attribute "test"))
+    .
+    (attribute_item) *
     .
     (function_item
         name: (_) @run)


### PR DESCRIPTION
We were marking `#[cfg(test)]`ed function as a test, which is wrong.
Also allow for other attribute_items (such as #[should_panic]) between test attribute and a function item.

Release Notes:

- N/A
