### PR TITLE
Add event for yarn project identification

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -315,6 +315,8 @@ impl Telemetry {
     pub fn report_app_event(self: &Arc<Self>, operation: String) -> Event {
         let event = Event::App(AppEvent { operation });
 
+        dbg!(&event);
+
         self.report_event(event.clone());
 
         event

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -315,8 +315,6 @@ impl Telemetry {
     pub fn report_app_event(self: &Arc<Self>, operation: String) -> Event {
         let event = Event::App(AppEvent { operation });
 
-        dbg!(&event);
-
         self.report_event(event.clone());
 
         event

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7962,9 +7962,6 @@ impl Project {
     ) {
         let worktree_id = worktree.update(cx, |worktree, _| worktree.id());
 
-        dbg!(&worktree_id);
-        dbg!(&self.yarn_worktree_ids_reported);
-
         if !self.yarn_worktree_ids_reported.contains(&worktree_id) {
             let is_yarn_project = updated_entries_set.iter().any(|(path, _, _)| {
                 path.as_ref()

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -229,7 +229,7 @@ pub struct Project {
     hosted_project_id: Option<ProjectId>,
     dev_server_project_id: Option<client::DevServerProjectId>,
     search_history: SearchHistory,
-    sent_yarn_project_event: bool,
+    yarn_worktree_ids_reported: Vec<WorktreeId>,
 }
 
 pub enum LanguageServerToQuery {
@@ -788,7 +788,7 @@ impl Project {
                 hosted_project_id: None,
                 dev_server_project_id: None,
                 search_history: Self::new_search_history(),
-                sent_yarn_project_event: false,
+                yarn_worktree_ids_reported: Vec::new(),
             }
         })
     }
@@ -947,7 +947,7 @@ impl Project {
                     .dev_server_project_id
                     .map(|dev_server_project_id| DevServerProjectId(dev_server_project_id)),
                 search_history: Self::new_search_history(),
-                sent_yarn_project_event: false,
+                yarn_worktree_ids_reported: Vec::new(),
             };
             this.set_role(role, cx);
             for worktree in worktrees {
@@ -7901,22 +7901,7 @@ impl Project {
                         changes.clone(),
                     ));
 
-                    if !this.sent_yarn_project_event {
-                        let is_yarn_project = changes.iter().any(|(path, _, _)| {
-                            path.as_ref()
-                                .file_name()
-                                .and_then(|name| name.to_str())
-                                .map(|name_str| name_str == "yarn.lock")
-                                .unwrap_or(false)
-                        });
-
-                        if is_yarn_project {
-                            this.client()
-                                .telemetry()
-                                .report_app_event("yarn project".to_string());
-                            this.sent_yarn_project_event = true;
-                        }
-                    }
+                    this.report_yarn_project(&worktree, changes, cx);
                 }
                 worktree::Event::UpdatedGitRepositories(updated_repos) => {
                     if is_local {
@@ -7967,6 +7952,35 @@ impl Project {
 
         cx.emit(Event::WorktreeAdded);
         self.metadata_changed(cx);
+    }
+
+    fn report_yarn_project(
+        &mut self,
+        worktree: &Model<Worktree>,
+        updated_entries_set: &UpdatedEntriesSet,
+        cx: &mut ModelContext<Self>,
+    ) {
+        let worktree_id = worktree.update(cx, |worktree, _| worktree.id());
+
+        dbg!(&worktree_id);
+        dbg!(&self.yarn_worktree_ids_reported);
+
+        if !self.yarn_worktree_ids_reported.contains(&worktree_id) {
+            let is_yarn_project = updated_entries_set.iter().any(|(path, _, _)| {
+                path.as_ref()
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(|name_str| name_str == "yarn.lock")
+                    .unwrap_or(false)
+            });
+
+            if is_yarn_project {
+                self.client()
+                    .telemetry()
+                    .report_app_event("open yarn project".to_string());
+                self.yarn_worktree_ids_reported.push(worktree_id);
+            }
+        }
     }
 
     fn update_local_worktree_buffers(


### PR DESCRIPTION
Report a `open yarn project` `app_event` for each worktree where `yarn.lock` is found and only report it once per session.

Release Notes:

- N/A
