### PR TITLE
vcs_menu: Fix header taking up too much space

### DIFF
--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -282,7 +282,6 @@ impl PickerDelegate for BranchListDelegate {
             });
             h_flex()
                 .px_3()
-                .h_full()
                 .justify_between()
                 .child(Label::new("Branches").size(LabelSize::Small))
                 .children(match_label)


### PR DESCRIPTION
We've spotted a regression following https://github.com/zed-industries/zed/pull/12468

![image](https://github.com/zed-industries/zed/assets/24362066/8e2659c7-50fe-4a09-af9d-d04416a66276)
This PR addresses that.
Release Notes:

- N/A
