### PR TITLE
ruby: Add support for running tests

### DIFF
--- a/extensions/ruby/languages/ruby/outline.scm
+++ b/extensions/ruby/languages/ruby/outline.scm
@@ -18,3 +18,9 @@
 (module
     "module" @context
     name: (_) @name) @item
+
+; Minitest/RSpec
+(call
+   method: (identifier) @run (#any-of? @run "describe" "context" "test")
+   arguments: (argument_list . (_) @name)
+) @item

--- a/extensions/ruby/languages/ruby/runnables.scm
+++ b/extensions/ruby/languages/ruby/runnables.scm
@@ -1,0 +1,49 @@
+; Adapted from the following sources:
+; Minitest: https://github.com/zidhuss/neotest-minitest/blob/main/lua/neotest-minitest/init.lua
+; RSpec: https://github.com/olimorris/neotest-rspec/blob/main/lua/neotest-rspec/init.lua
+
+; Minitest
+;; Rails unit tests
+(class
+    name: [
+      (constant) @run
+      (scope_resolution scope: (constant) name: (constant) @run)
+    ]
+    (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase)$"))
+) @minitest-test
+
+(call
+    method: (identifier) @run (#eq? @run "test")
+    arguments: (argument_list (string (string_content) @name))
+) @minitest-test
+
+; Methods that begin with test_
+(method
+    name: (identifier) @run (#match? @run "^test_")
+) @minitest-test
+
+; System tests that inherit from ApplicationSystemTestCase
+(class
+    name: (constant) @run (superclass) @superclass (#match? @superclass "(ApplicationSystemTestCase)$")
+) @minitest-test
+
+; RSpec
+
+; Example groups with literals
+(call
+   method: (identifier) @run (#any-of? @run "describe" "context")
+   arguments: (argument_list . (_) @name)
+) @rspec-test
+
+; Examples
+(call
+    method: (identifier) @run (#any-of? @run "it" "its" "specify")
+    arguments: (argument_list (string (string_content) @name))
+) @rspec-test
+
+; Examples (one-liner syntax)
+(call
+    method: (identifier) @run (#any-of? @run "it" "its" "specify")
+    block: (_) @name
+    !arguments
+) @rspec-test

--- a/extensions/ruby/languages/ruby/tasks.json
+++ b/extensions/ruby/languages/ruby/tasks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "label": "test $ZED_SYMBOL",
+    "command": "ruby",
+    "args": ["-Itest", "$ZED_FILE", "--name", "\"/$ZED_SYMBOL/\""],
+    "tags": ["minitest-test"]
+  },
+  {
+    "label": "rspec $ZED_SYMBOL",
+    "command": "./bin/rspec",
+    "args": ["\"$ZED_FILE:$ZED_ROW\""],
+    "tags": ["rspec-test"]
+  }
+]


### PR DESCRIPTION
Hello, this pull request adds two things related to each other. I hope it's fine to submit both in the same pull request but I am totally fine with submitting them in separate pull requests, just let me know. This is an initial version for both features. Thanks!

## Symbols outline support for testing frameworks: minitest and RSPec

Symbols outline support in [Minitest](https://github.com/minitest/minitest) (the testing framework that comes with Ruby on Rails out of the box) and RSpec (another testing framework that is popular in Ruby and Ruby on Rails world). Here are some screenshots:

### Minitest

Given this Ruby code:

```ruby
require "test_helper"

class CategoryTest < ActiveSupport::TestCase
  context "validations" do
    subject { build(:category) }

    should validate_presence_of(:title)
    should validate_length_of(:title).is_at_most(255)
    should validate_uniqueness_of(:title)
  end
end

class TestNamesWithMiniTest < ActiveSupport::TestCase
  def test_foo_1; assert true; end
  def test_foo_2; assert true; end
  def test_bar_1; assert true; end
  def test_bar_2; assert true; end
end
```

We have this symbols outline:

![CleanShot 2024-05-20 at 12 35 46@2x](https://github.com/zed-industries/zed/assets/1894248/c63a61d8-38cc-4969-a49b-dd9ce6920a0e)

### RSpec

I used `mastodon` application for testing because it's written in Ruby. Given the following file https://github.com/mastodon/mastodon/blob/main/spec/models/account_spec.rb We have the following symbols outline:

![CleanShot 2024-05-20 at 12 44 42@2x](https://github.com/zed-industries/zed/assets/1894248/a754cf4c-f9cc-43f3-b365-1ce0ff942941)



## Running Ruby tests

### Minitest

Given the same file as above, we have the following workflow:


https://github.com/zed-industries/zed/assets/1894248/dc335495-3460-4a6d-95c4-e4cbc87a1ea0



### RSpec

Given the following file `https://github.com/mastodon/mastodon/blob/main/spec/models/account_spec.rb` We have the following  workflow:


https://github.com/zed-industries/zed/assets/1894248/a17067ea-73b6-4229-8f1b-1b88dde63401

<hr />

Release Notes:

- N/A
