### PR TITLE
astro: Fix Tailwind LS not working in attributes

### DIFF
--- a/extensions/astro/languages/astro/overrides.scm
+++ b/extensions/astro/languages/astro/overrides.scm
@@ -1,0 +1,6 @@
+[
+  (attribute_value)
+  (quoted_attribute_value)
+] @string
+
+(comment) @comment


### PR DESCRIPTION
This fixes #12402.

We already had the `tailwind-language-server` config in Astro's `config.toml` here: https://github.com/zed-industries/zed/blob/fd39f20842967f0fb8a6c508bc2e1ebaefbaf15f/extensions/astro/languages/astro/config.toml#L17-L23

But it's not enough to add `overrides.string` to the `config.toml`, you also need an `overrides.scm` file that sets the overrides.

And, tricky bit, when you add a single override to the `overrides.scm` file you have to add all of them that Zed knows about. In my case, I had to add `@comment` too, because Zed somehow expects that.

Release Notes:

- Fixed `tailwind-language-server` not working in attributes inside of `*.astro` files. ([#12402](https://github.com/zed-industries/zed/issues/12402)).

Demo/proof:

https://github.com/zed-industries/zed/assets/1185253/05677a2d-831d-4e05-a1a2-4d1730ce2a46


