### PR TITLE
ruby: Add proper indentation for singleton methods

### DIFF
--- a/extensions/ruby/languages/ruby/indents.scm
+++ b/extensions/ruby/languages/ruby/indents.scm
@@ -2,6 +2,7 @@
 (class "end" @end) @indent
 (module "end" @end) @indent
 (begin "end" @end) @indent
+(singleton_method "end" @end) @indent
 (do_block "end" @end) @indent
 
 (then) @indent


### PR DESCRIPTION
Hi. Currently, Zed uses incorrect indentation for singleton methods:

```ruby
def self.build
| # <= cursor position after hitting Enter
end
```

Handling the `singleton_method` token indentation
changes this behavior to the following:

```ruby
def self.build
  | # <= cursor position after hitting Enter
end
```

## Before

https://github.com/zed-industries/zed/assets/1894248/40fc2b37-692f-469f-9cbe-05cbb1ab4c3c

## After


https://github.com/zed-industries/zed/assets/1894248/d9ba8d27-fd17-4c74-b22c-a4de124739a3



Release Notes:

- N/A

