### PR TITLE
Gate auto update

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -453,7 +453,7 @@
     // Send anonymized usage data like what languages you're using Zed with.
     "metrics": true
   },
-  // Automatically update Zed
+  // Automatically update Zed. This option may be ignored on Linux if installed through a package manager.
   "auto_update": true,
   // Diagnostics configuration.
   "diagnostics": {

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -12,9 +12,12 @@ workspace = true
 path = "src/activity_indicator.rs"
 doctest = false
 
+[features]
+auto_update = ["dep:auto_update"]
+
 [dependencies]
 anyhow.workspace = true
-auto_update.workspace = true
+auto_update = { workspace = true, optional = true }
 editor.workspace = true
 extension.workspace = true
 futures.workspace = true

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -27,10 +27,11 @@ test-support = [
     "workspace/test-support",
     "http/test-support",
 ]
+auto_update = ["dep:auto_update"]
 
 [dependencies]
 anyhow.workspace = true
-auto_update.workspace = true
+auto_update = { workspace = true, optional = true }
 call.workspace = true
 channel.workspace = true
 client.workspace = true

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -1,5 +1,8 @@
 use crate::face_pile::FacePile;
+
+#[cfg(feature = "auto_update")]
 use auto_update::AutoUpdateStatus;
+
 use call::{ActiveCall, ParticipantLocation, Room};
 use client::{proto::PeerId, Client, User, UserStore};
 use gpui::{
@@ -654,7 +657,9 @@ impl CollabTitlebarItem {
     fn render_connection_status(
         &self,
         status: &client::Status,
-        cx: &mut ViewContext<Self>,
+
+        #[cfg(feature = "auto_update")] cx: &mut ViewContext<Self>,
+        #[cfg(not(feature = "auto_update"))] _cx: &mut ViewContext<Self>,
     ) -> Option<AnyElement> {
         match status {
             client::Status::ConnectionError
@@ -668,6 +673,7 @@ impl CollabTitlebarItem {
                     .tooltip(|cx| Tooltip::text("Disconnected", cx))
                     .into_any_element(),
             ),
+            #[cfg(feature = "auto_update")]
             client::Status::UpgradeRequired => {
                 let auto_updater = auto_update::AutoUpdater::get(cx);
                 let label = match auto_updater.map(|auto_update| auto_update.read(cx).status()) {
@@ -695,6 +701,11 @@ impl CollabTitlebarItem {
                         .into_any_element(),
                 )
             }
+            #[cfg(not(feature = "auto_update"))]
+            client::Status::UpgradeRequired => Some(
+                Button::new("connection-status", "Please update Zed to Collaborate")
+                    .into_any_element(),
+            ),
             _ => None,
         }
     }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -14,13 +14,17 @@ workspace = true
 name = "Zed"
 path = "src/main.rs"
 
+[features]
+# default = ["auto_update"]
+auto_update = ["dep:auto_update", "activity_indicator/auto_update", "collab_ui/auto_update"]
+
 [dependencies]
 activity_indicator.workspace = true
 anyhow.workspace = true
 assets.workspace = true
 assistant.workspace = true
 audio.workspace = true
-auto_update.workspace = true
+auto_update = { workspace = true, optional = true }
 backtrace = "0.3"
 breadcrumbs.workspace = true
 call.workspace = true

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -15,7 +15,7 @@ name = "Zed"
 path = "src/main.rs"
 
 [features]
-# default = ["auto_update"]
+default = ["auto_update"]
 auto_update = ["dep:auto_update", "activity_indicator/auto_update", "collab_ui/auto_update"]
 
 [dependencies]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -380,6 +380,7 @@ fn main() {
         });
         AppState::set_global(Arc::downgrade(&app_state), cx);
 
+        #[cfg(feature = "auto_update")]
         auto_update::init(client.http_client(), cx);
 
         reliability::init(client.http_client(), installation_id, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -152,6 +152,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
             status_bar.add_right_item(cursor_position, cx);
         });
 
+        #[cfg(feature = "auto_update")]
         auto_update::notify_of_any_new_update(cx);
 
         let handle = cx.view().downgrade();

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -10,6 +10,7 @@ pub fn app_menus() -> Vec<Menu<'static>> {
             name: "Zed",
             items: vec![
                 MenuItem::action("About Zed…", super::About),
+                #[cfg(feature = "auto_update")]
                 MenuItem::action("Check for Updates", auto_update::Check),
                 MenuItem::separator(),
                 MenuItem::submenu(Menu {


### PR DESCRIPTION
Adds a compile time flag called `auto_update` which enables auto-updates. This flag is enabled by default and fully disables auto-updating so that installations through packages aren't accidentally broken. This does not change the default settings file; that still needs to be patched by packages.

Closes #12588 
CC: #12622 

Release Notes:

- N/A
