### PR TITLE
Polish prompt library UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,6 @@ dependencies = [
  "anthropic",
  "anyhow",
  "assistant_slash_command",
- "async-watch",
  "cargo_toml",
  "chrono",
  "client",
@@ -822,15 +821,6 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tungstenite 0.16.0",
-]
-
-[[package]]
-name = "async-watch"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a078faf4e27c0c6cc0efb20e5da59dcccc04968ebf2801d8e0b2195124cdcdb2"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]

--- a/assets/icons/zed_assistant_filled.svg
+++ b/assets/icons/zed_assistant_filled.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 1.75L5.88467 5.14092C5.82759 5.31446 5.73055 5.47218 5.60136 5.60136C5.47218 5.73055 5.31446 5.82759 5.14092 5.88467L1.75 7L5.14092 8.11533C5.31446 8.17241 5.47218 8.26945 5.60136 8.39864C5.73055 8.52782 5.82759 8.68554 5.88467 8.85908L7 12.25L8.11533 8.85908C8.17241 8.68554 8.26945 8.52782 8.39864 8.39864C8.52782 8.26945 8.68554 8.17241 8.85908 8.11533L12.25 7L8.85908 5.88467C8.68554 5.82759 8.52782 5.73055 8.39864 5.60136C8.26945 5.47218 8.17241 5.31446 8.11533 5.14092L7 1.75Z" fill="black" stroke="black" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.91667 1.75V4.08333M1.75 2.91667H4.08333" stroke="black" stroke-opacity="0.75" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.0833 9.91667V12.25M9.91667 11.0833H12.25" stroke="black" stroke-opacity="0.75" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 anyhow.workspace = true
 anthropic = { workspace = true, features = ["schemars"] }
 assistant_slash_command.workspace = true
-async-watch.workspace = true
 cargo_toml.workspace = true
 chrono.workspace = true
 client.workspace = true

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -19,14 +19,13 @@ use command_palette_hooks::CommandPaletteFilter;
 pub(crate) use completion_provider::*;
 use gpui::{actions, AppContext, Global, SharedString, UpdateGlobal};
 pub(crate) use model_selector::*;
