### PR TITLE
indent guides: Toggle action

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -273,6 +273,7 @@ gpui::actions!(
         ToggleHunkDiff,
         ToggleInlayHints,
         ToggleLineNumbers,
+        ToggleIndentGuides,
         ToggleSoftWrap,
         Transpose,
         Undo,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9640,6 +9640,22 @@ impl Editor {
         cx.notify();
     }
 
+    pub fn toggle_indent_guides(&mut self, _: &ToggleIndentGuides, cx: &mut ViewContext<Self>) {
+        let currently_enabled = self.should_show_indent_guides(cx);
+        self.show_indent_guides = Some(!currently_enabled);
+        cx.notify();
+    }
+
+    fn should_show_indent_guides(&self, cx: &mut ViewContext<Self>) -> bool {
+        self.show_indent_guides.unwrap_or_else(|| {
+            self.buffer
+                .read(cx)
+                .settings_at(0, cx)
+                .indent_guides
+                .enabled
+        })
+    }
+
     pub fn toggle_line_numbers(&mut self, _: &ToggleLineNumbers, cx: &mut ViewContext<Self>) {
         let mut editor_settings = EditorSettings::get_global(cx).clone();
         editor_settings.gutter.line_numbers = !editor_settings.gutter.line_numbers;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -318,6 +318,7 @@ impl EditorElement {
         register_action(view, cx, Editor::open_excerpts_in_split);
         register_action(view, cx, Editor::toggle_soft_wrap);
         register_action(view, cx, Editor::toggle_line_numbers);
+        register_action(view, cx, Editor::toggle_indent_guides);
         register_action(view, cx, Editor::toggle_inlay_hints);
         register_action(view, cx, hover_popover::hover);
         register_action(view, cx, Editor::reveal_in_finder);
@@ -1473,10 +1474,9 @@ impl EditorElement {
         snapshot: &DisplaySnapshot,
         cx: &mut WindowContext,
     ) -> Option<Vec<IndentGuideLayout>> {
-        let indent_guides =
-            self.editor
-                .read(cx)
-                .indent_guides(visible_buffer_range, snapshot, cx)?;
+        let indent_guides = self.editor.update(cx, |editor, cx| {
+            editor.indent_guides(visible_buffer_range, snapshot, cx)
+        })?;
 
         let active_indent_guide_indices = self.editor.update(cx, |editor, cx| {
             editor

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -35,14 +35,11 @@ impl Editor {
         &self,
         visible_buffer_range: Range<MultiBufferRow>,
         snapshot: &DisplaySnapshot,
-        cx: &AppContext,
+        cx: &mut ViewContext<Editor>,
     ) -> Option<Vec<MultiBufferIndentGuide>> {
-        if self.show_indent_guides == Some(false) {
-            return None;
-        }
+        let enabled = self.should_show_indent_guides(cx);
 
-        let settings = self.buffer.read(cx).settings_at(0, cx);
-        if settings.indent_guides.enabled {
+        if enabled {
             Some(indent_guides_in_range(visible_buffer_range, snapshot, cx))
         } else {
             None


### PR DESCRIPTION
Added a new action `editor: Toggle indent guides`, to show/hide indent guides

Release Notes:

- N/A
