### PR TITLE
Fix documentation for setting up ruby-lsp

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -60,6 +60,11 @@ Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell 
         }
       }
     }
+  },
+  "language_overrides": {
+    "Ruby": {
+      "language_servers": ["ruby-lsp"]
+    }
   }
 }
 ```

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -61,7 +61,7 @@ Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell 
       }
     }
   },
-  "language_overrides": {
+  "languages": {
     "Ruby": {
       "language_servers": ["ruby-lsp"]
     }


### PR DESCRIPTION
Release Notes:

- N/A

`ruby-lsp` is disable by default [since here](https://github.com/zed-industries/zed/pull/11768/files). The docs forgot to mention that you also need to override `language_servers` option for Ruby language