### PR TITLE
Disable indent guides for single line editors

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1697,6 +1697,12 @@ impl Editor {
         cx.on_focus(&focus_handle, Self::handle_focus).detach();
         cx.on_blur(&focus_handle, Self::handle_blur).detach();
 
+        let show_indent_guides = if mode == EditorMode::SingleLine {
+            Some(false)
+        } else {
+            None
+        };
+
         let mut this = Self {
             focus_handle,
             buffer: buffer.clone(),
@@ -1726,7 +1732,7 @@ impl Editor {
             show_git_diff_gutter: None,
             show_code_actions: None,
             show_wrap_guides: None,
-            show_indent_guides: None,
+            show_indent_guides,
             placeholder_text: None,
             highlight_order: 0,
             highlighted_rows: HashMap::default(),


### PR DESCRIPTION
This PR disables indent guides by default for single line editors. Right now indent guides show up in the project search editor (which is only a single line)

<img width="715" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/0b61da71-6f64-424d-9612-6a34eac4686a">


Release Notes:

- Fixed an issue where indent guides would show up in a single line editor (e.g. project search, buffer search)