### PR TITLE
ruby: Pass initialization options to LSPs

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -1,9 +1,9 @@
 # Ruby
 
 - Tree Sitter: [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby)
-- Language Server: [solargraph](https://github.com/castwide/solargraph)
+- Language Servers: [solargraph](https://github.com/castwide/solargraph), [ruby-lsp](https://github.com/Shopify/ruby-lsp)
 
-### Setup
+### Setting up `solargraph`
 
 Zed currently doesn't install Solargraph automatically. To use Solargraph, you need to install the gem. Zed just looks for an executable called `solargraph` on your `PATH`.
 
@@ -37,3 +37,29 @@ Solargraph has formatting and diagnostics disabled by default. We can tell Zed t
 ### Configuration
 
 Solargraph reads its configuration from a file called `.solargraph.yml` in the root of your project. For more information about this file, see the [Solargraph configuration documentation](https://solargraph.org/guides/configuration).
+
+### Setting up `ruby-lsp`
+
+Zed currently doesn't install Ruby LSP automatically. To use Ruby LSP, you need to install the gem. Zed just looks for an executable called `ruby-lsp` on your `PATH`.
+
+You can install the gem manually with the following command:
+
+```shell
+gem install ruby-lsp
+```
+
+Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell Zed to disable it by adding the following to your `settings.json`:
+
+```json
+{
+  "lsp": {
+    "ruby-lsp": {
+      "initialization_options": {
+        "enabledFeatures": {
+          "diagnostics": false
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
Hi,

This pull request adds ability to pass `initialization_options` to both `solargraph` and `ruby-lsp` language servers. Additionally it updates the documentation to reflect that and the recently added `ruby-lsp` server. I hope that is OK to keep documentation update in this pull request, but I am totally fine with creating another pull request for that. Thanks.

Release Notes:

- Added ability to pass `initialization_options` to LSP servers.
