### PR TITLE
Support setting custom background color for syntax highlighting

### DIFF
--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -139,6 +139,10 @@ impl ThemeRegistry {
                                 .and_then(|color| try_parse_color(color).ok()),
                             font_style: highlight.font_style.map(Into::into),
                             font_weight: highlight.font_weight.map(Into::into),
+                            background_color: highlight
+                                .background_color
+                                .as_ref()
+                                .and_then(|color| try_parse_color(color).ok()),
                             ..Default::default()
                         },
                     )

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -137,12 +137,12 @@ impl ThemeRegistry {
                                 .color
                                 .as_ref()
                                 .and_then(|color| try_parse_color(color).ok()),
-                            font_style: highlight.font_style.map(Into::into),
-                            font_weight: highlight.font_weight.map(Into::into),
                             background_color: highlight
                                 .background_color
                                 .as_ref()
                                 .and_then(|color| try_parse_color(color).ok()),
+                            font_style: highlight.font_style.map(Into::into),
+                            font_weight: highlight.font_weight.map(Into::into),
                             ..Default::default()
                         },
                     )

--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -123,6 +123,10 @@ impl ThemeStyleContent {
                         font_weight: style
                             .font_weight
                             .map(|font_weight| FontWeight::from(font_weight)),
+                        background_color: style
+                            .background_color
+                            .as_ref()
+                            .and_then(|color| try_parse_color(color).ok()),
                         ..Default::default()
                     },
                 )
@@ -1309,11 +1313,17 @@ pub struct HighlightStyleContent {
 
     #[serde(deserialize_with = "treat_error_as_none")]
     pub font_weight: Option<FontWeightContent>,
+
+    #[serde(deserialize_with = "treat_error_as_none")]
+    pub background_color: Option<String>,
 }
 
 impl HighlightStyleContent {
     pub fn is_empty(&self) -> bool {
-        self.color.is_none() && self.font_style.is_none() && self.font_weight.is_none()
+        self.color.is_none()
+            && self.font_style.is_none()
+            && self.font_weight.is_none()
+            && self.background_color.is_none()
     }
 }
 

--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -117,16 +117,16 @@ impl ThemeStyleContent {
                             .color
                             .as_ref()
                             .and_then(|color| try_parse_color(color).ok()),
+                        background_color: style
+                            .background_color
+                            .as_ref()
+                            .and_then(|color| try_parse_color(color).ok()),
                         font_style: style
                             .font_style
                             .map(|font_style| FontStyle::from(font_style)),
                         font_weight: style
                             .font_weight
                             .map(|font_weight| FontWeight::from(font_weight)),
-                        background_color: style
-                            .background_color
-                            .as_ref()
-                            .and_then(|color| try_parse_color(color).ok()),
                         ..Default::default()
                     },
                 )
@@ -1309,21 +1309,21 @@ pub struct HighlightStyleContent {
     pub color: Option<String>,
 
     #[serde(deserialize_with = "treat_error_as_none")]
+    pub background_color: Option<String>,
+
+    #[serde(deserialize_with = "treat_error_as_none")]
     pub font_style: Option<FontStyleContent>,
 
     #[serde(deserialize_with = "treat_error_as_none")]
     pub font_weight: Option<FontWeightContent>,
-
-    #[serde(deserialize_with = "treat_error_as_none")]
-    pub background_color: Option<String>,
 }
 
 impl HighlightStyleContent {
     pub fn is_empty(&self) -> bool {
         self.color.is_none()
+            && self.background_color.is_none()
             && self.font_style.is_none()
             && self.font_weight.is_none()
-            && self.background_color.is_none()
     }
 }
 

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -241,6 +241,7 @@ impl VsCodeThemeConverter {
 
             let highlight_style = HighlightStyleContent {
                 color: token_color.settings.foreground.clone(),
+                background_color: token_color.settings.background.clone(),
                 font_style: token_color
                     .settings
                     .font_style


### PR DESCRIPTION
Release Notes:

- Added support for `background_color` in `syntax` map in `theme.json`.

This adds support for setting a `background_color` for styles inside the `syntax` map for themes defined in `theme.json`. The field is optional so there should be no backwards compatibility issues.

It is worth noting that the current behaviour for selecting text is that the background colours will mix/blend (I'm not sure the correct term here). Changing this behaviour, or making it configurable, looks to be a far more complex issue and I'm not sure I know how to do it.