### PR TITLE
Add **/node_modules to file_scan_exclusions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -446,7 +446,8 @@
     "**/.DS_Store",
     "**/Thumbs.db",
     "**/.classpath",
-    "**/.settings"
+    "**/.settings",
+    "**/node_modules"
   ],
   // Git gutter behavior configuration.
   "git": {


### PR DESCRIPTION
For new users on my team, the first thing that we have to change to get viable search performance is adding `"**/node_modules"` to `file_scan_exclusions`.

Apologies if this is the wrong way to solve this problem, but search is interminably slow and painful without this change, so I thought I'd try PR-ing this addition to see if there's appetite for including it by default!

Release Notes:

- Improved the default `file_scan_exclusions` by including `"**/node_modules"`, to improve search performance by default.