### PR TITLE
Fix ctrl click to open file on windows

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -405,7 +405,7 @@ impl TerminalBuilder {
         let _io_thread = event_loop.spawn(); // DANGER
 
         let url_regex = RegexSearch::new(r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`]+"#).unwrap();
-        let word_regex = RegexSearch::new(r#"[\$\+\w.\[\]:/@\-~]+"#).unwrap();
+        let word_regex = RegexSearch::new(r#"[\$\+\w.\[\]:/\\@\-~]+"#).unwrap();
 
         let terminal = Terminal {
             task,


### PR DESCRIPTION
There were two issues:
1. the `ModifiersChanged` event was never emitted on windows.
macOS, x11 and wayland have separate events for this, while on windows they are sent via the usual `keyup` and `keydown` events, but `parse_keydown_msg_keystroke` just ignored them.
2. the word segmenting regex didn't include '\' so paths weren't correctly detected

fixes https://github.com/zed-industries/zed/issues/12321

Release Notes:

- N/A
