### PR TITLE
Disable `calls.share_on_join` by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -170,7 +170,7 @@
     // Join calls with the microphone live by default
     "mute_on_join": false,
     // Share your project when you are the first to join a channel
-    "share_on_join": true
+    "share_on_join": false
   },
   // Toolbar related settings
   "toolbar": {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4564,11 +4564,14 @@ async fn join_channel_internal(
         if room.remote_participants().len() == 0 && !room.local_participant_is_guest() {
             if let Some(workspace) = requesting_window {
                 let project = workspace.update(cx, |workspace, cx| {
-                    if !CallSettings::get_global(cx).share_on_join {
+                    let project = workspace.project.read(cx);
+                    let is_dev_server = project.dev_server_project_id().is_some();
+
+                    if !is_dev_server && !CallSettings::get_global(cx).share_on_join {
                         return None;
                     }
-                    let project = workspace.project.read(cx);
-                    if (project.is_local() || project.dev_server_project_id().is_some())
+
+                    if (project.is_local() || is_dev_server)
                         && project.visible_worktrees(cx).any(|tree| {
                             tree.read(cx)
                                 .root_entry()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4560,8 +4560,9 @@ async fn join_channel_internal(
         if let Some((project, host)) = room.most_active_project(cx) {
             return Some(join_in_room_project(project, host, app_state.clone(), cx));
         }
-        // if you are the first to join a channel, share your project
-        if room.remote_participants().len() == 0 && !room.local_participant_is_guest() {
+
+        // If you are the first to join a channel, see if you should share your project.
+        if room.remote_participants().is_empty() && !room.local_participant_is_guest() {
             if let Some(workspace) = requesting_window {
                 let project = workspace.update(cx, |workspace, cx| {
                     let project = workspace.project.read(cx);

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1567,7 +1567,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   // Join calls with the microphone live by default
   "mute_on_join": false,
   // Share your project when you are the first to join a channel
-  "share_on_join": true
+  "share_on_join": false
 },
 ```
 


### PR DESCRIPTION
This PR changes the default value of the `calls.share_on_join` setting from `true` to `false`.

Nathan mentioned that project sharing should be opt-in so that projects aren't shared unless you intend for them to be.

Release Notes:

- Changed the default `calls.share_on_join` value to `false`.
