### PR TITLE
Create prompts dir if it doesn't exist

### DIFF
--- a/crates/assistant/src/prompts/prompt_library.rs
+++ b/crates/assistant/src/prompts/prompt_library.rs
@@ -129,6 +129,7 @@ impl PromptLibrary {
     /// Load the state of the prompt library from the file system
     /// or create a new one if it doesn't exist
     pub async fn load_index(fs: Arc<dyn Fs>) -> anyhow::Result<Self> {
+        fs.create_dir(&PROMPTS_DIR).await?;
         let path = PROMPTS_DIR.join("index.json");
 
         let state = if fs.is_file(&path).await {


### PR DESCRIPTION
Fixes
```
[2024-05-26T11:46:46+02:00 ERROR util] crates/assistant/src/assistant_panel.rs:153: No such file or directory (os error 2)
```

Release Notes:

- N/A
