### PR TITLE
Add xdg trash support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ name = "fs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ashpd",
  "async-tar",
  "async-trait",
  "cocoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,6 +255,7 @@ zed_actions = { path = "crates/zed_actions" }
 
 anyhow = "1.0.57"
 any_vec = "0.13"
+ashpd = "0.8.0"
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
 async-fs = "1.6"
 async-recursion = "1.0.0"
@@ -283,9 +284,7 @@ futures-batch = "0.6.1"
 futures-lite = "1.13"
 git2 = { version = "0.18", default-features = false }
 globset = "0.4"
-heed = { version = "0.20.1", features = [
-    "read-txn-no-tls",
-] }
+heed = { version = "0.20.1", features = ["read-txn-no-tls"] }
 hex = "0.4.3"
 ignore = "0.4.22"
 indoc = "1"
@@ -492,7 +491,7 @@ type_complexity = "allow"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(gles)' # used in gpui
+    'cfg(gles)', # used in gpui
 ] }
 
 [workspace.metadata.cargo-machete]

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -46,6 +46,9 @@ notify = "6.1.1"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+ashpd.workspace = true
+
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -3,8 +3,11 @@ use git::GitHostingProviderRegistry;
 
 #[cfg(target_os = "linux")]
 use ashpd::desktop::trash;
+#[cfg(target_os = "linux")]
+use std::{os::fd::AsFd,fs::File};
+
 #[cfg(unix)]
-use std::os::{fd::AsFd, unix::fs::MetadataExt};
+use std::os::unix::fs::MetadataExt;
 
 use async_tar::Archive;
 use futures::{future::BoxFuture, AsyncRead, Stream, StreamExt};
@@ -19,7 +22,6 @@ use smol::io::AsyncWriteExt;
 use std::io::Write;
 use std::sync::Arc;
 use std::{
-    fs::File,
     io,
     path::{Component, Path, PathBuf},
     pin::Pin,

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -4,7 +4,7 @@ use git::GitHostingProviderRegistry;
 #[cfg(target_os = "linux")]
 use ashpd::desktop::trash;
 #[cfg(target_os = "linux")]
-use std::{os::fd::AsFd,fs::File};
+use std::{fs::File, os::fd::AsFd};
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -4,7 +4,7 @@ use git::GitHostingProviderRegistry;
 #[cfg(target_os = "linux")]
 use ashpd::desktop::trash;
 #[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
+use std::os::{fd::AsFd, unix::fs::MetadataExt};
 
 use async_tar::Archive;
 use futures::{future::BoxFuture, AsyncRead, Stream, StreamExt};
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use std::{
     fs::File,
     io,
-    os::fd::AsFd,
     path::{Component, Path, PathBuf},
     pin::Pin,
     time::{Duration, SystemTime},
@@ -280,8 +279,6 @@ impl Fs for RealFs {
 
     #[cfg(target_os = "linux")]
     async fn trash_file(&self, path: &Path, _options: RemoveOptions) -> Result<()> {
-        use std::fs::File;
-
         let file = File::open(path)?;
         match trash::trash_file(&file.as_fd()).await {
             Ok(_) => Ok(()),

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -12,7 +12,12 @@ workspace = true
 
 [features]
 default = []
-test-support = ["backtrace", "collections/test-support", "util/test-support", "http/test-support"]
+test-support = [
+    "backtrace",
+    "collections/test-support",
+    "util/test-support",
+    "http/test-support",
+]
 runtime_shaders = []
 macos-blade = ["blade-graphics", "blade-macros", "bytemuck"]
 
@@ -102,7 +107,7 @@ copypasta = "0.10.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 as-raw-xcb-connection = "1"
-ashpd = "0.8.0"
+ashpd.workspace = true
 calloop = "0.12.4"
 calloop-wayland-source = "0.2.0"
 wayland-backend = { version = "0.3.3", features = ["client_system"] }
@@ -126,7 +131,10 @@ x11rb = { version = "0.13.0", features = [
     "resource_manager",
 ] }
 xkbcommon = { version = "0.7", features = ["wayland", "x11"] }
-xim = { git = "https://github.com/npmania/xim-rs", rev = "27132caffc5b9bc9c432ca4afad184ab6e7c16af", features = ["x11rb-xcb", "x11rb-client"] }
+xim = { git = "https://github.com/npmania/xim-rs", rev = "27132caffc5b9bc9c432ca4afad184ab6e7c16af", features = [
+    "x11rb-xcb",
+    "x11rb-client",
+] }
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true


### PR DESCRIPTION
- Added support for xdg trash when deleting files on linux
- moved ashpd depency to toplevel to use it in both fs and gpui

If I need to add test, or change anything, please let me know. I tested locally by creating and deleting a file and confirming it showed up in my trashcan, but that probably a less than ideal method of confirming correct behavior

Also, I could remove the delete directory function for linux, and change the one configured for macos to compile for both macos and linux (they are the same, the version of the function they are calling is different). 

Release Notes:

- N/A