### PR TITLE
Improve support for OpenAI-compatible services

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -78,7 +78,7 @@ impl Model {
         }
     }
 
-    pub fn id(&self) -> &str {
+    pub fn id(&self) -> &'static str {
         match self {
             Self::ThreePointFiveTurbo => "gpt-3.5-turbo",
             Self::Four => "gpt-4",

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -101,7 +101,7 @@ impl Model {
             Self::Four => "gpt-4",
             Self::FourTurbo => "gpt-4-turbo",
             Self::FourOmni => "gpt-4o",
-            Self::Custom { name, .. } => &name,
+            Self::Custom { name, .. } => name,
         }
     }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -43,6 +43,10 @@ impl From<Role> for String {
     }
 }
 
+fn custom_default_max_token_count() -> usize {
+    128000
+}
+
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
@@ -58,6 +62,7 @@ pub enum Model {
     #[serde(rename = "custom")]
     Custom {
         name: String,
+        #[serde(default = "custom_default_max_token_count")]
         max_token_count: usize,
     },
 }

--- a/docs/src/assistant-panel.md
+++ b/docs/src/assistant-panel.md
@@ -101,11 +101,39 @@ To do so, add the following to your Zed `settings.json`:
 
 The custom URL here is `http://localhost:11434/v1`.
 
+## Using a custom model for OpenAI
+
+Sometimes you may want to use a custom model for OpenAI-compatible endpoints. To do so, add the following to your Zed `settings.json`:
+
+```json
+{
+  "assistant": {
+    "version": "1",
+    "provider": {
+      "name": "openai",
+      "type": "openai",
+      "default_model": {
+        "custom": {
+          "name": "example",  // The name of the model
+          "max_token_count": 128000  // The maximum token count for the model
+        }
+      }
+    }
+  }
+}
+```
+
+`max_token_count` is optional and defaults to 128000.
+
 ## Using Ollama on macOS
 
-You can use Ollama with the Zed assistant by making Ollama appear as an OpenAPI endpoint.
+You can use Ollama with the Zed assistant by customizing API endpoints and models.
 
-1. Add the following to your Zed `settings.json`:
+1. Download, for example, the `mistral` model with Ollama:
+  ```
+  ollama run mistral
+  ```
+2. Add the following to your Zed `settings.json`:
 
   ```json
   {
@@ -114,25 +142,21 @@ You can use Ollama with the Zed assistant by making Ollama appear as an OpenAPI 
       "provider": {
         "name": "openai",
         "type": "openai",
-        "default_model": "gpt-4-turbo-preview",
+        "default_model": {
+          "custom": {
+            "name": "mistral"
+          }
+        },
         "api_url": "http://localhost:11434/v1"
       }
     }
   }
   ```
-2. Download, for example, the `mistral` model with Ollama:
-  ```
-  ollama run mistral
-  ```
-3. Copy the model and change its name to match the model in the Zed `settings.json`:
-  ```
-  ollama cp mistral gpt-4-turbo-preview
-  ```
-4. Use `assistant: reset key` (see the [Setup](#setup) section above) and enter the following API key:
+3. Use `assistant: reset key` (see the [Setup](#setup) section above) and enter the following API key:
   ```
   ollama
   ```
-5. Restart Zed
+4. Restart Zed
 
 ## Prompt Library
 


### PR DESCRIPTION
Currently, OpenAI supports custom API endpoints, but the inability to customize the model remains a limitation. For example, when using Ollama, the model name needs to be manually renamed to gpt-4-turbo-preview, and some third-party OpenAI-compatible services that use different model names cannot be used(e.g., https://platform.deepseek.com/api-docs/). This PR implements custom model names and max token count, aiming to provide greater flexibility.

I am unsure if it is necessary to implement proper `id` and `from_id` methods for custom models, because in the only use case for `from_id`, the called API endpoint is fixed as OPEN_AI_API_URL, which would not succeed in general use cases for custom models. Additionally, implementing a proper `id` method would require changing the return type from &str to String, which would have a broader impact. Hope someone can give me some advice.

Release Notes:

- Improved support for OpenAI-compatible services

![48333276(1)](https://github.com/zed-industries/zed/assets/32017007/0d89f617-ea5a-4440-aba9-a19ffd398f76)
