### PR TITLE
Remove default language settings that are provided by extensions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -672,9 +672,6 @@
     "Elixir": {
       "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
-    "Gleam": {
-      "tab_size": 2
-    },
     "Go": {
       "code_actions_on_format": {
         "source.organizeImports": true
@@ -710,9 +707,6 @@
         "allowed": true
       }
     },
-    "Make": {
-      "hard_tabs": true
-    },
     "Markdown": {
       "format_on_save": "off",
       "prettier": {
@@ -724,9 +718,6 @@
         "allowed": true,
         "plugins": ["@prettier/plugin-php"]
       }
-    },
-    "Prisma": {
-      "tab_size": 2
     },
     "Ruby": {
       "language_servers": ["solargraph", "!ruby-lsp", "..."]


### PR DESCRIPTION
This PR removes some default language settings that are now provided by their respective extensions.

In #10296 we added the ability for the language configuration within extensions to provide certain language settings (e.g., `tab_size`).

New versions of the extensions have been published that take advantage of that and have been in circulation for over a month now. To that end, we no longer need these settings provided as defaults.

Release Notes:

- N/A