-use prompt_library::PromptStore;
 pub(crate) use saved_conversation::*;
 use semantic_index::{CloudEmbeddingProvider, SemanticIndex};
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
 use slash_command::{
-    active_command, file_command, project_command, prompt_command, rustdoc_command, search_command,
-    tabs_command,
+    active_command, default_command, file_command, project_command, prompt_command,
+    rustdoc_command, search_command, tabs_command,
 };
 use std::{
     fmt::{self, Display},
@@ -303,17 +302,9 @@ fn register_slash_commands(cx: &mut AppContext) {
     slash_command_registry.register_command(tabs_command::TabsSlashCommand, true);
     slash_command_registry.register_command(project_command::ProjectSlashCommand, true);
     slash_command_registry.register_command(search_command::SearchSlashCommand, true);
+    slash_command_registry.register_command(prompt_command::PromptSlashCommand, true);
+    slash_command_registry.register_command(default_command::DefaultSlashCommand, true);
     slash_command_registry.register_command(rustdoc_command::RustdocSlashCommand, false);
-
-    let store = PromptStore::global(cx);
-    cx.background_executor()
-        .spawn(async move {
-            let store = store.await?;
-            slash_command_registry
-                .register_command(prompt_command::PromptSlashCommand::new(store), true);
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
 }
 
 #[cfg(test)]

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,11 +1,11 @@
 use crate::{
     assistant_settings::{AssistantDockPosition, AssistantSettings},
     codegen::{self, Codegen, CodegenKind},
-    prompt_library::{open_prompt_library, PromptMetadata, PromptStore},
+    prompt_library::open_prompt_library,
     prompts::generate_content_prompt,
     search::*,
     slash_command::{
-        prompt_command::PromptPlaceholder, SlashCommandCompletionProvider, SlashCommandLine,
+        default_command::DefaultSlashCommand, SlashCommandCompletionProvider, SlashCommandLine,
         SlashCommandRegistry,
     },
     ApplyEdit, Assist, CompletionProvider, ConfirmCommand, CycleMessageRole, InlineAssist,
@@ -14,7 +14,7 @@ use crate::{
     SavedMessage, Split, ToggleFocus, ToggleHistory, ToggleModelSelector,
 };
 use anyhow::{anyhow, Result};
-use assistant_slash_command::{SlashCommandOutput, SlashCommandOutputSection};
+use assistant_slash_command::{SlashCommand, SlashCommandOutput, SlashCommandOutputSection};
 use client::telemetry::Telemetry;
 use collections::{hash_map, BTreeSet, HashMap, HashSet, VecDeque};
 use editor::{actions::ShowCompletions, GutterDimensions};
@@ -118,14 +118,6 @@ pub struct AssistantPanel {
     _watch_saved_conversations: Task<Result<()>>,
     authentication_prompt: Option<AnyView>,
     model_menu_handle: PopoverMenuHandle<ContextMenu>,
-    default_prompt: DefaultPrompt,
-    _watch_prompt_store: Task<()>,
-}
-
-#[derive(Default)]
-struct DefaultPrompt {
-    text: String,
-    sections: Vec<SlashCommandOutputSection<usize>>,
 }
 
 struct ActiveConversationEditor {
@@ -146,8 +138,6 @@ impl AssistantPanel {
                 .await
                 .log_err()
                 .unwrap_or_default();
-            let prompt_store = cx.update(|cx| PromptStore::global(cx))?.await?;
-            let default_prompts = prompt_store.load_default().await?;
 
             // TODO: deserialize state.
             let workspace_handle = workspace.clone();
@@ -171,22 +161,6 @@ impl AssistantPanel {
                         }
 
                         anyhow::Ok(())
-                    });
-
-                    let _watch_prompt_store = cx.spawn(|this, mut cx| async move {
-                        let mut updates = prompt_store.updates();
-                        while updates.changed().await.is_ok() {
-                            let Some(prompts) = prompt_store.load_default().await.log_err() else {
-                                continue;
-                            };
-
-                            if this
-                                .update(&mut cx, |this, _cx| this.update_default_prompt(prompts))
-                                .is_err()
-                            {
-                                break;
-                            }
-                        }
                     });
 
                     let toolbar = cx.new_view(|cx| {
@@ -216,7 +190,7 @@ impl AssistantPanel {
                     })
                     .detach();
 
-                    let mut this = Self {
+                    Self {
                         workspace: workspace_handle,
                         active_conversation_editor: None,
                         show_saved_conversations: false,
@@ -239,11 +213,7 @@ impl AssistantPanel {
                         _watch_saved_conversations,
                         authentication_prompt: None,
                         model_menu_handle: PopoverMenuHandle::default(),
-                        default_prompt: DefaultPrompt::default(),
-                        _watch_prompt_store,
-                    };
-                    this.update_default_prompt(default_prompts);
-                    this
+                    }
                 })
             })
         })
