### PR TITLE
Use `UpdateGlobal` accessors in more places

### DIFF
--- a/crates/assistant2/src/assistant2.rs
+++ b/crates/assistant2/src/assistant2.rs
@@ -24,7 +24,8 @@ use fs::Fs;
 use futures::{future::join_all, StreamExt};
 use gpui::{
     list, AnyElement, AppContext, AsyncWindowContext, ClickEvent, EventEmitter, FocusHandle,
-    FocusableView, ListAlignment, ListState, Model, ReadGlobal, Render, Task, View, WeakView,
+    FocusableView, ListAlignment, ListState, Model, ReadGlobal, Render, Task, UpdateGlobal, View,
+    WeakView,
 };
 use language::{language_settings::SoftWrap, LanguageRegistry};
 use markdown::{Markdown, MarkdownStyle};
@@ -124,7 +125,7 @@ impl AssistantPanel {
             })?;
 
             cx.new_view(|cx| {
-                let project_index = cx.update_global(|semantic_index: &mut SemanticIndex, cx| {
+                let project_index = SemanticIndex::update_global(cx, |semantic_index, cx| {
                     semantic_index.project_index(project.clone(), cx)
                 });
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -17,8 +17,7 @@ use futures::{
     TryFutureExt as _, TryStreamExt,
 };
 use gpui::{
-    actions, AnyModel, AnyWeakModel, AppContext, AsyncAppContext, BorrowAppContext, Global, Model,
-    Task, WeakModel,
+    actions, AnyModel, AnyWeakModel, AppContext, AsyncAppContext, Global, Model, Task, WeakModel,
 };
 use http::{HttpClient, HttpClientWithUrl};
 use lazy_static::lazy_static;
@@ -29,7 +28,7 @@ use release_channel::{AppVersion, ReleaseChannel};
 use rpc::proto::{AnyTypedEnvelope, EntityMessage, EnvelopedMessage, PeerId, RequestMessage};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{Settings, SettingsSources, SettingsStore};
+use settings::{Settings, SettingsSources};
 use std::fmt;
 use std::pin::Pin;
 use std::{
@@ -141,10 +140,8 @@ impl Settings for ProxySettings {
 
 pub fn init_settings(cx: &mut AppContext) {
     TelemetrySettings::register(cx);
-    cx.update_global(|store: &mut SettingsStore, cx| {
-        store.register_setting::<ClientSettings>(cx);
-        store.register_setting::<ProxySettings>(cx);
-    });
+    ClientSettings::register(cx);
+    ProxySettings::register(cx);
 }
 
 pub fn init(client: &Arc<Client>, cx: &mut AppContext) {

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -19,7 +19,7 @@ use editor::{
 };
 use futures::StreamExt;
 use git::diff::DiffHunkStatus;
-use gpui::{BorrowAppContext, TestAppContext, VisualContext, VisualTestContext};
+use gpui::{TestAppContext, UpdateGlobal, VisualContext, VisualTestContext};
 use indoc::indoc;
 use language::{
     language_settings::{AllLanguageSettings, InlayHintSettings},
@@ -1517,7 +1517,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
     cx_b.update(editor::init);
 
     cx_a.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
@@ -1531,7 +1531,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
         });
     });
     cx_b.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
@@ -1779,7 +1779,7 @@ async fn test_inlay_hint_refresh_is_forwarded(
     cx_b.update(editor::init);
 
     cx_a.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: false,
@@ -1793,7 +1793,7 @@ async fn test_inlay_hint_refresh_is_forwarded(
         });
     });
     cx_b.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.defaults.inlay_hints = Some(InlayHintSettings {
                     enabled: true,
@@ -2269,14 +2269,14 @@ async fn test_git_blame_is_forwarded(cx_a: &mut TestAppContext, cx_b: &mut TestA
         min_column: None,
     });
     cx_a.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<ProjectSettings>(cx, |settings| {
                 settings.git.inline_blame = inline_blame_off_settings;
             });
         });
     });
     cx_b.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<ProjectSettings>(cx, |settings| {
                 settings.git.inline_blame = inline_blame_off_settings;
             });

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -13,8 +13,8 @@ use fs::{FakeFs, Fs as _, RemoveOptions};
 use futures::{channel::mpsc, StreamExt as _};
 use git::repository::GitFileStatus;
 use gpui::{
-    px, size, AppContext, BackgroundExecutor, BorrowAppContext, Model, Modifiers, MouseButton,
-    MouseDownEvent, TestAppContext,
+    px, size, AppContext, BackgroundExecutor, Model, Modifiers, MouseButton, MouseDownEvent,
+    TestAppContext, UpdateGlobal,
 };
 use language::{
     language_settings::{AllLanguageSettings, Formatter, PrettierSettings},
@@ -4401,7 +4401,7 @@ async fn test_formatting_buffer(
     // Ensure buffer can be formatted using an external command. Notice how the
     // host's configuration is honored as opposed to using the guest's settings.
     cx_a.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, |file| {
                 file.defaults.formatter = Some(Formatter::External {
                     command: "awk".into(),
@@ -4485,7 +4485,7 @@ async fn test_prettier_formatting_buffer(
     let buffer_b = cx_b.executor().spawn(open_buffer).await.unwrap();
 
     cx_a.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, |file| {
                 file.defaults.formatter = Some(Formatter::Auto);
                 file.defaults.prettier = Some(PrettierSettings {
@@ -4496,7 +4496,7 @@ async fn test_prettier_formatting_buffer(
         });
     });
     cx_b.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, |file| {
                 file.defaults.formatter = Some(Formatter::LanguageServer);
                 file.defaults.prettier = Some(PrettierSettings {

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -12,7 +12,7 @@ use command_palette_hooks::{
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     actions, Action, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Global,
-    ParentElement, Render, Styled, Task, View, ViewContext, VisualContext, WeakView,
+    ParentElement, Render, Styled, Task, UpdateGlobal, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
 
@@ -362,7 +362,7 @@ impl PickerDelegate for CommandPaletteDelegate {
 
         self.matches.clear();
         self.commands.clear();
-        cx.update_global(|hit_counts: &mut HitCounts, _| {
+        HitCounts::update_global(cx, |hit_counts, _cx| {
             *hit_counts.0.entry(command.name).or_default() += 1;
         });
         let action = command.action;

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -273,7 +273,7 @@ mod tests {
     };
     use fs::FakeFs;
     use futures::StreamExt;
-    use gpui::{BackgroundExecutor, BorrowAppContext, Context, TestAppContext};
+    use gpui::{BackgroundExecutor, Context, TestAppContext, UpdateGlobal};
     use indoc::indoc;
     use language::{
         language_settings::{AllLanguageSettings, AllLanguageSettingsContent},
@@ -1138,7 +1138,7 @@ mod tests {
             editor::init_settings(cx);
             Project::init_settings(cx);
             workspace::init_settings(cx);
-            cx.update_global(|store: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |store: &mut SettingsStore, cx| {
                 store.update_user_settings::<AllLanguageSettings>(cx, f);
             });
         });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9,7 +9,7 @@ use crate::{
     JoinLines,
 };
 use futures::StreamExt;
-use gpui::{div, TestAppContext, VisualTestContext, WindowBounds, WindowOptions};
+use gpui::{div, TestAppContext, UpdateGlobal, VisualTestContext, WindowBounds, WindowOptions};
 use indoc::indoc;
 use language::{
     language_settings::{
@@ -11436,7 +11436,7 @@ pub(crate) fn update_test_language_settings(
     f: impl Fn(&mut AllLanguageSettingsContent),
 ) {
     _ = cx.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<AllLanguageSettings>(cx, f);
         });
     });
@@ -11447,7 +11447,7 @@ pub(crate) fn update_test_project_settings(
     f: impl Fn(&mut ProjectSettings),
 ) {
     _ = cx.update(|cx| {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings::<ProjectSettings>(cx, f);
         });
     });

--- a/crates/headless/src/headless.rs
+++ b/crates/headless/src/headless.rs
@@ -4,7 +4,7 @@ use client::{user::UserStore, Client, ClientSettings};
 use fs::Fs;
 use futures::Future;
 use gpui::{
-    AppContext, AsyncAppContext, BorrowAppContext, Context, Global, Model, ModelContext, Task,
+    AppContext, AsyncAppContext, Context, Global, Model, ModelContext, Task, UpdateGlobal,
     WeakModel,
 };
 use language::LanguageRegistry;
@@ -41,7 +41,7 @@ pub fn init(client: Arc<Client>, app_state: AppState, cx: &mut AppContext) -> Ta
     cx.set_global(GlobalDevServer(dev_server.clone()));
 
     // Dev server cannot have any private files for now
-    cx.update_global(|store: &mut SettingsStore, _| {
+    SettingsStore::update_global(cx, |store, _cx| {
         let old_settings = store.get::<WorktreeSettings>(None);
         store.override_global(WorktreeSettings {
             private_files: Some(vec![]),

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use gpui::{AppContext, BorrowAppContext};
+use gpui::{AppContext, UpdateGlobal};
 pub use language::*;
 use node_runtime::NodeRuntime;
 use rust_embed::RustEmbed;
@@ -223,7 +223,7 @@ pub fn init(
             let language_settings = languages.language_settings();
             if language_settings != prev_language_settings {
                 cx.update(|cx| {
-                    cx.update_global(|settings: &mut SettingsStore, cx| {
+                    SettingsStore::update_global(cx, |settings, cx| {
                         settings
                             .set_extension_settings(language_settings.clone(), cx)
                             .log_err();

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1,7 +1,7 @@
 use crate::{Event, *};
 use fs::FakeFs;
 use futures::{future, StreamExt};
-use gpui::AppContext;
+use gpui::{AppContext, UpdateGlobal};
 use language::{
     language_settings::{AllLanguageSettings, LanguageSettingsContent},
     tree_sitter_rust, tree_sitter_typescript, Diagnostic, FakeLspAdapter, LanguageConfig,
@@ -1501,7 +1501,7 @@ async fn test_toggling_enable_language_server(cx: &mut gpui::TestAppContext) {
 
     // Disable Rust language server, ensuring only that server gets stopped.
     cx.update(|cx| {
-        cx.update_global(|settings: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |settings, cx| {
             settings.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.languages.insert(
                     Arc::from("Rust"),
@@ -1520,7 +1520,7 @@ async fn test_toggling_enable_language_server(cx: &mut gpui::TestAppContext) {
     // Enable Rust and disable JavaScript language servers, ensuring that the
     // former gets started again and that the latter stops.
     cx.update(|cx| {
-        cx.update_global(|settings: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |settings, cx| {
             settings.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                 settings.languages.insert(
                     Arc::from("Rust"),

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -15,8 +15,8 @@ use gpui::{
     actions, div, Action, AnyElement, AnyView, AppContext, Context as _, Element, EntityId,
     EventEmitter, FocusHandle, FocusableView, FontStyle, FontWeight, Global, Hsla,
     InteractiveElement, IntoElement, Model, ModelContext, ParentElement, Point, Render,
-    SharedString, Styled, Subscription, Task, TextStyle, View, ViewContext, VisualContext,
-    WeakModel, WeakView, WhiteSpace, WindowContext,
+    SharedString, Styled, Subscription, Task, TextStyle, UpdateGlobal, View, ViewContext,
+    VisualContext, WeakModel, WeakView, WhiteSpace, WindowContext,
 };
 use menu::Confirm;
 use project::{search::SearchQuery, search_history::SearchHistoryCursor, Project, ProjectPath};
@@ -526,8 +526,8 @@ impl Item for ProjectSearchView {
 impl ProjectSearchView {
     fn toggle_filters(&mut self, cx: &mut ViewContext<Self>) {
         self.filters_enabled = !self.filters_enabled;
-        cx.update_global(|state: &mut ActiveSettings, cx| {
-            state.0.insert(
+        ActiveSettings::update_global(cx, |settings, cx| {
+            settings.0.insert(
                 self.model.read(cx).project.downgrade(),
                 self.current_settings(),
             );
@@ -540,10 +540,11 @@ impl ProjectSearchView {
             filters_enabled: self.filters_enabled,
         }
     }
+
     fn toggle_search_option(&mut self, option: SearchOptions, cx: &mut ViewContext<Self>) {
         self.search_options.toggle(option);
-        cx.update_global(|state: &mut ActiveSettings, cx| {
-            state.0.insert(
+        ActiveSettings::update_global(cx, |settings, cx| {
+            settings.0.insert(
                 self.model.read(cx).project.downgrade(),
                 self.current_settings(),
             );

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -2,7 +2,7 @@ use crate::{settings_store::SettingsStore, Settings};
 use anyhow::{Context, Result};
 use fs::Fs;
 use futures::{channel::mpsc, StreamExt};
-use gpui::{AppContext, BackgroundExecutor, BorrowAppContext};
+use gpui::{AppContext, BackgroundExecutor, UpdateGlobal};
 use std::{io::ErrorKind, path::PathBuf, sync::Arc, time::Duration};
 use util::{paths, ResultExt};
 
@@ -70,7 +70,7 @@ pub fn handle_settings_file_changes(
         .background_executor()
         .block(user_settings_file_rx.next())
         .unwrap();
-    cx.update_global(|store: &mut SettingsStore, cx| {
+    SettingsStore::update_global(cx, |store, cx| {
         store
             .set_user_settings(&user_settings_content, cx)
             .log_err();

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use collections::{btree_map, hash_map, BTreeMap, HashMap};
-use gpui::{AppContext, AsyncAppContext, BorrowAppContext, Global};
+use gpui::{AppContext, AsyncAppContext, BorrowAppContext, Global, UpdateGlobal};
 use lazy_static::lazy_static;
 use schemars::{gen::SchemaGenerator, schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Deserialize as _, Serialize};
@@ -49,7 +49,7 @@ pub trait Settings: 'static + Send + Sync {
     where
         Self: Sized,
     {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             store.register_setting::<Self>(cx);
         });
     }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -3,8 +3,8 @@ use feature_flags::FeatureFlagAppExt;
 use fs::Fs;
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, impl_actions, AppContext, DismissEvent, EventEmitter, FocusableView, Render, View,
-    ViewContext, VisualContext, WeakView,
+    actions, impl_actions, AppContext, DismissEvent, EventEmitter, FocusableView, Render,
+    UpdateGlobal, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
 use serde::Deserialize;
@@ -165,7 +165,7 @@ impl ThemeSelectorDelegate {
     }
 
     fn set_theme(theme: Arc<Theme>, cx: &mut AppContext) {
-        cx.update_global(|store: &mut SettingsStore, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
             let mut theme_settings = store.get::<ThemeSettings>(None).clone();
             theme_settings.active_theme = theme;
             theme_settings.apply_theme_overrides();

--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -1,8 +1,6 @@
 use crate::{insert::NormalBefore, Vim, VimModeSetting};
 use editor::{Editor, EditorEvent};
-use gpui::{
-    Action, AppContext, BorrowAppContext, Entity, EntityId, View, ViewContext, WindowContext,
-};
+use gpui::{Action, AppContext, Entity, EntityId, UpdateGlobal, View, ViewContext, WindowContext};
 use settings::{Settings, SettingsStore};
 
 pub fn init(cx: &mut AppContext) {
@@ -63,7 +61,7 @@ fn blurred(editor: View<Editor>, cx: &mut WindowContext) {
 }
 
 fn released(entity_id: EntityId, cx: &mut AppContext) {
-    cx.update_global(|vim: &mut Vim, _| {
+    Vim::update_global(cx, |vim, _cx| {
         if vim
             .active_editor
             .as_ref()

--- a/crates/vim/src/test/neovim_backed_test_context.rs
+++ b/crates/vim/src/test/neovim_backed_test_context.rs
@@ -1,4 +1,4 @@
-use gpui::{px, size, BorrowAppContext, Context};
+use gpui::{px, size, Context, UpdateGlobal};
 use indoc::indoc;
 use settings::SettingsStore;
 use std::{
@@ -196,7 +196,7 @@ impl NeovimBackedTestContext {
             .await;
 
         self.update(|cx| {
-            cx.update_global(|settings: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
                 settings.update_user_settings::<AllLanguageSettings>(cx, |settings| {
                     settings.defaults.soft_wrap = Some(SoftWrap::PreferredLineLength);
                     settings.defaults.preferred_line_length = Some(columns);

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -56,7 +56,7 @@ impl VimTestContext {
 
     pub fn new_with_lsp(mut cx: EditorLspTestContext, enabled: bool) -> VimTestContext {
         cx.update(|cx| {
-            cx.update_global(|store: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings::<VimModeSetting>(cx, |s| *s = Some(enabled));
             });
             settings::KeymapFile::load_asset("keymaps/default-macos.json", cx).unwrap();
@@ -104,7 +104,7 @@ impl VimTestContext {
 
     pub fn enable_vim(&mut self) {
         self.cx.update(|cx| {
-            cx.update_global(|store: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings::<VimModeSetting>(cx, |s| *s = Some(true));
             });
         })

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -112,7 +112,7 @@ impl VimTestContext {
 
     pub fn disable_vim(&mut self) {
         self.cx.update(|cx| {
-            cx.update_global(|store: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings::<VimModeSetting>(cx, |s| *s = Some(false));
             });
         })

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -27,7 +27,7 @@ use editor::{
 };
 use gpui::{
     actions, impl_actions, Action, AppContext, EntityId, FocusableView, Global, KeystrokeEvent,
-    Subscription, View, ViewContext, WeakView, WindowContext,
+    Subscription, UpdateGlobal, View, ViewContext, WeakView, WindowContext,
 };
 use language::{CursorShape, Point, SelectionGoal, TransactionId};
 pub use mode_indicator::ModeIndicator;
@@ -106,11 +106,11 @@ pub fn init(cx: &mut AppContext) {
     CommandPaletteFilter::update_global(cx, |filter, _| {
         filter.hide_namespace(Vim::NAMESPACE);
     });
-    cx.update_global(|vim: &mut Vim, cx: &mut AppContext| {
+    Vim::update_global(cx, |vim, cx| {
         vim.set_enabled(VimModeSetting::get_global(cx).0, cx)
     });
     cx.observe_global::<SettingsStore>(|cx| {
-        cx.update_global(|vim: &mut Vim, cx: &mut AppContext| {
+        Vim::update_global(cx, |vim, cx| {
             vim.set_enabled(VimModeSetting::get_global(cx).0, cx)
         });
     })

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5183,8 +5183,8 @@ mod tests {
     };
     use fs::FakeFs;
     use gpui::{
-        px, BorrowAppContext, DismissEvent, Empty, EventEmitter, FocusHandle, FocusableView,
-        Render, TestAppContext, VisualTestContext,
+        px, DismissEvent, Empty, EventEmitter, FocusHandle, FocusableView, Render, TestAppContext,
+        UpdateGlobal, VisualTestContext,
     };
     use project::{Project, ProjectEntryId};
     use serde_json::json;
@@ -5606,7 +5606,7 @@ mod tests {
 
         // Autosave on window change.
         item.update(cx, |item, cx| {
-            cx.update_global(|settings: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
                 settings.update_user_settings::<WorkspaceSettings>(cx, |settings| {
                     settings.autosave = Some(AutosaveSetting::OnWindowChange);
                 })
@@ -5626,7 +5626,7 @@ mod tests {
         // Autosave on focus change.
         item.update(cx, |item, cx| {
             cx.focus_self();
-            cx.update_global(|settings: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
                 settings.update_user_settings::<WorkspaceSettings>(cx, |settings| {
                     settings.autosave = Some(AutosaveSetting::OnFocusChange);
                 })
@@ -5649,7 +5649,7 @@ mod tests {
 
         // Autosave after delay.
         item.update(cx, |item, cx| {
-            cx.update_global(|settings: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
                 settings.update_user_settings::<WorkspaceSettings>(cx, |settings| {
                     settings.autosave = Some(AutosaveSetting::AfterDelay { milliseconds: 500 });
                 })
@@ -5668,7 +5668,7 @@ mod tests {
 
         // Autosave on focus change, ensuring closing the tab counts as such.
         item.update(cx, |item, cx| {
-            cx.update_global(|settings: &mut SettingsStore, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
                 settings.update_user_settings::<WorkspaceSettings>(cx, |settings| {
                     settings.autosave = Some(AutosaveSetting::OnFocusChange);
                 })

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -943,7 +943,8 @@ fn watch_languages(_fs: Arc<dyn fs::Fs>, _languages: Arc<LanguageRegistry>, _cx:
 fn watch_file_types(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
     use std::time::Duration;
 
-    use gpui::BorrowAppContext;
+    use file_icons::FileIcons;
+    use gpui::UpdateGlobal;
 
     let path = {
         let p = Path::new("assets/icons/file_icons/file_types.json");
@@ -957,7 +958,7 @@ fn watch_file_types(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
         let mut events = fs.watch(path.as_path(), Duration::from_millis(100)).await;
         while (events.next().await).is_some() {
             cx.update(|cx| {
-                cx.update_global(|file_types, _| {
+                FileIcons::update_global(cx, |file_types, _cx| {
                     *file_types = file_icons::FileIcons::new(Assets);
                 });
             })


### PR DESCRIPTION
This PR updates a number of instances that were previously using `cx.update_global` to use `UpdateGlobal::update_global` instead.

Release Notes:

- N/A
