### PR TITLE
Disable `vtsls` by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -700,6 +700,7 @@
       }
     },
     "JavaScript": {
+      "language_servers": ["typescript-language-server", "!vtsls", ".."],
       "prettier": {
         "allowed": true
       }
@@ -748,6 +749,7 @@
       }
     },
     "TSX": {
+      "language_servers": ["typescript-language-server", "!vtsls", ".."],
       "prettier": {
         "allowed": true
       }
@@ -758,6 +760,7 @@
       }
     },
     "TypeScript": {
+      "language_servers": ["typescript-language-server", "!vtsls", ".."],
       "prettier": {
         "allowed": true
       }

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -38,7 +38,7 @@ struct TypeScriptVersions {
 #[async_trait(?Send)]
 impl LspAdapter for VtslsLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName("vtsls-language-server".into())
+        LanguageServerName("vtsls".into())
     }
 
     async fn fetch_latest_server_version(


### PR DESCRIPTION
This PR adds default settings to disable `vtsls` by default so that there aren't multiple TypeScript language servers running.

I also renamed the language server from `vtsls-language-server` to just `vtsls`, since the `-language-server` suffix was redundant.

Release Notes:

- N/A