@@ -264,55 +234,6 @@ impl AssistantPanel {
         self.toolbar
             .update(cx, |toolbar, cx| toolbar.focus_changed(false, cx));
         cx.notify();
-    }
-
-    fn update_default_prompt(&mut self, prompts: Vec<(PromptMetadata, String)>) {
-        self.default_prompt.text.clear();
-        self.default_prompt.sections.clear();
-        if !prompts.is_empty() {
-            self.default_prompt.text.push_str("Default Prompt:\n");
-        }
-
-        for (metadata, body) in prompts {
-            let section_start = self.default_prompt.text.len();
-            self.default_prompt.text.push_str(&body);
-            let section_end = self.default_prompt.text.len();
-            self.default_prompt
-                .sections
-                .push(SlashCommandOutputSection {
-                    range: section_start..section_end,
-                    render_placeholder: Arc::new(move |id, unfold, _cx| {
-                        PromptPlaceholder {
-                            title: metadata
-                                .title
-                                .clone()
-                                .unwrap_or_else(|| SharedString::from("Untitled")),
-                            id,
-                            unfold,
-                        }
-                        .into_any_element()
-                    }),
-                });
-            self.default_prompt.text.push('\n');
-        }
-        self.default_prompt.text.pop();
-
-        if !self.default_prompt.text.is_empty() {
-            self.default_prompt.sections.insert(
-                0,
-                SlashCommandOutputSection {
-                    range: 0..self.default_prompt.text.len(),
-                    render_placeholder: Arc::new(move |id, unfold, _cx| {
-                        PromptPlaceholder {
-                            title: "Default".into(),
-                            id,
-                            unfold,
-                        }
-                        .into_any_element()
-                    }),
-                },
-            )
-        }
     }
 
     fn completion_provider_changed(
@@ -862,7 +783,6 @@ impl AssistantPanel {
 
         let editor = cx.new_view(|cx| {
             ConversationEditor::new(
-                &self.default_prompt,
                 self.languages.clone(),
                 self.slash_commands.clone(),
                 self.fs.clone(),
@@ -2596,7 +2516,6 @@ pub struct ConversationEditor {
 
 impl ConversationEditor {
     fn new(
-        default_prompt: &DefaultPrompt,
         language_registry: Arc<LanguageRegistry>,
         slash_command_registry: Arc<SlashCommandRegistry>,
         fs: Arc<dyn Fs>,
@@ -2618,31 +2537,7 @@ impl ConversationEditor {
 
         let mut this =
             Self::for_conversation(conversation, fs, workspace, lsp_adapter_delegate, cx);
-
-        if !default_prompt.text.is_empty() {
-            this.editor
-                .update(cx, |editor, cx| editor.insert(&default_prompt.text, cx));
-            let snapshot = this.conversation.read(cx).buffer.read(cx).text_snapshot();
-            this.insert_slash_command_output_sections(
-                default_prompt
-                    .sections
-                    .iter()
-                    .map(|section| SlashCommandOutputSection {
-                        range: snapshot.anchor_after(section.range.start)
-                            ..snapshot.anchor_before(section.range.end),
-                        render_placeholder: section.render_placeholder.clone(),
-                    }),
-                cx,
-            );
-            this.split(&Split, cx);
-            this.conversation.update(cx, |this, _cx| {
-                this.messages_metadata
-                    .get_mut(&MessageId::default())
-                    .unwrap()
-                    .role = Role::System;
-            });
-        }
-
+        this.insert_default_prompt(cx);
         this
     }
 
@@ -2693,6 +2588,31 @@ impl ConversationEditor {
         };
         this.update_message_headers(cx);
         this
+    }
+
+    fn insert_default_prompt(&mut self, cx: &mut ViewContext<Self>) {
+        let command_name = DefaultSlashCommand.name();
+        self.editor.update(cx, |editor, cx| {
+            editor.insert(&format!("/{command_name}"), cx)
+        });
+        self.split(&Split, cx);
+        let command = self.conversation.update(cx, |conversation, cx| {
+            conversation
+                .messages_metadata
+                .get_mut(&MessageId::default())
+                .unwrap()
+                .role = Role::System;
+            conversation.reparse_slash_commands(cx);
+            conversation.pending_slash_commands[0].clone()
+        });
+
+        self.run_command(
+            command.source_range,
+            &command.name,
+            command.argument.as_deref(),
+            self.workspace.clone(),
+            cx,
+        );
     }
 
     fn assist(&mut self, _: &Assist, cx: &mut ViewContext<Self>) {

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -80,7 +80,7 @@ pub fn open_prompt_library(
                 cx.open_window(
                     WindowOptions {
                         titlebar: Some(TitlebarOptions {
-                            title: None,
+                            title: Some("Prompt Library".into()),
                             appears_transparent: true,
                             traffic_light_position: Some(point(px(9.0), px(9.0))),
                         }),

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -470,6 +470,10 @@ impl PromptLibrary {
         }
     }
 
+    fn cancel(&mut self, _: &menu::Cancel, cx: &mut ViewContext<Self>) {
+        self.picker.update(cx, |picker, cx| picker.focus(cx));
+    }
+
     fn handle_prompt_editor_event(
         &mut self,
         prompt_id: PromptId,
@@ -607,7 +611,13 @@ impl PromptLibrary {
                                         ),
                                 ),
                         )
-                        .child(div().flex_grow().p(Spacing::Large.rems(cx)).child(editor)),
+                        .child(
+                            div()
+                                .on_action(cx.listener(Self::cancel))
+                                .flex_grow()
+                                .p(Spacing::Large.rems(cx))
+                                .child(editor),
+                        ),
                 )
             }))
     }

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -1,4 +1,6 @@
+use crate::slash_command::SlashCommandLine;
 use anyhow::{anyhow, Result};
+use assistant_slash_command::SlashCommandRegistry;
 use chrono::{DateTime, Utc};
 use collections::HashMap;
 use editor::{Editor, EditorEvent};
@@ -6,14 +8,17 @@ use futures::{
     future::{self, BoxFuture, Shared},
     FutureExt,
 };
-use fuzzy::StringMatchCandidate;
+use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{
     actions, point, size, AppContext, BackgroundExecutor, Bounds, DevicePixels, Empty,
-    EventEmitter, Global, PromptLevel, ReadGlobal, Subscription, Task, TitlebarOptions, View,
-    WindowBounds, WindowHandle, WindowOptions,
+    EventEmitter, Global, Model, PromptLevel, ReadGlobal, Subscription, Task, TitlebarOptions,
+    View, WindowBounds, WindowHandle, WindowOptions,
 };
 use heed::{types::SerdeBincode, Database, RoTxn};
-use language::{language_settings::SoftWrap, Buffer, LanguageRegistry};
+use language::{
+    language_settings::SoftWrap, Buffer, Documentation, LanguageRegistry, LanguageServerId, Point,
+    ToPoint as _,
+};
 use parking_lot::RwLock;
 use picker::{Picker, PickerDelegate};
 use rope::Rope;
@@ -424,6 +429,8 @@ impl PromptLibrary {
                             editor.set_show_gutter(false, cx);
                             editor.set_show_wrap_guides(false, cx);
                             editor.set_show_indent_guides(false, cx);
+                            editor
+                                .set_completion_provider(Box::new(SlashCommandCompletionProvider));
                             if focus {
                                 editor.focus(cx);
                             }
@@ -960,5 +967,125 @@ fn title_from_body(body: impl IntoIterator<Item = char>) -> Option<SharedString>
         }
     } else {
         None
+    }
+}
+
+struct SlashCommandCompletionProvider;
+
+impl editor::CompletionProvider for SlashCommandCompletionProvider {
+    fn completions(
+        &self,
+        buffer: &Model<Buffer>,
+        buffer_position: language::Anchor,
+        cx: &mut ViewContext<Editor>,
+    ) -> Task<Result<Vec<project::Completion>>> {
+        let Some((command_name, name_range)) = buffer.update(cx, |buffer, _cx| {
+            let position = buffer_position.to_point(buffer);
+            let line_start = Point::new(position.row, 0);
+            let mut lines = buffer.text_for_range(line_start..position).lines();
+            let line = lines.next()?;
+            let call = SlashCommandLine::parse(line)?;
+
+            if call.argument.is_some() {
+                // Don't autocomplete arguments.
+                None
+            } else {
+                let name = line[call.name.clone()].to_string();
+                let name_range_start = Point::new(position.row, call.name.start as u32);
+                let name_range_end = Point::new(position.row, call.name.end as u32);
+                let name_range =
+                    buffer.anchor_after(name_range_start)..buffer.anchor_after(name_range_end);
+                Some((name, name_range))
+            }
+        }) else {
+            return Task::ready(Ok(Vec::new()));
+        };
+
+        let commands = SlashCommandRegistry::global(cx);
+        let candidates = commands
+            .command_names()
+            .into_iter()
+            .enumerate()
+            .map(|(ix, def)| StringMatchCandidate {
+                id: ix,
+                string: def.to_string(),
+                char_bag: def.as_ref().into(),
+            })
+            .collect::<Vec<_>>();
+        let command_name = command_name.to_string();
+        cx.spawn(|_, mut cx| async move {
+            let matches = match_strings(
+                &candidates,
+                &command_name,
+                true,
+                usize::MAX,
+                &Default::default(),
+                cx.background_executor().clone(),
+            )
+            .await;
+            cx.update(|cx| {
+                matches
+                    .into_iter()
+                    .filter_map(|mat| {
+                        let command = commands.command(&mat.string)?;
+                        let mut new_text = mat.string.clone();
+                        let requires_argument = command.requires_argument();
+                        if requires_argument {
+                            new_text.push(' ');
+                        }
+
+                        Some(project::Completion {
+                            old_range: name_range.clone(),
+                            documentation: Some(Documentation::SingleLine(command.description())),
+                            new_text,
+                            label: command.label(cx),
+                            server_id: LanguageServerId(0),
+                            lsp_completion: Default::default(),
+                            show_new_completions_on_confirm: false,
+                            confirm: None,
+                        })
+                    })
+                    .collect()
+            })
+        })
+    }
+
+    fn resolve_completions(
+        &self,
+        _: Model<Buffer>,
+        _: Vec<usize>,
+        _: Arc<RwLock<Box<[project::Completion]>>>,
+        _: &mut ViewContext<Editor>,
+    ) -> Task<Result<bool>> {
+        Task::ready(Ok(true))
+    }
+
+    fn apply_additional_edits_for_completion(
+        &self,
+        _: Model<Buffer>,
+        _: project::Completion,
+        _: bool,
+        _: &mut ViewContext<Editor>,
+    ) -> Task<Result<Option<language::Transaction>>> {
+        Task::ready(Ok(None))
+    }
+
+    fn is_completion_trigger(
+        &self,
+        buffer: &Model<Buffer>,
+        position: language::Anchor,
+        _text: &str,
+        _trigger_in_words: bool,
+        cx: &mut ViewContext<Editor>,
+    ) -> bool {
+        let buffer = buffer.read(cx);
+        let position = position.to_point(buffer);
+        let line_start = Point::new(position.row, 0);
+        let mut lines = buffer.text_for_range(line_start..position).lines();
+        if let Some(line) = lines.next() {
+            SlashCommandLine::parse(line).is_some()
+        } else {
+            false
+        }
     }
 }

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -797,8 +797,8 @@ impl PromptStore {
         })
     }
 
