### PR TITLE
windows: Slightly improve font rendering quality

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1390,6 +1390,24 @@ fn get_system_ui_font_name() -> SharedString {
     }
 }
 
+#[inline]
+fn get_render_target_property(
+    pixel_format: DXGI_FORMAT,
+    alpha_mode: D2D1_ALPHA_MODE,
+) -> D2D1_RENDER_TARGET_PROPERTIES {
+    D2D1_RENDER_TARGET_PROPERTIES {
+        r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
+        pixelFormat: D2D1_PIXEL_FORMAT {
+            format: pixel_format,
+            alphaMode: alpha_mode,
+        },
+        dpiX: 96.0,
+        dpiY: 96.0,
+        usage: D2D1_RENDER_TARGET_USAGE_NONE,
+        minLevel: D2D1_FEATURE_LEVEL_DEFAULT,
+    }
+}
+
 const DEFAULT_LOCALE_NAME: PCWSTR = windows::core::w!("en-US");
 const BRUSH_COLOR: D2D1_COLOR_F = D2D1_COLOR_F {
     r: 1.0,

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -79,6 +79,22 @@ impl DirectWriteComponent {
             let factory: IDWriteFactory5 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
             let bitmap_factory: IWICImagingFactory2 =
                 CoCreateInstance(&CLSID_WICImagingFactory2, None, CLSCTX_INPROC_SERVER)?;
+            #[cfg(debug_assertions)]
+            let d2d1_factory: ID2D1Factory = {
+                // install debug layer:
+                // https://learn.microsoft.com/en-us/windows/win32/Direct2D/installing-the-direct2d-debug-layer
+                D2D1CreateFactory(
+                    D2D1_FACTORY_TYPE_MULTI_THREADED,
+                    Some(&D2D1_FACTORY_OPTIONS {
+                        debugLevel: D2D1_DEBUG_LEVEL_INFORMATION,
+                    }),
+                )
+                .or_else(|_| {
+                    log::warn!("Can not enable D2D1Factory debug layer.");
+                    D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None)
+                })?
+            };
+            #[cfg(not(debug_assertions))]
             let d2d1_factory: ID2D1Factory =
                 D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None)?;
             // The `IDWriteInMemoryFontFileLoader` here is supported starting from

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -148,7 +148,7 @@ impl GlyphRenderingParams {
                 enhanced_contrast,
                 gray_contrast,
                 cleartype_level,
-                DWRITE_PIXEL_GEOMETRY_FLAT,
+                DWRITE_PIXEL_GEOMETRY_RGB,
                 DWRITE_RENDERING_MODE1_NATURAL_SYMMETRIC,
                 grid_fit_mode,
             )?;
