### PR TITLE
php/elixir: Bump extensions versions to 0.0.6 and 0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13297,7 +13297,7 @@ dependencies = [
 
 [[package]]
 name = "zed_elixir"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]
@@ -13396,7 +13396,7 @@ dependencies = [
 
 [[package]]
 name = "zed_php"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "zed_extension_api 0.0.4",
 ]

--- a/extensions/elixir/Cargo.toml
+++ b/extensions/elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_elixir"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/elixir/extension.toml
+++ b/extensions/elixir/extension.toml
@@ -1,7 +1,7 @@
 id = "elixir"
 name = "Elixir"
 description = "Elixir support."
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/php/Cargo.toml
+++ b/extensions/php/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_php"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/php/extension.toml
+++ b/extensions/php/extension.toml
@@ -1,7 +1,7 @@
 id = "php"
 name = "PHP"
 description = "PHP support."
-version = "0.0.5"
+version = "0.0.6"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Includes:
- https://github.com/zed-industries/zed/pull/12526
- https://github.com/zed-industries/zed/pull/11879
- https://github.com/zed-industries/zed/pull/12467

Release Notes:

- N/A