### PR TITLE
Change default Prettier's `useTabs` settings based on Zed settings

### DIFF
--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -292,6 +292,12 @@ impl Prettier {
                                     )),
                                 );
                             }
+                            if !options.contains_key("useTabs") {
+                                options.insert(
+                                    "useTabs".to_string(),
+                                    serde_json::Value::Bool(language_settings.hard_tabs),
+                                );
+                            }
                             Some(options)
                         } else {
                             None


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/7656

When a project is formatted by Prettier that Zed installs, make it respect Zed's `hard_tabs` settings by passing the value into Prettier config as `useTabs`.

https://github.com/zed-industries/zed/assets/2690773/80345cdd-d4f8-40b2-ab56-dba6b9646c70

Release Notes:

- Fixed default Prettier not respecting Zed's `hard_tabs` settings