### PR TITLE
inline assistant: Fix overlapping wrap/indent guides

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3510,6 +3510,7 @@ impl Render for InlineAssistant {
             .py_2()
             .border_y_1()
             .border_color(cx.theme().colors().border)
+            .bg(cx.theme().colors().editor_background)
             .on_action(cx.listener(Self::confirm))
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(Self::toggle_include_conversation))


### PR DESCRIPTION
Before:

<img width="603" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/08b7566c-4afa-40b6-8e73-4b03d26572b7">

After:

<img width="539" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/ebd69e15-c1e1-485e-9c11-35b4316ede40">


Fixes #9819

Release Notes:

- Fix wrap guides overlapping with the inline assistant ([#9819](https://github.com/zed-industries/zed/issues/9819)).

