### PR TITLE
Make `SyntaxTheme::new_test` only available in tests

### DIFF
--- a/crates/theme/src/styles/syntax.rs
+++ b/crates/theme/src/styles/syntax.rs
@@ -127,7 +127,7 @@ impl SyntaxTheme {
         }
     }
 
-    // TODO: Get this working with `#[cfg(test)]`. Why isn't it?
+    #[cfg(any(test, feature = "test-support"))]
     pub fn new_test(colors: impl IntoIterator<Item = (&'static str, Hsla)>) -> Self {
         SyntaxTheme {
             highlights: colors


### PR DESCRIPTION
This PR addresses a TODO comment by making `SyntaxTheme::new_test` only available in tests.

We needed to make it available when the `test-support` feature was enabled for it to be used in tests outside of the `theme` crate.

Release Notes:

- N/A
