### PR TITLE
chore: Fix clippy for upcoming 1.79 Rust release

### DIFF
--- a/crates/collab/src/tests/randomized_test_helpers.rs
+++ b/crates/collab/src/tests/randomized_test_helpers.rs
@@ -69,7 +69,6 @@ struct TestPlan<T: RandomizedTest> {
 pub struct UserTestPlan {
     pub user_id: UserId,
     pub username: String,
-    pub allow_client_reconnection: bool,
     pub allow_client_disconnection: bool,
     next_root_id: usize,
     operation_ix: usize,
@@ -237,7 +236,6 @@ impl<T: RandomizedTest> TestPlan<T> {
                 next_root_id: 0,
                 operation_ix: 0,
                 allow_client_disconnection,
-                allow_client_reconnection,
             });
         }
 

--- a/crates/color/src/color.rs
+++ b/crates/color/src/color.rs
@@ -129,10 +129,10 @@ where
 impl Clamp for RGBAColor {
     fn clamp(self) -> Self {
         RGBAColor {
-            r: self.r.min(1.0).max(0.0),
-            g: self.g.min(1.0).max(0.0),
-            b: self.b.min(1.0).max(0.0),
-            a: self.a.min(1.0).max(0.0),
+            r: self.r.clamp(0., 1.),
+            g: self.g.clamp(0., 1.),
+            b: self.b.clamp(0., 1.),
+            a: self.a.clamp(0., 1.),
         }
     }
 }

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -322,7 +322,6 @@ pub fn update_inlay_link_and_hover_points(
                                     hover_popover::hover_at_inlay(
                                         editor,
                                         InlayHover {
-                                            excerpt: excerpt_id,
                                             tooltip: match tooltip {
                                                 InlayHintTooltip::String(text) => HoverBlock {
                                                     text,
@@ -370,7 +369,6 @@ pub fn update_inlay_link_and_hover_points(
                                         hover_popover::hover_at_inlay(
                                             editor,
                                             InlayHover {
-                                                excerpt: excerpt_id,
                                                 tooltip: match tooltip {
                                                     InlayHintLabelPartTooltip::String(text) => {
                                                         HoverBlock {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -3,7 +3,7 @@ use crate::{
     hover_links::{InlayHighlight, RangeInEditor},
     scroll::ScrollAmount,
     Anchor, AnchorRangeExt, DisplayPoint, DisplayRow, Editor, EditorSettings, EditorSnapshot,
-    EditorStyle, ExcerptId, Hover, RangeToAnchorExt,
+    EditorStyle, Hover, RangeToAnchorExt,
 };
 use futures::{stream::FuturesUnordered, FutureExt};
 use gpui::{
@@ -49,7 +49,6 @@ pub fn hover_at(editor: &mut Editor, anchor: Option<Anchor>, cx: &mut ViewContex
 }
 
 pub struct InlayHover {
-    pub excerpt: ExcerptId,
     pub range: InlayHighlight,
     pub tooltip: HoverBlock,
 }

--- a/crates/gpui/src/platform/mac/display_link.rs
+++ b/crates/gpui/src/platform/mac/display_link.rs
@@ -201,7 +201,7 @@ mod sys {
 
     #[link(name = "CoreFoundation", kind = "framework")]
     #[link(name = "CoreVideo", kind = "framework")]
-    #[allow(improper_ctypes, clippy::duplicated_attributes)]
+    #[allow(improper_ctypes, unknown_lints, clippy::duplicated_attributes)]
     extern "C" {
         pub fn CVDisplayLinkCreateWithActiveCGDisplays(
             display_link_out: *mut *mut CVDisplayLink,

--- a/crates/gpui/src/platform/mac/display_link.rs
+++ b/crates/gpui/src/platform/mac/display_link.rs
@@ -201,7 +201,7 @@ mod sys {
 
     #[link(name = "CoreFoundation", kind = "framework")]
     #[link(name = "CoreVideo", kind = "framework")]
-    #[allow(improper_ctypes)]
+    #[allow(improper_ctypes, clippy::duplicated_attributes)]
     extern "C" {
         pub fn CVDisplayLinkCreateWithActiveCGDisplays(
             display_link_out: *mut *mut CVDisplayLink,

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -63,7 +63,9 @@ impl TaffyLayoutEngine {
             let parent_id = self
                 .taffy
                 // This is safe because LayoutId is repr(transparent) to taffy::tree::NodeId.
-                .new_with_children(taffy_style, unsafe { std::mem::transmute(children) })
+                .new_with_children(taffy_style, unsafe {
+                    std::mem::transmute::<&[LayoutId], &[taffy::NodeId]>(children)
+                })
                 .expect(EXPECT_MESSAGE)
                 .into();
             self.children_to_parents

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -48,7 +48,6 @@ pub struct SyntaxMapMatches<'a> {
 
 #[derive(Debug)]
 pub struct SyntaxMapCapture<'a> {
-    pub depth: usize,
     pub node: Node<'a>,
     pub index: u32,
     pub grammar_index: usize,
@@ -886,7 +885,9 @@ impl<'a> SyntaxMapCaptures<'a> {
 
             // TODO - add a Tree-sitter API to remove the need for this.
             let cursor = unsafe {
-                std::mem::transmute::<_, &'static mut QueryCursor>(query_cursor.deref_mut())
+                std::mem::transmute::<&mut tree_sitter::QueryCursor, &'static mut QueryCursor>(
+                    query_cursor.deref_mut(),
+                )
             };
 
             cursor.set_byte_range(range.clone());
@@ -933,7 +934,6 @@ impl<'a> SyntaxMapCaptures<'a> {
         let layer = self.layers[..self.active_layer_count].first()?;
         let capture = layer.next_capture?;
         Some(SyntaxMapCapture {
-            depth: layer.depth,
             grammar_index: layer.grammar_index,
             index: capture.index,
             node: capture.node,
@@ -1004,7 +1004,9 @@ impl<'a> SyntaxMapMatches<'a> {
 
             // TODO - add a Tree-sitter API to remove the need for this.
             let cursor = unsafe {
-                std::mem::transmute::<_, &'static mut QueryCursor>(query_cursor.deref_mut())
+                std::mem::transmute::<&mut tree_sitter::QueryCursor, &'static mut QueryCursor>(
+                    query_cursor.deref_mut(),
+                )
             };
 
             cursor.set_byte_range(range.clone());

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -10282,7 +10282,7 @@ impl Project {
     fn deserialize_symbol(serialized_symbol: proto::Symbol) -> Result<CoreSymbol> {
         let source_worktree_id = WorktreeId::from_proto(serialized_symbol.source_worktree_id);
         let worktree_id = WorktreeId::from_proto(serialized_symbol.worktree_id);
-        let kind = unsafe { mem::transmute(serialized_symbol.kind) };
+        let kind = unsafe { mem::transmute::<i32, lsp::SymbolKind>(serialized_symbol.kind) };
         let path = ProjectPath {
             worktree_id,
             path: PathBuf::from(serialized_symbol.path).into(),
@@ -11393,7 +11393,7 @@ fn serialize_symbol(symbol: &Symbol) -> proto::Symbol {
         worktree_id: symbol.path.worktree_id.to_proto(),
         path: symbol.path.path.to_string_lossy().to_string(),
         name: symbol.name.clone(),
-        kind: unsafe { mem::transmute(symbol.kind) },
+        kind: unsafe { mem::transmute::<lsp::SymbolKind, i32>(symbol.kind) },
         start: Some(proto::PointUtf16 {
             row: symbol.range.start.0.row,
             column: symbol.range.start.0.column,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -38,7 +38,7 @@ pub struct GitSettings {
 
 impl GitSettings {
     pub fn inline_blame_enabled(&self) -> bool {
-        #[allow(clippy::manual_unwrap_or_default)]
+        #[allow(unknown_lints, clippy::manual_unwrap_or_default)]
         match self.inline_blame {
             Some(InlineBlameSettings { enabled, .. }) => enabled,
             _ => false,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -38,6 +38,7 @@ pub struct GitSettings {
 
 impl GitSettings {
     pub fn inline_blame_enabled(&self) -> bool {
+        #[allow(clippy::manual_unwrap_or_default)]
         match self.inline_blame {
             Some(InlineBlameSettings { enabled, .. }) => enabled,
             _ => false,

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1295,7 +1295,7 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
             project
                 .language_servers_running_disk_based_diagnostics()
                 .collect::<Vec<_>>(),
-            [LanguageServerId(0); 0]
+            [] as [language::LanguageServerId; 0]
         );
     });
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3969,8 +3969,7 @@ impl Workspace {
     fn adjust_padding(padding: Option<f32>) -> f32 {
         padding
             .unwrap_or(Self::DEFAULT_PADDING)
-            .min(Self::MAX_PADDING)
-            .max(0.0)
+            .clamp(0.0, Self::MAX_PADDING)
     }
 }
 


### PR DESCRIPTION
1.79 is due for release in a week.
Release Notes:

- N/A
