### PR TITLE
Fix composed inputs (dead keys) in vim emulation

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -193,6 +193,10 @@ fn observe_keystrokes(keystroke_event: &KeystrokeEvent, cx: &mut WindowContext) 
         return;
     }
 
+    if let None = keystroke_event.keystroke.ime_key {
+        return;
+    }
+
     Vim::update(cx, |vim, cx| match vim.active_operator() {
         Some(
             Operator::FindForward { .. }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -189,11 +189,7 @@ fn observe_keystrokes(keystroke_event: &KeystrokeEvent, cx: &mut WindowContext) 
         if action.name().starts_with("vim::") {
             return;
         }
-    } else if cx.has_pending_keystrokes() {
-        return;
-    }
-
-    if let None = keystroke_event.keystroke.ime_key {
+    } else if cx.has_pending_keystrokes() || keystroke_event.keystroke.ime_key.is_none() {
         return;
     }
 
@@ -257,7 +253,7 @@ impl Vim {
                     })
                 }
             }
-            EditorEvent::InputIgnored { text } => {
+            EditorEvent::InputIgnored { text } if text != &"¨".into() && text != &"´".into() => {
                 Vim::active_editor_input_ignored(text.clone(), cx);
                 Vim::record_insertion(text, None, cx)
             }


### PR DESCRIPTION
This PR fixes actions in vim emulation such as `ci"` or `di'` on keyboard layouts where quotes require multiple keystrokes. The tests that were passing before this commit still pass, but it might be wise to do some additional testing since I jumped into this codebase an hour ago and I have no idea what I'm doing (feedback is very welcome).

Release Notes:

- Fixed #12522
