### PR TITLE
Introduce custom fold placeholders

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -189,7 +189,7 @@ pub struct LanguageModelChoiceDelta {
 struct MessageMetadata {
     role: Role,
     status: MessageStatus,
-    // todo!("delete this")
+    // TODO: Delete this
     #[serde(skip)]
     ambient_context: AmbientContextSnapshot,
 }

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -19,6 +19,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 use client::telemetry::Telemetry;
 use collections::{hash_map, HashMap, HashSet, VecDeque};
+use editor::FoldPlaceholder;
 use editor::{
     actions::{FoldAt, MoveDown, MoveUp},
     display_map::{
@@ -2943,6 +2944,13 @@ impl ConversationEditor {
                         .insert_flaps(
                             [Flap::new(
                                 start..end,
+                                FoldPlaceholder {
+                                    render: Arc::new(|_, _, _| {
+                                        div().child("PLACEHOLDER").into_any()
+                                    }),
+                                    text: "",
+                                    constrain_width: false,
+                                },
                                 render_slash_command_output_toggle,
                                 render_slash_command_output_trailer,
                             )],

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -35,7 +35,7 @@ use fs::Fs;
 use futures::StreamExt;
 use gpui::{
     canvas, div, point, relative, rems, uniform_list, Action, AnyElement, AnyView, AppContext,
-    AsyncAppContext, AsyncWindowContext, AvailableSpace, ClipboardItem, Context, Entity,
+    AsyncAppContext, AsyncWindowContext, AvailableSpace, ClipboardItem, Context, Empty, Entity,
     EventEmitter, FocusHandle, FocusableView, FontStyle, FontWeight, HighlightStyle,
     InteractiveElement, IntoElement, Model, ModelContext, ParentElement, Pixels, Render,
     SharedString, StatefulInteractiveElement, Styled, Subscription, Task, TextStyle,
@@ -2945,10 +2945,7 @@ impl ConversationEditor {
                             [Flap::new(
                                 start..end,
                                 FoldPlaceholder {
-                                    render: Arc::new(|_, _, _| {
-                                        div().child("PLACEHOLDER").into_any()
-                                    }),
-                                    text: "",
+                                    render: Arc::new(|_, _, _| Empty.into_any()),
                                     constrain_width: false,
                                 },
                                 render_slash_command_output_toggle,

--- a/crates/assistant2/src/assistant2.rs
+++ b/crates/assistant2/src/assistant2.rs
@@ -869,7 +869,6 @@ impl AssistantChat {
                             crate::ui::ChatMessage::new(
                                 *id,
                                 UserOrAssistant::User(self.user_store.read(cx).current_user()),
-                                // todo!(): clean up the vec usage
                                 vec![
                                     body.clone().into_any_element(),
                                     h_flex()

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -105,6 +105,7 @@ pub struct DisplayMap {
 }
 
 impl DisplayMap {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         buffer: Model<MultiBuffer>,
         font: Font,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -174,7 +174,12 @@ impl DisplayMap {
         self.fold(
             other
                 .folds_in_range(0..other.buffer_snapshot.len())
-                .map(|fold| (fold.range.to_offset(&other.buffer_snapshot), fold.text)),
+                .map(|fold| {
+                    (
+                        fold.range.to_offset(&other.buffer_snapshot),
+                        fold.placeholder,
+                    )
+                }),
             cx,
         );
     }

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -875,7 +875,7 @@ impl<'a> Iterator for BlockChunks<'a> {
 
         Some(Chunk {
             text: prefix,
-            ..self.input_chunk
+            ..self.input_chunk.clone()
         })
     }
 }

--- a/crates/editor/src/display_map/flap_map.rs
+++ b/crates/editor/src/display_map/flap_map.rs
@@ -6,6 +6,8 @@ use sum_tree::{Bias, SeekTarget, SumTree};
 use text::Point;
 use ui::WindowContext;
 
+use crate::FoldPlaceholder;
+
 #[derive(Copy, Clone, Default, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct FlapId(usize);
 
@@ -76,6 +78,7 @@ type RenderTrailerFn =
 #[derive(Clone)]
 pub struct Flap {
     pub range: Range<Anchor>,
+    pub placeholder: FoldPlaceholder,
     pub render_toggle: RenderToggleFn,
     pub render_trailer: RenderTrailerFn,
 }
@@ -83,6 +86,7 @@ pub struct Flap {
 impl Flap {
     pub fn new<RenderToggle, ToggleElement, RenderTrailer, TrailerElement>(
         range: Range<Anchor>,
+        placeholder: FoldPlaceholder,
         render_toggle: RenderToggle,
         render_trailer: RenderTrailer,
     ) -> Self
@@ -107,6 +111,7 @@ impl Flap {
     {
         Flap {
             range,
+            placeholder,
             render_toggle: Arc::new(move |row, folded, toggle, cx| {
                 render_toggle(row, folded, toggle, cx).into_any_element()
             }),
@@ -256,11 +261,13 @@ mod test {
         let flaps = [
             Flap::new(
                 snapshot.anchor_before(Point::new(1, 0))..snapshot.anchor_after(Point::new(1, 5)),
+                FoldPlaceholder::test(),
                 |_row, _folded, _toggle, _cx| div(),
                 |_row, _folded, _cx| div(),
             ),
             Flap::new(
                 snapshot.anchor_before(Point::new(3, 0))..snapshot.anchor_after(Point::new(3, 5)),
+                FoldPlaceholder::test(),
                 |_row, _folded, _toggle, _cx| div(),
                 |_row, _folded, _cx| div(),
             ),

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -2,16 +2,46 @@ use super::{
     inlay_map::{InlayBufferRows, InlayChunks, InlayEdit, InlayOffset, InlayPoint, InlaySnapshot},
     Highlights,
 };
-use gpui::{ElementId, HighlightStyle, Hsla};
-use language::{Chunk, Edit, Point, TextSummary};
+use gpui::{AnyElement, ElementId, WindowContext};
+use language::{Chunk, ChunkRenderer, Edit, Point, TextSummary};
 use multi_buffer::{Anchor, AnchorRangeExt, MultiBufferRow, MultiBufferSnapshot, ToOffset};
 use std::{
     cmp::{self, Ordering},
-    iter,
+    fmt, iter,
     ops::{Add, AddAssign, Deref, DerefMut, Range, Sub},
+    sync::Arc,
 };
 use sum_tree::{Bias, Cursor, FilterCursor, SumTree};
 use util::post_inc;
+
+#[derive(Clone)]
+pub struct FoldPlaceholder {
+    /// Creates an element to represent this fold's placeholder.
+    pub render: Arc<dyn Send + Sync + Fn(FoldId, Range<Anchor>, &mut WindowContext) -> AnyElement>,
+    /// If true, the element is constrained to the shaped width of the text.
+    pub constrain_width: bool,
+    /// A textual representation of this placeholder, which can be used to constrain its width.
+    pub text: &'static str,
+}
+
+impl Eq for FoldPlaceholder {}
+
+impl PartialEq for FoldPlaceholder {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.render, &other.render)
+            && self.constrain_width == other.constrain_width
+            && self.text == other.text
+    }
+}
+
+impl fmt::Debug for FoldPlaceholder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FoldPlaceholder")
+            .field("text", &self.text)
+            .field("constrain_width", &self.constrain_width)
+            .finish()
+    }
+}
 
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialOrd, PartialEq)]
 pub struct FoldPoint(pub Point);
@@ -54,7 +84,7 @@ impl FoldPoint {
         let mut offset = cursor.start().1.output.len;
         if !overshoot.is_zero() {
             let transform = cursor.item().expect("display point out of range");
-            assert!(transform.output_text.is_none());
+            assert!(transform.placeholder.is_none());
             let end_inlay_offset = snapshot
                 .inlay_snapshot
                 .to_offset(InlayPoint(cursor.start().1.input.lines + overshoot));
@@ -75,7 +105,7 @@ pub(crate) struct FoldMapWriter<'a>(&'a mut FoldMap);
 impl<'a> FoldMapWriter<'a> {
     pub(crate) fn fold<T: ToOffset>(
         &mut self,
-        ranges: impl IntoIterator<Item = (Range<T>, &'static str)>,
+        ranges: impl IntoIterator<Item = (Range<T>, FoldPlaceholder)>,
     ) -> (FoldSnapshot, Vec<FoldEdit>) {
         let mut edits = Vec::new();
         let mut folds = Vec::new();
@@ -99,7 +129,7 @@ impl<'a> FoldMapWriter<'a> {
             folds.push(Fold {
                 id: FoldId(post_inc(&mut self.0.next_fold_id.0)),
                 range: fold_range,
-                text: fold_text,
+                placeholder: fold_text,
             });
 
             let inlay_range =
@@ -183,7 +213,6 @@ impl<'a> FoldMapWriter<'a> {
 /// See the [`display_map` module documentation](crate::display_map) for more information.
 pub(crate) struct FoldMap {
     snapshot: FoldSnapshot,
-    ellipses_color: Option<Hsla>,
     next_fold_id: FoldId,
 }
 
@@ -198,15 +227,13 @@ impl FoldMap {
                             input: inlay_snapshot.text_summary(),
                             output: inlay_snapshot.text_summary(),
                         },
-                        output_text: None,
+                        placeholder: None,
                     },
                     &(),
                 ),
                 inlay_snapshot: inlay_snapshot.clone(),
                 version: 0,
-                ellipses_color: None,
             },
-            ellipses_color: None,
             next_fold_id: FoldId::default(),
         };
         let snapshot = this.snapshot.clone();
@@ -230,15 +257,6 @@ impl FoldMap {
     ) -> (FoldMapWriter, FoldSnapshot, Vec<FoldEdit>) {
         let (snapshot, edits) = self.read(inlay_snapshot, edits);
         (FoldMapWriter(self), snapshot, edits)
-    }
-
-    pub fn set_ellipses_color(&mut self, color: Hsla) -> bool {
-        if self.ellipses_color == Some(color) {
-            false
-        } else {
-            self.ellipses_color = Some(color);
-            true
-        }
     }
 
     fn check_invariants(&self) {
@@ -329,9 +347,9 @@ impl FoldMap {
                             let buffer_start = fold.range.start.to_offset(&inlay_snapshot.buffer);
                             let buffer_end = fold.range.end.to_offset(&inlay_snapshot.buffer);
                             (
+                                fold.clone(),
                                 inlay_snapshot.to_inlay_offset(buffer_start)
                                     ..inlay_snapshot.to_inlay_offset(buffer_end),
-                                fold.text,
                             )
                         });
                         folds_cursor.next(&inlay_snapshot.buffer);
@@ -342,17 +360,17 @@ impl FoldMap {
 
                 while folds
                     .peek()
-                    .map_or(false, |(fold_range, _)| fold_range.start < edit.new.end)
+                    .map_or(false, |(_, fold_range)| fold_range.start < edit.new.end)
                 {
-                    let (mut fold_range, fold_text) = folds.next().unwrap();
+                    let (fold, mut fold_range) = folds.next().unwrap();
                     let sum = new_transforms.summary();
 
                     assert!(fold_range.start.0 >= sum.input.len);
 
-                    while folds.peek().map_or(false, |(next_fold_range, _)| {
+                    while folds.peek().map_or(false, |(_, next_fold_range)| {
                         next_fold_range.start <= fold_range.end
                     }) {
-                        let (next_fold_range, _) = folds.next().unwrap();
+                        let (_, next_fold_range) = folds.next().unwrap();
                         if next_fold_range.end > fold_range.end {
                             fold_range.end = next_fold_range.end;
                         }
@@ -367,21 +385,34 @@ impl FoldMap {
                                     output: text_summary.clone(),
                                     input: text_summary,
                                 },
-                                output_text: None,
+                                placeholder: None,
                             },
                             &(),
                         );
                     }
 
                     if fold_range.end > fold_range.start {
+                        let fold_id = fold.id;
                         new_transforms.push(
                             Transform {
                                 summary: TransformSummary {
-                                    output: TextSummary::from(fold_text),
+                                    output: TextSummary::from(fold.placeholder.text),
                                     input: inlay_snapshot
                                         .text_summary_for_range(fold_range.start..fold_range.end),
                                 },
-                                output_text: Some(fold_text),
+                                placeholder: Some(TransformPlaceholder {
+                                    text: fold.placeholder.text,
+                                    renderer: ChunkRenderer {
+                                        render: Arc::new(move |cx| {
+                                            (fold.placeholder.render)(
+                                                fold_id,
+                                                fold.range.0.clone(),
+                                                cx,
+                                            )
+                                        }),
+                                        constrain_width: fold.placeholder.constrain_width,
+                                    },
+                                }),
                             },
                             &(),
                         );
@@ -398,7 +429,7 @@ impl FoldMap {
                                 output: text_summary.clone(),
                                 input: text_summary,
                             },
-                            output_text: None,
+                            placeholder: None,
                         },
                         &(),
                     );
@@ -414,7 +445,7 @@ impl FoldMap {
                             output: text_summary.clone(),
                             input: text_summary,
                         },
-                        output_text: None,
+                        placeholder: None,
                     },
                     &(),
                 );
@@ -484,7 +515,6 @@ pub struct FoldSnapshot {
     folds: SumTree<Fold>,
     pub inlay_snapshot: InlaySnapshot,
     pub version: usize,
-    pub ellipses_color: Option<Hsla>,
 }
 
 impl FoldSnapshot {
@@ -508,9 +538,9 @@ impl FoldSnapshot {
         if let Some(transform) = cursor.item() {
             let start_in_transform = range.start.0 - cursor.start().0 .0;
             let end_in_transform = cmp::min(range.end, cursor.end(&()).0).0 - cursor.start().0 .0;
-            if let Some(output_text) = transform.output_text {
+            if let Some(placeholder) = transform.placeholder.as_ref() {
                 summary = TextSummary::from(
-                    &output_text
+                    &placeholder.text
                         [start_in_transform.column as usize..end_in_transform.column as usize],
                 );
             } else {
@@ -533,8 +563,9 @@ impl FoldSnapshot {
                 .output;
             if let Some(transform) = cursor.item() {
                 let end_in_transform = range.end.0 - cursor.start().0 .0;
-                if let Some(output_text) = transform.output_text {
-                    summary += TextSummary::from(&output_text[..end_in_transform.column as usize]);
+                if let Some(placeholder) = transform.placeholder.as_ref() {
+                    summary +=
+                        TextSummary::from(&placeholder.text[..end_in_transform.column as usize]);
                 } else {
                     let inlay_start = self.inlay_snapshot.to_offset(cursor.start().1);
                     let inlay_end = self
@@ -631,7 +662,7 @@ impl FoldSnapshot {
         let inlay_offset = self.inlay_snapshot.to_inlay_offset(buffer_offset);
         let mut cursor = self.transforms.cursor::<InlayOffset>();
         cursor.seek(&inlay_offset, Bias::Right, &());
-        cursor.item().map_or(false, |t| t.output_text.is_some())
+        cursor.item().map_or(false, |t| t.placeholder.is_some())
     }
 
     pub fn is_line_folded(&self, buffer_row: MultiBufferRow) -> bool {
@@ -646,7 +677,7 @@ impl FoldSnapshot {
                     let buffer_point = self.inlay_snapshot.to_buffer_point(inlay_point);
                     if buffer_point.row != buffer_row.0 {
                         return false;
-                    } else if transform.output_text.is_some() {
+                    } else if transform.placeholder.is_some() {
                         return true;
                     }
                 }
@@ -693,7 +724,6 @@ impl FoldSnapshot {
             inlay_offset: inlay_start,
             output_offset: range.start.0,
             max_output_offset: range.end.0,
-            ellipses_color: self.ellipses_color,
         }
     }
 
@@ -720,7 +750,7 @@ impl FoldSnapshot {
         cursor.seek(&point, Bias::Right, &());
         if let Some(transform) = cursor.item() {
             let transform_start = cursor.start().0 .0;
-            if transform.output_text.is_some() {
+            if transform.placeholder.is_some() {
                 if point.0 == transform_start || matches!(bias, Bias::Left) {
                     FoldPoint(transform_start)
                 } else {
@@ -810,15 +840,21 @@ fn consolidate_fold_edits(edits: &mut Vec<FoldEdit>) {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default)]
 struct Transform {
     summary: TransformSummary,
-    output_text: Option<&'static str>,
+    placeholder: Option<TransformPlaceholder>,
+}
+
+#[derive(Clone, Debug)]
+struct TransformPlaceholder {
+    text: &'static str,
+    renderer: ChunkRenderer,
 }
 
 impl Transform {
     fn is_fold(&self) -> bool {
-        self.output_text.is_some()
+        self.placeholder.is_some()
     }
 }
 
@@ -858,7 +894,7 @@ impl Into<ElementId> for FoldId {
 pub struct Fold {
     pub id: FoldId,
     pub range: FoldRange,
-    pub text: &'static str,
+    pub placeholder: FoldPlaceholder,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1004,7 +1040,6 @@ pub struct FoldChunks<'a> {
     inlay_offset: InlayOffset,
     output_offset: usize,
     max_output_offset: usize,
-    ellipses_color: Option<Hsla>,
 }
 
 impl<'a> Iterator for FoldChunks<'a> {
@@ -1019,7 +1054,7 @@ impl<'a> Iterator for FoldChunks<'a> {
 
         // If we're in a fold, then return the fold's display text and
         // advance the transform and buffer cursors to the end of the fold.
-        if let Some(output_text) = transform.output_text {
+        if let Some(placeholder) = transform.placeholder.as_ref() {
             self.inlay_chunk.take();
             self.inlay_offset += InlayOffset(transform.summary.input.len);
             self.inlay_chunks.seek(self.inlay_offset);
@@ -1030,13 +1065,10 @@ impl<'a> Iterator for FoldChunks<'a> {
                 self.transform_cursor.next(&());
             }
 
-            self.output_offset += output_text.len();
+            self.output_offset += placeholder.text.len();
             return Some(Chunk {
-                text: output_text,
-                highlight_style: self.ellipses_color.map(|color| HighlightStyle {
-                    color: Some(color),
-                    ..Default::default()
-                }),
+                text: placeholder.text,
+                renderer: Some(placeholder.renderer.clone()),
                 ..Default::default()
             });
         }
@@ -1048,7 +1080,7 @@ impl<'a> Iterator for FoldChunks<'a> {
         }
 
         // Otherwise, take a chunk from the buffer's text.
-        if let Some((buffer_chunk_start, mut chunk)) = self.inlay_chunk {
+        if let Some((buffer_chunk_start, mut chunk)) = self.inlay_chunk.clone() {
             let buffer_chunk_end = buffer_chunk_start + InlayOffset(chunk.text.len());
             let transform_end = self.transform_cursor.end(&()).1;
             let chunk_end = buffer_chunk_end.min(transform_end);
@@ -1146,13 +1178,23 @@ mod tests {
     use super::*;
     use crate::{display_map::inlay_map::InlayMap, MultiBuffer, ToPoint};
     use collections::HashSet;
+    use gpui::Empty;
     use rand::prelude::*;
     use settings::SettingsStore;
     use std::{env, mem};
     use text::Patch;
+    use ui::IntoElement;
     use util::test::sample_text;
     use util::RandomCharIter;
     use Bias::{Left, Right};
+
+    fn placeholder() -> FoldPlaceholder {
+        FoldPlaceholder {
+            render: Arc::new(|_id, _range, _cx| Empty.into_any_element()),
+            constrain_width: true,
+            text: "⋯",
+        }
+    }
 
     #[gpui::test]
     fn test_basic_folds(cx: &mut gpui::AppContext) {
@@ -1165,8 +1207,8 @@ mod tests {
 
         let (mut writer, _, _) = map.write(inlay_snapshot, vec![]);
         let (snapshot2, edits) = writer.fold(vec![
-            (Point::new(0, 2)..Point::new(2, 2), "⋯"),
-            (Point::new(2, 4)..Point::new(4, 1), "⋯"),
+            (Point::new(0, 2)..Point::new(2, 2), placeholder()),
+            (Point::new(2, 4)..Point::new(4, 1), placeholder()),
         ]);
         assert_eq!(snapshot2.text(), "aa⋯cc⋯eeeee");
         assert_eq!(
@@ -1245,19 +1287,19 @@ mod tests {
             let mut map = FoldMap::new(inlay_snapshot.clone()).0;
 
             let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
-            writer.fold(vec![(5..8, "⋯")]);
+            writer.fold(vec![(5..8, placeholder())]);
             let (snapshot, _) = map.read(inlay_snapshot.clone(), vec![]);
             assert_eq!(snapshot.text(), "abcde⋯ijkl");
 
             // Create an fold adjacent to the start of the first fold.
             let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
-            writer.fold(vec![(0..1, "⋯"), (2..5, "⋯")]);
+            writer.fold(vec![(0..1, placeholder()), (2..5, placeholder())]);
             let (snapshot, _) = map.read(inlay_snapshot.clone(), vec![]);
             assert_eq!(snapshot.text(), "⋯b⋯ijkl");
 
             // Create an fold adjacent to the end of the first fold.
             let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
-            writer.fold(vec![(11..11, "⋯"), (8..10, "⋯")]);
+            writer.fold(vec![(11..11, placeholder()), (8..10, placeholder())]);
             let (snapshot, _) = map.read(inlay_snapshot.clone(), vec![]);
             assert_eq!(snapshot.text(), "⋯b⋯kl");
         }
@@ -1267,7 +1309,7 @@ mod tests {
 
             // Create two adjacent folds.
             let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
-            writer.fold(vec![(0..2, "⋯"), (2..5, "⋯")]);
+            writer.fold(vec![(0..2, placeholder()), (2..5, placeholder())]);
             let (snapshot, _) = map.read(inlay_snapshot, vec![]);
             assert_eq!(snapshot.text(), "⋯fghijkl");
 
@@ -1291,10 +1333,10 @@ mod tests {
         let mut map = FoldMap::new(inlay_snapshot.clone()).0;
         let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
         writer.fold(vec![
-            (Point::new(0, 2)..Point::new(2, 2), "⋯"),
-            (Point::new(0, 4)..Point::new(1, 0), "⋯"),
-            (Point::new(1, 2)..Point::new(3, 2), "⋯"),
-            (Point::new(3, 1)..Point::new(4, 1), "⋯"),
+            (Point::new(0, 2)..Point::new(2, 2), placeholder()),
+            (Point::new(0, 4)..Point::new(1, 0), placeholder()),
+            (Point::new(1, 2)..Point::new(3, 2), placeholder()),
+            (Point::new(3, 1)..Point::new(4, 1), placeholder()),
         ]);
         let (snapshot, _) = map.read(inlay_snapshot, vec![]);
         assert_eq!(snapshot.text(), "aa⋯eeeee");
@@ -1311,8 +1353,8 @@ mod tests {
 
         let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
         writer.fold(vec![
-            (Point::new(0, 2)..Point::new(2, 2), "⋯"),
-            (Point::new(3, 1)..Point::new(4, 1), "⋯"),
+            (Point::new(0, 2)..Point::new(2, 2), placeholder()),
+            (Point::new(3, 1)..Point::new(4, 1), placeholder()),
         ]);
         let (snapshot, _) = map.read(inlay_snapshot.clone(), vec![]);
         assert_eq!(snapshot.text(), "aa⋯cccc\nd⋯eeeee");
@@ -1336,10 +1378,10 @@ mod tests {
 
         let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
         writer.fold(vec![
-            (Point::new(0, 2)..Point::new(2, 2), "⋯"),
-            (Point::new(0, 4)..Point::new(1, 0), "⋯"),
-            (Point::new(1, 2)..Point::new(3, 2), "⋯"),
-            (Point::new(3, 1)..Point::new(4, 1), "⋯"),
+            (Point::new(0, 2)..Point::new(2, 2), placeholder()),
+            (Point::new(0, 4)..Point::new(1, 0), placeholder()),
+            (Point::new(1, 2)..Point::new(3, 2), placeholder()),
+            (Point::new(3, 1)..Point::new(4, 1), placeholder()),
         ]);
         let (snapshot, _) = map.read(inlay_snapshot.clone(), vec![]);
         let fold_ranges = snapshot
@@ -1640,8 +1682,8 @@ mod tests {
 
         let (mut writer, _, _) = map.write(inlay_snapshot.clone(), vec![]);
         writer.fold(vec![
-            (Point::new(0, 2)..Point::new(2, 2), "⋯"),
-            (Point::new(3, 1)..Point::new(4, 1), "⋯"),
+            (Point::new(0, 2)..Point::new(2, 2), placeholder()),
+            (Point::new(3, 1)..Point::new(4, 1), placeholder()),
         ]);
 
         let (snapshot, _) = map.read(inlay_snapshot, vec![]);
@@ -1670,7 +1712,7 @@ mod tests {
                 .map(|fold| {
                     (
                         fold.range.start.to_offset(buffer)..fold.range.end.to_offset(buffer),
-                        fold.text,
+                        fold.placeholder.text,
                     )
                 })
                 .peekable();
@@ -1723,7 +1765,15 @@ mod tests {
                     for _ in 0..rng.gen_range(1..=2) {
                         let end = buffer.clip_offset(rng.gen_range(0..=buffer.len()), Right);
                         let start = buffer.clip_offset(rng.gen_range(0..=end), Left);
-                        let text = if rng.gen() { "⋯" } else { "" };
+                        let text = if rng.gen() {
+                            placeholder()
+                        } else {
+                            FoldPlaceholder {
+                                text: "",
+                                render: Arc::new(|_, _, _| Empty.into_any_element()),
+                                constrain_width: true,
+                            }
+                        };
                         to_fold.push((start..end, text));
                     }
                     log::info!("folding {:?}", to_fold);

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -2,7 +2,7 @@ use super::{
     inlay_map::{InlayBufferRows, InlayChunks, InlayEdit, InlayOffset, InlayPoint, InlaySnapshot},
     Highlights,
 };
-use gpui::{AnyElement, ElementId, IntoElement, WindowContext};
+use gpui::{AnyElement, ElementId, WindowContext};
 use language::{Chunk, ChunkRenderer, Edit, Point, TextSummary};
 use multi_buffer::{Anchor, AnchorRangeExt, MultiBufferRow, MultiBufferSnapshot, ToOffset};
 use std::{
@@ -25,6 +25,8 @@ pub struct FoldPlaceholder {
 impl FoldPlaceholder {
     #[cfg(any(test, feature = "test-support"))]
     pub fn test() -> Self {
+        use gpui::IntoElement;
+
         Self {
             render: Arc::new(|_id, _range, _cx| gpui::Empty.into_any_element()),
             constrain_width: true,

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -284,7 +284,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                 self.output_offset.0 += prefix.len();
                 let mut prefix = Chunk {
                     text: prefix,
-                    ..*chunk
+                    ..chunk.clone()
                 };
                 if !self.active_highlights.is_empty() {
                     let mut highlight_style = HighlightStyle::default();

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -508,7 +508,7 @@ impl<'a> Iterator for TabChunks<'a> {
                         self.chunk.text = suffix;
                         return Some(Chunk {
                             text: prefix,
-                            ..self.chunk
+                            ..self.chunk.clone()
                         });
                     } else {
                         self.chunk.text = &self.chunk.text[1..];
@@ -529,7 +529,7 @@ impl<'a> Iterator for TabChunks<'a> {
                         return Some(Chunk {
                             text: &SPACES[..len as usize],
                             is_tab: true,
-                            ..self.chunk
+                            ..self.chunk.clone()
                         });
                     }
                 }

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -812,7 +812,7 @@ impl<'a> Iterator for WrapChunks<'a> {
             self.transforms.next(&());
             return Some(Chunk {
                 text: &display_text[start_ix..end_ix],
-                ..self.input_chunk
+                ..self.input_chunk.clone()
             });
         }
 
@@ -842,7 +842,7 @@ impl<'a> Iterator for WrapChunks<'a> {
         self.input_chunk.text = suffix;
         Some(Chunk {
             text: prefix,
-            ..self.input_chunk
+            ..self.input_chunk.clone()
         })
     }
 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5826,7 +5826,7 @@ impl Editor {
                         let mut end = fold.range.end.to_point(&buffer);
                         start.row -= row_delta;
                         end.row -= row_delta;
-                        refold_ranges.push((start..end, fold.text));
+                        refold_ranges.push((start..end, fold.placeholder));
                     }
                 }
             }
@@ -5920,7 +5920,7 @@ impl Editor {
                         let mut end = fold.range.end.to_point(&buffer);
                         start.row += row_delta;
                         end.row += row_delta;
-                        refold_ranges.push((start..end, fold.text));
+                        refold_ranges.push((start..end, fold.placeholder));
                     }
                 }
             }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1579,7 +1579,6 @@ impl Editor {
         let font_size = style.font_size.to_pixels(cx.rem_size());
         let editor = cx.view().downgrade();
         let fold_placeholder = FoldPlaceholder {
-            text: "⋯",
             constrain_width: true,
             render: Arc::new(move |fold_id, fold_range, cx| {
                 let editor = editor.clone();
@@ -9339,14 +9338,14 @@ impl Editor {
         let buffer_row = fold_at.buffer_row;
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
 
-        if let Some((fold_range, fold_text)) = display_map.foldable_range(buffer_row) {
+        if let Some((fold_range, placeholder)) = display_map.foldable_range(buffer_row) {
             let autoscroll = self
                 .selections
                 .all::<Point>(cx)
                 .iter()
                 .any(|selection| fold_range.overlaps(&selection.range()));
 
-            self.fold_ranges([(fold_range, fold_text)], autoscroll, cx);
+            self.fold_ranges([(fold_range, placeholder)], autoscroll, cx);
         }
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1581,12 +1581,17 @@ impl Editor {
         let fold_placeholder = FoldPlaceholder {
             text: "⋯",
             constrain_width: true,
-            render: Arc::new(move |fold_id, fold_range, _cx| {
+            render: Arc::new(move |fold_id, fold_range, cx| {
                 let editor = editor.clone();
                 div()
                     .id(fold_id)
+                    .bg(cx.theme().colors().ghost_element_background)
+                    .hover(|style| style.bg(cx.theme().colors().ghost_element_hover))
+                    .active(|style| style.bg(cx.theme().colors().ghost_element_active))
+                    .rounded_sm()
                     .size_full()
                     .cursor_pointer()
+                    .child("⋯")
                     .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
                     .on_click(move |_, cx| {
                         editor

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -52,8 +52,8 @@ use clock::ReplicaId;
 use collections::{BTreeMap, Bound, HashMap, HashSet, VecDeque};
 use convert_case::{Case, Casing};
 use debounced_delay::DebouncedDelay;
-pub use display_map::DisplayPoint;
 use display_map::*;
+pub use display_map::{DisplayPoint, FoldPlaceholder};
 use editor_settings::CurrentLineHighlight;
 pub use editor_settings::EditorSettings;
 use element::LineWithInvisibles;
@@ -1577,8 +1577,44 @@ impl Editor {
     ) -> Self {
         let style = cx.text_style();
         let font_size = style.font_size.to_pixels(cx.rem_size());
+        let editor = cx.view().downgrade();
+        let fold_placeholder = FoldPlaceholder {
+            text: "⋯",
+            constrain_width: true,
+            render: Arc::new(move |fold_id, fold_range, _cx| {
+                let editor = editor.clone();
+                div()
+                    .id(fold_id)
+                    .size_full()
+                    .cursor_pointer()
+                    .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
+                    .on_click(move |_, cx| {
+                        editor
+                            .update(cx, |editor, cx| {
+                                editor.unfold_ranges(
+                                    [fold_range.start..fold_range.end],
+                                    true,
+                                    false,
+                                    cx,
+                                );
+                                cx.stop_propagation();
+                            })
+                            .ok();
+                    })
+                    .into_any()
+            }),
+        };
         let display_map = cx.new_model(|cx| {
-            DisplayMap::new(buffer.clone(), style.font(), font_size, None, 2, 1, cx)
+            DisplayMap::new(
+                buffer.clone(),
+                style.font(),
+                font_size,
+                None,
+                2,
+                1,
+                fold_placeholder,
+                cx,
+            )
         });
 
         let selections = SelectionsCollection::new(display_map.clone(), buffer.clone());
@@ -5826,7 +5862,7 @@ impl Editor {
                         let mut end = fold.range.end.to_point(&buffer);
                         start.row -= row_delta;
                         end.row -= row_delta;
-                        refold_ranges.push((start..end, fold.placeholder));
+                        refold_ranges.push((start..end, fold.placeholder.clone()));
                     }
                 }
             }
@@ -5920,7 +5956,7 @@ impl Editor {
                         let mut end = fold.range.end.to_point(&buffer);
                         start.row += row_delta;
                         end.row += row_delta;
-                        refold_ranges.push((start..end, fold.placeholder));
+                        refold_ranges.push((start..end, fold.placeholder.clone()));
                     }
                 }
             }
@@ -9359,9 +9395,9 @@ impl Editor {
                         .buffer_snapshot
                         .line_len(MultiBufferRow(s.end.row)),
                 );
-                (start..end, "⋯")
+                (start..end, display_map.fold_placeholder.clone())
             } else {
-                (s.start..s.end, "⋯")
+                (s.start..s.end, display_map.fold_placeholder.clone())
             }
         });
         self.fold_ranges(ranges, true, cx);
@@ -9369,7 +9405,7 @@ impl Editor {
 
     pub fn fold_ranges<T: ToOffset + Clone>(
         &mut self,
-        ranges: impl IntoIterator<Item = (Range<T>, &'static str)>,
+        ranges: impl IntoIterator<Item = (Range<T>, FoldPlaceholder)>,
         auto_scroll: bool,
         cx: &mut ViewContext<Self>,
     ) {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -496,8 +496,8 @@ fn test_clone(cx: &mut TestAppContext) {
         editor.change_selections(None, cx, |s| s.select_ranges(selection_ranges.clone()));
         editor.fold_ranges(
             [
-                (Point::new(1, 0)..Point::new(2, 0), "⋯"),
-                (Point::new(3, 0)..Point::new(4, 0), "⋯"),
+                (Point::new(1, 0)..Point::new(2, 0), FoldPlaceholder::test()),
+                (Point::new(3, 0)..Point::new(4, 0), FoldPlaceholder::test()),
             ],
             true,
             cx,
@@ -905,9 +905,9 @@ fn test_move_cursor_multibyte(cx: &mut TestAppContext) {
     _ = view.update(cx, |view, cx| {
         view.fold_ranges(
             vec![
-                (Point::new(0, 6)..Point::new(0, 12), "⋯"),
-                (Point::new(1, 2)..Point::new(1, 4), "⋯"),
-                (Point::new(2, 4)..Point::new(2, 8), "⋯"),
+                (Point::new(0, 6)..Point::new(0, 12), FoldPlaceholder::test()),
+                (Point::new(1, 2)..Point::new(1, 4), FoldPlaceholder::test()),
+                (Point::new(2, 4)..Point::new(2, 8), FoldPlaceholder::test()),
             ],
             true,
             cx,
@@ -3409,9 +3409,9 @@ fn test_move_line_up_down(cx: &mut TestAppContext) {
     _ = view.update(cx, |view, cx| {
         view.fold_ranges(
             vec![
-                (Point::new(0, 2)..Point::new(1, 2), "⋯"),
-                (Point::new(2, 3)..Point::new(4, 1), "⋯"),
-                (Point::new(7, 0)..Point::new(8, 4), "⋯"),
+                (Point::new(0, 2)..Point::new(1, 2), FoldPlaceholder::test()),
+                (Point::new(2, 3)..Point::new(4, 1), FoldPlaceholder::test()),
+                (Point::new(7, 0)..Point::new(8, 4), FoldPlaceholder::test()),
             ],
             true,
             cx,
@@ -3893,9 +3893,9 @@ fn test_split_selection_into_lines(cx: &mut TestAppContext) {
     _ = view.update(cx, |view, cx| {
         view.fold_ranges(
             vec![
-                (Point::new(0, 2)..Point::new(1, 2), "⋯"),
-                (Point::new(2, 3)..Point::new(4, 1), "⋯"),
-                (Point::new(7, 0)..Point::new(8, 4), "⋯"),
+                (Point::new(0, 2)..Point::new(1, 2), FoldPlaceholder::test()),
+                (Point::new(2, 3)..Point::new(4, 1), FoldPlaceholder::test()),
+                (Point::new(7, 0)..Point::new(8, 4), FoldPlaceholder::test()),
             ],
             true,
             cx,
@@ -4550,8 +4550,14 @@ async fn test_select_larger_smaller_syntax_node(cx: &mut gpui::TestAppContext) {
     _ = view.update(cx, |view, cx| {
         view.fold_ranges(
             vec![
-                (Point::new(0, 21)..Point::new(0, 24), "⋯"),
-                (Point::new(3, 20)..Point::new(3, 22), "⋯"),
+                (
+                    Point::new(0, 21)..Point::new(0, 24),
+                    FoldPlaceholder::test(),
+                ),
+                (
+                    Point::new(3, 20)..Point::new(3, 22),
+                    FoldPlaceholder::test(),
+                ),
             ],
             true,
             cx,
@@ -11973,6 +11979,7 @@ fn test_flap_insertion_and_rendering(cx: &mut TestAppContext) {
 
             let flap = Flap::new(
                 range,
+                FoldPlaceholder::test(),
                 {
                     let toggle_callback = render_args.clone();
                     move |row, folded, callback, _cx| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -873,7 +873,7 @@ impl EditorElement {
             .folds_in_range(visible_anchor_range.clone())
             .filter_map(|fold| {
                 // Skip folds that have no text.
-                if fold.placeholder.is_empty() {
+                if fold.placeholder.constrain_width && fold.placeholder.text.is_empty() {
                     return None;
                 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3745,6 +3745,7 @@ pub(crate) struct LineWithInvisibles {
     font_size: Pixels,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum LineFragment {
     Text(ShapedLine),
     Element {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -873,7 +873,7 @@ impl EditorElement {
             .folds_in_range(visible_anchor_range.clone())
             .filter_map(|fold| {
                 // Skip folds that have no text.
-                if fold.text.is_empty() {
+                if fold.placeholder.is_empty() {
                     return None;
                 }
 

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -577,7 +577,7 @@ mod tests {
     use crate::{
         display_map::Inlay,
         test::{editor_test_context::EditorTestContext, marked_display_snapshot},
-        Buffer, DisplayMap, DisplayRow, ExcerptRange, InlayId, MultiBuffer,
+        Buffer, DisplayMap, DisplayRow, ExcerptRange, FoldPlaceholder, InlayId, MultiBuffer,
     };
     use gpui::{font, Context as _};
     use language::Capability;
@@ -695,8 +695,18 @@ mod tests {
         let font_size = px(14.0);
         let buffer = MultiBuffer::build_simple(input_text, cx);
         let buffer_snapshot = buffer.read(cx).snapshot(cx);
-        let display_map =
-            cx.new_model(|cx| DisplayMap::new(buffer, font, font_size, None, 1, 1, cx));
+        let display_map = cx.new_model(|cx| {
+            DisplayMap::new(
+                buffer,
+                font,
+                font_size,
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                cx,
+            )
+        });
 
         // add all kinds of inlays between two word boundaries: we should be able to cross them all, when looking for another boundary
         let mut id = 0;
@@ -901,8 +911,18 @@ mod tests {
                 );
                 multibuffer
             });
-            let display_map =
-                cx.new_model(|cx| DisplayMap::new(multibuffer, font, px(14.0), None, 2, 2, cx));
+            let display_map = cx.new_model(|cx| {
+                DisplayMap::new(
+                    multibuffer,
+                    font,
+                    px(14.0),
+                    None,
+                    2,
+                    2,
+                    FoldPlaceholder::test(),
+                    cx,
+                )
+            });
             let snapshot = display_map.update(cx, |map, cx| map.snapshot(cx));
 
             assert_eq!(snapshot.text(), "\n\nabc\ndefg\n\n\nhijkl\nmn");

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -251,12 +251,10 @@ impl Editor {
                     let end_column = cmp::min(display_map.line_len(head.row()), head.column() + 3);
                     target_left = target_left.min(
                         layouts[head.row().minus(start_row) as usize]
-                            .line
                             .x_for_index(start_column as usize),
                     );
                     target_right = target_right.max(
                         layouts[head.row().minus(start_row) as usize]
-                            .line
                             .x_for_index(end_column as usize)
                             + max_glyph_width,
                     );

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -3,11 +3,9 @@ pub mod editor_test_context;
 
 use crate::{
     display_map::{DisplayMap, DisplaySnapshot, ToDisplayPoint},
-    DisplayPoint, Editor, EditorMode, MultiBuffer,
+    DisplayPoint, Editor, EditorMode, FoldPlaceholder, MultiBuffer,
 };
-
 use gpui::{Context, Font, FontFeatures, FontStyle, FontWeight, Model, Pixels, ViewContext};
-
 use project::Project;
 use util::test::{marked_text_offsets, marked_text_ranges};
 
@@ -35,7 +33,18 @@ pub fn marked_display_snapshot(
     let font_size: Pixels = 14usize.into();
 
     let buffer = MultiBuffer::build_simple(&unmarked_text, cx);
-    let display_map = cx.new_model(|cx| DisplayMap::new(buffer, font, font_size, None, 1, 1, cx));
+    let display_map = cx.new_model(|cx| {
+        DisplayMap::new(
+            buffer,
+            font,
+            font_size,
+            None,
+            1,
+            1,
+            FoldPlaceholder::test(),
+            cx,
+        )
+    });
     let snapshot = display_map.update(cx, |map, cx| map.snapshot(cx));
     let markers = markers
         .into_iter()

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -143,7 +143,7 @@ impl StyledText {
         }
     }
 
-    /// todo!()
+    /// Get the layout for this element. This can be used to map indices to pixels and vice versa.
     pub fn layout(&self) -> &TextLayout {
         &self.layout
     }
@@ -232,7 +232,7 @@ impl IntoElement for StyledText {
     }
 }
 
-/// todo!()
+/// The Layout for TextElement. This can be used to map indices to pixels and vice versa.
 #[derive(Default, Clone)]
 pub struct TextLayout(Arc<Mutex<Option<TextLayoutInner>>>);
 
@@ -358,7 +358,7 @@ impl TextLayout {
         }
     }
 
-    /// todo!()
+    /// Get the byte index into the input of the pixel position.
     pub fn index_for_position(&self, mut position: Point<Pixels>) -> Result<usize, usize> {
         let element_state = self.lock();
         let element_state = element_state
@@ -392,7 +392,7 @@ impl TextLayout {
         Err(line_start_ix.saturating_sub(1))
     }
 
-    /// todo!()
+    /// Get the pixel position for the given byte index.
     pub fn position_for_index(&self, index: usize) -> Option<Point<Pixels>> {
         let element_state = self.lock();
         let element_state = element_state
@@ -423,17 +423,17 @@ impl TextLayout {
         None
     }
 
-    /// todo!()
+    /// The bounds of this layout.
     pub fn bounds(&self) -> Bounds<Pixels> {
         self.0.lock().as_ref().unwrap().bounds.unwrap()
     }
 
-    /// todo!()
+    /// The line height for this layout.
     pub fn line_height(&self) -> Pixels {
         self.0.lock().as_ref().unwrap().line_height
     }
 
-    /// todo!()
+    /// The text for this layout.
     pub fn text(&self) -> String {
         self.0
             .lock()

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -302,7 +302,7 @@ impl WrappedLineLayout {
         }
     }
 
-    /// todo!()
+    /// Returns the pixel position for the given byte index.
     pub fn position_for_index(&self, index: usize, line_height: Pixels) -> Option<Point<Pixels>> {
         let mut line_start_ix = 0;
         let mut line_end_indices = self


### PR DESCRIPTION
This pull request replaces the static `⋯` character we used to insert when folding a range with a custom render function that return an `AnyElement`. We plan to use this in the assistant, but for now this should be behavior-preserving.

Release Notes:

- N/A