### PR TITLE
Add prev/next change buttons in Quick Action Bar

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8138,7 +8138,7 @@ impl Editor {
         }
     }
 
-    fn go_to_hunk(&mut self, _: &GoToHunk, cx: &mut ViewContext<Self>) {
+    pub fn go_to_hunk(&mut self, _: &GoToHunk, cx: &mut ViewContext<Self>) {
         let snapshot = self
             .display_map
             .update(cx, |display_map, cx| display_map.snapshot(cx));
@@ -8166,7 +8166,7 @@ impl Editor {
         }
     }
 
-    fn go_to_prev_hunk(&mut self, _: &GoToPrevHunk, cx: &mut ViewContext<Self>) {
+    pub fn go_to_prev_hunk(&mut self, _: &GoToPrevHunk, cx: &mut ViewContext<Self>) {
         let snapshot = self
             .display_map
             .update(cx, |display_map, cx| display_map.snapshot(cx));

--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -87,7 +87,12 @@ impl Render for QuickActionBar {
             return div().id("empty quick action bar");
         };
 
-        let has_git_diffs = editor.read(cx).buffer().read(cx).snapshot(cx).has_git_diffs();
+        let has_git_diffs = editor
+            .read(cx)
+            .buffer()
+            .read(cx)
+            .snapshot(cx)
+            .has_git_diffs();
 
         let search_button = Some(QuickActionBarButton::new(
             "toggle buffer search",
@@ -114,7 +119,7 @@ impl Render for QuickActionBar {
             "Previous Change",
             {
                 let editor = editor.clone();
-                move |_, cx| { 
+                move |_, cx| {
                     editor.update(cx, |editor: &mut Editor, cx| {
                         editor.go_to_prev_hunk(&GoToPrevHunk, cx);
                     });
@@ -131,7 +136,7 @@ impl Render for QuickActionBar {
             "Next Change",
             {
                 let editor = editor.clone();
-                move |_, cx| { 
+                move |_, cx| {
                     editor.update(cx, |editor, cx| {
                         editor.go_to_hunk(&GoToHunk, cx);
                     });


### PR DESCRIPTION

Release Notes:

- Added buttons for jumping to previous/next changes (aka hunks)

In vscode, there are arrow buttons for jumping to changed lines in Working Tree mode.
![resim](https://github.com/zed-industries/zed/assets/1047345/50f4f045-799e-4fd0-a6cf-6fb77ef75f4d)

Similarly, I added prev/next buttons for same functionality to Quick Action Bar _if file has git diff_.

I was unaware of hunk commands until lately, thus I believe it is more user-friendly to demonstrate that Zed provides this functionality.
Could you please share your thoughts? I'd appreciate it.

https://github.com/zed-industries/zed/assets/1047345/bb6e7ac3-0c19-4b6c-b15c-076292bad9d9
