### PR TITLE
project panel: Add Duplicate action

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -130,6 +130,7 @@ actions!(
         Copy,
         CopyPath,
         CopyRelativePath,
+        Duplicate,
         RevealInFinder,
         Cut,
         Paste,
@@ -460,6 +461,7 @@ impl ProjectPanel {
                             .separator()
                             .action("Cut", Box::new(Cut))
                             .action("Copy", Box::new(Copy))
+                            .action("Duplicate", Box::new(Duplicate))
                             // TODO: Paste should always be visible, but disabled when clipboard is empty
                             .when_some(self.clipboard_entry, |menu, entry| {
                                 menu.when(entry.worktree_id() == worktree_id, |menu| {
@@ -1156,6 +1158,11 @@ impl ProjectPanel {
         });
     }
 
+    fn duplicate(&mut self, _: &Duplicate, cx: &mut ViewContext<Self>) {
+        self.copy(&Copy {}, cx);
+        self.paste(&Paste {}, cx);
+    }
+
     fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {
         if let Some((worktree, entry)) = self.selected_entry(cx) {
             cx.write_to_clipboard(ClipboardItem::new(
@@ -1831,6 +1838,7 @@ impl Render for ProjectPanel {
                         .on_action(cx.listener(Self::cut))
                         .on_action(cx.listener(Self::copy))
                         .on_action(cx.listener(Self::paste))
+                        .on_action(cx.listener(Self::duplicate))
                 })
                 .when(project.is_local(), |el| {
                     el.on_action(cx.listener(Self::reveal_in_finder))


### PR DESCRIPTION
This fixes #5304 by adding a new Duplicate action to the project panel context menu.

It really is implemented on top of copy&paste.



Release Notes:

- Added a Duplicate action to the project panel. ([#5304](https://github.com/zed-industries/zed/issues/5304)).


https://github.com/zed-industries/zed/assets/1185253/f0fa6a4b-f066-47df-84f0-257a049800d1

