### PR TITLE
Auto updater disabler

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -138,20 +138,24 @@ pub fn init(http_client: Arc<HttpClientWithUrl>, cx: &mut AppContext) {
     let auto_updater = cx.new_model(|cx| {
         let updater = AutoUpdater::new(version, http_client);
 
-        let mut update_subscription = AutoUpdateSetting::get_global(cx)
-            .0
-            .then(|| updater.start_polling(cx));
+        if option_env!("ZED_UPDATE_EXPLANATION").is_none()
+            && std::env::var("ZED_UPDATE_EXPLANATION").is_err()
+        {
+            let mut update_subscription = AutoUpdateSetting::get_global(cx)
+                .0
+                .then(|| updater.start_polling(cx));
 
-        cx.observe_global::<SettingsStore>(move |updater, cx| {
-            if AutoUpdateSetting::get_global(cx).0 {
-                if update_subscription.is_none() {
-                    update_subscription = Some(updater.start_polling(cx))
+            cx.observe_global::<SettingsStore>(move |updater, cx| {
+                if AutoUpdateSetting::get_global(cx).0 {
+                    if update_subscription.is_none() {
+                        update_subscription = Some(updater.start_polling(cx))
+                    }
+                } else {
+                    update_subscription.take();
                 }
-            } else {
-                update_subscription.take();
-            }
-        })
-        .detach();
+            })
+            .detach();
+        }
 
         updater
     });
@@ -159,6 +163,26 @@ pub fn init(http_client: Arc<HttpClientWithUrl>, cx: &mut AppContext) {
 }
 
 pub fn check(_: &Check, cx: &mut WindowContext) {
+    if let Some(message) = option_env!("ZED_UPDATE_EXPLANATION") {
+        drop(cx.prompt(
+            gpui::PromptLevel::Info,
+            &format!("Zed was installed via a package manager."),
+            Some(message),
+            &["Ok"],
+        ));
+        return;
+    }
+
+    if let Some(message) = option_env!("ZED_UPDATE_EXPLANATION") {
+        drop(cx.prompt(
+            gpui::PromptLevel::Info,
+            &format!("Zed was installed via a package manager."),
+            Some(message),
+            &["Ok"],
+        ));
+        return;
+    }
+
     if let Some(updater) = AutoUpdater::get(cx) {
         updater.update(cx, |updater, cx| updater.poll(cx));
     } else {
@@ -342,16 +366,6 @@ impl AutoUpdater {
     }
 
     async fn update(this: Model<Self>, mut cx: AsyncAppContext) -> Result<()> {
-        // Skip auto-update for flatpaks
-        #[cfg(target_os = "linux")]
-        if matches!(std::env::var("ZED_IS_FLATPAK_INSTALL"), Ok(_)) {
-            this.update(&mut cx, |this, cx| {
-                this.status = AutoUpdateStatus::Idle;
-                cx.notify();
-            })?;
-            return Ok(());
-        }
-
         let (client, current_version) = this.read_with(&cx, |this, _| {
             (this.http_client.clone(), this.current_version)
         })?;

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -166,7 +166,7 @@ pub fn check(_: &Check, cx: &mut WindowContext) {
     if let Some(message) = option_env!("ZED_UPDATE_EXPLANATION") {
         drop(cx.prompt(
             gpui::PromptLevel::Info,
-            &format!("Zed was installed via a package manager."),
+            "Zed was installed via a package manager.",
             Some(message),
             &["Ok"],
         ));
@@ -176,7 +176,7 @@ pub fn check(_: &Check, cx: &mut WindowContext) {
     if let Some(message) = option_env!("ZED_UPDATE_EXPLANATION") {
         drop(cx.prompt(
             gpui::PromptLevel::Info,
-            &format!("Zed was installed via a package manager."),
+            "Zed was installed via a package manager.",
             Some(message),
             &["Ok"],
         ));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -314,7 +314,7 @@ mod flatpak {
         if let Some(flatpak_dir) = get_flatpak_dir() {
             let mut args = vec!["/usr/bin/flatpak-spawn".into(), "--host".into()];
             args.append(&mut get_xdg_env_args());
-            args.push("--env=ZED_IS_FLATPAK_INSTALL=1".into());
+            args.push("--env=ZED_UPDATE_EXPLANATION=Please use flatpak to update zed".into());
             args.push(
                 format!(
                     "--env={EXTRA_LIB_ENV_NAME}={}",
@@ -347,7 +347,7 @@ mod flatpak {
         {
             if args.zed.is_none() {
                 args.zed = Some("/app/libexec/zed-editor".into());
-                env::set_var("ZED_IS_FLATPAK_INSTALL", "1");
+                env::set_var("ZED_UPDATE_EXPLANATION", "Please use flatpak to update zed");
             }
         }
         args

--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -83,6 +83,7 @@ Zed has two main binaries:
 * If you are going to provide a `.desktop` file you can find a template in `crates/zed/resources/zed.desktop.in`, and use `envsubst` to populate it with the values required.
 * You will need to ensure that the necessary libraries are installed. You can get the current list by [inspecting the built binary](https://github.com/zed-industries/zed/blob/059a4141b756cf4afac4c977afc488539aec6470/script/bundle-linux#L65-L70) on your system.
 * For an example of a complete build script, see [script/bundle-linux](https://github.com/zed-industries/zed/blob/main/script/bundle-linux).
+* You can disable Zed's auto updates and provide instructions for users who try to Update zed manually by building (or running) Zed with the environment variable `ZED_UPDATE_EXPLANATION`. For example: `ZED_UPDATE_EXPLANATION="Please use flatpak to update zed."`.
 
 ### Other things to note
 
@@ -92,7 +93,6 @@ However, we realize that many distros have other priorities. We want to work wit
 
 * Zed is a fast moving early-phase project. We typically release 2-3 builds a week to fix user-reported issues and release major features.
 * There are a couple of other `zed` binaries that may be present on linux systems ([1](https://openzfs.github.io/openzfs-docs/man/v2.2/8/zed.8.html), [2](https://zed.brimdata.io/docs/commands/zed)).
-* We automatically install updates to Zed by default (though we do need a way for [package managers to opt out](https://github.com/zed-industries/zed/issues/12588)).
 * Zed automatically installs the correct version of common developer tools in the same way as rustup/rbenv/pyenv, etc. We understand that this is contentious, [see here](https://github.com/zed-industries/zed/issues/12589).
 * We allow users to install extensions on their own and from [zed-industries/extensions](https://github.com/zed-industries/extensions). These extensions may install further tooling as needed, such as language servers. In the long run we would like to make this safer, [see here](https://github.com/zed-industries/zed/issues/12358).
 * Zed connects to a number of online services by default (AI, telemetry, collaboration). AI and our telemetry can be disabled by your users with their own zed settings or by patching our [default settings file](https://github.com/zed-industries/zed/blob/main/assets/settings/default.json).


### PR DESCRIPTION
Supersedes https://github.com/zed-industries/zed/pull/12659
Fixes https://github.com/zed-industries/zed/issues/12588

One of Zed's core features is our collaboration software. As such, it is important that we notify the user when their RPC protocol is out of date, and how to update it. This PR adds a mechanism to replace the existing auto updater with a message explaining how to update Zed for this environment.

Release Notes:

- N/A