### PR TITLE
cpp: Highlight sized type specifiers as keywords

### DIFF
--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -91,6 +91,7 @@
   "volatile"
   "while"
   (primitive_type)
+  (sized_type_specifier)
   (type_qualifier)
 ] @keyword
 


### PR DESCRIPTION
Without this, `unsigned` or `unsigned int` is not highlighted properly: `int` is a primitive_type but `unsigned` is a sized_type_specifier. This is already handled in C as both are part of @type highlight group.

Before:
![image](https://github.com/zed-industries/zed/assets/1106629/7210b769-9dff-428c-9e4f-55b652f91674)

After:
![image](https://github.com/zed-industries/zed/assets/1106629/8661c412-30f0-4b44-a4a2-1860a0b56a4e)

Release Notes:

- N/A
