### PR TITLE
Fix recent project index order

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -228,8 +228,8 @@ impl PickerDelegate for RecentProjectsDelegate {
         let candidates = self
             .workspaces
             .iter()
-            .filter(|(id, _)| !self.is_current_workspace(*id, cx))
             .enumerate()
+            .filter(|(_, (id, _))| !self.is_current_workspace(*id, cx))
             .map(|(id, (_, location))| {
                 let combined_string = match location {
                     SerializedWorkspaceLocation::Local(paths, _) => paths


### PR DESCRIPTION
Fixed bug introduced in: https://github.com/zed-industries/zed/pull/12502

Release Notes:
- N/A

Filtering before `enumerate` call breaks project order and instead of hiding current project it hides some other project.