### PR TITLE
Remove stray `println!`

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3728,7 +3728,6 @@ impl EditorElement {
                         Some(pixels * rem_size_scale)
                     }
                     AbsoluteLength::Rems(rems) => {
-                        println!("here!!!!");
                         Some(rems.to_pixels(ui::BASE_REM_SIZE_IN_PX.into()))
                     }
                 }


### PR DESCRIPTION
This PR removes a stray `println!` left over from #11844.

Release Notes:

- N/A
