### PR TITLE
Copy information popover to clipboard on click

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -6,9 +6,9 @@ use crate::{
 };
 use futures::{stream::FuturesUnordered, FutureExt};
 use gpui::{
-    div, px, AnyElement, CursorStyle, Hsla, InteractiveElement, IntoElement, MouseButton,
-    ParentElement, Pixels, SharedString, Size, StatefulInteractiveElement, Styled, Task,
-    ViewContext, WeakView,
+    div, px, AnyElement, ClipboardItem, CursorStyle, Hsla, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, Pixels, SharedString, Size, StatefulInteractiveElement, Styled,
+    Task, ViewContext, WeakView,
 };
 use language::{markdown, DiagnosticEntry, Language, LanguageRegistry, ParsedMarkdown};
 
@@ -501,6 +501,7 @@ impl InfoPopover {
         workspace: Option<WeakView<Workspace>>,
         cx: &mut ViewContext<Editor>,
     ) -> AnyElement {
+        let popover_text = (&self.parsed_content.text).clone();
         div()
             .id("info_popover")
             .elevation_2(cx)
@@ -508,10 +509,15 @@ impl InfoPopover {
             .overflow_y_scroll()
             .max_w(max_size.width)
             .max_h(max_size.height)
+            .cursor(CursorStyle::PointingHand)
+            .tooltip(move |cx| Tooltip::text("Copy to Clipboard", cx))
             // Prevent a mouse down/move on the popover from being propagated to the editor,
             // because that would dismiss the popover.
             .on_mouse_move(|_, cx| cx.stop_propagation())
             .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
+            .on_click(cx.listener(move |_, _, cx| {
+                cx.write_to_clipboard(ClipboardItem::new(popover_text.clone()));
+            }))
             .child(crate::render_parsed_markdown(
                 "content",
                 &self.parsed_content,


### PR DESCRIPTION
Release Notes:

- Added the ability to copy an info popover on click. 

<img width="843" alt="image" src="https://github.com/zed-industries/zed/assets/50590465/1cb401a1-a3de-46d2-8b94-3d3e20a23013">

Although this doesn't solve #5236, this change makes getting information out of popovers easier until a complete solution is created. 