### PR TITLE
Fix deleted hunk offset when zooming

### DIFF
--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -309,17 +309,18 @@ impl Editor {
         let deleted_hunk_color = deleted_hunk_color(cx);
         let (editor_height, editor_with_deleted_text) =
             editor_with_deleted_text(diff_base_buffer, deleted_hunk_color, hunk, cx);
-        let parent_gutter_offset = self.gutter_dimensions.width + self.gutter_dimensions.margin;
+        let editor_model = cx.model().clone();
         let mut new_block_ids = self.insert_blocks(
             Some(BlockProperties {
                 position: hunk.multi_buffer_range.start,
                 height: editor_height.max(deleted_text_height),
                 style: BlockStyle::Flex,
-                render: Box::new(move |_| {
+                render: Box::new(move |cx| {
+                    let gutter_dimensions = editor_model.read(cx).gutter_dimensions;
                     div()
                         .bg(deleted_hunk_color)
                         .size_full()
-                        .pl(parent_gutter_offset)
+                        .pl(gutter_dimensions.width + gutter_dimensions.margin)
                         .child(editor_with_deleted_text.clone())
                         .into_any_element()
                 }),


### PR DESCRIPTION
Release Notes:

- Fixed an issue where expanded hunks could be rendered at the wrong position when zooming
- Fixed an issue where expanded hunks could be rendered at the wrong position when toggling git blame ([#11941](https://github.com/zed-industries/zed/issues/11941))
