### PR TITLE
Fix hang when opening URL in first browser window

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -485,7 +485,7 @@ pub(super) fn open_uri_internal(uri: &str, activation_token: Option<&str>) {
         if let Some(token) = activation_token {
             command.env("XDG_ACTIVATION_TOKEN", token);
         }
-        match command.status() {
+        match command.spawn() {
             Ok(_) => return,
             Err(err) => last_err = Some(err),
         }


### PR DESCRIPTION
If opening a url opens the first browser window the call does not return completely blocking the ui until the browser window is closed. Using spawn instead of status does not block, but we will loose the exitstatus of the browser window.

Release Notes:

- N/A