### PR TITLE
rustdoc_to_markdown: Support bold and italics

### DIFF
--- a/crates/rustdoc_to_markdown/src/markdown_writer.rs
+++ b/crates/rustdoc_to_markdown/src/markdown_writer.rs
@@ -132,8 +132,12 @@ impl MarkdownWriter {
 
     fn start_tag(&mut self, tag: &HtmlElement) -> StartTagOutcome {
         if tag.is_inline() && self.is_inside("p") {
-            if !self.markdown.ends_with(' ') {
-                self.push_str(" ");
+            if let Some(parent) = self.current_element_stack.iter().last() {
+                if !parent.is_inline() {
+                    if !self.markdown.ends_with(' ') {
+                        self.push_str(" ");
+                    }
+                }
             }
         }
 
@@ -146,6 +150,8 @@ impl MarkdownWriter {
             "h5" => self.push_str("\n\n##### "),
             "h6" => self.push_str("\n\n###### "),
             "p" => self.push_blank_line(),
+            "strong" => self.push_str("**"),
+            "em" => self.push_str("_"),
             "code" => {
                 if !self.is_inside("pre") {
                     self.push_str("`");
@@ -219,6 +225,8 @@ impl MarkdownWriter {
     fn end_tag(&mut self, tag: &HtmlElement) {
         match tag.tag.as_str() {
             "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => self.push_str("\n\n"),
+            "strong" => self.push_str("**"),
+            "em" => self.push_str("_"),
             "code" => {
                 if !self.is_inside("pre") {
                     self.push_str("`");

--- a/crates/rustdoc_to_markdown/src/rustdoc_to_markdown.rs
+++ b/crates/rustdoc_to_markdown/src/rustdoc_to_markdown.rs
@@ -114,7 +114,7 @@ mod tests {
         let expected = indoc! {"
             ## Serde
 
-            Serde is a framework for serializing and deserializing Rust data structures efficiently and generically.
+            Serde is a framework for _**ser**_ializing and _**de**_serializing Rust data structures efficiently and generically.
 
             The Serde ecosystem consists of data structures that know how to serialize and deserialize themselves along with data formats that know how to serialize and deserialize other things. Serde provides the layer by which these two groups interact with each other, allowing any supported data structure to be serialized and deserialized using any supported data format.
 
@@ -123,6 +123,25 @@ mod tests {
             ### Design
 
             Where many other languages rely on runtime reflection for serializing data, Serde is instead built on Rust’s powerful trait system. A data structure that knows how to serialize and deserialize itself is one that implements Serde’s `Serialize` and `Deserialize` traits (or uses Serde’s derive attribute to automatically generate implementations at compile time). This avoids any overhead of reflection or runtime type information. In fact in many situations the interaction between data structure and data format can be completely optimized away by the Rust compiler, leaving Serde serialization to perform the same speed as a handwritten serializer for the specific selection of data structure and data format.
+        "}
+        .trim();
+
+        assert_eq!(
+            convert_rustdoc_to_markdown(html.as_bytes()).unwrap(),
+            expected
+        )
+    }
+
+    #[test]
+    fn test_styled_text() {
+        let html = indoc! {r#"
+            <p>This text is <strong>bolded</strong>.</p>
+            <p>This text is <em>italicized</em>.</p>
+        "#};
+        let expected = indoc! {"
+            This text is **bolded**.
+
+            This text is _italicized_.
         "}
         .trim();
 


### PR DESCRIPTION
This PR extends `rustdoc_to_markdown` with support for bold and italic text.

Release Notes:

- N/A
