### PR TITLE
Fix `npm install` error with some languages

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -226,18 +226,18 @@ impl NodeRuntime for RealNodeRuntime {
 
             let node_binary = installation_path.join(NODE_PATH);
             let npm_file = installation_path.join(NPM_PATH);
-            let mut env_path = vec![node_binary
+            let mut env_path = vec![vec![node_binary
                 .parent()
                 .expect("invalid node binary path")
-                .to_path_buf()];
+                .to_path_buf()]];
 
             if let Some(existing_path) = std::env::var_os("PATH") {
-                if !existing_path.is_empty() {
-                    let paths = std::env::split_paths(&existing_path).collect::<Vec<_>>();
-                    env_path.extend(paths);
-                }
+                let mut paths = std::env::split_paths(&existing_path).collect::<Vec<_>>();
+                env_path.append(&mut paths);
             }
-            let env_path = std::env::join_paths(&env_path)?;
+
+            let env_path =
+                std::env::join_paths(env_path).context("failed to create PATH env variable")?;
 
             if smol::fs::metadata(&node_binary).await.is_err() {
                 return Err(anyhow!("missing node binary file"));

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -227,17 +227,18 @@ impl NodeRuntime for RealNodeRuntime {
             let node_binary = installation_path.join(NODE_PATH);
             // std::env::set_var(key, value);
             let npm_file = installation_path.join(NPM_PATH);
-            let mut env_path = node_binary
+            let env_path = node_binary
                 .parent()
                 .expect("invalid node binary path")
                 .to_path_buf();
+            let mut env_path = env_path.to_string_lossy().to_string();
             println!("============================================");
-            println!("  Env path: {}", env_path.display());
+            println!("  Env path: {}", env_path);
 
             if let Some(existing_path) = std::env::var_os("PATH") {
                 if !existing_path.is_empty() {
-                    env_path.push(":");
-                    env_path.push(&existing_path);
+                    env_path.push_str(":");
+                    env_path.push_str(existing_path.to_str().unwrap());
                 }
             }
 
@@ -249,7 +250,7 @@ impl NodeRuntime for RealNodeRuntime {
                 return Err(anyhow!("missing npm file"));
             }
             println!("============================================");
-            println!("  Env path: {}", env_path.display());
+            println!("  Env path: {}", env_path);
 
             let mut command = Command::new(node_binary);
             command.env_clear();

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -232,8 +232,6 @@ impl NodeRuntime for RealNodeRuntime {
                 .expect("invalid node binary path")
                 .to_path_buf();
             let mut env_path = env_path.to_string_lossy().to_string();
-            println!("============================================");
-            println!("  Env path: {}", env_path);
 
             if let Some(existing_path) = std::env::var_os("PATH") {
                 if !existing_path.is_empty() {
@@ -249,8 +247,6 @@ impl NodeRuntime for RealNodeRuntime {
             if smol::fs::metadata(&npm_file).await.is_err() {
                 return Err(anyhow!("missing npm file"));
             }
-            println!("============================================");
-            println!("  Env path: {}", env_path);
 
             let mut command = Command::new(node_binary);
             command.env_clear();

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -225,7 +225,6 @@ impl NodeRuntime for RealNodeRuntime {
             let installation_path = self.install_if_needed().await?;
 
             let node_binary = installation_path.join(NODE_PATH);
-            // std::env::set_var(key, value);
             let npm_file = installation_path.join(NPM_PATH);
             let env_path = node_binary
                 .parent()

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -226,18 +226,18 @@ impl NodeRuntime for RealNodeRuntime {
 
             let node_binary = installation_path.join(NODE_PATH);
             let npm_file = installation_path.join(NPM_PATH);
-            let env_path = node_binary
+            let mut env_path = vec![node_binary
                 .parent()
                 .expect("invalid node binary path")
-                .to_path_buf();
-            let mut env_path = env_path.to_string_lossy().to_string();
+                .to_path_buf()];
 
             if let Some(existing_path) = std::env::var_os("PATH") {
                 if !existing_path.is_empty() {
-                    env_path.push_str(":");
-                    env_path.push_str(existing_path.to_str().unwrap());
+                    let paths = std::env::split_paths(&existing_path).collect::<Vec<_>>();
+                    env_path.extend(paths);
                 }
             }
+            let env_path = std::env::join_paths(&env_path)?;
 
             if smol::fs::metadata(&node_binary).await.is_err() {
                 return Err(anyhow!("missing node binary file"));

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -225,11 +225,14 @@ impl NodeRuntime for RealNodeRuntime {
             let installation_path = self.install_if_needed().await?;
 
             let node_binary = installation_path.join(NODE_PATH);
+            // std::env::set_var(key, value);
             let npm_file = installation_path.join(NPM_PATH);
             let mut env_path = node_binary
                 .parent()
                 .expect("invalid node binary path")
                 .to_path_buf();
+            println!("============================================");
+            println!("  Env path: {}", env_path.display());
 
             if let Some(existing_path) = std::env::var_os("PATH") {
                 if !existing_path.is_empty() {
@@ -245,6 +248,8 @@ impl NodeRuntime for RealNodeRuntime {
             if smol::fs::metadata(&npm_file).await.is_err() {
                 return Err(anyhow!("missing npm file"));
             }
+            println!("============================================");
+            println!("  Env path: {}", env_path.display());
 
             let mut command = Command::new(node_binary);
             command.env_clear();

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -226,10 +226,10 @@ impl NodeRuntime for RealNodeRuntime {
 
             let node_binary = installation_path.join(NODE_PATH);
             let npm_file = installation_path.join(NPM_PATH);
-            let mut env_path = vec![vec![node_binary
+            let mut env_path = vec![node_binary
                 .parent()
                 .expect("invalid node binary path")
-                .to_path_buf()]];
+                .to_path_buf()];
 
             if let Some(existing_path) = std::env::var_os("PATH") {
                 let mut paths = std::env::split_paths(&existing_path).collect::<Vec<_>>();


### PR DESCRIPTION
If you have already installed `node` using `brew install node`, you are fine. If you did not install `node` on you local machine, it fails. 

The `node_binary` path is actually not included in environment variable. When run `npm install`, some extensions like `eslint`, may run some commands like `sh -c node .....`. Since `node_binary` path is not included in `PATH` variable, `sh -c node ...` will fail complaining that "command not found". If you have installed `node` before, `node` is already included in `PATH`, so you are fine. If not, it fails.

Closes #11890

Release Notes:

- Fixed Zed's internal Node runtime not being put in `$PATH` correctly when running language servers and other commands with `node`. ([#11890](https://github.com/zed-industries/zed/issues/11890))
