### PR TITLE
Speed up is_dirty and has_conflict

### DIFF
--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -139,6 +139,14 @@ fn test_random_edits(mut rng: StdRng) {
             assert_eq!(old_text, new_text);
         }
 
+        assert_eq!(
+            buffer.has_edits_since(&old_buffer.version),
+            buffer
+                .edits_since::<usize>(&old_buffer.version)
+                .next()
+                .is_some(),
+        );
+
         let subscription_edits = subscription.consume();
         log::info!(
             "applying subscription edits since version {:?} to old text: {:?}: {:?}",


### PR DESCRIPTION
I noticed that scrolling the assistant panel was very slow in debug mode, after running a completion. From profiling, I saw that it was due to the buffer's `is_dirty` and `has_conflict` checks, which use `edits_since` to check if there are any non-undone edits since the saved version.

I optimized this in two ways:
* I introduced a specialized `has_edits_since` method on text buffers, which allows us to more cheaply check if the buffer has been edited since a given version, without some of the overhead involved in computing what the edits actually are.
* In the case of `has_conflict`, we don't even need to call that method in the case where the buffer doesn't have a file (is untitled, as is the case in the assistant panel). Buffers without files cannot be in conflict.

Release Notes:

- Improved performance of editing the assistant panel and untitled buffers with many edits.