### PR TITLE
ruby: Remove outline for running tests

### DIFF
--- a/extensions/ruby/languages/ruby/outline.scm
+++ b/extensions/ruby/languages/ruby/outline.scm
@@ -18,9 +18,3 @@
 (module
     "module" @context
     name: (_) @name) @item
-
-; Minitest/RSpec
-(call
-   method: (identifier) @run (#any-of? @run "describe" "context" "test")
-   arguments: (argument_list . (_) @name)
-) @item

--- a/extensions/ruby/languages/ruby/runnables.scm
+++ b/extensions/ruby/languages/ruby/runnables.scm
@@ -10,16 +10,16 @@
           (constant) @run
           (scope_resolution scope: (constant) name: (constant) @run)
         ]
-        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase)$"))
-    ) @minitest-test
+        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase|Minitest::Test)$"))
+    ) @_minitest-test
     (#set! tag minitest-test)
 )
 
 (
     (call
         method: (identifier) @run (#eq? @run "test")
-        arguments: (argument_list (string (string_content) @name))
-    ) @minitest-test
+        arguments: (argument_list (string (string_content) @_name))
+    ) @_minitest-test
     (#set! tag minitest-test)
 )
 
@@ -27,7 +27,7 @@
 (
     (method
         name: (identifier) @run (#match? @run "^test_")
-    ) @minitest-test
+    ) @_minitest-test
     (#set! tag minitest-test)
 )
 
@@ -35,27 +35,17 @@
 (
     (class
         name: (constant) @run (superclass) @superclass (#match? @superclass "(ApplicationSystemTestCase)$")
-    ) @minitest-test
+    ) @_minitest-test
     (#set! tag minitest-test)
 )
 
 ; RSpec
-
-; Example groups with literals
-(
-    (call
-       method: (identifier) @run (#any-of? @run "describe" "context")
-       arguments: (argument_list . (_) @name)
-    ) @rspec-test
-    (#set! tag rspec-test)
-)
-
 ; Examples
 (
     (call
-        method: (identifier) @run (#any-of? @run "it" "its" "specify")
-        arguments: (argument_list (string (string_content) @name))
-    ) @rspec-test
+       method: (identifier) @run (#any-of? @run "describe" "context" "it" "its" "specify")
+       arguments: (argument_list . (_) @_name)
+    ) @_rspec-test
     (#set! tag rspec-test)
 )
 
@@ -63,8 +53,8 @@
 (
     (call
         method: (identifier) @run (#any-of? @run "it" "its" "specify")
-        block: (_) @name
+        block: (_) @_name
         !arguments
-    ) @rspec-test
+    ) @_rspec-test
     (#set! tag rspec-test)
 )

--- a/extensions/ruby/languages/ruby/tasks.json
+++ b/extensions/ruby/languages/ruby/tasks.json
@@ -1,14 +1,8 @@
 [
   {
-    "label": "test $ZED_SYMBOL",
-    "command": "ruby",
-    "args": ["-Itest", "$ZED_FILE", "--name", "\"/$ZED_SYMBOL/\""],
-    "tags": ["minitest-test"]
-  },
-  {
-    "label": "rspec $ZED_SYMBOL",
+    "label": "rspec $ZED_RELATIVE_FILE:$ZED_ROW",
     "command": "./bin/rspec",
-    "args": ["\"$ZED_FILE:$ZED_ROW\""],
+    "args": ["\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
     "tags": ["rspec-test"]
   }
 ]


### PR DESCRIPTION
Hi, this pull request superseeds the https://github.com/zed-industries/zed/pull/12624
and removes queries for runnables from `outline.scm`. This pull request has couple things to mention:

- Removed task for running tests with `minitest` as I think it's not reliable in its state because, AFAIK, the only way to run `minitest` with the specific line, i.e. `bundle exec rake test spec/models/some_model.rb:12` is to use it with Rails. The support for `minitest` is still there and users can add their own task, for instance, when they use `minitest` in Rails to get support for running tests:

  ```json
  {
    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
    "command": "./bin/rails",
    "args": ["test", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
    "tags": ["minitest-test"]
  }
  ```

  **Question:** Perhaps that should be mentioned in the Ruby extension documentation?

- Adjusted runnables queries to work without `ZED_SYMBOL`.

Release Notes:

- N/A
