### PR TITLE
[WIP] Require extensions to request downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,6 +3831,7 @@ dependencies = [
  "editor",
  "extension",
  "fs",
+ "futures 0.3.28",
  "fuzzy",
  "gpui",
  "language",

--- a/crates/extension/src/wasm_host/wit/since_v0_0_7.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_0_7.rs
@@ -310,6 +310,15 @@ impl ExtensionImports for WasmState {
         file_type: DownloadedFileType,
     ) -> wasmtime::Result<Result<(), String>> {
         maybe!(async {
+            if !self
+                .host
+                .language_registry
+                .request_download_permission(&url)
+                .await
+            {
+                return Err(anyhow!("Download permission for '{url}' denied"));
+            }
+
             let path = PathBuf::from(path);
             let extension_work_dir = self.host.work_dir.join(self.manifest.id.as_ref());
 

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -21,6 +21,7 @@ db.workspace = true
 editor.workspace = true
 extension.workspace = true
 fs.workspace = true
+futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/extensions_ui/src/download_permission.rs
+++ b/crates/extensions_ui/src/download_permission.rs
@@ -1,0 +1,62 @@
+use std::collections::VecDeque;
+
+use futures::{channel::mpsc, StreamExt};
+use gpui::{Model, VisualContext};
+use ui::{Context, SharedString, ViewContext};
+use workspace::{
+    notifications::{simple_message_notification, NotificationId},
+    Workspace,
+};
+
+pub(crate) fn download_permission(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
+    let mut request_rx = workspace.app_state().languages.download_request_rx();
+    let notification_queue: Model<VecDeque<(String, mpsc::UnboundedSender<bool>)>> =
+        cx.new_model(|_| VecDeque::new());
+
+    cx.observe(&notification_queue, |workspace, queue, cx| {
+        if queue.read(cx).is_empty() {
+            return;
+        }
+
+        while let Some((url, response_tx)) = queue.update(cx, |queue, cx| {
+            let request = queue.pop_front();
+            cx.notify();
+            request
+        }) {
+            struct DownloadRequestNotification;
+
+            let notification_id = NotificationId::identified::<DownloadRequestNotification>(
+                SharedString::from(url.clone()),
+            );
+            workspace.show_notification(notification_id, cx, |cx| {
+                let response_tx_clone = response_tx.clone();
+                cx.new_view(|_cx| {
+                    simple_message_notification::MessageNotification::new(format!(
+                        "Allow '{url}' to be downloaded?"
+                    ))
+                    .with_click_message("Yes")
+                    .on_click(move |_| {
+                        response_tx.unbounded_send(true).unwrap();
+                    })
+                    .with_secondary_click_message("No")
+                    .on_secondary_click(move |_| {
+                        response_tx_clone.unbounded_send(false).unwrap();
+                    })
+                })
+            });
+        }
+    })
+    .detach();
+
+    cx.spawn(|_workspace, mut cx| async move {
+        while let Some((url, response_tx)) = request_rx.next().await {
+            notification_queue
+                .update(&mut cx, |queue, cx| {
+                    queue.push_back((url, response_tx));
+                    cx.notify();
+                })
+                .unwrap();
+        }
+    })
+    .detach();
+}

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1,4 +1,5 @@
 mod components;
+mod download_permission;
 mod extension_suggest;
 mod extension_version_selector;
 
@@ -8,6 +9,7 @@ use crate::extension_version_selector::{
 };
 use client::telemetry::Telemetry;
 use client::ExtensionMetadata;
+use download_permission::download_permission;
 use editor::{Editor, EditorElement, EditorStyle};
 use extension::{ExtensionManifest, ExtensionOperation, ExtensionStore};
 use fuzzy::{match_strings, StringMatchCandidate};
@@ -79,6 +81,7 @@ pub fn init(cx: &mut AppContext) {
             _ => {}
         })
         .detach();
+        download_permission(workspace, cx);
     })
     .detach();
 }


### PR DESCRIPTION
Closes #12589 

This a WIP PR which will make extensions require user input before downloading binaries; with the aim of making Zed a bit more friendly for the security conscious. It still requires a fair bit of work to get working well though.

Current status:

- [x] Add async function called from the download function which creates a request notification.
- [x] Pass extension name to notification.
- [ ] Add setting to dictate the behavior of this feature (ie. always ask (default), always allow, never allow).
- [ ] Prevent repeat popup's due to lsp restart (not sure the best way to do with. Comments welcome)
- [ ] Remember selection per-lsp.

Also not sure about the best way to handle when declines occur without changing the api. Currently it just gives an Err which causes the lsp to attempt a restart.

Release Notes:

- Added notification for extensions requesting file downloads
