### PR TITLE
Implement 'Cmd+W with no open tabs closes the window', with a setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -84,6 +84,15 @@
   "restore_on_startup": "last_workspace",
   // Size of the drop target in the editor.
   "drop_target_size": 0.2,
+  // Whether the window should be closed when using 'close active item' on a window with no items.
+  // May take 3 values:
+  //  1. Use the current platform's convention
+  //         "close_window_when_no_tabs": "auto"
+  //  2. Always close the window:
+  //         "close_window_when_no_tabs": "on",
+  //  3. Never close the window
+  //         "close_window_when_no_tabs": "off",
+  "close_window_when_no_tabs": "auto",
   // Whether the cursor blinks in the editor.
   "cursor_blink": true,
   // How to highlight the current line in the editor.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -87,12 +87,12 @@
   // Whether the window should be closed when using 'close active item' on a window with no tabs.
   // May take 3 values:
   //  1. Use the current platform's convention
-  //         "close_window_when_no_tabs": "auto"
+  //         "when_closing_with_no_tabs": "platform_default"
   //  2. Always close the window:
-  //         "close_window_when_no_tabs": "on",
+  //         "when_closing_with_no_tabs": "close_window",
   //  3. Never close the window
-  //         "close_window_when_no_tabs": "off",
-  "close_window_when_no_tabs": "auto",
+  //         "when_closing_with_no_tabs": "keep_window_open",
+  "when_closing_with_no_tabs": "platform_default",
   // Whether the cursor blinks in the editor.
   "cursor_blink": true,
   // How to highlight the current line in the editor.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -84,7 +84,7 @@
   "restore_on_startup": "last_workspace",
   // Size of the drop target in the editor.
   "drop_target_size": 0.2,
-  // Whether the window should be closed when using 'close active item' on a window with no items.
+  // Whether the window should be closed when using 'close active item' on a window with no tabs.
   // May take 3 values:
   //  1. Use the current platform's convention
   //         "close_window_when_no_tabs": "auto"

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     toolbar::Toolbar,
     workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings},
-    NewCenterTerminal, NewFile, NewSearch, OpenInTerminal, OpenTerminal, OpenVisible,
+    CloseWindow, NewCenterTerminal, NewFile, NewSearch, OpenInTerminal, OpenTerminal, OpenVisible,
     SplitDirection, ToggleZoom, Workspace,
 };
 use anyhow::Result;
@@ -948,6 +948,14 @@ impl Pane {
         cx: &mut ViewContext<Self>,
     ) -> Option<Task<Result<()>>> {
         if self.items.is_empty() {
+            // Close the window when there's no active items to close, if configured
+            if WorkspaceSettings::get_global(cx)
+                .close_window_when_no_tabs
+                .should_close()
+            {
+                cx.dispatch_action(Box::new(CloseWindow));
+            }
+
             return None;
         }
         let active_item_id = self.items[self.active_item_index].item_id();

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -950,7 +950,7 @@ impl Pane {
         if self.items.is_empty() {
             // Close the window when there's no active items to close, if configured
             if WorkspaceSettings::get_global(cx)
-                .close_window_when_no_tabs
+                .when_closing_with_no_tabs
                 .should_close()
             {
                 cx.dispatch_action(Box::new(CloseWindow));

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -13,6 +13,29 @@ pub struct WorkspaceSettings {
     pub autosave: AutosaveSetting,
     pub restore_on_startup: RestoreOnStartupBehaviour,
     pub drop_target_size: f32,
+    pub close_window_when_no_tabs: CloseWindowWhenNoItems,
+}
+
+#[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CloseWindowWhenNoItems {
+    /// Match platform conventions by default, so "on" on macOS and "off" everywhere else
+    #[default]
+    Auto,
+    /// Close the window when there are no tabs
+    On,
+    /// Leave the window open when there are no tabs
+    Off,
+}
+
+impl CloseWindowWhenNoItems {
+    pub fn should_close(&self) -> bool {
+        match self {
+            CloseWindowWhenNoItems::Auto => cfg!(target_os = "macos"),
+            CloseWindowWhenNoItems::On => true,
+            CloseWindowWhenNoItems::Off => false,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -56,6 +79,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: `0.2` (20% of the smaller dimension of the workspace)
     pub drop_target_size: Option<f32>,
+    /// Whether to close the window when using 'close active tab' on a workspace with no tabs
+    ///
+    /// Default: auto ("on" on macOS, "off" otherwise)
+    pub close_window_when_no_tabs: Option<CloseWindowWhenNoItems>,
 }
 
 #[derive(Deserialize)]

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -79,7 +79,7 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: `0.2` (20% of the smaller dimension of the workspace)
     pub drop_target_size: Option<f32>,
-    /// Whether to close the window when using 'close active tab' on a workspace with no tabs
+    /// Whether to close the window when using 'close active item' on a workspace with no tabs
     ///
     /// Default: auto ("on" on macOS, "off" otherwise)
     pub close_window_when_no_tabs: Option<CloseWindowWhenNoItems>,

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -13,7 +13,7 @@ pub struct WorkspaceSettings {
     pub autosave: AutosaveSetting,
     pub restore_on_startup: RestoreOnStartupBehaviour,
     pub drop_target_size: f32,
-    pub close_window_when_no_tabs: CloseWindowWhenNoItems,
+    pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -21,19 +21,19 @@ pub struct WorkspaceSettings {
 pub enum CloseWindowWhenNoItems {
     /// Match platform conventions by default, so "on" on macOS and "off" everywhere else
     #[default]
-    Auto,
+    PlatformDefault,
     /// Close the window when there are no tabs
-    On,
+    CloseWindow,
     /// Leave the window open when there are no tabs
-    Off,
+    KeepWindowOpen,
 }
 
 impl CloseWindowWhenNoItems {
     pub fn should_close(&self) -> bool {
         match self {
-            CloseWindowWhenNoItems::Auto => cfg!(target_os = "macos"),
-            CloseWindowWhenNoItems::On => true,
-            CloseWindowWhenNoItems::Off => false,
+            CloseWindowWhenNoItems::PlatformDefault => cfg!(target_os = "macos"),
+            CloseWindowWhenNoItems::CloseWindow => true,
+            CloseWindowWhenNoItems::KeepWindowOpen => false,
         }
     }
 }
@@ -82,7 +82,7 @@ pub struct WorkspaceSettingsContent {
     /// Whether to close the window when using 'close active item' on a workspace with no tabs
     ///
     /// Default: auto ("on" on macOS, "off" otherwise)
-    pub close_window_when_no_tabs: Option<CloseWindowWhenNoItems>,
+    pub when_closing_with_no_tabs: Option<CloseWindowWhenNoItems>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Follow up to: https://github.com/zed-industries/zed/pull/10986

However, I have set this to have a default behavior of 'auto': matching the current platform's conventions, rather than a default value of 'off'.

fixes https://github.com/zed-industries/zed/issues/5322.

Release Notes:

- Changed the behavior of `workspace::CloseActiveItem`: when you're using macOS and there are no open tabs, it now closes the window ([#5322](https://github.com/zed-industries/zed/issues/5322)). This can be controlled with a new setting, `when_closing_with_no_tabs`, to disable it on macOS, or enable it on other platforms.