### PR TITLE
windows: Improve file_finder to support match with unix style path

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -54,7 +54,7 @@ struct Args {
 fn parse_path_with_position(
     argument_str: &str,
 ) -> Result<PathLikeWithPosition<PathBuf>, std::convert::Infallible> {
-    PathLikeWithPosition::parse_str(argument_str, |path_str| {
+    PathLikeWithPosition::parse_str(argument_str, |_, path_str| {
         Ok(Path::new(path_str).to_path_buf())
     })
 }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -800,7 +800,7 @@ impl PickerDelegate for FileFinderDelegate {
             cx.notify();
             Task::ready(())
         } else {
-            let query = PathLikeWithPosition::parse_str(&raw_query, |path_like_str| {
+            let query = PathLikeWithPosition::parse_str(raw_query, |path_like_str| {
                 Ok::<_, std::convert::Infallible>(FileSearchQuery {
                     raw_query: raw_query.to_owned(),
                     file_query_end: if path_like_str == raw_query {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -800,8 +800,6 @@ impl PickerDelegate for FileFinderDelegate {
             cx.notify();
             Task::ready(())
         } else {
-            #[cfg(windows)]
-            let raw_query = raw_query.replace('/', "\\");
             let query = PathLikeWithPosition::parse_str(&raw_query, |path_like_str| {
                 Ok::<_, std::convert::Infallible>(FileSearchQuery {
                     raw_query: raw_query.to_owned(),

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -800,17 +800,18 @@ impl PickerDelegate for FileFinderDelegate {
             cx.notify();
             Task::ready(())
         } else {
-            let query = PathLikeWithPosition::parse_str(raw_query, |path_like_str| {
-                Ok::<_, std::convert::Infallible>(FileSearchQuery {
-                    raw_query: raw_query.to_owned(),
-                    file_query_end: if path_like_str == raw_query {
-                        None
-                    } else {
-                        Some(path_like_str.len())
-                    },
+            let query =
+                PathLikeWithPosition::parse_str(&raw_query, |formated_query, path_like_str| {
+                    Ok::<_, std::convert::Infallible>(FileSearchQuery {
+                        raw_query: formated_query.to_owned(),
+                        file_query_end: if path_like_str == raw_query {
+                            None
+                        } else {
+                            Some(path_like_str.len())
+                        },
+                    })
                 })
-            })
-            .expect("infallible");
+                .expect("infallible");
 
             if Path::new(query.path_like.path_query()).is_absolute() {
                 self.lookup_absolute_path(query, cx)

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -801,9 +801,9 @@ impl PickerDelegate for FileFinderDelegate {
             Task::ready(())
         } else {
             let query =
-                PathLikeWithPosition::parse_str(&raw_query, |formated_query, path_like_str| {
+                PathLikeWithPosition::parse_str(&raw_query, |normalized_query, path_like_str| {
                     Ok::<_, std::convert::Infallible>(FileSearchQuery {
-                        raw_query: formated_query.to_owned(),
+                        raw_query: normalized_query.to_owned(),
                         file_query_end: if path_like_str == raw_query {
                             None
                         } else {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -800,7 +800,9 @@ impl PickerDelegate for FileFinderDelegate {
             cx.notify();
             Task::ready(())
         } else {
-            let query = PathLikeWithPosition::parse_str(raw_query, |path_like_str| {
+            #[cfg(windows)]
+            let raw_query = raw_query.replace('/', "\\");
+            let query = PathLikeWithPosition::parse_str(&raw_query, |path_like_str| {
                 Ok::<_, std::convert::Infallible>(FileSearchQuery {
                     raw_query: raw_query.to_owned(),
                     file_query_end: if path_like_str == raw_query {

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1816,9 +1816,9 @@ fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
 }
 
 fn test_path_like(test_str: &str) -> PathLikeWithPosition<FileSearchQuery> {
-    PathLikeWithPosition::parse_str(test_str, |formated, path_like_str| {
+    PathLikeWithPosition::parse_str(test_str, |normalized_query, path_like_str| {
         Ok::<_, std::convert::Infallible>(FileSearchQuery {
-            raw_query: formated.to_owned(),
+            raw_query: normalized_query.to_owned(),
             file_query_end: if path_like_str == test_str {
                 None
             } else {

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1816,9 +1816,9 @@ fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
 }
 
 fn test_path_like(test_str: &str) -> PathLikeWithPosition<FileSearchQuery> {
-    PathLikeWithPosition::parse_str(test_str, |path_like_str| {
+    PathLikeWithPosition::parse_str(test_str, |formated, path_like_str| {
         Ok::<_, std::convert::Infallible>(FileSearchQuery {
-            raw_query: test_str.to_owned(),
+            raw_query: formated.to_owned(),
             file_query_end: if path_like_str == test_str {
                 None
             } else {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -636,7 +636,7 @@ fn possible_open_targets(
     maybe_path: &String,
     cx: &mut ViewContext<TerminalView>,
 ) -> Task<Vec<(PathLikeWithPosition<PathBuf>, Metadata)>> {
-    let path_like = PathLikeWithPosition::parse_str(maybe_path.as_str(), |path_str| {
+    let path_like = PathLikeWithPosition::parse_str(maybe_path.as_str(), |_, path_str| {
         Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
     })
     .expect("infallible");

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -182,7 +182,7 @@ impl<P> PathLikeWithPosition<P> {
     /// Parses a string that possibly has `:row:column` suffix.
     /// Ignores trailing `:`s, so `test.rs:22:` is parsed as `test.rs:22`.
     /// If any of the row/column component parsing fails, the whole string is then parsed as a path like.
-    /// If on windows, will replace `/` with `\` in the path for compatibility.
+    /// If on Windows, will replace `/` with `\` in the path for compatibility.
     pub fn parse_str<E>(
         s: &str,
         parse_path_like_str: impl Fn(&str) -> Result<P, E>,

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -195,6 +195,9 @@ impl<P> PathLikeWithPosition<P> {
             })
         };
 
+        #[cfg(target_os = "windows")]
+        let s = &s.replace('/', "\\");
+
         let trimmed = s.trim();
 
         #[cfg(target_os = "windows")]
@@ -203,9 +206,6 @@ impl<P> PathLikeWithPosition<P> {
             if is_absolute {
                 return Self::parse_absolute_path(trimmed, parse_path_like_str);
             }
-
-            // Replace `/` with `\` for compatibility.
-            let trimmed = trimmed.replace('/', "\\");
         }
 
         match trimmed.split_once(FILE_ROW_COLUMN_DELIMITER) {
@@ -538,6 +538,14 @@ mod tests {
                 PathLikeWithPosition {
                     path_like: "crates\\utils\\paths.rs".to_string(),
                     row: None,
+                    column: None,
+                },
+            ),
+            (
+                "crates/utils/paths.rs:101",
+                PathLikeWithPosition {
+                    path_like: "crates\\utils\\paths.rs".to_string(),
+                    row: Some(101),
                     column: None,
                 },
             ),

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -185,11 +185,11 @@ impl<P> PathLikeWithPosition<P> {
     /// If on Windows, will replace `/` with `\` in the path for compatibility.
     pub fn parse_str<E>(
         s: &str,
-        parse_path_like_str: impl Fn(&str) -> Result<P, E>,
+        parse_path_like_str: impl Fn(&str, &str) -> Result<P, E>,
     ) -> Result<Self, E> {
         let fallback = |fallback_str| {
             Ok(Self {
-                path_like: parse_path_like_str(fallback_str)?,
+                path_like: parse_path_like_str(s, fallback_str)?,
                 row: None,
                 column: None,
             })
@@ -229,7 +229,7 @@ impl<P> PathLikeWithPosition<P> {
                         Ok(row) => {
                             if maybe_col_str.is_empty() {
                                 Ok(Self {
-                                    path_like: parse_path_like_str(path_like_str)?,
+                                    path_like: parse_path_like_str(s, path_like_str)?,
                                     row: Some(row),
                                     column: None,
                                 })
@@ -238,12 +238,12 @@ impl<P> PathLikeWithPosition<P> {
                                     maybe_col_str.split_once(':').unwrap_or((maybe_col_str, ""));
                                 match maybe_col_str.parse::<u32>() {
                                     Ok(col) => Ok(Self {
-                                        path_like: parse_path_like_str(path_like_str)?,
+                                        path_like: parse_path_like_str(s, path_like_str)?,
                                         row: Some(row),
                                         column: Some(col),
                                     }),
                                     Err(_) => Ok(Self {
-                                        path_like: parse_path_like_str(path_like_str)?,
+                                        path_like: parse_path_like_str(s, path_like_str)?,
                                         row: Some(row),
                                         column: None,
                                     }),
@@ -251,7 +251,7 @@ impl<P> PathLikeWithPosition<P> {
                             }
                         }
                         Err(_) => Ok(Self {
-                            path_like: parse_path_like_str(path_like_str)?,
+                            path_like: parse_path_like_str(s, path_like_str)?,
                             row: None,
                             column: None,
                         }),
@@ -393,7 +393,7 @@ mod tests {
     type TestPath = PathLikeWithPosition<String>;
 
     fn parse_str(s: &str) -> TestPath {
-        TestPath::parse_str(s, |s| Ok::<_, std::convert::Infallible>(s.to_string()))
+        TestPath::parse_str(s, |_, s| Ok::<_, std::convert::Infallible>(s.to_string()))
             .expect("infallible")
     }
 

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -182,6 +182,7 @@ impl<P> PathLikeWithPosition<P> {
     /// Parses a string that possibly has `:row:column` suffix.
     /// Ignores trailing `:`s, so `test.rs:22:` is parsed as `test.rs:22`.
     /// If any of the row/column component parsing fails, the whole string is then parsed as a path like.
+    /// If on windows, will replace `/` with `\` in the path for compatibility.
     pub fn parse_str<E>(
         s: &str,
         parse_path_like_str: impl Fn(&str) -> Result<P, E>,
@@ -202,6 +203,9 @@ impl<P> PathLikeWithPosition<P> {
             if is_absolute {
                 return Self::parse_absolute_path(trimmed, parse_path_like_str);
             }
+
+            // Replace `/` with `\` for compatibility.
+            let trimmed = trimmed.replace('/', "\\");
         }
 
         match trimmed.split_once(FILE_ROW_COLUMN_DELIMITER) {
@@ -526,6 +530,14 @@ mod tests {
                 PathLikeWithPosition {
                     path_like: "C:\\Users\\someone\\test_file.rs".to_string(),
                     row: Some(1902),
+                    column: None,
+                },
+            ),
+            (
+                "crates/utils/paths.rs",
+                PathLikeWithPosition {
+                    path_like: "crates\\utils\\paths.rs".to_string(),
+                    row: None,
                     column: None,
                 },
             ),

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -55,7 +55,7 @@ impl OpenRequest {
     fn parse_file_path(&mut self, file: &str) {
         if let Some(decoded) = urlencoding::decode(file).log_err() {
             if let Some(path_buf) =
-                PathLikeWithPosition::parse_str(&decoded, |s| PathBuf::try_from(s)).log_err()
+                PathLikeWithPosition::parse_str(&decoded, |_, s| PathBuf::try_from(s)).log_err()
             {
                 self.open_paths.push(path_buf)
             }
@@ -291,7 +291,7 @@ pub async fn handle_cli_connection(
                         .map(|path_with_position_string| {
                             PathLikeWithPosition::parse_str(
                                 &path_with_position_string,
-                                |path_str| {
+                                |_, path_str| {
                                     Ok::<_, std::convert::Infallible>(
                                         Path::new(path_str).to_path_buf(),
                                     )


### PR DESCRIPTION
Release Notes:

- Improved file_finder to support match with Unix style path.


Sometimes we may get the Unix style path string, for example the result of `git status`:

```bash
$ git status
On branch improve-file-finder-match-unix-paths
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   crates/file_finder/src/file_finder.rs
```

For example, from GitHub page:

<img width="760" alt="image" src="https://github.com/zed-industries/zed/assets/5518/c6fe8d8a-839e-4eef-a162-43b1dde09593">

If we copy that path to file_finder, it will not match any files on Windows.

## Before

<img width="699" alt="屏幕截图 2024-05-28 001037" src="https://github.com/zed-industries/zed/assets/5518/2d2d729e-7d27-421b-9a38-cfe4e53cc033">


## After

Use Unix style path:

<img width="689" alt="屏幕截图 2024-05-28 001150" src="https://github.com/zed-industries/zed/assets/5518/e82dc8d6-bd6c-4b78-bd91-5b5210da73c4">

Use Windows style path:

<img width="629" alt="屏幕截图 2024-05-28 001302" src="https://github.com/zed-industries/zed/assets/5518/4892019e-b2f4-41aa-bbf7-2f5f8af7aafa">
