### PR TITLE
typescript: Pass `hostInfo` to `tsserver`

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -167,6 +167,7 @@ impl LspAdapter for TypeScriptLspAdapter {
     ) -> Result<Option<serde_json::Value>> {
         Ok(Some(json!({
             "provideFormatter": true,
+            "hostInfo": "zed",
             "tsserver": {
                 "path": "node_modules/typescript/lib",
             },


### PR DESCRIPTION
- Added `hostInfo` property to zed's typescript plugin. This can be useful for telemetry (for e.g. identifying the usage of editors based on typescript usage) when building typescript plugins.

- VSCode / IntelliJ based editors already set this property ([see](https://github.com/microsoft/vscode/blob/aa31bfc9fd1746626b3efe86f41b9c172d5f4d23/extensions/typescript-language-features/src/typescriptServiceClient.ts#L574))

The config option as available —  https://github.com/typescript-language-server/typescript-language-server/blob/master/docs/configuration.md#initializationoptions

Release Notes:

- N/A
