### PR TITLE
x11: Implement various window functions

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -42,6 +42,8 @@ use super::{XimCallbackEvent, XimHandler};
 use crate::platform::linux::is_within_click_distance;
 use crate::platform::linux::platform::DOUBLE_CLICK_INTERVAL;
 
+pub(super) const XINPUT_MASTER_DEVICE: u16 = 1;
+
 pub(crate) struct WindowRef {
     window: X11WindowStatePtr,
     refresh_event_token: RegistrationToken,
@@ -180,7 +182,7 @@ impl X11Client {
         );
 
         let master_device_query = xcb_connection
-            .xinput_xi_query_device(1_u16)
+            .xinput_xi_query_device(XINPUT_MASTER_DEVICE)
             .unwrap()
             .reply()
             .unwrap();

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -37,7 +37,7 @@ use super::{
     super::{open_uri_internal, SCROLL_LINES},
     X11Display, X11WindowStatePtr, XcbAtoms,
 };
-use super::{button_from_mask, button_of_key, modifiers_from_state};
+use super::{button_of_key, modifiers_from_state, pressed_button_from_mask};
 use super::{XimCallbackEvent, XimHandler};
 use crate::platform::linux::is_within_click_distance;
 use crate::platform::linux::platform::DOUBLE_CLICK_INTERVAL;
@@ -544,7 +544,7 @@ impl X11Client {
             Event::XinputMotion(event) => {
                 let window = self.get_window(event.event)?;
                 let state = self.0.borrow();
-                let pressed_button = button_from_mask(event.button_mask[0]);
+                let pressed_button = pressed_button_from_mask(event.button_mask[0]);
                 let position = point(
                     px(event.event_x as f32 / u16::MAX as f32 / state.scale_factor),
                     px(event.event_y as f32 / u16::MAX as f32 / state.scale_factor),
@@ -627,7 +627,7 @@ impl X11Client {
 
                 let window = self.get_window(event.event)?;
                 let state = self.0.borrow();
-                let pressed_button = button_from_mask(event.buttons[0]);
+                let pressed_button = pressed_button_from_mask(event.buttons[0]);
                 let position = point(
                     px(event.event_x as f32 / u16::MAX as f32 / state.scale_factor),
                     px(event.event_y as f32 / u16::MAX as f32 / state.scale_factor),

--- a/crates/gpui/src/platform/linux/x11/event.rs
+++ b/crates/gpui/src/platform/linux/x11/event.rs
@@ -37,7 +37,7 @@ pub(crate) fn modifiers_from_xinput_info(modifier_info: xinput::ModifierInfo) ->
     }
 }
 
-pub(crate) fn button_from_mask(button_mask: u32) -> Option<MouseButton> {
+pub(crate) fn pressed_button_from_mask(button_mask: u32) -> Option<MouseButton> {
     Some(if button_mask & 2 == 2 {
         MouseButton::Left
     } else if button_mask & 4 == 4 {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -16,9 +16,9 @@ use util::ResultExt;
 use x11rb::{
     connection::{Connection as _, RequestConnection as _},
     protocol::{
-        render::{self, ConnectionExt as _},
+        render,
         xinput::{self, ConnectionExt as _},
-        xproto::{self, ConnectionExt as _, CreateWindowAux},
+        xproto::{self, Atom, ClientMessageEvent, ConnectionExt as _, CreateWindowAux, EventMask},
     },
     resource_manager::Database,
     wrapper::ConnectionExt as _,
@@ -45,10 +45,14 @@ x11rb::atom_manager! {
         UTF8_STRING,
         WM_PROTOCOLS,
         WM_DELETE_WINDOW,
+        WM_CHANGE_STATE,
         _NET_WM_NAME,
         _NET_WM_STATE,
         _NET_WM_STATE_MAXIMIZED_VERT,
         _NET_WM_STATE_MAXIMIZED_HORZ,
+        _NET_WM_STATE_FULLSCREEN,
+        _NET_WM_STATE_HIDDEN,
+        _NET_WM_STATE_FOCUSED,
     }
 }
 
@@ -158,6 +162,7 @@ pub(crate) struct X11WindowState {
     client: X11ClientStatePtr,
     executor: ForegroundExecutor,
     atoms: XcbAtoms,
+    x_root_window: xproto::Window,
     raw: RawWindow,
     bounds: Bounds<i32>,
     scale_factor: f32,
@@ -359,6 +364,7 @@ impl X11WindowState {
             executor,
             display: Rc::new(X11Display::new(xcb_connection, x_screen_index).unwrap()),
             raw,
+            x_root_window: visual_set.root,
             bounds: params.bounds.map(|v| v.0),
             scale_factor,
             renderer: BladeRenderer::new(gpu, config),
@@ -403,6 +409,12 @@ impl Drop for X11Window {
     }
 }
 
+enum WmHintPropertyState {
+    Remove = 0,
+    Add = 1,
+    Toggle = 2,
+}
+
 impl X11Window {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -430,6 +442,48 @@ impl X11Window {
             xcb_connection: xcb_connection.clone(),
             x_window,
         })
+    }
+
+    fn set_wm_hints(&self, wm_hint_property_state: WmHintPropertyState, prop1: u32, prop2: u32) {
+        let state = self.0.state.borrow();
+        let message = ClientMessageEvent::new(
+            32,
+            self.0.x_window,
+            state.atoms._NET_WM_STATE,
+            [wm_hint_property_state as u32, prop1, prop2, 1, 0],
+        );
+        self.0
+            .xcb_connection
+            .send_event(
+                false,
+                state.x_root_window,
+                EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+                message,
+            )
+            .unwrap();
+    }
+
+    fn get_wm_hints(&self) -> Vec<u32> {
+        let reply = self
+            .0
+            .xcb_connection
+            .get_property(
+                false,
+                self.0.x_window,
+                self.0.state.borrow().atoms._NET_WM_STATE,
+                xproto::AtomEnum::ATOM,
+                0,
+                u32::MAX,
+            )
+            .unwrap()
+            .reply()
+            .unwrap();
+        // Reply is in u8 but atoms are represented as u32
+        reply
+            .value
+            .chunks_exact(4)
+            .map(|chunk| u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect()
     }
 }
 
@@ -555,12 +609,15 @@ impl PlatformWindow for X11Window {
         self.0.state.borrow().bounds.map(|v| v.into())
     }
 
-    // todo(linux)
     fn is_maximized(&self) -> bool {
-        false
+        let state = self.0.state.borrow();
+        let wm_hints = self.get_wm_hints();
+        // If a maximized window gets minimized, it will still have the maximized properties.
+        !wm_hints.contains(&state.atoms._NET_WM_STATE_HIDDEN)
+            && wm_hints.contains(&state.atoms._NET_WM_STATE_MAXIMIZED_VERT)
+            && wm_hints.contains(&state.atoms._NET_WM_STATE_MAXIMIZED_HORZ)
     }
 
-    // todo(linux)
     fn window_bounds(&self) -> WindowBounds {
         let state = self.0.state.borrow();
         WindowBounds::Windowed(state.bounds.map(|p| DevicePixels(p)))
@@ -630,9 +687,10 @@ impl PlatformWindow for X11Window {
             .log_err();
     }
 
-    // todo(linux)
     fn is_active(&self) -> bool {
-        false
+        let state = self.0.state.borrow();
+        self.get_wm_hints()
+            .contains(&state.atoms._NET_WM_STATE_FOCUSED)
     }
 
     fn set_title(&mut self, title: &str) {
@@ -665,13 +723,16 @@ impl PlatformWindow for X11Window {
         data.push(b'\0');
         data.extend(app_id.bytes()); // class
 
-        self.0.xcb_connection.change_property8(
-            xproto::PropMode::REPLACE,
-            self.0.x_window,
-            xproto::AtomEnum::WM_CLASS,
-            xproto::AtomEnum::STRING,
-            &data,
-        );
+        self.0
+            .xcb_connection
+            .change_property8(
+                xproto::PropMode::REPLACE,
+                self.0.x_window,
+                xproto::AtomEnum::WM_CLASS,
+                xproto::AtomEnum::STRING,
+                &data,
+            )
+            .unwrap();
     }
 
     // todo(linux)
@@ -693,24 +754,47 @@ impl PlatformWindow for X11Window {
         unimplemented!()
     }
 
-    // todo(linux)
     fn minimize(&self) {
-        unimplemented!()
+        let state = self.0.state.borrow();
+        let message = ClientMessageEvent::new(
+            32,
+            self.0.x_window,
+            state.atoms.WM_CHANGE_STATE,
+            [3, 0, 0, 0, 0],
+        );
+        self.0
+            .xcb_connection
+            .send_event(
+                false,
+                state.x_root_window,
+                EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+                message,
+            )
+            .unwrap();
     }
 
-    // todo(linux)
     fn zoom(&self) {
-        unimplemented!()
+        let state = self.0.state.borrow();
+        self.set_wm_hints(
+            WmHintPropertyState::Toggle,
+            state.atoms._NET_WM_STATE_MAXIMIZED_VERT,
+            state.atoms._NET_WM_STATE_MAXIMIZED_HORZ,
+        );
     }
 
-    // todo(linux)
     fn toggle_fullscreen(&self) {
-        unimplemented!()
+        let state = self.0.state.borrow();
+        self.set_wm_hints(
+            WmHintPropertyState::Toggle,
+            state.atoms._NET_WM_STATE_FULLSCREEN,
+            xproto::AtomEnum::NONE.into(),
+        );
     }
 
-    // todo(linux)
     fn is_fullscreen(&self) -> bool {
-        false
+        let state = self.0.state.borrow();
+        self.get_wm_hints()
+            .contains(&state.atoms._NET_WM_STATE_FULLSCREEN)
     }
 
     fn on_request_frame(&self, callback: Box<dyn FnMut()>) {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -756,11 +756,12 @@ impl PlatformWindow for X11Window {
 
     fn minimize(&self) {
         let state = self.0.state.borrow();
+        const WINDOW_ICONIC_STATE: u32 = 3;
         let message = ClientMessageEvent::new(
             32,
             self.0.x_window,
             state.atoms.WM_CHANGE_STATE,
-            [3, 0, 0, 0, 0],
+            [WINDOW_ICONIC_STATE, 0, 0, 0, 0],
         );
         self.0
             .xcb_connection

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -632,7 +632,7 @@ impl PlatformWindow for X11Window {
     fn is_maximized(&self) -> bool {
         let state = self.0.state.borrow();
         let wm_hints = self.get_wm_hints();
-        // If a maximized window gets minimized, it will still have the maximized properties.
+        // A maximized window that gets minimized will still retain its maximized state.
         !wm_hints.contains(&state.atoms._NET_WM_STATE_HIDDEN)
             && wm_hints.contains(&state.atoms._NET_WM_STATE_MAXIMIZED_VERT)
             && wm_hints.contains(&state.atoms._NET_WM_STATE_MAXIMIZED_HORZ)

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1146,12 +1146,12 @@ impl<'a> WindowContext<'a> {
         self.window.platform_window.zoom();
     }
 
-    /// Opens the native title bar context menu, useful when implementing client side decorations (Wayland only)
+    /// Opens the native title bar context menu, useful when implementing client side decorations (Wayland and X11)
     pub fn show_window_menu(&self, position: Point<Pixels>) {
         self.window.platform_window.show_window_menu(position)
     }
 
-    /// Tells the compositor to take control of window movement (Wayland only)
+    /// Tells the compositor to take control of window movement (Wayland and X11)
     ///
     /// Events may not be received during a move operation.
     pub fn start_system_move(&self) {


### PR DESCRIPTION
This (mostly) allows the CSD added in https://github.com/zed-industries/zed/pull/11525 to work in X11. It's still a bit buggy as it detects a second window drag right after the first one finishes, but it's probably better to change the way window drags are detected in the title bar itself (as that causes other issues).

The CSD can be tested by changing the return value of `should_render_window_controls` to true.

Also fixes F11 crashing.

Release Notes:

- N/A
