### PR TITLE
docs: Update Ruby docs

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -3,7 +3,25 @@
 - Tree Sitter: [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby)
 - Language Servers: [solargraph](https://github.com/castwide/solargraph), [ruby-lsp](https://github.com/Shopify/ruby-lsp)
 
-### Setting up `solargraph`
+## Choosing a language server
+
+The Ruby extension offers both `solargraph` and `ruby-lsp` language server support.
+
+`solargraph` is enabled by default.
+
+To switch to `ruby-lsp`, add the following to your `settings.json`:
+
+```json
+{
+  "languages": {
+    "Ruby": {
+      "language_servers": ["ruby-lsp", "..."]
+    }
+  }
+}
+```
+
+## Setting up `solargraph`
 
 Zed currently doesn't install Solargraph automatically. To use Solargraph, you need to install the gem. Zed just looks for an executable called `solargraph` on your `PATH`.
 
@@ -38,7 +56,7 @@ Solargraph has formatting and diagnostics disabled by default. We can tell Zed t
 
 Solargraph reads its configuration from a file called `.solargraph.yml` in the root of your project. For more information about this file, see the [Solargraph configuration documentation](https://solargraph.org/guides/configuration).
 
-### Setting up `ruby-lsp`
+## Setting up `ruby-lsp`
 
 Zed currently doesn't install Ruby LSP automatically. To use Ruby LSP, you need to install the gem. Zed just looks for an executable called `ruby-lsp` on your `PATH`.
 


### PR DESCRIPTION
This PR updates the Ruby docs with a note on how to switch to using `ruby-lsp`.

Release Notes:

- N/A
