### PR TITLE
json: Add runnable for `package.json` and `composer.json` scripts

### DIFF
--- a/crates/languages/src/json/runnables.scm
+++ b/crates/languages/src/json/runnables.scm
@@ -5,12 +5,12 @@
         (object
             (pair
                 key: (string
-                    (string_content) @name
-                    (#eq? @name "scripts")
+                    (string_content) @_name
+                    (#eq? @_name "scripts")
                 )
                 value: (object
                     (pair
-                        key: (string (string_content) @run)
+                        key: (string (string_content) @run @script)
                         value: (string (string_content))
                     )
                 )

--- a/crates/languages/src/json/runnables.scm
+++ b/crates/languages/src/json/runnables.scm
@@ -17,4 +17,5 @@
         )
     )
     (#set! tag package-script)
+    (#set! tag composer-script)
 )

--- a/crates/languages/src/json/runnables.scm
+++ b/crates/languages/src/json/runnables.scm
@@ -1,0 +1,21 @@
+; Add support package.json script runnable
+
+(
+    (document
+        (object
+            (pair
+                key: (string
+                    (string_content) @name
+                    (#eq? @name "scripts")
+                )
+                value: (object
+                    (pair
+                        key: (string (string_content) @run)
+                        value: (string (string_content))
+                    )
+                )
+            )
+        )
+    ) @package-script
+    (#set! tag package-script)
+)

--- a/crates/languages/src/json/runnables.scm
+++ b/crates/languages/src/json/runnables.scm
@@ -15,6 +15,6 @@
                 )
             )
         )
-    ) @package-script
+    )
     (#set! tag package-script)
 )

--- a/crates/languages/src/json/runnables.scm
+++ b/crates/languages/src/json/runnables.scm
@@ -1,4 +1,4 @@
-; Add support package.json script runnable
+; Add support `package.json` and `composer.json` script runnable
 
 (
     (document
@@ -11,7 +11,6 @@
                 value: (object
                     (pair
                         key: (string (string_content) @run @script)
-                        value: (string (string_content))
                     )
                 )
             )

--- a/crates/languages/src/json/tasks.json
+++ b/crates/languages/src/json/tasks.json
@@ -1,8 +1,8 @@
 [
   {
-    "label": "package script $ZED_SYMBOL",
+    "label": "package script $ZED_CUSTOM_script",
     "command": "npm run",
-    "args": ["$ZED_SYMBOL"],
+    "args": ["$ZED_CUSTOM_script"],
     "tags": ["package-script"]
   }
 ]

--- a/crates/languages/src/json/tasks.json
+++ b/crates/languages/src/json/tasks.json
@@ -9,6 +9,6 @@
     "label": "composer script $ZED_CUSTOM_script",
     "command": "composer",
     "args": ["$ZED_CUSTOM_script"],
-    "tags": ["package-script"]
+    "tags": ["composer-script"]
   }
 ]

--- a/crates/languages/src/json/tasks.json
+++ b/crates/languages/src/json/tasks.json
@@ -1,0 +1,8 @@
+[
+  {
+    "label": "package script $ZED_SYMBOL",
+    "command": "npm run",
+    "args": ["$ZED_SYMBOL"],
+    "tags": ["package-script"]
+  }
+]

--- a/crates/languages/src/json/tasks.json
+++ b/crates/languages/src/json/tasks.json
@@ -4,5 +4,11 @@
     "command": "npm run",
     "args": ["$ZED_CUSTOM_script"],
     "tags": ["package-script"]
+  },
+  {
+    "label": "composer script $ZED_CUSTOM_script",
+    "command": "composer",
+    "args": ["$ZED_CUSTOM_script"],
+    "tags": ["package-script"]
   }
 ]


### PR DESCRIPTION
**Package.json**

https://github.com/zed-industries/zed/assets/62463826/f8ca12a5-1292-4465-83e1-3c2ab65f5833

**Composer.json**

https://github.com/zed-industries/zed/assets/62463826/61f9e74d-c6ed-4329-855b-d0161e0a117b

Release Notes:

- Added runnable for `package.json` and `composer.json` scripts ([#12215](https://github.com/zed-industries/zed/issues/12215)).