### PR TITLE
Fix key-bindings doc typo

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -12,7 +12,7 @@ We have a growing collection of pre-defined keymaps in [zed repository's keymaps
 - TextMate
 - VSCode (default)
 
-These keymaps can be set via the `base_keymap` setting in your `keymap.json` file. Additionally, if you'd like to work from a clean slate, you can provide `"None"` to the setting.
+These keymaps can be set via the `base_keymap` setting in your `settings.json` file. Additionally, if you'd like to work from a clean slate, you can provide `"None"` to the setting.
 
 ## Custom key bindings
 


### PR DESCRIPTION
`base_keymap` is a property of `settings.json`, not `keymap.json`. If you run "toggle base keymap selector" and select a particular editor, you will notice that it places the `base_keymap` property in `settings.json`.

Release Notes:

- N/A