@@ -755,10 +755,8 @@ impl DirectWriteState {
                 .subpixel_variant
                 .map(|v| v as f32 / SUBPIXEL_VARIANTS as f32);
             let baseline_origin = D2D_POINT_2F {
-                // x: subpixel_shift.x / params.scale_factor,
-                x: 0.0,
-                // y: subpixel_shift.y / params.scale_factor,
-                y: 0.0,
+                x: subpixel_shift.x / params.scale_factor,
+                y: subpixel_shift.y / params.scale_factor,
             };
 
             // This `cast()` action here should never fail since we are running on Win10+, and

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -766,7 +766,7 @@ impl DirectWriteState {
             render_target.SetDpi(96.0 * params.scale_factor, 96.0 * params.scale_factor);
 
             if params.is_emoji {
-                render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE);
+                // render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE);
                 render_target.SetTextRenderingParams(&self.components.rendering_params.emoji);
                 render_target.BeginDraw();
                 // WARN: only DWRITE_GLYPH_IMAGE_FORMATS_COLR has been tested

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -596,7 +596,6 @@ impl DirectWriteState {
             isSideways: BOOL(0),
             bidiLevel: 0,
         };
-        // unsafe { render_target.SetDpi(96.0 * params.scale_factor, 96.0 * params.scale_factor) };
         let bounds = unsafe {
             render_target.GetGlyphRunWorldBounds(
                 D2D_POINT_2F { x: 0.0, y: 0.0 },

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -682,7 +682,7 @@ impl DirectWriteState {
             total_bytes = bitmap_size.height.0 as usize * bitmap_size.width.0 as usize;
             bitmap_format = &GUID_WICPixelFormat8bppAlpha;
             render_target_property =
-                get_render_target_property(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_UNKNOWN);
+                get_render_target_property(DXGI_FORMAT_A8_UNORM, D2D1_ALPHA_MODE_STRAIGHT);
             bitmap_width = bitmap_size.width.0 as u32 * 2;
             bitmap_height = bitmap_size.height.0 as u32 * 2;
             bitmap_stride = bitmap_size.width.0 as u32;

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -79,22 +79,6 @@ impl DirectWriteComponent {
             let factory: IDWriteFactory5 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
             let bitmap_factory: IWICImagingFactory2 =
                 CoCreateInstance(&CLSID_WICImagingFactory2, None, CLSCTX_INPROC_SERVER)?;
-            #[cfg(debug_assertions)]
-            let d2d1_factory: ID2D1Factory = {
-                // install debug layer:
-                // https://learn.microsoft.com/en-us/windows/win32/Direct2D/installing-the-direct2d-debug-layer
-                D2D1CreateFactory(
-                    D2D1_FACTORY_TYPE_MULTI_THREADED,
-                    Some(&D2D1_FACTORY_OPTIONS {
-                        debugLevel: D2D1_DEBUG_LEVEL_INFORMATION,
-                    }),
-                )
-                .or_else(|_| {
-                    log::warn!("Can not enable D2D1Factory debug layer.");
-                    D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None)
-                })?
-            };
-            #[cfg(not(debug_assertions))]
             let d2d1_factory: ID2D1Factory =
                 D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None)?;
             // The `IDWriteInMemoryFontFileLoader` here is supported starting from

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -793,17 +793,13 @@ impl DirectWriteState {
                 }
             } else {
                 let scaler = self.components.bitmap_factory.CreateBitmapScaler()?;
-                scaler
-                    .Initialize(
-                        &bitmap,
-                        bitmap_size.width.0 as u32,
-                        bitmap_size.height.0 as u32,
-                        WICBitmapInterpolationModeHighQualityCubic,
-                    )
-                    .unwrap();
-                scaler
-                    .CopyPixels(std::ptr::null() as _, bitmap_stride, &mut raw_data)
-                    .unwrap();
+                scaler.Initialize(
+                    &bitmap,
+                    bitmap_size.width.0 as u32,
+                    bitmap_size.height.0 as u32,
+                    WICBitmapInterpolationModeHighQualityCubic,
+                )?;
+                scaler.CopyPixels(std::ptr::null() as _, bitmap_stride, &mut raw_data)?;
             }
             Ok((bitmap_size, raw_data))
         }

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1297,8 +1297,8 @@ fn make_direct_write_feature(feature_name: &str, parameter: u32) -> DWRITE_FONT_
 
 #[inline]
 fn make_open_type_tag(tag_name: &str) -> u32 {
-    assert_eq!(tag_name.chars().count(), 4);
     let bytes = tag_name.bytes().collect_vec();
+    assert_eq!(bytes.len(), 4);
     ((bytes[3] as u32) << 24)
         | ((bytes[2] as u32) << 16)
         | ((bytes[1] as u32) << 8)

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -784,22 +784,10 @@ impl DirectWriteState {
                 );
             }
             render_target.EndDraw(None, None)?;
+
             let mut raw_data = vec![0u8; total_bytes];
-            // let converter = &self.components.render_context.converter;
-            let converter = self.components.bitmap_factory.CreateFormatConverter()?;
-            converter
-                .Initialize(
-                    &bitmap,
-                    &GUID_WICPixelFormat8bppGray,
-                    WICBitmapDitherTypeNone,
-                    None,
-                    0.0,
-                    WICBitmapPaletteTypeCustom,
-                )
-                .unwrap();
-            // bitmap.CopyPixels(std::ptr::null() as _, bitmap_stride, &mut raw_data)?;
-            converter.CopyPixels(std::ptr::null() as _, bitmap_stride, &mut raw_data)?;
             if params.is_emoji {
+                bitmap.CopyPixels(std::ptr::null() as _, bitmap_stride, &mut raw_data)?;
                 // Convert from BGRA with premultiplied alpha to BGRA with straight alpha.
                 for pixel in raw_data.chunks_exact_mut(4) {
                     let a = pixel[3] as f32 / 255.;
@@ -807,6 +795,19 @@ impl DirectWriteState {
                     pixel[1] = (pixel[1] as f32 / a) as u8;
                     pixel[2] = (pixel[2] as f32 / a) as u8;
                 }
+            } else {
+                let converter = self.components.bitmap_factory.CreateFormatConverter()?;
+                converter
+                    .Initialize(
+                        &bitmap,
+                        &GUID_WICPixelFormat8bppGray,
+                        WICBitmapDitherTypeNone,
+                        None,
+                        0.0,
+                        WICBitmapPaletteTypeCustom,
+                    )
+                    .unwrap();
+                converter.CopyPixels(std::ptr::null() as _, bitmap_stride, &mut raw_data)?;
             }
             Ok((bitmap_size, raw_data))
         }

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -751,8 +751,10 @@ impl DirectWriteState {
             // This `cast()` action here should never fail since we are running on Win10+, and
             // ID2D1DeviceContext4 requires Win8+
             let render_target = render_target.cast::<ID2D1DeviceContext4>().unwrap();
+            render_target.SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
             render_target.BeginDraw();
             if params.is_emoji {
+                render_target.SetTextRenderingParams(&self.components.rendering_params.emoji);
                 // WARN: only DWRITE_GLYPH_IMAGE_FORMATS_COLR has been tested
                 let enumerator = self.components.factory.TranslateColorGlyphRun(
                     baseline_origin,
@@ -803,21 +805,7 @@ impl DirectWriteState {
                     }
                 }
             } else {
-                render_target.SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
-                let render_param = self
-                    .components
-                    .factory
-                    .CreateCustomRenderingParams(
-                        1.0,
-                        1.0,
-                        1.0,
-                        1.0,
-                        DWRITE_PIXEL_GEOMETRY_FLAT,
-                        DWRITE_RENDERING_MODE1_NATURAL_SYMMETRIC,
-                        DWRITE_GRID_FIT_MODE_DEFAULT,
-                    )
-                    .unwrap();
-                render_target.SetTextRenderingParams(&render_param);
+                render_target.SetTextRenderingParams(&self.components.rendering_params.text);
                 render_target.DrawGlyphRun(
                     baseline_origin,
                     &glyph_run,

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -154,7 +154,6 @@ impl GlyphRenderContext {
                     D2D1_ALPHA_MODE_PREMULTIPLIED,
                 ))?;
                 let target = target.cast::<ID2D1DeviceContext4>()?;
-                target.SetUnitMode(D2D1_UNIT_MODE_DIPS);
                 target.SetTextRenderingParams(&params);
                 target
             };
@@ -592,6 +591,10 @@ impl DirectWriteState {
 
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
         let render_target = &self.components.render_context.dc_target;
+        unsafe {
+            render_target.SetUnitMode(D2D1_UNIT_MODE_DIPS);
+            render_target.SetDpi(96.0 * params.scale_factor, 96.0 * params.scale_factor);
+        }
         let font = &self.fonts[params.font_id.0];
         let glyph_id = [params.glyph_id.0 as u16];
         let advance = [0.0f32];

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -611,18 +611,14 @@ impl DirectWriteState {
             })
         } else {
             Ok(Bounds {
-                origin: Point {
-                    x: DevicePixels((bounds.left * params.scale_factor) as i32),
-                    y: DevicePixels((bounds.top * params.scale_factor) as i32),
-                },
-                size: Size {
-                    width: DevicePixels(
-                        ((bounds.right - bounds.left) * params.scale_factor) as i32,
-                    ),
-                    height: DevicePixels(
-                        ((bounds.bottom - bounds.top) * params.scale_factor) as i32,
-                    ),
-                },
+                origin: point(
+                    ((bounds.left * params.scale_factor) as i32).into(),
+                    ((bounds.top * params.scale_factor) as i32).into(),
+                ),
+                size: size(
+                    (((bounds.right - bounds.left) * params.scale_factor) as i32).into(),
+                    (((bounds.bottom - bounds.top) * params.scale_factor) as i32).into(),
+                ),
             })
         }
     }

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -564,61 +564,6 @@ impl DirectWriteState {
         }
     }
 
