### PR TITLE
docs: Remove references to `language_overrides`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -12,7 +12,7 @@ The following global settings can be overridden with a folder-specific configura
 - `format_on_save`
 - `formatter`
 - `hard_tabs`
-- `language_overrides`
+- `languages`
 - `preferred_line_length`
 - `remove_trailing_whitespace_on_save`
 - `soft_wrap`
@@ -858,18 +858,18 @@ Settings-related hint updates are not debounced.
 }
 ```
 
-## Language Overrides
+## Languages
 
-- Description: Configuration overrides for specific languages.
-- Setting: `language_overrides`
+- Description: Configuration for specific languages.
+- Setting: `languages`
 - Default: `null`
 
 **Options**
 
-To override settings for a language, add an entry for that languages name to the `language_overrides` value. Example:
+To override settings for a language, add an entry for that languages name to the `languages` value. Example:
 
 ```json
-"language_overrides": {
+"languages": {
   "C": {
     "format_on_save": "off",
     "preferred_line_length": 64,
@@ -1524,7 +1524,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
     "font_family": "FiraCode Nerd Font Mono",
     "blinking": "off"
   },
-  "language_overrides": {
+  "languages": {
     "C": {
       "format_on_save": "language_server",
       "preferred_line_length": 64,

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -27,7 +27,7 @@ If you prefer to format your code with [Mix](https://hexdocs.pm/mix/Mix.html), u
 
 ```json
 {
-  "language_overrides": {
+  "languages": {
     "Elixir": {
       "format_on_save": {
         "external": {

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -11,7 +11,7 @@ For example, if you have Prettier installed and on your `PATH`, you can use it t
 
 ```json
 {
-  "language_overrides": {
+  "languages": {
     "JavaScript": {
       "format_on_save": {
         "external": {

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -54,7 +54,7 @@ A common tool for formatting python code is [Black](https://black.readthedocs.io
 
 ```json
 {
-  "language_overrides": {
+  "languages": {
     "Python": {
       "format_on_save": {
         "external": {


### PR DESCRIPTION
This PR replaces references to `language_overrides` in the docs with just `languages`.

`language_overrides` is an alias for `languages`, and we want to move towards just using `languages`.

Release Notes:

- N/A
