### PR TITLE
theme: Properly merge `SyntaxTheme` styles to allow for partial overrides

### DIFF
--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -118,38 +118,36 @@ impl ThemeRegistry {
             };
             player_colors.merge(&user_theme.style.players);
 
-            let mut syntax_colors = match user_theme.appearance {
+            let syntax_theme = match user_theme.appearance {
                 AppearanceContent::Light => SyntaxTheme::light(),
                 AppearanceContent::Dark => SyntaxTheme::dark(),
             };
+            let syntax_highlights = user_theme
+                .style
+                .syntax
+                .iter()
+                .map(|(syntax_token, highlight)| {
+                    (
+                        syntax_token.clone(),
+                        HighlightStyle {
+                            color: highlight
+                                .color
+                                .as_ref()
+                                .and_then(|color| try_parse_color(color).ok()),
+                            font_style: highlight.font_style.map(Into::into),
+                            font_weight: highlight.font_weight.map(Into::into),
+                            ..Default::default()
+                        },
+                    )
+                })
+                .collect::<Vec<_>>();
+            let syntax_theme = SyntaxTheme::merge(Arc::new(syntax_theme), syntax_highlights);
 
             let window_background_appearance = user_theme
                 .style
                 .window_background_appearance
                 .map(Into::into)
                 .unwrap_or_default();
-
-            if !user_theme.style.syntax.is_empty() {
-                syntax_colors.highlights = user_theme
-                    .style
-                    .syntax
-                    .iter()
-                    .map(|(syntax_token, highlight)| {
-                        (
-                            syntax_token.clone(),
-                            HighlightStyle {
-                                color: highlight
-                                    .color
-                                    .as_ref()
-                                    .and_then(|color| try_parse_color(color).ok()),
-                                font_style: highlight.font_style.map(Into::into),
-                                font_weight: highlight.font_weight.map(Into::into),
-                                ..Default::default()
-                            },
-                        )
-                    })
-                    .collect::<Vec<_>>();
-            }
 
             Theme {
                 id: uuid::Uuid::new_v4().to_string(),
@@ -164,7 +162,7 @@ impl ThemeRegistry {
                     colors: theme_colors,
                     status: status_colors,
                     player: player_colors,
-                    syntax: Arc::new(syntax_colors),
+                    syntax: syntax_theme,
                     accents: Vec::new(),
                 },
             }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -325,15 +325,8 @@ impl ThemeSettings {
                 .status
                 .refine(&theme_overrides.status_colors_refinement());
             base_theme.styles.player.merge(&theme_overrides.players);
-            base_theme.styles.syntax = Arc::new(SyntaxTheme {
-                highlights: {
-                    let mut highlights = base_theme.styles.syntax.highlights.clone();
-                    // Overrides come second in the highlight list so that they take precedence
-                    // over the ones in the base theme.
-                    highlights.extend(theme_overrides.syntax_overrides());
-                    highlights
-                },
-            });
+            base_theme.styles.syntax =
+                SyntaxTheme::merge(base_theme.styles.syntax, theme_overrides.syntax_overrides());
 
             self.active_theme = Arc::new(base_theme);
         }

--- a/crates/theme/src/styles/syntax.rs
+++ b/crates/theme/src/styles/syntax.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use gpui::{HighlightStyle, Hsla};
 
 use crate::{
@@ -154,5 +156,36 @@ impl SyntaxTheme {
 
     pub fn color(&self, name: &str) -> Hsla {
         self.get(name).color.unwrap_or_default()
+    }
+
+    /// Returns a new [`Arc<SyntaxTheme>`] with the given syntax overrides merged in.
+    pub fn merge(base: Arc<Self>, syntax_overrides: Vec<(String, HighlightStyle)>) -> Arc<Self> {
+        let mut merged_highlights = base.highlights.clone();
+
+        for (name, highlight) in syntax_overrides {
+            if let Some((_, existing_highlight)) = merged_highlights
+                .iter_mut()
+                .find(|(existing_name, _)| existing_name == &name)
+            {
+                existing_highlight.color = highlight.color.or(existing_highlight.color);
+                existing_highlight.font_weight =
+                    highlight.font_weight.or(existing_highlight.font_weight);
+                existing_highlight.font_style =
+                    highlight.font_style.or(existing_highlight.font_style);
+                existing_highlight.background_color = highlight
+                    .background_color
+                    .or(existing_highlight.background_color);
+                existing_highlight.underline = highlight.underline.or(existing_highlight.underline);
+                existing_highlight.strikethrough =
+                    highlight.strikethrough.or(existing_highlight.strikethrough);
+                existing_highlight.fade_out = highlight.fade_out.or(existing_highlight.fade_out);
+            } else {
+                merged_highlights.push((name, highlight));
+            }
+        }
+
+        Arc::new(Self {
+            highlights: merged_highlights,
+        })
     }
 }


### PR DESCRIPTION
This PR improves the merging behavior for the `SyntaxTheme` such that user-provided values get merged into the base theme.

This makes it possible to override individual styles without clobbering the unspecified styles in the base theme.

Release Notes:

- Improved merging of `syntax` styles in the theme.