### PR TITLE
Add basic proxy settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -842,14 +842,9 @@
   "line_indicator_format": "long",
   // Set a proxy to use. The proxy protocol is specified by the URI scheme.
   //
-  // - `http`: Proxy. Default when no scheme is specified.
-  // - `https`: HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and
-  //   NSS)
-  // - `socks4`: SOCKS4 Proxy.
-  // - `socks4a`: SOCKS4a Proxy. Proxy resolves URL hostname.
-  // - `socks5`: SOCKS5 Proxy.
-  // - `socks5h`: SOCKS5 Proxy. Proxy resolves URL hostname.
-  //
+  // Supported URI scheme: `http`, `https`, `socks4`, `socks4a`, `socks5`,
+  // `socks5h`. `http` will be used when no scheme is specified.
+  // 
   // By default no proxy will be used, or Zed will try get proxy settings from
   // environment variables.
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -840,6 +840,21 @@
   //   - `long`: "2 selections, 15 lines, 32 characters"
   // Default: long
   "line_indicator_format": "long",
-  // TODO:
+  // Set a proxy to use. The proxy protocol is specified by the URI scheme.
+  //
+  // - **`http`**: Proxy. Default when no scheme is specified.
+  // - **`https`**: HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and
+  //   NSS)
+  // - **`socks4`**: SOCKS4 Proxy.
+  // - **`socks4a`**: SOCKS4a Proxy. Proxy resolves URL hostname.
+  // - **`socks5`**: SOCKS5 Proxy.
+  // - **`socks5h`**: SOCKS5 Proxy. Proxy resolves URL hostname.
+  //
+  // By default no proxy will be used, or Zed will try get proxy settings from
+  // environment variables.
+  //
+  // Examples:
+  //   - proxy = "socks5://localhost:10808"
+  //   - proxy = "http://127.0.0.1:10809"
   "proxy": null
 }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -103,14 +103,7 @@
   // Hide the values of in variables from visual display in private files
   "redact_private_values": false,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": [
-    "**/.env*",
-    "**/*.pem",
-    "**/*.key",
-    "**/*.cert",
-    "**/*.crt",
-    "**/secrets.yml"
-  ],
+  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -311,9 +304,7 @@
   // The list of language servers to use (or disable) for all languages.
   //
   // This is typically customized on a per-language basis.
-  "language_servers": [
-    "..."
-  ],
+  "language_servers": ["..."],
   // When to automatically save edited buffers. This setting can
   // take four values.
   //
@@ -448,9 +439,7 @@
   "copilot": {
     // The set of glob patterns for which copilot should be disabled
     // in any matching file.
-    "disabled_globs": [
-      ".env"
-    ]
+    "disabled_globs": [".env"]
   },
   // Settings specific to journaling
   "journal": {
@@ -561,12 +550,7 @@
         // Default directories to search for virtual environments, relative
         // to the current working directory. We recommend overriding this
         // in your project's settings, rather than globally.
-        "directories": [
-          ".env",
-          "env",
-          ".venv",
-          "venv"
-        ],
+        "directories": [".env", "env", ".venv", "venv"],
         // Can also be `csh`, `fish`, and `nushell`
         "activate_script": "default"
       }
@@ -612,9 +596,7 @@
     "Astro": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-astro"
-        ]
+        "plugins": ["prettier-plugin-astro"]
       }
     },
     "Blade": {
@@ -634,12 +616,7 @@
       }
     },
     "Elixir": {
-      "language_servers": [
-        "elixir-ls",
-        "!next-ls",
-        "!lexical",
-        "..."
-      ]
+      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
     "Gleam": {
       "tab_size": 2
@@ -655,12 +632,7 @@
       }
     },
     "HEEX": {
-      "language_servers": [
-        "elixir-ls",
-        "!next-ls",
-        "!lexical",
-        "..."
-      ]
+      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
     "HTML": {
       "prettier": {
@@ -670,9 +642,7 @@
     "Java": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-java"
-        ]
+        "plugins": ["prettier-plugin-java"]
       }
     },
     "JavaScript": {
@@ -697,20 +667,14 @@
     "PHP": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "@prettier/plugin-php"
-        ]
+        "plugins": ["@prettier/plugin-php"]
       }
     },
     "Prisma": {
       "tab_size": 2
     },
     "Ruby": {
-      "language_servers": [
-        "solargraph",
-        "!ruby-lsp",
-        "..."
-      ]
+      "language_servers": ["solargraph", "!ruby-lsp", "..."]
     },
     "SCSS": {
       "prettier": {
@@ -720,17 +684,13 @@
     "SQL": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-sql"
-        ]
+        "plugins": ["prettier-plugin-sql"]
       }
     },
     "Svelte": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-svelte"
