### PR TITLE
Stop silently appending a system prompt for edit formatting

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2101,16 +2101,10 @@ impl Conversation {
     }
 
     fn to_completion_request(&self, cx: &mut ModelContext<Conversation>) -> LanguageModelRequest {
-        let edits_system_prompt = LanguageModelRequestMessage {
-            role: Role::System,
-            content: include_str!("./system_prompts/edits.md").to_string(),
-        };
-
-        let messages = Some(edits_system_prompt).into_iter().chain(
-            self.messages(cx)
-                .filter(|message| matches!(message.status, MessageStatus::Done))
-                .map(|message| message.to_request_message(self.buffer.read(cx))),
-        );
+        let messages = self
+            .messages(cx)
+            .filter(|message| matches!(message.status, MessageStatus::Done))
+            .map(|message| message.to_request_message(self.buffer.read(cx)));
 
         LanguageModelRequest {
             model: self.model.clone(),

--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -172,6 +172,8 @@ spec:
                 secretKeyRef:
                   name: slack
                   key: panics_webhook
+            - name: COMPLETE_WITH_LANGUAGE_MODEL_RATE_LIMIT_PER_HOUR
+              value: "1000"
             - name: SUPERMAVEN_ADMIN_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
We should reintroduce this as part of the prompt library.

Release Notes:

- Removed an over-eager system prompt from the assistant that was causing misbehavior. Going forward, our intent is to always let you observe and edit text before we send it.

/cc @as-cii 