### PR TITLE
Use rust-analyzer from path if possible

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8467,7 +8467,6 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "some other init value": false
                 })),
-                detect_path: true,
             },
         );
     });
@@ -8487,7 +8486,6 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "anotherInitValue": false
                 })),
-                detect_path: true,
             },
         );
     });
@@ -8507,7 +8505,6 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "anotherInitValue": false
                 })),
-                detect_path: true,
             },
         );
     });
@@ -8525,7 +8522,6 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 binary: None,
                 settings: None,
                 initialization_options: None,
-                detect_path: true,
             },
         );
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8467,6 +8467,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "some other init value": false
                 })),
+                detect_path: true,
             },
         );
     });
@@ -8486,6 +8487,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "anotherInitValue": false
                 })),
+                detect_path: true,
             },
         );
     });
@@ -8505,6 +8507,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "anotherInitValue": false
                 })),
+                detect_path: true,
             },
         );
     });
@@ -8522,6 +8525,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 binary: None,
                 settings: None,
                 initialization_options: None,
+                detect_path: true,
             },
         );
     });

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -35,13 +35,12 @@ impl super::LspAdapter for CLspAdapter {
                 .and_then(|s| s.binary.clone())
         });
 
-        if let Ok(Some(BinarySettings {
-            path: Some(path),
-            arguments,
-            ..
-        })) = configured_binary
-        {
-            Some(LanguageServerBinary {
+        match configured_binary {
+            Ok(Some(BinarySettings {
+                path: Some(path),
+                arguments,
+                ..
+            })) => Some(LanguageServerBinary {
                 path: path.into(),
                 arguments: arguments
                     .unwrap_or_default()
@@ -49,15 +48,20 @@ impl super::LspAdapter for CLspAdapter {
                     .map(|arg| arg.into())
                     .collect(),
                 env: None,
-            })
-        } else {
-            let env = delegate.shell_env().await;
-            let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
-            Some(LanguageServerBinary {
-                path,
-                arguments: vec![],
-                env: Some(env),
-            })
+            }),
+            Ok(Some(BinarySettings {
+                path_lookup: Some(false),
+                ..
+            })) => None,
+            _ => {
+                let env = delegate.shell_env().await;
+                let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
+                Some(LanguageServerBinary {
+                    path,
+                    arguments: vec![],
+                    env: Some(env),
+                })
+            }
         }
     }
 

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -38,7 +38,7 @@ impl super::LspAdapter for CLspAdapter {
         if let Ok(Some(BinarySettings {
             path: Some(path),
             arguments,
-            path_lookup: _,
+            ..
         })) = configured_binary
         {
             Some(LanguageServerBinary {

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -38,6 +38,7 @@ impl super::LspAdapter for CLspAdapter {
         if let Ok(Some(BinarySettings {
             path: Some(path),
             arguments,
+            path_lookup: _,
         })) = configured_binary
         {
             Some(LanguageServerBinary {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -81,6 +81,7 @@ impl super::LspAdapter for GoLspAdapter {
         if let Ok(Some(BinarySettings {
             path: Some(path),
             arguments,
+            ..
         })) = configured_binary
         {
             Some(LanguageServerBinary {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -78,13 +78,12 @@ impl super::LspAdapter for GoLspAdapter {
                 .and_then(|s| s.binary.clone())
         });
 
-        if let Ok(Some(BinarySettings {
-            path: Some(path),
-            arguments,
-            ..
-        })) = configured_binary
-        {
-            Some(LanguageServerBinary {
+        match configured_binary {
+            Ok(Some(BinarySettings {
+                path: Some(path),
+                arguments,
+                ..
+            })) => Some(LanguageServerBinary {
                 path: path.into(),
                 arguments: arguments
                     .unwrap_or_default()
@@ -92,15 +91,20 @@ impl super::LspAdapter for GoLspAdapter {
                     .map(|arg| arg.into())
                     .collect(),
                 env: None,
-            })
-        } else {
-            let env = delegate.shell_env().await;
-            let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
-            Some(LanguageServerBinary {
-                path,
-                arguments: server_binary_arguments(),
-                env: Some(env),
-            })
+            }),
+            Ok(Some(BinarySettings {
+                path_lookup: Some(false),
+                ..
+            })) => None,
+            _ => {
+                let env = delegate.shell_env().await;
+                let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
+                Some(LanguageServerBinary {
+                    path,
+                    arguments: server_binary_arguments(),
+                    env: Some(env),
+                })
+            }
         }
     }
 

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -60,6 +60,7 @@ impl LspAdapter for RustLspAdapter {
                 env: None,
             })
         } else {
+            log::info!("Trying to use `rust-analyzer` from PATH");
             let env = delegate.shell_env().await;
             let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
             Some(LanguageServerBinary {

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -38,19 +38,29 @@ impl LspAdapter for RustLspAdapter {
         delegate: &dyn LspAdapterDelegate,
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
-        let configured_binary = cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(Self::SERVER_NAME)
-                .and_then(|s| s.binary.clone())
+        let needed_settings = cx.update(|cx| {
+            let ra_settings = ProjectSettings::get_global(cx).lsp.get(Self::SERVER_NAME);
+            let detect_path = ra_settings.map(|s| s.detect_path).unwrap_or_else(|| {
+                log::info!("rust-analyzer settings not found, defaulting to detecting from PATH");
+                true
+            });
+            let binary = ra_settings.and_then(|s| s.binary.clone());
+            (binary, detect_path)
         });
 
-        if let Ok(Some(BinarySettings {
-            path: Some(path),
-            arguments,
-        })) = configured_binary
-        {
-            Some(LanguageServerBinary {
+        let (configured_binary, detect_path) = match needed_settings {
+            Ok((binary, detect_path)) => (Ok(binary), detect_path),
+            Err(e) => {
+                log::error!("Error reading rust-analyzer settings: {e:?}, proceeding with caution");
+                (Err(e), true)
+            }
+        };
+
+        match configured_binary {
+            Ok(Some(BinarySettings {
+                path: Some(path),
+                arguments,
+            })) => Some(LanguageServerBinary {
                 path: path.into(),
                 arguments: arguments
                     .unwrap_or_default()
@@ -58,16 +68,18 @@ impl LspAdapter for RustLspAdapter {
                     .map(|arg| arg.into())
                     .collect(),
                 env: None,
-            })
-        } else {
-            log::info!("Trying to use `rust-analyzer` from PATH");
-            let env = delegate.shell_env().await;
-            let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
-            Some(LanguageServerBinary {
-                path,
-                arguments: vec![],
-                env: Some(env),
-            })
+            }),
+            _ if detect_path => {
+                log::info!("Trying to use `rust-analyzer` from PATH");
+                let env = delegate.shell_env().await;
+                let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
+                Some(LanguageServerBinary {
+                    path,
+                    arguments: vec![],
+                    env: Some(env),
+                })
+            }
+            _ => None,
         }
     }
 

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -101,6 +101,9 @@ pub struct LspSettings {
     pub binary: Option<BinarySettings>,
     pub initialization_options: Option<serde_json::Value>,
     pub settings: Option<serde_json::Value>,
+
+    #[serde(default = "true_value")]
+    pub detect_path: bool,
 }
 
 impl Settings for ProjectSettings {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -93,6 +93,7 @@ const fn true_value() -> bool {
 pub struct BinarySettings {
     pub path: Option<String>,
     pub arguments: Option<Vec<String>>,
+    pub path_lookup: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -101,9 +102,6 @@ pub struct LspSettings {
     pub binary: Option<BinarySettings>,
     pub initialization_options: Option<serde_json::Value>,
     pub settings: Option<serde_json::Value>,
-
-    #[serde(default = "true_value")]
-    pub detect_path: bool,
 }
 
 impl Settings for ProjectSettings {


### PR DESCRIPTION
Release Notes:
- Added support for looking up the `rust-analyzer` binary in `$PATH`. This allows using such tools as `asdf` and nix to configure per-folder rust installations. To enable this behavior, use the `path_lookup` key when configuring the `rust-analyzer` `binary`: `{"lsp": {"rust-analyzer": {"binary": {"path_lookup": true }}}}`.

Question: Should we always pass the environment, no matter if the binary is pulled from settings or found in path?
