### PR TITLE
docs: Add an entry for msys2 package

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -64,6 +64,19 @@ And to run the tests:
 cargo test --workspace
 ```
 
+## Installing from msys2
+
+[MSYS2](https://msys2.org/) distribution provides Zed as a package. To download the prebuilt binary, run
+
+```
+pacman -S mingw-w64-ucrt-x86_64-zed
+```
+
+then you can run `zed` in a UCRT64 shell.
+
+> [!NOTE]
+> Please, report any issue in https://github.com/msys2/MINGW-packages/issues first.
+
 ## Troubleshooting
 
 ### Can't compile zed


### PR DESCRIPTION
a package for Zed is now avialable in msys2 repository so let the users know about it. [package page](https://packages.msys2.org/base/mingw-w64-zed)

Release Notes:

- N/A
