### PR TITLE
indent guides: Use primary buffer language to determine tab size

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3153,10 +3153,7 @@ impl BufferSnapshot {
         range: Range<Anchor>,
         cx: &AppContext,
     ) -> Vec<IndentGuide> {
-        fn tab_size_for_row(this: &BufferSnapshot, row: BufferRow, cx: &AppContext) -> u32 {
-            let language = this.language_at(Point::new(row, 0));
-            language_settings(language, None, cx).tab_size.get() as u32
-        }
+        let tab_size = language_settings(self.language(), None, cx).tab_size.get() as u32;
 
         let start_row = range.start.to_point(self).row;
         let end_row = range.end.to_point(self).row;
@@ -3166,9 +3163,6 @@ impl BufferSnapshot {
 
         let mut result_vec = Vec::new();
         let mut indent_stack = SmallVec::<[IndentGuide; 8]>::new();
-
-        // TODO: This should be calculated for every row but it is pretty expensive
-        let tab_size = tab_size_for_row(self, start_row, cx);
 
         while let Some((first_row, mut line_indent)) = row_indents.next() {
             let current_depth = indent_stack.len() as u32;


### PR DESCRIPTION
When indent guides were still WIP, I thought it might be a good idea to detect the tab size for every line individually, so we can handle files with  mixed indentations. However, while optimizing the performance of indent guides I found that getting the language at a given anchor was pretty expensive, therefore I only resolved the language for the first visible row. However, this could lead to some weird flickering, where the indent guides would use different tab sizes depending on the first visible row (see #12492). This can be fixed by just using the primary buffer language size.

So as of right now indent guides cannot handle files with mixed indentations. Im not sure if anyone actually does/expects this, but one use case I could imagine is something like this:
User x has a svelte file, where the tab size is set to `4`. However the svelte code uses typescript inside a script tag, which User x wants to use a tab size of `2`. The approach used here would not work for this, but then again I think our formatter  does not even support something like this. Im probably overcomplicating things, so let's stick with the simple solution for now.

Release Notes:

- Fixed an issue where indent guides would use an incorrect tab size ([#12492](https://github.com/zed-industries/zed/issues/12492)).

