### PR TITLE
vim: Add gU/gu/g~

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -381,6 +381,9 @@
       "shift-s": "vim::SubstituteLine",
       ">": ["vim::PushOperator", "Indent"],
       "<": ["vim::PushOperator", "Outdent"],
+      "g u": ["vim::PushOperator", "Lowercase"],
+      "g shift-u": ["vim::PushOperator", "Uppercase"],
+      "g ~": ["vim::PushOperator", "OppositeCase"],
       "ctrl-pagedown": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
       // tree-sitter related commands

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -21,6 +21,7 @@ use crate::{
     surrounds::{check_and_move_to_valid_bracket_pair, SurroundsType},
     Vim,
 };
+use case::{change_case_motion, change_case_object, CaseTarget};
 use collections::BTreeSet;
 use editor::display_map::ToDisplayPoint;
 use editor::scroll::Autoscroll;
@@ -198,6 +199,15 @@ pub fn normal_motion(
             Some(Operator::AddSurrounds { target: None }) => {}
             Some(Operator::Indent) => indent_motion(vim, motion, times, IndentDirection::In, cx),
             Some(Operator::Outdent) => indent_motion(vim, motion, times, IndentDirection::Out, cx),
+            Some(Operator::Lowercase) => {
+                change_case_motion(vim, motion, times, CaseTarget::Lowercase, cx)
+            }
+            Some(Operator::Uppercase) => {
+                change_case_motion(vim, motion, times, CaseTarget::Uppercase, cx)
+            }
+            Some(Operator::OppositeCase) => {
+                change_case_motion(vim, motion, times, CaseTarget::OppositeCase, cx)
+            }
             Some(operator) => {
                 // Can't do anything for text objects, Ignoring
                 error!("Unexpected normal mode motion operator: {:?}", operator)
@@ -219,6 +229,15 @@ pub fn normal_object(object: Object, cx: &mut WindowContext) {
                 }
                 Some(Operator::Outdent) => {
                     indent_object(vim, object, around, IndentDirection::Out, cx)
+                }
+                Some(Operator::Lowercase) => {
+                    change_case_object(vim, object, around, CaseTarget::Lowercase, cx)
+                }
+                Some(Operator::Uppercase) => {
+                    change_case_object(vim, object, around, CaseTarget::Uppercase, cx)
+                }
+                Some(Operator::OppositeCase) => {
+                    change_case_object(vim, object, around, CaseTarget::OppositeCase, cx)
                 }
                 Some(Operator::AddSurrounds { target: None }) => {
                     waiting_operator = Some(Operator::AddSurrounds {

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -63,6 +63,10 @@ pub enum Operator {
     Jump { line: bool },
     Indent,
     Outdent,
+
+    Lowercase,
+    Uppercase,
+    OppositeCase,
 }
 
 #[derive(Default, Clone)]
@@ -270,6 +274,9 @@ impl Operator {
             Operator::Jump { line: false } => "`",
             Operator::Indent => ">",
             Operator::Outdent => "<",
+            Operator::Uppercase => "gU",
+            Operator::Lowercase => "gu",
+            Operator::OppositeCase => "g~",
         }
     }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -539,6 +539,9 @@ impl Vim {
                 | Operator::Replace
                 | Operator::Indent
                 | Operator::Outdent
+                | Operator::Lowercase
+                | Operator::Uppercase
+                | Operator::OppositeCase
         ) {
             self.start_recording(cx)
         };

--- a/crates/vim/test_data/test_change_case_motion.json
+++ b/crates/vim/test_data/test_change_case_motion.json
@@ -1,0 +1,23 @@
+{"Put":{"state":"ˇabc def"}}
+{"Key":"g"}
+{"Key":"shift-u"}
+{"Key":"w"}
+{"Get":{"state":"ˇABC def","mode":"Normal"}}
+{"Key":"g"}
+{"Key":"u"}
+{"Key":"w"}
+{"Get":{"state":"ˇabc def","mode":"Normal"}}
+{"Key":"g"}
+{"Key":"~"}
+{"Key":"w"}
+{"Get":{"state":"ˇABC def","mode":"Normal"}}
+{"Key":"."}
+{"Get":{"state":"ˇabc def","mode":"Normal"}}
+{"Put":{"state":"abˇc def"}}
+{"Key":"g"}
+{"Key":"~"}
+{"Key":"i"}
+{"Key":"w"}
+{"Get":{"state":"ˇABC def","mode":"Normal"}}
+{"Key":"."}
+{"Get":{"state":"ˇabc def","mode":"Normal"}}


### PR DESCRIPTION
Co-Authored-By: ethanmsl@gmail.com

Release Notes:

- vim: Added `gu`/`gU`/`g~` for changing case. (#12565)
