### PR TITLE
Introduce `/search` command to assistant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "rope",
  "schemars",
  "search",
+ "semantic_index",
  "serde",
  "serde_json",
  "settings",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -41,6 +41,7 @@ regex.workspace = true
 rope.workspace = true
 schemars.workspace = true
 search.workspace = true
+semantic_index.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,4 +1,5 @@
 use crate::prompts::{generate_content_prompt, PromptLibrary, PromptManager};
+use crate::slash_command::search_command;
 use crate::{
     assistant_settings::{AssistantDockPosition, AssistantSettings, ZedDotDevModel},
     codegen::{self, Codegen, CodegenKind},
@@ -208,6 +209,7 @@ impl AssistantPanel {
                     );
                     slash_command_registry.register_command(active_command::ActiveSlashCommand);
                     slash_command_registry.register_command(project_command::ProjectSlashCommand);
+                    slash_command_registry.register_command(search_command::SearchSlashCommand);
 
                     Self {
                         workspace: workspace_handle,

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -20,6 +20,7 @@ pub mod active_command;
 pub mod file_command;
 pub mod project_command;
 pub mod prompt_command;
+pub mod search_command;
 
 pub(crate) struct SlashCommandCompletionProvider {
     editor: WeakView<ConversationEditor>,

--- a/crates/assistant/src/slash_command/active_command.rs
+++ b/crates/assistant/src/slash_command/active_command.rs
@@ -1,5 +1,6 @@
 use super::{file_command::FilePlaceholder, SlashCommand, SlashCommandOutput};
 use anyhow::{anyhow, Result};
+use assistant_slash_command::SlashCommandOutputSection;
 use collections::HashMap;
 use editor::Editor;
 use gpui::{AppContext, Entity, Task, WeakView};
@@ -96,16 +97,22 @@ impl SlashCommand for ActiveSlashCommand {
                     }
                 });
                 cx.foreground_executor().spawn(async move {
+                    let text = text.await;
+                    let range = 0..text.len();
                     Ok(SlashCommandOutput {
-                        text: text.await,
-                        render_placeholder: Arc::new(move |id, unfold, _| {
-                            FilePlaceholder {
-                                id,
-                                path: path.clone(),
-                                unfold,
-                            }
-                            .into_any_element()
-                        }),
+                        text,
+                        sections: vec![SlashCommandOutputSection {
+                            range,
+                            render_placeholder: Arc::new(move |id, unfold, _| {
+                                FilePlaceholder {
+                                    id,
+                                    path: path.clone(),
+                                    line_range: None,
+                                    unfold,
+                                }
+                                .into_any_element()
+                            }),
+                        }],
                     })
                 })
             } else {

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -1,5 +1,6 @@
 use super::{SlashCommand, SlashCommandOutput};
 use anyhow::{anyhow, Context, Result};
+use assistant_slash_command::SlashCommandOutputSection;
 use fs::Fs;
 use gpui::{AppContext, Model, Task, WeakView};
 use language::LspAdapterDelegate;
@@ -131,18 +132,21 @@ impl SlashCommand for ProjectSlashCommand {
 
             cx.foreground_executor().spawn(async move {
                 let text = output.await?;
-
+                let range = 0..text.len();
                 Ok(SlashCommandOutput {
                     text,
-                    render_placeholder: Arc::new(move |id, unfold, _cx| {
-                        ButtonLike::new(id)
-                            .style(ButtonStyle::Filled)
-                            .layer(ElevationIndex::ElevatedSurface)
-                            .child(Icon::new(IconName::FileTree))
-                            .child(Label::new("Project"))
-                            .on_click(move |_, cx| unfold(cx))
-                            .into_any_element()
-                    }),
+                    sections: vec![SlashCommandOutputSection {
+                        range,
+                        render_placeholder: Arc::new(move |id, unfold, _cx| {
+                            ButtonLike::new(id)
+                                .style(ButtonStyle::Filled)
+                                .layer(ElevationIndex::ElevatedSurface)
+                                .child(Icon::new(IconName::FileTree))
+                                .child(Label::new("Project"))
+                                .on_click(move |_, cx| unfold(cx))
+                                .into_any_element()
+                        }),
+                    }],
                 })
             })
         });

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -1,6 +1,7 @@
 use super::{SlashCommand, SlashCommandOutput};
 use crate::prompts::PromptLibrary;
 use anyhow::{anyhow, Context, Result};
