### PR TITLE
Prevent folder expansion when all items are closed

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1133,13 +1133,13 @@ impl Pane {
             }
         }
 
-        let active_item_id = self.active_item().unwrap().item_id();
+        let active_item_id = self.active_item().map(|item| item.item_id());
 
         items_to_close.sort_by_key(|item| {
             // Put the currently active item at the end, because if the currently active item is not closed last
             // closing the currently active item will cause the focus to switch to another item
             // This will cause Zed to expand the content of the currently active item
-            active_item_id == item.item_id()
+            active_item_id.filter(|&id| id == item.item_id()).is_some()
               // If a buffer is open both in a singleton editor and in a multibuffer, make sure
               // to focus the singleton buffer when prompting to save that buffer, as opposed
               // to focusing the multibuffer, because this gives the user a more clear idea

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1133,11 +1133,19 @@ impl Pane {
             }
         }
 
-        // If a buffer is open both in a singleton editor and in a multibuffer, make sure
-        // to focus the singleton buffer when prompting to save that buffer, as opposed
-        // to focusing the multibuffer, because this gives the user a more clear idea
-        // of what content they would be saving.
-        items_to_close.sort_by_key(|item| !item.is_singleton(cx));
+        let active_item_id = self.active_item().unwrap().item_id();
+
+        items_to_close.sort_by_key(|item| {
+            // Put the currently active item at the end, because if the currently active item is not closed last
+            // closing the currently active item will cause the focus to switch to another item
+            // This will cause Zed to expand the content of the currently active item
+            active_item_id == item.item_id()
+              // If a buffer is open both in a singleton editor and in a multibuffer, make sure
+              // to focus the singleton buffer when prompting to save that buffer, as opposed
+              // to focusing the multibuffer, because this gives the user a more clear idea
+              // of what content they would be saving.
+              || !item.is_singleton(cx)
+        });
 
         let workspace = self.workspace.clone();
         cx.spawn(|pane, mut cx| async move {


### PR DESCRIPTION
Release Notes:

- Prevent folder expansion when all items are closed

### Problem
When all items are closed, the next activated file expands (see the video below).

https://github.com/zed-industries/zed/assets/21101490/a7631cd2-4e97-4954-8b01-d283dd4796be


### Cause
When the currently active item is closed, Zed tries to activate the previously active item. Activating an item by default expands the corresponding folder, which can result in folders being expanded when all files are closed.

### Fixed Video

https://github.com/zed-industries/zed/assets/21101490/d30f05c5-6d86-4e11-b349-337fa75586f3

