### PR TITLE
linux: Add `make` dependency for Debian and Ubuntu

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -15,6 +15,7 @@ if [[ -n $apt ]]; then
   deps=(
     gcc
     g++
+    make
     libasound2-dev
     libfontconfig-dev
     libwayland-dev


### PR DESCRIPTION
Fixes #12251.

Release Notes:

- N/A