### PR TITLE
golang: autoclose backticks

### DIFF
--- a/crates/languages/src/go/config.toml
+++ b/crates/languages/src/go/config.toml
@@ -9,6 +9,7 @@ brackets = [
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "`", end = "`", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 tab_size = 4


### PR DESCRIPTION
Fixes #12025



Release Notes:
- Fixed backtick characters not getting autoclosed in Golang files (#12025).
