### PR TITLE
wayland: Refactor clipboard implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,12 +1799,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.4.2",
+ "log",
+ "polling 3.3.2",
+ "rustix 0.38.32",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
 name = "calloop-wayland-source"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
 dependencies = [
- "calloop",
+ "calloop 0.12.4",
+ "rustix 0.38.32",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
  "rustix 0.38.32",
  "wayland-backend",
  "wayland-client",
@@ -4719,8 +4745,8 @@ dependencies = [
  "blade-util",
  "block",
  "bytemuck",
- "calloop",
- "calloop-wayland-source",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
  "cbindgen",
  "cocoa",
  "collections",
@@ -9546,8 +9572,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
  "bitflags 2.4.2",
- "calloop",
- "calloop-wayland-source",
+ "calloop 0.12.4",
+ "calloop-wayland-source 0.2.0",
  "cursor-icon",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,20 +1786,6 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
-dependencies = [
- "bitflags 2.4.2",
- "log",
- "polling 3.3.2",
- "rustix 0.38.32",
- "slab",
- "thiserror",
-]
-
-[[package]]
-name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
@@ -1814,23 +1800,11 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
-dependencies = [
- "calloop 0.12.4",
- "rustix 0.38.32",
- "wayland-backend",
- "wayland-client",
-]
-
-[[package]]
-name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop 0.13.0",
+ "calloop",
  "rustix 0.38.32",
  "wayland-backend",
  "wayland-client",
@@ -2646,20 +2620,6 @@ dependencies = [
  "ui",
  "util",
  "workspace",
-]
-
-[[package]]
-name = "copypasta"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb85422867ca93da58b7f95fb5c0c10f6183ed6e1ef8841568968a896d3a858"
-dependencies = [
- "clipboard-win",
- "objc",
- "objc-foundation",
- "objc_id",
- "smithay-clipboard",
- "x11-clipboard",
 ]
 
 [[package]]
@@ -4745,12 +4705,12 @@ dependencies = [
  "blade-util",
  "block",
  "bytemuck",
- "calloop 0.13.0",
- "calloop-wayland-source 0.3.0",
+ "calloop",
+ "calloop-wayland-source",
  "cbindgen",
+ "clipboard-win",
  "cocoa",
  "collections",
- "copypasta",
  "core-foundation",
  "core-graphics",
  "core-text",
@@ -4811,6 +4771,7 @@ dependencies = [
  "wayland-protocols-plasma",
  "windows 0.57.0",
  "windows-core 0.57.0",
+ "x11-clipboard",
  "x11rb",
  "xim",
  "xkbcommon",
@@ -6895,32 +6856,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]
@@ -9564,42 +9505,6 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
-
-[[package]]
-name = "smithay-client-toolkit"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
-dependencies = [
- "bitflags 2.4.2",
- "calloop 0.12.4",
- "calloop-wayland-source 0.2.0",
- "cursor-icon",
- "libc",
- "log",
- "memmap2 0.9.4",
- "rustix 0.38.32",
- "thiserror",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-clipboard"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c091e7354ea8059d6ad99eace06dd13ddeedbb0ac72d40a9a6e7ff790525882d"
-dependencies = [
- "libc",
- "smithay-client-toolkit",
- "wayland-backend",
-]
 
 [[package]]
 name = "smol"
@@ -12269,17 +12174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wayland-csd-frame"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
-dependencies = [
- "bitflags 2.4.2",
- "cursor-icon",
- "wayland-backend",
-]
-
-[[package]]
 name = "wayland-cursor"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12316,19 +12210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wayland-protocols-wlr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
-dependencies = [
- "bitflags 2.4.2",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
 name = "wayland-scanner"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12347,7 +12228,6 @@ checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
 dependencies = [
  "dlib",
  "log",
- "once_cell",
  "pkg-config",
 ]
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2205,7 +2205,7 @@ impl Editor {
         // Copy selections to primary selection buffer
         #[cfg(target_os = "linux")]
         if local {
-            let selections = self.selections.all::<usize>(cx);
+            let selections = &self.selections.disjoint;
             let buffer_handle = self.buffer.read(cx).read(cx);
 
             let mut text = String::new();

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -104,7 +104,6 @@ blade-macros.workspace = true
 blade-util.workspace = true
 bytemuck = "1"
 cosmic-text = { git = "https://github.com/pop-os/cosmic-text", rev = "542b20c" }
-copypasta = "0.10.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 as-raw-xcb-connection = "1"
@@ -136,10 +135,13 @@ xim = { git = "https://github.com/npmania/xim-rs", rev = "27132caffc5b9bc9c432ca
     "x11rb-xcb",
     "x11rb-client",
 ] }
+x11-clipboard = "0.9.2"
+
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
 windows-core = "0.57"
+clipboard-win = "3.1.1"
 
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "2.4"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -137,7 +137,6 @@ xim = { git = "https://github.com/npmania/xim-rs", rev = "27132caffc5b9bc9c432ca
 ] }
 x11-clipboard = "0.9.2"
 
-
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
 windows-core = "0.57"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -109,8 +109,8 @@ copypasta = "0.10.1"
 [target.'cfg(target_os = "linux")'.dependencies]
 as-raw-xcb-connection = "1"
 ashpd.workspace = true
-calloop = "0.12.4"
-calloop-wayland-source = "0.2.0"
+calloop = "0.13.0"
+calloop-wayland-source = "0.3.0"
 wayland-backend = { version = "0.3.3", features = ["client_system"] }
 wayland-client = { version = "0.31.2" }
 wayland-cursor = "0.31.1"

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -22,7 +22,6 @@ use ashpd::desktop::file_chooser::{OpenFileRequest, SaveFileRequest};
 use async_task::Runnable;
 use calloop::channel::Channel;
 use calloop::{EventLoop, LoopHandle, LoopSignal};
-use copypasta::ClipboardProvider;
 use filedescriptor::FileDescriptor;
 use flume::{Receiver, Sender};
 use futures::channel::oneshot;

--- a/crates/gpui/src/platform/linux/wayland.rs
+++ b/crates/gpui/src/platform/linux/wayland.rs
@@ -1,4 +1,5 @@
 mod client;
+mod clipboard;
 mod cursor;
 mod display;
 mod serial;

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -531,7 +531,7 @@ impl WaylandClient {
             loop_handle: handle.clone(),
             enter_token: None,
             cursor_style: None,
-            clipboard: Clipboard::new(conn.clone()),
+            clipboard: Clipboard::new(conn.clone(), handle.clone()),
             data_offers: Vec::new(),
             primary_data_offer: None,
             cursor,

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -679,6 +679,7 @@ impl LinuxClient for WaylandClient {
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
             let serial = state.serial_tracker.get(SerialKind::KeyEnter);
             let data_source = data_device_manager.create_data_source(&state.globals.qh, ());
+            data_source.offer(state.clipboard.self_mime());
             data_source.offer(TEXT_MIME_TYPE.to_string());
             data_device.set_selection(Some(&data_source), serial);
             state.clipboard.set_contents(item.text);

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -39,7 +39,9 @@ use wayland_protocols::wp::cursor_shape::v1::client::{
 use wayland_protocols::wp::fractional_scale::v1::client::{
     wp_fractional_scale_manager_v1, wp_fractional_scale_v1,
 };
-use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1;
+use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::{
+    self, ZwpPrimarySelectionOfferV1,
+};
 use wayland_protocols::wp::primary_selection::zv1::client::{
     zwp_primary_selection_device_manager_v1, zwp_primary_selection_device_v1,
     zwp_primary_selection_source_v1,
@@ -1938,8 +1940,33 @@ impl Dispatch<zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1, ()>
     }
 
     event_created_child!(WaylandClientStatePtr, zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1, [
-        zwp_primary_selection_device_v1::EVT_DATA_OFFER_OPCODE => (zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1, ()),
+        zwp_primary_selection_device_v1::EVT_DATA_OFFER_OPCODE => (zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1, ()),
     ]);
+}
+
+impl Dispatch<zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1, ()>
+    for WaylandClientStatePtr
+{
+    fn event(
+        this: &mut Self,
+        _data_offer: &zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1,
+        event: zwp_primary_selection_offer_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let client = this.get_client();
+        let mut state = client.borrow_mut();
+
+        match event {
+            zwp_primary_selection_offer_v1::Event::Offer { mime_type } => {
+                if let Some(offer) = state.primary_data_offer.as_mut() {
+                    offer.add_mime_type(mime_type);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 impl Dispatch<zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1, ()>

--- a/crates/gpui/src/platform/linux/wayland/clipboard.rs
+++ b/crates/gpui/src/platform/linux/wayland/clipboard.rs
@@ -27,24 +27,11 @@ pub(crate) struct Clipboard {
     current_primary_offer: Option<DataOffer<ZwpPrimarySelectionOfferV1>>,
 }
 
-// Reference: https://specifications.freedesktop.org/clipboards-spec/clipboards-latest.txt
-// pub(crate) enum TargetSelection {
-//     Clipboard(WlDataOffer),
-//     Primary(ZwpPrimarySelectionOfferV1),
-// }
-
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct DataOffer<T> {
-    inner: T,
+    pub inner: T,
     mime_types: Vec<String>,
 }
-
-// // At most we have to store three data offers: drag and drop, primary selection and clipboard.
-// const MAX_DATA_OFFERS: usize = 3;
-
-// pub(crate) struct DataOffersMap {
-//     inner: SmallVec<[(ObjectId, DataOffer); MAX_DATA_OFFERS]>,
-// }
 
 impl<T> DataOffer<T> {
     pub fn new(offer: T) -> Self {
@@ -62,35 +49,6 @@ impl<T> DataOffer<T> {
         self.mime_types.iter().any(|t| t == mime_type)
     }
 }
-
-// impl DataOffersMap {
-//     pub fn new() -> Self {
-//         Self {
-//             inner: SmallVec::new(),
-//         }
-//     }
-
-//     pub fn insert(&mut self, id: ObjectId, data_offer: DataOffer) {
-//         if self.inner.len() == MAX_DATA_OFFERS {
-//             self.inner.remove(0);
-//         }
-//         self.inner.push((id, data_offer));
-//     }
-
-//     pub fn get(&self, id: &ObjectId) -> Option<&DataOffer> {
-//         self.inner
-//             .iter()
-//             .find(|(key, _)| key == id)
-//             .map(|(_, value)| value)
-//     }
-
-//     pub fn get_mut(&mut self, id: &ObjectId) -> Option<&mut DataOffer> {
-//         self.inner
-//             .iter_mut()
-//             .find(|(key, _)| key == id)
-//             .map(|(_, value)| value)
-//     }
-// }
 
 impl Clipboard {
     pub fn new(connection: Connection) -> Self {
@@ -118,19 +76,11 @@ impl Clipboard {
 
     pub fn set_offer(&mut self, data_offer: Option<DataOffer<WlDataOffer>>) {
         self.cached_read = None;
-        // TODO: destroy old offer
-        // if let Some(old_offer) = self.current_offer.take() {
-        //     old_offer.inner.destroy();
-        // }
         self.current_offer = data_offer;
     }
 
     pub fn set_primary_offer(&mut self, data_offer: Option<DataOffer<ZwpPrimarySelectionOfferV1>>) {
         self.cached_primary_read = None;
-        // TODO: destroy old offer
-        // if let Some(old_offer) = self.current_offer.take() {
-        //     old_offer.inner.destroy();
-        // }
         self.current_primary_offer = data_offer;
     }
 
@@ -148,7 +98,6 @@ impl Clipboard {
     }
 
     pub fn send_primary(&self, _mime_type: String, fd: OwnedFd) {
-        println!("send_primary");
         if let Some(primary_contents) = &self.primary_contents {
             let mut file = FileDescriptor::new(fd);
             if let Err(err) = file.write(primary_contents.as_bytes()) {
@@ -192,7 +141,6 @@ impl Clipboard {
     }
 
     pub fn read_primary(&mut self) -> Option<String> {
-        println!("read_primary");
         let offer = self.current_primary_offer.clone()?;
         if let Some(cached) = self.cached_primary_read.clone() {
             return Some(cached);

--- a/crates/gpui/src/platform/linux/wayland/clipboard.rs
+++ b/crates/gpui/src/platform/linux/wayland/clipboard.rs
@@ -10,6 +10,7 @@ use wayland_client::{
     protocol::{wl_data_offer::WlDataOffer, wl_data_source::WlDataSource},
     Connection, Proxy,
 };
+use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1;
 
 use crate::platform::linux::platform::read_fd;
 
@@ -19,27 +20,39 @@ pub(crate) const FILE_LIST_MIME_TYPE: &str = "text/uri-list";
 pub(crate) struct Clipboard {
     connection: Connection,
     self_mime: String,
+
+    // Internal clipboard
     contents: Option<String>,
-    // External clipboard contents
+    primary_contents: Option<String>,
+
+    // External clipboard
     cached_read: Option<String>,
-    current_offer: Option<DataOffer>,
+    current_offer: Option<DataOffer<WlDataOffer>>,
+    cached_primary_read: Option<String>,
+    current_primary_offer: Option<DataOffer<ZwpPrimarySelectionOfferV1>>,
 }
 
+// Reference: https://specifications.freedesktop.org/clipboards-spec/clipboards-latest.txt
+// pub(crate) enum TargetSelection {
+//     Clipboard(WlDataOffer),
+//     Primary(ZwpPrimarySelectionOfferV1),
+// }
+
 #[derive(Clone)]
-pub(crate) struct DataOffer {
-    inner: WlDataOffer,
+pub(crate) struct DataOffer<T> {
+    inner: T,
     mime_types: Vec<String>,
 }
 
-// At most we have to store three data offers: drag and drop, primary selection and clipboard.
-const MAX_DATA_OFFERS: usize = 3;
+// // At most we have to store three data offers: drag and drop, primary selection and clipboard.
+// const MAX_DATA_OFFERS: usize = 3;
 
-pub(crate) struct DataOffersMap {
-    inner: SmallVec<[(ObjectId, DataOffer); MAX_DATA_OFFERS]>,
-}
+// pub(crate) struct DataOffersMap {
+//     inner: SmallVec<[(ObjectId, DataOffer); MAX_DATA_OFFERS]>,
+// }
 
-impl DataOffer {
-    pub fn new(offer: WlDataOffer) -> Self {
+impl<T> DataOffer<T> {
+    pub fn new(offer: T) -> Self {
         Self {
             inner: offer,
             mime_types: Vec::new(),
@@ -55,63 +68,82 @@ impl DataOffer {
     }
 }
 
-impl DataOffersMap {
-    pub fn new() -> Self {
-        Self {
-            inner: SmallVec::new(),
-        }
-    }
+// impl DataOffersMap {
+//     pub fn new() -> Self {
+//         Self {
+//             inner: SmallVec::new(),
+//         }
+//     }
 
-    pub fn insert(&mut self, id: ObjectId, data_offer: DataOffer) {
-        if self.inner.len() == MAX_DATA_OFFERS {
-            self.inner.remove(0);
-        }
-        self.inner.push((id, data_offer));
-    }
+//     pub fn insert(&mut self, id: ObjectId, data_offer: DataOffer) {
+//         if self.inner.len() == MAX_DATA_OFFERS {
+//             self.inner.remove(0);
+//         }
+//         self.inner.push((id, data_offer));
+//     }
 
-    pub fn get(&self, id: &ObjectId) -> Option<&DataOffer> {
-        self.inner
-            .iter()
-            .find(|(key, _)| key == id)
-            .map(|(_, value)| value)
-    }
+//     pub fn get(&self, id: &ObjectId) -> Option<&DataOffer> {
+//         self.inner
+//             .iter()
+//             .find(|(key, _)| key == id)
+//             .map(|(_, value)| value)
+//     }
 
-    pub fn get_mut(&mut self, id: &ObjectId) -> Option<&mut DataOffer> {
-        self.inner
-            .iter_mut()
-            .find(|(key, _)| key == id)
-            .map(|(_, value)| value)
-    }
-}
+//     pub fn get_mut(&mut self, id: &ObjectId) -> Option<&mut DataOffer> {
+//         self.inner
+//             .iter_mut()
+//             .find(|(key, _)| key == id)
+//             .map(|(_, value)| value)
+//     }
+// }
 
 impl Clipboard {
     pub fn new(connection: Connection) -> Self {
         Self {
             connection,
             self_mime: format!("pid/{}", std::process::id()),
+
             contents: None,
+            primary_contents: None,
+
             cached_read: None,
             current_offer: None,
+            cached_primary_read: None,
+            current_primary_offer: None,
         }
     }
 
-    pub fn set_contents(&mut self, text: String) {
+    pub fn set(&mut self, text: String) {
         self.contents = Some(text);
     }
 
-    pub fn set_offer(&mut self, data_offer: Option<DataOffer>) {
+    pub fn set_primary(&mut self, text: String) {
+        self.primary_contents = Some(text);
+    }
+
+    pub fn set_offer(&mut self, data_offer: Option<DataOffer<WlDataOffer>>) {
         self.cached_read = None;
-        if let Some(old_offer) = self.current_offer.take() {
-            old_offer.inner.destroy();
-        }
+        // TODO: destroy old offer
+        // if let Some(old_offer) = self.current_offer.take() {
+        //     old_offer.inner.destroy();
+        // }
         self.current_offer = data_offer;
+    }
+
+    pub fn set_primary_offer(&mut self, data_offer: Option<DataOffer<ZwpPrimarySelectionOfferV1>>) {
+        self.cached_primary_read = None;
+        // TODO: destroy old offer
+        // if let Some(old_offer) = self.current_offer.take() {
+        //     old_offer.inner.destroy();
+        // }
+        self.current_primary_offer = data_offer;
     }
 
     pub fn self_mime(&self) -> String {
         self.self_mime.clone()
     }
 
-    pub fn handle_send(&self, _mime_type: String, fd: OwnedFd) {
+    pub fn send(&self, _mime_type: String, fd: OwnedFd) {
         if let Some(contents) = &self.contents {
             let mut file = FileDescriptor::new(fd);
             if let Err(err) = file.write(contents.as_bytes()) {
@@ -120,31 +152,39 @@ impl Clipboard {
         }
     }
 
-    pub fn handle_read(&mut self) -> Option<String> {
-        if let Some(cached_read) = self.cached_read.clone() {
-            return Some(cached_read);
+    pub fn send_primary(&self, _mime_type: String, fd: OwnedFd) {
+        println!("send_primary");
+        if let Some(primary_contents) = &self.primary_contents {
+            let mut file = FileDescriptor::new(fd);
+            if let Err(err) = file.write(primary_contents.as_bytes()) {
+                log::error!("error sending clipboard data: {err:?}");
+            }
+        }
+    }
+
+    pub fn read(&mut self) -> Option<String> {
+        let offer = self.current_offer.clone()?;
+        if let Some(cached) = self.cached_read.clone() {
+            return Some(cached);
         }
 
-        let data_offer = self.current_offer.clone()?;
-        if data_offer.has_mime_type(&self.self_mime) {
+        if offer.has_mime_type(&self.self_mime) {
             return self.contents.clone();
         }
-        if !data_offer.has_mime_type(TEXT_MIME_TYPE) {
+        if !offer.has_mime_type(TEXT_MIME_TYPE) {
             return None;
         }
 
         let pipe = Pipe::new().unwrap();
-        data_offer
-            .inner
-            .receive(TEXT_MIME_TYPE.to_string(), unsafe {
-                BorrowedFd::borrow_raw(pipe.write.as_raw_fd())
-            });
+        offer.inner.receive(TEXT_MIME_TYPE.to_string(), unsafe {
+            BorrowedFd::borrow_raw(pipe.write.as_raw_fd())
+        });
         let fd = pipe.read;
         drop(pipe.write);
 
         self.connection.flush().unwrap();
 
-        let result = match unsafe { read_fd(fd) } {
+        match unsafe { read_fd(fd) } {
             Ok(v) => {
                 self.cached_read = Some(v.clone());
                 Some(v)
@@ -153,9 +193,41 @@ impl Clipboard {
                 log::error!("error reading clipboard pipe: {err:?}");
                 None
             }
-        };
+        }
+    }
 
-        println!("{result:?}");
-        result
+    pub fn read_primary(&mut self) -> Option<String> {
+        println!("read_primary");
+        let offer = self.current_primary_offer.clone()?;
+        if let Some(cached) = self.cached_primary_read.clone() {
+            return Some(cached);
+        }
+
+        if offer.has_mime_type(&self.self_mime) {
+            return self.contents.clone();
+        }
+        if !offer.has_mime_type(TEXT_MIME_TYPE) {
+            return None;
+        }
+
+        let pipe = Pipe::new().unwrap();
+        offer.inner.receive(TEXT_MIME_TYPE.to_string(), unsafe {
+            BorrowedFd::borrow_raw(pipe.write.as_raw_fd())
+        });
+        let fd = pipe.read;
+        drop(pipe.write);
+
+        self.connection.flush().unwrap();
+
+        match unsafe { read_fd(fd) } {
+            Ok(v) => {
+                self.cached_primary_read = Some(v.clone());
+                Some(v)
+            }
+            Err(err) => {
+                log::error!("error reading clipboard pipe: {err:?}");
+                None
+            }
+        }
     }
 }

--- a/crates/gpui/src/platform/linux/wayland/clipboard.rs
+++ b/crates/gpui/src/platform/linux/wayland/clipboard.rs
@@ -4,12 +4,7 @@ use std::{
 };
 
 use filedescriptor::{FileDescriptor, Pipe};
-use smallvec::SmallVec;
-use wayland_backend::client::ObjectId;
-use wayland_client::{
-    protocol::{wl_data_offer::WlDataOffer, wl_data_source::WlDataSource},
-    Connection, Proxy,
-};
+use wayland_client::{protocol::wl_data_offer::WlDataOffer, Connection};
 use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1;
 
 use crate::platform::linux::platform::read_fd;
@@ -204,7 +199,7 @@ impl Clipboard {
         }
 
         if offer.has_mime_type(&self.self_mime) {
-            return self.contents.clone();
+            return self.primary_contents.clone();
         }
         if !offer.has_mime_type(TEXT_MIME_TYPE) {
             return None;

--- a/crates/gpui/src/platform/linux/wayland/clipboard.rs
+++ b/crates/gpui/src/platform/linux/wayland/clipboard.rs
@@ -4,9 +4,11 @@ use std::{
 };
 
 use filedescriptor::{FileDescriptor, Pipe};
+use smallvec::SmallVec;
+use wayland_backend::client::ObjectId;
 use wayland_client::{
     protocol::{wl_data_offer::WlDataOffer, wl_data_source::WlDataSource},
-    Connection,
+    Connection, Proxy,
 };
 
 use crate::platform::linux::platform::read_fd;
@@ -15,41 +17,98 @@ pub(crate) const TEXT_MIME_TYPE: &str = "text/plain;charset=utf-8";
 pub(crate) const FILE_LIST_MIME_TYPE: &str = "text/uri-list";
 
 pub(crate) struct Clipboard {
-    pending_write: Option<String>,
+    connection: Connection,
+    contents: Option<String>,
+    // External clipboard contents
     cached_read: Option<String>,
-    pending_read: Option<WlDataOffer>,
+    current_offer: Option<DataOffer>,
 }
 
-impl Drop for Clipboard {
-    fn drop(&mut self) {
-        if let Some(pending_read) = &self.pending_read {
-            pending_read.destroy();
+#[derive(Clone)]
+pub(crate) struct DataOffer {
+    inner: WlDataOffer,
+    mime_types: Vec<String>,
+}
+
+// At most we have to store three data offers: drag and drop, primary selection and clipboard.
+const MAX_DATA_OFFERS: usize = 3;
+
+pub(crate) struct DataOffersMap {
+    inner: SmallVec<[(ObjectId, DataOffer); MAX_DATA_OFFERS]>,
+}
+
+impl DataOffer {
+    pub fn new(offer: WlDataOffer) -> Self {
+        Self {
+            inner: offer,
+            mime_types: Vec::new(),
         }
+    }
+
+    pub fn add_mime_type(&mut self, mime_type: String) {
+        self.mime_types.push(mime_type)
+    }
+
+    pub fn has_mime_type(&self, mime_type: &str) -> bool {
+        self.mime_types.iter().any(|t| t == mime_type)
+    }
+}
+
+impl DataOffersMap {
+    pub fn new() -> Self {
+        Self {
+            inner: SmallVec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, id: ObjectId, data_offer: DataOffer) {
+        if self.inner.len() == MAX_DATA_OFFERS {
+            self.inner.remove(0);
+        }
+        self.inner.push((id, data_offer));
+    }
+
+    pub fn get(&self, id: &ObjectId) -> Option<&DataOffer> {
+        self.inner
+            .iter()
+            .find(|(key, _)| key == id)
+            .map(|(_, value)| value)
+    }
+
+    pub fn get_mut(&mut self, id: &ObjectId) -> Option<&mut DataOffer> {
+        self.inner
+            .iter_mut()
+            .find(|(key, _)| key == id)
+            .map(|(_, value)| value)
     }
 }
 
 impl Clipboard {
-    pub fn new() -> Self {
+    pub fn new(connection: Connection) -> Self {
         Self {
-            pending_write: None,
+            connection,
+            contents: None,
             cached_read: None,
-            pending_read: None,
+            current_offer: None,
         }
     }
 
-    pub fn set_pending_write(&mut self, text: String) {
-        self.pending_write = Some(text);
+    pub fn set_contents(&mut self, text: String) {
+        self.contents = Some(text);
     }
 
-    pub fn set_pending_read(&mut self, data_offer: Option<WlDataOffer>) {
+    pub fn set_offer(&mut self, data_offer: Option<DataOffer>) {
         self.cached_read = None;
-        self.pending_read = data_offer;
+        if let Some(old_offer) = self.current_offer.take() {
+            old_offer.inner.destroy();
+        }
+        self.current_offer = data_offer;
     }
 
     pub fn handle_send(&self, _mime_type: String, fd: OwnedFd) {
-        if let Some(pending_write) = &self.pending_write {
+        if let Some(contents) = &self.contents {
             let mut file = FileDescriptor::new(fd);
-            if let Err(err) = file.write(pending_write.as_bytes()) {
+            if let Err(err) = file.write(contents.as_bytes()) {
                 log::error!("error sending clipboard data: {err:?}");
             }
         }
@@ -60,13 +119,21 @@ impl Clipboard {
             return Some(cached_read);
         }
 
-        let data_offer = self.pending_read.take()?;
+        let data_offer = self.current_offer.clone()?;
+        if !data_offer.has_mime_type(TEXT_MIME_TYPE) {
+            return None;
+        }
+
         let pipe = Pipe::new().unwrap();
-        data_offer.receive(TEXT_MIME_TYPE.to_string(), unsafe {
-            BorrowedFd::borrow_raw(pipe.write.as_raw_fd())
-        });
+        data_offer
+            .inner
+            .receive(TEXT_MIME_TYPE.to_string(), unsafe {
+                BorrowedFd::borrow_raw(pipe.write.as_raw_fd())
+            });
         let fd = pipe.read;
         drop(pipe.write);
+
+        self.connection.flush().unwrap();
 
         let result = match unsafe { read_fd(fd) } {
             Ok(v) => {
@@ -80,7 +147,6 @@ impl Clipboard {
         };
 
         println!("{result:?}");
-        data_offer.destroy();
         result
     }
 }

--- a/crates/gpui/src/platform/linux/wayland/clipboard.rs
+++ b/crates/gpui/src/platform/linux/wayland/clipboard.rs
@@ -1,0 +1,86 @@
+use std::{
+    io::Write,
+    os::fd::{AsRawFd, BorrowedFd, OwnedFd},
+};
+
+use filedescriptor::{FileDescriptor, Pipe};
+use wayland_client::{
+    protocol::{wl_data_offer::WlDataOffer, wl_data_source::WlDataSource},
+    Connection,
+};
+
+use crate::platform::linux::platform::read_fd;
+
+pub(crate) const TEXT_MIME_TYPE: &str = "text/plain;charset=utf-8";
+pub(crate) const FILE_LIST_MIME_TYPE: &str = "text/uri-list";
+
+pub(crate) struct Clipboard {
+    pending_write: Option<String>,
+    cached_read: Option<String>,
+    pending_read: Option<WlDataOffer>,
+}
+
+impl Drop for Clipboard {
+    fn drop(&mut self) {
+        if let Some(pending_read) = &self.pending_read {
+            pending_read.destroy();
+        }
+    }
+}
+
+impl Clipboard {
+    pub fn new() -> Self {
+        Self {
+            pending_write: None,
+            cached_read: None,
+            pending_read: None,
+        }
+    }
+
+    pub fn set_pending_write(&mut self, text: String) {
+        self.pending_write = Some(text);
+    }
+
+    pub fn set_pending_read(&mut self, data_offer: Option<WlDataOffer>) {
+        self.cached_read = None;
+        self.pending_read = data_offer;
+    }
+
+    pub fn handle_send(&self, _mime_type: String, fd: OwnedFd) {
+        if let Some(pending_write) = &self.pending_write {
+            let mut file = FileDescriptor::new(fd);
+            if let Err(err) = file.write(pending_write.as_bytes()) {
+                log::error!("error sending clipboard data: {err:?}");
+            }
+        }
+    }
+
+    pub fn handle_read(&mut self) -> Option<String> {
+        if let Some(cached_read) = self.cached_read.clone() {
+            return Some(cached_read);
+        }
+
+        let data_offer = self.pending_read.take()?;
+        let pipe = Pipe::new().unwrap();
+        data_offer.receive(TEXT_MIME_TYPE.to_string(), unsafe {
+            BorrowedFd::borrow_raw(pipe.write.as_raw_fd())
+        });
+        let fd = pipe.read;
+        drop(pipe.write);
+
+        let result = match unsafe { read_fd(fd) } {
+            Ok(v) => {
+                self.cached_read = Some(v.clone());
+                Some(v)
+            }
+            Err(err) => {
+                log::error!("error reading clipboard pipe: {err:?}");
+                None
+            }
+        };
+
+        println!("{result:?}");
+        data_offer.destroy();
+        result
+    }
+}

--- a/crates/gpui/src/platform/linux/wayland/serial.rs
+++ b/crates/gpui/src/platform/linux/wayland/serial.rs
@@ -6,6 +6,7 @@ pub(crate) enum SerialKind {
     InputMethod,
     MouseEnter,
     MousePress,
+    KeyEnter,
     KeyPress,
 }
 

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1101,10 +1101,8 @@ impl LinuxClient for X11Client {
                 state.clipboard.getter.atoms.property,
                 Duration::from_secs(3),
             )
-            .map(|text| String::from_utf8(text))
-            .ok()?
             .map(|text| crate::ClipboardItem {
-                text,
+                text: String::from_utf8(text).unwrap(),
                 metadata: None,
             })
             .ok()
@@ -1120,10 +1118,8 @@ impl LinuxClient for X11Client {
                 state.clipboard.getter.atoms.property,
                 Duration::from_secs(3),
             )
-            .map(|text| String::from_utf8(text))
-            .ok()?
             .map(|text| crate::ClipboardItem {
-                text,
+                text: String::from_utf8(text).unwrap(),
                 metadata: None,
             })
             .ok()

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -8,10 +8,8 @@ use calloop::generic::{FdWrapper, Generic};
 use calloop::{EventLoop, LoopHandle, RegistrationToken};
 
 use collections::HashMap;
-use copypasta::x11_clipboard::{Clipboard, Primary, X11ClipboardContext};
-use copypasta::ClipboardProvider;
-
 use util::ResultExt;
+
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::cursor;
 use x11rb::errors::ConnectionError;
@@ -129,8 +127,7 @@ pub struct X11ClientState {
     pub(crate) scroll_y: Option<f32>,
 
     pub(crate) common: LinuxCommon,
-    pub(crate) clipboard: X11ClipboardContext<Clipboard>,
-    pub(crate) primary: X11ClipboardContext<Primary>,
+    pub(crate) clipboard: x11_clipboard::Clipboard,
 }
 
 #[derive(Clone)]
@@ -277,8 +274,7 @@ impl X11Client {
             .reply()
             .unwrap();
 
-        let clipboard = X11ClipboardContext::<Clipboard>::new().unwrap();
-        let primary = X11ClipboardContext::<Primary>::new().unwrap();
+        let clipboard = x11_clipboard::Clipboard::new().unwrap();
 
         let xcb_connection = Rc::new(xcb_connection);
 
@@ -399,7 +395,6 @@ impl X11Client {
             scroll_y: None,
 
             clipboard,
-            primary,
         })))
     }
 
@@ -1073,35 +1068,65 @@ impl LinuxClient for X11Client {
     }
 
     fn write_to_primary(&self, item: crate::ClipboardItem) {
-        self.0.borrow_mut().primary.set_contents(item.text).ok();
+        let state = self.0.borrow_mut();
+        state
+            .clipboard
+            .store(
+                state.clipboard.setter.atoms.primary,
+                state.clipboard.setter.atoms.utf8_string,
+                item.text().as_bytes(),
+            )
+            .ok();
     }
 
     fn write_to_clipboard(&self, item: crate::ClipboardItem) {
-        self.0.borrow_mut().clipboard.set_contents(item.text).ok();
+        let state = self.0.borrow_mut();
+        state
+            .clipboard
+            .store(
+                state.clipboard.setter.atoms.clipboard,
+                state.clipboard.setter.atoms.utf8_string,
+                item.text().as_bytes(),
+            )
+            .ok();
     }
 
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {
-        self.0
-            .borrow_mut()
-            .primary
-            .get_contents()
-            .ok()
+        let state = self.0.borrow_mut();
+        state
+            .clipboard
+            .load(
+                state.clipboard.getter.atoms.primary,
+                state.clipboard.getter.atoms.utf8_string,
+                state.clipboard.getter.atoms.property,
+                Duration::from_secs(3),
+            )
+            .map(|text| String::from_utf8(text))
+            .ok()?
             .map(|text| crate::ClipboardItem {
                 text,
                 metadata: None,
             })
+            .ok()
     }
 
     fn read_from_clipboard(&self) -> Option<crate::ClipboardItem> {
-        self.0
-            .borrow_mut()
+        let state = self.0.borrow_mut();
+        state
             .clipboard
-            .get_contents()
-            .ok()
+            .load(
+                state.clipboard.getter.atoms.clipboard,
+                state.clipboard.getter.atoms.utf8_string,
+                state.clipboard.getter.atoms.property,
+                Duration::from_secs(3),
+            )
+            .map(|text| String::from_utf8(text))
+            .ok()?
             .map(|text| crate::ClipboardItem {
                 text,
                 metadata: None,
             })
+            .ok()
     }
 
     fn run(&self) {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -12,7 +12,7 @@ use std::{
 
 use ::util::ResultExt;
 use anyhow::{anyhow, Context, Result};
-use copypasta::{ClipboardContext, ClipboardProvider};
+use clipboard_win::{get_clipboard_string, set_clipboard_string};
 use futures::channel::oneshot::{self, Receiver};
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -502,16 +502,14 @@ impl Platform for WindowsPlatform {
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
         if item.text.len() > 0 {
-            let mut ctx = ClipboardContext::new().unwrap();
-            ctx.set_contents(item.text().to_owned()).unwrap();
+            set_clipboard_string(item.text()).unwrap();
         }
     }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
-        let mut ctx = ClipboardContext::new().unwrap();
-        let content = ctx.get_contents().ok()?;
+        let text = get_clipboard_string().ok()?;
         Some(ClipboardItem {
-            text: content,
+            text,
             metadata: None,
         })
     }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/12054

Replaces the `copypasta`/`smithay-clipboard` implementation with a new, custom one

TODO list:

- [x] Cleanup code
- [x] Remove `smithay-clipboard`
- [x] Add more mime types to the supported list

Release Notes:

- Fixed drag and drop on Gnome
- Fixed clipboard paste on Hyprland
