### PR TITLE
Vim smorgasbord

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -155,6 +155,7 @@
       "g shift-t": "pane::ActivatePrevItem",
       "g d": "editor::GoToDefinition",
       "g shift-d": "editor::GoToTypeDefinition",
+      "g cmd-d": "editor::GoToImplementation",
       "g x": "editor::OpenUrl",
       "g n": "vim::SelectNextMatch",
       "g shift-n": "vim::SelectPreviousMatch",
@@ -244,6 +245,10 @@
           "displayLines": true
         }
       ],
+      "] d": "editor::GoToDiagnostic",
+      "[ d": "editor::GoToPrevDiagnostic",
+      "] c": "editor::GoToHunk",
+      "[ c": "editor::GoToPrevHunk",
       "g ]": "editor::GoToDiagnostic",
       "g [": "editor::GoToPrevDiagnostic",
       "g i": ["workspace::SendKeystrokes", "` ^ i"],

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -245,10 +245,6 @@
           "displayLines": true
         }
       ],
-      "] d": "editor::GoToDiagnostic",
-      "[ d": "editor::GoToPrevDiagnostic",
-      "] c": "editor::GoToHunk",
-      "[ c": "editor::GoToPrevHunk",
       "g ]": "editor::GoToDiagnostic",
       "g [": "editor::GoToPrevDiagnostic",
       "g i": ["workspace::SendKeystrokes", "` ^ i"],
@@ -389,7 +385,11 @@
       "ctrl-pageup": "pane::ActivatePrevItem",
       // tree-sitter related commands
       "[ x": "editor::SelectLargerSyntaxNode",
-      "] x": "editor::SelectSmallerSyntaxNode"
+      "] x": "editor::SelectSmallerSyntaxNode",
+      "] d": "editor::GoToDiagnostic",
+      "[ d": "editor::GoToPrevDiagnostic",
+      "] c": "editor::GoToHunk",
+      "[ c": "editor::GoToPrevHunk"
     }
   },
   {

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -16,10 +16,11 @@ Vim mode has several "core Zed" key bindings, that will help you make the most o
 
 ```
 # Language server
-g d   Go to definition
-g D   Go to type definition
-c d   Rename (change definition)
-g A   Go to All references to the current word
+g d     Go to definition
+g D     Go to type definition
+g cmd-d Go to implementation
+c d     Rename (change definition)
+g A     Go to All references to the current word
 
 g s   Find symbol in current file
 g S   Find symbol in entire project
@@ -28,6 +29,10 @@ g ]   Go to next diagnostic
 g [   Go to previous diagnostic
 g h   Show inline error (hover)
 g .   Open the code actions menu
+
+# Git
+] c   Go to previous git change
+[ c   Go to next git change
 
 # Treesitter
 ] x   Select a smaller syntax node
@@ -190,6 +195,9 @@ Currently supported vim-specific commands:
 As any Zed command is available, you may find that it's helpful to remember mnemonics that run the correct command. For example:
 
 ```
+:diff    Toggle Hunk [Diff]
+:diffs    Toggle all Hunk [Diffs]
+:revert  Revert Selected Hunks
 :cpp  [C]o[p]y [P]ath to file
 :crp  [C]opy [r]elative [P]ath
 :reveal [Reveal] in finder


### PR DESCRIPTION
Release Notes:

- vim: Added `]d/[d` for go to prev/next diagnostic
- vim: Added `]c/[c` to go to prev/next git change (`:diff` and `:revert` show the diff and revert it)
- vim: Added `g cmd-d` for go to implementation
