### PR TITLE
php: Bump to v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13234,7 +13234,7 @@ dependencies = [
 
 [[package]]
 name = "zed_php"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "zed_extension_api 0.0.4",
 ]

--- a/extensions/php/Cargo.toml
+++ b/extensions/php/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_php"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/php/extension.toml
+++ b/extensions/php/extension.toml
@@ -1,7 +1,7 @@
 id = "php"
 name = "PHP"
 description = "PHP support."
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the PHP extension to v0.0.4.

Changes:

- https://github.com/zed-industries/zed/pull/11514

Release Notes:

- N/A
