### PR TITLE
Use repository mutex more sparingly. Don't hold it while running git status.

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9975,11 +9975,9 @@ impl Editor {
 
         const REMOTE_NAME: &str = "origin";
         let origin_url = repo
-            .lock()
             .remote_url(REMOTE_NAME)
             .ok_or_else(|| anyhow!("remote \"{REMOTE_NAME}\" not found"))?;
         let sha = repo
-            .lock()
             .head_sha()
             .ok_or_else(|| anyhow!("failed to read HEAD SHA"))?;
         let selections = self.selections.all::<Point>(cx);

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -12,19 +12,13 @@ use std::os::unix::fs::MetadataExt;
 use async_tar::Archive;
 use futures::{future::BoxFuture, AsyncRead, Stream, StreamExt};
 use git::repository::{GitRepository, RealGitRepository};
-use git2::Repository as LibGitRepository;
-use parking_lot::Mutex;
 use rope::Rope;
-
-#[cfg(any(test, feature = "test-support"))]
-use smol::io::AsyncReadExt;
 use smol::io::AsyncWriteExt;
-use std::io::Write;
-use std::sync::Arc;
 use std::{
-    io,
+    io::{self, Write},
     path::{Component, Path, PathBuf},
     pin::Pin,
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 use tempfile::{NamedTempFile, TempDir};
@@ -35,6 +29,10 @@ use util::{paths, ResultExt};
 use collections::{btree_map, BTreeMap};
 #[cfg(any(test, feature = "test-support"))]
 use git::repository::{FakeGitRepositoryState, GitFileStatus};
+#[cfg(any(test, feature = "test-support"))]
+use parking_lot::Mutex;
+#[cfg(any(test, feature = "test-support"))]
+use smol::io::AsyncReadExt;
 #[cfg(any(test, feature = "test-support"))]
 use std::ffi::OsStr;
 
@@ -83,7 +81,7 @@ pub trait Fs: Send + Sync {
         latency: Duration,
     ) -> Pin<Box<dyn Send + Stream<Item = Vec<PathBuf>>>>;
 
-    fn open_repo(&self, abs_dot_git: &Path) -> Option<Arc<Mutex<dyn GitRepository>>>;
+    fn open_repo(&self, abs_dot_git: &Path) -> Option<Arc<dyn GitRepository>>;
     fn is_fake(&self) -> bool;
     async fn is_case_sensitive(&self) -> Result<bool>;
     #[cfg(any(test, feature = "test-support"))]
@@ -506,16 +504,13 @@ impl Fs for RealFs {
         })))
     }
 
-    fn open_repo(&self, dotgit_path: &Path) -> Option<Arc<Mutex<dyn GitRepository>>> {
-        LibGitRepository::open(dotgit_path)
-            .log_err()
-            .map::<Arc<Mutex<dyn GitRepository>>, _>(|libgit_repository| {
-                Arc::new(Mutex::new(RealGitRepository::new(
-                    libgit_repository,
-                    self.git_binary_path.clone(),
-                    self.git_hosting_provider_registry.clone(),
-                )))
-            })
+    fn open_repo(&self, dotgit_path: &Path) -> Option<Arc<dyn GitRepository>> {
+        let repo = git2::Repository::open(dotgit_path).log_err()?;
+        Some(Arc::new(RealGitRepository::new(
+            repo,
+            self.git_binary_path.clone(),
+            self.git_hosting_provider_registry.clone(),
+        )))
     }
 
     fn is_fake(&self) -> bool {
@@ -1489,7 +1484,7 @@ impl Fs for FakeFs {
         }))
     }
 
-    fn open_repo(&self, abs_dot_git: &Path) -> Option<Arc<Mutex<dyn GitRepository>>> {
+    fn open_repo(&self, abs_dot_git: &Path) -> Option<Arc<dyn GitRepository>> {
         let state = self.state.lock();
         let entry = state.read_path(abs_dot_git).unwrap();
         let mut entry = entry.lock();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7856,10 +7856,7 @@ impl Project {
                                     None
                                 } else {
                                     let relative_path = repo.relativize(&snapshot, &path).ok()?;
-                                    local_repo_entry
-                                        .repo()
-                                        .lock()
-                                        .load_index_text(&relative_path)
+                                    local_repo_entry.repo().load_index_text(&relative_path)
                                 };
                                 Some((buffer, base_text))
                             }
@@ -8194,7 +8191,7 @@ impl Project {
         &self,
         project_path: &ProjectPath,
         cx: &AppContext,
-    ) -> Option<Arc<Mutex<dyn GitRepository>>> {
+    ) -> Option<Arc<dyn GitRepository>> {
         self.worktree_for_id(project_path.worktree_id, cx)?
             .read(cx)
             .as_local()?
@@ -8202,10 +8199,7 @@ impl Project {
             .local_git_repo(&project_path.path)
     }
 
-    pub fn get_first_worktree_root_repo(
-        &self,
-        cx: &AppContext,
-    ) -> Option<Arc<Mutex<dyn GitRepository>>> {
+    pub fn get_first_worktree_root_repo(&self, cx: &AppContext) -> Option<Arc<dyn GitRepository>> {
         let worktree = self.visible_worktrees(cx).next()?.read(cx).as_local()?;
         let root_entry = worktree.root_git_entry()?;
 
@@ -8255,8 +8249,7 @@ impl Project {
 
             cx.background_executor().spawn(async move {
                 let (repo, relative_path, content) = blame_params?;
-                let lock = repo.lock();
-                lock.blame(&relative_path, content)
+                repo.blame(&relative_path, content)
                     .with_context(|| format!("Failed to blame {:?}", relative_path.0))
             })
         } else {

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -109,7 +109,7 @@ impl BranchListDelegate {
             .get_first_worktree_root_repo(cx)
             .context("failed to get root repository for first worktree")?;
 
-        let all_branches = repo.lock().branches()?;
+        let all_branches = repo.branches()?;
         Ok(Self {
             matches: vec![],
             workspace: handle,
@@ -237,7 +237,6 @@ impl PickerDelegate for BranchListDelegate {
                         .get_first_worktree_root_repo(cx)
                         .context("failed to get root repository for first worktree")?;
                     let status = repo
-                        .lock()
                         .change_branch(&current_pick);
                     if status.is_err() {
                         this.delegate.display_error_toast(format!("Failed to checkout branch '{current_pick}', check for conflicts or unstashed files"), cx);
@@ -316,8 +315,6 @@ impl PickerDelegate for BranchListDelegate {
                                             let repo = project
                                                 .get_first_worktree_root_repo(cx)
                                                 .context("failed to get root repository for first worktree")?;
-                                            let repo = repo
-                                                .lock();
                                             let status = repo
                                                 .create_branch(&current_pick);
                                             if status.is_err() {


### PR DESCRIPTION
Previously, each git `Repository` object was held inside of a mutex. This was needed because libgit2's Repository object is (as one would expect) not thread safe. But now, the two longest-running git operations that Zed performs, (`status` and `blame`) do not use libgit2 - they invoke the `git` executable. For these operations, it's not necessary to hold a lock on the repository.

In this PR, I've moved our mutex usage so that it only wraps the libgit2 calls, not our `git` subprocess spawns. The main user-facing impact of this is that the UI is much more responsive when initially opening a project with a very large git repository (e.g. `chromium`, `webkit`, `linux`).

Release Notes:

- Improved Zed's responsiveness when initially opening a project containing a very large git repository.