### PR TITLE
Add ability to scroll popovers with vim

### DIFF
--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -185,7 +185,8 @@ impl Editor {
         }) else {
             return false;
         };
-        popover.scroll(amount, cx)
+        popover.scroll(amount, cx);
+        true
     }
 
     fn cmd_click_reveal_task(

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -1,5 +1,6 @@
 use crate::{
     hover_popover::{self, InlayHover},
+    scroll::ScrollAmount,
     Anchor, Editor, EditorSnapshot, FindAllReferences, GoToDefinition, GoToTypeDefinition, InlayId,
     PointForPosition, SelectPhase,
 };
@@ -38,7 +39,11 @@ impl RangeInEditor {
         }
     }
 
-    fn point_within_range(&self, trigger_point: &TriggerPoint, snapshot: &EditorSnapshot) -> bool {
+    pub fn point_within_range(
+        &self,
+        trigger_point: &TriggerPoint,
+        snapshot: &EditorSnapshot,
+    ) -> bool {
         match (self, trigger_point) {
             (Self::Text(range), TriggerPoint::Text(point)) => {
                 let point_after_start = range.start.cmp(point, &snapshot.buffer_snapshot).is_le();
@@ -167,6 +172,20 @@ impl Editor {
             }
         })
         .detach();
+    }
+
+    pub fn scroll_hover(&mut self, amount: &ScrollAmount, cx: &mut ViewContext<Self>) -> bool {
+        let selection = self.selections.newest_anchor().head();
+        let snapshot = self.snapshot(cx);
+
+        let Some(popover) = self.hover_state.info_popovers.iter().find(|popover| {
+            popover
+                .symbol_range
+                .point_within_range(&TriggerPoint::Text(selection), &snapshot)
+        }) else {
+            return false;
+        };
+        popover.scroll(amount, cx)
     }
 
     fn cmd_click_reveal_task(

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -426,7 +426,7 @@ async fn parse_blocks(
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct HoverState {
     pub info_popovers: Vec<InfoPopover>,
     pub diagnostic_popover: Option<DiagnosticPopover>,
@@ -490,7 +490,7 @@ impl HoverState {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct InfoPopover {
     pub symbol_range: RangeInEditor,
     pub parsed_content: ParsedMarkdown,
@@ -508,7 +508,6 @@ impl InfoPopover {
         div()
             .id("info_popover")
             .elevation_2(cx)
-            .p_2()
             .overflow_y_scroll()
             .track_scroll(&self.scroll_handle)
             .max_w(max_size.width)
@@ -517,24 +516,24 @@ impl InfoPopover {
             // because that would dismiss the popover.
             .on_mouse_move(|_, cx| cx.stop_propagation())
             .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
-            .child(crate::render_parsed_markdown(
+            .child(div().p_2().child(crate::render_parsed_markdown(
                 "content",
                 &self.parsed_content,
                 style,
                 workspace,
                 cx,
-            ))
+            )))
             .into_any_element()
     }
 
-    pub fn scroll(&self, amount: &ScrollAmount, cx: &mut ViewContext<Editor>) -> bool {
+    pub fn scroll(&self, amount: &ScrollAmount, cx: &mut ViewContext<Editor>) {
         let mut current = self.scroll_handle.offset();
         current.y -= amount.pixels(
             cx.line_height(),
             self.scroll_handle.bounds().size.height - px(16.),
         ) / 2.0;
         cx.notify();
-        self.scroll_handle.scroll_to(current)
+        self.scroll_handle.set_offset(current);
     }
 }
 

--- a/crates/editor/src/scroll/scroll_amount.rs
+++ b/crates/editor/src/scroll/scroll_amount.rs
@@ -1,7 +1,8 @@
 use crate::Editor;
 use serde::Deserialize;
+use ui::{px, Pixels};
 
-#[derive(Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub enum ScrollAmount {
     // Scroll N lines (positive is towards the end of the document)
     Line(f32),
@@ -23,6 +24,13 @@ impl ScrollAmount {
                     (l * count).trunc()
                 })
                 .unwrap_or(0.),
+        }
+    }
+
+    pub fn pixels(&self, line_height: Pixels, height: Pixels) -> Pixels {
+        match self {
+            ScrollAmount::Line(x) => px(line_height.0 * x),
+            ScrollAmount::Page(x) => px(height.0 * x),
         }
     }
 }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2437,7 +2437,7 @@ where
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ScrollHandleState {
     offset: Rc<RefCell<Point<Pixels>>>,
     bounds: Bounds<Pixels>,
@@ -2449,7 +2449,7 @@ struct ScrollHandleState {
 /// A handle to the scrollable aspects of an element.
 /// Used for accessing scroll state, like the current scroll offset,
 /// and for mutating the scroll state, like scrolling to a specific child.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ScrollHandle(Rc<RefCell<ScrollHandleState>>);
 
 impl Default for ScrollHandle {
@@ -2526,12 +2526,12 @@ impl ScrollHandle {
         }
     }
 
-    /// Scroll to an offset
-    pub fn scroll_to(&self, mut position: Point<Pixels>) -> bool {
+    /// Set the offset explcitly. The offset is the distance from the top left of the
+    /// parent container to the top left of the first child.
+    /// As you scroll further down the offset becomes more negative.
+    pub fn set_offset(&self, mut position: Point<Pixels>) {
         let state = self.0.borrow();
-        let mut offset = state.offset.borrow_mut();
-        *offset = position;
-        return true;
+        *state.offset.borrow_mut() = position;
     }
 
     /// Get the logical scroll top, based on a child index and a pixel offset.

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2526,6 +2526,14 @@ impl ScrollHandle {
         }
     }
 
+    /// Scroll to an offset
+    pub fn scroll_to(&self, mut position: Point<Pixels>) -> bool {
+        let state = self.0.borrow();
+        let mut offset = state.offset.borrow_mut();
+        *offset = position;
+        return true;
+    }
+
     /// Get the logical scroll top, based on a child index and a pixel offset.
     pub fn logical_scroll_top(&self) -> (usize, Pixels) {
         let ix = self.top_item();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2526,7 +2526,7 @@ impl ScrollHandle {
         }
     }
 
-    /// Set the offset explcitly. The offset is the distance from the top left of the
+    /// Set the offset explicitly. The offset is the distance from the top left of the
     /// parent container to the top left of the first child.
     /// As you scroll further down the offset becomes more negative.
     pub fn set_offset(&self, mut position: Point<Pixels>) {

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -69,6 +69,10 @@ fn scroll_editor(
     let should_move_cursor = editor.newest_selection_on_screen(cx).is_eq();
     let old_top_anchor = editor.scroll_manager.anchor().anchor;
 
+    if editor.scroll_hover(amount, cx) {
+        return;
+    }
+
     editor.scroll_screen(amount, cx);
     if should_move_cursor {
         let visible_rows = if let Some(visible_rows) = editor.visible_line_count() {


### PR DESCRIPTION
Co-Authored-By: ahmadraheel@gmail.com



Release Notes:

- vim: allow scrolling the currently open information overlay using `ctrl-{u,d,e,y}`etc. (#11883)
