### PR TITLE
python: Add highlighting to variables

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -44,6 +44,10 @@
   (float)
 ] @number
 
+; Variables
+(assignment
+  left: (identifier) @variable)
+
 (comment) @comment
 (string) @string
 (escape_sequence) @escape


### PR DESCRIPTION
If you have any suggestion or I have missed something let me know, thanks!

Release Notes:

- Fixes this [issue](https://github.com/zed-industries/zed/issues/11666)

Release Notes:

- Python theme highlight for variables

PS. Sorry for the confusion I had some trouble with the double account Licence agreement. 
