### PR TITLE
task: Rebind UseSelectedQuery in modal to F2

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -639,7 +639,7 @@
   {
     "context": "Picker",
     "bindings": {
-      "alt-e": "picker::UseSelectedQuery",
+      "f2": "picker::UseSelectedQuery",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
       "cmd-alt-enter": ["picker::ConfirmInput", { "secondary": true }]
     }


### PR DESCRIPTION
Also fix click handler for "Rerun last task".

Fixes #12580
Release Notes:

- Fixed click handler for "rerun last task" in task modal not working.
- Rebound "picker::UseSelectedQuery" from `opt-E` to `F2`.
