### PR TITLE
Highlight files ending in `mdwn` as Markdown

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -1,6 +1,6 @@
 name = "Markdown"
 grammar = "markdown"
-path_suffixes = ["md", "mdx"]
+path_suffixes = ["md", "mdx", "mdwn"]
 word_characters = ["-"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
Highlight files ending in `mdwn` as Markdown.

(Ikiwiki uses `mdwn` as the file extension for Markdown.)

This pull request was inspired by this one:

- #1209/

Release Notes:

- Added ".mdwn" as a Markdown file extension.