### PR TITLE
ruby: Use two spaces per indentation level

### DIFF
--- a/extensions/ruby/languages/ruby/config.toml
+++ b/extensions/ruby/languages/ruby/config.toml
@@ -38,3 +38,4 @@ brackets = [
     ] },
 ]
 collapsed_placeholder = "# ..."
+tab_size = 2


### PR DESCRIPTION
Hello, this pull request changes the indentation level for Ruby language from 2 spaces to the most used setting in the Ruby world: 2 spaces per indentation level.
This setting is mentioned in the [Ruby style guide from the Rubocop (Ruby linter and formatter) team](https://rubystyle.guide/#spaces-indentation) and/or in another popular Rubocop configuration tool - [`standardrb`](https://github.com/standardrb/standard/blob/main/config/base.yml#L233) Thanks!

Release Notes:

- N/A
