### PR TITLE
html: release 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13208,7 +13208,7 @@ dependencies = [
 
 [[package]]
 name = "zed_html"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -16,12 +16,12 @@ brackets = [
 ]
 word_characters = ["$", "#"]
 tab_size = 2
-scope_opt_in_language_servers = ["tailwindcss-language-server","vscode-html-language-server", "emmet-language-server"]
+scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-server"]
 
 [overrides.element]
 line_comments = { remove = true }
 block_comment = ["{/* ", " */}"]
-opt_into_language_servers = ["emmet-language-server", "vscode-html-language-server"]
+opt_into_language_servers = ["emmet-language-server"]
 
 [overrides.string]
 word_characters = ["-"]

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -14,13 +14,13 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
 word_characters = ["#", "$"]
-scope_opt_in_language_servers = ["vscode-html-language-server", "tailwindcss-language-server", "emmet-language-server"]
+scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-server"]
 tab_size = 2
 
 [overrides.element]
 line_comments = { remove = true }
 block_comment = ["{/* ", " */}"]
-opt_into_language_servers = ["vscode-html-language-server", "emmet-language-server"]
+opt_into_language_servers = ["emmet-language-server"]
 
 [overrides.string]
 word_characters = ["-"]

--- a/extensions/html/Cargo.toml
+++ b/extensions/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_html"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/html/extension.toml
+++ b/extensions/html/extension.toml
@@ -1,7 +1,7 @@
 id = "html"
 name = "HTML"
 description = "HTML support."
-version = "0.0.2"
+version = "0.1.0"
 schema_version = 1
 authors = ["Isaac Clayton <slightknack@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"
@@ -9,14 +9,9 @@ repository = "https://github.com/zed-industries/zed"
 [language_servers.vscode-html-language-server]
 name = "vscode-html-language-server"
 language = "HTML"
-languages = ["TypeScript", "HTML", "TSX", "JavaScript", "JSDoc"]
 
 [language_servers.vscode-html-language-server.language_ids]
 "HTML" = "html"
-"PHP" = "php"
-"ERB" = "eruby"
-"JavaScript" = "javascriptreact"
-"TSX" = "typescriptreact"
 "CSS" = "css"
 
 [grammars.html]

--- a/extensions/html/src/html.rs
+++ b/extensions/html/src/html.rs
@@ -1,3 +1,4 @@
+use crate::zed::settings::LspSettings;
 use std::{env, fs, path::PathBuf};
 use zed_extension_api::{self as zed, Result};
 
@@ -94,6 +95,17 @@ impl zed::Extension for HtmlExtension {
             ],
             env: Default::default(),
         })
+    }
+    fn language_server_workspace_configuration(
+        &mut self,
+        id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        let settings = LspSettings::for_worktree("vscode-html-language-server", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 }
 

--- a/extensions/html/src/html.rs
+++ b/extensions/html/src/html.rs
@@ -98,10 +98,10 @@ impl zed::Extension for HtmlExtension {
     }
     fn language_server_workspace_configuration(
         &mut self,
-        id: &zed::LanguageServerId,
+        server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<Option<zed::serde_json::Value>> {
-        let settings = LspSettings::for_worktree("vscode-html-language-server", worktree)
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
             .ok()
             .and_then(|lsp_settings| lsp_settings.settings.clone())
             .unwrap_or_default();


### PR DESCRIPTION
Add config for tag autoclosing: add following to lsp section of your settings:
    "vscode-html-language-server": {
      "settings": {
        "html": { "tagAutoclosing": true }
      }
    }

It also accepts `css`, `js/ts` and `javascript` as options.

Disable HTML language server in JS/TS/TSX files for now. I decided to disable it for now as it caused excessive edits in these types of files (as reported by @mariansimecek in https://github.com/zed-industries/zed/pull/11761#issuecomment-2122038107); it looks like HTML language server tries to track language ranges (e.g. whether a particular span is TS/HTML fragment etc) just like we do. However in plain JS/TSX files it seems like it treats the whole file as one big chunk of HTML, which is.. not right, to say the least.

No release note, as HTML extension goodies are not on Preview yet.

Release Notes:

- N/A
