### PR TITLE
Add config option for terminal cursor style

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -612,7 +612,20 @@
     "toolbar": {
       // Whether to display the terminal title in its toolbar.
       "title": true
-    }
+    },
+    // Set the cursor style in the terminal.
+    // May take 5 values:
+    //  1. Cursor is a block like `█`.
+    //         "cursor_style": "block",
+    //  2. Cursor is an underscore like `_`.
+    //         "cursor_style": "underline",
+    //  3. Cursor is a vertical bar `⎸`.
+    //         "cursor_style": "beam",
+    //  4. Cursor is a box like `▯`.
+    //         "cursor_style": "hollow_block",
+    //  5. Invisible cursor.
+    //         "cursor_style": "hidden",
+    "cursor_style": "block"
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.
     // "font_size": 15,

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -175,6 +175,7 @@ impl Project {
             Some(settings.blinking),
             settings.alternate_scroll,
             settings.max_scroll_history_lines,
+            settings.cursor_style,
             window,
             completion_tx,
         )

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -18,7 +18,9 @@ use alacritty_terminal::{
         Config, RenderableCursor, TermMode,
     },
     tty::{self, setup_env},
-    vte::ansi::{ClearMode, Handler, NamedPrivateMode, PrivateMode, Rgb},
+    vte::ansi::{
+        ClearMode, CursorStyle as AlacCursorStyle, Handler, NamedPrivateMode, PrivateMode, Rgb,
+    },
     Term,
 };
 use anyhow::{bail, Result};
@@ -40,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use settings::Settings;
 use smol::channel::{Receiver, Sender};
 use task::TaskId;
-use terminal_settings::{AlternateScroll, Shell, TerminalBlink, TerminalSettings};
+use terminal_settings::{AlternateScroll, CursorStyle, Shell, TerminalBlink, TerminalSettings};
 use theme::{ActiveTheme, Theme};
 use util::truncate_and_trailoff;
 
@@ -305,6 +307,7 @@ impl TerminalBuilder {
         blink_settings: Option<TerminalBlink>,
         alternate_scroll: AlternateScroll,
         max_scroll_history_lines: Option<usize>,
+        cursor_style: CursorStyle,
         window: AnyWindowHandle,
         completion_tx: Sender<()>,
     ) -> Result<TerminalBuilder> {
@@ -346,8 +349,12 @@ impl TerminalBuilder {
                 .unwrap_or(DEFAULT_SCROLL_HISTORY_LINES)
                 .min(MAX_SCROLL_HISTORY_LINES)
         };
+
+        let default_cursor_style = AlacCursorStyle::from(cursor_style);
+
         let config = Config {
             scrolling_history,
+            default_cursor_style,
             ..Config::default()
         };
 

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -1,3 +1,6 @@
+use alacritty_terminal::vte::ansi::{
+    CursorShape as AlacCursorShape, CursorStyle as AlacCursorStyle,
+};
 use collections::HashMap;
 use gpui::{px, AbsoluteLength, AppContext, FontFeatures, FontWeight, Pixels};
 use schemars::{
@@ -44,6 +47,7 @@ pub struct TerminalSettings {
     pub detect_venv: VenvSettings,
     pub max_scroll_history_lines: Option<usize>,
     pub toolbar: Toolbar,
+    pub cursor_style: CursorStyle,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -171,6 +175,10 @@ pub struct TerminalSettingsContent {
     pub max_scroll_history_lines: Option<usize>,
     /// Toolbar related settings
     pub toolbar: Option<ToolbarContent>,
+    /// Sets the cursor style in the terminal.
+    ///
+    /// Default: block
+    pub cursor_style: Option<CursorStyle>,
 }
 
 impl settings::Settings for TerminalSettings {
@@ -298,4 +306,37 @@ pub struct ToolbarContent {
     ///
     /// Default: true
     pub title: Option<bool>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorStyle {
+    /// Cursor is a block like `█`.
+    #[default]
+    Block,
+    /// Cursor is an underscore like `_`.
+    Underline,
+    /// Cursor is a vertical bar like `⎸`.
+    Beam,
+    /// Cursor is a box like `▯`.
+    HollowBlock,
+    /// Invisible cursor.
+    Hidden,
+}
+
+impl From<CursorStyle> for AlacCursorStyle {
+    fn from(value: CursorStyle) -> Self {
+        let shape = match value {
+            CursorStyle::Block => AlacCursorShape::Block,
+            CursorStyle::Underline => AlacCursorShape::Underline,
+            CursorStyle::Beam => AlacCursorShape::Beam,
+            CursorStyle::HollowBlock => AlacCursorShape::HollowBlock,
+            CursorStyle::Hidden => AlacCursorShape::Hidden,
+        };
+
+        AlacCursorStyle {
+            shape,
+            blinking: false,
+        }
+    }
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1171,6 +1171,7 @@ These values take in the same options as the root-level settings with the same n
   "alternate_scroll": "off",
   "blinking": "terminal_controlled",
   "copy_on_select": false,
+  "cursor_style": "block",
   "env": {},
   "font_family": null,
   "font_features": null,
@@ -1248,6 +1249,54 @@ These values take in the same options as the root-level settings with the same n
 **Options**
 
 `boolean` values
+
+### Cursor Style
+
+- Description: Set the cursor style in the terminal.
+- Setting: `cursor_style`
+- Default: `block`
+
+**Options**
+
+1. Cursor is a block like `█`.
+
+```json
+{
+  "cursor_style": "block"
+}
+```
+
+2. Cursor is an underscore like `_`.
+
+```json
+{
+  "cursor_style": "underline"
+}
+```
+
+3. Cursor is a vertical bar like `⎸`.
+
+```json
+{
+  "cursor_style": "beam"
+}
+```
+
+4. Cursor is a box like `▯`.
+
+```json
+{
+  "cursor_style": "hollow_block"
+}
+```
+
+5. Invisible cursor.
+
+```json
+{
+  "cursor_style": "hidden"
+}
+```
 
 ### Env
 


### PR DESCRIPTION
The terminal cursor can be configured as a block, beam, underline, hollow block, or it can be completely hidden.

Release Notes:

- Added config option for terminal cursor style.
