### PR TITLE
Update One Light modified color

### DIFF
--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -491,7 +491,7 @@
         "info": "#5c78e2ff",
         "info.background": "#e2e2faff",
         "info.border": "#cbcdf6ff",
-        "modified": "#855f00ff",
+        "modified": "#c28604ff",
         "modified.background": "#faf2e6ff",
         "modified.border": "#f4e7d1ff",
         "predictive": "#9b9ec6ff",

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -376,7 +376,6 @@
         }
       }
     },
-
     {
       "name": "One Light",
       "appearance": "light",

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -491,7 +491,7 @@
         "info": "#5c78e2ff",
         "info.background": "#e2e2faff",
         "info.border": "#cbcdf6ff",
-        "modified": "#c28604ff",
+        "modified": "#a47a23ff",
         "modified.background": "#faf2e6ff",
         "modified.border": "#f4e7d1ff",
         "predictive": "#9b9ec6ff",

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -376,6 +376,7 @@
         }
       }
     },
+
     {
       "name": "One Light",
       "appearance": "light",
@@ -491,7 +492,7 @@
         "info": "#5c78e2ff",
         "info.background": "#e2e2faff",
         "info.border": "#cbcdf6ff",
-        "modified": "#dec184ff",
+        "modified": "#855f00ff",
         "modified.background": "#faf2e6ff",
         "modified.border": "#f4e7d1ff",
         "predictive": "#9b9ec6ff",


### PR DESCRIPTION
Release Notes:

- Changed the `modified` color on the one-light color theme to a more readable value

The current color in the file tree for modified files is basically unreadable in the default light mode
<img width="238" alt="image" src="https://github.com/zed-industries/zed/assets/50590465/e553673f-1c24-41d9-b1b9-1dbbb7419d1e">

This change just changes the color to match that of the one-light theme present in vscode
~~old proposal: https://github.com/zed-industries/zed/assets/50590465/b4dc4030-bcd8-429a-84b8-2744e213e492~~
new proposal:
<img width="378" alt="image" src="https://github.com/zed-industries/zed/assets/50590465/41c53019-8cf3-4927-9879-47937388cde8">

This does have a side-effect of changing the modified color on the side in the editor, but personally I think this change is negligable.


