### PR TITLE
windows: Make "Reveal in Finder" always open the file explorer

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -435,7 +435,7 @@ impl Platform for WindowsPlatform {
                 if path.is_empty() {
                     return;
                 }
-                open_target(path);
+                open_target_in_explorer(path);
             })
             .detach();
     }
@@ -730,6 +730,25 @@ fn open_target(target: &str) {
         );
         if ret.0 <= 32 {
             log::error!("Unable to open target: {}", std::io::Error::last_os_error());
+        }
+    }
+}
+
+fn open_target_in_explorer(target: &str) {
+    unsafe {
+        let ret = ShellExecuteW(
+            None,
+            windows::core::w!("open"),
+            windows::core::w!("explorer.exe"),
+            &HSTRING::from(format!("/select,{}", target).as_str()),
+            None,
+            SW_SHOWDEFAULT,
+        );
+        if ret.0 <= 32 {
+            log::error!(
+                "Unable to open target in explorer: {}",
+                std::io::Error::last_os_error()
+            );
         }
     }
 }


### PR DESCRIPTION
At the current moment, the "Reveal in Finder" behavior on Windows "opens" the file using direct execution. This causes files to be opened with whatever software they are associated with (i.e. will open Sublime Text instead of the file explorer).

Release Notes:

- Fixed "Reveal in Finder" on Windows to open with the File Explorer. The new behavior always opens the file explorer with the target folder/file pre-selected.

https://github.com/zed-industries/zed/assets/28355157/b8ba471d-2f5b-4529-90c3-4dc59f308b99