-    pub fn load_default(&self) -> Task<Result<Vec<(PromptMetadata, String)>>> {
-        let default_metadatas = self
+    pub fn default_prompt_metadata(&self) -> Vec<PromptMetadata> {
+        return self
             .metadata_cache
             .read()
             .metadata
@@ -806,23 +806,6 @@ impl PromptStore {
             .filter(|metadata| metadata.default)
             .cloned()
             .collect::<Vec<_>>();
-        let env = self.env.clone();
-        let bodies = self.bodies;
-        self.executor.spawn(async move {
-            let txn = env.read_txn()?;
-
-            let mut default_prompts = Vec::new();
-            for metadata in default_metadatas {
-                if let Some(body) = bodies.get(&txn, &metadata.id)? {
-                    if !body.is_empty() {
-                        default_prompts.push((metadata, body));
-                    }
-                }
-            }
-
-            default_prompts.sort_unstable_by_key(|(metadata, _)| metadata.saved_at);
-            Ok(default_prompts)
-        })
     }
 
     pub fn delete(&self, id: PromptId) -> Task<Result<()>> {

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -291,9 +291,9 @@ impl PickerDelegate for PromptPickerDelegate {
                                 IconButton::new(
                                     "toggle-default-prompt",
                                     if default {
-                                        IconName::StarFilled
+                                        IconName::ZedAssistantFilled
                                     } else {
-                                        IconName::Star
+                                        IconName::ZedAssistant
                                     },
                                 )
                                 .shape(IconButtonShape::Square)
@@ -740,9 +740,9 @@ impl PromptLibrary {
                                     IconButton::new(
                                         "toggle-default-prompt",
                                         if prompt_metadata.default {
-                                            IconName::StarFilled
+                                            IconName::ZedAssistantFilled
                                         } else {
-                                            IconName::Star
+                                            IconName::ZedAssistant
                                         },
                                     )
                                     .size(ButtonSize::Large)

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -137,8 +137,8 @@ enum PromptPickerEvent {
 enum PromptPickerEntry {
     DefaultPromptsHeader,
     DefaultPromptsEmpty,
-    PromptsHeader,
-    PromptsEmpty,
+    AllPromptsHeader,
+    AllPromptsEmpty,
     Prompt(PromptMetadata),
 }
 
@@ -200,9 +200,9 @@ impl PickerDelegate for PromptPickerDelegate {
                         entries.extend(default_prompts.into_iter().map(PromptPickerEntry::Prompt));
                     }
 
-                    entries.push(PromptPickerEntry::PromptsHeader);
+                    entries.push(PromptPickerEntry::AllPromptsHeader);
                     if prompts.is_empty() {
-                        entries.push(PromptPickerEntry::PromptsEmpty);
+                        entries.push(PromptPickerEntry::AllPromptsEmpty);
                     } else {
                         entries.extend(prompts.into_iter().map(PromptPickerEntry::Prompt));
                     }
@@ -257,12 +257,12 @@ impl PickerDelegate for PromptPickerDelegate {
                     .selected(selected)
                     .into_any_element()
             }
-            PromptPickerEntry::PromptsHeader => ListHeader::new("Prompts")
+            PromptPickerEntry::AllPromptsHeader => ListHeader::new("All Prompts")
                 .inset(true)
                 .start_slot(Icon::new(IconName::Library))
                 .selected(selected)
                 .into_any_element(),
-            PromptPickerEntry::PromptsEmpty => ListSubHeader::new("No prompts")
+            PromptPickerEntry::AllPromptsEmpty => ListSubHeader::new("No prompts")
                 .inset(true)
                 .selected(selected)
                 .into_any_element(),

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -17,6 +17,7 @@ use std::{
 use workspace::Workspace;
 
 pub mod active_command;
+pub mod default_command;
 pub mod file_command;
 pub mod project_command;
 pub mod prompt_command;

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -117,6 +117,7 @@ impl SlashCommandCompletionProvider {
                                                 command_range.clone(),
                                                 &command_name,
                                                 None,
+                                                true,
                                                 workspace.clone(),
                                                 cx,
                                             );
@@ -178,6 +179,7 @@ impl SlashCommandCompletionProvider {
                                             command_range.clone(),
                                             &command_name,
                                             Some(&arg),
+                                            true,
                                             workspace.clone(),
                                             cx,
                                         );

--- a/crates/assistant/src/slash_command/active_command.rs
+++ b/crates/assistant/src/slash_command/active_command.rs
@@ -96,6 +96,7 @@ impl SlashCommand for ActiveSlashCommand {
                             .into_any_element()
                         }),
                     }],
+                    run_commands_in_text: false,
                 })
             })
         });

