### PR TITLE
Implement Indent & Outdent as operators

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -378,8 +378,8 @@
       "r": ["vim::PushOperator", "Replace"],
       "s": "vim::Substitute",
       "shift-s": "vim::SubstituteLine",
-      "> >": "vim::Indent",
-      "< <": "vim::Outdent",
+      ">": ["vim::PushOperator", "Indent"],
+      "<": ["vim::PushOperator", "Outdent"],
       "ctrl-pagedown": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
       // tree-sitter related commands
@@ -452,6 +452,18 @@
     "context": "Editor && vim_operator == ys",
     "bindings": {
       "s": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "Editor && vim_operator == >",
+    "bindings": {
+      ">": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "Editor && vim_operator == <",
+    "bindings": {
+      "<": "vim::CurrentLine"
     }
   },
   {

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -309,7 +309,7 @@ impl KeyBindingContextPredicate {
                 source = skip_whitespace(rest);
                 Ok((
                     KeyBindingContextPredicate::Identifier(operator.to_string().into()),
-                    source
+                    source,
                 ))
             }
             _ => Err(anyhow!("unexpected character {next:?}")),

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -344,7 +344,7 @@ const PRECEDENCE_EQ: u32 = 4;
 const PRECEDENCE_NOT: u32 = 5;
 
 fn is_identifier_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '-'
+    c.is_alphanumeric() || c == '_' || c == '-' || c == '>' || c == '<'
 }
 
 fn skip_whitespace(source: &str) -> &str {

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -304,6 +304,14 @@ impl KeyBindingContextPredicate {
                     source,
                 ))
             }
+            _ if is_vim_operator_char(next) => {
+                let (operator, rest) = source.split_at(1);
+                source = skip_whitespace(rest);
+                Ok((
+                    KeyBindingContextPredicate::Identifier(operator.to_string().into()),
+                    source
+                ))
+            }
             _ => Err(anyhow!("unexpected character {next:?}")),
         }
     }
@@ -344,7 +352,11 @@ const PRECEDENCE_EQ: u32 = 4;
 const PRECEDENCE_NOT: u32 = 5;
 
 fn is_identifier_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '-' || c == '>' || c == '<'
