### PR TITLE
Extract `SlashCommand` trait from `assistant`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ version = "0.1.0"
 dependencies = [
  "anthropic",
  "anyhow",
+ "assistant_slash_command",
  "cargo_toml",
  "chrono",
  "client",
@@ -424,6 +425,18 @@ dependencies = [
  "unindent",
  "util",
  "workspace",
+]
+
+[[package]]
+name = "assistant_slash_command"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "collections",
+ "derive_more",
+ "futures 0.3.28",
+ "gpui",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/assets",
     "crates/assistant",
     "crates/assistant2",
+    "crates/assistant_slash_command",
     "crates/assistant_tooling",
     "crates/audio",
     "crates/auto_update",
@@ -148,6 +149,7 @@ anthropic = { path = "crates/anthropic" }
 assets = { path = "crates/assets" }
 assistant = { path = "crates/assistant" }
 assistant2 = { path = "crates/assistant2" }
+assistant_slash_command = { path = "crates/assistant_slash_command" }
 assistant_tooling = { path = "crates/assistant_tooling" }
 audio = { path = "crates/audio" }
 auto_update = { path = "crates/auto_update" }

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 anthropic = { workspace = true, features = ["schemars"] }
+assistant_slash_command.workspace = true
 cargo_toml.workspace = true
 chrono.workspace = true
 client.workspace = true

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -17,7 +17,6 @@ use client::{proto, Client};
 use command_palette_hooks::CommandPaletteFilter;
 pub(crate) use completion_provider::*;
 use gpui::{actions, AppContext, Global, SharedString, UpdateGlobal};
-pub(crate) use prompts::prompt_library::*;
 pub(crate) use saved_conversation::*;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};

--- a/crates/assistant_slash_command/Cargo.toml
+++ b/crates/assistant_slash_command/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "assistant_slash_command"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/assistant_slash_command.rs"
+
+[dependencies]
+anyhow.workspace = true
+collections.workspace = true
+derive_more.workspace = true
+futures.workspace = true
+gpui.workspace = true
+parking_lot.workspace = true

--- a/crates/assistant_slash_command/LICENSE-GPL
+++ b/crates/assistant_slash_command/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -1,0 +1,50 @@
+mod slash_command_registry;
+
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::channel::oneshot;
+use gpui::{AppContext, Task};
+
+pub use slash_command_registry::*;
+
+pub fn init(cx: &mut AppContext) {
+    SlashCommandRegistry::default_global(cx);
+}
+
+pub trait SlashCommand: 'static + Send + Sync {
+    fn name(&self) -> String;
+    fn description(&self) -> String;
+    fn complete_argument(
+        &self,
+        query: String,
+        cancel: Arc<AtomicBool>,
+        cx: &mut AppContext,
+    ) -> Task<Result<Vec<String>>>;
+    fn requires_argument(&self) -> bool;
+    fn run(&self, argument: Option<&str>, cx: &mut AppContext) -> SlashCommandInvocation;
+}
+
+pub struct SlashCommandInvocation {
+    pub output: Task<Result<String>>,
+    pub invalidated: oneshot::Receiver<()>,
+    pub cleanup: SlashCommandCleanup,
+}
+
+#[derive(Default)]
+pub struct SlashCommandCleanup(Option<Box<dyn FnOnce()>>);
+
+impl SlashCommandCleanup {
+    pub fn new(cleanup: impl FnOnce() + 'static) -> Self {
+        Self(Some(Box::new(cleanup)))
+    }
+}
+
+impl Drop for SlashCommandCleanup {
+    fn drop(&mut self) {
+        if let Some(cleanup) = self.0.take() {
+            cleanup();
+        }
+    }
+}

--- a/crates/assistant_slash_command/src/slash_command_registry.rs
+++ b/crates/assistant_slash_command/src/slash_command_registry.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use collections::HashMap;
+use derive_more::{Deref, DerefMut};
+use gpui::Global;
+use gpui::{AppContext, ReadGlobal};
+use parking_lot::RwLock;
+
+use crate::SlashCommand;
+
+#[derive(Default, Deref, DerefMut)]
+struct GlobalSlashCommandRegistry(Arc<SlashCommandRegistry>);
+
+impl Global for GlobalSlashCommandRegistry {}
+
+#[derive(Default)]
+struct SlashCommandRegistryState {
+    commands: HashMap<Arc<str>, Arc<dyn SlashCommand>>,
+}
+
+#[derive(Default)]
+pub struct SlashCommandRegistry {
+    state: RwLock<SlashCommandRegistryState>,
+}
+
+impl SlashCommandRegistry {
+    /// Returns the global [`SlashCommandRegistry`].
+    pub fn global(cx: &AppContext) -> Arc<Self> {
+        GlobalSlashCommandRegistry::global(cx).0.clone()
+    }
+
+    /// Returns the global [`SlashCommandRegistry`].
+    ///
+    /// Inserts a default [`SlashCommandRegistry`] if one does not yet exist.
+    pub fn default_global(cx: &mut AppContext) -> Arc<Self> {
+        cx.default_global::<GlobalSlashCommandRegistry>().0.clone()
+    }
+
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: RwLock::new(SlashCommandRegistryState {
+                commands: HashMap::default(),
+            }),
+        })
+    }
+
+    /// Registers the provided [`SlashCommand`].
+    pub fn register_command(&self, command: impl SlashCommand) {
+        self.state
+            .write()
+            .commands
+            .insert(command.name().into(), Arc::new(command));
+    }
+
+    /// Returns the names of registered [`SlashCommand`]s.
+    pub fn command_names(&self) -> Vec<Arc<str>> {
+        self.state.read().commands.keys().cloned().collect()
+    }
+
+    /// Returns the [`SlashCommand`] with the given name.
+    pub fn command(&self, name: &str) -> Option<Arc<dyn SlashCommand>> {
+        self.state.read().commands.get(name).cloned()
+    }
+}


### PR DESCRIPTION
This PR extracts the `SlashCommand` trait (along with the `SlashCommandRegistry`) from the `assistant` crate.

This will allow us to register slash commands from extensions without having to make `extension` depend on `assistant`.

Release Notes:

- N/A
