### PR TITLE
ruby: Add a new injection for regular expressions

### DIFF
--- a/extensions/ruby/languages/ruby/injections.scm
+++ b/extensions/ruby/languages/ruby/injections.scm
@@ -1,2 +1,6 @@
 (heredoc_body
   (heredoc_end) @language) @content
+
+((regex
+  (string_content) @content)
+  (#set! "language" "regex"))


### PR DESCRIPTION
# Summary

Hello. This pull request adds a new injection to `injections.scm` for Ruby language to highlight regular expressions. Thanks.

## Before

![CleanShot 2024-05-31 at 16 25 46@2x](https://github.com/zed-industries/zed/assets/1894248/8b88718e-8f13-4d61-b6f9-6a25b3ebcc57)

## After

![after](https://github.com/zed-industries/zed/assets/1894248/e11f6ec3-45c6-40f8-b6d9-ddbfd16a3331)

Release Notes:

- N/A
