### PR TITLE
editor: Add Cut, Copy, and Paste actions to the context menu

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -1,6 +1,7 @@
 use crate::{
-    DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition, GoToImplementation,
-    GoToTypeDefinition, Rename, RevealInFinder, SelectMode, ToggleCodeActions,
+    Copy, Cut, DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition,
+    GoToImplementation, GoToTypeDefinition, Paste, Rename, RevealInFinder, SelectMode,
+    ToggleCodeActions,
 };
 use gpui::{DismissEvent, Pixels, Point, Subscription, View, ViewContext};
 use workspace::OpenInTerminal;
@@ -84,6 +85,10 @@ pub fn deploy_context_menu(
                         deployed_from_indicator: None,
                     }),
                 )
+                .separator()
+                .action("Cut", Box::new(Cut))
+                .action("Copy", Box::new(Copy))
+                .action("Paste", Box::new(Paste))
                 .separator()
                 .action("Reveal in Finder", Box::new(RevealInFinder))
                 .action("Open in Terminal", Box::new(OpenInTerminal));


### PR DESCRIPTION
Hi, I saw someone on Twitter mentioned that missing Cut, Copy and Paste actions in the context menu in the editor block them from using Zed. It turns out that resolving this issue is simply a matter of adding these actions to the mouse context menu. To keep items in the context menu grouped, I placed them at the top of the menu with a separator at the end. Let me know if that's OK. Thanks!

Here is the screenshot:

![CleanShot 2024-05-16 at 07 04 44@2x](https://github.com/zed-industries/zed/assets/1894248/2ac84001-cdd7-4c01-b597-c5b1dc3e7fa3)

Release Notes:

- Added "Cut", "Copy", and "Paste" actions to the context menu ([#4280](https://github.com/zed-industries/zed/issues/4280)).



