### PR TITLE
Selection Constraint search/replace

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -3,7 +3,7 @@ mod registrar;
 use crate::{
     search_bar::render_nav_button, FocusSearch, NextHistoryQuery, PreviousHistoryQuery, ReplaceAll,
     ReplaceNext, SearchOptions, SelectAllMatches, SelectNextMatch, SelectPrevMatch,
-    ToggleCaseSensitive, ToggleRegex, ToggleReplace, ToggleWholeWord,
+    ToggleCaseSensitive, ToggleRegex, ToggleReplace, ToggleSelection, ToggleWholeWord,
 };
 use any_vec::AnyVec;
 use collections::HashMap;
@@ -225,6 +225,14 @@ impl Render for BufferSearchBar {
                                 SearchOptions::WHOLE_WORD,
                                 cx.listener(|this, _, cx| {
                                     this.toggle_whole_word(&ToggleWholeWord, cx)
+                                }),
+                            )
+                        }))
+                        .children(supported_options.word.then(|| {
+                            self.render_search_option_button(
+                                SearchOptions::SELECTION,
+                                cx.listener(|this, _, cx| {
+                                    this.toggle_selection(&ToggleSelection, cx)
                                 }),
                             )
                         }))
@@ -821,6 +829,10 @@ impl BufferSearchBar {
 
     fn toggle_whole_word(&mut self, _: &ToggleWholeWord, cx: &mut ViewContext<Self>) {
         self.toggle_search_option(SearchOptions::WHOLE_WORD, cx)
+    }
+
+    fn toggle_selection(&mut self, _: &ToggleSelection, cx: &mut ViewContext<Self>) {
+        self.toggle_search_option(SearchOptions::SELECTION, cx)
     }
 
     fn toggle_regex(&mut self, _: &ToggleRegex, cx: &mut ViewContext<Self>) {

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -25,6 +25,7 @@ actions!(
         ToggleIncludeIgnored,
         ToggleRegex,
         ToggleReplace,
+        ToggleSelection,
         SelectNextMatch,
         SelectPrevMatch,
         SelectAllMatches,
@@ -43,6 +44,7 @@ bitflags! {
         const CASE_SENSITIVE = 0b010;
         const INCLUDE_IGNORED = 0b100;
         const REGEX = 0b1000;
+        const SELECTION = 0b10000;
     }
 }
 
@@ -53,6 +55,7 @@ impl SearchOptions {
             SearchOptions::CASE_SENSITIVE => "match case",
             SearchOptions::INCLUDE_IGNORED => "include Ignored",
             SearchOptions::REGEX => "regular expression",
+            SearchOptions::SELECTION => "Only in Selection",
             _ => panic!("{:?} is not a named SearchOption", self),
         }
     }
@@ -63,6 +66,7 @@ impl SearchOptions {
             SearchOptions::CASE_SENSITIVE => ui::IconName::CaseSensitive,
             SearchOptions::INCLUDE_IGNORED => ui::IconName::FileGit,
             SearchOptions::REGEX => ui::IconName::Regex,
+            SearchOptions::SELECTION => ui::IconName::FileGit,
             _ => panic!("{:?} is not a named SearchOption", self),
         }
     }
@@ -73,6 +77,7 @@ impl SearchOptions {
             SearchOptions::CASE_SENSITIVE => Box::new(ToggleCaseSensitive),
             SearchOptions::INCLUDE_IGNORED => Box::new(ToggleIncludeIgnored),
             SearchOptions::REGEX => Box::new(ToggleRegex),
+            SearchOptions::SELECTION => Box::new(ToggleWholeWord),
             _ => panic!("{:?} is not a named SearchOption", self),
         }
     }


### PR DESCRIPTION
## Release Notes

The aim of this PR is to add the ability to constraint the search/replace functionality to only check within selected text. This could be useful when a user wants to narrow down the area of their search, or when searching within all matches from a previous search 

## Road map 

- [x] Get basic icon showing within search bar
- [ ] Get selection constraint working with regular search (In progress)
- [ ] Get selection constraint working with regular expression searches 
- [ ] Create/Get a better icon to represent this setting within the search bar
- [ ] Get project wide search working with this constraint 

References Issue: #8617 
