### PR TITLE
tasks: Fix $ZED_SELECTED_TEXT ignoring line_mode

### DIFF
--- a/crates/editor/src/tasks.rs
+++ b/crates/editor/src/tasks.rs
@@ -7,6 +7,7 @@ use gpui::WindowContext;
 use language::{BasicContextProvider, ContextProvider};
 use project::{Location, WorktreeId};
 use task::{TaskContext, TaskVariables, VariableName};
+use text::Point;
 use util::ResultExt;
 use workspace::Workspace;
 
@@ -56,7 +57,11 @@ fn task_context_with_editor(
     cx: &mut WindowContext<'_>,
 ) -> Option<TaskContext> {
     let (selection, buffer, editor_snapshot) = {
-        let selection = editor.selections.newest::<usize>(cx);
+        let mut selection = editor.selections.newest::<Point>(cx);
+        if editor.selections.line_mode {
+            selection.start = Point::new(selection.start.row, 0);
+            selection.end = Point::new(selection.end.row + 1, 0);
+        }
         let (buffer, _, _) = editor
             .buffer()
             .read(cx)


### PR DESCRIPTION
When you press `V` to go into visual-line mode in Vim, `selections.line_mode` is true and the selection contains _lines_.

But `$ZED_SELECTED_TEXT` always contained just the cursor location or any non-line-mode selection that was previously made.

Release Notes:

- Fixed `$ZED_SELECTED_TEXT` variable in Tasks ignoring whether visual-line-mode in Vim was used.