### PR TITLE
Always default to creating a new window on open recent

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -473,7 +473,7 @@ impl CollabTitlebarItem {
                 Tooltip::for_action(
                     "Recent Projects",
                     &recent_projects::OpenRecent {
-                        create_new_window: false,
+                        create_new_window: true,
                     },
                     cx,
                 )
@@ -481,7 +481,7 @@ impl CollabTitlebarItem {
             .on_click(cx.listener(move |_, _, cx| {
                 if let Some(workspace) = workspace.upgrade() {
                     workspace.update(cx, |workspace, cx| {
-                        RecentProjects::open(workspace, false, cx);
+                        RecentProjects::open(workspace, true, cx);
                     })
                 }
             }))

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -202,7 +202,7 @@ impl PickerDelegate for RecentProjectsDelegate {
             )
         };
         Arc::from(format!(
-            "{reuse_window} reuses this window, {create_window} opens a new one",
+            "{create_window} opens a new window, {reuse_window} reuses this one",
         ))
     }
 

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -779,7 +779,7 @@ mod tests {
             !cx.has_pending_prompt(),
             "Should have no pending prompt on dirty project before opening the new recent project"
         );
-        cx.dispatch_action(*workspace, menu::Confirm);
+        cx.dispatch_action(*workspace, menu::SecondaryConfirm); //secondary confirm opens in the same window
         workspace
             .update(cx, |workspace, cx| {
                 assert!(

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -815,7 +815,7 @@ mod tests {
         cx.dispatch_action(
             (*workspace).into(),
             OpenRecent {
-                create_new_window: false,
+                create_new_window: true,
             },
         );
         workspace


### PR DESCRIPTION

Release Notes:

- Fixed #12202 

There are three methods of prompting to open a recent project. Using the keyboard shortcut, using the menu bar, and clicking the project name in the top left of the window. Before, clicking the project name would map `enter` to reusing the current window and while `⌘enter` opens the project in a new window, and the other two had the reverse mapping. This PR standardizes all three methods to open a new window by default, and reuse the same window with the command key. 

<img width="621" alt="image" src="https://github.com/zed-industries/zed/assets/50590465/27ee3a09-d432-4a18-ba5b-eb2a5c27bdb6">
 