### PR TITLE
assistant: Add missing `lints.workspace`

### DIFF
--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/assistant.rs"
 doctest = false


### PR DESCRIPTION
This PR adds the missing `lints.workspace` setting to the `assistant` crate's `Cargo.toml`.

Release Notes:

- N/A
