### PR TITLE
editor: Cancel ongoing completion requests more eagerly

### DIFF
--- a/crates/editor/src/debounced_delay.rs
+++ b/crates/editor/src/debounced_delay.rs
@@ -29,13 +29,9 @@ impl DebouncedDelay {
         let (sender, mut receiver) = oneshot::channel::<()>();
         self.cancel_channel = Some(sender);
 
-        let previous_task = self.task.take();
+        drop(self.task.take());
         self.task = Some(cx.spawn(move |model, mut cx| async move {
             let mut timer = cx.background_executor().timer(delay).fuse();
-            if let Some(previous_task) = previous_task {
-                previous_task.await;
-            }
-
             futures::select_biased! {
                 _ = receiver => return,
                 _ = timer => {}


### PR DESCRIPTION
Previously, we were:
- cancelling previous requests only after the latest one has completed
- always running the debounced documentation resolution to completion, even when we had no need for it.

In this commit, we drop the ongoing completion requests as soon as the new one is fired.
Fixes #5166 

Release Notes:

- Improved performance and reliability of completions in large Typescript projects