+use assistant_slash_command::SlashCommandOutputSection;
 use fuzzy::StringMatchCandidate;
 use gpui::{AppContext, Task, WeakView};
 use language::LspAdapterDelegate;
@@ -94,17 +95,21 @@ impl SlashCommand for PromptSlashCommand {
         });
         cx.foreground_executor().spawn(async move {
             let prompt = prompt.await?;
+            let range = 0..prompt.len();
             Ok(SlashCommandOutput {
                 text: prompt,
-                render_placeholder: Arc::new(move |id, unfold, _cx| {
-                    ButtonLike::new(id)
-                        .style(ButtonStyle::Filled)
-                        .layer(ElevationIndex::ElevatedSurface)
-                        .child(Icon::new(IconName::Library))
-                        .child(Label::new(title.clone()))
-                        .on_click(move |_, cx| unfold(cx))
-                        .into_any_element()
-                }),
+                sections: vec![SlashCommandOutputSection {
+                    range,
+                    render_placeholder: Arc::new(move |id, unfold, _cx| {
+                        ButtonLike::new(id)
+                            .style(ButtonStyle::Filled)
+                            .layer(ElevationIndex::ElevatedSurface)
+                            .child(Icon::new(IconName::Library))
+                            .child(Label::new(title.clone()))
+                            .on_click(move |_, cx| unfold(cx))
+                            .into_any_element()
+                    }),
+                }],
             })
         })
     }

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -1,0 +1,118 @@
+use super::{SlashCommand, SlashCommandOutput};
+use anyhow::Result;
+use gpui::{AppContext, RenderOnce, Task, WeakView};
+use language::LspAdapterDelegate;
+use semantic_index::SemanticIndex;
+use std::sync::{atomic::AtomicBool, Arc};
+use ui::{prelude::*, ButtonLike, ElevationIndex, Icon, IconName};
+use workspace::Workspace;
+
+pub(crate) struct SearchSlashCommand;
+
+impl SlashCommand for SearchSlashCommand {
+    fn name(&self) -> String {
+        "search".into()
+    }
+
+    fn description(&self) -> String {
+        "semantically search files".into()
+    }
+
+    fn tooltip_text(&self) -> String {
+        "search".into()
+    }
+
+    fn requires_argument(&self) -> bool {
+        true
+    }
+
+    fn complete_argument(
+        &self,
+        _query: String,
+        _cancel: Arc<AtomicBool>,
+        _cx: &mut AppContext,
+    ) -> Task<Result<Vec<String>>> {
+        Task::ready(Ok(Vec::new()))
+    }
+
+    fn run(
+        self: Arc<Self>,
+        argument: Option<&str>,
+        workspace: WeakView<Workspace>,
+        _delegate: Arc<dyn LspAdapterDelegate>,
+        cx: &mut WindowContext,
+    ) -> Task<Result<SlashCommandOutput>> {
+        let Some(workspace) = workspace.upgrade() else {
+            return Task::ready(Err(anyhow::anyhow!("workspace was dropped")));
+        };
+        let Some(argument) = argument else {
+            return Task::ready(Err(anyhow::anyhow!("missing search query")));
+        };
+        if argument.is_empty() {
+            return Task::ready(Err(anyhow::anyhow!("missing search query")));
+        }
+
+        let project = workspace.read(cx).project().clone();
+        let argument = argument.to_string();
+        let fs = project.read(cx).fs().clone();
+        let project_index =
+            cx.update_global(|index: &mut SemanticIndex, cx| index.project_index(project, cx));
+
+        cx.spawn(|cx| async move {
+            let results = project_index
+                .read_with(&cx, |project_index, cx| {
+                    project_index.search(argument, 5, cx)
+                })?
+                .await?;
+
+            let mut output = String::new();
+            for result in results {
+                let content = result
+                    .worktree
+                    .read_with(&cx, |worktree, _cx| {
+                        let entry_abs_path = worktree.abs_path().join(&result.path);
+                        async {
+                            let entry_abs_path = entry_abs_path;
+                            fs.load(&entry_abs_path).await
+                        }
+                    })?
+                    .await?;
+
+                let range_start = result.range.start.min(content.len());
+                let range_end = result.range.end.min(content.len());
+
+                let start_line = content[0..range_start].matches('\n').count() + 1;
+                let end_line = content[0..range_end].matches('\n').count() + 1;
+                let start_line_byte_offset = content[0..range_start]
+                    .rfind('\n')
+                    .map(|pos| pos + 1)
+                    .unwrap_or_default();
+                let end_line_byte_offset = content[range_end..]
+                    .find('\n')
+                    .map(|pos| range_end + pos)
+                    .unwrap_or_else(|| content.len());
+                output.push_str(&format!(
+                    "```{}:{}-{}\n",
+                    result.path.display(),
+                    start_line,
+                    end_line,
+                ));
+                output.push_str(&content[start_line_byte_offset..end_line_byte_offset]);
+                output.push_str("\n```\n\n");
+            }
+
+            Ok(SlashCommandOutput {
+                text: output,
+                render_placeholder: Arc::new(move |id, unfold, _cx| {
+                    ButtonLike::new(id)
+                        .style(ButtonStyle::Filled)
+                        .layer(ElevationIndex::ElevatedSurface)
+                        .child(Icon::new(IconName::MagnifyingGlass))
+                        .child(Label::new("Search Results"))
+                        .on_click(move |_, cx| unfold(cx))
+                        .into_any_element()
+                }),
+            })
+        })
+    }
+}

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -1,10 +1,16 @@
-use super::{SlashCommand, SlashCommandOutput};
+use super::{file_command::FilePlaceholder, SlashCommand, SlashCommandOutput};
 use anyhow::Result;
