### PR TITLE
gleam: Detect tests using `describe` API for Startest

### DIFF
--- a/extensions/gleam/languages/gleam/runnables.scm
+++ b/extensions/gleam/languages/gleam/runnables.scm
@@ -4,3 +4,17 @@
     (function name: (_) @run
         (#match? @run ".*_test$"))
 ) @gleam-test
+
+; `describe` API for Startest.
+(
+    (function_call
+        function: (_) @name
+        (#any-of? @name "describe" "it")
+        arguments: (arguments
+            .
+            (argument
+                value: (string (quoted_content) @run)
+            )
+        )
+    )
+) @gleam-test


### PR DESCRIPTION
This PR updates the Gleam runnables to detect tests using the `describe` API in Startest.

This isn't entirely functional yet, as it is still just uses the test function name to run the tests (which Startest doesn't yet support).

Release Notes:

- N/A