+    c.is_alphanumeric() || c == '_' || c == '-'
+}
+
+fn is_vim_operator_char(c: char) -> bool {
+    c == '>' || c == '<'
 }
 
 fn skip_whitespace(source: &str) -> &str {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -9,6 +9,7 @@ mod scroll;
 pub(crate) mod search;
 pub mod substitute;
 mod yank;
+mod indent;
 
 use std::sync::Arc;
 
@@ -33,6 +34,7 @@ use self::{
     change::{change_motion, change_object},
     delete::{delete_motion, delete_object},
     yank::{yank_motion, yank_object},
+    indent::{indent_motion, indent_object, IndentDirection},
 };
 
 actions!(
@@ -182,6 +184,8 @@ pub fn normal_motion(
             Some(Operator::Delete) => delete_motion(vim, motion, times, cx),
             Some(Operator::Yank) => yank_motion(vim, motion, times, cx),
             Some(Operator::AddSurrounds { target: None }) => {}
+            Some(Operator::Indent) => indent_motion(vim, motion, times, IndentDirection::In, cx),
+            Some(Operator::Outdent) => indent_motion(vim, motion, times, IndentDirection::Out, cx),
             Some(operator) => {
                 // Can't do anything for text objects, Ignoring
                 error!("Unexpected normal mode motion operator: {:?}", operator)
@@ -198,6 +202,12 @@ pub fn normal_object(object: Object, cx: &mut WindowContext) {
                 Some(Operator::Change) => change_object(vim, object, around, cx),
                 Some(Operator::Delete) => delete_object(vim, object, around, cx),
                 Some(Operator::Yank) => yank_object(vim, object, around, cx),
+                Some(Operator::Indent) => indent_object(
+                    vim, object, around, IndentDirection::In, cx
+                ),
+                Some(Operator::Outdent) => indent_object(
+                    vim, object, around, IndentDirection::Out, cx
+                ),
                 Some(Operator::AddSurrounds { target: None }) => {
                     waiting_operator = Some(Operator::AddSurrounds {
                         target: Some(SurroundsType::Object(object)),

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -2,6 +2,7 @@ mod case;
 mod change;
 mod delete;
 mod increment;
+mod indent;
 pub(crate) mod mark;
 mod paste;
 pub(crate) mod repeat;
@@ -9,7 +10,6 @@ mod scroll;
 pub(crate) mod search;
 pub mod substitute;
 mod yank;
-mod indent;
 
 use std::sync::Arc;
 
@@ -33,8 +33,8 @@ use self::{
     case::{change_case, convert_to_lower_case, convert_to_upper_case},
     change::{change_motion, change_object},
     delete::{delete_motion, delete_object},
-    yank::{yank_motion, yank_object},
     indent::{indent_motion, indent_object, IndentDirection},
+    yank::{yank_motion, yank_object},
 };
 
 actions!(
@@ -202,12 +202,12 @@ pub fn normal_object(object: Object, cx: &mut WindowContext) {
                 Some(Operator::Change) => change_object(vim, object, around, cx),
                 Some(Operator::Delete) => delete_object(vim, object, around, cx),
                 Some(Operator::Yank) => yank_object(vim, object, around, cx),
-                Some(Operator::Indent) => indent_object(
-                    vim, object, around, IndentDirection::In, cx
-                ),
-                Some(Operator::Outdent) => indent_object(
-                    vim, object, around, IndentDirection::Out, cx
-                ),
+                Some(Operator::Indent) => {
+                    indent_object(vim, object, around, IndentDirection::In, cx)
+                }
+                Some(Operator::Outdent) => {
+                    indent_object(vim, object, around, IndentDirection::Out, cx)
+                }
                 Some(Operator::AddSurrounds { target: None }) => {
                     waiting_operator = Some(Operator::AddSurrounds {
                         target: Some(SurroundsType::Object(object)),

--- a/crates/vim/src/normal/indent.rs
+++ b/crates/vim/src/normal/indent.rs
@@ -1,0 +1,90 @@
+use crate::{motion::Motion, object::Object, Vim, SelectionGoal};
+use collections::HashMap;
+use gpui::WindowContext;
+
+#[derive(PartialEq, Eq)]
+pub(super) enum IndentDirection {
+    In,
+    Out
+}
+
+pub fn indent_motion(
+    vim: &mut Vim,
+    motion: Motion,
+    times: Option<usize>,
+    dir: IndentDirection,
+    cx: &mut WindowContext
+) {
+    vim.stop_recording();
+    vim.update_active_editor(cx, |_, editor, cx| {
+        let text_layout_details = editor.text_layout_details(cx);
+        editor.transact(cx, |editor, cx| {
+            let mut original_positions: HashMap<_, _> = Default::default();
+            editor.change_selections(None, cx, |s| {
+                s.move_with(|map, selection| {
+                    let cursor = selection.head();
+                    original_positions.insert(selection.id, (cursor, map.line_len(cursor.row())));
+                    motion.expand_selection(map, selection, times, false, &text_layout_details);
+                });
+            });
+            if dir == IndentDirection::In {
+                editor.indent(&Default::default(), cx);
+            } else {
+                editor.outdent(&Default::default(), cx);
+            }
+            editor.change_selections(None, cx, |s| {
+                s.move_with(|map, selection| {
+                    let (mut cursor, line_len) = original_positions.remove(
+                        &selection.id
+                    ).unwrap();
+                    if dir == IndentDirection::In {
+                        *cursor.column_mut() += map.line_len(cursor.row()) - line_len;
+                    } else {
+                        *cursor.column_mut() -= line_len - map.line_len(cursor.row());
+                    }
+                    selection.collapse_to(cursor, selection.goal);
+                });
+            });
+        });
+    });
+}
+
+pub fn indent_object(
+    vim: &mut Vim,
+    object: Object,
+    around: bool,
+    dir: IndentDirection,
+    cx: &mut WindowContext
+) {
+    vim.stop_recording();
+    vim.update_active_editor(cx, |_, editor, cx| {
+        editor.transact(cx, |editor, cx| {
+            let mut original_positions: HashMap<_, _> = Default::default();
+            editor.change_selections(None, cx, |s| {
+                s.move_with(|map, selection| {
+                    let cursor = selection.head();
+                    original_positions.insert(selection.id, (cursor, map.line_len(cursor.row())));
+                    object.expand_selection(map, selection, around);
+                });
+            });
+            if dir == IndentDirection::In {
+                editor.indent(&Default::default(), cx);
+            } else {
+                editor.outdent(&Default::default(), cx);
+            }
+            editor.change_selections(None, cx, |s| {
+                s.move_with(|map, selection| {
+                    let (mut cursor, line_len) = original_positions.remove(
+                        &selection.id
+                    ).unwrap();
+                    if dir == IndentDirection::In {
+                        *cursor.column_mut() += map.line_len(cursor.row()) - line_len;
+                    } else {
+                        *cursor.column_mut() -= line_len - map.line_len(cursor.row());
+                    }
+                    selection.collapse_to(cursor, SelectionGoal::None);
+                });
+            });
+        });
+    });
+}

--- a/crates/vim/src/normal/indent.rs
+++ b/crates/vim/src/normal/indent.rs
@@ -1,4 +1,4 @@
-use crate::{motion::Motion, object::Object, Vim, SelectionGoal};
+use crate::{motion::Motion, object::Object, Vim};
 use collections::HashMap;
 use gpui::WindowContext;
 
@@ -82,7 +82,7 @@ pub fn indent_object(
                     } else {
                         *cursor.column_mut() -= line_len - map.line_len(cursor.row());
                     }
-                    selection.collapse_to(cursor, SelectionGoal::None);
+                    selection.collapse_to(cursor, selection.goal);
                 });
             });
         });

--- a/crates/vim/src/normal/indent.rs
+++ b/crates/vim/src/normal/indent.rs
@@ -70,7 +70,7 @@ pub fn indent_object(
             editor.change_selections(None, cx, |s| {
                 s.move_with(|map, selection| {
                     let anchor = original_positions.remove(&selection.id).unwrap();
-                    selection.collapse_to(anchor.to_display_point(map), selection.goal);
+                    selection.collapse_to(anchor.to_display_point(map), SelectionGoal::None);
                 });
             });
         });

--- a/crates/vim/src/normal/indent.rs
+++ b/crates/vim/src/normal/indent.rs
@@ -5,7 +5,7 @@ use gpui::WindowContext;
 #[derive(PartialEq, Eq)]
 pub(super) enum IndentDirection {
     In,
-    Out
+    Out,
 }
 
 pub fn indent_motion(
@@ -13,7 +13,7 @@ pub fn indent_motion(
     motion: Motion,
     times: Option<usize>,
     dir: IndentDirection,
-    cx: &mut WindowContext
+    cx: &mut WindowContext,
 ) {
     vim.stop_recording();
     vim.update_active_editor(cx, |_, editor, cx| {
@@ -34,9 +34,7 @@ pub fn indent_motion(
             }
             editor.change_selections(None, cx, |s| {
                 s.move_with(|map, selection| {
-                    let (mut cursor, line_len) = original_positions.remove(
-                        &selection.id
-                    ).unwrap();
+                    let (mut cursor, line_len) = original_positions.remove(&selection.id).unwrap();
                     if dir == IndentDirection::In {
                         *cursor.column_mut() += map.line_len(cursor.row()) - line_len;
                     } else {
@@ -54,7 +52,7 @@ pub fn indent_object(
     object: Object,
     around: bool,
     dir: IndentDirection,
-    cx: &mut WindowContext
+    cx: &mut WindowContext,
 ) {
     vim.stop_recording();
     vim.update_active_editor(cx, |_, editor, cx| {
@@ -74,9 +72,7 @@ pub fn indent_object(
             }
             editor.change_selections(None, cx, |s| {
                 s.move_with(|map, selection| {
-                    let (mut cursor, line_len) = original_positions.remove(
-                        &selection.id
-                    ).unwrap();
+                    let (mut cursor, line_len) = original_positions.remove(&selection.id).unwrap();
                     if dir == IndentDirection::In {
                         *cursor.column_mut() += map.line_len(cursor.row()) - line_len;
                     } else {

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -61,6 +61,8 @@ pub enum Operator {
     DeleteSurrounds,
     Mark,
     Jump { line: bool },
+    Indent,
+    Outdent,
 }
 
 #[derive(Default, Clone)]
@@ -266,6 +268,8 @@ impl Operator {
             Operator::Mark => "m",
             Operator::Jump { line: true } => "'",
             Operator::Jump { line: false } => "`",
+            Operator::Indent => ">",
+            Operator::Outdent => "<",
         }
     }
 

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -180,6 +180,33 @@ async fn test_indent_outdent(cx: &mut gpui::TestAppContext) {
     // works in visual mode
     cx.simulate_keystrokes("shift-v down >");
     cx.assert_editor_state("aa\n    bb\n    cˇc");
+    
+    // works as operator
+    cx.set_state("aa\nbˇb\ncc\n", Mode::Normal);
+    cx.simulate_keystrokes("> j");
+    cx.assert_editor_state("aa\n    bˇb\n    cc\n");
+    cx.simulate_keystrokes("< k");
+    cx.assert_editor_state("aa\nbˇb\n    cc\n");
+    cx.simulate_keystrokes("> i p");
+    cx.assert_editor_state("    aa\n    bˇb\n        cc\n");
+    cx.simulate_keystrokes("< i p");
+    cx.assert_editor_state("aa\nbˇb\n    cc\n");
+    cx.simulate_keystrokes("< i p");
+    cx.assert_editor_state("aa\nbˇb\ncc\n");
+
+    cx.set_state("ˇaa\nbb\ncc\n", Mode::Normal);
+    cx.simulate_keystrokes("> 2 j");
+    cx.assert_editor_state("    ˇaa\n    bb\n    cc\n");
+
+    cx.set_state("aa\nbb\nˇcc\n", Mode::Normal);
+    cx.simulate_keystrokes("> 2 k");
+    cx.assert_editor_state("    aa\n    bb\n    ˇcc\n");
+
+    cx.set_state("a\nb\nccˇc\n", Mode::Normal);
+    cx.simulate_keystrokes("> 2 k");
+    cx.assert_editor_state("    a\n    b\n    ccˇc\n");
+    cx.simulate_keystrokes(".");
+    cx.assert_editor_state("        a\n        b\n        ccˇc\n");
 }
 
 #[gpui::test]

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -180,7 +180,7 @@ async fn test_indent_outdent(cx: &mut gpui::TestAppContext) {
     // works in visual mode
     cx.simulate_keystrokes("shift-v down >");
     cx.assert_editor_state("aa\n    bb\n    cˇc");
-    
+
     // works as operator
     cx.set_state("aa\nbˇb\ncc\n", Mode::Normal);
     cx.simulate_keystrokes("> j");

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -534,7 +534,7 @@ impl Vim {
     fn push_operator(&mut self, operator: Operator, cx: &mut WindowContext) {
         if matches!(
             operator,
-            Operator::Change | Operator::Delete | Operator::Replace
+            Operator::Change | Operator::Delete | Operator::Replace | Operator::Indent | Operator::Outdent
         ) {
             self.start_recording(cx)
         };

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -534,7 +534,11 @@ impl Vim {
     fn push_operator(&mut self, operator: Operator, cx: &mut WindowContext) {
         if matches!(
             operator,
-            Operator::Change | Operator::Delete | Operator::Replace | Operator::Indent | Operator::Outdent
+            Operator::Change
+                | Operator::Delete
+                | Operator::Replace
+                | Operator::Indent
+                | Operator::Outdent
         ) {
             self.start_recording(cx)
         };


### PR DESCRIPTION
Release Notes:

- Fixes [#9697](https://github.com/zed-industries/zed/issues/9697).

Implements `>` and `<` with motions and text objects.
Works with repeat action `.`