-use gpui::{AppContext, RenderOnce, Task, WeakView};
-use language::LspAdapterDelegate;
+use assistant_slash_command::SlashCommandOutputSection;
+use gpui::{AppContext, Task, WeakView};
+use language::{LineEnding, LspAdapterDelegate};
 use semantic_index::SemanticIndex;
-use std::sync::{atomic::AtomicBool, Arc};
+use std::{
+    fmt::Write,
+    path::PathBuf,
+    sync::{atomic::AtomicBool, Arc},
+};
 use ui::{prelude::*, ButtonLike, ElevationIndex, Icon, IconName};
+use util::ResultExt;
 use workspace::Workspace;
 
 pub(crate) struct SearchSlashCommand;
@@ -61,58 +67,84 @@ impl SlashCommand for SearchSlashCommand {
         cx.spawn(|cx| async move {
             let results = project_index
                 .read_with(&cx, |project_index, cx| {
-                    project_index.search(argument, 5, cx)
+                    project_index.search(argument.clone(), 5, cx)
                 })?
                 .await?;
 
-            let mut output = String::new();
+            let mut sections = Vec::new();
+            let mut text = format!("Search results for {argument}:\n");
             for result in results {
-                let content = result
-                    .worktree
-                    .read_with(&cx, |worktree, _cx| {
+                let (full_path, file_content) =
+                    result.worktree.read_with(&cx, |worktree, _cx| {
                         let entry_abs_path = worktree.abs_path().join(&result.path);
-                        async {
+                        let mut entry_full_path = PathBuf::from(worktree.root_name());
+                        entry_full_path.push(&result.path);
+                        let file_content = async {
                             let entry_abs_path = entry_abs_path;
                             fs.load(&entry_abs_path).await
-                        }
-                    })?
-                    .await?;
+                        };
+                        (entry_full_path, file_content)
+                    })?;
 
-                let range_start = result.range.start.min(content.len());
-                let range_end = result.range.end.min(content.len());
+                if let Some(file_content) = file_content.await.log_err() {
+                    let range_start = result.range.start.min(file_content.len());
+                    let range_end = result.range.end.min(file_content.len());
 
-                let start_line = content[0..range_start].matches('\n').count() + 1;
-                let end_line = content[0..range_end].matches('\n').count() + 1;
-                let start_line_byte_offset = content[0..range_start]
-                    .rfind('\n')
-                    .map(|pos| pos + 1)
-                    .unwrap_or_default();
-                let end_line_byte_offset = content[range_end..]
-                    .find('\n')
-                    .map(|pos| range_end + pos)
-                    .unwrap_or_else(|| content.len());
-                output.push_str(&format!(
-                    "```{}:{}-{}\n",
-                    result.path.display(),
-                    start_line,
-                    end_line,
-                ));
-                output.push_str(&content[start_line_byte_offset..end_line_byte_offset]);
-                output.push_str("\n```\n\n");
+                    let start_line = file_content[0..range_start].matches('\n').count() as u32 + 1;
+                    let end_line = file_content[0..range_end].matches('\n').count() as u32 + 1;
+                    let start_line_byte_offset = file_content[0..range_start]
+                        .rfind('\n')
+                        .map(|pos| pos + 1)
+                        .unwrap_or_default();
+                    let end_line_byte_offset = file_content[range_end..]
+                        .find('\n')
+                        .map(|pos| range_end + pos)
+                        .unwrap_or_else(|| file_content.len());
+
+                    let section_start_ix = text.len();
+                    writeln!(
+                        text,
+                        "```{}:{}-{}",
+                        result.path.display(),
+                        start_line,
+                        end_line,
+                    )?;
+                    let mut excerpt =
+                        file_content[start_line_byte_offset..end_line_byte_offset].to_string();
+                    LineEnding::normalize(&mut excerpt);
+                    text.push_str(&excerpt);
+                    writeln!(text, "\n```\n")?;
+                    let section_end_ix = text.len() - 1;
+
+                    sections.push(SlashCommandOutputSection {
+                        range: section_start_ix..section_end_ix,
+                        render_placeholder: Arc::new(move |id, unfold, _| {
+                            FilePlaceholder {
+                                id,
+                                path: Some(full_path.clone()),
+                                line_range: Some(start_line..end_line),
+                                unfold,
+                            }
+                            .into_any_element()
+                        }),
+                    });
+                }
             }
 
-            Ok(SlashCommandOutput {
-                text: output,
+            let argument = SharedString::from(argument);
+            sections.push(SlashCommandOutputSection {
+                range: 0..text.len(),
                 render_placeholder: Arc::new(move |id, unfold, _cx| {
                     ButtonLike::new(id)
                         .style(ButtonStyle::Filled)
                         .layer(ElevationIndex::ElevatedSurface)
                         .child(Icon::new(IconName::MagnifyingGlass))
-                        .child(Label::new("Search Results"))
+                        .child(Label::new(argument.clone()))
                         .on_click(move |_, cx| unfold(cx))
                         .into_any_element()
                 }),
-            })
+            });
+            Ok(SlashCommandOutput { text, sections })
         })
     }
 }

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -71,8 +71,7 @@ impl SlashCommand for SearchSlashCommand {
                 })?
                 .await?;
 