-        ]
+        "plugins": ["prettier-plugin-svelte"]
       }
     },
     "TSX": {
@@ -756,9 +716,7 @@
     "XML": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "@prettier/plugin-xml"
-        ]
+        "plugins": ["@prettier/plugin-xml"]
       }
     },
     "YAML": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -842,13 +842,13 @@
   "line_indicator_format": "long",
   // Set a proxy to use. The proxy protocol is specified by the URI scheme.
   //
-  // - **`http`**: Proxy. Default when no scheme is specified.
-  // - **`https`**: HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and
+  // - `http`: Proxy. Default when no scheme is specified.
+  // - `https`: HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and
   //   NSS)
-  // - **`socks4`**: SOCKS4 Proxy.
-  // - **`socks4a`**: SOCKS4a Proxy. Proxy resolves URL hostname.
-  // - **`socks5`**: SOCKS5 Proxy.
-  // - **`socks5h`**: SOCKS5 Proxy. Proxy resolves URL hostname.
+  // - `socks4`: SOCKS4 Proxy.
+  // - `socks4a`: SOCKS4a Proxy. Proxy resolves URL hostname.
+  // - `socks5`: SOCKS5 Proxy.
+  // - `socks5h`: SOCKS5 Proxy. Proxy resolves URL hostname.
   //
   // By default no proxy will be used, or Zed will try get proxy settings from
   // environment variables.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -854,7 +854,7 @@
   // environment variables.
   //
   // Examples:
-  //   - proxy = "socks5://localhost:10808"
-  //   - proxy = "http://127.0.0.1:10809"
+  //   - "proxy" = "socks5://localhost:10808"
+  //   - "proxy" = "http://127.0.0.1:10809"
   "proxy": null
 }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -841,8 +841,5 @@
   // Default: long
   "line_indicator_format": "long",
   // TODO:
-  "proxy": {
-    "http_proxy": "",
-    "https_proxy": ""
-  }
+  "proxy": ""
 }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -103,7 +103,14 @@
   // Hide the values of in variables from visual display in private files
   "redact_private_values": false,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.cert",
+    "**/*.crt",
+    "**/secrets.yml"
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -304,7 +311,9 @@
   // The list of language servers to use (or disable) for all languages.
   //
   // This is typically customized on a per-language basis.
-  "language_servers": ["..."],
+  "language_servers": [
+    "..."
+  ],
   // When to automatically save edited buffers. This setting can
   // take four values.
   //
@@ -439,7 +448,9 @@
   "copilot": {
     // The set of glob patterns for which copilot should be disabled
     // in any matching file.
-    "disabled_globs": [".env"]
+    "disabled_globs": [
+      ".env"
+    ]
   },
   // Settings specific to journaling
   "journal": {
@@ -550,7 +561,12 @@
         // Default directories to search for virtual environments, relative
         // to the current working directory. We recommend overriding this
         // in your project's settings, rather than globally.
-        "directories": [".env", "env", ".venv", "venv"],
+        "directories": [
+          ".env",
+          "env",
+          ".venv",
+          "venv"
+        ],
         // Can also be `csh`, `fish`, and `nushell`
         "activate_script": "default"
       }
