### PR TITLE
Show Delete shortcuts in project panel context menu

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -569,8 +569,8 @@
       "enter": "project_panel::Rename",
       "backspace": "project_panel::Trash",
       "delete": "project_panel::Trash",
-      "ctrl-backspace": ["project_panel::Delete", { "skip_prompt": true }],
-      "ctrl-delete": ["project_panel::Delete", { "skip_prompt": true }],
+      "ctrl-backspace": ["project_panel::Delete", { "skip_prompt": false }],
+      "ctrl-delete": ["project_panel::Delete", { "skip_prompt": false }],
       "alt-ctrl-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -578,10 +578,10 @@
       "cmd-alt-c": "project_panel::CopyPath",
       "alt-cmd-shift-c": "project_panel::CopyRelativePath",
       "enter": "project_panel::Rename",
-      "backspace": "project_panel::Trash",
-      "delete": "project_panel::Trash",
-      "cmd-backspace": ["project_panel::Delete", { "skip_prompt": true }],
-      "cmd-delete": ["project_panel::Delete", { "skip_prompt": true }],
+      "backspace": ["project_panel::Trash", { "skip_prompt": false }],
+      "delete": ["project_panel::Trash", { "skip_prompt": false }],
+      "cmd-backspace": ["project_panel::Delete", { "skip_prompt": false }],
+      "cmd-delete": ["project_panel::Delete", { "skip_prompt": false }],
       "alt-cmd-r": "project_panel::RevealInFinder",
       "alt-shift-f": "project_panel::NewSearchInDirectory"
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/12234 by making both default keymap and the menu `Delete` action declarations to have the same `skip_prompt` value.
`Trash` action got more explicit `skip_prompt` declarations in this PR, but those were the defaults already, so not changed.

Now, `Delete` action in the project panel will always show a prompt before removing, both on the keystroke and menu item click.
To note, VSCode does skips prompt for the `Trash` action, so we might want to change that too (later?), the PR does not alter it.

Release Notes:

- Shows Delete action binding keys in the project panel context menu ([12234](https://github.com/zed-industries/zed/issues/12234))