-            let mut sections = Vec::new();
-            let mut text = format!("Search results for {argument}:\n");
+            let mut loaded_results = Vec::new();
             for result in results {
                 let (full_path, file_content) =
                     result.worktree.read_with(&cx, |worktree, _cx| {
@@ -85,66 +84,81 @@ impl SlashCommand for SearchSlashCommand {
                         };
                         (entry_full_path, file_content)
                     })?;
-
                 if let Some(file_content) = file_content.await.log_err() {
-                    let range_start = result.range.start.min(file_content.len());
-                    let range_end = result.range.end.min(file_content.len());
-
-                    let start_line = file_content[0..range_start].matches('\n').count() as u32 + 1;
-                    let end_line = file_content[0..range_end].matches('\n').count() as u32 + 1;
-                    let start_line_byte_offset = file_content[0..range_start]
-                        .rfind('\n')
-                        .map(|pos| pos + 1)
-                        .unwrap_or_default();
-                    let end_line_byte_offset = file_content[range_end..]
-                        .find('\n')
-                        .map(|pos| range_end + pos)
-                        .unwrap_or_else(|| file_content.len());
-
-                    let section_start_ix = text.len();
-                    writeln!(
-                        text,
-                        "```{}:{}-{}",
-                        result.path.display(),
-                        start_line,
-                        end_line,
-                    )?;
-                    let mut excerpt =
-                        file_content[start_line_byte_offset..end_line_byte_offset].to_string();
-                    LineEnding::normalize(&mut excerpt);
-                    text.push_str(&excerpt);
-                    writeln!(text, "\n```\n")?;
-                    let section_end_ix = text.len() - 1;
-
-                    sections.push(SlashCommandOutputSection {
-                        range: section_start_ix..section_end_ix,
-                        render_placeholder: Arc::new(move |id, unfold, _| {
-                            FilePlaceholder {
-                                id,
-                                path: Some(full_path.clone()),
-                                line_range: Some(start_line..end_line),
-                                unfold,
-                            }
-                            .into_any_element()
-                        }),
-                    });
+                    loaded_results.push((result, full_path, file_content));
                 }
             }
 
