### PR TITLE
ui: Don't break flex layout when using `WithRemSize`

### DIFF
--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -269,7 +269,7 @@ impl Render for ContextMenu {
         let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
 
         div().occlude().elevation_2(cx).flex().flex_row().child(
-            WithRemSize::new(ui_font_size).child(
+            WithRemSize::new(ui_font_size).flex().child(
                 v_flex()
                     .min_w(px(200.))
                     .track_focus(&self.focus_handle)

--- a/crates/ui/src/with_rem_size.rs
+++ b/crates/ui/src/with_rem_size.rs
@@ -1,6 +1,6 @@
 use gpui::{
     div, AnyElement, Bounds, Div, DivFrameState, Element, ElementId, GlobalElementId, Hitbox,
-    IntoElement, LayoutId, ParentElement, Pixels, WindowContext,
+    IntoElement, LayoutId, ParentElement, Pixels, StyleRefinement, Styled, WindowContext,
 };
 
 /// An element that sets a particular rem size for its children.
@@ -15,6 +15,12 @@ impl WithRemSize {
             div: div(),
             rem_size: rem_size.into(),
         }
+    }
+}
+
+impl Styled for WithRemSize {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.div.style()
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where the flex hierarchy was getting broken by the use of `WithRemSize`.

Release Notes:

- N/A
