### PR TITLE
Use cwd to run package.json script

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -36,7 +36,7 @@ pub(super) fn json_task_context() -> ContextProviderWithTasks {
         },
         TaskTemplate {
             label: "composer script $ZED_CUSTOM_script".to_owned(),
-            command: "composer".to_owned(),
+            command: "composer -d $ZED_DIRNAME".to_owned(),
             args: vec![VariableName::Custom("script".into()).template_value()],
             tags: vec!["composer-script".into()],
             ..TaskTemplate::default()

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -29,7 +29,7 @@ pub(super) fn json_task_context() -> ContextProviderWithTasks {
     ContextProviderWithTasks::new(TaskTemplates(vec![
         TaskTemplate {
             label: "package script $ZED_CUSTOM_script".to_owned(),
-            command: "npm run".to_owned(),
+            command: "npm --prefix $ZED_DIRNAME run".to_owned(),
             args: vec![VariableName::Custom("script".into()).template_value()],
             tags: vec!["package-script".into()],
             ..TaskTemplate::default()


### PR DESCRIPTION
Fixes case when `package.json` is not in root directory. 
Usually in mono repository, where multiple `package.json` may be present

Release Notes:

- Fixed runnable for package.json, so it will work in any directory 