@@ -596,7 +612,9 @@
     "Astro": {
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-astro"]
+        "plugins": [
+          "prettier-plugin-astro"
+        ]
       }
     },
     "Blade": {
@@ -616,7 +634,12 @@
       }
     },
     "Elixir": {
-      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": [
+        "elixir-ls",
+        "!next-ls",
+        "!lexical",
+        "..."
+      ]
     },
     "Gleam": {
       "tab_size": 2
@@ -632,7 +655,12 @@
       }
     },
     "HEEX": {
-      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": [
+        "elixir-ls",
+        "!next-ls",
+        "!lexical",
+        "..."
+      ]
     },
     "HTML": {
       "prettier": {
@@ -642,7 +670,9 @@
     "Java": {
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-java"]
+        "plugins": [
+          "prettier-plugin-java"
+        ]
       }
     },
     "JavaScript": {
@@ -667,14 +697,20 @@
     "PHP": {
       "prettier": {
         "allowed": true,
-        "plugins": ["@prettier/plugin-php"]
+        "plugins": [
+          "@prettier/plugin-php"
+        ]
       }
     },
     "Prisma": {
       "tab_size": 2
     },
     "Ruby": {
-      "language_servers": ["solargraph", "!ruby-lsp", "..."]
+      "language_servers": [
+        "solargraph",
+        "!ruby-lsp",
+        "..."
+      ]
     },
     "SCSS": {
       "prettier": {
@@ -684,13 +720,17 @@
     "SQL": {
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-sql"]
+        "plugins": [
+          "prettier-plugin-sql"
+        ]
       }
     },
     "Svelte": {
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-svelte"]
+        "plugins": [
+          "prettier-plugin-svelte"
+        ]
       }
     },
     "TSX": {
@@ -716,7 +756,9 @@
     "XML": {
       "prettier": {
         "allowed": true,
-        "plugins": ["@prettier/plugin-xml"]
+        "plugins": [
+          "@prettier/plugin-xml"
+        ]
       }
     },
     "YAML": {
@@ -797,5 +839,10 @@
   //   - `short`: "2 s, 15 l, 32 c"
   //   - `long`: "2 selections, 15 lines, 32 characters"
   // Default: long
-  "line_indicator_format": "long"
+  "line_indicator_format": "long",
+  // TODO:
+  "proxy": {
+    "http_proxy": "",
+    "https_proxy": ""
+  }
 }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -841,5 +841,5 @@
   // Default: long
   "line_indicator_format": "long",
   // TODO:
-  "proxy": ""
+  "proxy": null
 }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -134,19 +134,8 @@ impl Settings for ProxySettings {
             proxy: sources
                 .user
                 .as_ref()
-                .and_then(|value| {
-                    value
-                        .proxy
-                        .as_ref()
-                        .and_then(|p| if p.len() == 0 { None } else { Some(p.clone()) })
-                })
-                .or(sources.default.proxy.as_ref().and_then(|p| {
-                    if p.len() == 0 {
-                        None
-                    } else {
-                        Some(p.clone())
-                    }
-                })),
+                .and_then(|value| value.proxy.clone())
+                .or(sources.default.proxy.clone()),
         })
     }
 }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -141,10 +141,10 @@ impl Settings for ProxySettings {
 }
 
 pub fn init_settings(cx: &mut AppContext) {
-    TelemetrySettings::register(cx);
-    ProxySettings::register(cx);
     cx.update_global(|store: &mut SettingsStore, cx| {
+        store.register_setting::<TelemetrySettings>(cx);
         store.register_setting::<ClientSettings>(cx);
+        store.register_setting::<ProxySettings>(cx);
     });
 }
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -114,8 +114,46 @@ impl Settings for ClientSettings {
     }
 }
 
