### PR TITLE
Fix jetbrains keymap alt-enter to do `search::SelectAllMatches`

### DIFF
--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -53,7 +53,6 @@
       "cmd-alt-b": "editor::GoToDefinitionSplit",
       "cmd-shift-b": "editor::GoToTypeDefinition",
       "cmd-alt-shift-b": "editor::GoToTypeDefinitionSplit",
-      "alt-enter": "editor::ToggleCodeActions",
       "f2": "editor::GoToDiagnostic",
       "cmd-f2": "editor::GoToPrevDiagnostic",
       "ctrl-alt-shift-down": "editor::GoToHunk",
@@ -70,7 +69,8 @@
       "cmd-f12": "outline::Toggle",
       "cmd-7": "outline::Toggle",
       "cmd-shift-o": "file_finder::Toggle",
-      "cmd-l": "go_to_line::Toggle"
+      "cmd-l": "go_to_line::Toggle",
+      "alt-enter": "editor::ToggleCodeActions"
     }
   },
   {


### PR DESCRIPTION
The default keymap uses alt-enter for `SelectAllMatches` for `context: BufferSearchBar`.

Jetbrains keymap uses alt-enter for `ToggleCodeActions` for `context: Editor`.

When focusing on search bar, currently alt-enter does not perform `SelectAllMatches`, whereas `ToggleCodeActions` is triggered instead, because search bar's text input element has `context: Editor mode=single_line`.

This PR restricts `ToggleCodeActions` to `Editor (full mode)` context to allow `SelectAllMatches` to be triggered for alt-enter when the search bar is active.

Release Notes:

- Fixed #11840 : Fix jetbrains keymap alt-enter to do `search::SelectAllMatches`.

