### PR TITLE
ruby: Capture the heredoc content only and downcase the language

### DIFF
--- a/extensions/ruby/languages/ruby/injections.scm
+++ b/extensions/ruby/languages/ruby/injections.scm
@@ -1,2 +1,4 @@
 (heredoc_body
-  (heredoc_end) @language) @content
+  (heredoc_content) @content
+  (heredoc_end) @language
+  (#downcase! @language))


### PR DESCRIPTION
# Summary

Hi. Current `heredoc` injection for Ruby language captures the `heredoc_end` token. That's a bit incorrect because we want to capture the content only. Suppose we have the following Ruby code:

```ruby
<<~JS
  function myFunc() {
    const myConstant = [];
  }

  let a = '1'
JS
```

And this is its syntax tree:

```
[program] [0, 0] - [7, 0]
  [heredoc_beginning] [0, 0] - [0, 5]
  [heredoc_body] [0, 5] - [6, 2]
    [heredoc_content] [0, 5] - [6, 0]
    [heredoc_end] [6, 0] - [6, 2]
```

Current injection capture all content of the `heredoc_body`:

![CleanShot 2024-05-31 at 17 03 31@2x](https://github.com/zed-industries/zed/assets/1894248/ff8c5195-b532-42d2-91b1-48405a6d3b50)

But we want to capture the `heredoc_content` only and this PR resolves that, additionally it downcases the language like Zed does in other languages like Terraform.

![CleanShot 2024-05-31 at 17 05 17@2x](https://github.com/zed-industries/zed/assets/1894248/e81dabd0-3246-4ef2-9524-a7adcb9242ab)


Release Notes:

- N/A
