### PR TITLE
Format default settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -103,7 +103,14 @@
   // Hide the values of in variables from visual display in private files
   "redact_private_values": false,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.cert",
+    "**/*.crt",
+    "**/secrets.yml"
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -802,7 +809,7 @@
   //
   // Supported URI scheme: `http`, `https`, `socks4`, `socks4a`, `socks5`,
   // `socks5h`. `http` will be used when no scheme is specified.
-  // 
+  //
   // By default no proxy will be used, or Zed will try get proxy settings from
   // environment variables.
   //


### PR DESCRIPTION
This PR formats `default.json`, as it had gotten out-of-sync with Prettier.

Release Notes:

- N/A
