### PR TITLE
go: Highlight constant identifiers

### DIFF
--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -110,6 +110,9 @@
   (imaginary_literal)
 ] @number
 
+(const_spec
+  name: (identifier) @constant)
+
 [
   (true)
   (false)


### PR DESCRIPTION

Release Notes:

- N/A
