### PR TITLE
rustdoc_to_markdown: Don't push blank space after newline

### DIFF
--- a/crates/rustdoc_to_markdown/src/markdown_writer.rs
+++ b/crates/rustdoc_to_markdown/src/markdown_writer.rs
@@ -134,7 +134,7 @@ impl MarkdownWriter {
         if tag.is_inline() && self.is_inside("p") {
             if let Some(parent) = self.current_element_stack.iter().last() {
                 if !parent.is_inline() {
-                    if !self.markdown.ends_with(' ') {
+                    if !(self.markdown.ends_with(' ') || self.markdown.ends_with('\n')) {
                         self.push_str(" ");
                     }
                 }


### PR DESCRIPTION
This PR fixes a small issue in `rustdoc_to_markdown` where we could push a blank space after a newline, leading to an unwanted leading space.

Release Notes:

- N/A
