### PR TITLE
Always include context when performing inline transformation

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -36,7 +36,6 @@ actions!(
         ResetKey,
         InlineAssist,
         InsertActivePrompt,
-        ToggleIncludeConversation,
         ToggleHistory,
         ApplyEdit,
         ConfirmCommand


### PR DESCRIPTION
Release Notes:

- Improved clarity for inline transformations by always including the active assistant context.