### PR TITLE
Block publishing of `zed_extension_api` v0.0.7

### DIFF
--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -8,6 +8,10 @@ keywords = ["zed", "extension"]
 edition = "2021"
 license = "Apache-2.0"
 
+# Don't publish v0.0.7 until we're ready to commit to the breaking API changes
+# Marshall is DRI on this.
+publish = false
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
This PR adds a temporary block on publishing v0.0.7 of the `zed_extension_api`.

We have breaking changes to the extension API that are currently staged on `main` and are still being iterated on, so we don't want to publish again until we're ready to commit to the new API.

This change is intended to prevent accidental publishing of the crate before we're ready.

Release Notes:

- N/A
