### PR TITLE
Feat: Add python variables theme highlighting

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -61,6 +61,11 @@
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
 
+; Variables
+
+(assignment
+  left: (identifier) @variable)
+
 ; Docstrings.
 (function_definition
   "async"?

--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -62,7 +62,6 @@
   "}" @punctuation.special) @embedded
 
 ; Variables
-
 (assignment
   left: (identifier) @variable)
 


### PR DESCRIPTION
If you have any suggestion or I have missed something let me know, thanks!

Release Notes:

- Fixes this [issue](https://github.com/zed-industries/zed/issues/11666)

Release Notes:

- Python theme highlight for variables
