### PR TITLE
docs: Demonstrate disabling `solargraph` when enabling `ruby-lsp`

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -15,7 +15,7 @@ To switch to `ruby-lsp`, add the following to your `settings.json`:
 {
   "languages": {
     "Ruby": {
-      "language_servers": ["ruby-lsp", "..."]
+      "language_servers": ["ruby-lsp", "!solargraph", "..."]
     }
   }
 }


### PR DESCRIPTION
This PR fixes a small issue in the Ruby docs, where we weren't properly demonstrating that `solargraph` should be disabled when enabling `ruby-lsp`.

Release Notes:

- N/A
