### PR TITLE
Add !vimwaiting to togglecomment 

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -568,7 +568,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == normal",
+    "context": "Editor && vim_mode == normal && !VimWaiting",
     "bindings": {
       "g c c": "editor::ToggleComments"
     }


### PR DESCRIPTION
Release Notes:
-Fixed #12483 
It turns out to be very simple. `fg` has conflict with `gc` mapping so when you type g editor state is pending.
