### PR TITLE
Rename `workspace::Restart` action into `workspace::Reload`

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -285,10 +285,10 @@ impl ActivityIndicator {
                     icon: None,
                     message: "Click to restart and update Zed".to_string(),
                     on_click: Some(Arc::new({
-                        let restart = workspace::Restart {
+                        let reload = workspace::Reload {
                             binary_path: Some(binary_path.clone()),
                         };
-                        move |_, cx| workspace::restart(&restart, cx)
+                        move |_, cx| workspace::reload(&reload, cx)
                     })),
                 },
                 AutoUpdateStatus::Errored => Content {

--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -686,7 +686,7 @@ impl CollabTitlebarItem {
                         .on_click(|_, cx| {
                             if let Some(auto_updater) = auto_update::AutoUpdater::get(cx) {
                                 if auto_updater.read(cx).status().is_updated() {
-                                    workspace::restart(&Default::default(), cx);
+                                    workspace::reload(&Default::default(), cx);
                                     return;
                                 }
                             }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -185,7 +185,7 @@ pub struct CloseInactiveTabsAndPanes {
 pub struct SendKeystrokes(pub String);
 
 #[derive(Clone, Deserialize, PartialEq, Default)]
-pub struct Restart {
+pub struct Reload {
     pub binary_path: Option<PathBuf>,
 }
 
@@ -198,7 +198,7 @@ impl_actions!(
         CloseInactiveTabsAndPanes,
         NewFileInDirection,
         OpenTerminal,
-        Restart,
+        Reload,
         Save,
         SaveAll,
         SwapPaneInDirection,
@@ -282,7 +282,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {
     notifications::init(cx);
 
     cx.on_action(Workspace::close_global);
-    cx.on_action(restart);
+    cx.on_action(reload);
 
     cx.on_action({
         let app_state = Arc::downgrade(&app_state);
@@ -5086,7 +5086,7 @@ pub fn join_in_room_project(
     })
 }
 
-pub fn restart(restart: &Restart, cx: &mut AppContext) {
+pub fn reload(reload: &Reload, cx: &mut AppContext) {
     let should_confirm = WorkspaceSettings::get_global(cx).confirm_quit;
     let mut workspace_windows = cx
         .windows()
@@ -5112,7 +5112,7 @@ pub fn restart(restart: &Restart, cx: &mut AppContext) {
             .ok();
     }
 
-    let binary_path = restart.binary_path.clone();
+    let binary_path = reload.binary_path.clone();
     cx.spawn(|mut cx| async move {
         if let Some(prompt) = prompt {
             let answer = prompt.await?;


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/12609

Instead of adding some ordering mechanism to the actions, rename the action so that it's not interfering with the `editor: restart language server` command.

Before:
![image](https://github.com/zed-industries/zed/assets/2690773/b5e86eda-d766-49fc-a25b-f8b9fdb7b521)
![image](https://github.com/zed-industries/zed/assets/2690773/c5edeb56-12aa-496b-bb6f-dc705cbb9ae3)


After:
![image](https://github.com/zed-industries/zed/assets/2690773/ed30c68d-bfdd-4e00-bb5d-0be52fbe4e16)
![Screenshot 2024-06-05 at 09 46 25](https://github.com/zed-industries/zed/assets/2690773/9fe4eb52-0399-4321-85a9-3b07c11395ce)


Release Notes:

- Improved language server restart command ergonomics by renaming `workspace::Restart` action into `workspace::Reload` to remove any other "restart"-worded actions in the list