### PR TITLE
Cargo.toml: fix build warning caused by unused manifest key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -492,10 +492,5 @@ non_canonical_partial_ord_impl = "allow"
 reversed_empty_ranges = "allow"
 type_complexity = "allow"
 
-[workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(gles)' # used in gpui
-] }
-
 [workspace.metadata.cargo-machete]
 ignored = ["bindgen", "cbindgen", "prost_build", "serde"]


### PR DESCRIPTION

#12310 recently introduced a build warning

```rust
warning: zed/Cargo.toml: unused manifest key: workspace.lints.rust.unexpected_cfgs.check-cfg
```

By removing this code the build warning goes away

```rust
[workspace.lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = [
    'cfg(gles)' # used in gpui
] }
```

Release Notes:

- N/A
