### PR TITLE
Call `OleInitialize` to fix `DirectWrite` in `TestPlatform` on windows

### DIFF
--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -38,6 +38,12 @@ pub(crate) struct TestPrompts {
 
 impl TestPlatform {
     pub fn new(executor: BackgroundExecutor, foreground_executor: ForegroundExecutor) -> Rc<Self> {
+        #[cfg(target_os = "windows")]
+        unsafe {
+            windows::Win32::System::Ole::OleInitialize(None)
+                .expect("unable to initialize Windows OLE");
+        }
+
         Rc::new_cyclic(|weak| TestPlatform {
             background_executor: executor,
             foreground_executor,


### PR DESCRIPTION
Running the tests on windows currently fails for every gpui test using the `TestPlatform` with 

```rs
called `Result::unwrap()` on an `Err` value: CoInitialize has not been called. (0x800401F0)
```
trying to call `CoCreateInstance`in the `DirectWriteComponent`.

The `WindowsPlatform` calls [`OleInitialize`](https://learn.microsoft.com/de-de/windows/win32/api/ole2/nf-ole2-oleinitialize) which internally calls `CoInitializeEx` so I just copied that to the `TestPlatform`.

Release Notes:

- N/A
