### PR TITLE
ruby: Add "it" to outline symbols list for tests

### DIFF
--- a/extensions/ruby/languages/ruby/outline.scm
+++ b/extensions/ruby/languages/ruby/outline.scm
@@ -21,6 +21,6 @@
 
 ; Minitest/RSpec
 (call
-   method: (identifier) @run (#any-of? @run "describe" "context" "test")
+   method: (identifier) @run (#any-of? @run "describe" "context" "test" "it")
    arguments: (argument_list . (_) @name)
 ) @item


### PR DESCRIPTION
Hi. This pull request adds "it" to the outline symbols list to fix getting the correct symbol for running tests. Consider the following example:

```ruby
describe '#verified?' do # Runnable
    context 'when verified_at is set' do # Runnable
      let(:verified_at) { Time.now.utc.iso8601 }

      it 'returns true' do # Runnable
        expect(subject.verified?).to be true
      end
    end
  end
```

Currently if you click on the `it 'returns true'` Ruby extension will start this test but the outer node will be captured and used as a symbol:

![CleanShot 2024-06-04 at 06 59 41@2x](https://github.com/zed-industries/zed/assets/1894248/e411d7c3-fcf6-4d0b-b102-21859bfc2648)

With the fix here the symbol is captured correctly:

![CleanShot 2024-06-04 at 07 00 58@2x](https://github.com/zed-industries/zed/assets/1894248/f252246c-51ac-4a18-819b-e13bdaf9fd3e)


Release Notes:

- N/A
