### PR TITLE
Fix `npm install` command with a `URI://localhost:port` proxy setting

### DIFF
--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -58,7 +58,14 @@ impl HttpClientWithUrl {
     /// Returns a new [`HttpClientWithUrl`] with the given base URL.
     pub fn new(base_url: impl Into<String>, unparsed_proxy: Option<String>) -> Self {
         let parsed_proxy = get_proxy(unparsed_proxy);
-        let proxy_string = parsed_proxy.as_ref().map(|p| p.to_string());
+        let proxy_string = parsed_proxy.as_ref().map(|p| {
+            // Map proxy settings from `http://localhost:10809` to `http://127.0.0.1:10809`
+            // NodeRuntime without environment information can not parse `localhost`
+            // correctly.
+            p.to_string()
+                .to_ascii_lowercase()
+                .replace("localhost", "127.0.0.1")
+        });
         Self {
             base_url: Mutex::new(base_url.into()),
             client: client(parsed_proxy),

--- a/crates/http/src/http.rs
+++ b/crates/http/src/http.rs
@@ -62,6 +62,7 @@ impl HttpClientWithUrl {
             // Map proxy settings from `http://localhost:10809` to `http://127.0.0.1:10809`
             // NodeRuntime without environment information can not parse `localhost`
             // correctly.
+            // TODO: map to `[::1]` if we are using ipv6
             p.to_string()
                 .to_ascii_lowercase()
                 .replace("localhost", "127.0.0.1")

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -267,7 +267,7 @@ impl NodeRuntime for RealNodeRuntime {
             }
 
             if let Some(proxy) = self.http.proxy() {
-                command.args(["--proxy".into(), parse_local_host(proxy)]);
+                command.args(["--proxy", proxy]);
             }
 
             #[cfg(windows)]
@@ -433,10 +433,4 @@ impl NodeRuntime for FakeNodeRuntime {
     ) -> anyhow::Result<()> {
         unreachable!("Should not install packages {packages:?}")
     }
-}
-
-/// Mapping proxy settings `http://localhost:10809` to `http://127.0.0.1:10809`
-#[inline]
-fn parse_local_host(input: &str) -> String {
-    input.to_ascii_lowercase().replace("localhost", "127.0.0.1")
 }

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -267,7 +267,7 @@ impl NodeRuntime for RealNodeRuntime {
             }
 
             if let Some(proxy) = self.http.proxy() {
-                command.args(["--proxy", proxy]);
+                command.args(["--proxy".into(), parse_local_host(proxy)]);
             }
 
             #[cfg(windows)]
@@ -433,4 +433,9 @@ impl NodeRuntime for FakeNodeRuntime {
     ) -> anyhow::Result<()> {
         unreachable!("Should not install packages {packages:?}")
     }
+}
+
+#[inline]
+fn parse_local_host(input: &str) -> String {
+    input.to_ascii_lowercase().replace("localhost", "127.0.0.1")
 }

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -435,6 +435,7 @@ impl NodeRuntime for FakeNodeRuntime {
     }
 }
 
+/// Mapping proxy settings `http://localhost:10809` to `http://127.0.0.1:10809`
 #[inline]
 fn parse_local_host(input: &str) -> String {
     input.to_ascii_lowercase().replace("localhost", "127.0.0.1")


### PR DESCRIPTION
NodeRuntime without environment information can not parse `localhost` correctly.

Release Notes:

- N/A
