### PR TITLE
zed_extension_api: Add `github_release_by_tag_name`

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -16,7 +16,8 @@ pub use serde_json;
 pub use wit::{
     download_file, make_file_executable,
     zed::extension::github::{
-        latest_github_release, GithubRelease, GithubReleaseAsset, GithubReleaseOptions,
+        github_release_by_tag_name, latest_github_release, GithubRelease, GithubReleaseAsset,
+        GithubReleaseOptions,
     },
     zed::extension::nodejs::{
         node_binary_path, npm_install_package, npm_package_installed_version,

--- a/crates/extension_api/wit/since_v0.0.7/github.wit
+++ b/crates/extension_api/wit/since_v0.0.7/github.wit
@@ -25,4 +25,9 @@ interface github {
 
     /// Returns the latest release for the given GitHub repository.
     latest-github-release: func(repo: string, options: github-release-options) -> result<github-release, string>;
+
+    /// Returns the GitHub release with the specified tag name for the given GitHub repository.
+    ///
+    /// Returns an error if a release with the given tag name does not exist.
+    github-release-by-tag-name: func(repo: string, tag: string) -> result<github-release, string>;
 }


### PR DESCRIPTION
This PR adds a new `github_release_by_tag_name` method to the `zed_extension_api` to allow for retrieving a GitHub release by its tag name.

Release Notes:

- N/A
