### PR TITLE
Fix editor scrolling when closing tab using middle mouse button

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -542,7 +542,7 @@ impl EditorElement {
         text_hitbox: &Hitbox,
         cx: &mut ViewContext<Editor>,
     ) {
-        if cx.default_prevented() {
+        if !text_hitbox.is_hovered(cx) || cx.default_prevented() {
             return;
         }
 


### PR DESCRIPTION
#12005 introduced a side effect, that would cause the editor to react to a scroll event when using the middle mouse button to close a tab

Before:

https://github.com/zed-industries/zed/assets/53836821/46cb2e71-e9d5-477c-b34a-dc9b6bc9b1f1

After:

https://github.com/zed-industries/zed/assets/53836821/6ada7985-97c9-4b52-848f-c7f9461c5216

Release Notes:

- Fixed an issue where the editor would scroll upwards if other tabs were closed using the middle mouse button