### PR TITLE
Rename conversations to contexts

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -545,7 +545,7 @@
     }
   },
   {
-    "context": "ConversationEditor > Editor",
+    "context": "ContextEditor > Editor",
     "bindings": {
       "ctrl-enter": "assistant::Assist",
       "ctrl-s": "workspace::Save",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -228,7 +228,7 @@
     }
   },
   {
-    "context": "ConversationEditor > Editor",
+    "context": "ContextEditor > Editor",
     "bindings": {
       "cmd-enter": "assistant::Assist",
       "cmd-s": "workspace::Save",

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -1,7 +1,7 @@
 pub mod assistant_panel;
 pub mod assistant_settings;
 mod completion_provider;
-mod conversation_store;
+mod context_store;
 mod inline_assistant;
 mod model_selector;
 mod prompt_library;
@@ -17,7 +17,7 @@ use assistant_slash_command::SlashCommandRegistry;
 use client::{proto, Client};
 use command_palette_hooks::CommandPaletteFilter;
 pub(crate) use completion_provider::*;
-pub(crate) use conversation_store::*;
+pub(crate) use context_store::*;
 use gpui::{actions, AppContext, Global, SharedString, UpdateGlobal};
 pub(crate) use inline_assistant::*;
 pub(crate) use model_selector::*;

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -66,7 +66,7 @@ impl InlineAssistant {
         &mut self,
         editor: &View<Editor>,
         workspace: Option<WeakView<Workspace>>,
-        include_conversation: bool,
+        include_context: bool,
         cx: &mut WindowContext,
     ) {
         let selection = editor.read(cx).selections.newest_anchor().clone();
@@ -144,7 +144,7 @@ impl InlineAssistant {
         self.pending_assists.insert(
             inline_assist_id,
             PendingInlineAssist {
-                include_conversation,
+                include_context,
                 editor: editor.downgrade(),
                 inline_assist_editor: Some((block_id, inline_assist_editor.clone())),
                 codegen: codegen.clone(),
@@ -375,11 +375,11 @@ impl InlineAssistant {
             return;
         };
 
-        let conversation = if pending_assist.include_conversation {
+        let context = if pending_assist.include_context {
             pending_assist.workspace.as_ref().and_then(|workspace| {
                 let workspace = workspace.upgrade()?.read(cx);
                 let assistant_panel = workspace.panel::<AssistantPanel>(cx)?;
-                assistant_panel.read(cx).active_conversation(cx)
+                assistant_panel.read(cx).active_context(cx)
             })
         } else {
             None
@@ -461,8 +461,8 @@ impl InlineAssistant {
         });
 
         let mut messages = Vec::new();
-        if let Some(conversation) = conversation {
-            let request = conversation.read(cx).to_completion_request(cx);
+        if let Some(context) = context {
+            let request = context.read(cx).to_completion_request(cx);
             messages = request.messages;
         }
         let model = CompletionProvider::global(cx).model();
@@ -818,7 +818,7 @@ struct PendingInlineAssist {
     codegen: Model<Codegen>,
     _subscriptions: Vec<Subscription>,
     workspace: Option<WeakView<Workspace>>,
-    include_conversation: bool,
+    include_context: bool,
 }
 
 #[derive(Debug)]

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -1,4 +1,4 @@
-use crate::assistant_panel::ConversationEditor;
+use crate::assistant_panel::ContextEditor;
 use anyhow::Result;
 pub use assistant_slash_command::{SlashCommand, SlashCommandOutput, SlashCommandRegistry};
 use editor::{CompletionProvider, Editor};
@@ -29,7 +29,7 @@ pub mod tabs_command;
 pub(crate) struct SlashCommandCompletionProvider {
     commands: Arc<SlashCommandRegistry>,
     cancel_flag: Mutex<Arc<AtomicBool>>,
-    editor: Option<WeakView<ConversationEditor>>,
+    editor: Option<WeakView<ContextEditor>>,
     workspace: Option<WeakView<Workspace>>,
 }
 
@@ -43,7 +43,7 @@ pub(crate) struct SlashCommandLine {
 impl SlashCommandCompletionProvider {
     pub fn new(
         commands: Arc<SlashCommandRegistry>,
-        editor: Option<WeakView<ConversationEditor>>,
+        editor: Option<WeakView<ContextEditor>>,
         workspace: Option<WeakView<Workspace>>,
     ) -> Self {
         Self {

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -21,7 +21,7 @@ lazy_static::lazy_static! {
     } else {
         HOME.join(".config").join("zed")
     };
-    pub static ref CONVERSATIONS_DIR: PathBuf = if cfg!(target_os = "macos") {
+    pub static ref CONTEXTS_DIR: PathBuf = if cfg!(target_os = "macos") {
         CONFIG_DIR.join("conversations")
     } else {
         SUPPORT_DIR.join("conversations")


### PR DESCRIPTION
This just changes nomenclature within the codebase and should have no external effect.

Release Notes:

- N/A
