### PR TITLE
docs: Fix path to "configuring-zed" page in Python lang doc

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -48,7 +48,7 @@ venv = ".venv"
 
 ### Code formatting
 
-The Pyright language server does not provide code formatting. If you want to automatically reformat your Python code when saving, you'll need to specify an \_external_code formatter in your settings. See the [configuration](../configuring_zed.md) documentation for more information.
+The Pyright language server does not provide code formatting. If you want to automatically reformat your Python code when saving, you'll need to specify an \_external_code formatter in your settings. See the [configuration](../configuring-zed.md) documentation for more information.
 
 A common tool for formatting python code is [Black](https://black.readthedocs.io/en/stable/). If you have Black installed globally, you can use it to format Python files by adding the following to your `settings.json`:
 


### PR DESCRIPTION
Fix path to the `configuring-zed` page in Python language documentation.

Release Notes:

- N/A
