### PR TITLE
Remove wiring for `assistant2`

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -3,10 +3,5 @@
     "label": "clippy",
     "command": "cargo",
     "args": ["xtask", "clippy"]
-  },
-  {
-    "label": "assistant2",
-    "command": "cargo",
-    "args": ["run", "-p", "assistant2", "--example", "assistant_example"]
   }
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9712,7 +9712,6 @@ name = "storybook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assistant2",
  "clap 4.4.4",
  "collab_ui",
  "ctrlc",
@@ -12934,7 +12933,6 @@ dependencies = [
  "anyhow",
  "assets",
  "assistant",
- "assistant2",
  "audio",
  "auto_update",
  "backtrace",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -208,14 +208,6 @@
     }
   },
   {
-    "context": "AssistantChat > Editor", // Used in the assistant2 crate
-    "bindings": {
-      "enter": ["assistant2::Submit", "Simple"],
-      "cmd-enter": ["assistant2::Submit", "Codebase"],
-      "escape": "assistant2::Cancel"
-    }
-  },
-  {
     "context": "AssistantPanel", // Used in the assistant crate, which we're replacing
     "bindings": {
       "cmd-g": "search::SelectNextMatch",

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/storybook.rs"
 
 [dependencies]
 anyhow.workspace = true
-assistant2 = { workspace = true, features = ["stories"] }
 clap = { workspace = true, features = ["derive", "string"] }
 collab_ui = { workspace = true, features = ["stories"] }
 ctrlc = "3.4"

--- a/crates/storybook/src/story_selector.rs
+++ b/crates/storybook/src/story_selector.rs
@@ -12,8 +12,6 @@ use ui::prelude::*;
 #[derive(Debug, PartialEq, Eq, Clone, Copy, strum::Display, EnumString, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum ComponentStory {
-    AssistantChatMessage,
-    AssistantChatNotice,
     AutoHeightEditor,
     Avatar,
     Button,
@@ -46,10 +44,6 @@ pub enum ComponentStory {
 impl ComponentStory {
     pub fn story(&self, cx: &mut WindowContext) -> AnyView {
         match self {
-            Self::AssistantChatMessage => {
-                cx.new_view(|_cx| assistant2::ui::ChatMessageStory).into()
-            }
-            Self::AssistantChatNotice => cx.new_view(|_cx| assistant2::ui::ChatNoticeStory).into(),
             Self::AutoHeightEditor => AutoHeightEditorStory::new(cx).into(),
             Self::Avatar => cx.new_view(|_| ui::AvatarStory).into(),
             Self::Button => cx.new_view(|_| ui::ButtonStory).into(),

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -19,7 +19,6 @@ activity_indicator.workspace = true
 anyhow.workspace = true
 assets.workspace = true
 assistant.workspace = true
-assistant2.workspace = true
 audio.workspace = true
 auto_update.workspace = true
 backtrace = "0.3"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -175,7 +175,6 @@ fn init_ui(app_state: Arc<AppState>, cx: &mut AppContext) -> Result<()> {
     inline_completion_registry::init(app_state.client.telemetry().clone(), cx);
 
     assistant::init(app_state.client.clone(), cx);
-    assistant2::init(app_state.client.clone(), cx);
 
     cx.observe_global::<SettingsStore>({
         let languages = app_state.languages.clone();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -225,30 +225,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
         })
         .detach();
 
-        let mut current_user = app_state.user_store.read(cx).watch_current_user();
-
-        cx.spawn(|workspace_handle, mut cx| async move {
-            while let Some(user) = current_user.next().await {
-                if user.is_some() {
-                    // User known now, can check feature flags / staff
-                    // At this point, should have the user with staff status available
-                    let use_assistant2 = cx.update(|cx| assistant2::enabled(cx))?;
-                    if use_assistant2 {
-                        let panel =
-                            assistant2::AssistantPanel::load(workspace_handle.clone(), cx.clone())
-                                .await?;
-                        workspace_handle.update(&mut cx, |workspace, cx| {
-                            workspace.add_panel(panel, cx);
-                        })?;
-                    }
-
-                    break;
-                }
-            }
-            anyhow::Ok(())
-        })
-        .detach();
-
         workspace
             .register_action(about)
             .register_action(|_, _: &Minimize, cx| {


### PR DESCRIPTION
This PR removes the wiring for `assistant2` that hooks it up to Zed.

Since we're focusing in on improving the current assistant, we don't need this present in Zed.

I left the `assistant2` crate intact for now, to make it easier to reference any code from it.

Release Notes:

- N/A
