### PR TITLE
Show filtered project panel when multi buffer is active

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -149,6 +149,9 @@ use workspace::{OpenInTerminal, OpenTerminal, Toast};
 
 use crate::hover_links::find_url;
 
+pub const FILE_HEADER_HEIGHT: u8 = 1;
+pub const MULTI_BUFFER_EXCERPT_HEADER_HEIGHT: u8 = 1;
+pub const MULTI_BUFFER_EXCERPT_FOOTER_HEIGHT: u8 = 1;
 pub const DEFAULT_MULTIBUFFER_CONTEXT: u32 = 2;
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
 const MAX_LINE_LEN: usize = 1024;
@@ -524,6 +527,7 @@ pub struct Editor {
     expect_bounds_change: Option<Bounds<Pixels>>,
     tasks: BTreeMap<(BufferId, BufferRow), RunnableTasks>,
     tasks_update_task: Option<Task<()>>,
+    file_header_size: u8,
 }
 
 #[derive(Clone)]
@@ -1630,9 +1634,8 @@ impl Editor {
             }),
             merge_adjacent: true,
         };
+        let file_header_size = if show_excerpt_controls { 3 } else { 2 };
         let display_map = cx.new_model(|cx| {
-            let file_header_size = if show_excerpt_controls { 3 } else { 2 };
-
             DisplayMap::new(
                 buffer.clone(),
                 style.font(),
@@ -1640,8 +1643,8 @@ impl Editor {
                 None,
                 show_excerpt_controls,
                 file_header_size,
-                1,
-                1,
+                MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+                MULTI_BUFFER_EXCERPT_FOOTER_HEIGHT,
                 fold_placeholder,
                 cx,
             )
@@ -1783,6 +1786,7 @@ impl Editor {
             git_blame_inline_enabled: ProjectSettings::get_global(cx).git.inline_blame_enabled(),
             blame: None,
             blame_subscription: None,
+            file_header_size,
             tasks: Default::default(),
             _subscriptions: vec![
                 cx.observe(&buffer, Self::on_buffer_changed),
@@ -11002,6 +11006,10 @@ impl Editor {
             })
         }));
         self
+    }
+
+    pub fn file_header_size(&self) -> u8 {
+        self.file_header_size
     }
 }
 

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -20,6 +20,7 @@ editor.workspace = true
 file_icons.workspace = true
 git.workspace = true
 gpui.workspace = true
