### PR TITLE
windows: Fix project prepare_ssh_shell to support setting PATH on Windows

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -417,6 +417,7 @@ mod tests {
 
     #[test]
     fn test_add_environment_path_empty_env() {
+        let tmp_path = std::path::PathBuf::from("/tmp/new");
         let mut env = HashMap::default();
         env.insert("OTHER".to_string(), "aaa".to_string());
         let os_path = std::env::var("PATH").unwrap();

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -377,7 +377,7 @@ fn prepare_ssh_shell(
     Ok(Shell::WithArguments { program, args })
 }
 
-fn prepare_env_paths(env: &mut HashMap<String, String>, add_path: &Path) -> anyhow::Result<()> {
+fn add_environment_path(env: &mut HashMap<String, String>, new_path: &Path) -> anyhow::Result<()> {
     let mut env_paths = vec![add_path.to_path_buf()];
     if let Some(path) = env.get("PATH").or(env::var("PATH").ok().as_ref()) {
         let mut paths = std::env::split_paths(&path).collect::<Vec<_>>();

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -268,7 +268,7 @@ impl Project {
             );
 
             // We need to set the PATH to include the virtual environment's bin directory
-            prepare_env_paths(env, &path.join("bin")).log_err();
+            add_environment_path(env, &path.join("bin")).log_err();
         }
     }
 
@@ -370,7 +370,7 @@ fn prepare_ssh_shell(
     #[cfg(not(target_os = "windows"))]
     std::fs::set_permissions(ssh_path, smol::fs::unix::PermissionsExt::from_mode(0o755))?;
 
-    prepare_env_paths(env, tmp_dir)?;
+    add_environment_path(env, tmp_dir)?;
 
     let mut args = shlex::split(&ssh_command).unwrap_or_default();
     let program = args.drain(0..1).next().unwrap_or("ssh".to_string());
@@ -395,7 +395,7 @@ mod tests {
     use collections::HashMap;
 
     #[test]
-    fn test_prepare_env_paths() {
+    fn test_add_environment_path() {
         let tmp_path = std::path::PathBuf::from("/tmp/new");
         let mut env = HashMap::default();
         let old_path = if cfg!(windows) {
@@ -406,7 +406,7 @@ mod tests {
         env.insert("PATH".to_string(), old_path.to_string());
         env.insert("OTHER".to_string(), "aaa".to_string());
 
-        super::prepare_env_paths(&mut env, &tmp_path).unwrap();
+        super::add_environment_path(&mut env, &tmp_path).unwrap();
         if cfg!(windows) {
             assert_eq!(env.get("PATH").unwrap(), &format!("/tmp/new;{}", old_path));
         } else {
@@ -417,7 +417,7 @@ mod tests {
         let mut env = HashMap::default();
         env.insert("OTHER".to_string(), "aaa".to_string());
         let os_path = std::env::var("PATH").unwrap();
-        super::prepare_env_paths(&mut env, &tmp_path).unwrap();
+        super::add_environment_path(&mut env, &tmp_path).unwrap();
         if cfg!(windows) {
             assert_eq!(env.get("PATH").unwrap(), &format!("/tmp/new;{}", os_path));
         } else {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -398,14 +398,19 @@ mod tests {
     fn test_prepare_env_paths() {
         let tmp_path = std::path::PathBuf::from("/tmp/new");
         let mut env = HashMap::default();
-        env.insert("PATH".to_string(), "/usr/bin:/usr/local/bin".to_string());
+        let old_path = if cfg!(windows) {
+            "/usr/bin;/usr/local/bin"
+        } else {
+            "/usr/bin:/usr/local/bin"
+        };
+        env.insert("PATH".to_string(), old_path.to_string());
         env.insert("OTHER".to_string(), "aaa".to_string());
 
         super::prepare_env_paths(&mut env, &tmp_path).unwrap();
         if cfg!(windows) {
-            assert_eq!(env.get("PATH").unwrap(), "/tmp/new;/usr/bin;/usr/local/bin");
+            assert_eq!(env.get("PATH").unwrap(), &format!("/tmp/new;{}", old_path));
         } else {
-            assert_eq!(env.get("PATH").unwrap(), "/tmp/new:/usr/bin:/usr/local/bin");
+            assert_eq!(env.get("PATH").unwrap(), &format!("/tmp/new:{}", old_path));
         }
         assert_eq!(env.get("OTHER").unwrap(), "aaa");
 

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -378,7 +378,7 @@ fn prepare_ssh_shell(
 }
 
 fn add_environment_path(env: &mut HashMap<String, String>, new_path: &Path) -> anyhow::Result<()> {
-    let mut env_paths = vec![add_path.to_path_buf()];
+    let mut env_paths = vec![new_path.to_path_buf()];
     if let Some(path) = env.get("PATH").or(env::var("PATH").ok().as_ref()) {
         let mut paths = std::env::split_paths(&path).collect::<Vec<_>>();
         env_paths.append(&mut paths);
@@ -395,7 +395,7 @@ mod tests {
     use collections::HashMap;
 
     #[test]
-    fn test_add_environment_path() {
+    fn test_add_environment_path_with_existing_env() {
         let tmp_path = std::path::PathBuf::from("/tmp/new");
         let mut env = HashMap::default();
         let old_path = if cfg!(windows) {
@@ -413,7 +413,10 @@ mod tests {
             assert_eq!(env.get("PATH").unwrap(), &format!("/tmp/new:{}", old_path));
         }
         assert_eq!(env.get("OTHER").unwrap(), "aaa");
+    }
 
+    #[test]
+    fn test_add_environment_path_empty_env() {
         let mut env = HashMap::default();
         env.insert("OTHER".to_string(), "aaa".to_string());
         let os_path = std::env::var("PATH").unwrap();

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -395,7 +395,7 @@ mod tests {
     use collections::HashMap;
 
     #[test]
-    fn test_add_environment_path_with_existing_env() {
+    fn test_add_environment_path_with_existing_path() {
         let tmp_path = std::path::PathBuf::from("/tmp/new");
         let mut env = HashMap::default();
         let old_path = if cfg!(windows) {
@@ -416,7 +416,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_environment_path_with_empty_env() {
+    fn test_add_environment_path_with_empty_path() {
         let tmp_path = std::path::PathBuf::from("/tmp/new");
         let mut env = HashMap::default();
         env.insert("OTHER".to_string(), "aaa".to_string());

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -416,7 +416,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_environment_path_empty_env() {
+    fn test_add_environment_path_with_empty_env() {
         let tmp_path = std::path::PathBuf::from("/tmp/new");
         let mut env = HashMap::default();
         env.insert("OTHER".to_string(), "aaa".to_string());


### PR DESCRIPTION
Release Notes:

- N/A

Update to use `std::env::join_paths` to prepare `PATH` env.

Ref https://github.com/zed-industries/zed/pull/12087#issuecomment-2122852384 @mrnugget 