### PR TITLE
node_runtime: Restrict the `windows` dependency to the Windows target

### DIFF
--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -31,10 +31,10 @@ smol.workspace = true
 tempfile = { workspace = true, optional = true }
 util.workspace = true
 walkdir = "2.5.0"
-windows.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 async-std = { version = "1.12.0", features = ["unstable"] }
+windows.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
This PR fixes an issue where the `windows` dependency was being included on non-Windows targets.

Resolves https://github.com/zed-industries/zed/issues/12282.

Release Notes:

- N/A
