### PR TITLE
collab_ui: remove branch menu popover in favor of opening a modal

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -118,16 +118,6 @@ impl RecentProjects {
             modal
         })
     }
-
-    pub fn open_popover(workspace: WeakView<Workspace>, cx: &mut WindowContext<'_>) -> View<Self> {
-        cx.new_view(|cx| {
-            Self::new(
-                RecentProjectsDelegate::new(workspace, false, false),
-                20.,
-                cx,
-            )
-        })
-    }
 }
 
 impl EventEmitter<DismissEvent> for RecentProjects {}

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -21,7 +21,7 @@ actions!(branches, [OpenRecent]);
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(|workspace: &mut Workspace, _| {
         workspace.register_action(|workspace, action, cx| {
-            BranchList::toggle_modal(workspace, action, cx).log_err();
+            BranchList::open(workspace, action, cx).log_err();
         });
     })
     .detach();
@@ -43,7 +43,7 @@ impl BranchList {
             _subscription,
         }
     }
-    fn toggle_modal(
+    pub fn open(
         workspace: &mut Workspace,
         _: &OpenRecent,
         cx: &mut ViewContext<Workspace>,
@@ -75,16 +75,6 @@ impl Render for BranchList {
                 })
             }))
     }
-}
-
-pub fn build_branch_list(
-    workspace: View<Workspace>,
-    cx: &mut WindowContext<'_>,
-) -> Result<View<BranchList>> {
-    let delegate = workspace.update(cx, |workspace, cx| {
-        BranchListDelegate::new(workspace, cx.view().clone(), 29, cx)
-    })?;
-    Ok(cx.new_view(move |cx| BranchList::new(delegate, 20., cx)))
 }
 
 pub struct BranchListDelegate {


### PR DESCRIPTION
This commit also removes a bunch of dead code.

Fixes #12544

Release Notes:

- Removed branch popover menu - clicking on the branch name in left-hand corner now always opens a branch modal
