### PR TITLE
linux: Use filesystem based unix socket instead of abstract namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,7 +2148,6 @@ dependencies = [
  "exec",
  "fork",
  "ipc-channel",
- "libc",
  "once_cell",
  "plist",
  "release_channel",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-libc.workspace = true
 ipc-channel = "0.18"
 once_cell.workspace = true
 release_channel.workspace = true


### PR DESCRIPTION
Release Notes:

- N/A

fixes: unable to launch multiple zed instances even if the support dirs are different(example: bwrap based sandboxing)