--- a/crates/assistant/src/slash_command/default_command.rs
+++ b/crates/assistant/src/slash_command/default_command.rs
@@ -59,6 +59,7 @@ impl SlashCommand for DefaultSlashCommand {
                     writeln!(text, "/prompt {}", title).unwrap();
                 }
             }
+            text.pop();
 
             Ok(SlashCommandOutput {
                 sections: vec![SlashCommandOutputSection {

--- a/crates/assistant/src/slash_command/default_command.rs
+++ b/crates/assistant/src/slash_command/default_command.rs
@@ -1,0 +1,99 @@
+use super::{prompt_command::PromptPlaceholder, SlashCommand, SlashCommandOutput};
+use crate::prompt_library::PromptStore;
+use anyhow::{anyhow, Result};
+use assistant_slash_command::SlashCommandOutputSection;
+use gpui::{AppContext, Task, WeakView};
+use language::LspAdapterDelegate;
+use std::sync::{atomic::AtomicBool, Arc};
+use ui::prelude::*;
+use workspace::Workspace;
+
+pub(crate) struct DefaultSlashCommand;
+
+impl SlashCommand for DefaultSlashCommand {
+    fn name(&self) -> String {
+        "default".into()
+    }
+
+    fn description(&self) -> String {
+        "insert default prompt".into()
+    }
+
+    fn menu_text(&self) -> String {
+        "Insert Default Prompt".into()
+    }
+
+    fn requires_argument(&self) -> bool {
+        false
+    }
+
+    fn complete_argument(
+        &self,
+        _query: String,
+        _cancellation_flag: Arc<AtomicBool>,
+        _workspace: WeakView<Workspace>,
+        _cx: &mut AppContext,
+    ) -> Task<Result<Vec<String>>> {
+        Task::ready(Err(anyhow!("this command does not require argument")))
+    }
+
+    fn run(
+        self: Arc<Self>,
+        _argument: Option<&str>,
+        _workspace: WeakView<Workspace>,
+        _delegate: Arc<dyn LspAdapterDelegate>,
+        cx: &mut WindowContext,
+    ) -> Task<Result<SlashCommandOutput>> {
+        let store = PromptStore::global(cx);
+        cx.background_executor().spawn(async move {
+            let store = store.await?;
+            let mut text = String::new();
+            let mut sections = Vec::new();
+
+            let prompts = store.load_default().await?;
+            if !prompts.is_empty() {
+                text.push_str("Default Prompt:\n");
+            }
+
+            for (metadata, body) in prompts {
+                let section_start = text.len();
+                text.push_str(&body);
+                let section_end = text.len();
+                sections.push(SlashCommandOutputSection {
+                    range: section_start..section_end,
+                    render_placeholder: Arc::new(move |id, unfold, _cx| {
+                        PromptPlaceholder {
+                            title: metadata
+                                .title
+                                .clone()
+                                .unwrap_or_else(|| SharedString::from("Untitled")),
+                            id,
+                            unfold,
+                        }
+                        .into_any_element()
+                    }),
+                });
+                text.push('\n');
+            }
+
+            if !text.is_empty() {
+                sections.insert(
+                    0,
+                    SlashCommandOutputSection {
+                        range: 0..text.len(),
+                        render_placeholder: Arc::new(move |id, unfold, _cx| {
+                            PromptPlaceholder {
+                                title: "Default".into(),
+                                id,
+                                unfold,
+                            }
+                            .into_any_element()
+                        }),
+                    },
+                )
+            }
+
+            Ok(SlashCommandOutput { text, sections })
+        })
+    }
+}

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -187,6 +187,7 @@ impl SlashCommand for FileSlashCommand {
                         .into_any_element()
                     }),
                 }],
+                run_commands_in_text: false,
             })
         })
     }

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -148,6 +148,7 @@ impl SlashCommand for ProjectSlashCommand {
                                 .into_any_element()
                         }),
                     }],
