### PR TITLE
Make prompt library icon in context panel staff-only for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "ctor",
  "editor",
  "env_logger",
+ "feature_flags",
  "file_icons",
  "fs",
  "futures 0.3.28",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -22,6 +22,7 @@ client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
 editor.workspace = true
+feature_flags.workspace = true
 file_icons.workspace = true
 fs.workspace = true
 futures.workspace = true

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -192,10 +192,13 @@ impl UserStore {
 
                                 cx.update(|cx| {
                                     if let Some(info) = info {
-                                        cx.update_flags(info.staff, info.flags);
+                                        let disable_staff = std::env::var("ZED_DISABLE_STAFF")
+                                            .map_or(false, |v| v != "" && v != "0");
+                                        let staff = info.staff && !disable_staff;
+                                        cx.update_flags(staff, info.flags);
                                         client.telemetry.set_authenticated_user_info(
                                             Some(info.metrics_id.clone()),
-                                            info.staff,
+                                            staff,
                                         )
                                     }
                                 })?;

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -14,6 +14,12 @@ impl FeatureFlags {
 
 impl Global for FeatureFlags {}
 
+/// To create a feature flag, implement this trait on a trivial type and use it as
+/// a generic parameter when called [`FeatureFlagAppExt::has_flag`].
+///
+/// Feature flags are always enabled for members of Zed staff. To disable this behavior
+/// so you can test flags being disabled, set ZED_DISABLE_STAFF=1 in your environment,
+/// which will force Zed to treat the current user as non-staff.
 pub trait FeatureFlag {
     const NAME: &'static str;
 }


### PR DESCRIPTION
This is still pretty raw, so I'd like to hold off on shipping it to all users.

Release Notes:

- Hide the prompt library for non-staff until it is in a more complete state.
