### PR TITLE
Add tooltips for project panel entry, code actions, run button

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4577,6 +4577,7 @@ impl Editor {
                     .size(ui::ButtonSize::None)
                     .icon_color(Color::Muted)
                     .selected(is_active)
+                    .tooltip(|cx| Tooltip::text("Code Actions", cx))
                     .on_click(cx.listener(move |editor, _e, cx| {
                         editor.focus(cx);
                         editor.toggle_code_actions(
@@ -4615,6 +4616,7 @@ impl Editor {
             .size(ui::ButtonSize::None)
             .icon_color(Color::Muted)
             .selected(is_active)
+            .tooltip(|cx| Tooltip::text("Run", cx))
             .on_click(cx.listener(move |editor, _e, cx| {
                 editor.focus(cx);
                 editor.toggle_code_actions(


### PR DESCRIPTION
Project Panel entries show tooltip with full path and git status.


Release Notes:

- Added tooltips
   - Project Panel entries show absolute path and git status
   - Code Actions (Bolt Icon) and Run button also show tooltips.