### PR TITLE
Check validity of new.range too

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -867,10 +867,12 @@ fn compare_diagnostics(
     snapshot: &language::BufferSnapshot,
 ) -> Ordering {
     use language::ToOffset;
-    // The old diagnostics may point to a previously open Buffer for this file.
-    if !old.range.start.is_valid(snapshot) {
+
+    // The diagnostics may point to a previously open Buffer for this file.
+    if !old.range.start.is_valid(snapshot) || !new.range.start.is_valid(snapshot) {
         return Ordering::Greater;
     }
+
     old.range
         .start
         .to_offset(snapshot)


### PR DESCRIPTION
I'm not certain yet how it could be invalid, but we are still seeing
panics here.

Release Notes:

- Fixed a panic when opening the diagnostics view