+language.workspace = true
 menu.workspace = true
 pretty_assertions.workspace = true
 project.workspace = true

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2234,6 +2234,15 @@ impl ProjectPanel {
                                                 )
                                             });
                                         if let Some(anchor) = scroll_target {
+                                            project_panel.marked_entries.clear();
+                                            project_panel.marked_entries.insert(SelectedEntry {
+                                                worktree_id,
+                                                entry_id,
+                                            });
+                                            project_panel.selection = Some(SelectedEntry {
+                                                worktree_id,
+                                                entry_id,
+                                            });
                                             active_editor.update(cx, |editor, cx| {
                                                 editor.set_scroll_anchor(
                                                     ScrollAnchor {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1705,7 +1705,7 @@ impl ProjectPanel {
             }
 
             // TODO kb slow and odd
-            if active_multi_buffer_entries.is_some() {
+            let sort_before_the_propagation = if active_multi_buffer_entries.is_some() {
                 let mut dir_entries_to_re_add = HashMap::default();
                 visible_worktree_entries.retain(|entry| {
                     let is_new_entry = new_entries.contains(&entry.id);
@@ -1737,8 +1737,14 @@ impl ProjectPanel {
                     retain_visible_entry
                 });
                 visible_worktree_entries.extend(dir_entries_to_re_add.into_values());
-            }
+                true
+            } else {
+                false
+            };
 
+            if !sort_before_the_propagation {
+                snapshot.propagate_git_statuses(&mut visible_worktree_entries);
+            }
             visible_worktree_entries.sort_by(|entry_a, entry_b| {
                 let mut components_a = entry_a.path.components().peekable();
                 let mut components_b = entry_b.path.components().peekable();
@@ -1784,7 +1790,9 @@ impl ProjectPanel {
                     }
                 }
             });
-            snapshot.propagate_git_statuses(&mut visible_worktree_entries);
+            if sort_before_the_propagation {
+                snapshot.propagate_git_statuses(&mut visible_worktree_entries);
+            }
             self.visible_entries
                 .push((worktree_id, visible_worktree_entries));
         }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -53,7 +53,7 @@ pub struct ProjectPanel {
     focus_handle: FocusHandle,
     visible_entries: Vec<(WorktreeId, Vec<Entry>)>,
     last_worktree_root_id: Option<ProjectEntryId>,
-    expanded_dir_ids: HashMap<WorktreeId, Vec<ProjectEntryId>>,
+    expanded_dir_ids: HashMap<WorktreeId, BTreeSet<ProjectEntryId>>,
     unfolded_dir_ids: HashSet<ProjectEntryId>,
     // Currently selected entry in a file tree
     selection: Option<SelectedEntry>,
@@ -302,7 +302,7 @@ impl ProjectPanel {
                 focus_handle,
                 visible_entries: Default::default(),
                 last_worktree_root_id: None,
-                expanded_dir_ids: Default::default(),
+                expanded_dir_ids: HashMap::default(),
                 unfolded_dir_ids: Default::default(),
                 selection: None,
                 marked_entries: Default::default(),
@@ -624,17 +624,14 @@ impl ProjectPanel {
                         return;
                     };
 
-                match expanded_dir_ids.binary_search(&entry_id) {
-                    Ok(_) => self.select_next(&SelectNext, cx),
-                    Err(ix) => {
-                        self.project.update(cx, |project, cx| {
-                            project.expand_entry(worktree_id, entry_id, cx);
-                        });
-
-                        expanded_dir_ids.insert(ix, entry_id);
-                        self.update_visible_entries(None, cx);
-                        cx.notify();
-                    }
+                if expanded_dir_ids.insert(entry_id) {
+                    self.project.update(cx, |project, cx| {
+                        project.expand_entry(worktree_id, entry_id, cx);
+                    });
+                    self.update_visible_entries(None, cx);
+                    cx.notify()
+                } else {
+                    self.select_next(&SelectNext, cx)
                 }
             }
         }
@@ -652,22 +649,16 @@ impl ProjectPanel {
 
             loop {
                 let entry_id = entry.id;
-                match expanded_dir_ids.binary_search(&entry_id) {
-                    Ok(ix) => {
-                        expanded_dir_ids.remove(ix);
-                        self.update_visible_entries(Some((worktree_id, entry_id)), cx);
-                        cx.notify();
-                        break;
-                    }
-                    Err(_) => {
-                        if let Some(parent_entry) =
-                            entry.path.parent().and_then(|p| worktree.entry_for_path(p))
-                        {
-                            entry = parent_entry;
-                        } else {
-                            break;
-                        }
-                    }
+                if expanded_dir_ids.remove(&entry_id) {
+                    self.update_visible_entries(Some((worktree_id, entry_id)), cx);
+                    cx.notify();
+                    break;
+                } else if let Some(parent_entry) =
+                    entry.path.parent().and_then(|p| worktree.entry_for_path(p))
+                {
+                    entry = parent_entry;
+                } else {
+                    break;
                 }
             }
         }
@@ -686,14 +677,9 @@ impl ProjectPanel {
         if let Some(worktree_id) = self.project.read(cx).worktree_id_for_entry(entry_id, cx) {
             if let Some(expanded_dir_ids) = self.expanded_dir_ids.get_mut(&worktree_id) {
                 self.project.update(cx, |project, cx| {
-                    match expanded_dir_ids.binary_search(&entry_id) {
-                        Ok(ix) => {
-                            expanded_dir_ids.remove(ix);
-                        }
-                        Err(ix) => {
-                            project.expand_entry(worktree_id, entry_id, cx);
-                            expanded_dir_ids.insert(ix, entry_id);
-                        }
+                    if !expanded_dir_ids.remove(&entry_id) {
+                        project.expand_entry(worktree_id, entry_id, cx);
+                        expanded_dir_ids.insert(entry_id);
                     }
                 });
                 self.update_visible_entries(Some((worktree_id, entry_id)), cx);
@@ -898,9 +884,7 @@ impl ProjectPanel {
                 if let Some(mut entry) = worktree.entry_for_id(entry_id) {
                     loop {
                         if entry.is_dir() {
-                            if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
-                                expanded_dir_ids.insert(ix, entry.id);
-                            }
+                            expanded_dir_ids.insert(entry.id);
                             directory_id = entry.id;
                             break;
                         } else {
@@ -1525,9 +1509,7 @@ impl ProjectPanel {
                 continue;
             };
             if entry.is_dir() {
-                if let Err(idx) = expanded_dir_ids.binary_search(&entry.id) {
-                    expanded_dir_ids.insert(idx, entry.id);
-                }
+                expanded_dir_ids.insert(entry.id);
             }
         }
 
@@ -1576,9 +1558,9 @@ impl ProjectPanel {
                     // The first time a worktree's root entry becomes available,
                     // mark that root entry as expanded.
                     if let Some(entry) = snapshot.root_entry() {
-                        e.insert(vec![entry.id]).as_slice()
+                        e.insert(BTreeSet::from([entry.id]))
                     } else {
-                        &[]
+                        e.insert(BTreeSet::new())
                     }
                 }
             };
@@ -1643,9 +1625,7 @@ impl ProjectPanel {
                         is_symlink: entry.is_symlink,
                     });
                 }
-                if expanded_dir_ids.binary_search(&entry.id).is_err()
-                    && entry_iter.advance_to_sibling()
-                {
+                if !expanded_dir_ids.contains(&entry.id) && entry_iter.advance_to_sibling() {
                     continue;
                 }
                 entry_iter.advance();
@@ -1664,6 +1644,10 @@ impl ProjectPanel {
                     }
                 })
             }
+            self.expanded_dir_ids
+                .entry(worktree_id)
+                .or_default()
+                .extend(entries_to_re_add.iter().map(|entry| entry.id));
             visible_worktree_entries.extend(entries_to_re_add);
 
             snapshot.propagate_git_statuses(&mut visible_worktree_entries);
@@ -1747,10 +1731,7 @@ impl ProjectPanel {
 
                 if let Some(mut entry) = worktree.entry_for_id(entry_id) {
                     loop {
-                        if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
-                            expanded_dir_ids.insert(ix, entry.id);
-                        }
-
+                        expanded_dir_ids.insert(entry.id);
                         if let Some(parent_entry) =
                             entry.path.parent().and_then(|p| worktree.entry_for_path(p))
                         {
@@ -1831,16 +1812,13 @@ impl ProjectPanel {
             if let Some(worktree) = self.project.read(cx).worktree_for_id(*worktree_id, cx) {
                 let snapshot = worktree.read(cx).snapshot();
                 let root_name = OsStr::new(snapshot.root_name());
-                let expanded_entry_ids = self
-                    .expanded_dir_ids
-                    .get(&snapshot.id())
-                    .map(Vec::as_slice)
-                    .unwrap_or(&[]);
+                let expanded_entry_ids = self.expanded_dir_ids.get(&snapshot.id());
 
                 let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
                 for entry in visible_worktree_entries[entry_range].iter() {
                     let status = git_status_setting.then(|| entry.git_status).flatten();
-                    let is_expanded = expanded_entry_ids.binary_search(&entry.id).is_ok();
+                    let is_expanded =
+                        expanded_entry_ids.map_or(false, |ids| ids.contains(&entry.id));
                     let icon = match entry.kind {
                         EntryKind::File(_) => {
                             if show_file_icons {


### PR DESCRIPTION
Prototypes a project panel mode, that filters its contents whenever a multi buffer is activated.
Switching back to singleton buffers, or absent or zero excerpts multi buffer restores the usual project panel view, switching to another multi buffer updates the items filtered and expanded.

Regular project panel:
<img width="1049" alt="Screenshot 2024-05-30 at 02 52 45" src="https://github.com/zed-industries/zed/assets/2690773/722fc017-0659-448b-8d10-8d22b4bbf3fa">

Filtered and autoexpanded, after doing a project search:
<img width="1401" alt="Screenshot 2024-05-30 at 02 52 53" src="https://github.com/zed-industries/zed/assets/2690773/9d02cef8-778d-4a99-97bf-bfaa457e9c83">

The filtered mode maintains similar look and feel as the regular project panel, modulo interacting with the multi buffer.
Clicking any file scrolls the multi buffer to the corresponding file header, vice versa, changing the selection in the multi buffer, reveals the corresponding project panel entry.

TODO: 
- [ ] approach validation
- [ ] tests
- [ ] performance improvements 