### PR TITLE
elixir: Add runnable tasks

### DIFF
--- a/extensions/elixir/languages/elixir/runnables.scm
+++ b/extensions/elixir/languages/elixir/runnables.scm
@@ -1,0 +1,20 @@
+; Macros `describe` and `test`.
+; This matches the ExUnit test style.
+(
+    (call
+        target: (identifier) @run (#any-of? @run "describe" "test")
+    ) @elixir-test
+    (#set! tag elixir-test)
+)
+
+; Modules containing at least one `describe` or `test`.
+; This matches the ExUnit test style.
+(
+    (call
+        target: (identifier) @run (#eq? @run "defmodule")
+        (do_block
+            (call target: (identifier) @keyword (#any-of? @keyword "describe" "test"))
+        )
+    ) @elixir-module-test
+    (#set! tag elixir-module-test)
+)

--- a/extensions/elixir/languages/elixir/runnables.scm
+++ b/extensions/elixir/languages/elixir/runnables.scm
@@ -3,7 +3,7 @@
 (
     (call
         target: (identifier) @run (#any-of? @run "describe" "test")
-    ) @elixir-test
+    ) @_elixir-test
     (#set! tag elixir-test)
 )
 
@@ -13,8 +13,8 @@
     (call
         target: (identifier) @run (#eq? @run "defmodule")
         (do_block
-            (call target: (identifier) @keyword (#any-of? @keyword "describe" "test"))
+            (call target: (identifier) @_keyword (#any-of? @_keyword "describe" "test"))
         )
-    ) @elixir-module-test
+    ) @_elixir-module-test
     (#set! tag elixir-module-test)
 )

--- a/extensions/elixir/languages/elixir/tasks.json
+++ b/extensions/elixir/languages/elixir/tasks.json
@@ -13,12 +13,14 @@
   {
     "label": "mix test $ZED_RELATIVE_FILE",
     "command": "mix",
-    "args": ["test", "$ZED_RELATIVE_FILE"]
+    "args": ["test", "$ZED_RELATIVE_FILE"],
+    "tags": ["elixir-module-test"]
   },
   {
     "label": "mix test $ZED_RELATIVE_FILE:$ZED_ROW",
     "command": "mix",
-    "args": ["test", "$ZED_RELATIVE_FILE:$ZED_ROW"]
+    "args": ["test", "$ZED_RELATIVE_FILE:$ZED_ROW"],
+    "tags": ["elixir-test"]
   },
   {
     "label": "Elixir: break line",


### PR DESCRIPTION
Release Notes:

- Added runnable tasks to Elixir tests (modules, `describe` and `test` blocks)

https://github.com/zed-industries/zed/assets/7737375/06f1b4cb-0364-4c30-982d-6dda3193b5d2





