### PR TITLE
Add separate JSONC language

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -671,7 +671,9 @@
   //   "TOML": ["Embargo.lock"]
   // }
   //
-  "file_types": {},
+  "file_types": {
+    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json"]
+  },
   // The extensions that Zed should automatically install on startup.
   //
   // If you don't want any of these extensions, add this field to your settings

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -511,7 +511,7 @@ impl LanguageRegistry {
     ) -> impl Future<Output = Result<Arc<Language>>> {
         let filename = path.file_name().and_then(|name| name.to_str());
         let extension = path.extension_or_hidden_file_name();
-        let path_suffixes = [extension, filename];
+        let path_suffixes = [extension, filename, path.to_str()];
         let empty = GlobSet::empty();
 
         let rx = self.get_or_load_language(move |language_name, config| {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -647,6 +647,16 @@ impl settings::Settings for AllLanguageSettings {
 
         let mut file_types: HashMap<Arc<str>, GlobSet> = HashMap::default();
 
+        for (language, suffixes) in &default_value.file_types {
+            let mut builder = GlobSetBuilder::new();
+
+            for suffix in suffixes {
+                builder.add(Glob::new(suffix)?);
+            }
+
+            file_types.insert(language.clone(), builder.build()?);
+        }
+
         for user_settings in sources.customizations() {
             if let Some(copilot) = user_settings.features.as_ref().and_then(|f| f.copilot) {
                 copilot_enabled = Some(copilot);
@@ -688,6 +698,7 @@ impl settings::Settings for AllLanguageSettings {
 
                 let default_value = default_value.file_types.get(&language.clone());
 
+                // Merge the default value with the user's value.
                 if let Some(suffixes) = default_value {
                     for suffix in suffixes {
                         builder.add(Glob::new(suffix)?);

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -646,6 +646,7 @@ impl settings::Settings for AllLanguageSettings {
             .ok_or_else(Self::missing_default)?;
 
         let mut file_types: HashMap<Arc<str>, GlobSet> = HashMap::default();
+
         for user_settings in sources.customizations() {
             if let Some(copilot) = user_settings.features.as_ref().and_then(|f| f.copilot) {
                 copilot_enabled = Some(copilot);
@@ -684,6 +685,14 @@ impl settings::Settings for AllLanguageSettings {
 
             for (language, suffixes) in &user_settings.file_types {
                 let mut builder = GlobSetBuilder::new();
+
+                let default_value = default_value.file_types.get(&language.clone());
+
+                if let Some(suffixes) = default_value {
+                    for suffix in suffixes {
+                        builder.add(Glob::new(suffix)?);
+                    }
+                }
 
                 for suffix in suffixes {
                     builder.add(Glob::new(suffix)?);

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -203,7 +203,12 @@ impl LspAdapter for JsonLspAdapter {
     }
 
     fn language_ids(&self) -> HashMap<String, String> {
-        [("JSON".into(), "jsonc".into())].into_iter().collect()
+        [
+            ("JSON".into(), "json".into()),
+            ("JSONC".into(), "jsonc".into()),
+        ]
+        .into_iter()
+        .collect()
     }
 }
 

--- a/crates/languages/src/jsonc/brackets.scm
+++ b/crates/languages/src/jsonc/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/crates/languages/src/jsonc/config.toml
+++ b/crates/languages/src/jsonc/config.toml
@@ -1,0 +1,12 @@
+name = "JSONC"
+grammar = "jsonc"
+path_suffixes = ["jsonc"]
+line_comments = ["// "]
+autoclose_before = ",]}"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]
+tab_size = 2
+prettier_parser_name = "jsonc"

--- a/crates/languages/src/jsonc/embedding.scm
+++ b/crates/languages/src/jsonc/embedding.scm
@@ -1,0 +1,14 @@
+; Only produce one embedding for the entire file.
+(document) @item
+
+; Collapse arrays, except for the first object.
+(array
+  "[" @keep
+  .
+  (object)? @keep
+  "]" @keep) @collapse
+
+; Collapse string values (but not keys).
+(pair value: (string
+  "\"" @keep
+  "\"" @keep) @collapse)

--- a/crates/languages/src/jsonc/highlights.scm
+++ b/crates/languages/src/jsonc/highlights.scm
@@ -1,0 +1,21 @@
+(comment) @comment
+
+(string) @string
+
+(pair
+  key: (string) @property.json_key)
+
+(number) @number
+
+[
+  (true)
+  (false)
+  (null)
+] @constant
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket

--- a/crates/languages/src/jsonc/indents.scm
+++ b/crates/languages/src/jsonc/indents.scm
@@ -1,0 +1,2 @@
+(array "]" @end) @indent
+(object "}" @end) @indent

--- a/crates/languages/src/jsonc/outline.scm
+++ b/crates/languages/src/jsonc/outline.scm
@@ -1,0 +1,2 @@
+(pair
+  key: (string (string_content) @name)) @item

--- a/crates/languages/src/jsonc/overrides.scm
+++ b/crates/languages/src/jsonc/overrides.scm
@@ -1,0 +1,1 @@
+(string) @string

--- a/crates/languages/src/jsonc/redactions.scm
+++ b/crates/languages/src/jsonc/redactions.scm
@@ -1,0 +1,4 @@
+(pair value: (number) @redact)
+(pair value: (string) @redact)
+(array (number) @redact)
+(array (string) @redact)

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -45,6 +45,7 @@ pub fn init(
         ("gowork", tree_sitter_gowork::language()),
         ("jsdoc", tree_sitter_jsdoc::language()),
         ("json", tree_sitter_json::language()),
+        ("jsonc", tree_sitter_json::language()),
         ("markdown", tree_sitter_markdown::language()),
         ("proto", tree_sitter_proto::language()),
         ("python", tree_sitter_python::language()),
@@ -117,6 +118,14 @@ pub fn init(
 
     language!(
         "json",
+        vec![Arc::new(json::JsonLspAdapter::new(
+            node_runtime.clone(),
+            languages.clone(),
+        ))],
+        json_task_context()
+    );
+    language!(
+        "jsonc",
         vec![Arc::new(json::JsonLspAdapter::new(
             node_runtime.clone(),
             languages.clone(),


### PR DESCRIPTION
Resolves https://github.com/zed-industries/extensions/issues/860 and https://github.com/zed-industries/zed/issues/10921, also https://github.com/biomejs/biome-zed/issues/11.

### Problem:
When opening .json files, zed allows comments by default in the JSON language, which can cause some problems.
For example, language-servers also get "json" as the language, which may show errors for those comments.

<img width="935" alt="image" src="https://github.com/zed-industries/zed/assets/10381895/fed3d83d-abc0-44b5-9982-eb249bb04c3b">

### Solution:

This PR adds a JSONC language. 

<img width="816" alt="image" src="https://github.com/zed-industries/zed/assets/10381895/8b40e671-d4f0-4e8d-80cb-82ee7c0ec490">

This allows for more specific configuration for language servers. 
Also any json file can be set explicitly to be JSONC using the file_types setting:

```jsonc
{
  "file_types": {
    // set all .json files to be seen as JSONC
    "JSONC": ["*.json"]
  }
}
```


Release Notes:

- N/A
