### PR TITLE
php: Update Pest tree-sitter queries to capture single quotes

### DIFF
--- a/extensions/php/languages/php/outline.scm
+++ b/extensions/php/languages/php/outline.scm
@@ -35,7 +35,10 @@
     arguments: (arguments
         .
         (argument
-            (encapsed_string (string_value) @name)
+            [
+              (encapsed_string (string_value) @name)
+              (string (string_value) @name)
+            ]
         )
     )
 ) @item

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -94,7 +94,10 @@
         arguments: (arguments
             .
             (argument
-                (encapsed_string (string_value) @run)
+                [
+                  (encapsed_string (string_value) @run)
+                  (string (string_value) @run)
+                ]
             )
         )
     ) @pest-test


### PR DESCRIPTION
Improved PHP Pest outline and runnables to support single quoted arguments ([#12461](https://github.com/zed-industries/zed/issues/12461)).

Release Notes:

- N/A

| Before | After |
|--------|--------|
| ![image](https://github.com/zed-industries/zed/assets/428033/e0966510-da11-4a80-8901-7dba541ab721) |  ![CleanShot 2024-05-29 at 20 13 00@2x](https://github.com/zed-industries/zed/assets/428033/5f7ab492-2791-4a04-9ec3-f0adfa9b2986) |
| ![CleanShot 2024-05-29 at 20 18 11@2x](https://github.com/zed-industries/zed/assets/428033/ac6bf58b-4e7d-410d-af51-328c41a76ba0) | ![CleanShot 2024-05-29 at 20 14 35@2x](https://github.com/zed-industries/zed/assets/428033/1d226bb8-f102-4171-906d-e122ab8299cf) |