### PR TITLE
Fix hunk diff hitbox

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2947,8 +2947,8 @@ impl EditorElement {
                 let end_y = start_y + line_height;
 
                 let width = 0.275 * line_height;
-                let highlight_origin = bounds.origin + point(-width, start_y);
-                let highlight_size = size(width * 2., end_y - start_y);
+                let highlight_origin = bounds.origin + point(px(0.), start_y);
+                let highlight_size = size(width, end_y - start_y);
                 Bounds::new(highlight_origin, highlight_size)
             }
             DisplayDiffHunk::Unfolded {
@@ -2980,8 +2980,8 @@ impl EditorElement {
                     let end_y = end_row_in_current_excerpt.as_f32() * line_height - scroll_top;
 
                     let width = 0.275 * line_height;
-                    let highlight_origin = bounds.origin + point(-width, start_y);
-                    let highlight_size = size(width * 2., end_y - start_y);
+                    let highlight_origin = bounds.origin + point(px(0.), start_y);
+                    let highlight_size = size(width, end_y - start_y);
                     Bounds::new(highlight_origin, highlight_size)
                 }
                 DiffHunkStatus::Removed => {
@@ -2992,8 +2992,8 @@ impl EditorElement {
                     let end_y = start_y + line_height;
 
                     let width = 0.35 * line_height;
-                    let highlight_origin = bounds.origin + point(-width, start_y);
-                    let highlight_size = size(width * 2., end_y - start_y);
+                    let highlight_origin = bounds.origin + point(px(0.), start_y);
+                    let highlight_size = size(width, end_y - start_y);
                     Bounds::new(highlight_origin, highlight_size)
                 }
             },

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2911,7 +2911,13 @@ impl EditorElement {
                                 Corners::all(0.05 * line_height),
                             ),
                             DiffHunkStatus::Removed => (
-                                hunk_hitbox.bounds,
+                                Bounds::new(
+                                    point(
+                                        hunk_hitbox.origin.x - hunk_hitbox.size.width,
+                                        hunk_hitbox.origin.y,
+                                    ),
+                                    size(hunk_hitbox.size.width * px(2.), hunk_hitbox.size.height),
+                                ),
                                 cx.theme().status().deleted,
                                 Corners::all(1. * line_height),
                             ),


### PR DESCRIPTION
You can see in the video that hunks were getting toggled even when clicking on the scrollbar.

https://github.com/zed-industries/zed/assets/53836821/11f201e8-c5f1-49c8-a4d2-ac3b3343b5a8

This happened because the hitbox was actually extended to the left of the hunk indicator, I believe that was done so that "Removed" hunk indicators rendered correctly (Red triangles)

Fixed:

https://github.com/zed-industries/zed/assets/53836821/7b451b37-da85-4e56-9127-2a5512bd9e7a

Release Notes:

- Fixed hunk indicators getting expanded when clicking near them (but not on them)
