### PR TITLE
indent guides: Respect language specific settings in multibuffers

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9770,13 +9770,19 @@ impl Editor {
     }
 
     pub fn toggle_indent_guides(&mut self, _: &ToggleIndentGuides, cx: &mut ViewContext<Self>) {
-        let currently_enabled = self.should_show_indent_guides();
+        let currently_enabled = self.should_show_indent_guides().unwrap_or_else(|| {
+            self.buffer
+                .read(cx)
+                .settings_at(0, cx)
+                .indent_guides
+                .enabled
+        });
         self.show_indent_guides = Some(!currently_enabled);
         cx.notify();
     }
 
-    fn should_show_indent_guides(&self) -> bool {
-        self.show_indent_guides.unwrap_or(true)
+    fn should_show_indent_guides(&self) -> Option<bool> {
+        self.show_indent_guides
     }
 
     pub fn toggle_line_numbers(&mut self, _: &ToggleLineNumbers, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9770,19 +9770,13 @@ impl Editor {
     }
 
     pub fn toggle_indent_guides(&mut self, _: &ToggleIndentGuides, cx: &mut ViewContext<Self>) {
-        let currently_enabled = self.should_show_indent_guides(cx);
+        let currently_enabled = self.should_show_indent_guides();
         self.show_indent_guides = Some(!currently_enabled);
         cx.notify();
     }
 
-    fn should_show_indent_guides(&self, cx: &mut ViewContext<Self>) -> bool {
-        self.show_indent_guides.unwrap_or_else(|| {
-            self.buffer
-                .read(cx)
-                .settings_at(0, cx)
-                .indent_guides
-                .enabled
-        })
+    fn should_show_indent_guides(&self) -> bool {
+        self.show_indent_guides.unwrap_or(true)
     }
 
     pub fn toggle_line_numbers(&mut self, _: &ToggleLineNumbers, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9770,7 +9770,7 @@ impl Editor {
     }
 
     pub fn toggle_indent_guides(&mut self, _: &ToggleIndentGuides, cx: &mut ViewContext<Self>) {
-        let currently_enabled = self.should_show_indent_guides().unwrap_or_else(|| {
+        let currently_enabled = self.should_show_indent_guides(cx).unwrap_or_else(|| {
             self.buffer
                 .read(cx)
                 .settings_at(0, cx)
@@ -9781,8 +9781,21 @@ impl Editor {
         cx.notify();
     }
 
-    fn should_show_indent_guides(&self) -> Option<bool> {
-        self.show_indent_guides
+    fn should_show_indent_guides(&self, cx: &mut ViewContext<Self>) -> Option<bool> {
+        match self.show_indent_guides {
+            Some(show_indent_guides) => Some(show_indent_guides),
+            None => {
+                if let Some(buffer) = self.buffer.read(cx).as_singleton() {
+                    Some(
+                        language_settings::language_settings(buffer.read(cx).language(), None, cx)
+                            .indent_guides
+                            .enabled,
+                    )
+                } else {
+                    None
+                }
+            }
+        }
     }
 
     pub fn toggle_line_numbers(&mut self, _: &ToggleLineNumbers, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9770,7 +9770,7 @@ impl Editor {
     }
 
     pub fn toggle_indent_guides(&mut self, _: &ToggleIndentGuides, cx: &mut ViewContext<Self>) {
-        let currently_enabled = self.should_show_indent_guides(cx).unwrap_or_else(|| {
+        let currently_enabled = self.should_show_indent_guides().unwrap_or_else(|| {
             self.buffer
                 .read(cx)
                 .settings_at(0, cx)
@@ -9781,21 +9781,8 @@ impl Editor {
         cx.notify();
     }
 
-    fn should_show_indent_guides(&self, cx: &mut ViewContext<Self>) -> Option<bool> {
-        match self.show_indent_guides {
-            Some(show_indent_guides) => Some(show_indent_guides),
-            None => {
-                if let Some(buffer) = self.buffer.read(cx).as_singleton() {
-                    Some(
-                        language_settings::language_settings(buffer.read(cx).language(), None, cx)
-                            .indent_guides
-                            .enabled,
-                    )
-                } else {
-                    None
-                }
-            }
-        }
+    fn should_show_indent_guides(&self) -> Option<bool> {
+        self.show_indent_guides
     }
 
     pub fn toggle_line_numbers(&mut self, _: &ToggleLineNumbers, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11552,7 +11552,10 @@ fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -
         end_row,
         depth,
         tab_size: 4,
-        settings: IndentGuideSettings::default(),
+        settings: IndentGuideSettings {
+            enabled: true,
+            ..Default::default()
+        },
     }
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -17,8 +17,8 @@ use language::{
     },
     BracketPairConfig,
     Capability::ReadWrite,
-    FakeLspAdapter, IndentGuide, LanguageConfig, LanguageConfigOverride, LanguageMatcher, Override,
-    Point,
+    FakeLspAdapter, IndentGuide, IndentGuideStyle, LanguageConfig, LanguageConfigOverride,
+    LanguageMatcher, Override, Point,
 };
 use multi_buffer::MultiBufferIndentGuide;
 use parking_lot::Mutex;
@@ -11543,6 +11543,21 @@ fn assert_indent_guides(
     assert_eq!(indent_guides, expected, "Indent guides do not match");
 }
 
+fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -> IndentGuide {
+    IndentGuide {
+        buffer_id,
+        start_row,
+        end_row,
+        depth,
+        tab_size: 4,
+        style: IndentGuideStyle {
+            line_width: 1,
+            coloring: language_settings::IndentGuideColoring::Disabled,
+            background_coloring: language_settings::IndentGuideBackgroundColoring::Disabled,
+        },
+    }
+}
+
 #[gpui::test]
 async fn test_indent_guide_single_line(cx: &mut gpui::TestAppContext) {
     let (buffer_id, mut cx) = setup_indent_guides_editor(
@@ -11555,12 +11570,7 @@ async fn test_indent_guide_single_line(cx: &mut gpui::TestAppContext) {
     )
     .await;
 
-    assert_indent_guides(
-        0..3,
-        vec![IndentGuide::new(buffer_id, 1, 1, 0, 4)],
-        None,
-        &mut cx,
-    );
+    assert_indent_guides(0..3, vec![indent_guide(buffer_id, 1, 1, 0)], None, &mut cx);
 }
 
 #[gpui::test]
@@ -11576,12 +11586,7 @@ async fn test_indent_guide_simple_block(cx: &mut gpui::TestAppContext) {
     )
     .await;
 
-    assert_indent_guides(
-        0..4,
-        vec![IndentGuide::new(buffer_id, 1, 2, 0, 4)],
-        None,
-        &mut cx,
-    );
+    assert_indent_guides(0..4, vec![indent_guide(buffer_id, 1, 2, 0)], None, &mut cx);
 }
 
 #[gpui::test]
@@ -11604,9 +11609,9 @@ async fn test_indent_guide_nested(cx: &mut gpui::TestAppContext) {
     assert_indent_guides(
         0..8,
         vec![
-            IndentGuide::new(buffer_id, 1, 6, 0, 4),
-            IndentGuide::new(buffer_id, 3, 3, 1, 4),
-            IndentGuide::new(buffer_id, 5, 5, 1, 4),
+            indent_guide(buffer_id, 1, 6, 0),
+            indent_guide(buffer_id, 3, 3, 1),
+            indent_guide(buffer_id, 5, 5, 1),
         ],
         None,
         &mut cx,
@@ -11630,8 +11635,8 @@ async fn test_indent_guide_tab(cx: &mut gpui::TestAppContext) {
     assert_indent_guides(
         0..5,
         vec![
-            IndentGuide::new(buffer_id, 1, 3, 0, 4),
-            IndentGuide::new(buffer_id, 2, 2, 1, 4),
+            indent_guide(buffer_id, 1, 3, 0),
+            indent_guide(buffer_id, 2, 2, 1),
         ],
         None,
         &mut cx,
@@ -11652,12 +11657,7 @@ async fn test_indent_guide_continues_on_empty_line(cx: &mut gpui::TestAppContext
     )
     .await;
 
-    assert_indent_guides(
-        0..5,
-        vec![IndentGuide::new(buffer_id, 1, 3, 0, 4)],
-        None,
-        &mut cx,
-    );
+    assert_indent_guides(0..5, vec![indent_guide(buffer_id, 1, 3, 0)], None, &mut cx);
 }
 
 #[gpui::test]
@@ -11683,9 +11683,9 @@ async fn test_indent_guide_complex(cx: &mut gpui::TestAppContext) {
     assert_indent_guides(
         0..11,
         vec![
-            IndentGuide::new(buffer_id, 1, 9, 0, 4),
-            IndentGuide::new(buffer_id, 6, 6, 1, 4),
-            IndentGuide::new(buffer_id, 8, 8, 1, 4),
+            indent_guide(buffer_id, 1, 9, 0),
+            indent_guide(buffer_id, 6, 6, 1),
+            indent_guide(buffer_id, 8, 8, 1),
         ],
         None,
         &mut cx,
@@ -11715,9 +11715,9 @@ async fn test_indent_guide_starts_off_screen(cx: &mut gpui::TestAppContext) {
     assert_indent_guides(
         1..11,
         vec![
-            IndentGuide::new(buffer_id, 1, 9, 0, 4),
-            IndentGuide::new(buffer_id, 6, 6, 1, 4),
-            IndentGuide::new(buffer_id, 8, 8, 1, 4),
+            indent_guide(buffer_id, 1, 9, 0),
+            indent_guide(buffer_id, 6, 6, 1),
+            indent_guide(buffer_id, 8, 8, 1),
         ],
         None,
         &mut cx,
@@ -11747,9 +11747,9 @@ async fn test_indent_guide_ends_off_screen(cx: &mut gpui::TestAppContext) {
     assert_indent_guides(
         1..10,
         vec![
-            IndentGuide::new(buffer_id, 1, 9, 0, 4),
-            IndentGuide::new(buffer_id, 6, 6, 1, 4),
-            IndentGuide::new(buffer_id, 8, 8, 1, 4),
+            indent_guide(buffer_id, 1, 9, 0),
+            indent_guide(buffer_id, 6, 6, 1),
+            indent_guide(buffer_id, 8, 8, 1),
         ],
         None,
         &mut cx,
@@ -11775,9 +11775,9 @@ async fn test_indent_guide_without_brackets(cx: &mut gpui::TestAppContext) {
     assert_indent_guides(
         1..10,
         vec![
-            IndentGuide::new(buffer_id, 1, 4, 0, 4),
-            IndentGuide::new(buffer_id, 2, 3, 1, 4),
-            IndentGuide::new(buffer_id, 3, 3, 2, 4),
+            indent_guide(buffer_id, 1, 4, 0),
+            indent_guide(buffer_id, 2, 3, 1),
+            indent_guide(buffer_id, 3, 3, 2),
         ],
         None,
         &mut cx,
@@ -11802,8 +11802,8 @@ async fn test_indent_guide_ends_before_empty_line(cx: &mut gpui::TestAppContext)
     assert_indent_guides(
         0..6,
         vec![
-            IndentGuide::new(buffer_id, 1, 2, 0, 4),
-            IndentGuide::new(buffer_id, 2, 2, 1, 4),
+            indent_guide(buffer_id, 1, 2, 0),
+            indent_guide(buffer_id, 2, 2, 1),
         ],
         None,
         &mut cx,
@@ -11825,12 +11825,7 @@ async fn test_indent_guide_continuing_off_screen(cx: &mut gpui::TestAppContext) 
     )
     .await;
 
-    assert_indent_guides(
-        0..1,
-        vec![IndentGuide::new(buffer_id, 1, 1, 0, 4)],
-        None,
-        &mut cx,
-    );
+    assert_indent_guides(0..1, vec![indent_guide(buffer_id, 1, 1, 0)], None, &mut cx);
 }
 
 #[gpui::test]
@@ -11852,8 +11847,8 @@ async fn test_indent_guide_tabs(cx: &mut gpui::TestAppContext) {
     assert_indent_guides(
         0..6,
         vec![
-            IndentGuide::new(buffer_id, 1, 6, 0, 4),
-            IndentGuide::new(buffer_id, 3, 4, 1, 4),
+            indent_guide(buffer_id, 1, 6, 0),
+            indent_guide(buffer_id, 3, 4, 1),
         ],
         None,
         &mut cx,
@@ -11880,7 +11875,7 @@ async fn test_active_indent_guide_single_line(cx: &mut gpui::TestAppContext) {
 
     assert_indent_guides(
         0..3,
-        vec![IndentGuide::new(buffer_id, 1, 1, 0, 4)],
+        vec![indent_guide(buffer_id, 1, 1, 0)],
         Some(vec![0]),
         &mut cx,
     );
@@ -11909,8 +11904,8 @@ async fn test_active_indent_guide_respect_indented_range(cx: &mut gpui::TestAppC
     assert_indent_guides(
         0..4,
         vec![
-            IndentGuide::new(buffer_id, 1, 3, 0, 4),
-            IndentGuide::new(buffer_id, 2, 2, 1, 4),
+            indent_guide(buffer_id, 1, 3, 0),
+            indent_guide(buffer_id, 2, 2, 1),
         ],
         Some(vec![1]),
         &mut cx,
@@ -11925,8 +11920,8 @@ async fn test_active_indent_guide_respect_indented_range(cx: &mut gpui::TestAppC
     assert_indent_guides(
         0..4,
         vec![
-            IndentGuide::new(buffer_id, 1, 3, 0, 4),
-            IndentGuide::new(buffer_id, 2, 2, 1, 4),
+            indent_guide(buffer_id, 1, 3, 0),
+            indent_guide(buffer_id, 2, 2, 1),
         ],
         Some(vec![1]),
         &mut cx,
@@ -11941,8 +11936,8 @@ async fn test_active_indent_guide_respect_indented_range(cx: &mut gpui::TestAppC
     assert_indent_guides(
         0..4,
         vec![
-            IndentGuide::new(buffer_id, 1, 3, 0, 4),
-            IndentGuide::new(buffer_id, 2, 2, 1, 4),
+            indent_guide(buffer_id, 1, 3, 0),
+            indent_guide(buffer_id, 2, 2, 1),
         ],
         Some(vec![0]),
         &mut cx,
@@ -11971,7 +11966,7 @@ async fn test_active_indent_guide_empty_line(cx: &mut gpui::TestAppContext) {
 
     assert_indent_guides(
         0..5,
-        vec![IndentGuide::new(buffer_id, 1, 3, 0, 4)],
+        vec![indent_guide(buffer_id, 1, 3, 0)],
         Some(vec![0]),
         &mut cx,
     );
@@ -11997,7 +11992,7 @@ async fn test_active_indent_guide_non_matching_indent(cx: &mut gpui::TestAppCont
 
     assert_indent_guides(
         0..3,
-        vec![IndentGuide::new(buffer_id, 1, 2, 0, 4)],
+        vec![indent_guide(buffer_id, 1, 2, 0)],
         Some(vec![0]),
         &mut cx,
     );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11506,7 +11506,7 @@ fn assert_indent_guides(
         let snapshot = editor.snapshot(cx).display_snapshot;
         let mut indent_guides: Vec<_> = crate::indent_guides::indent_guides_in_range(
             MultiBufferRow(range.start)..MultiBufferRow(range.end),
-            None,
+            true,
             &snapshot,
             cx,
         );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11554,6 +11554,7 @@ fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -
         tab_size: 4,
         settings: IndentGuideSettings {
             enabled: true,
+            line_width: 1,
             ..Default::default()
         },
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11506,6 +11506,7 @@ fn assert_indent_guides(
         let snapshot = editor.snapshot(cx).display_snapshot;
         let mut indent_guides: Vec<_> = crate::indent_guides::indent_guides_in_range(
             MultiBufferRow(range.start)..MultiBufferRow(range.end),
+            None,
             &snapshot,
             cx,
         );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -17,9 +17,10 @@ use language::{
     },
     BracketPairConfig,
     Capability::ReadWrite,
-    FakeLspAdapter, IndentGuide, IndentGuideStyle, LanguageConfig, LanguageConfigOverride,
-    LanguageMatcher, Override, Point,
+    FakeLspAdapter, IndentGuide, LanguageConfig, LanguageConfigOverride, LanguageMatcher, Override,
+    Point,
 };
+use language_settings::IndentGuideSettings;
 use multi_buffer::MultiBufferIndentGuide;
 use parking_lot::Mutex;
 use project::project_settings::{LspSettings, ProjectSettings};
@@ -11550,11 +11551,7 @@ fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -
         end_row,
         depth,
         tab_size: 4,
-        style: IndentGuideStyle {
-            line_width: 1,
-            coloring: language_settings::IndentGuideColoring::Disabled,
-            background_coloring: language_settings::IndentGuideBackgroundColoring::Disabled,
-        },
+        settings: IndentGuideSettings::default(),
     }
 }
 

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -37,9 +37,7 @@ impl Editor {
         snapshot: &DisplaySnapshot,
         cx: &mut ViewContext<Editor>,
     ) -> Option<Vec<MultiBufferIndentGuide>> {
-        let enabled = self.should_show_indent_guides(cx);
-
-        if enabled {
+        if self.should_show_indent_guides() {
             Some(indent_guides_in_range(visible_buffer_range, snapshot, cx))
         } else {
             None

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -39,7 +39,7 @@ impl Editor {
     ) -> Option<Vec<MultiBufferIndentGuide>> {
         let show_indent_guides = self.should_show_indent_guides().unwrap_or_else(|| {
             if let Some(buffer) = self.buffer().read(cx).as_singleton() {
-                language_settings(buffer.read(cx).language(), None, cx)
+                language_settings(buffer.read(cx).language(), buffer.read(cx).file(), cx)
                     .indent_guides
                     .enabled
             } else {

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -37,7 +37,7 @@ impl Editor {
         snapshot: &DisplaySnapshot,
         cx: &mut ViewContext<Editor>,
     ) -> Option<Vec<MultiBufferIndentGuide>> {
-        if self.should_show_indent_guides() {
+        if self.should_show_indent_guides().unwrap_or(true) {
             Some(indent_guides_in_range(visible_buffer_range, snapshot, cx))
         } else {
             None

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -37,7 +37,7 @@ impl Editor {
         snapshot: &DisplaySnapshot,
         cx: &mut ViewContext<Editor>,
     ) -> Option<Vec<MultiBufferIndentGuide>> {
-        if self.should_show_indent_guides().unwrap_or(true) {
+        if self.should_show_indent_guides(cx).unwrap_or(true) {
             Some(indent_guides_in_range(visible_buffer_range, snapshot, cx))
         } else {
             None

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -53,7 +53,7 @@ impl Editor {
 
         Some(indent_guides_in_range(
             visible_buffer_range,
-            self.should_show_indent_guides(),
+            self.should_show_indent_guides() == Some(true),
             snapshot,
             cx,
         ))
@@ -149,7 +149,7 @@ impl Editor {
 
 pub fn indent_guides_in_range(
     visible_buffer_range: Range<MultiBufferRow>,
-    overwrite_if_enabled: Option<bool>,
+    ignore_disabled_for_language: bool,
     snapshot: &DisplaySnapshot,
     cx: &AppContext,
 ) -> Vec<MultiBufferIndentGuide> {
@@ -162,7 +162,7 @@ pub fn indent_guides_in_range(
 
     snapshot
         .buffer_snapshot
-        .indent_guides_in_range(start_anchor..end_anchor, overwrite_if_enabled, cx)
+        .indent_guides_in_range(start_anchor..end_anchor, ignore_disabled_for_language, cx)
         .into_iter()
         .filter(|indent_guide| {
             // Filter out indent guides that are inside a fold

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -6,9 +6,7 @@ pub use crate::{
 };
 use crate::{
     diagnostic_set::{DiagnosticEntry, DiagnosticGroup},
-    language_settings::{
-        language_settings, IndentGuideBackgroundColoring, IndentGuideColoring, LanguageSettings,
-    },
+    language_settings::{language_settings, IndentGuideSettings, LanguageSettings},
     markdown::parse_markdown,
     outline::OutlineItem,
     syntax_map::{
@@ -544,35 +542,10 @@ pub struct IndentGuide {
     pub end_row: BufferRow,
     pub depth: u32,
     pub tab_size: u32,
-    pub style: IndentGuideStyle,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct IndentGuideStyle {
-    pub line_width: u32,
-    pub coloring: IndentGuideColoring,
-    pub background_coloring: IndentGuideBackgroundColoring,
+    pub settings: IndentGuideSettings,
 }
 
 impl IndentGuide {
-    pub fn new(
-        buffer_id: BufferId,
-        start_row: BufferRow,
-        end_row: BufferRow,
-        depth: u32,
-        tab_size: u32,
-        style: IndentGuideStyle,
-    ) -> Self {
-        Self {
-            buffer_id,
-            start_row,
-            end_row,
-            depth,
-            tab_size,
-            style,
-        }
-    }
-
     pub fn indent_level(&self) -> u32 {
         self.depth * self.tab_size
     }
@@ -3166,15 +3139,7 @@ impl BufferSnapshot {
         cx: &AppContext,
     ) -> Vec<IndentGuide> {
         let language_settings = language_settings(self.language(), None, cx);
-        if !language_settings.indent_guides.enabled {
-            return Vec::default();
-        }
-        let indent_guide_settings = language_settings.indent_guides;
-        let style = IndentGuideStyle {
-            coloring: indent_guide_settings.coloring,
-            background_coloring: indent_guide_settings.background_coloring,
-            line_width: indent_guide_settings.line_width,
-        };
+        let settings = language_settings.indent_guides;
         let tab_size = language_settings.tab_size.get() as u32;
 
         let start_row = range.start.to_point(self).row;
@@ -3256,7 +3221,7 @@ impl BufferSnapshot {
                         end_row: last_row,
                         depth: next_depth,
                         tab_size,
-                        style,
+                        settings,
                     });
                 }
             }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3153,7 +3153,11 @@ impl BufferSnapshot {
         range: Range<Anchor>,
         cx: &AppContext,
     ) -> Vec<IndentGuide> {
-        let tab_size = language_settings(self.language(), None, cx).tab_size.get() as u32;
+        let language_settings = language_settings(self.language(), None, cx);
+        if !language_settings.indent_guides.enabled {
+            return Vec::default();
+        }
+        let tab_size = language_settings.tab_size.get() as u32;
 
         let start_row = range.start.to_point(self).row;
         let end_row = range.end.to_point(self).row;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3139,7 +3139,7 @@ impl BufferSnapshot {
         overwrite_if_enabled: Option<bool>,
         cx: &AppContext,
     ) -> Vec<IndentGuide> {
-        let language_settings = language_settings(self.language(), None, cx);
+        let language_settings = language_settings(self.language(), self.file.as_ref(), cx);
         let settings = language_settings.indent_guides;
         if !(overwrite_if_enabled.unwrap_or(settings.enabled)) {
             return Vec::new();

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -6,7 +6,9 @@ pub use crate::{
 };
 use crate::{
     diagnostic_set::{DiagnosticEntry, DiagnosticGroup},
-    language_settings::{language_settings, LanguageSettings},
+    language_settings::{
+        language_settings, IndentGuideBackgroundColoring, IndentGuideColoring, LanguageSettings,
+    },
     markdown::parse_markdown,
     outline::OutlineItem,
     syntax_map::{
@@ -542,6 +544,14 @@ pub struct IndentGuide {
     pub end_row: BufferRow,
     pub depth: u32,
     pub tab_size: u32,
+    pub style: IndentGuideStyle,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IndentGuideStyle {
+    pub line_width: u32,
+    pub coloring: IndentGuideColoring,
+    pub background_coloring: IndentGuideBackgroundColoring,
 }
 
 impl IndentGuide {
@@ -551,6 +561,7 @@ impl IndentGuide {
         end_row: BufferRow,
         depth: u32,
         tab_size: u32,
+        style: IndentGuideStyle,
     ) -> Self {
         Self {
             buffer_id,
@@ -558,6 +569,7 @@ impl IndentGuide {
             end_row,
             depth,
             tab_size,
+            style,
         }
     }
 
@@ -3157,6 +3169,12 @@ impl BufferSnapshot {
         if !language_settings.indent_guides.enabled {
             return Vec::default();
         }
+        let indent_guide_settings = language_settings.indent_guides;
+        let style = IndentGuideStyle {
+            coloring: indent_guide_settings.coloring,
+            background_coloring: indent_guide_settings.background_coloring,
+            line_width: indent_guide_settings.line_width,
+        };
         let tab_size = language_settings.tab_size.get() as u32;
 
         let start_row = range.start.to_point(self).row;
@@ -3238,6 +3256,7 @@ impl BufferSnapshot {
                         end_row: last_row,
                         depth: next_depth,
                         tab_size,
+                        style,
                     });
                 }
             }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3136,10 +3136,14 @@ impl BufferSnapshot {
     pub fn indent_guides_in_range(
         &self,
         range: Range<Anchor>,
+        overwrite_if_enabled: Option<bool>,
         cx: &AppContext,
     ) -> Vec<IndentGuide> {
         let language_settings = language_settings(self.language(), None, cx);
         let settings = language_settings.indent_guides;
+        if !(overwrite_if_enabled.unwrap_or(settings.enabled)) {
+            return Vec::new();
+        }
         let tab_size = language_settings.tab_size.get() as u32;
 
         let start_row = range.start.to_point(self).row;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3136,12 +3136,12 @@ impl BufferSnapshot {
     pub fn indent_guides_in_range(
         &self,
         range: Range<Anchor>,
-        overwrite_if_enabled: Option<bool>,
+        ignore_disabled_for_language: bool,
         cx: &AppContext,
     ) -> Vec<IndentGuide> {
         let language_settings = language_settings(self.language(), self.file.as_ref(), cx);
         let settings = language_settings.indent_guides;
-        if !(overwrite_if_enabled.unwrap_or(settings.enabled)) {
+        if !ignore_disabled_for_language && !settings.enabled {
             return Vec::new();
         }
         let tab_size = language_settings.tab_size.get() as u32;

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3289,7 +3289,7 @@ impl MultiBufferSnapshot {
     pub fn indent_guides_in_range(
         &self,
         range: Range<Anchor>,
-        overwrite_if_enabled: Option<bool>,
+        ignore_disabled_for_language: bool,
         cx: &AppContext,
     ) -> Vec<MultiBufferIndentGuide> {
         // Fast path for singleton buffers, we can skip the conversion between offsets.
@@ -3297,7 +3297,7 @@ impl MultiBufferSnapshot {
             return snapshot
                 .indent_guides_in_range(
                     range.start.text_anchor..range.end.text_anchor,
-                    overwrite_if_enabled,
+                    ignore_disabled_for_language,
                     cx,
                 )
                 .into_iter()
@@ -3319,7 +3319,11 @@ impl MultiBufferSnapshot {
 
                 excerpt
                     .buffer
-                    .indent_guides_in_range(excerpt.range.context.clone(), overwrite_if_enabled, cx)
+                    .indent_guides_in_range(
+                        excerpt.range.context.clone(),
+                        ignore_disabled_for_language,
+                        cx,
+                    )
                     .into_iter()
                     .map(move |indent_guide| {
                         let start_row = excerpt_offset_row

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3289,12 +3289,17 @@ impl MultiBufferSnapshot {
     pub fn indent_guides_in_range(
         &self,
         range: Range<Anchor>,
+        overwrite_if_enabled: Option<bool>,
         cx: &AppContext,
     ) -> Vec<MultiBufferIndentGuide> {
         // Fast path for singleton buffers, we can skip the conversion between offsets.
         if let Some((_, _, snapshot)) = self.as_singleton() {
             return snapshot
-                .indent_guides_in_range(range.start.text_anchor..range.end.text_anchor, cx)
+                .indent_guides_in_range(
+                    range.start.text_anchor..range.end.text_anchor,
+                    overwrite_if_enabled,
+                    cx,
+                )
                 .into_iter()
                 .map(|guide| MultiBufferIndentGuide {
                     multibuffer_row_range: MultiBufferRow(guide.start_row)
@@ -3314,7 +3319,7 @@ impl MultiBufferSnapshot {
 
                 excerpt
                     .buffer
-                    .indent_guides_in_range(excerpt.range.context.clone(), cx)
+                    .indent_guides_in_range(excerpt.range.context.clone(), overwrite_if_enabled, cx)
                     .into_iter()
                     .map(move |indent_guide| {
                         let start_row = excerpt_offset_row


### PR DESCRIPTION
Indent guides can be configured per language, meaning that in a multi buffer we can get excerpts where indent guides should be disabled/enabled/styled differently than other excerpts.

Imagine the following scenario, i have indent guides disabled in my settings, but want to enable them for JS and Python. I also want to use a different line width for python files. Something like this is now supported:

<img width="445" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/0c91411c-145c-4210-a883-4c469d5cb828">

And the relevant settings for the example above:
```json
"indent_guides": {
  "enabled": false
},
"languages": {
  "JavaScript": {
    "indent_guides": {
      "enabled": true
    }
  },
  "Python": {
    "indent_guides": {
      "enabled": true,
      "line_width": 5
    }
  }
}
```



Release Notes:

- Respect language specific settings when showing indent guides in a multibuffer
- Fixes an issue where indent guide specific settings were not recognized when specified in local settings
