### PR TITLE
Force 60 minutes timeout for all regular CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   style:
+    timeout-minutes: 60
     name: Check formatting and spelling
     runs-on:
       - self-hosted
@@ -77,6 +78,7 @@ jobs:
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${BUF_BASE_BRANCH},subdir=crates/rpc/proto/"
 
   macos_tests:
+    timeout-minutes: 60
     name: (macOS) Run Clippy and tests
     runs-on:
       - self-hosted
@@ -101,6 +103,7 @@ jobs:
 
   # todo(linux): Actually run the tests
   linux_tests:
+    timeout-minutes: 60
     name: (Linux) Run Clippy and tests
     runs-on:
       - self-hosted
@@ -122,6 +125,7 @@ jobs:
 
   # todo(windows): Actually run the tests
   windows_tests:
+    timeout-minutes: 60
     name: (Windows) Run Clippy and tests
     runs-on: hosted-windows-1
     steps:
@@ -142,6 +146,7 @@ jobs:
         run: cargo build -p zed
 
   bundle-mac:
+    timeout-minutes: 60
     name: Create a macOS bundle
     runs-on:
       - self-hosted
@@ -252,6 +257,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   bundle-linux:
+    timeout-minutes: 60
     name: Create a Linux bundle
     runs-on:
       - self-hosted

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   style:
+    timeout-minutes: 60
     name: Check formatting and Clippy lints
     if: github.repository_owner == 'zed-industries'
     runs-on:
@@ -33,6 +34,7 @@ jobs:
       - name: Run clippy
         run: cargo xtask clippy
   tests:
+    timeout-minutes: 60
     name: Run tests
     if: github.repository_owner == 'zed-industries'
     runs-on:
@@ -49,6 +51,7 @@ jobs:
         uses: ./.github/actions/run_tests
 
   bundle-mac:
+    timeout-minutes: 60
     name: Create a macOS bundle
     if: github.repository_owner == 'zed-industries'
     runs-on:
@@ -91,6 +94,7 @@ jobs:
         run: script/upload-nightly macos
 
   bundle-deb:
+    timeout-minutes: 60
     name: Create a Linux *.tar.gz bundle
     if: github.repository_owner == 'zed-industries'
     runs-on:


### PR DESCRIPTION
After gazing at https://github.com/zed-industries/zed/actions/runs/9296132630/job/25596939148 for some time, I've decided to add a hard limit on every test-related CI job.

Release Notes:

- N/A
