### PR TITLE
Fix TSX and JavaScript shorthand property syntax highlighting

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -5,6 +5,8 @@
 ; Properties
 
 (property_identifier) @property
+(shorthand_property_identifier) @property
+(shorthand_property_identifier_pattern) @property
 
 ; Function and method calls
 

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -5,6 +5,8 @@
 ; Properties
 
 (property_identifier) @property
+(shorthand_property_identifier) @property
+(shorthand_property_identifier_pattern) @property
 
 ; Function and method calls
 


### PR DESCRIPTION
This replicates the fix for the TypeScript language for https://github.com/zed-industries/zed/issues/5239 in https://github.com/zed-industries/zed/pull/12505 for the TSX and JavaScript languages, fixing https://github.com/zed-industries/zed/issues/12510 and fixing https://github.com/zed-industries/zed/issues/12509 .

See https://github.com/zed-industries/zed/pull/12505#issuecomment-2141002505 .

Keep in mind I don't have a proper Zed local development environment setup to test these simple changes.

Release Notes:

- Fixed TSX shorthand property syntax highlighting ([#12510](https://github.com/zed-industries/zed/issues/12510)).
- Fixed JavaScript shorthand property syntax highlighting ([#12509](https://github.com/zed-industries/zed/issues/12509)).