### PR TITLE
Create parent if needed when renaming file to e.g. `path/to/file.txt`

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1461,6 +1461,10 @@ impl LocalWorktree {
                 && abs_old_path != abs_new_path
                 && abs_old_path_lower == abs_new_path_lower;
 
+            if let Some(parent) = abs_new_path.parent() {
+                fs.create_dir(parent).await?;
+            }
+
             fs.rename(
                 &abs_old_path,
                 &abs_new_path,


### PR DESCRIPTION
Release Notes:

- Create parent folders when renaming a file to e.g. `path/to/file.txt`

https://github.com/zed-industries/zed/assets/22177966/6899fb46-8199-43c3-bab5-4b95b5261395

