### PR TITLE
Add glob support for custom file type language

### DIFF
--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -184,7 +184,10 @@ async fn test_language_for_file_with_custom_file_types(cx: &mut TestAppContext) 
             settings.file_types.extend([
                 ("TypeScript".into(), vec!["js".into()]),
                 ("C++".into(), vec!["c".into()]),
-                ("Dockerfile".into(), vec!["Dockerfile".into(), "Dockerfile.*".into()]),
+                (
+                    "Dockerfile".into(),
+                    vec!["Dockerfile".into(), "Dockerfile.*".into()],
+                ),
             ]);
         })
     });

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -184,6 +184,7 @@ async fn test_language_for_file_with_custom_file_types(cx: &mut TestAppContext) 
             settings.file_types.extend([
                 ("TypeScript".into(), vec!["js".into()]),
                 ("C++".into(), vec!["c".into()]),
+                ("Dockerfile".into(), vec!["Dockerfile*".into()]),
             ]);
         })
     });
@@ -223,6 +224,14 @@ async fn test_language_for_file_with_custom_file_types(cx: &mut TestAppContext) 
             },
             ..Default::default()
         },
+        LanguageConfig {
+            name: "Dockerfile".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["Dockerfile".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
     ] {
         languages.add(Arc::new(Language::new(config, None)));
     }
@@ -237,6 +246,11 @@ async fn test_language_for_file_with_custom_file_types(cx: &mut TestAppContext) 
         .await
         .unwrap();
     assert_eq!(language.name().as_ref(), "C++");
+    let language = cx
+        .read(|cx| languages.language_for_file(&file("Dockerfile.dev"), None, cx))
+        .await
+        .unwrap();
+    assert_eq!(language.name().as_ref(), "Dockerfile");
 }
 
 fn file(path: &str) -> Arc<dyn File> {

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -184,7 +184,7 @@ async fn test_language_for_file_with_custom_file_types(cx: &mut TestAppContext) 
             settings.file_types.extend([
                 ("TypeScript".into(), vec!["js".into()]),
                 ("C++".into(), vec!["c".into()]),
-                ("Dockerfile".into(), vec!["Dockerfile*".into()]),
+                ("Dockerfile".into(), vec!["Dockerfile".into(), "Dockerfile.*".into()]),
             ]);
         })
     });

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -651,18 +651,19 @@ The result is still `)))` and not `))))))`, which is what it would be by default
 ## File Types
 
 - Setting: `file_types`
-- Description: Configure how Zed selects a language for a file based on its filename or extension.
+- Description: Configure how Zed selects a language for a file based on its filename or extension. Supports glob entries.
 - Default: `{}`
 
 **Examples**
 
-To interpret all `.c` files as C++, and files called `MyLockFile` as TOML:
+To interpret all `.c` files as C++, files called `MyLockFile` as TOML and files starting with `Dockerfile` as Dockerfile:
 
 ```json
 {
   "file_types": {
     "C++": ["c"],
-    "TOML": ["MyLockFile"]
+    "TOML": ["MyLockFile"],
+    "Dockerfile": ["Dockerfile*"]
   }
 }
 ```


### PR DESCRIPTION

Release Notes:

- Added glob support for file_types configuration ([#10765](https://github.com/zed-industries/zed/issues/10765)).

`file_types` can now be written like this:

```json
"file_types": {
  "Dockerfile": [
    "Dockerfile",
    "Dockerfile.*",
  ]
}
```