### PR TITLE
Implement "join pane into next"

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -121,6 +121,7 @@ actions!(
         CloseItemsToTheRight,
         GoBack,
         GoForward,
+        JoinIntoNext,
         ReopenClosedItem,
         SplitLeft,
         SplitUp,
@@ -146,6 +147,7 @@ pub enum Event {
     Remove,
     RemoveItem { item_id: EntityId },
     Split(SplitDirection),
+    JoinIntoNext,
     ChangeItemTitle,
     Focus,
     ZoomIn,
@@ -172,6 +174,7 @@ impl fmt::Debug for Event {
                 .debug_struct("Split")
                 .field("direction", direction)
                 .finish(),
+            Event::JoinIntoNext => f.write_str("JoinIntoNext"),
             Event::ChangeItemTitle => f.write_str("ChangeItemTitle"),
             Event::Focus => f.write_str("Focus"),
             Event::ZoomIn => f.write_str("ZoomIn"),
@@ -606,6 +609,10 @@ impl Pane {
                 })
             })
         }
+    }
+
+    fn join_into_next(&mut self, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::JoinIntoNext);
     }
 
     fn history_updated(&mut self, cx: &mut ViewContext<Self>) {
@@ -2076,6 +2083,7 @@ impl Render for Pane {
             .on_action(cx.listener(|pane, _: &SplitDown, cx| pane.split(SplitDirection::Down, cx)))
             .on_action(cx.listener(|pane, _: &GoBack, cx| pane.navigate_backward(cx)))
             .on_action(cx.listener(|pane, _: &GoForward, cx| pane.navigate_forward(cx)))
+            .on_action(cx.listener(|pane, _: &JoinIntoNext, cx| pane.join_into_next(cx)))
             .on_action(cx.listener(Pane::toggle_zoom))
             .on_action(cx.listener(|pane: &mut Pane, action: &ActivateItem, cx| {
                 pane.activate_item(action.0, true, true, cx);


### PR DESCRIPTION

Release Notes:

- Added "join pane into next" action ([#12409](https://github.com/zed-industries/zed/issues/12409))



https://github.com/zed-industries/zed/assets/727422/00cc8599-e5d6-4fb8-9f0d-9b232d2210ef


---

This is just the basic implementation. I wanted to get some feedback/validation before going forwards.

I think the next steps may be:

* Add test. Probably by adding something to the existing `test_panels` (sic).
* Deduplicate pane items when joining. VSCode does this. Without this, since items are cloned on pane split, it's then annoying to join panes and get both the original item and its previously cloned item into the same pane.
  * The `Item` trait could get a `should_deduplicate_with(&dyn Pane)` or similar. Each `Item` would decide if it's "the same" as the other item following its own logic, e. g. `Editor` would deduplicate if it has the same buffers as the other `Item`.