+                    run_commands_in_text: false,
                 })
             })
         });

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -8,15 +8,7 @@ use std::sync::{atomic::AtomicBool, Arc};
 use ui::{prelude::*, ButtonLike, ElevationIndex};
 use workspace::Workspace;
 
-pub(crate) struct PromptSlashCommand {
-    store: Arc<PromptStore>,
-}
-
-impl PromptSlashCommand {
-    pub fn new(store: Arc<PromptStore>) -> Self {
-        Self { store }
-    }
-}
+pub(crate) struct PromptSlashCommand;
 
 impl SlashCommand for PromptSlashCommand {
     fn name(&self) -> String {
@@ -42,9 +34,9 @@ impl SlashCommand for PromptSlashCommand {
         _workspace: WeakView<Workspace>,
         cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
-        let store = self.store.clone();
+        let store = PromptStore::global(cx);
         cx.background_executor().spawn(async move {
-            let prompts = store.search(query).await;
+            let prompts = store.await?.search(query).await;
             Ok(prompts
                 .into_iter()
                 .filter_map(|prompt| Some(prompt.title?.to_string()))
@@ -63,11 +55,12 @@ impl SlashCommand for PromptSlashCommand {
             return Task::ready(Err(anyhow!("missing prompt name")));
         };
 
-        let store = self.store.clone();
+        let store = PromptStore::global(cx);
         let title = SharedString::from(title.to_string());
         let prompt = cx.background_executor().spawn({
             let title = title.clone();
             async move {
+                let store = store.await?;
                 let prompt_id = store
                     .id_for_title(&title)
                     .with_context(|| format!("no prompt found with title {:?}", title))?;

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -84,6 +84,7 @@ impl SlashCommand for PromptSlashCommand {
                         .into_any_element()
                     }),
                 }],
+                run_commands_in_text: true,
             })
         })
     }

--- a/crates/assistant/src/slash_command/rustdoc_command.rs
+++ b/crates/assistant/src/slash_command/rustdoc_command.rs
@@ -192,6 +192,7 @@ impl SlashCommand for RustdocSlashCommand {
                         .into_any_element()
                     }),
                 }],