+#[derive(Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProxySettingsContent {
+    proxy: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct ProxySettings {
+    pub proxy: Option<String>,
+}
+
+impl Settings for ProxySettings {
+    const KEY: Option<&'static str> = None;
+
+    type FileContent = ProxySettingsContent;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        Ok(Self {
+            proxy: sources
+                .user
+                .as_ref()
+                .and_then(|value| {
+                    value
+                        .proxy
+                        .as_ref()
+                        .and_then(|p| if p.len() == 0 { None } else { Some(p.clone()) })
+                })
+                .or(sources.default.proxy.as_ref().and_then(|p| {
+                    if p.len() == 0 {
+                        None
+                    } else {
+                        Some(p.clone())
+                    }
+                })),
+        })
+    }
+}
+
 pub fn init_settings(cx: &mut AppContext) {
     TelemetrySettings::register(cx);
+    ProxySettings::register(cx);
     cx.update_global(|store: &mut SettingsStore, cx| {
         store.register_setting::<ClientSettings>(cx);
     });
@@ -512,6 +550,7 @@ impl Client {
         let clock = Arc::new(clock::RealSystemClock);
         let http = Arc::new(HttpClientWithUrl::new(
             &ClientSettings::get_global(cx).server_url,
+            ProxySettings::get_global(cx).proxy.clone(),
         ));
         Self::new(clock, http.clone(), cx)
     }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -133,7 +133,6 @@ impl Settings for ProxySettings {
         Ok(Self {
             proxy: sources
                 .user
-                .as_ref()
                 .and_then(|value| value.proxy.clone())
                 .or(sources.default.proxy.clone()),
         })

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -140,8 +140,8 @@ impl Settings for ProxySettings {
 }
 
 pub fn init_settings(cx: &mut AppContext) {
+    TelemetrySettings::register(cx);
     cx.update_global(|store: &mut SettingsStore, cx| {
-        store.register_setting::<TelemetrySettings>(cx);
         store.register_setting::<ClientSettings>(cx);
         store.register_setting::<ProxySettings>(cx);
     });

--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -67,7 +67,7 @@ impl ExtensionBuilder {
     pub fn new(cache_dir: PathBuf) -> Self {
         Self {
             cache_dir,
-            http: http::client(),
+            http: http::client(None),
         }
     }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -115,7 +115,7 @@ impl App {
         Self(AppContext::new(
             current_platform(),
             Arc::new(()),
-            http::client(),
+            http::client(None),
         ))
     }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -652,7 +652,7 @@ impl AppContext {
     }
 
     /// Updates the http client assigned to GPUI
-    pub fn udpate_http_client(&mut self, new_client: Arc<dyn HttpClient>) {
+    pub fn update_http_client(&mut self, new_client: Arc<dyn HttpClient>) {
         self.http_client = new_client;
     }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -651,6 +651,11 @@ impl AppContext {
         self.platform.local_timezone()
     }
 
+    /// Updates the http client assigned to GPUI
+    pub fn udpate_http_client(&mut self, new_client: Arc<dyn HttpClient>) {
+        self.http_client = new_client;
+    }
+
     /// Returns the http client assigned to GPUI
     pub fn http_client(&self) -> Arc<dyn HttpClient> {
         self.http_client.clone()

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -16,7 +16,7 @@ use std::{
 };
 pub use url::Url;
 
-pub fn get_proxy(proxy: Option<String>) -> Option<isahc::http::Uri> {
+fn get_proxy(proxy: Option<String>) -> Option<isahc::http::Uri> {
     macro_rules! try_env {
         ($($env:literal),+) => {
             $(
@@ -114,8 +114,8 @@ impl HttpClient for Arc<HttpClientWithUrl> {
         self.client.send(req)
     }
 
-    fn proxy_settings(&self) -> Option<String> {
-        self.proxy_settings.clone()
+    fn proxy_settings(&self) -> &Option<String> {
+        &self.proxy_settings
     }
 }
 
@@ -127,8 +127,8 @@ impl HttpClient for HttpClientWithUrl {
         self.client.send(req)
     }
 
-    fn proxy_settings(&self) -> Option<String> {
-        self.proxy_settings.clone()
+    fn proxy_settings(&self) -> &Option<String> {
+        &self.proxy_settings
     }
 }
 
@@ -175,7 +175,7 @@ pub trait HttpClient: Send + Sync {
         }
     }
 
-    fn proxy_settings(&self) -> Option<String>;
+    fn proxy_settings(&self) -> &Option<String>;
 }
 
 pub fn client(proxy: Option<isahc::http::Uri>) -> Arc<dyn HttpClient> {
@@ -198,9 +198,9 @@ impl HttpClient for isahc::HttpClient {
         Box::pin(async move { client.send_async(req).await })
     }
 
-    fn proxy_settings(&self) -> Option<String> {
+    fn proxy_settings(&self) -> &Option<String> {
         // TODO:
-        None
+        &None
     }
 }
 
@@ -269,7 +269,7 @@ impl HttpClient for FakeHttpClient {
         Box::pin(async move { future.await.map(Into::into) })
     }
 
-    fn proxy_settings(&self) -> Option<String> {
-        None
+    fn proxy_settings(&self) -> &Option<String> {
+        &None
     }
 }

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -114,8 +114,8 @@ impl HttpClient for Arc<HttpClientWithUrl> {
         self.client.send(req)
     }
 
-    fn proxy(&self) -> &Option<String> {
-        &self.proxy
+    fn proxy(&self) -> Option<&str> {
+        self.proxy.as_ref().map(|x| x.as_str())
     }
 }
 
@@ -127,8 +127,8 @@ impl HttpClient for HttpClientWithUrl {
         self.client.send(req)
     }
 
-    fn proxy(&self) -> &Option<String> {
-        &self.proxy
+    fn proxy(&self) -> Option<&str> {
+        self.proxy.as_ref().map(|x| x.as_str())
     }
 }
 
@@ -175,7 +175,7 @@ pub trait HttpClient: Send + Sync {
         }
     }
 
-    fn proxy(&self) -> &Option<String>;
+    fn proxy(&self) -> Option<&str>;
 }
 
 pub fn client(proxy: Option<isahc::http::Uri>) -> Arc<dyn HttpClient> {
@@ -198,8 +198,8 @@ impl HttpClient for isahc::HttpClient {
         Box::pin(async move { client.send_async(req).await })
     }
 
-    fn proxy(&self) -> &Option<String> {
-        &None
+    fn proxy(&self) -> Option<&str> {
+        None
     }
 }
 
@@ -268,7 +268,7 @@ impl HttpClient for FakeHttpClient {
         Box::pin(async move { future.await.map(Into::into) })
     }
 
-    fn proxy(&self) -> &Option<String> {
-        &None
+    fn proxy(&self) -> Option<&str> {
+        None
     }
 }

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -199,7 +199,6 @@ impl HttpClient for isahc::HttpClient {
     }
 
     fn proxy(&self) -> &Option<String> {
-        // TODO:
         &None
     }
 }

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -8,7 +8,6 @@ pub use isahc::{
     http::{Method, StatusCode, Uri},
     AsyncBody, Error, HttpClient as IsahcHttpClient, Request, Response,
 };
-use serde::Deserialize;
 #[cfg(feature = "test-support")]
 use std::fmt;
 use std::{
@@ -46,11 +45,6 @@ fn get_proxy(proxy: Option<String>) -> Option<isahc::http::Uri> {
             );
             None
         })
-}
-
-#[derive(Deserialize)]
-pub struct ProxySettings {
-    proxy: String,
 }
 
 /// An [`HttpClient`] that has a base URL.

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -56,10 +56,8 @@ pub struct HttpClientWithUrl {
 impl HttpClientWithUrl {
     /// Returns a new [`HttpClientWithUrl`] with the given base URL.
     pub fn new(base_url: impl Into<String>, proxy: Option<String>) -> Self {
-        println!("Configure proxy: {:?}", proxy);
         Self {
             base_url: Mutex::new(base_url.into()),
-            // client: client(proxy),
             client: client(proxy),
         }
     }

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -58,7 +58,7 @@ impl HttpClientWithUrl {
     /// Returns a new [`HttpClientWithUrl`] with the given base URL.
     pub fn new(base_url: impl Into<String>, unparsed_proxy: Option<String>) -> Self {
         let proxy = get_proxy(unparsed_proxy);
-        let proxy_settings = proxy.as_ref().and_then(|p| Some(p.to_string()));
+        let proxy_settings = proxy.as_ref().map(|p| p.to_string());
         Self {
             base_url: Mutex::new(base_url.into()),
             client: client(proxy),

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -115,7 +115,7 @@ impl HttpClient for Arc<HttpClientWithUrl> {
     }
 
     fn proxy(&self) -> Option<&str> {
-        self.proxy.as_ref().map(|x| x.as_str())
+        self.proxy.as_deref()
     }
 }
 
@@ -128,7 +128,7 @@ impl HttpClient for HttpClientWithUrl {
     }
 
     fn proxy(&self) -> Option<&str> {
-        self.proxy.as_ref().map(|x| x.as_str())
+        self.proxy.as_deref()
     }
 }
 

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -16,7 +16,7 @@ use std::{
 };
 pub use url::Url;
 
-fn get_proxy(proxy: Option<String>) -> Option<isahc::http::Uri> {
+pub fn get_proxy(proxy: Option<String>) -> Option<isahc::http::Uri> {
     macro_rules! try_env {
         ($($env:literal),+) => {
             $(

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -206,6 +206,10 @@ impl RealNodeRuntime {
 
         anyhow::Ok(node_dir)
     }
+
+    // pub fn configure_proxy(&self) {
+    //     if self.http.
+    // }
 }
 
 #[async_trait::async_trait]

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -206,10 +206,6 @@ impl RealNodeRuntime {
 
         anyhow::Ok(node_dir)
     }
-
-    // pub fn configure_proxy(&self) {
-    //     if self.http.
-    // }
 }
 
 #[async_trait::async_trait]

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -266,14 +266,17 @@ impl NodeRuntime for RealNodeRuntime {
                 command.args(["--prefix".into(), directory.to_path_buf()]);
             }
 
-            if let Some(proxy) = http::http_proxy_from_env() {
-                command.args(["--proxy".into(), proxy.to_string()]);
+            if let Some(proxy) = self.http.proxy_settings() {
+                command.args(["--proxy", proxy]);
             }
 
             #[cfg(windows)]
             {
                 // SYSTEMROOT is a critical environment variables for Windows.
-                if let Some(val) = std::env::var("SYSTEMROOT") {
+                if let Some(val) = std::env::var("SYSTEMROOT")
+                    .context("Missing environment variable: SYSTEMROOT!")
+                    .log_err()
+                {
                     command.env("SYSTEMROOT", val);
                 }
                 command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -266,7 +266,7 @@ impl NodeRuntime for RealNodeRuntime {
                 command.args(["--prefix".into(), directory.to_path_buf()]);
             }
 
-            if let Some(proxy) = self.http.proxy_settings() {
+            if let Some(proxy) = self.http.proxy() {
                 command.args(["--proxy", proxy]);
             }
 

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -266,8 +266,18 @@ impl NodeRuntime for RealNodeRuntime {
                 command.args(["--prefix".into(), directory.to_path_buf()]);
             }
 
+            if let Some(proxy) = http::http_proxy_from_env() {
+                command.args(["--proxy".into(), proxy.to_string()]);
+            }
+
             #[cfg(windows)]
-            command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
+            {
+                // SYSTEMROOT is a critical environment variables for Windows.
+                if let Some(val) = std::env::var("SYSTEMROOT") {
+                    command.env("SYSTEMROOT", val);
+                }
+                command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
+            }
 
             command.output().await.map_err(|e| anyhow!("{e}"))
         };

--- a/crates/semantic_index/examples/index.rs
+++ b/crates/semantic_index/examples/index.rs
@@ -26,7 +26,7 @@ fn main() {
         });
 
         let clock = Arc::new(FakeSystemClock::default());
-        let http = Arc::new(HttpClientWithUrl::new("http://localhost:11434"));
+        let http = Arc::new(HttpClientWithUrl::new("http://localhost:11434", None));
 
         let client = client::Client::new(clock, http.clone(), cx);
         Client::set_global(client.clone(), cx);

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -418,6 +418,7 @@ impl SettingsStore {
         if settings.is_object() {
             self.raw_default_settings = settings;
             self.recompute_values(None, cx)?;
+            println!("Setting: {:#?}", self);
             Ok(())
         } else {
             Err(anyhow!("settings must be an object"))

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -418,7 +418,6 @@ impl SettingsStore {
         if settings.is_object() {
             self.raw_default_settings = settings;
             self.recompute_values(None, cx)?;
-            println!("Setting: {:#?}", self);
             Ok(())
         } else {
             Err(anyhow!("settings must be an object"))

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -343,6 +343,7 @@ fn main() {
 
         client::init_settings(cx);
         let client = Client::production(cx);
+        cx.udpate_http_client(client.http_client().clone());
         let mut languages =
             LanguageRegistry::new(login_shell_env_loaded, cx.background_executor().clone());
         languages.set_language_server_download_dir(paths::LANGUAGES_DIR.clone());

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -343,7 +343,7 @@ fn main() {
 
         client::init_settings(cx);
         let client = Client::production(cx);
-        cx.udpate_http_client(client.http_client().clone());
+        cx.update_http_client(client.http_client().clone());
         let mut languages =
             LanguageRegistry::new(login_shell_env_loaded, cx.background_executor().clone());
         languages.set_language_server_download_dir(paths::LANGUAGES_DIR.clone());


### PR DESCRIPTION
Adding `proxy` keyword to configure proxy while using zed. After setting the proxy, restart Zed to acctually use the proxy.

Example setting: 
```rust
"proxy" = "socks5://localhost:10808"
"proxy" = "http://127.0.0.1:10809"
```

Closes #9424, closes #9422, closes #8650, closes #5032, closes #6701, closes #11890 

Release Notes:

- Added a setting to configure proxy.

