### PR TITLE
Preserve a trailing user message in the context editor

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6958,7 +6958,7 @@ async fn test_advance_downward_on_toggle_comment(cx: &mut gpui::TestAppContext) 
     cx.assert_editor_state(indoc!(
         "fn a() {
              // dog();
-             catˇ();
+             ˇcat();
         }"
     ));
 
@@ -6974,7 +6974,7 @@ async fn test_advance_downward_on_toggle_comment(cx: &mut gpui::TestAppContext) 
     });
     cx.assert_editor_state(indoc!(
         "fn a() {
-             // «dog()ˇ»;
+             «// dog()ˇ»;
              cat();
         }"
     ));
@@ -6992,7 +6992,7 @@ async fn test_advance_downward_on_toggle_comment(cx: &mut gpui::TestAppContext) 
     cx.assert_editor_state(indoc!(
         "fn a() {
              // dog();
-             catˇ(ˇ);
+             ˇcat(ˇ);
         }"
     ));
 
@@ -7008,7 +7008,7 @@ async fn test_advance_downward_on_toggle_comment(cx: &mut gpui::TestAppContext) 
     });
     cx.assert_editor_state(indoc!(
         "fn a() {
-             // ˇdˇog«()ˇ»;
+             ˇ// dˇog«()ˇ»;
              cat();
         }"
     ));

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -534,20 +534,14 @@ impl<'a> MutableSelectionsCollection<'a> {
             }
         }
 
-        self.collection.disjoint = Arc::from_iter(selections.into_iter().map(|selection| {
-            let end_bias = if selection.end > selection.start {
-                Bias::Left
-            } else {
-                Bias::Right
-            };
-            Selection {
+        self.collection.disjoint =
+            Arc::from_iter(selections.into_iter().map(|selection| Selection {
                 id: selection.id,
-                start: buffer.anchor_after(selection.start),
-                end: buffer.anchor_at(selection.end, end_bias),
+                start: buffer.anchor_before(selection.start),
+                end: buffer.anchor_before(selection.end),
                 reversed: selection.reversed,
                 goal: selection.goal,
-            }
-        }));
+            }));
 
         self.collection.pending = None;
         self.selections_changed = true;


### PR DESCRIPTION
To make this work, I had to switch the bias of selections to always be left on the start and the end. This has broken some tests, and will probably be a bit of a project, however, it's also a pretty long overdue change.

Release Notes:

- In the assistant panel, Zed now ensures there is always a trailing user message.