### PR TITLE
Add placeholder for extension slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "task",
  "theme",
  "toml 0.8.10",
+ "ui",
  "url",
  "util",
  "wasm-encoder",

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -39,6 +39,7 @@ serde_json.workspace = true
 settings.workspace = true
 theme.workspace = true
 toml.workspace = true
+ui.workspace = true
 url.workspace = true
 util.workspace = true
 wasm-encoder.workspace = true


### PR DESCRIPTION
This PR adds a slightly better placeholder for extension slash commands than the current "TODO" text.

Right now we display the command name and an arbitrary icon.

<img width="644" alt="Screenshot 2024-05-28 at 12 15 07 PM" src="https://github.com/zed-industries/zed/assets/1486634/11761797-5ccc-4209-8b00-70b714f10a78">

Release Notes:

- N/A