-    unsafe fn get_glyphrun_analysis(
-        &self,
-        params: &RenderGlyphParams,
-    ) -> windows::core::Result<IDWriteGlyphRunAnalysis> {
-        let font = &self.fonts[params.font_id.0];
-        let glyph_id = [params.glyph_id.0 as u16];
-        let advance = [0.0f32];
-        let offset = [DWRITE_GLYPH_OFFSET::default()];
-        let glyph_run = DWRITE_GLYPH_RUN {
-            fontFace: unsafe { std::mem::transmute_copy(&font.font_face) },
-            fontEmSize: params.font_size.0,
-            glyphCount: 1,
-            glyphIndices: glyph_id.as_ptr(),
-            glyphAdvances: advance.as_ptr(),
-            glyphOffsets: offset.as_ptr(),
-            isSideways: BOOL(0),
-            bidiLevel: 0,
-        };
-        let transform = DWRITE_MATRIX {
-            m11: params.scale_factor,
-            m12: 0.0,
-            m21: 0.0,
-            m22: params.scale_factor,
-            dx: 0.0,
-            dy: 0.0,
-        };
-        self.components.factory.CreateGlyphRunAnalysis(
-            &glyph_run as _,
-            Some(&transform as _),
-            DWRITE_RENDERING_MODE1_NATURAL,
-            DWRITE_MEASURING_MODE_NATURAL,
-            DWRITE_GRID_FIT_MODE_DEFAULT,
-            DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE,
-            0.0,
-            0.0,
-        )
-    }
-
-    // fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
-    //     unsafe {
-    //         let glyph_run_analysis = self.get_glyphrun_analysis(params)?;
-    //         let bounds = glyph_run_analysis.GetAlphaTextureBounds(DWRITE_TEXTURE_CLEARTYPE_3x1)?;
-
-    //         Ok(Bounds {
-    //             origin: Point {
-    //                 x: DevicePixels(bounds.left),
-    //                 y: DevicePixels(bounds.top),
-    //             },
-    //             size: Size {
-    //                 width: DevicePixels(bounds.right - bounds.left),
-    //                 height: DevicePixels(bounds.bottom - bounds.top),
-    //             },
-    //         })
-    //     }
-    // }
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
         let render_target_property = D2D1_RENDER_TARGET_PROPERTIES {
             r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -755,8 +755,10 @@ impl DirectWriteState {
                 .subpixel_variant
                 .map(|v| v as f32 / SUBPIXEL_VARIANTS as f32);
             let baseline_origin = D2D_POINT_2F {
-                x: subpixel_shift.x / params.scale_factor,
-                y: subpixel_shift.y / params.scale_factor,
+                // x: subpixel_shift.x / params.scale_factor,
+                x: 0.0,
+                // y: subpixel_shift.y / params.scale_factor,
+                y: 0.0,
             };
 
             // This `cast()` action here should never fail since we are running on Win10+, and
@@ -766,7 +768,6 @@ impl DirectWriteState {
             render_target.SetDpi(96.0 * params.scale_factor, 96.0 * params.scale_factor);
 
             if params.is_emoji {
-                // render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE);
                 render_target.SetTextRenderingParams(&self.components.rendering_params.emoji);
                 render_target.BeginDraw();
                 // WARN: only DWRITE_GLYPH_IMAGE_FORMATS_COLR has been tested
@@ -819,7 +820,6 @@ impl DirectWriteState {
                     }
                 }
             } else {
-                render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
                 render_target.SetTextRenderingParams(&self.components.rendering_params.text);
                 render_target.BeginDraw();
                 render_target.DrawGlyphRun(

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -743,7 +743,6 @@ impl DirectWriteState {
             // This `cast()` action here should never fail since we are running on Win10+, and
             // ID2D1DeviceContext4 requires Win8+
             let render_target = render_target.cast::<ID2D1DeviceContext4>().unwrap();
-            render_target.SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
             render_target.BeginDraw();
             if params.is_emoji {
                 render_target.SetTextRenderingParams(&self.components.rendering_params.emoji);

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -620,65 +620,65 @@ impl DirectWriteState {
     //     }
     // }
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
-        unsafe {
-            // bitmap_format = &GUID_WICPixelFormat8bppAlpha;
-            let render_target_property = D2D1_RENDER_TARGET_PROPERTIES {
-                r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
-                pixelFormat: D2D1_PIXEL_FORMAT {
-                    format: DXGI_FORMAT_B8G8R8A8_UNORM,
-                    alphaMode: D2D1_ALPHA_MODE_IGNORE,
-                },
-                dpiX: params.scale_factor * 96.0,
-                dpiY: params.scale_factor * 96.0,
-                usage: D2D1_RENDER_TARGET_USAGE_NONE,
-                minLevel: D2D1_FEATURE_LEVEL_DEFAULT,
-            };
-            let render_target = self
-                .components
+        let render_target_property = D2D1_RENDER_TARGET_PROPERTIES {
+            r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            pixelFormat: D2D1_PIXEL_FORMAT {
+                format: DXGI_FORMAT_B8G8R8A8_UNORM,
+                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+            },
+            dpiX: params.scale_factor * 96.0,
+            dpiY: params.scale_factor * 96.0,
+            usage: D2D1_RENDER_TARGET_USAGE_NONE,
+            minLevel: D2D1_FEATURE_LEVEL_DEFAULT,
+        };
+        let render_target = unsafe {
+            self.components
                 .d2d1_factory
-                .CreateDCRenderTarget(&render_target_property)?;
-            let render_target = render_target.cast::<ID2D1DeviceContext4>()?;
-            let font = &self.fonts[params.font_id.0];
-            let glyph_id = [params.glyph_id.0 as u16];
-            let advance = [0.0f32];
-            let offset = [DWRITE_GLYPH_OFFSET::default()];
-            let glyph_run = DWRITE_GLYPH_RUN {
-                fontFace: unsafe { std::mem::transmute_copy(&font.font_face) },
-                fontEmSize: params.font_size.0,
-                glyphCount: 1,
-                glyphIndices: glyph_id.as_ptr(),
-                glyphAdvances: advance.as_ptr(),
-                glyphOffsets: offset.as_ptr(),
-                isSideways: BOOL(0),
-                bidiLevel: 0,
-            };
-            let bounds = render_target.GetGlyphRunWorldBounds(
+                .CreateDCRenderTarget(&render_target_property)?
+        };
+        let render_target = render_target.cast::<ID2D1DeviceContext4>()?;
+        let font = &self.fonts[params.font_id.0];
+        let glyph_id = [params.glyph_id.0 as u16];
+        let advance = [0.0f32];
+        let offset = [DWRITE_GLYPH_OFFSET::default()];
+        let glyph_run = DWRITE_GLYPH_RUN {
+            fontFace: unsafe { std::mem::transmute_copy(&font.font_face) },
+            fontEmSize: params.font_size.0,
+            glyphCount: 1,
+            glyphIndices: glyph_id.as_ptr(),
+            glyphAdvances: advance.as_ptr(),
+            glyphOffsets: offset.as_ptr(),
+            isSideways: BOOL(0),
+            bidiLevel: 0,
+        };
+        let bounds = unsafe {
+            render_target.GetGlyphRunWorldBounds(
                 D2D_POINT_2F { x: 0.0, y: 0.0 },
                 &glyph_run,
                 DWRITE_MEASURING_MODE_NATURAL,
-            )?;
+            )?
+        };
 
-            if bounds.right < bounds.left {
-                Ok(Bounds {
-                    origin: point(0.into(), 0.into()),
-                    size: size(0.into(), 0.into()),
-                })
-            } else {
-                Ok(Bounds {
-                    origin: Point {
-                        x: DevicePixels((bounds.left * params.scale_factor) as i32),
-                        y: DevicePixels((bounds.top * params.scale_factor) as i32),
-                    },
-                    size: Size {
-                        width: DevicePixels(
-                            ((bounds.right - bounds.left) * params.scale_factor) as i32,
-                        ),
-                        height: DevicePixels(
-                            ((bounds.bottom - bounds.top) * params.scale_factor) as i32,
-                        ),
-                    },
-                })
-            }
+        if bounds.right < bounds.left {
+            Ok(Bounds {
+                origin: point(0.into(), 0.into()),
+                size: size(0.into(), 0.into()),
+            })
+        } else {
+            Ok(Bounds {
+                origin: Point {
+                    x: DevicePixels((bounds.left * params.scale_factor) as i32),
+                    y: DevicePixels((bounds.top * params.scale_factor) as i32),
+                },
+                size: Size {
+                    width: DevicePixels(
+                        ((bounds.right - bounds.left) * params.scale_factor) as i32,
+                    ),
+                    height: DevicePixels(
+                        ((bounds.bottom - bounds.top) * params.scale_factor) as i32,
+                    ),
+                },
+            })
         }
     }
 

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -611,12 +611,12 @@ impl DirectWriteState {
         } else {
             Ok(Bounds {
                 origin: point(
-                    ((bounds.left * params.scale_factor) as i32).into(),
-                    ((bounds.top * params.scale_factor) as i32).into(),
+                    ((bounds.left * params.scale_factor).ceil() as i32).into(),
+                    ((bounds.top * params.scale_factor).ceil() as i32).into(),
                 ),
                 size: size(
-                    (((bounds.right - bounds.left) * params.scale_factor) as i32).into(),
-                    (((bounds.bottom - bounds.top) * params.scale_factor) as i32).into(),
+                    (((bounds.right - bounds.left) * params.scale_factor).ceil() as i32).into(),
+                    (((bounds.bottom - bounds.top) * params.scale_factor).ceil() as i32).into(),
                 ),
             })
         }

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -743,9 +743,10 @@ impl DirectWriteState {
             // This `cast()` action here should never fail since we are running on Win10+, and
             // ID2D1DeviceContext4 requires Win8+
             let render_target = render_target.cast::<ID2D1DeviceContext4>().unwrap();
-            render_target.BeginDraw();
             if params.is_emoji {
+                render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE);
                 render_target.SetTextRenderingParams(&self.components.rendering_params.emoji);
+                render_target.BeginDraw();
                 // WARN: only DWRITE_GLYPH_IMAGE_FORMATS_COLR has been tested
                 let enumerator = self.components.factory.TranslateColorGlyphRun(
                     baseline_origin,
@@ -796,7 +797,9 @@ impl DirectWriteState {
                     }
                 }
             } else {
+                render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
                 render_target.SetTextRenderingParams(&self.components.rendering_params.text);
+                render_target.BeginDraw();
                 render_target.DrawGlyphRun(
                     baseline_origin,
                     &glyph_run,

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -595,6 +595,17 @@ impl DirectWriteState {
             isSideways: BOOL(0),
             bidiLevel: 0,
         };
+        if params.is_emoji {
+            unsafe {
+                render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE);
+                render_target.SetTextRenderingParams(&self.components.rendering_params.emoji);
+            }
+        } else {
+            unsafe {
+                render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
+                render_target.SetTextRenderingParams(&self.components.rendering_params.text);
+            }
+        }
         let bounds = unsafe {
             render_target.GetGlyphRunWorldBounds(
                 D2D_POINT_2F { x: 0.0, y: 0.0 },

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -680,9 +680,7 @@ impl DirectWriteState {
         let advance = [glyph_bounds.size.width.0 as f32];
         let offset = [DWRITE_GLYPH_OFFSET {
             advanceOffset: -glyph_bounds.origin.x.0 as f32 / params.scale_factor,
-            // advanceOffset: 0.0,
             ascenderOffset: glyph_bounds.origin.y.0 as f32 / params.scale_factor,
-            // ascenderOffset: 0.0,
         }];
         let glyph_run = DWRITE_GLYPH_RUN {
             fontFace: unsafe { std::mem::transmute_copy(&font_info.font_face) },
@@ -758,9 +756,7 @@ impl DirectWriteState {
                 .map(|v| v as f32 / SUBPIXEL_VARIANTS as f32);
             let baseline_origin = D2D_POINT_2F {
                 x: subpixel_shift.x / params.scale_factor,
-                // x: 0.0,
                 y: subpixel_shift.y / params.scale_factor,
-                // y: 0.0,
             };
 
             // This `cast()` action here should never fail since we are running on Win10+, and
@@ -770,7 +766,7 @@ impl DirectWriteState {
             render_target.SetDpi(96.0 * params.scale_factor, 96.0 * params.scale_factor);
 
             if params.is_emoji {
-                // render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE);
+                render_target.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE);
                 render_target.SetTextRenderingParams(&self.components.rendering_params.emoji);
                 render_target.BeginDraw();
                 // WARN: only DWRITE_GLYPH_IMAGE_FORMATS_COLR has been tested

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -8,7 +8,6 @@ use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use smallvec::SmallVec;
 use windows::{
     core::*,
-    Foundation::Numerics::Matrix3x2,
     Win32::{
         Foundation::*,
         Globalization::GetUserDefaultLocaleName,
@@ -682,14 +681,7 @@ impl DirectWriteState {
         };
         let brush_property = D2D1_BRUSH_PROPERTIES {
             opacity: 1.0,
-            transform: Matrix3x2 {
-                M11: params.scale_factor,
-                M12: 0.0,
-                M21: 0.0,
-                M22: params.scale_factor,
-                M31: 0.0,
-                M32: 0.0,
-            },
+            ..Default::default()
         };
 
         let total_bytes;

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -788,7 +788,7 @@ impl DirectWriteState {
                     }
                 }
             } else {
-                render_target.SetTextRenderingParams(&self.components.rendering_params.text);
+                render_target.SetTextRenderingParams(&self.components.rendering_params.params);
                 render_target.BeginDraw();
                 render_target.DrawGlyphRun(
                     baseline_origin,


### PR DESCRIPTION
Upper before this PR, lower after.

![Screenshot 2024-05-20 144852](https://github.com/zed-industries/zed/assets/14981363/88995482-3a98-41be-9c2c-6b781bef6ad2)

This PR manually applies a MSAA to the font atlas. Before this PR, the font may seem aliased ( espeacially on low DPI monitors ), that's because `DirectWrite` and `CoreText` ( on which currently `Zed` built the whole text system ) uses different anti-aliasing strategy. The different anti-aliasing approach used by `DirectWrite` and `CoreText`:

![Screenshot 2024-05-20 151114](https://github.com/zed-industries/zed/assets/14981363/21a2fc1e-48a2-4cff-a9d1-41602eff3658)

The upper is `VSCode` font rendering result, middle `macOS`, lower this PR ( pic captured with same font face, same font size, same DPI, same physical resolution, same editor theme, and same magnification rate ).

This PR brings a quality similiar to `CoreText`. What's more, from the `VSCode` image, you can see how `DirectWrite` sub-pixel anti-aliasing is performed on the edge of the glyph. Can we achieve the same rendering quality? Currently, No. `Zed` use a grayscale image to render glyph, and a sub-pixel anti-aliasing `DirectWrite` requires all RGB channels and the foreground color of the rendering glyph, which `Zed` dose not provide.

So, to achieve the quality of `VSCode` font rendering, the text system of `Zed` needs much much more efforts to refactor the codes.


Release Notes:

- N/A
