### PR TITLE
Remove F2 keybind for Rename on MacOS and Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -559,7 +559,6 @@
       "shift-insert": "project_panel::Paste",
       "ctrl-alt-c": "project_panel::CopyPath",
       "alt-ctrl-shift-c": "project_panel::CopyRelativePath",
-      "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
       "backspace": "project_panel::Trash",
       "delete": "project_panel::Trash",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -559,6 +559,7 @@
       "shift-insert": "project_panel::Paste",
       "ctrl-alt-c": "project_panel::CopyPath",
       "alt-ctrl-shift-c": "project_panel::CopyRelativePath",
+      "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
       "backspace": "project_panel::Trash",
       "delete": "project_panel::Trash",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -571,7 +571,6 @@
       "cmd-v": "project_panel::Paste",
       "cmd-alt-c": "project_panel::CopyPath",
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
-      "f2": "project_panel::Rename",
       "enter": "project_panel::Rename",
       "backspace": "project_panel::Trash",
       "delete": "project_panel::Trash",


### PR DESCRIPTION
Fix [#11608](https://github.com/zed-industries/zed/issues/11608)

Release Notes:

- Changed rename keybind from F2 to Enter in right-click context menu ([#11608](https://github.com/zed-industries/zed/issues/11608)).
![image](https://github.com/zed-industries/zed/assets/30131536/5ebdbb04-ff4e-46ff-80fb-9e95b2b3d285)
