### PR TITLE
Remove dependencies from the Worktree crate and make it more focused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12902,7 +12902,6 @@ dependencies = [
  "itertools 0.11.0",
  "language",
  "log",
- "lsp",
  "parking_lot",
  "postage",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12887,7 +12887,6 @@ name = "worktree"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "client",
  "clock",
  "collections",
  "env_logger",

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -83,7 +83,10 @@ async fn test_host_disconnect(
     let project_b = client_b.build_dev_server_project(project_id, cx_b).await;
     cx_a.background_executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| tree.as_local().unwrap().is_shared()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| tree
+        .as_local()
+        .unwrap()
+        .has_update_observer()));
 
     let workspace_b = cx_b
         .add_window(|cx| Workspace::new(None, project_b.clone(), client_b.app_state.clone(), cx));
@@ -120,7 +123,10 @@ async fn test_host_disconnect(
 
     project_b.read_with(cx_b, |project, _| project.is_read_only());
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| !tree.as_local().unwrap().is_shared()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| !tree
+        .as_local()
+        .unwrap()
+        .has_update_observer()));
 
     // Ensure client B's edited state is reset and that the whole window is blurred.
 

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -1378,7 +1378,10 @@ async fn test_unshare_project(
     let project_b = client_b.build_dev_server_project(project_id, cx_b).await;
     executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| tree.as_local().unwrap().is_shared()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| tree
+        .as_local()
+        .unwrap()
+        .has_update_observer()));
 
     project_b
         .update(cx_b, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
@@ -1403,7 +1406,10 @@ async fn test_unshare_project(
         .unwrap();
     executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| !tree.as_local().unwrap().is_shared()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| !tree
+        .as_local()
+        .unwrap()
+        .has_update_observer()));
 
     assert!(project_c.read_with(cx_c, |project, _| project.is_disconnected()));
 
