### PR TITLE
editor: Add ToggleTabBar action

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -289,6 +289,7 @@ gpui::actions!(
         ToggleLineNumbers,
         ToggleIndentGuides,
         ToggleSoftWrap,
+        ToggleTabBar,
         Transpose,
         Undo,
         UndoSelection,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -113,7 +113,7 @@ use rpc::{proto::*, ErrorExt};
 use scroll::{Autoscroll, OngoingScroll, ScrollAnchor, ScrollManager, ScrollbarAutoHide};
 use selections_collection::{resolve_multiple, MutableSelectionsCollection, SelectionsCollection};
 use serde::{Deserialize, Serialize};
-use settings::{Settings, SettingsStore};
+use settings::{update_settings_file, Settings, SettingsStore};
 use smallvec::SmallVec;
 use snippet::Snippet;
 use std::ops::Not as _;
@@ -145,7 +145,7 @@ use workspace::notifications::{DetachAndPromptErr, NotificationId};
 use workspace::{
     searchable::SearchEvent, ItemNavHistory, SplitDirection, ViewId, Workspace, WorkspaceId,
 };
-use workspace::{OpenInTerminal, OpenTerminal, Toast};
+use workspace::{OpenInTerminal, OpenTerminal, TabBarSettings, Toast};
 
 use crate::hover_links::find_url;
 
@@ -9767,6 +9767,17 @@ impl Editor {
             self.soft_wrap_mode_override = Some(soft_wrap);
         }
         cx.notify();
+    }
+
+    pub fn toggle_tab_bar(&mut self, _: &ToggleTabBar, cx: &mut ViewContext<Self>) {
+        let Some(workspace) = self.workspace() else {
+            return;
+        };
+        let fs = workspace.read(cx).app_state().fs.clone();
+        let current_show = TabBarSettings::get_global(cx).show;
+        update_settings_file::<TabBarSettings>(fs, cx, move |setting| {
+            setting.show = Some(!current_show);
+        });
     }
 
     pub fn toggle_indent_guides(&mut self, _: &ToggleIndentGuides, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -318,6 +318,7 @@ impl EditorElement {
         register_action(view, cx, Editor::open_excerpts);
         register_action(view, cx, Editor::open_excerpts_in_split);
         register_action(view, cx, Editor::toggle_soft_wrap);
+        register_action(view, cx, Editor::toggle_tab_bar);
         register_action(view, cx, Editor::toggle_line_numbers);
         register_action(view, cx, Editor::toggle_indent_guides);
         register_action(view, cx, Editor::toggle_inlay_hints);


### PR DESCRIPTION
This PR adds the `editor: toggle tab bar` action that hides / shows the tab bar and updates the `tab_bar.show` setting in `settings.json` accordingly.

First mentioned in https://github.com/zed-industries/zed/pull/7356#issuecomment-2118445379.

Release Notes:

- Added the `editor: toggle tab bar` action.
