### PR TITLE
typescript: Fix shorthand property highlight

### DIFF
--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -5,6 +5,8 @@
 ; Properties
 
 (property_identifier) @property
+(shorthand_property_identifier) @property
+(shorthand_property_identifier_pattern) @property
 
 ; Function and method calls
 


### PR DESCRIPTION
Release Notes:

- Fixed Typescript shorthand property highlight ([#5239](https://github.com/zed-industries/zed/issues/5239)).

Closes: #5239