### PR TITLE
chore: added inl to cpp config

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -74,6 +74,7 @@
     "ib": "storage",
     "ico": "image",
     "ini": "settings",
+    "inl": "cpp",
     "j2k": "image",
     "java": "java",
     "jfif": "image",

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp"]
+path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl"]
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
Release Notes:

- Added `inl` to cpp config ([#12605 ](https://github.com/zed-industries/zed/issues/12605)).

Screenshot:
<img width="1027" alt="image" src="https://github.com/zed-industries/zed/assets/19250981/1d35d35c-d31c-4feb-b2ca-a417972fadf6">

