### PR TITLE
tasks: Expose captured variables to ContextProvider

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -406,6 +406,7 @@ struct RunnableTasks {
     templates: Vec<(TaskSourceKind, TaskTemplate)>,
     // We need the column at which the task context evaluation should take place.
     column: u32,
+    // Values of all named captures, including those starting with '_'
     extra_variables: HashMap<String, String>,
 }
 
@@ -3973,7 +3974,7 @@ impl Editor {
 
                     this.completion_tasks.clear();
                     this.discard_inline_completion(false, cx);
-                    let task_context = tasks.as_ref().zip(this.workspace.clone()).and_then(
+                    let tasks = tasks.as_ref().zip(this.workspace.clone()).and_then(
                         |(tasks, (workspace, _))| {
                             let position = Point::new(buffer_row, tasks.1.column);
                             let range_start = buffer.read(cx).anchor_at(position, Bias::Right);
@@ -3981,43 +3982,45 @@ impl Editor {
                                 buffer: buffer.clone(),
                                 range: range_start..range_start,
                             };
+                            // Fill in the environmental variables from the tree-sitter captures
+                            let mut captured_task_variables = TaskVariables::default();
+                            for (capture_name, value) in tasks.1.extra_variables.clone() {
+                                captured_task_variables.insert(
+                                    task::VariableName::Custom(capture_name.into()),
+                                    value.clone(),
+                                );
+                            }
+
                             workspace
                                 .update(cx, |workspace, cx| {
-                                    tasks::task_context_for_location(workspace, location, cx)
+                                    tasks::task_context_for_location(
+                                        captured_task_variables,
+                                        workspace,
+                                        location,
+                                        cx,
+                                    )
                                 })
                                 .ok()
                                 .flatten()
+                                .map(|task_context| {
+                                    Arc::new(ResolvedTasks {
+                                        templates: tasks
+                                            .1
+                                            .templates
+                                            .iter()
+                                            .filter_map(|(kind, template)| {
+                                                template
+                                                    .resolve_task(&kind.to_id_base(), &task_context)
+                                                    .map(|task| (kind.clone(), task))
+                                            })
+                                            .collect(),
+                                        position: snapshot.buffer_snapshot.anchor_before(
+                                            Point::new(multibuffer_point.row, tasks.1.column),
+                                        ),
+                                    })
+                                })
                         },
                     );
-                    let tasks = tasks.zip(task_context).map(|(tasks, mut task_context)| {
-                        // Fill in the environmental variables from the tree-sitter captures
-                        let mut additional_task_variables = TaskVariables::default();
-                        for (capture_name, value) in tasks.1.extra_variables.clone() {
-                            additional_task_variables.insert(
-                                task::VariableName::Custom(capture_name.into()),
-                                value.clone(),
-                            );
-                        }
-                        task_context
-                            .task_variables
-                            .extend(additional_task_variables);
-
-                        Arc::new(ResolvedTasks {
-                            templates: tasks
-                                .1
-                                .templates
-                                .iter()
-                                .filter_map(|(kind, template)| {
-                                    template
-                                        .resolve_task(&kind.to_id_base(), &task_context)
-                                        .map(|task| (kind.clone(), task))
-                                })
-                                .collect(),
-                            position: snapshot
-                                .buffer_snapshot
-                                .anchor_before(Point::new(multibuffer_point.row, tasks.1.column)),
-                        })
-                    });
                     let spawn_straight_away = tasks
                         .as_ref()
                         .map_or(false, |tasks| tasks.templates.len() == 1)

--- a/crates/editor/src/tasks.rs
+++ b/crates/editor/src/tasks.rs
@@ -4,8 +4,8 @@ use std::{path::Path, sync::Arc};
 
 use anyhow::Context;
 use gpui::WindowContext;
-use language::{BasicContextProvider, ContextProvider};
-use project::{Location, WorktreeId};
+use language::ContextProvider;
+use project::{BasicContextProvider, Location, WorktreeId};
 use task::{TaskContext, TaskVariables, VariableName};
 use util::ResultExt;
 use workspace::Workspace;

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -30,10 +30,10 @@ use gpui::{
 };
 use http::{AsyncBody, HttpClient, HttpClientWithUrl};
 use language::{
-    ContextProviderWithTasks, LanguageConfig, LanguageMatcher, LanguageQueries, LanguageRegistry,
-    QUERY_FILENAME_PREFIXES,
+    LanguageConfig, LanguageMatcher, LanguageQueries, LanguageRegistry, QUERY_FILENAME_PREFIXES,
 };
 use node_runtime::NodeRuntime;
+use project::ContextProviderWithTasks;
 use semantic_version::SemanticVersion;
 use serde::{Deserialize, Serialize};
 use settings::Settings;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3024,6 +3024,7 @@ impl BufferSnapshot {
                 tags.sort_by_key(|(range, _)| range == &maximum_range);
                 let split_point = tags.partition_point(|(range, _)| range != &maximum_range);
                 let (extra_captures, tags) = tags.split_at(split_point);
+
                 let extra_captures = extra_captures
                     .into_iter()
                     .map(|(range, name)| {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -58,9 +58,7 @@ use std::{
 };
 use syntax_map::{QueryCursorHandle, SyntaxSnapshot};
 use task::RunnableTag;
-pub use task_context::{
-    BasicContextProvider, ContextProvider, ContextProviderWithTasks, RunnableRange,
-};
+pub use task_context::{ContextProvider, RunnableRange};
 use theme::SyntaxTheme;
 use tree_sitter::{self, wasmtime, Query, QueryCursor, WasmStore};
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1014,7 +1014,7 @@ impl Language {
         for (ix, name) in query.capture_names().iter().enumerate() {
             if *name == "run" {
                 run_capture_index = Some(ix as u32);
-            } else if !name.starts_with('_') {
+            } else {
                 runnable_tags.insert(ix as u32, RunnableTag(name.to_string().into()));
             }
         }

--- a/crates/language/src/task_context.rs
+++ b/crates/language/src/task_context.rs
@@ -1,4 +1,4 @@
-use std::{ops::Range, path::Path};
+use std::ops::Range;
 
 use crate::{Location, Runnable};
 

--- a/crates/language/src/task_context.rs
+++ b/crates/language/src/task_context.rs
@@ -22,7 +22,7 @@ pub trait ContextProvider: Send + Sync {
     /// Builds a specific context to be placed on top of the basic one (replacing all conflicting entries) and to be used for task resolving later.
     fn build_context(
         &self,
-        _worktree_abs_path: Option<&Path>,
+        _variables: &TaskVariables,
         _location: &Location,
         _cx: &mut AppContext,
     ) -> Result<TaskVariables> {

--- a/crates/language/src/task_context.rs
+++ b/crates/language/src/task_context.rs
@@ -33,9 +33,4 @@ pub trait ContextProvider: Send + Sync {
     fn associated_tasks(&self) -> Option<TaskTemplates> {
         None
     }
-
-    // Determines whether the [`BasicContextProvider`] variables should be filled too (if `false`), or omitted (if `true`).
-    fn is_basic(&self) -> bool {
-        false
-    }
 }

--- a/crates/language/src/task_context.rs
+++ b/crates/language/src/task_context.rs
@@ -5,8 +5,8 @@ use crate::{Location, Runnable};
 use anyhow::Result;
 use collections::HashMap;
 use gpui::AppContext;
-use task::{TaskTemplates, TaskVariables, VariableName};
-use text::{BufferId, Point, ToPoint};
+use task::{TaskTemplates, TaskVariables};
+use text::BufferId;
 
 pub struct RunnableRange {
     pub buffer_id: BufferId,
@@ -37,96 +37,5 @@ pub trait ContextProvider: Send + Sync {
     // Determines whether the [`BasicContextProvider`] variables should be filled too (if `false`), or omitted (if `true`).
     fn is_basic(&self) -> bool {
         false
-    }
-}
-
-/// A context provided that tries to provide values for all non-custom [`VariableName`] variants for a currently opened file.
-/// Applied as a base for every custom [`ContextProvider`] unless explicitly oped out.
-pub struct BasicContextProvider;
-
-impl ContextProvider for BasicContextProvider {
-    fn is_basic(&self) -> bool {
-        true
-    }
-
-    fn build_context(
-        &self,
-        worktree_abs_path: Option<&Path>,
-        location: &Location,
-        cx: &mut AppContext,
-    ) -> Result<TaskVariables> {
-        let buffer = location.buffer.read(cx);
-        let buffer_snapshot = buffer.snapshot();
-        let symbols = buffer_snapshot.symbols_containing(location.range.start, None);
-        let symbol = symbols.unwrap_or_default().last().map(|symbol| {
-            let range = symbol
-                .name_ranges
-                .last()
-                .cloned()
-                .unwrap_or(0..symbol.text.len());
-            symbol.text[range].to_string()
-        });
-
-        let current_file = buffer
-            .file()
-            .and_then(|file| file.as_local())
-            .map(|file| file.abs_path(cx).to_string_lossy().to_string());
-        let Point { row, column } = location.range.start.to_point(&buffer_snapshot);
-        let row = row + 1;
-        let column = column + 1;
-        let selected_text = buffer
-            .chars_for_range(location.range.clone())
-            .collect::<String>();
-
-        let mut task_variables = TaskVariables::from_iter([
-            (VariableName::Row, row.to_string()),
-            (VariableName::Column, column.to_string()),
-        ]);
-
-        if let Some(symbol) = symbol {
-            task_variables.insert(VariableName::Symbol, symbol);
-        }
-        if !selected_text.trim().is_empty() {
-            task_variables.insert(VariableName::SelectedText, selected_text);
-        }
-        if let Some(path) = current_file {
-            task_variables.insert(VariableName::File, path);
-        }
-        if let Some(worktree_path) = worktree_abs_path {
-            task_variables.insert(
-                VariableName::WorktreeRoot,
-                worktree_path.to_string_lossy().to_string(),
-            );
-        }
-
-        Ok(task_variables)
-    }
-}
-
-/// A ContextProvider that doesn't provide any task variables on it's own, though it has some associated tasks.
-pub struct ContextProviderWithTasks {
-    templates: TaskTemplates,
-}
-
-impl ContextProviderWithTasks {
-    pub fn new(definitions: TaskTemplates) -> Self {
-        Self {
-            templates: definitions,
-        }
-    }
-}
-
-impl ContextProvider for ContextProviderWithTasks {
-    fn associated_tasks(&self) -> Option<TaskTemplates> {
-        Some(self.templates.clone())
-    }
-
-    fn build_context(
-        &self,
-        worktree_abs_path: Option<&Path>,
-        location: &Location,
-        cx: &mut AppContext,
-    ) -> Result<TaskVariables> {
-        BasicContextProvider.build_context(worktree_abs_path, location, cx)
     }
 }

--- a/crates/languages/src/bash.rs
+++ b/crates/languages/src/bash.rs
@@ -1,4 +1,4 @@
-use language::ContextProviderWithTasks;
+use project::ContextProviderWithTasks;
 use task::{TaskTemplate, TaskTemplates, VariableName};
 
 pub(super) fn bash_task_context() -> ContextProviderWithTasks {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -16,7 +16,7 @@ use std::{
     borrow::Cow,
     ffi::{OsStr, OsString},
     ops::Range,
-    path::{Path, PathBuf},
+    path::PathBuf,
     str,
     sync::{
         atomic::{AtomicBool, Ordering::SeqCst},
@@ -447,7 +447,7 @@ const GO_PACKAGE_TASK_VARIABLE: VariableName = VariableName::Custom(Cow::Borrowe
 impl ContextProvider for GoContextProvider {
     fn build_context(
         &self,
-        worktree_abs_path: Option<&Path>,
+        variables: &TaskVariables,
         location: &Location,
         cx: &mut gpui::AppContext,
     ) -> Result<TaskVariables> {
@@ -465,7 +465,8 @@ impl ContextProvider for GoContextProvider {
                 // Prefer the relative form `./my-nested-package/is-here` over
                 // absolute path, because it's more readable in the modal, but
                 // the absolute path also works.
-                let package_name = worktree_abs_path
+                let package_name = variables
+                    .get(&VariableName::WorktreeRoot)
                     .and_then(|worktree_abs_path| buffer_dir.strip_prefix(worktree_abs_path).ok())
                     .map(|relative_pkg_dir| {
                         if relative_pkg_dir.as_os_str().is_empty() {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use language::{ContextProviderWithTasks, LanguageServerName, LspAdapter, LspAdapterDelegate};
+use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::LanguageServerBinary;
 use node_runtime::NodeRuntime;
+use project::ContextProviderWithTasks;
 use std::{
     any::Any,
     ffi::OsString,

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -328,7 +328,7 @@ const RUST_PACKAGE_TASK_VARIABLE: VariableName =
 impl ContextProvider for RustContextProvider {
     fn build_context(
         &self,
-        _: Option<&Path>,
+        _: &TaskVariables,
         location: &Location,
         cx: &mut gpui::AppContext,
     ) -> Result<TaskVariables> {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -113,7 +113,9 @@ pub use fs::*;
 pub use language::Location;
 #[cfg(any(test, feature = "test-support"))]
 pub use prettier::FORMAT_SUFFIX as TEST_PRETTIER_FORMAT_SUFFIX;
-pub use task_inventory::{Inventory, TaskSourceKind};
+pub use task_inventory::{
+    BasicContextProvider, ContextProviderWithTasks, Inventory, TaskSourceKind,
+};
 pub use worktree::{
     DiagnosticSummary, Entry, EntryKind, File, LocalWorktree, PathChange, ProjectEntryId,
     RepositoryEntry, UpdatedEntriesSet, UpdatedGitRepositoriesSet, Worktree, WorktreeId,

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -499,10 +499,6 @@ mod test_inventory {
 pub struct BasicContextProvider;
 
 impl ContextProvider for BasicContextProvider {
-    fn is_basic(&self) -> bool {
-        true
-    }
-
     fn build_context(
         &self,
         worktree_abs_path: Option<&Path>,

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -189,6 +189,16 @@ impl TaskVariables {
     pub fn get(&self, key: &VariableName) -> Option<&str> {
         self.0.get(key).map(|s| s.as_str())
     }
+    /// Clear out variables obtained from tree-sitter queries, which are prefixed with '_' character
+    pub fn sweep(&mut self) {
+        self.0.retain(|name, _| {
+            if let VariableName::Custom(name) = name {
+                !name.starts_with('_')
+            } else {
+                true
+            }
+        })
+    }
 }
 
 impl FromIterator<(VariableName, String)> for TaskVariables {

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -185,6 +185,10 @@ impl TaskVariables {
     pub fn extend(&mut self, other: Self) {
         self.0.extend(other.0);
     }
+    /// Get the value associated with given variable name, if there is one.
+    pub fn get(&self, key: &VariableName) -> Option<&str> {
+        self.0.get(key).map(|s| s.as_str())
+    }
 }
 
 impl FromIterator<(VariableName, String)> for TaskVariables {

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -154,7 +154,7 @@ mod tests {
     use editor::Editor;
     use gpui::{Entity, TestAppContext};
     use language::{Language, LanguageConfig};
-    use project::{FakeFs, Project};
+    use project::{BasicContextProvider, FakeFs, Project};
     use serde_json::json;
     use task::{TaskContext, TaskVariables, VariableName};
     use ui::VisualContext;
@@ -191,7 +191,7 @@ mod tests {
             }),
         )
         .await;
-
+        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
         let rust_language = Arc::new(
             Language::new(
                 LanguageConfig::default(),
@@ -203,7 +203,7 @@ mod tests {
             name: (_) @name) @item"#,
             )
             .unwrap()
-            .with_context_provider(Some(Arc::new(BasicContextProvider))),
+            .with_context_provider(Some(Arc::new(BasicContextProvider::new(project.clone())))),
         );
 
         let typescript_language = Arc::new(
@@ -221,9 +221,9 @@ mod tests {
                       ")" @context)) @item"#,
             )
             .unwrap()
-            .with_context_provider(Some(Arc::new(BasicContextProvider))),
+            .with_context_provider(Some(Arc::new(BasicContextProvider::new(project.clone())))),
         );
-        let project = Project::test(fs, ["/dir".as_ref()], cx).await;
+
         let worktree_id = project.update(cx, |project, cx| {
             project.worktrees().next().unwrap().read(cx).id()
         });

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -153,7 +153,7 @@ mod tests {
 
     use editor::Editor;
     use gpui::{Entity, TestAppContext};
-    use language::{BasicContextProvider, Language, LanguageConfig};
+    use language::{Language, LanguageConfig};
     use project::{FakeFs, Project};
     use serde_json::json;
     use task::{TaskContext, TaskVariables, VariableName};

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -540,8 +540,8 @@ mod tests {
 
     use editor::Editor;
     use gpui::{TestAppContext, VisualTestContext};
-    use language::{ContextProviderWithTasks, Language, LanguageConfig, LanguageMatcher, Point};
-    use project::{FakeFs, Project};
+    use language::{Language, LanguageConfig, LanguageMatcher, Point};
+    use project::{ContextProviderWithTasks, FakeFs, Project};
     use serde_json::json;
     use task::TaskTemplates;
     use workspace::CloseInactiveTabsAndPanes;


### PR DESCRIPTION
This PR changes the interface of ContextProvider, allowing it to inspect *all* variables set so far during the process of building `TaskVariables`. This makes it possible to capture e.g. an identifier in tree-sitter query, process it and then export it as a task variable.

Notably, the list of variables includes captures prefixed with leading underscore; they are removed after all calls to `build_context`, but it makes it possible to capture something and then conditionally preserve it (and perhaps modify it).

Release Notes:

- N/A
