### PR TITLE
tasks: Use unique id for run indicator

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4560,7 +4560,7 @@ impl Editor {
         row: DisplayRow,
         cx: &mut ViewContext<Self>,
     ) -> IconButton {
-        IconButton::new("run_indicator", ui::IconName::Play)
+        IconButton::new(("run_indicator", row.0 as usize), ui::IconName::Play)
             .icon_size(IconSize::XSmall)
             .size(ui::ButtonSize::None)
             .icon_color(Color::Muted)


### PR DESCRIPTION
This fixes a small visual issue with the run indicator. As all run indicators use the same element id they all show up as pressed when clicking on a single button. We can safely use a combination of "run_indicator" and the actual row as the element id, as there can only ever be one run indicator per line.

Before:

<img width="552" alt="Screenshot 2024-05-15 at 12 24 08" src="https://github.com/zed-industries/zed/assets/53836821/18779f1a-0984-488f-83fd-4a6a561f223e">

After:

<img width="633" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/07ea26b5-06ad-4955-8250-d96d4704220c">


Release Notes:

- Fixed an issue where all run buttons would show up as pressed when clicking on a single run button