+                run_commands_in_text: false,
             })
         })
     }

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -181,7 +181,11 @@ impl SlashCommand for SearchSlashCommand {
                         }),
                     });
 
-                    SlashCommandOutput { text, sections }
+                    SlashCommandOutput {
+                        text,
+                        sections,
+                        run_commands_in_text: false,
+                    }
                 })
                 .await;
 

--- a/crates/assistant/src/slash_command/tabs_command.rs
+++ b/crates/assistant/src/slash_command/tabs_command.rs
@@ -109,7 +109,11 @@ impl SlashCommand for TabsSlashCommand {
                     });
                 }
 
-                Ok(SlashCommandOutput { text, sections })
+                Ok(SlashCommandOutput {
+                    text,
+                    sections,
+                    run_commands_in_text: false,
+                })
             }),
             Err(error) => Task::ready(Err(error)),
         }

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -52,6 +52,7 @@ pub type RenderFoldPlaceholder = Arc<
 pub struct SlashCommandOutput {
     pub text: String,
     pub sections: Vec<SlashCommandOutputSection<usize>>,
+    pub run_commands_in_text: bool,
 }
 
 #[derive(Clone)]

--- a/crates/extension/src/extension_slash_command.rs
+++ b/crates/extension/src/extension_slash_command.rs
@@ -100,6 +100,7 @@ impl SlashCommand for ExtensionSlashCommand {
                         }
                     }),
                 }],
