### PR TITLE
Autocomplete commands that don't require access to workspace in prompt library

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2580,9 +2580,9 @@ impl ConversationEditor {
         let slash_command_registry = conversation.read(cx).slash_command_registry.clone();
 
         let completion_provider = SlashCommandCompletionProvider::new(
-            cx.view().downgrade(),
             slash_command_registry.clone(),
-            workspace.downgrade(),
+            Some(cx.view().downgrade()),
+            Some(workspace.downgrade()),
         );
 
         let editor = cx.new_view(|cx| {

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -27,10 +27,10 @@ pub mod search_command;
 pub mod tabs_command;
 
 pub(crate) struct SlashCommandCompletionProvider {
-    editor: WeakView<ConversationEditor>,
     commands: Arc<SlashCommandRegistry>,
     cancel_flag: Mutex<Arc<AtomicBool>>,
-    workspace: WeakView<Workspace>,
+    editor: Option<WeakView<ConversationEditor>>,
+    workspace: Option<WeakView<Workspace>>,
 }
 
 pub(crate) struct SlashCommandLine {
@@ -42,9 +42,9 @@ pub(crate) struct SlashCommandLine {
 
 impl SlashCommandCompletionProvider {
     pub fn new(
-        editor: WeakView<ConversationEditor>,
         commands: Arc<SlashCommandRegistry>,
-        workspace: WeakView<Workspace>,
+        editor: Option<WeakView<ConversationEditor>>,
+        workspace: Option<WeakView<Workspace>>,
     ) -> Self {
         Self {
             cancel_flag: Mutex::new(Arc::new(AtomicBool::new(false))),
@@ -98,6 +98,30 @@ impl SlashCommandCompletionProvider {
                             new_text.push(' ');
                         }
 
+                        let confirm = editor.clone().zip(workspace.clone()).and_then(
+                            |(editor, workspace)| {
+                                (!requires_argument).then(|| {
+                                    let command_name = mat.string.clone();
+                                    let command_range = command_range.clone();
+                                    let editor = editor.clone();
+                                    let workspace = workspace.clone();
+                                    Arc::new(move |cx: &mut WindowContext| {
+                                        editor
+                                            .update(cx, |editor, cx| {
+                                                editor.run_command(
+                                                    command_range.clone(),
+                                                    &command_name,
+                                                    None,
+                                                    true,
+                                                    workspace.clone(),
+                                                    cx,
+                                                );
+                                            })
+                                            .ok();
+                                    }) as Arc<_>
+                                })
+                            },
+                        );
                         Some(project::Completion {
                             old_range: name_range.clone(),
                             documentation: Some(Documentation::SingleLine(command.description())),
@@ -106,26 +130,7 @@ impl SlashCommandCompletionProvider {
                             server_id: LanguageServerId(0),
                             lsp_completion: Default::default(),
                             show_new_completions_on_confirm: requires_argument,
-                            confirm: (!requires_argument).then(|| {
-                                let command_name = mat.string.clone();
-                                let command_range = command_range.clone();
-                                let editor = editor.clone();
-                                let workspace = workspace.clone();
-                                Arc::new(move |cx: &mut WindowContext| {
-                                    editor
-                                        .update(cx, |editor, cx| {
-                                            editor.run_command(
-                                                command_range.clone(),
-                                                &command_name,
-                                                None,
-                                                true,
-                                                workspace.clone(),
-                                                cx,
-                                            );
-                                        })
-                                        .ok();
-                                }) as Arc<_>
-                            }),
+                            confirm,
                         })
                     })
                     .collect()
@@ -160,34 +165,42 @@ impl SlashCommandCompletionProvider {
                 Ok(completions
                     .await?
                     .into_iter()
-                    .map(|arg| project::Completion {
-                        old_range: argument_range.clone(),
-                        label: CodeLabel::plain(arg.clone(), None),
-                        new_text: arg.clone(),
-                        documentation: None,
-                        server_id: LanguageServerId(0),
-                        lsp_completion: Default::default(),
-                        show_new_completions_on_confirm: false,
-                        confirm: Some(Arc::new({
-                            let command_name = command_name.clone();
-                            let command_range = command_range.clone();
-                            let editor = editor.clone();
-                            let workspace = workspace.clone();
-                            move |cx| {
-                                editor
-                                    .update(cx, |editor, cx| {
-                                        editor.run_command(
-                                            command_range.clone(),
-                                            &command_name,
-                                            Some(&arg),
-                                            true,
-                                            workspace.clone(),
-                                            cx,
-                                        );
-                                    })
-                                    .ok();
-                            }
-                        })),
+                    .map(|command_argument| {
+                        let confirm =
+                            editor
+                                .clone()
+                                .zip(workspace.clone())
+                                .map(|(editor, workspace)| {
+                                    Arc::new({
+                                        let command_range = command_range.clone();
+                                        let command_name = command_name.clone();
+                                        let command_argument = command_argument.clone();
+                                        move |cx: &mut WindowContext| {
+                                            editor
+                                                .update(cx, |editor, cx| {
+                                                    editor.run_command(
+                                                        command_range.clone(),
+                                                        &command_name,
+                                                        Some(&command_argument),
+                                                        true,
+                                                        workspace.clone(),
+                                                        cx,
+                                                    );
+                                                })
+                                                .ok();
+                                        }
+                                    }) as Arc<_>
+                                });
+                        project::Completion {
+                            old_range: argument_range.clone(),
+                            label: CodeLabel::plain(command_argument.clone(), None),
+                            new_text: command_argument.clone(),
+                            documentation: None,
+                            server_id: LanguageServerId(0),
+                            lsp_completion: Default::default(),
+                            show_new_completions_on_confirm: false,
+                            confirm,
+                        }
                     })
                     .collect())
             })

--- a/crates/assistant/src/slash_command/active_command.rs
+++ b/crates/assistant/src/slash_command/active_command.rs
@@ -27,7 +27,7 @@ impl SlashCommand for ActiveSlashCommand {
         &self,
         _query: String,
         _cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Err(anyhow!("this command does not require argument")))

--- a/crates/assistant/src/slash_command/default_command.rs
+++ b/crates/assistant/src/slash_command/default_command.rs
@@ -34,7 +34,7 @@ impl SlashCommand for DefaultSlashCommand {
         &self,
         _query: String,
         _cancellation_flag: Arc<AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Err(anyhow!("this command does not require argument")))

--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -62,7 +62,7 @@ impl SlashCommand for FetchSlashCommand {
         &self,
         _query: String,
         _cancel: Arc<AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Ok(Vec::new()))

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -101,10 +101,10 @@ impl SlashCommand for FileSlashCommand {
         &self,
         query: String,
         cancellation_flag: Arc<AtomicBool>,
-        workspace: WeakView<Workspace>,
+        workspace: Option<WeakView<Workspace>>,
         cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
-        let Some(workspace) = workspace.upgrade() else {
+        let Some(workspace) = workspace.and_then(|workspace| workspace.upgrade()) else {
             return Task::ready(Err(anyhow!("workspace was dropped")));
         };
 

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -105,7 +105,7 @@ impl SlashCommand for ProjectSlashCommand {
         &self,
         _query: String,
         _cancel: Arc<AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Err(anyhow!("this command does not require argument")))

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -31,7 +31,7 @@ impl SlashCommand for PromptSlashCommand {
         &self,
         query: String,
         _cancellation_flag: Arc<AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         let store = PromptStore::global(cx);

--- a/crates/assistant/src/slash_command/rustdoc_command.rs
+++ b/crates/assistant/src/slash_command/rustdoc_command.rs
@@ -119,7 +119,7 @@ impl SlashCommand for RustdocSlashCommand {
         &self,
         _query: String,
         _cancel: Arc<AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Ok(Vec::new()))

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -47,7 +47,7 @@ impl SlashCommand for SearchSlashCommand {
         &self,
         _query: String,
         _cancel: Arc<AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Ok(Vec::new()))

--- a/crates/assistant/src/slash_command/tabs_command.rs
+++ b/crates/assistant/src/slash_command/tabs_command.rs
@@ -32,7 +32,7 @@ impl SlashCommand for TabsSlashCommand {
         &self,
         _query: String,
         _cancel: Arc<std::sync::atomic::AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Err(anyhow!("this command does not require argument")))

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -25,7 +25,7 @@ pub trait SlashCommand: 'static + Send + Sync {
         &self,
         query: String,
         cancel: Arc<AtomicBool>,
-        workspace: WeakView<Workspace>,
+        workspace: Option<WeakView<Workspace>>,
         cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>>;
     fn requires_argument(&self) -> bool;

--- a/crates/extension/src/extension_slash_command.rs
+++ b/crates/extension/src/extension_slash_command.rs
@@ -39,7 +39,7 @@ impl SlashCommand for ExtensionSlashCommand {
         &self,
         _query: String,
         _cancel: Arc<AtomicBool>,
-        _workspace: WeakView<Workspace>,
+        _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Ok(Vec::new()))


### PR DESCRIPTION
This is useful to autocomplete prompts when writing a new one in the prompt library.

Release Notes:

- N/A
