### PR TITLE
Revert "Fix aside affecting parent popover height (#11859)"

### DIFF
--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -40,14 +40,10 @@ pub struct Popover {
 
 impl RenderOnce for Popover {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
-        h_flex()
-            .items_start()
+        div()
+            .flex()
             .gap_1()
-            .child(
-                div()
-                    .flex()
-                    .child(v_flex().elevation_2(cx).px_1().children(self.children)),
-            )
+            .child(v_flex().elevation_2(cx).px_1().children(self.children))
             .when_some(self.aside, |this, aside| {
                 this.child(
                     v_flex()


### PR DESCRIPTION
This reverts commit d3dfa91254f8cbc7f4779463b30a3df1677c395d.

This change can cause weird behavior where the completion menu ends up positioned away from the cursor location:

<img width="1062" alt="Screenshot 2024-05-16 at 6 43 17 PM" src="https://github.com/zed-industries/zed/assets/1486634/0462a874-4fe3-4ca9-88ce-8d5d0b4009fe">

With the change reverted:

<img width="1026" alt="Screenshot 2024-05-16 at 6 43 35 PM" src="https://github.com/zed-industries/zed/assets/1486634/9fc7b9a1-0cfb-4a84-8f6b-b481a785ceca">

Release Notes:

- Fixed an issue where the completion menu would sometimes appear detached from the cursor location (preview only).
