### PR TITLE
Handle Wikipedia code blocks in `/fetch` command

### DIFF
--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -43,12 +43,15 @@ impl FetchSlashCommand {
             Box::new(markdown::ListHandler),
             Box::new(markdown::TableHandler::new()),
             Box::new(markdown::StyledTextHandler),
-            Box::new(markdown::CodeHandler),
         ];
         if url.contains("wikipedia.org") {
             use html_to_markdown::structure::wikipedia;
 
             handlers.push(Box::new(wikipedia::WikipediaChromeRemover));
+            handlers.push(Box::new(wikipedia::WikipediaInfoboxHandler));
+            handlers.push(Box::new(wikipedia::WikipediaCodeHandler::new()));
+        } else {
+            handlers.push(Box::new(markdown::CodeHandler));
         }
 
         convert_html_to_markdown(&body[..], handlers)

--- a/crates/html_to_markdown/src/markdown_writer.rs
+++ b/crates/html_to_markdown/src/markdown_writer.rs
@@ -162,7 +162,7 @@ impl MarkdownWriter {
         }
 
         let text = text
-            .trim_matches(|char| char == '\n' || char == '\r')
+            .trim_matches(|char| char == '\n' || char == '\r' || char == '\t')
             .replace('\n', " ");
 
         self.push_str(&text);


### PR DESCRIPTION
This PR extends the `/fetch` command with support for Wikipedia code blocks.

Release Notes:

- N/A
