### PR TITLE
rustdoc_to_markdown: Clean up heading spacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8639,6 +8639,7 @@ dependencies = [
  "html5ever",
  "indoc",
  "markup5ever_rcdom",
+ "regex",
 ]
 
 [[package]]

--- a/crates/rustdoc_to_markdown/Cargo.toml
+++ b/crates/rustdoc_to_markdown/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/rustdoc_to_markdown.rs"
 anyhow.workspace = true
 html5ever.workspace = true
 markup5ever_rcdom.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true


### PR DESCRIPTION
This PR cleans up the spacing around the Markdown headings in the output so that they are consistent.

Release Notes:

- N/A