@@ -1415,7 +1421,10 @@ async fn test_unshare_project(
     let project_c2 = client_c.build_dev_server_project(project_id, cx_c).await;
     executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| tree.as_local().unwrap().is_shared()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| tree
+        .as_local()
+        .unwrap()
+        .has_update_observer()));
     project_c2
         .update(cx_c, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
         .await
@@ -1522,7 +1531,7 @@ async fn test_project_reconnect(
     executor.run_until_parked();
 
     let worktree1_id = worktree_a1.read_with(cx_a, |worktree, _| {
-        assert!(worktree.as_local().unwrap().is_shared());
+        assert!(worktree.as_local().unwrap().has_update_observer());
         worktree.id()
     });
     let (worktree_a2, _) = project_a1
@@ -1534,7 +1543,7 @@ async fn test_project_reconnect(
     executor.run_until_parked();
 
     let worktree2_id = worktree_a2.read_with(cx_a, |tree, _| {
-        assert!(tree.as_local().unwrap().is_shared());
+        assert!(tree.as_local().unwrap().has_update_observer());
         tree.id()
     });
     executor.run_until_parked();
@@ -1568,7 +1577,7 @@ async fn test_project_reconnect(
     });
 
     worktree_a1.read_with(cx_a, |tree, _| {
-        assert!(tree.as_local().unwrap().is_shared())
+        assert!(tree.as_local().unwrap().has_update_observer())
     });
 
     // While client A is disconnected, add and remove files from client A's project.
@@ -1611,7 +1620,7 @@ async fn test_project_reconnect(
         .await;
 
     let worktree3_id = worktree_a3.read_with(cx_a, |tree, _| {
-        assert!(!tree.as_local().unwrap().is_shared());
+        assert!(!tree.as_local().unwrap().has_update_observer());
         tree.id()
     });
     executor.run_until_parked();
@@ -1634,7 +1643,11 @@ async fn test_project_reconnect(
 
     project_a1.read_with(cx_a, |project, cx| {
         assert!(project.is_shared());
-        assert!(worktree_a1.read(cx).as_local().unwrap().is_shared());
+        assert!(worktree_a1
+            .read(cx)
+            .as_local()
+            .unwrap()
+            .has_update_observer());
         assert_eq!(
             worktree_a1
                 .read(cx)
@@ -1652,7 +1665,11 @@ async fn test_project_reconnect(
                 "subdir2/i.txt"
             ]
         );
-        assert!(worktree_a3.read(cx).as_local().unwrap().is_shared());
+        assert!(worktree_a3
+            .read(cx)
+            .as_local()
+            .unwrap()
+            .has_update_observer());
         assert_eq!(
             worktree_a3
                 .read(cx)
@@ -1733,7 +1750,7 @@ async fn test_project_reconnect(
     executor.run_until_parked();
 
     let worktree4_id = worktree_a4.read_with(cx_a, |tree, _| {
-        assert!(tree.as_local().unwrap().is_shared());
+        assert!(tree.as_local().unwrap().has_update_observer());
         tree.id()
     });
     project_a1.update(cx_a, |project, cx| {

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1044,7 +1044,6 @@ async fn get_copilot_lsp(http: Arc<dyn HttpClient>) -> anyhow::Result<PathBuf> {
 mod tests {
     use super::*;
     use gpui::TestAppContext;
-    use language::BufferId;
 
     #[gpui::test(iterations = 10)]
     async fn test_buffer_management(cx: &mut TestAppContext) {
@@ -1256,17 +1255,6 @@ mod tests {
         }
 
         fn load(&self, _: &AppContext) -> Task<Result<String>> {
-            unimplemented!()
-        }
-
-        fn buffer_reloaded(
-            &self,
-            _: BufferId,
-            _: &clock::Global,
-            _: language::LineEnding,
-            _: Option<std::time::SystemTime>,
-            _: &mut AppContext,
-        ) {
             unimplemented!()
         }
     }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -382,16 +382,6 @@ pub trait LocalFile: File {
     /// Loads the file's contents from disk.
     fn load(&self, cx: &AppContext) -> Task<Result<String>>;
 
-    /// Called when the buffer is reloaded from disk.
-    fn buffer_reloaded(
-        &self,
-        buffer_id: BufferId,
-        version: &clock::Global,
-        line_ending: LineEnding,
-        mtime: Option<SystemTime>,
-        cx: &mut AppContext,
-    );
-
     /// Returns true if the file should not be shared with collaborators.
     fn is_private(&self, _: &AppContext) -> bool {
         false
@@ -884,15 +874,6 @@ impl Buffer {
         self.saved_version = version;
         self.text.set_line_ending(line_ending);
         self.saved_mtime = mtime;
-        if let Some(file) = self.file.as_ref().and_then(|f| f.as_local()) {
-            file.buffer_reloaded(
-                self.remote_id(),
-                &self.saved_version,
-                self.line_ending(),
-                self.saved_mtime,
-                cx,
-            );
-        }
         cx.emit(Event::Reloaded);
         cx.notify();
     }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2986,7 +2986,7 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
 
     let updates = Arc::new(Mutex::new(Vec::new()));
     tree.update(cx, |tree, cx| {
-        let _ = tree.as_local_mut().unwrap().observe_updates(0, cx, {
+        tree.as_local_mut().unwrap().observe_updates(0, cx, {
             let updates = updates.clone();
             move |update| {
                 updates.lock().push(update);

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2955,7 +2955,6 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
     }));
 
     let project = Project::test(Arc::new(RealFs::default()), [dir.path()], cx).await;
-    let rpc = project.update(cx, |p, _| p.client.clone());
 
     let buffer_for_path = |path: &'static str, cx: &mut gpui::TestAppContext| {
         let buffer = project.update(cx, |p, cx| p.open_local_buffer(dir.path().join(path), cx));
@@ -2996,7 +2995,7 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
         });
     });
 
-    let remote = cx.update(|cx| Worktree::remote(1, 1, metadata, rpc.clone(), cx));
+    let remote = cx.update(|cx| Worktree::remote(1, metadata, cx));
 
     cx.executor().run_until_parked();
 

--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -36,7 +36,6 @@ ignore.workspace = true
 itertools.workspace = true
 language.workspace = true
 log.workspace = true
-lsp.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 rpc.workspace = true

--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [features]
 test-support = [
-    "client/test-support",
     "language/test-support",
     "settings/test-support",
     "text/test-support",
@@ -24,7 +23,6 @@ test-support = [
 
 [dependencies]
 anyhow.workspace = true
-client.workspace = true
 clock.workspace = true
 collections.workspace = true
 fs.workspace = true

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -461,16 +461,16 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     // Open a file that is nested inside of a gitignored directory that
     // has not yet been expanded.
     let prev_read_dir_count = fs.read_dir_call_count();
-    let buffer = tree
+    let (file, _, _) = tree
         .update(cx, |tree, cx| {
             tree.as_local_mut()
                 .unwrap()
-                .load_buffer("one/node_modules/b/b1.js".as_ref(), cx)
+                .load_file("one/node_modules/b/b1.js".as_ref(), cx)
         })
         .await
         .unwrap();
 
-    tree.read_with(cx, |tree, cx| {
+    tree.read_with(cx, |tree, _| {
         assert_eq!(
             tree.entries(true)
                 .map(|entry| (entry.path.as_ref(), entry.is_ignored))
@@ -491,10 +491,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
             ]
         );
 
-        assert_eq!(
-            buffer.read(cx).file().unwrap().path().as_ref(),
-            Path::new("one/node_modules/b/b1.js")
-        );
+        assert_eq!(file.path.as_ref(), Path::new("one/node_modules/b/b1.js"));
 
         // Only the newly-expanded directories are scanned.
         assert_eq!(fs.read_dir_call_count() - prev_read_dir_count, 2);
@@ -503,16 +500,16 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     // Open another file in a different subdirectory of the same
     // gitignored directory.
     let prev_read_dir_count = fs.read_dir_call_count();
-    let buffer = tree
+    let (file, _, _) = tree
         .update(cx, |tree, cx| {
             tree.as_local_mut()
                 .unwrap()
-                .load_buffer("one/node_modules/a/a2.js".as_ref(), cx)
+                .load_file("one/node_modules/a/a2.js".as_ref(), cx)
         })
         .await
         .unwrap();
 
-    tree.read_with(cx, |tree, cx| {
+    tree.read_with(cx, |tree, _| {
         assert_eq!(
             tree.entries(true)
                 .map(|entry| (entry.path.as_ref(), entry.is_ignored))
@@ -535,10 +532,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
             ]
         );
 
-        assert_eq!(
-            buffer.read(cx).file().unwrap().path().as_ref(),
-            Path::new("one/node_modules/a/a2.js")
-        );
+        assert_eq!(file.path.as_ref(), Path::new("one/node_modules/a/a2.js"));
 
         // Only the newly-expanded directory is scanned.
         assert_eq!(fs.read_dir_call_count() - prev_read_dir_count, 1);


### PR DESCRIPTION
The `worktree` crate mainly provides an in-memory model of a directory and its git repositories. But because it was originally extracted from the Project crate, it also contained lingering bits of code that were outside of that area:
* it had a little bit of logic related to buffers (though most buffer management lives in `project`)
* it had a *little* bit of logic for storing diagnostics (though the vast majority of LSP and diagnostic logic lives in `project`)
* it had a little bit of logic for sending RPC message (though the *receiving* logic for those RPC messages lived in `project`)

In this PR, I've moved those concerns entirely to the project crate (where they were already dealt with for the most part), so that the worktree crate can be more focused on its main job, and have fewer dependencies.

Worktree no longer depends on `client` or `lsp`. It still depends on `language`, but only because of `impl language::File for worktree::File`.

Release Notes:

- N/A