-            let argument = SharedString::from(argument);
-            sections.push(SlashCommandOutputSection {
-                range: 0..text.len(),
-                render_placeholder: Arc::new(move |id, unfold, _cx| {
-                    ButtonLike::new(id)
-                        .style(ButtonStyle::Filled)
-                        .layer(ElevationIndex::ElevatedSurface)
-                        .child(Icon::new(IconName::MagnifyingGlass))
-                        .child(Label::new(argument.clone()))
-                        .on_click(move |_, cx| unfold(cx))
-                        .into_any_element()
-                }),
-            });
-            Ok(SlashCommandOutput { text, sections })
+            let output = cx
+                .background_executor()
+                .spawn(async move {
+                    let mut text = format!("Search results for {argument}:\n");
+                    let mut sections = Vec::new();
+                    for (result, full_path, file_content) in loaded_results {
+                        let range_start = result.range.start.min(file_content.len());
+                        let range_end = result.range.end.min(file_content.len());
+
+                        let start_line =
+                            file_content[0..range_start].matches('\n').count() as u32 + 1;
+                        let end_line = file_content[0..range_end].matches('\n').count() as u32 + 1;
+                        let start_line_byte_offset = file_content[0..range_start]
+                            .rfind('\n')
+                            .map(|pos| pos + 1)
+                            .unwrap_or_default();
+                        let end_line_byte_offset = file_content[range_end..]
+                            .find('\n')
+                            .map(|pos| range_end + pos)
+                            .unwrap_or_else(|| file_content.len());
+
+                        let section_start_ix = text.len();
+                        writeln!(
+                            text,
+                            "```{}:{}-{}",
+                            result.path.display(),
+                            start_line,
+                            end_line,
+                        )
+                        .unwrap();
+                        let mut excerpt =
+                            file_content[start_line_byte_offset..end_line_byte_offset].to_string();
+                        LineEnding::normalize(&mut excerpt);
+                        text.push_str(&excerpt);
+                        writeln!(text, "\n```\n").unwrap();
+                        let section_end_ix = text.len() - 1;
+
+                        sections.push(SlashCommandOutputSection {
+                            range: section_start_ix..section_end_ix,
+                            render_placeholder: Arc::new(move |id, unfold, _| {
+                                FilePlaceholder {
+                                    id,
+                                    path: Some(full_path.clone()),
+                                    line_range: Some(start_line..end_line),
+                                    unfold,
+                                }
+                                .into_any_element()
+                            }),
+                        });
+                    }
+
+                    let argument = SharedString::from(argument);
+                    sections.push(SlashCommandOutputSection {
+                        range: 0..text.len(),
+                        render_placeholder: Arc::new(move |id, unfold, _cx| {
+                            ButtonLike::new(id)
+                                .style(ButtonStyle::Filled)
+                                .layer(ElevationIndex::ElevatedSurface)
+                                .child(Icon::new(IconName::MagnifyingGlass))
+                                .child(Label::new(argument.clone()))
+                                .on_click(move |_, cx| unfold(cx))
+                                .into_any_element()
+                        }),
+                    });
+
+                    SlashCommandOutput { text, sections }
+                })
+                .await;
+
+            Ok(output)
         })
     }
 }

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -4,7 +4,10 @@ use anyhow::Result;
 use gpui::{AnyElement, AppContext, ElementId, Task, WeakView, WindowContext};
 use language::LspAdapterDelegate;
 pub use slash_command_registry::*;
