### PR TITLE
macOS: Allow creating directories in file-open panel

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -599,6 +599,7 @@ impl Platform for MacPlatform {
                     panel.setCanChooseDirectories_(options.directories.to_objc());
                     panel.setCanChooseFiles_(options.files.to_objc());
                     panel.setAllowsMultipleSelection_(options.multiple.to_objc());
+                    panel.setCanCreateDirectories(true.to_objc());
                     panel.setResolvesAliases_(false.to_objc());
                     let done_tx = Cell::new(Some(done_tx));
                     let block = ConcreteBlock::new(move |response: NSModalResponse| {


### PR DESCRIPTION
I don't know whether there are any hard UI guidelines that dictate whether this should be allowed or not, but I think it's very handy and missed it.

I also think it makes sense to have this in a directory-centric editor in which opening a directory creates a new window.

Release Notes:

- Added ability to create directory in open-file dialog on macOS.

![screenshot-2024-05-22-15 05 03@2x](https://github.com/zed-industries/zed/assets/1185253/939a2a88-16b2-4a91-a344-f73c5615d831)