+                run_commands_in_text: false,
             })
         })
     }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -656,7 +656,7 @@ impl MacWindow {
                 .as_ref()
                 .and_then(|t| t.title.as_ref().map(AsRef::as_ref))
             {
-                native_window.setTitle_(NSString::alloc(nil).init_str(title));
+                window.set_title(title);
             }
 
             native_window.setMovable_(is_movable as BOOL);

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -236,7 +236,12 @@ impl<D: PickerDelegate> Picker<D> {
     /// If `scroll_to_index` is true, the new selected index will be scrolled into view.
     ///
     /// If some effect is bound to `selected_index_changed`, it will be executed.
-    fn set_selected_index(&mut self, ix: usize, scroll_to_index: bool, cx: &mut ViewContext<Self>) {
+    pub fn set_selected_index(
+        &mut self,
+        ix: usize,
+        scroll_to_index: bool,
+        cx: &mut ViewContext<Self>,
+    ) {
         let previous_index = self.delegate.selected_index();
         self.delegate.set_selected_index(ix, cx);
         let current_index = self.delegate.selected_index();

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -192,6 +192,7 @@ pub enum IconName {
     WholeWord,
     XCircle,
     ZedAssistant,
+    ZedAssistantFilled,
     ZedXCopilot,
 }
 
@@ -315,6 +316,7 @@ impl IconName {
             IconName::WholeWord => "icons/word_search.svg",
             IconName::XCircle => "icons/error.svg",
             IconName::ZedAssistant => "icons/zed_assistant.svg",
+            IconName::ZedAssistantFilled => "icons/zed_assistant_filled.svg",
             IconName::ZedXCopilot => "icons/zed_x_copilot.svg",
             IconName::ArrowUpFromLine => "icons/arrow_up_from_line.svg",
         }

--- a/crates/ui/src/components/list/list_sub_header.rs
+++ b/crates/ui/src/components/list/list_sub_header.rs
@@ -6,6 +6,7 @@ pub struct ListSubHeader {
     label: SharedString,
     start_slot: Option<IconName>,
     inset: bool,
+    selected: bool,
 }
 
 impl ListSubHeader {
@@ -14,6 +15,7 @@ impl ListSubHeader {
             label: label.into(),
             start_slot: None,
             inset: false,
+            selected: false,
         }
     }
 
@@ -28,12 +30,22 @@ impl ListSubHeader {
     }
 }
 
+impl Selectable for ListSubHeader {
+    fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+}
+
 impl RenderOnce for ListSubHeader {
-    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
+    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         h_flex().flex_1().w_full().relative().py_1().child(
             div()
                 .h_6()
                 .when(self.inset, |this| this.px_2())
+                .when(self.selected, |this| {
+                    this.bg(cx.theme().colors().ghost_element_selected)
+                })
                 .flex()
                 .flex_1()
                 .w_full()


### PR DESCRIPTION
This could still use some improvement UI-wise but the user experience should be a lot better.

- [x] Show in "Window" application menu
- [x] Load prompt as it's selected in the picker
- [x] Refocus picker on `esc`
- [x] When creating a new prompt, if a new prompt already exists and is unedited, activate it instead
- [x] Add `/default` command
- [x] Evaluate /commands on prompt insertion
- [x] Autocomplete /commands (but don't evaluate) during prompt editing
- [x] Show token count using the settings model, right-aligned in the editor  
- [x] Picker 
- [x] Sorted alpha
- [x] 2 sublists
    - Default
        - Empty state: Star a prompt to add it to your default prompt
        - Otherwise show prompts with star on hover
    - All
        - Move prompts with star on hover

Release Notes:

- N/A