-use std::sync::{atomic::AtomicBool, Arc};
+use std::{
+    ops::Range,
+    sync::{atomic::AtomicBool, Arc},
+};
 use workspace::Workspace;
 
 pub fn init(cx: &mut AppContext) {
@@ -44,5 +47,11 @@ pub type RenderFoldPlaceholder = Arc<
 
 pub struct SlashCommandOutput {
     pub text: String,
+    pub sections: Vec<SlashCommandOutputSection<usize>>,
+}
+
+#[derive(Clone)]
+pub struct SlashCommandOutputSection<T> {
+    pub range: Range<T>,
     pub render_placeholder: RenderFoldPlaceholder,
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -72,7 +72,7 @@ pub use language_registry::{
 pub use lsp::LanguageServerId;
 pub use outline::{Outline, OutlineItem};
 pub use syntax_map::{OwnedSyntaxLayer, SyntaxLayer};
-pub use text::LineEnding;
+pub use text::{AnchorRangeExt, LineEnding};
 pub use tree_sitter::{Node, Parser, Tree, TreeCursor};
 
 /// Initializes the `language` crate.

--- a/crates/semantic_index/src/embedding/cloud.rs
+++ b/crates/semantic_index/src/embedding/cloud.rs
@@ -24,6 +24,10 @@ impl EmbeddingProvider for CloudEmbeddingProvider {
         // First, fetch any embeddings that are cached based on the requested texts' digests
         // Then compute any embeddings that are missing.
         async move {
+            if !self.client.status().borrow().is_connected() {
+                return Err(anyhow!("sign in required"));
+            }
+
             let cached_embeddings = self.client.request(proto::GetCachedEmbeddings {
                 model: self.model.clone(),
                 digests: texts

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1017,6 +1017,7 @@ mod tests {
         let workspace_1 = cx
             .read(|cx| cx.windows()[0].downcast::<Workspace>())
             .unwrap();
+        cx.run_until_parked();
         workspace_1
             .update(cx, |workspace, cx| {
                 assert_eq!(workspace.worktrees(cx).count(), 2);


### PR DESCRIPTION
This pull request introduces semantic search to the assistant using a slash command:

https://github.com/zed-industries/zed/assets/482957/62f39eae-d7d5-46bf-a356-dd081ff88312

Moreover, this also adds a status to pending slash commands, so that we can show when a query is running or whether it failed:

<img width="1588" alt="image" src="https://github.com/zed-industries/zed/assets/482957/e8d85960-6275-4552-a068-85efb74cfde1">

I think this could be better design-wise, but seems like a pretty good start.

Release Notes:

- N/A