### PR TITLE
Refactor: Make it possible to share a remote worktree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12898,7 +12898,6 @@ dependencies = [
  "gpui",
  "http 0.1.0",
  "ignore",
- "itertools 0.11.0",
  "language",
  "log",
  "parking_lot",

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -83,10 +83,7 @@ async fn test_host_disconnect(
     let project_b = client_b.build_dev_server_project(project_id, cx_b).await;
     cx_a.background_executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| tree
-        .as_local()
-        .unwrap()
-        .has_update_observer()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| tree.has_update_observer()));
 
     let workspace_b = cx_b
         .add_window(|cx| Workspace::new(None, project_b.clone(), client_b.app_state.clone(), cx));
@@ -123,10 +120,7 @@ async fn test_host_disconnect(
 
     project_b.read_with(cx_b, |project, _| project.is_read_only());
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| !tree
-        .as_local()
-        .unwrap()
-        .has_update_observer()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| !tree.has_update_observer()));
 
     // Ensure client B's edited state is reset and that the whole window is blurred.
 

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -1378,10 +1378,7 @@ async fn test_unshare_project(
     let project_b = client_b.build_dev_server_project(project_id, cx_b).await;
     executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| tree
-        .as_local()
-        .unwrap()
-        .has_update_observer()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| tree.has_update_observer()));
 
     project_b
         .update(cx_b, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
@@ -1406,10 +1403,7 @@ async fn test_unshare_project(
         .unwrap();
     executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| !tree
-        .as_local()
-        .unwrap()
-        .has_update_observer()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| !tree.has_update_observer()));
 
     assert!(project_c.read_with(cx_c, |project, _| project.is_disconnected()));
 
