### PR TITLE
wayland: Fix window bounds restoration

### DIFF
--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -712,7 +712,7 @@ impl Size<Length> {
 /// assert_eq!(bounds.origin, origin);
 /// assert_eq!(bounds.size, size);
 /// ```
-#[derive(Refineable, Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Refineable, Clone, Default, Debug, Eq, PartialEq, Hash)]
 #[refineable(Debug)]
 #[repr(C)]
 pub struct Bounds<T: Clone + Default + Debug> {

--- a/crates/gpui/src/platform/linux/wayland/display.rs
+++ b/crates/gpui/src/platform/linux/wayland/display.rs
@@ -12,6 +12,7 @@ use crate::{Bounds, DevicePixels, DisplayId, PlatformDisplay};
 pub(crate) struct WaylandDisplay {
     /// The ID of the wl_output object
     pub id: ObjectId,
+    pub name: Option<String>,
     pub bounds: Bounds<DevicePixels>,
 }
 
@@ -27,7 +28,11 @@ impl PlatformDisplay for WaylandDisplay {
     }
 
     fn uuid(&self) -> anyhow::Result<Uuid> {
-        Err(anyhow::anyhow!("Display UUID is not supported on Wayland"))
+        if let Some(name) = &self.name {
+            Ok(Uuid::new_v5(&Uuid::NAMESPACE_DNS, name.as_bytes()))
+        } else {
+            Err(anyhow::anyhow!("Wayland display does not have a name"))
+        }
     }
 
     fn bounds(&self) -> Bounds<DevicePixels> {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -401,7 +401,7 @@ impl WaylandWindowStatePtr {
                     return;
                 };
 
-                state.outputs.insert(id, *output);
+                state.outputs.insert(id, output.clone());
 
                 let scale = primary_output_scale(&mut state);
 
@@ -597,10 +597,10 @@ fn primary_output_scale(state: &mut RefMut<WaylandWindowState>) -> i32 {
     for (id, output) in state.outputs.iter() {
         if let Some((_, output_data)) = &current_output {
             if output.scale > output_data.scale {
-                current_output = Some((id.clone(), *output));
+                current_output = Some((id.clone(), output.clone()));
             }
         } else {
-            current_output = Some((id.clone(), *output));
+            current_output = Some((id.clone(), output.clone()));
         }
         scale = scale.max(output.scale);
     }
@@ -659,6 +659,7 @@ impl PlatformWindow for WaylandWindow {
         self.borrow().display.as_ref().map(|(id, display)| {
             Rc::new(WaylandDisplay {
                 id: id.clone(),
+                name: display.name.clone(),
                 bounds: display.bounds,
             }) as Rc<dyn PlatformDisplay>
         })


### PR DESCRIPTION
Fixes multiple issues that prevented window bounds restoration to not work on Wayland.

Note: Since the display uuid depends on the `wl_output.name` field, this only works properly on KDE 5.26+ or Gnome 44+ ([kwin commit](https://github.com/KDE/kwin/commit/330a02d862329893957532f46655c52c755f3731), [mutter](https://github.com/GNOME/mutter/commit/7e838b1115f195ba4c7b06169ade3407d29c66d0)).

Release Notes:

- N/A
