### PR TITLE
vue: Bump to v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13442,7 +13442,7 @@ dependencies = [
 
 [[package]]
 name = "zed_vue"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/vue/Cargo.toml
+++ b/extensions/vue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_vue"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/vue/extension.toml
+++ b/extensions/vue/extension.toml
@@ -1,7 +1,7 @@
 id = "vue"
 name = "Vue"
 description = "Vue support."
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Vue extension to v0.0.3.

Changes:

- #11482

Release Notes:

- N/A