@@ -1421,10 +1415,7 @@ async fn test_unshare_project(
     let project_c2 = client_c.build_dev_server_project(project_id, cx_c).await;
     executor.run_until_parked();
 
-    assert!(worktree_a.read_with(cx_a, |tree, _| tree
-        .as_local()
-        .unwrap()
-        .has_update_observer()));
+    assert!(worktree_a.read_with(cx_a, |tree, _| tree.has_update_observer()));
     project_c2
         .update(cx_c, |p, cx| p.open_buffer((worktree_id, "a.txt"), cx))
         .await
@@ -1531,7 +1522,7 @@ async fn test_project_reconnect(
     executor.run_until_parked();
 
     let worktree1_id = worktree_a1.read_with(cx_a, |worktree, _| {
-        assert!(worktree.as_local().unwrap().has_update_observer());
+        assert!(worktree.has_update_observer());
         worktree.id()
     });
     let (worktree_a2, _) = project_a1
@@ -1543,7 +1534,7 @@ async fn test_project_reconnect(
     executor.run_until_parked();
 
     let worktree2_id = worktree_a2.read_with(cx_a, |tree, _| {
-        assert!(tree.as_local().unwrap().has_update_observer());
+        assert!(tree.has_update_observer());
         tree.id()
     });
     executor.run_until_parked();
@@ -1576,9 +1567,7 @@ async fn test_project_reconnect(
         assert_eq!(project.collaborators().len(), 1);
     });
 
-    worktree_a1.read_with(cx_a, |tree, _| {
-        assert!(tree.as_local().unwrap().has_update_observer())
-    });
+    worktree_a1.read_with(cx_a, |tree, _| assert!(tree.has_update_observer()));
 
     // While client A is disconnected, add and remove files from client A's project.
     client_a
@@ -1620,7 +1609,7 @@ async fn test_project_reconnect(
         .await;
 
     let worktree3_id = worktree_a3.read_with(cx_a, |tree, _| {
-        assert!(!tree.as_local().unwrap().has_update_observer());
+        assert!(!tree.has_update_observer());
         tree.id()
     });
     executor.run_until_parked();
@@ -1643,11 +1632,7 @@ async fn test_project_reconnect(
 
     project_a1.read_with(cx_a, |project, cx| {
         assert!(project.is_shared());
-        assert!(worktree_a1
-            .read(cx)
-            .as_local()
-            .unwrap()
-            .has_update_observer());
+        assert!(worktree_a1.read(cx).has_update_observer());
         assert_eq!(
             worktree_a1
                 .read(cx)
@@ -1665,11 +1650,7 @@ async fn test_project_reconnect(
                 "subdir2/i.txt"
             ]
         );
-        assert!(worktree_a3
-            .read(cx)
-            .as_local()
-            .unwrap()
-            .has_update_observer());
+        assert!(worktree_a3.read(cx).has_update_observer());
         assert_eq!(
             worktree_a3
                 .read(cx)
@@ -1750,7 +1731,7 @@ async fn test_project_reconnect(
     executor.run_until_parked();
 
     let worktree4_id = worktree_a4.read_with(cx_a, |tree, _| {
-        assert!(tree.as_local().unwrap().has_update_observer());
+        assert!(tree.has_update_observer());
         tree.id()
     });
     project_a1.update(cx_a, |project, cx| {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -8364,14 +8364,12 @@ impl Project {
         self.worktree_for_id(project_path.worktree_id, cx)?
             .read(cx)
             .as_local()?
-            .snapshot()
             .local_git_repo(&project_path.path)
     }
 
     pub fn get_first_worktree_root_repo(&self, cx: &AppContext) -> Option<Arc<dyn GitRepository>> {
         let worktree = self.visible_worktrees(cx).next()?.read(cx).as_local()?;
         let root_entry = worktree.root_git_entry()?;
-
         worktree.get_local_repo(&root_entry)?.repo().clone().into()
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1626,18 +1626,12 @@ impl Project {
                                             }
                                         }
 
-                                        worktree.as_local_mut().unwrap().observe_updates(
-                                            project_id,
-                                            cx,
-                                            {
-                                                let client = client.clone();
-                                                move |update| {
-                                                    client
-                                                        .request(update)
-                                                        .map(|result| result.is_ok())
-                                                }
-                                            },
-                                        );
+                                        worktree.observe_updates(project_id, cx, {
+                                            let client = client.clone();
+                                            move |update| {
+                                                client.request(update).map(|result| result.is_ok())
+                                            }
+                                        });
 
                                         anyhow::Ok(())
                                     })?;
@@ -1788,7 +1782,7 @@ impl Project {
             for worktree_handle in self.worktrees.iter_mut() {
                 if let WorktreeHandle::Strong(worktree) = worktree_handle {
                     let is_visible = worktree.update(cx, |worktree, _| {
-                        worktree.as_local_mut().unwrap().stop_observing_updates();
+                        worktree.stop_observing_updates();
                         worktree.is_visible()
                     });
                     if !is_visible {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2995,7 +2995,15 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
         });
     });
 
-    let remote = cx.update(|cx| Worktree::remote(1, metadata, cx));
+    let remote = cx.update(|cx| {
+        Worktree::remote(
+            0,
+            1,
+            metadata,
+            Box::new(CollabRemoteWorktreeClient(project.read(cx).client())),
+            cx,
+        )
+    });
 
     cx.executor().run_until_parked();
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2981,8 +2981,7 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
 
     // Create a remote copy of this worktree.
     let tree = project.update(cx, |project, _| project.worktrees().next().unwrap());
-
-    let metadata = tree.update(cx, |tree, _| tree.as_local().unwrap().metadata_proto());
+    let metadata = tree.update(cx, |tree, _| tree.metadata_proto());
 
     let updates = Arc::new(Mutex::new(Vec::new()));
     tree.update(cx, |tree, cx| {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2986,12 +2986,10 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
 
     let updates = Arc::new(Mutex::new(Vec::new()));
     tree.update(cx, |tree, cx| {
-        tree.as_local_mut().unwrap().observe_updates(0, cx, {
-            let updates = updates.clone();
-            move |update| {
-                updates.lock().push(update);
-                async { true }
-            }
+        let updates = updates.clone();
+        tree.observe_updates(0, cx, move |update| {
+            updates.lock().push(update);
+            async { true }
         });
     });
 

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -435,6 +435,7 @@ impl Peer {
         self.connections.write().clear();
     }
 
+    /// Make a request and wait for a response.
     pub fn request<T: RequestMessage>(
         &self,
         receiver_id: ConnectionId,
@@ -462,28 +463,50 @@ impl Peer {
             .map_ok(|envelope| envelope.payload)
     }
 
-    pub fn request_internal<T: RequestMessage>(
+    fn request_internal<T: RequestMessage>(
         &self,
         original_sender_id: Option<ConnectionId>,
         receiver_id: ConnectionId,
         request: T,
     ) -> impl Future<Output = Result<TypedEnvelope<T::Response>>> {
+        let envelope = request.into_envelope(0, None, original_sender_id.map(Into::into));
+        let response = self.request_dynamic(receiver_id, envelope, T::NAME);
+        async move {
+            let (response, received_at) = response.await?;
+            Ok(TypedEnvelope {
+                message_id: response.id,
+                sender_id: receiver_id,
+                original_sender_id: response.original_sender_id,
+                payload: T::Response::from_envelope(response)
+                    .ok_or_else(|| anyhow!("received response of the wrong type"))?,
+                received_at,
+            })
+        }
+    }
+
+    /// Make a request and wait for a response.
+    ///
+    /// The caller must make sure to deserialize the response into the request's
+    /// response type. This interface is only useful in trait objects, where
+    /// generics can't be used. If you have a concrete type, use `request`.
+    pub fn request_dynamic(
+        &self,
+        receiver_id: ConnectionId,
+        mut envelope: proto::Envelope,
+        type_name: &'static str,
+    ) -> impl Future<Output = Result<(proto::Envelope, Instant)>> {
         let (tx, rx) = oneshot::channel();
         let send = self.connection_state(receiver_id).and_then(|connection| {
-            let message_id = connection.next_message_id.fetch_add(1, SeqCst);
+            envelope.id = connection.next_message_id.fetch_add(1, SeqCst);
             connection
                 .response_channels
                 .lock()
                 .as_mut()
                 .ok_or_else(|| anyhow!("connection was closed"))?
-                .insert(message_id, tx);
+                .insert(envelope.id, tx);
             connection
                 .outgoing_tx
-                .unbounded_send(proto::Message::Envelope(request.into_envelope(
-                    message_id,
-                    None,
-                    original_sender_id.map(Into::into),
-                )))
+                .unbounded_send(proto::Message::Envelope(envelope))
                 .map_err(|_| anyhow!("connection was closed"))?;
             Ok(())
         });
@@ -491,19 +514,10 @@ impl Peer {
             send?;
             let (response, received_at, _barrier) =
                 rx.await.map_err(|_| anyhow!("connection was closed"))?;
-
             if let Some(proto::envelope::Payload::Error(error)) = &response.payload {
-                Err(RpcError::from_proto(&error, T::NAME))
-            } else {
-                Ok(TypedEnvelope {
-                    message_id: response.id,
-                    sender_id: receiver_id,
-                    original_sender_id: response.original_sender_id,
-                    payload: T::Response::from_envelope(response)
-                        .ok_or_else(|| anyhow!("received response of the wrong type"))?,
-                    received_at,
-                })
+                return Err(RpcError::from_proto(&error, type_name));
             }
+            Ok((response, received_at))
         }
     }
 

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -632,8 +632,6 @@ impl SettingsStore {
             }
 
             // If the global settings file changed, reload the global value for the field.
-            project_settings_stack.clear();
-            paths_stack.clear();
             if changed_local_path.is_none() {
                 if let Some(value) = setting_value
                     .load_setting(
@@ -653,6 +651,8 @@ impl SettingsStore {
             }
 
             // Reload the local values for the setting.
+            paths_stack.clear();
+            project_settings_stack.clear();
             for ((root_id, path), local_settings) in &self.raw_local_settings {
                 // Build a stack of all of the local values for that setting.
                 while let Some(prev_entry) = paths_stack.last() {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1301,13 +1301,7 @@ mod tests {
             .unwrap();
 
         let entry = cx
-            .update(|cx| {
-                wt.update(cx, |wt, cx| {
-                    wt.as_local()
-                        .unwrap()
-                        .create_entry(Path::new(""), is_dir, cx)
-                })
-            })
+            .update(|cx| wt.update(cx, |wt, cx| wt.create_entry(Path::new(""), is_dir, cx)))
             .await
             .unwrap()
             .to_included()

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -343,36 +343,40 @@ impl<P> PathLikeWithPosition<P> {
 
 #[derive(Clone, Debug)]
 pub struct PathMatcher {
-    maybe_path: PathBuf,
+    source: String,
     glob: GlobMatcher,
 }
 
 impl std::fmt::Display for PathMatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.maybe_path.to_string_lossy().fmt(f)
+        self.source.fmt(f)
     }
 }
 
 impl PartialEq for PathMatcher {
     fn eq(&self, other: &Self) -> bool {
-        self.maybe_path.eq(&other.maybe_path)
+        self.source.eq(&other.source)
     }
 }
 
 impl Eq for PathMatcher {}
 
 impl PathMatcher {
-    pub fn new(maybe_glob: &str) -> Result<Self, globset::Error> {
+    pub fn new(source: &str) -> Result<Self, globset::Error> {
         Ok(PathMatcher {
-            glob: Glob::new(maybe_glob)?.compile_matcher(),
-            maybe_path: PathBuf::from(maybe_glob),
+            glob: Glob::new(source)?.compile_matcher(),
+            source: String::from(source),
         })
+    }
+
+    pub fn source(&self) -> &str {
+        &self.source
     }
 
     pub fn is_match<P: AsRef<Path>>(&self, other: P) -> bool {
         let other_path = other.as_ref();
-        other_path.starts_with(&self.maybe_path)
-            || other_path.ends_with(&self.maybe_path)
+        other_path.starts_with(Path::new(&self.source))
+            || other_path.ends_with(Path::new(&self.source))
             || self.glob.is_match(other_path)
             || self.check_with_end_separator(other_path)
     }

--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -31,7 +31,6 @@ fuzzy.workspace = true
 git.workspace = true
 gpui.workspace = true
 ignore.workspace = true
-itertools.workspace = true
 language.workspace = true
 log.workspace = true
 parking_lot.workspace = true

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1212,6 +1212,15 @@ impl LocalWorktree {
         self.settings.clone()
     }
 
+    pub fn local_git_repo(&self, path: &Path) -> Option<Arc<dyn GitRepository>> {
+        self.repo_for_path(path)
+            .map(|(_, entry)| entry.repo_ptr.clone())
+    }
+
+    pub fn get_local_repo(&self, repo: &RepositoryEntry) -> Option<&LocalRepositoryEntry> {
+        self.git_repositories.get(&repo.work_directory.0)
+    }
+
     fn load_file(&self, path: &Path, cx: &mut ModelContext<Worktree>) -> Task<Result<LoadedFile>> {
         let path = Arc::from(path);
         let abs_path = self.absolutize(&path);
@@ -2204,19 +2213,10 @@ impl Snapshot {
 }
 
 impl LocalSnapshot {
-    pub fn get_local_repo(&self, repo: &RepositoryEntry) -> Option<&LocalRepositoryEntry> {
-        self.git_repositories.get(&repo.work_directory.0)
-    }
-
     pub fn repo_for_path(&self, path: &Path) -> Option<(RepositoryEntry, &LocalRepositoryEntry)> {
         let (_, repo_entry) = self.repository_and_work_directory_for_path(path)?;
         let work_directory_id = repo_entry.work_directory_id();
         Some((repo_entry, self.git_repositories.get(&work_directory_id)?))
-    }
-
-    pub fn local_git_repo(&self, path: &Path) -> Option<Arc<dyn GitRepository>> {
-        self.repo_for_path(path)
-            .map(|(_, entry)| entry.repo_ptr.clone())
     }
 
     fn build_update(

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -868,13 +868,11 @@ impl Worktree {
         request: proto::ExpandProjectEntry,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ExpandProjectEntryResponse> {
-        let (scan_id, task) = this.update(&mut cx, |this, cx| {
-            (
-                this.scan_id(),
-                this.expand_entry(ProjectEntryId::from_proto(request.entry_id), cx),
-            )
+        let task = this.update(&mut cx, |this, cx| {
+            this.expand_entry(ProjectEntryId::from_proto(request.entry_id), cx)
         })?;
         task.ok_or_else(|| anyhow!("no such entry"))?.await?;
+        let scan_id = this.read_with(&cx, |this, _| this.scan_id())?;
         Ok(proto::ExpandProjectEntryResponse {
             worktree_scan_id: scan_id as u64,
         })

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -403,7 +403,7 @@ impl Worktree {
                     abs_path
                         .file_name()
                         .map_or(String::new(), |f| f.to_string_lossy().to_string()),
-                    abs_path.into(),
+                    abs_path,
                 ),
             };
 
@@ -1622,9 +1622,8 @@ impl RemoteWorktree {
         let envelope = request.into_envelope(0, None, None);
         let response = self.client.request(envelope, T::NAME);
         async move {
-            let response = response.await?;
-            Ok(T::Response::from_envelope(response)
-                .ok_or_else(|| anyhow!("received response of the wrong type"))?)
+            T::Response::from_envelope(response.await?)
+                .ok_or_else(|| anyhow!("received response of the wrong type"))
         }
     }
 
@@ -1661,7 +1660,7 @@ impl RemoteWorktree {
         }
     }
 
-    pub fn insert_entry(
+    fn insert_entry(
         &mut self,
         entry: proto::Entry,
         scan_id: usize,
@@ -1680,7 +1679,7 @@ impl RemoteWorktree {
         })
     }
 
-    pub fn delete_entry(
+    fn delete_entry(
         &mut self,
         id: ProjectEntryId,
         scan_id: usize,

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -1,10 +1,37 @@
+use std::{path::Path, sync::Arc};
+
 use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
+use util::paths::PathMatcher;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct WorktreeSettings {
+    pub file_scan_exclusions: Arc<[PathMatcher]>,
+    pub private_files: Arc<[PathMatcher]>,
+}
+
+impl WorktreeSettings {
+    pub fn is_path_private(&self, path: &Path) -> bool {
+        path.ancestors().any(|ancestor| {
+            self.private_files
+                .iter()
+                .any(|matcher| matcher.is_match(&ancestor))
+        })
+    }
+
+    pub fn is_path_excluded(&self, path: &Path) -> bool {
+        path.ancestors().any(|ancestor| {
+            self.file_scan_exclusions
+                .iter()
+                .any(|matcher| matcher.is_match(&ancestor))
+        })
+    }
+}
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
-pub struct WorktreeSettings {
+pub struct WorktreeSettingsContent {
     /// Completely ignore files matching globs from `file_scan_exclusions`
     ///
     /// Default: [
@@ -28,12 +55,37 @@ pub struct WorktreeSettings {
 impl Settings for WorktreeSettings {
     const KEY: Option<&'static str> = None;
 
-    type FileContent = Self;
+    type FileContent = WorktreeSettingsContent;
 
     fn load(
         sources: SettingsSources<Self::FileContent>,
         _: &mut AppContext,
     ) -> anyhow::Result<Self> {
-        sources.json_merge()
+        let result: WorktreeSettingsContent = sources.json_merge()?;
+        let mut file_scan_exclusions = result.file_scan_exclusions.unwrap_or_default();
+        let mut private_files = result.private_files.unwrap_or_default();
+        file_scan_exclusions.sort();
+        private_files.sort();
+        Ok(Self {
+            file_scan_exclusions: path_matchers(&file_scan_exclusions, "file_scan_exclusions"),
+            private_files: path_matchers(&private_files, "private_files"),
+        })
     }
+}
+
+fn path_matchers(values: &[String], context: &'static str) -> Arc<[PathMatcher]> {
+    values
+        .iter()
+        .filter_map(|pattern| {
+            PathMatcher::new(pattern)
+                .map(Some)
+                .unwrap_or_else(|e| {
+                    log::error!(
+                        "Skipping pattern {pattern} in `{}` project settings due to parsing error: {e:#}", context
+                    );
+                    None
+                })
+        })
+        .collect::<Vec<_>>()
+        .into()
 }

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -846,7 +846,7 @@ async fn test_write_file(cx: &mut TestAppContext) {
     tree.flush_fs_events(cx).await;
 
     tree.update(cx, |tree, cx| {
-        tree.as_local().unwrap().write_file(
+        tree.write_file(
             Path::new("tracked-dir/file.txt"),
             "hello".into(),
             Default::default(),
@@ -856,7 +856,7 @@ async fn test_write_file(cx: &mut TestAppContext) {
     .await
     .unwrap();
     tree.update(cx, |tree, cx| {
-        tree.as_local().unwrap().write_file(
+        tree.write_file(
             Path::new("ignored-dir/file.txt"),
             "world".into(),
             Default::default(),

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -453,11 +453,9 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     // Open a file that is nested inside of a gitignored directory that
     // has not yet been expanded.
     let prev_read_dir_count = fs.read_dir_call_count();
-    let (file, _, _) = tree
+    let loaded = tree
         .update(cx, |tree, cx| {
-            tree.as_local_mut()
-                .unwrap()
-                .load_file("one/node_modules/b/b1.js".as_ref(), cx)
+            tree.load_file("one/node_modules/b/b1.js".as_ref(), cx)
         })
         .await
         .unwrap();
@@ -483,7 +481,10 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
             ]
         );
 
-        assert_eq!(file.path.as_ref(), Path::new("one/node_modules/b/b1.js"));
+        assert_eq!(
+            loaded.file.path.as_ref(),
+            Path::new("one/node_modules/b/b1.js")
+        );
 
         // Only the newly-expanded directories are scanned.
         assert_eq!(fs.read_dir_call_count() - prev_read_dir_count, 2);
@@ -492,11 +493,9 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     // Open another file in a different subdirectory of the same
     // gitignored directory.
     let prev_read_dir_count = fs.read_dir_call_count();
-    let (file, _, _) = tree
+    let loaded = tree
         .update(cx, |tree, cx| {
-            tree.as_local_mut()
-                .unwrap()
-                .load_file("one/node_modules/a/a2.js".as_ref(), cx)
+            tree.load_file("one/node_modules/a/a2.js".as_ref(), cx)
         })
         .await
         .unwrap();
@@ -524,7 +523,10 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
             ]
         );
 
-        assert_eq!(file.path.as_ref(), Path::new("one/node_modules/a/a2.js"));
+        assert_eq!(
+            loaded.file.path.as_ref(),
+            Path::new("one/node_modules/a/a2.js")
+        );
 
         // Only the newly-expanded directory is scanned.
         assert_eq!(fs.read_dir_call_count() - prev_read_dir_count, 1);


### PR DESCRIPTION
This PR is an internal refactor in preparation for remote editing. It restructures the public interface of `Worktree`, reducing the number of call sites that assume that a worktree is local or remote.

* The Project no longer calls `worktree.as_local_mut().unwrap()` in code paths related to basic file operations
* Fewer code paths in the app rely on the worktree's `LocalSnapshot`
* Worktree-related RPC message handling is more fully encapsulated by the `Worktree` type.

to do:
* [x] file manipulation operations
* [x] sending worktree updates when sharing

for later
* opening buffers
* updating open buffers upon worktree changes

Release Notes:

- N/A
