### PR TITLE
Fix excluded file creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,6 +2404,7 @@ dependencies = [
  "util",
  "uuid",
  "workspace",
+ "worktree",
 ]
 
 [[package]]
@@ -10380,7 +10381,6 @@ dependencies = [
  "ui",
  "util",
  "workspace",
- "worktree",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7825,6 +7825,7 @@ dependencies = [
  "unicase",
  "util",
  "workspace",
+ "worktree",
 ]
 
 [[package]]
@@ -10379,6 +10380,7 @@ dependencies = [
  "ui",
  "util",
  "workspace",
+ "worktree",
 ]
 
 [[package]]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -107,4 +107,5 @@ theme.workspace = true
 unindent.workspace = true
 util.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
+worktree = { workspace = true, features = ["test-support"] }
 headless.workspace = true

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -3022,7 +3022,6 @@ async fn test_fs_operations(
     let project_b = client_b.build_dev_server_project(project_id, cx_b).await;
 
     let worktree_a = project_a.read_with(cx_a, |project, _| project.worktrees().next().unwrap());
-
     let worktree_b = project_b.read_with(cx_b, |project, _| project.worktrees().next().unwrap());
 
     let entry = project_b
@@ -3031,6 +3030,7 @@ async fn test_fs_operations(
         })
         .await
         .unwrap()
+        .to_included()
         .unwrap();
 
     worktree_a.read_with(cx_a, |worktree, _| {
@@ -3059,6 +3059,7 @@ async fn test_fs_operations(
         })
         .await
         .unwrap()
+        .to_included()
         .unwrap();
 
     worktree_a.read_with(cx_a, |worktree, _| {
@@ -3087,6 +3088,7 @@ async fn test_fs_operations(
         })
         .await
         .unwrap()
+        .to_included()
         .unwrap();
 
     worktree_a.read_with(cx_a, |worktree, _| {
@@ -3115,20 +3117,25 @@ async fn test_fs_operations(
         })
         .await
         .unwrap()
+        .to_included()
         .unwrap();
+
     project_b
         .update(cx_b, |project, cx| {
             project.create_entry((worktree_id, "DIR/SUBDIR"), true, cx)
         })
         .await
         .unwrap()
+        .to_included()
         .unwrap();
+
     project_b
         .update(cx_b, |project, cx| {
             project.create_entry((worktree_id, "DIR/SUBDIR/f.txt"), false, cx)
         })
         .await
         .unwrap()
+        .to_included()
         .unwrap();
 
     worktree_a.read_with(cx_a, |worktree, _| {

--- a/crates/gpui/src/platform/cosmic_text/text_system.rs
+++ b/crates/gpui/src/platform/cosmic_text/text_system.rs
@@ -294,7 +294,7 @@ impl CosmicTextSystemState {
                 .0,
             )
             .clone()
-            .unwrap();
+            .with_context(|| format!("no image for {params:?} in font {font:?}"))?;
         Ok(Bounds {
             origin: point(image.placement.left.into(), (-image.placement.top).into()),
             size: size(image.placement.width.into(), image.placement.height.into()),
@@ -328,7 +328,7 @@ impl CosmicTextSystemState {
                     .0,
                 )
                 .clone()
-                .unwrap();
+                .with_context(|| format!("no image for {params:?} in font {font:?}"))?;
 
             if params.is_emoji {
                 // Convert from RGBA to BGRA.

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -3127,6 +3127,7 @@ async fn test_buffer_identity_across_renames(cx: &mut gpui::TestAppContext) {
         })
         .unwrap()
         .await
+        .to_included()
         .unwrap();
     cx.executor().run_until_parked();
 
@@ -4465,6 +4466,7 @@ async fn test_create_entry(cx: &mut gpui::TestAppContext) {
         })
         .unwrap()
         .await
+        .to_included()
         .unwrap();
 
     // Can't create paths outside the project

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -34,6 +34,7 @@ ui.workspace = true
 unicase.workspace = true
 util.workspace = true
 client.workspace = true
+worktree.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -35,7 +35,7 @@ use unicase::UniCase;
 use util::{maybe, NumericPrefixWithSuffix, ResultExt, TryFutureExt};
 use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
-    notifications::DetachAndPromptErr,
+    notifications::{DetachAndPromptErr, NotifyTaskExt},
     OpenInTerminal, Workspace,
 };
 use worktree::CreatedEntry;
@@ -712,7 +712,7 @@ impl ProjectPanel {
 
     fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
         if let Some(task) = self.confirm_edit(cx) {
-            task.detach_and_prompt_err("File operation failed", cx, |e, _| Some(format!("{e}")));
+            task.detach_and_notify_err(cx);
         }
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2407,13 +2407,16 @@ impl ClipboardEntry {
 mod tests {
     use super::*;
     use collections::HashSet;
-    use gpui::{TestAppContext, View, VisualTestContext, WindowHandle};
+    use gpui::{Empty, TestAppContext, View, VisualTestContext, WindowHandle};
     use pretty_assertions::assert_eq;
     use project::{FakeFs, WorktreeSettings};
     use serde_json::json;
     use settings::SettingsStore;
     use std::path::{Path, PathBuf};
-    use workspace::AppState;
+    use workspace::{
+        item::{Item, ProjectItem},
+        register_project_item, AppState,
+    };
 
     #[gpui::test]
     async fn test_visible_list(cx: &mut gpui::TestAppContext) {
@@ -4526,6 +4529,199 @@ mod tests {
         );
     }
 
+    #[gpui::test]
+    async fn test_creating_excluded_entries(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings::<WorktreeSettings>(cx, |project_settings| {
+                    project_settings.file_scan_exclusions =
+                        Some(vec!["excluded_dir".to_string(), "**/.git".to_string()]);
+                });
+            });
+        });
+
+        cx.update(|cx| {
+            register_project_item::<TestProjectItemView>(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor().clone());
+        fs.insert_tree(
+            "/root1",
+            json!({
+                ".dockerignore": "",
+                ".git": {
+                    "HEAD": "",
+                },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), ["/root1".as_ref()], cx).await;
+        let workspace = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+        let cx = &mut VisualTestContext::from_window(*workspace, cx);
+        let panel = workspace
+            .update(cx, |workspace, cx| {
+                let panel = ProjectPanel::new(workspace, cx);
+                workspace.add_panel(panel.clone(), cx);
+                panel
+            })
+            .unwrap();
+
+        select_path(&panel, "root1", cx);
+        assert_eq!(
+            visible_entries_as_strings(&panel, 0..10, cx),
+            &["v root1  <== selected", "      .dockerignore",]
+        );
+        workspace
+            .update(cx, |workspace, cx| {
+                assert!(
+                    workspace.active_item(cx).is_none(),
+                    "Should have no active items in the beginning"
+                );
+            })
+            .unwrap();
+
+        let excluded_file_path = ".git/COMMIT_EDITMSG";
+        let excluded_dir_path = "excluded_dir";
+
+        panel.update(cx, |panel, cx| panel.new_file(&NewFile, cx));
+        panel.update(cx, |panel, cx| {
+            assert!(panel.filename_editor.read(cx).is_focused(cx));
+        });
+        panel
+            .update(cx, |panel, cx| {
+                panel
+                    .filename_editor
+                    .update(cx, |editor, cx| editor.set_text(excluded_file_path, cx));
+                panel.confirm_edit(cx).unwrap()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            visible_entries_as_strings(&panel, 0..13, cx),
+            &["v root1", "      .dockerignore"],
+            "Excluded dir should not be shown after opening a file in it"
+        );
+        panel.update(cx, |panel, cx| {
+            assert!(
+                !panel.filename_editor.read(cx).is_focused(cx),
+                "Should have closed the file name editor"
+            );
+        });
+        workspace
+            .update(cx, |workspace, cx| {
+                let active_entry_path = workspace
+                    .active_item(cx)
+                    .expect("should have opened and activated the excluded item")
+                    .act_as::<TestProjectItemView>(cx)
+                    .expect(
+                        "should have opened the corresponding project item for the excluded item",
+                    )
+                    .read(cx)
+                    .path
+                    .clone();
+                assert_eq!(
+                    active_entry_path.path.as_ref(),
+                    Path::new(excluded_file_path),
+                    "Should open the excluded file"
+                );
+
+                assert!(
+                    workspace.notification_ids().is_empty(),
+                    "Should have no notifications after opening an excluded file"
+                );
+            })
+            .unwrap();
+        assert!(
+            fs.is_file(Path::new("/root1/.git/COMMIT_EDITMSG")).await,
+            "Should have created the excluded file"
+        );
+
+        select_path(&panel, "root1", cx);
+        panel.update(cx, |panel, cx| panel.new_directory(&NewDirectory, cx));
+        panel.update(cx, |panel, cx| {
+            assert!(panel.filename_editor.read(cx).is_focused(cx));
+        });
+        panel
+            .update(cx, |panel, cx| {
+                panel
+                    .filename_editor
+                    .update(cx, |editor, cx| editor.set_text(excluded_file_path, cx));
+                panel.confirm_edit(cx).unwrap()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            visible_entries_as_strings(&panel, 0..13, cx),
+            &["v root1", "      .dockerignore"],
+            "Should not change the project panel after trying to create an excluded directorya directory with the same name as the excluded file"
+        );
+        panel.update(cx, |panel, cx| {
+            assert!(
+                !panel.filename_editor.read(cx).is_focused(cx),
+                "Should have closed the file name editor"
+            );
+        });
+        workspace
+            .update(cx, |workspace, cx| {
+                let notifications = workspace.notification_ids();
+                assert_eq!(
+                    notifications.len(),
+                    1,
+                    "Should receive one notification with the error message"
+                );
+                workspace.dismiss_notification(notifications.first().unwrap(), cx);
+                assert!(workspace.notification_ids().is_empty());
+            })
+            .unwrap();
+
+        select_path(&panel, "root1", cx);
+        panel.update(cx, |panel, cx| panel.new_directory(&NewDirectory, cx));
+        panel.update(cx, |panel, cx| {
+            assert!(panel.filename_editor.read(cx).is_focused(cx));
+        });
+        panel
+            .update(cx, |panel, cx| {
+                panel
+                    .filename_editor
+                    .update(cx, |editor, cx| editor.set_text(excluded_dir_path, cx));
+                panel.confirm_edit(cx).unwrap()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            visible_entries_as_strings(&panel, 0..13, cx),
+            &["v root1", "      .dockerignore"],
+            "Should not change the project panel after trying to create an excluded directory"
+        );
+        panel.update(cx, |panel, cx| {
+            assert!(
+                !panel.filename_editor.read(cx).is_focused(cx),
+                "Should have closed the file name editor"
+            );
+        });
+        workspace
+            .update(cx, |workspace, cx| {
+                let notifications = workspace.notification_ids();
+                assert_eq!(
+                    notifications.len(),
+                    1,
+                    "Should receive one notification explaining that no directory is actually shown"
+                );
+                workspace.dismiss_notification(notifications.first().unwrap(), cx);
+                assert!(workspace.notification_ids().is_empty());
+            })
+            .unwrap();
+        assert!(
+            fs.is_dir(Path::new("/root1/excluded_dir")).await,
+            "Should have created the excluded directory"
+        );
+    }
+
     fn toggle_expand_dir(
         panel: &View<ProjectPanel>,
         path: impl AsRef<Path>,
@@ -4753,5 +4949,69 @@ mod tests {
                 );
             })
             .unwrap();
+    }
+
+    struct TestProjectItemView {
+        focus_handle: FocusHandle,
+        path: ProjectPath,
+    }
+
+    struct TestProjectItem {
+        path: ProjectPath,
+    }
+
+    impl project::Item for TestProjectItem {
+        fn try_open(
+            _project: &Model<Project>,
+            path: &ProjectPath,
+            cx: &mut AppContext,
+        ) -> Option<Task<gpui::Result<Model<Self>>>> {
+            let path = path.clone();
+            Some(cx.spawn(|mut cx| async move { cx.new_model(|_| Self { path }) }))
+        }
+
+        fn entry_id(&self, _: &AppContext) -> Option<ProjectEntryId> {
+            None
+        }
+
+        fn project_path(&self, _: &AppContext) -> Option<ProjectPath> {
+            Some(self.path.clone())
+        }
+    }
+
+    impl ProjectItem for TestProjectItemView {
+        type Item = TestProjectItem;
+
+        fn for_project_item(
+            _: Model<Project>,
+            project_item: Model<Self::Item>,
+            cx: &mut ViewContext<Self>,
+        ) -> Self
+        where
+            Self: Sized,
+        {
+            Self {
+                path: project_item.update(cx, |project_item, _| project_item.path.clone()),
+                focus_handle: cx.focus_handle(),
+            }
+        }
+    }
+
+    impl Item for TestProjectItemView {
+        type Event = ();
+    }
+
+    impl EventEmitter<()> for TestProjectItemView {}
+
+    impl FocusableView for TestProjectItemView {
+        fn focus_handle(&self, _: &AppContext) -> FocusHandle {
+            self.focus_handle.clone()
+        }
+    }
+
+    impl Render for TestProjectItemView {
+        fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
+            Empty
+        }
     }
 }

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -35,6 +35,7 @@ terminal.workspace = true
 theme.workspace = true
 ui.workspace = true
 util.workspace = true
+worktree.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -35,7 +35,6 @@ terminal.workspace = true
 theme.workspace = true
 ui.workspace = true
 util.workspace = true
-worktree.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1143,6 +1143,7 @@ mod tests {
     use project::{Entry, Project, ProjectPath, Worktree};
     use std::path::Path;
     use workspace::AppState;
+    use worktree::CreatedEntry;
 
     // Working directory calculation tests
 
@@ -1308,8 +1309,13 @@ mod tests {
                 })
             })
             .await
-            .unwrap()
             .unwrap();
+        let entry = match entry {
+            CreatedEntry::Included(entry) => entry,
+            CreatedEntry::Excluded { abs_path } => {
+                panic!("Unexpected to receive an excluded entry at {abs_path:?}")
+            }
+        };
 
         (wt, entry)
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1143,7 +1143,6 @@ mod tests {
     use project::{Entry, Project, ProjectPath, Worktree};
     use std::path::Path;
     use workspace::AppState;
-    use worktree::CreatedEntry;
 
     // Working directory calculation tests
 
@@ -1309,13 +1308,9 @@ mod tests {
                 })
             })
             .await
+            .unwrap()
+            .to_included()
             .unwrap();
-        let entry = match entry {
-            CreatedEntry::Included(entry) => entry,
-            CreatedEntry::Excluded { abs_path } => {
-                panic!("Unexpected to receive an excluded entry at {abs_path:?}")
-            }
-        };
 
         (wt, entry)
     }

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -144,7 +144,7 @@ impl Workspace {
 
     pub fn show_error<E>(&mut self, err: &E, cx: &mut ViewContext<Self>)
     where
-        E: std::fmt::Debug,
+        E: std::fmt::Debug + std::fmt::Display,
     {
         struct WorkspaceErrorNotification;
 
@@ -153,7 +153,7 @@ impl Workspace {
             cx,
             |cx| {
                 cx.new_view(|_cx| {
-                    simple_message_notification::MessageNotification::new(format!("Error: {err:?}"))
+                    simple_message_notification::MessageNotification::new(format!("Error: {err:#}"))
                 })
             },
         );
@@ -464,7 +464,7 @@ pub trait NotifyResultExt {
 
 impl<T, E> NotifyResultExt for Result<T, E>
 where
-    E: std::fmt::Debug,
+    E: std::fmt::Debug + std::fmt::Display,
 {
     type Ok = T;
 
@@ -483,7 +483,7 @@ where
         match self {
             Ok(value) => Some(value),
             Err(err) => {
-                log::error!("TODO {err:?}");
+                log::error!("{err:?}");
                 cx.update_root(|view, cx| {
                     if let Ok(workspace) = view.downcast::<Workspace>() {
                         workspace.update(cx, |workspace, cx| workspace.show_error(&err, cx))
@@ -502,7 +502,7 @@ pub trait NotifyTaskExt {
 
 impl<R, E> NotifyTaskExt for Task<Result<R, E>>
 where
-    E: std::fmt::Debug + Sized + 'static,
+    E: std::fmt::Debug + std::fmt::Display + Sized + 'static,
     R: 'static,
 {
     fn detach_and_notify_err(self, cx: &mut WindowContext) {

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -122,6 +122,15 @@ impl Workspace {
         }
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn notification_ids(&self) -> Vec<NotificationId> {
+        self.notifications
+            .iter()
+            .map(|(id, _)| id)
+            .cloned()
+            .collect()
+    }
+
     pub fn show_notification<V: Notification>(
         &mut self,
         id: NotificationId,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -106,6 +106,16 @@ pub enum CreatedEntry {
     Excluded { abs_path: PathBuf },
 }
 
+#[cfg(any(test, feature = "test-support"))]
+impl CreatedEntry {
+    pub fn to_included(self) -> Option<Entry> {
+        match self {
+            CreatedEntry::Included(entry) => Some(entry),
+            CreatedEntry::Excluded { .. } => None,
+        }
+    }
+}
+
 pub struct LocalWorktree {
     snapshot: LocalSnapshot,
     scan_requests_tx: channel::Sender<ScanRequest>,

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    worktree_settings::WorktreeSettings, Entry, EntryKind, Event, PathChange, Snapshot, Worktree,
-    WorktreeModelHandle,
+    worktree_settings::WorktreeSettings, CreatedEntry, Entry, EntryKind, Event, PathChange,
+    Snapshot, Worktree, WorktreeModelHandle,
 };
 use anyhow::Result;
 use client::Client;
@@ -1204,7 +1204,7 @@ async fn test_create_directory_during_initial_scan(cx: &mut TestAppContext) {
         snapshot
     });
 
-    let entry = tree
+    let entry = match tree
         .update(cx, |tree, cx| {
             tree.as_local_mut()
                 .unwrap()
@@ -1212,7 +1212,12 @@ async fn test_create_directory_during_initial_scan(cx: &mut TestAppContext) {
         })
         .await
         .unwrap()
-        .unwrap();
+    {
+        CreatedEntry::Included(entry) => entry,
+        CreatedEntry::Excluded { abs_path } => {
+            panic!("Unexpected: created excluded path {abs_path:?}")
+        }
+    };
     assert!(entry.is_dir());
 
     cx.executor().run_until_parked();
@@ -1260,7 +1265,7 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
     .await
     .unwrap();
 
-    let entry = tree_fake
+    let entry = match tree_fake
         .update(cx, |tree, cx| {
             tree.as_local_mut()
                 .unwrap()
@@ -1268,7 +1273,12 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
         })
         .await
         .unwrap()
-        .unwrap();
+    {
+        CreatedEntry::Included(entry) => entry,
+        CreatedEntry::Excluded { abs_path } => {
+            panic!("Unexpected: created excluded path {abs_path:?}")
+        }
+    };
     assert!(entry.is_file());
 
     cx.executor().run_until_parked();
@@ -1302,7 +1312,7 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
     .await
     .unwrap();
 
-    let entry = tree_real
+    let entry = match tree_real
         .update(cx, |tree, cx| {
             tree.as_local_mut()
                 .unwrap()
@@ -1310,7 +1320,12 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
         })
         .await
         .unwrap()
-        .unwrap();
+    {
+        CreatedEntry::Included(entry) => entry,
+        CreatedEntry::Excluded { abs_path } => {
+            panic!("Unexpected: created excluded path {abs_path:?}")
+        }
+    };
     assert!(entry.is_file());
 
     cx.executor().run_until_parked();
@@ -1321,7 +1336,7 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
     });
 
     // Test smallest change
-    let entry = tree_real
+    let entry = match tree_real
         .update(cx, |tree, cx| {
             tree.as_local_mut()
                 .unwrap()
@@ -1329,7 +1344,12 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
         })
         .await
         .unwrap()
-        .unwrap();
+    {
+        CreatedEntry::Included(entry) => entry,
+        CreatedEntry::Excluded { abs_path } => {
+            panic!("Unexpected: created excluded path {abs_path:?}")
+        }
+    };
     assert!(entry.is_file());
 
     cx.executor().run_until_parked();


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/10890

* removes `unwrap()` that caused panics for text elements with no text, remaining after edit state is cleared but project entries are not updated, having the fake, "new entry"
* improves discoverability of the FS errors during file/directory creation: now those are shown as workspace notifications
* stops printing anyhow backtraces in workspace notifications, printing the more readable chain of contexts instead
* better indicates when new entries are created as excluded ones


Release Notes:

- Improve excluded entry creation workflow in the project panel ([10890](https://github.com/zed-industries/zed/issues/10890))