### PR TITLE
assistant: Add `/rustdoc` slash command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rope",
+ "rustdoc_to_markdown",
  "schemars",
  "search",
  "semantic_index",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -39,6 +39,7 @@ parking_lot.workspace = true
 project.workspace = true
 regex.workspace = true
 rope.workspace = true
+rustdoc_to_markdown.workspace = true
 schemars.workspace = true
 search.workspace = true
 semantic_index.workspace = true

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,5 +1,5 @@
 use crate::prompts::{generate_content_prompt, PromptLibrary, PromptManager};
-use crate::slash_command::{search_command, tabs_command};
+use crate::slash_command::{rustdoc_command, search_command, tabs_command};
 use crate::{
     assistant_settings::{AssistantDockPosition, AssistantSettings, ZedDotDevModel},
     codegen::{self, Codegen, CodegenKind},
@@ -210,6 +210,7 @@ impl AssistantPanel {
                     slash_command_registry.register_command(tabs_command::TabsSlashCommand);
                     slash_command_registry.register_command(project_command::ProjectSlashCommand);
                     slash_command_registry.register_command(search_command::SearchSlashCommand);
+                    slash_command_registry.register_command(rustdoc_command::RustdocSlashCommand);
 
                     Self {
                         workspace: workspace_handle,

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -20,6 +20,7 @@ pub mod active_command;
 pub mod file_command;
 pub mod project_command;
 pub mod prompt_command;
+pub mod rustdoc_command;
 pub mod search_command;
 pub mod tabs_command;
 

--- a/crates/assistant/src/slash_command/rustdoc_command.rs
+++ b/crates/assistant/src/slash_command/rustdoc_command.rs
@@ -1,0 +1,92 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use anyhow::Result;
+use assistant_slash_command::{SlashCommand, SlashCommandOutput, SlashCommandOutputSection};
+use gpui::{AppContext, Task, WeakView};
+use language::LspAdapterDelegate;
+use rustdoc_to_markdown::convert_rustdoc_to_markdown;
+use ui::{prelude::*, ButtonLike, ElevationIndex};
+use workspace::Workspace;
+
+pub(crate) struct RustdocSlashCommand;
+
+impl RustdocSlashCommand {
+    async fn build_message() -> Result<String> {
+        let html = include_str!("/Users/maxdeviant/projects/zed/target/doc/gpui/index.html");
+
+        convert_rustdoc_to_markdown(html)
+    }
+}
+
+impl SlashCommand for RustdocSlashCommand {
+    fn name(&self) -> String {
+        "rustdoc".into()
+    }
+
+    fn description(&self) -> String {
+        "insert the docs for a Rust crate".into()
+    }
+
+    fn tooltip_text(&self) -> String {
+        "insert rustdoc".into()
+    }
+
+    fn requires_argument(&self) -> bool {
+        false
+    }
+
+    fn complete_argument(
+        &self,
+        _query: String,
+        _cancel: Arc<AtomicBool>,
+        _workspace: WeakView<Workspace>,
+        _cx: &mut AppContext,
+    ) -> Task<Result<Vec<String>>> {
+        Task::ready(Ok(Vec::new()))
+    }
+
+    fn run(
+        self: Arc<Self>,
+        argument: Option<&str>,
+        workspace: WeakView<Workspace>,
+        delegate: Arc<dyn LspAdapterDelegate>,
+        cx: &mut WindowContext,
+    ) -> Task<Result<SlashCommandOutput>> {
+        let text = cx
+            .background_executor()
+            .spawn(async move { Self::build_message().await });
+        cx.foreground_executor().spawn(async move {
+            let text = text.await?;
+            let range = 0..text.len();
+            Ok(SlashCommandOutput {
+                text,
+                sections: vec![SlashCommandOutputSection {
+                    range,
+                    render_placeholder: Arc::new(move |id, unfold, _cx| {
+                        RustdocPlaceholder { id, unfold }.into_any_element()
+                    }),
+                }],
+            })
+        })
+    }
+}
+
+#[derive(IntoElement)]
+struct RustdocPlaceholder {
+    pub id: ElementId,
+    pub unfold: Arc<dyn Fn(&mut WindowContext)>,
+}
+
+impl RenderOnce for RustdocPlaceholder {
+    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
+        let unfold = self.unfold;
+
+        ButtonLike::new(self.id)
+            .style(ButtonStyle::Filled)
+            .layer(ElevationIndex::ElevatedSurface)
+            .child(Icon::new(IconName::FileRust))
+            .child(Label::new("rustdoc"))
+            .on_click(move |_, cx| unfold(cx))
+    }
+}

--- a/crates/rustdoc_to_markdown/examples/test.rs
+++ b/crates/rustdoc_to_markdown/examples/test.rs
@@ -23,7 +23,7 @@ pub fn main() {
     // ```
     // let html = include_str!("/path/to/zed/target/doc/gpui/index.html");
     // ```
-    let markdown = convert_rustdoc_to_markdown(html).unwrap();
+    let markdown = convert_rustdoc_to_markdown(html.as_bytes()).unwrap();
 
     println!("{markdown}");
 }

--- a/crates/rustdoc_to_markdown/src/markdown_writer.rs
+++ b/crates/rustdoc_to_markdown/src/markdown_writer.rs
@@ -135,16 +135,15 @@ impl MarkdownWriter {
                 }
             }
             "div" | "span" => {
-                if tag.attrs.borrow().iter().any(|attr| {
-                    attr.name.local.to_string() == "class"
-                        && attr.value.to_string() == "sidebar-elems"
-                }) {
-                    return StartTagOutcome::Skip;
-                }
+                let classes_to_skip = ["nav-container", "sidebar-elems", "out-of-band"];
 
                 if tag.attrs.borrow().iter().any(|attr| {
                     attr.name.local.to_string() == "class"
-                        && attr.value.to_string() == "out-of-band"
+                        && attr
+                            .value
+                            .to_string()
+                            .split(' ')
+                            .any(|class| classes_to_skip.contains(&class.trim()))
                 }) {
                     return StartTagOutcome::Skip;
                 }

--- a/crates/rustdoc_to_markdown/src/markdown_writer.rs
+++ b/crates/rustdoc_to_markdown/src/markdown_writer.rs
@@ -135,7 +135,6 @@ impl MarkdownWriter {
                     attr.name.local.to_string() == "class"
                         && attr
                             .value
-                            .to_string()
                             .split(' ')
                             .any(|class| classes_to_skip.contains(&class.trim()))
                 }) {

--- a/crates/rustdoc_to_markdown/src/markdown_writer.rs
+++ b/crates/rustdoc_to_markdown/src/markdown_writer.rs
@@ -36,12 +36,6 @@ impl MarkdownWriter {
             .any(|parent_element| parent_element.tag == tag)
     }
 
-    fn is_inside_heading(&self) -> bool {
-        ["h1", "h2", "h3", "h4", "h5", "h6"]
-            .into_iter()
-            .any(|heading| self.is_inside(heading))
-    }
-
     /// Appends the given string slice onto the end of the Markdown output.
     fn push_str(&mut self, str: &str) {
         self.markdown.push_str(str);
@@ -185,10 +179,6 @@ impl MarkdownWriter {
     fn visit_text(&mut self, text: String) -> Result<()> {
         if self.is_inside("pre") {
             self.push_str(&text);
-            return Ok(());
-        }
-
-        if self.is_inside_heading() && self.is_inside("a") {
             return Ok(());
         }
 

--- a/crates/rustdoc_to_markdown/src/rustdoc_to_markdown.rs
+++ b/crates/rustdoc_to_markdown/src/rustdoc_to_markdown.rs
@@ -4,6 +4,8 @@
 
 mod markdown_writer;
 
+use std::io::Read;
+
 use anyhow::{Context, Result};
 use html5ever::driver::ParseOpts;
 use html5ever::parse_document;
@@ -14,7 +16,7 @@ use markup5ever_rcdom::RcDom;
 use crate::markdown_writer::MarkdownWriter;
 
 /// Converts the provided rustdoc HTML to Markdown.
-pub fn convert_rustdoc_to_markdown(html: &str) -> Result<String> {
+pub fn convert_rustdoc_to_markdown(mut html: impl Read) -> Result<String> {
     let parse_options = ParseOpts {
         tree_builder: TreeBuilderOpts {
             drop_doctype: true,
@@ -24,7 +26,7 @@ pub fn convert_rustdoc_to_markdown(html: &str) -> Result<String> {
     };
     let dom = parse_document(RcDom::default(), parse_options)
         .from_utf8()
-        .read_from(&mut html.as_bytes())
+        .read_from(&mut html)
         .context("failed to parse rustdoc HTML")?;
 
     let markdown_writer = MarkdownWriter::new();


### PR DESCRIPTION
This PR adds a `/rustdoc` slash command for retrieving and inserting rustdoc docs into the Assistant.

Right now the command accepts the crate name as an argument and will return the top-level docs from `docs.rs`.

Release Notes:

- N/A
