### PR TITLE
eslint: Change default configuration to fix errors

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -319,6 +319,15 @@ impl LspAdapter for EsLintLspAdapter {
                 },
                 "problems": problems,
                 "codeActionOnSave": code_action_on_save,
+                "codeAction": {
+                    "disableRuleComment": {
+                        "enable": true,
+                        "location": "separateLine",
+                    },
+                    "showDocumentation": {
+                        "enable": true
+                    }
+                },
                 "experimental": {
                     "useFlatConfig": use_flat_config,
                 },


### PR DESCRIPTION
Without this, we'd get constant errors when typing something with ESLint enabled:

    [2024-05-16T10:32:30+02:00 WARN  project] Generic lsp request to node failed: Request textDocument/codeAction failed with message: Cannot read properties of undefined (reading 'disableRuleComment')
    [2024-05-16T10:32:30+02:00 ERROR util] crates/project/src/project.rs:7023: Request textDocument/codeAction failed with message: Cannot read properties of undefined (reading 'disableRuleComment')
    [2024-05-16T10:32:31+02:00 WARN  project] Generic lsp request to node failed: Request textDocument/codeAction failed with message: Cannot read properties of undefined (reading 'disableRuleComment')
    [2024-05-16T10:32:31+02:00 ERROR util] crates/project/src/project.rs:7023: Request textDocument/codeAction failed with message: Cannot read properties of undefined (reading 'disableRuleComment')

This is fixed by changing the default settings for ESLint language server to have those fields.

I don't think we need to make these configurable yet. These are defaults that multiple other plugins also use:

- vscode-eslint: https://sourcegraph.com/github.com/microsoft/vscode-eslint@4d9fc40e71c403d359beaccdd4a6f8d027031513/-/blob/client/src/client.ts?L702-703
- nvim-lspconfig: https://sourcegraph.com/github.com/neovim/nvim-lspconfig@a27179f56c6f98a4cdcc79ee2971b514815a4940/-/blob/lua/lspconfig/server_configurations/eslint.lua?L94-101
- coc-eslitn: https://sourcegraph.com/github.com/neoclide/coc-eslint@70eb10d294e068757743f9b580c724e92c5b977d/-/blob/src/index.ts?L698:17-698:35



Release Notes:

- Changed the default ESLint configuration to include the following in order to silence warnings/errors: `{"codeAction": { "disableRuleComment": { "enable": true, "location": "separateLine", }, "showDocumentation": { "enable": true } }}`