### PR TITLE
ruby: Allow opt-in to Tailwind LS in string

### DIFF
--- a/extensions/ruby/languages/ruby/config.toml
+++ b/extensions/ruby/languages/ruby/config.toml
@@ -40,3 +40,8 @@ brackets = [
 ]
 collapsed_placeholder = "# ..."
 tab_size = 2
+scope_opt_in_language_servers = ["tailwindcss-language-server"]
+
+[overrides.string]
+word_characters = ["-"]
+opt_into_language_servers = ["tailwindcss-language-server"]


### PR DESCRIPTION
This fixes #12728 as much as I can tell.

The problem was that inside ERB files, when inside Ruby code, we didn't treat `-` as part of the word, which broke completions.

So, with the change in here, and the following Zed settings, it works.

```json
{
  "languages": {
    "Ruby": {
      "language_servers": ["tailwindcss-language-server", "..."]
    }
  },
  "lsp": {
    "tailwindcss-language-server": {
      "settings": {
        "includeLanguages": {
          "erb": "html",
          "ruby": "html"
        },
        "experimental": {
          "classRegex": ["\\bclass:\\s*['\"]([^'\"]*)['\"]"]
        }
      }
    }
  }
}

```

This enabled `tailwindcss-language-server` for Ruby files and tells the language server to look for classes inside `class: ""` strings.

See demo video.

Release Notes:

- Fixed `tailwindcss-language-server` not being activated inside Ruby strings (inside `.erb`) ([#12728](https://github.com/zed-industries/zed/issues/12728)).

Demo video:

https://github.com/zed-industries/zed/assets/1185253/643343b4-d64f-4c4e-98a1-d10df0b24e31


