### PR TITLE
gomod and gowork add gopls server

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -107,8 +107,12 @@ pub fn init(
         vec![Arc::new(css::CssLspAdapter::new(node_runtime.clone())),]
     );
     language!("go", vec![Arc::new(go::GoLspAdapter)], GoContextProvider);
-    language!("gomod");
-    language!("gowork");
+    language!("gomod", vec![Arc::new(go::GoLspAdapter)], GoContextProvider);
+    language!(
+        "gowork",
+        vec![Arc::new(go::GoLspAdapter)],
+        GoContextProvider
+    );
     language!(
         "json",
         vec![Arc::new(json::JsonLspAdapter::new(


### PR DESCRIPTION
<img width="684" alt="image" src="https://github.com/zed-industries/zed/assets/45585937/c22e00d2-e197-44b3-864f-db20eaf47ff7">

Release Notes:

- Added `gopls` support when opening `go.mod` or `go.work` files.