### PR TITLE
Fix small markdown typo in Windows docs

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -23,7 +23,8 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 - Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with optional component `MSVC v*** - VS YYYY C++ x64/x86 build tools` and install Windows 11 or 10 SDK depending on your system
 
-> [!NOTE] > `v***` is your VS version and `YYYY` is year when your VS was released.
+> [!NOTE]
+> `v***` is your VS version and `YYYY` is year when your VS was released.
 
 ## Backend dependencies
 


### PR DESCRIPTION
Fixed a small issue in the windows docs where a note wasn't displaying correctly

Release Notes:

- N/A
