### PR TITLE
Fix repeatedly docking project panel

### DIFF
--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -52,6 +52,9 @@ pub fn watch_config_file(
                 }
 
                 if let Ok(contents) = fs.load(&path).await {
+                    if contents.len() == 0 {
+                        continue;
+                    }
                     if tx.unbounded_send(contents).is_err() {
                         break;
                     }


### PR DESCRIPTION
Close #11808, #9688 
Currently, is workaround method to fixed, I will find if have other better method.
In my pc, mini test config.json file contents:
```json
"project_panel": {
    "dock": "right"
  },
  "notification_panel": {
    "dock": "left"
  }
```

Release Notes:

- N/A
