### PR TITLE
gpui: Handle null string pointer in `window::insert_text`

### DIFF
--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -29,7 +29,10 @@ use cocoa::{
 };
 
 use objc::runtime::{BOOL, NO, YES};
-use std::ops::Range;
+use std::{
+    ffi::{c_char, CStr},
+    ops::Range,
+};
 
 pub(crate) use dispatcher::*;
 pub(crate) use display::*;
@@ -48,6 +51,21 @@ impl BoolExt for bool {
             YES
         } else {
             NO
+        }
+    }
+}
+
+trait NSStringExt {
+    unsafe fn to_str(&self) -> &str;
+}
+
+impl NSStringExt for id {
+    unsafe fn to_str(&self) -> &str {
+        let cstr = self.UTF8String();
+        if cstr.is_null() {
+            ""
+        } else {
+            CStr::from_ptr(cstr as *mut c_char).to_str().unwrap()
         }
     }
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1711,9 +1711,14 @@ extern "C" fn insert_text(this: &Object, _: Sel, text: id, replacement_range: NS
         } else {
             text
         };
-        let text = CStr::from_ptr(text.UTF8String() as *mut c_char)
-            .to_str()
-            .unwrap();
+
+        let cstr = text.UTF8String();
+        let text = if cstr.is_null() {
+            ""
+        } else {
+            CStr::from_ptr(cstr as *mut c_char).to_str().unwrap()
+        };
+
         let replacement_range = replacement_range.to_range();
         send_to_input_handler(
             this,

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1,4 +1,4 @@
-use super::{ns_string, renderer, MacDisplay, NSRange};
+use super::{ns_string, renderer, MacDisplay, NSRange, NSStringExt};
 use crate::{
     platform::PlatformInputHandler, point, px, size, AnyWindowHandle, Bounds, DevicePixels,
     DisplayLink, ExternalPaths, FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke,
@@ -39,7 +39,6 @@ use std::{
     ffi::{c_void, CStr},
     mem,
     ops::Range,
-    os::raw::c_char,
     path::PathBuf,
     ptr::{self, NonNull},
     rc::Rc,
@@ -1712,13 +1711,7 @@ extern "C" fn insert_text(this: &Object, _: Sel, text: id, replacement_range: NS
             text
         };
 
-        let cstr = text.UTF8String();
-        let text = if cstr.is_null() {
-            ""
-        } else {
-            CStr::from_ptr(cstr as *mut c_char).to_str().unwrap()
-        };
-
+        let text = text.to_str();
         let replacement_range = replacement_range.to_range();
         send_to_input_handler(
             this,
@@ -1744,9 +1737,7 @@ extern "C" fn set_marked_text(
         };
         let selected_range = selected_range.to_range();
         let replacement_range = replacement_range.to_range();
-        let text = CStr::from_ptr(text.UTF8String() as *mut c_char)
-            .to_str()
-            .unwrap();
+        let text = text.to_str();
 
         send_to_input_handler(
             this,


### PR DESCRIPTION
`[NSString UTF8String]` sometimes returns null (it's documented as such), and when it does, zed crashes in `window::insert_text`. I'm running into this sometimes when using alt-d to delete forward. It usually only happens with multiple cursors, but sometimes with a single cursor. It *might* only happen when using the "Unicode Hex Input" keyboard 'Input Source' (which I started using to avoid entering weird characters in zed when using emacs meta keybindings that I haven't defined in zed).

When using the US English input source, alt-d always results in a call to `insert_text`. When using the Unicode Hex Input source it usually doesn't, but when it does `text.UTF8String()` returns null. `text` isn't null. `[text length]` returns 1. `[text characterAtIndex: 0]` seems to always return `56797` (an undefined utf-16 codepoint).

Release Notes:

- Fixed crash on macOS when using certain input sources