### PR TITLE
Fix some warnings/issues uncovered by the new cfg checking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -492,5 +492,10 @@ non_canonical_partial_ord_impl = "allow"
 reversed_empty_ranges = "allow"
 type_complexity = "allow"
 
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(gles)' # used in gpui
+] }
+
 [workspace.metadata.cargo-machete]
 ignored = ["bindgen", "cbindgen", "prost_build", "serde"]

--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -713,7 +713,7 @@ impl Database {
                     .find_also_related(user::Entity)
                     .filter(channel_member::Column::ChannelId.eq(channel.root_id()));
 
-                if cfg!(any(test, sqlite)) && self.pool.get_database_backend() == DbBackend::Sqlite {
+                if cfg!(any(test, feature = "sqlite")) && self.pool.get_database_backend() == DbBackend::Sqlite {
                     query = query.filter(Expr::cust_with_values(
                         "UPPER(github_login) LIKE ?",
                         [Self::fuzzy_like_string(&filter.to_uppercase())],

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -8,6 +8,9 @@ license = "GPL-3.0-or-later"
 [lints]
 workspace = true
 
+[features]
+test-support = []
+
 [dependencies]
 anyhow.workspace = true
 async-compression.workspace = true

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -144,7 +144,6 @@ pub enum MarkdownTag {
 
     /// A footnote definition. The value contained is the footnote's label by which it can
     /// be referred to.
-    #[cfg_attr(feature = "serde", serde(borrow))]
     FootnoteDefinition(SharedString),
 
     /// A table. Contains a vector describing the text-alignment for each of its columns.


### PR DESCRIPTION
Rust recently got the ability to check for typos or errors in `cfg` attributes: https://blog.rust-lang.org/2024/05/06/check-cfg.html
This PR fixes the new warnings.

- gpui can be run with `RUSTFLAGS="--cfg gles"`, make this explicit in `[workspace.lints.rust]`
- `cfg!(any(test, sqlite))` was just a bug, it should be `feature(sqlite)`
- the `languages` crate had a `#[cfg(any(test, feature = "test-support"))]` function without ever declaring the `test-support` feature
- the `MarkdownTag` enum had  a `cfg_attr` for serde without actually having serde support


Now the only warnings when building are unused fields `InlayHover.excerpt`, `SavedConversationMetadata.path` , `UserTestPlan.allow_client_reconnection` and `SyntaxMapCapture.depth`.

Release Notes:

- N/A
