### PR TITLE
linux: Don't drag window with an active drag

### DIFF
--- a/crates/ui/src/components/title_bar/title_bar.rs
+++ b/crates/ui/src/components/title_bar/title_bar.rs
@@ -122,10 +122,12 @@ impl RenderOnce for TitleBar {
                     title_bar
                         .child(LinuxWindowControls::new(height, self.close_window_action))
                         .on_mouse_down(gpui::MouseButton::Right, move |ev, cx| {
-                            cx.show_window_menu(ev.position)
+                            if !cx.has_active_drag() {
+                                cx.show_window_menu(ev.position);
+                            }
                         })
                         .on_mouse_move(move |ev, cx| {
-                            if ev.dragging() {
+                            if ev.dragging() && !cx.has_active_drag() {
                                 cx.start_system_move();
                             }
                         })


### PR DESCRIPTION
Prevents dragging the window when there's an active drag.

Release Notes:

- N/A
