### PR TITLE
json: Fix tsconfig.json schema overriding other schemas (such as keymap)

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -85,6 +85,10 @@ impl JsonLspAdapter {
                 },
                 "schemas": [
                     {
+                        "fileMatch": ["tsconfig.json"],
+                        "schema":tsconfig_schema
+                    },
+                    {
                         "fileMatch": [
                             schema_file_match(&paths::SETTINGS),
                             &*paths::LOCAL_SETTINGS_RELATIVE_PATH,
@@ -101,11 +105,8 @@ impl JsonLspAdapter {
                             &*paths::LOCAL_TASKS_RELATIVE_PATH,
                         ],
                         "schema": tasks_schema,
-                    },
-                    {
-                        "fileMatch": "*/tsconfig.json",
-                        "schema":tsconfig_schema
                     }
+
                 ]
             }
         })


### PR DESCRIPTION
@mrnugget spotted that tsconfig.json schema is getting applied on current Nightly. I've tracked it down to a misconfiguration of JSON language server. Mea culpa.

No release note as that change has not went out to the public yet.

Release Notes:

- N/A
