### PR TITLE
Use the new assistant icon in the setup instructions

### DIFF
--- a/crates/assistant/src/completion_provider/anthropic.rs
+++ b/crates/assistant/src/completion_provider/anthropic.rs
@@ -349,7 +349,7 @@ impl Render for AuthenticationPrompt {
                 h_flex()
                     .gap_2()
                     .child(Label::new("Click on").size(LabelSize::Small))
-                    .child(Icon::new(IconName::Ai).size(IconSize::XSmall))
+                    .child(Icon::new(IconName::ZedAssistant).size(IconSize::XSmall))
                     .child(
                         Label::new("in the status bar to close this panel.").size(LabelSize::Small),
                     ),

--- a/crates/assistant/src/completion_provider/open_ai.rs
+++ b/crates/assistant/src/completion_provider/open_ai.rs
@@ -336,7 +336,7 @@ impl Render for AuthenticationPrompt {
                 h_flex()
                     .gap_2()
                     .child(Label::new("Click on").size(LabelSize::Small))
-                    .child(Icon::new(IconName::Ai).size(IconSize::XSmall))
+                    .child(Icon::new(IconName::ZedAssistant).size(IconSize::XSmall))
                     .child(
                         Label::new("in the status bar to close this panel.").size(LabelSize::Small),
                     ),


### PR DESCRIPTION
This is a PR with just a small visual adjustment, so instructions are up-to-date with the new icon.
I did not remove the "old" ai.svg as I am not sure if its gonna be used in the future or if its has been completely replaced by the new "zed assistant" icon.

Release Notes:

- Fixed the wrong icon being used in the assistant setup instructions.

For open ai

<img width="543" alt="image" src="https://github.com/zed-industries/zed/assets/61624214/5f18a8f4-6761-4df5-8482-92582545dee5">

and anthropic

<img width="544" alt="image" src="https://github.com/zed-industries/zed/assets/61624214/6ca3ed23-0f68-4c0d-bc8a-32ab7c607029">

how it looked before (Zed Preview 0.139.3 0c083b7f381d8d75632c5ce5bd60810cda195ad0):

<img width="526" alt="image" src="https://github.com/zed-industries/zed/assets/61624214/af9c9fa8-89ed-4f6a-88ca-b285b4c522c3">
