### PR TITLE
Fix aside affecting parent popover height

### DIFF
--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -40,14 +40,12 @@ pub struct Popover {
 
 impl RenderOnce for Popover {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
-        div()
-            .h_flex()
+        h_flex()
             .items_start()
             .gap_1()
             .child(
                 div()
                     .flex()
-                    .gap_1()
                     .child(v_flex().elevation_2(cx).px_1().children(self.children)),
             )
             .when_some(self.aside, |this, aside| {

--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -41,9 +41,15 @@ pub struct Popover {
 impl RenderOnce for Popover {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         div()
-            .flex()
+            .h_flex()
+            .items_start()
             .gap_1()
-            .child(v_flex().elevation_2(cx).px_1().children(self.children))
+            .child(
+                div()
+                    .flex()
+                    .gap_1()
+                    .child(v_flex().elevation_2(cx).px_1().children(self.children)),
+            )
             .when_some(self.aside, |this, aside| {
                 this.child(
                     v_flex()


### PR DESCRIPTION
Release Notes:

- Fixed the size of the completions menu changing based on the size of the aside ([#11722](https://github.com/zed-industries/zed/issues/11722)).
  - @JosephTLyons We had to revert this in https://github.com/zed-industries/zed/pull/11942.

https://github.com/zed-industries/zed/assets/30776250/c67e6fef-20f2-4dc5-92b3-09bb73f874a7

https://github.com/zed-industries/zed/assets/30776250/7467b8ee-6e66-42d7-a8cc-2df11df58c5e


