### PR TITLE
Add MSI packaging script using wix

### DIFF
--- a/script/msi/.gitignore
+++ b/script/msi/.gitignore
@@ -1,0 +1,2 @@
+/Zed.msi
+/Zed.wixpdb

--- a/script/msi/Zed.wxs
+++ b/script/msi/Zed.wxs
@@ -1,0 +1,27 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="Zed" Manufacturer="todo" Version="1.2.0.0"
+        UpgradeCode="b60cd678-9e93-453f-80ac-a7d602a6356e">
+        <MediaTemplate EmbedCab="true" />
+        <MajorUpgrade
+            AllowSameVersionUpgrades="yes"
+            DowngradeErrorMessage="A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via the Control Panel" />
+        <Icon Id="icon.ico" SourceFile="crates/zed/resources/windows/app-icon.ico" />
+
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="!(bind.Property.ProductName)" />
+        </StandardDirectory>
+
+        <Feature Id="Main">
+            <Component Directory="INSTALLFOLDER">
+                <File Source="target/release/Zed.exe" KeyPath="true">
+                    <Shortcut Id="Shortcut"
+                        Name="Zed"
+                        Icon="icon.ico"
+                        Directory="StartMenuFolder"
+                        Advertise="true">
+                    </Shortcut>
+                </File>
+            </Component>
+        </Feature>
+    </Package>
+</Wix>

--- a/script/msi/Zed.wxs
+++ b/script/msi/Zed.wxs
@@ -24,6 +24,36 @@
                         Advertise="true">
                     </Shortcut>
                 </File>
+                <File Source="crates/zed/resources/windows/app-icon.ico" Name="icon.ico" />
+            </Component>
+        </Feature>
+
+        <Feature Id="OpenWith">
+            <Component>
+                <!-- Add context menu entry for all files -->
+                <RegistryKey Root="HKCR" Key="*\shell\Zed">
+                    <RegistryValue Type="string" Value="Open with Zed" />
+                    <RegistryKey Key="command">
+                        <RegistryValue Type="string" Value='"[INSTALLFOLDER]Zed.exe" "%1"' />
+                    </RegistryKey>
+                    <RegistryValue Type="string" Name="Icon" Value="[INSTALLFOLDER]icon.ico" />
+                </RegistryKey>
+                <!-- Add context menu entry for all directories -->
+                <RegistryKey Root="HKCR" Key="Directory\shell\Zed">
+                    <RegistryValue Type="string" Value="Open with Zed" />
+                    <RegistryKey Key="command">
+                        <RegistryValue Type="string" Value='"[INSTALLFOLDER]Zed.exe" "%1"' />
+                    </RegistryKey>
+                    <RegistryValue Type="string" Name="Icon" Value="[INSTALLFOLDER]icon.ico" />
+                </RegistryKey>
+                <!-- Add context menu entry for background of directories -->
+                <RegistryKey Root="HKCR" Key="Directory\Background\shell\Zed">
+                    <RegistryValue Type="string" Value="Open with Zed" />
+                    <RegistryKey Key="command">
+                        <RegistryValue Type="string" Value='"[INSTALLFOLDER]Zed.exe" .' />
+                    </RegistryKey>
+                    <RegistryValue Type="string" Name="Icon" Value="[INSTALLFOLDER]\icon.ico" />
+                </RegistryKey>
             </Component>
         </Feature>
     </Package>

--- a/script/msi/Zed.wxs
+++ b/script/msi/Zed.wxs
@@ -7,6 +7,9 @@
             DowngradeErrorMessage="A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via the Control Panel" />
         <Icon Id="icon.ico" SourceFile="crates/zed/resources/windows/app-icon.ico" />
 
+        <!-- App icon in Add/Remove Programs-->
+        <Property Id="ARPPRODUCTICON" Value="icon.ico"></Property>
+
         <StandardDirectory Id="ProgramFilesFolder">
             <Directory Id="INSTALLFOLDER" Name="!(bind.Property.ProductName)" />
         </StandardDirectory>

--- a/script/msi/package.bat
+++ b/script/msi/package.bat
@@ -1,0 +1,1 @@
+wix build script/msi/Zed.wxs


### PR DESCRIPTION
implements #12288 

Add a simple wix package for building an MSI that
- installs Zed to `Program Files`
- `Open with Zed` menu in the file explorer

![image](https://github.com/zed-industries/zed/assets/22177966/439d28ec-876a-476e-99d6-7bf8244602f9)

## Open questions
1. the installer currently uncontionally installs the "Open with handler", should this be configurable? there's a wixui feature tree we could use https://wixtoolset.org/docs/tools/wixext/wixui/
2. do you wanna sign the installer? no idea how that works but I heard you might get a certificate from signpath.io for free for larger open source projects https://github.com/sigstore/fulcio/issues/250#issuecomment-1697130810 https://signpath.org/

Release Notes:

- N/A
