### PR TITLE
Increase chat message render text size

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -534,7 +534,7 @@ impl ChatPanel {
                         el.child(
                             v_flex()
                                 .w_full()
-                                .text_ui_sm(cx)
+                                .text_size(cx.rem_size())
                                 .id(element_id)
                                 .child(text.element("body".into(), cx)),
                         )


### PR DESCRIPTION
IMO, current message render text size is to small.

Release Notes:

- N/A
