### PR TITLE
svelte: Improve syntax highlighting

### DIFF
--- a/extensions/svelte/languages/svelte/injections.scm
+++ b/extensions/svelte/languages/svelte/injections.scm
@@ -1,32 +1,71 @@
 ; injections.scm
 ; --------------
+
+; match script tags without a lang tag
 ((script_element
-    (start_tag
-      (attribute
-        (quoted_attribute_value (attribute_value) @_language))?)
-     (raw_text) @content)
-  (#eq? @_language "")
+  (start_tag
+    (attribute
+      (attribute_name) @_name)*)
+    (raw_text) @content)
+  (#not-eq? @_name "lang")
   (#set! "language" "javascript"))
 
- ((script_element
-     (start_tag
-       (attribute
-         (quoted_attribute_value (attribute_value) @_language)))
-      (raw_text) @content)
-    (#eq? @_language "ts")
-    (#set! "language" "typescript"))
-
+; match javascript
 ((script_element
-    (start_tag
-        (attribute
-        (quoted_attribute_value (attribute_value) @_language)))
+  (start_tag
+    (attribute
+      (attribute_name) @_name
+      (quoted_attribute_value (attribute_value) @_value)))
     (raw_text) @content)
-  (#eq? @_language "typescript")
+  (#eq? @_name "lang")
+  (#eq? @_value "js")
+  (#set! "language" "javascript"))
+
+; match typescript
+((script_element
+  (start_tag
+    (attribute
+      (attribute_name) @_name
+      (quoted_attribute_value (attribute_value) @_value)))
+    (raw_text) @content)
+  (#eq? @_name "lang")
+  (#eq? @_value "ts")
   (#set! "language" "typescript"))
 
 (style_element
   (raw_text) @content
   (#set! "language" "css"))
+
+; match style tags without a lang tag
+((style_element
+  (start_tag
+    (attribute
+      (attribute_name) @_name)*)
+    (raw_text) @content)
+  (#not-eq? @_name "lang")
+  (#set! "language" "css"))
+
+; match css
+((style_element
+  (start_tag
+    (attribute
+      (attribute_name) @_name
+      (quoted_attribute_value (attribute_value) @_value)))
+    (raw_text) @content)
+  (#eq? @_name "lang")
+  (#eq? @_value "css")
+  (#set! "language" "css"))
+
+; match scss
+((style_element
+  (start_tag
+    (attribute
+      (attribute_name) @_name
+      (quoted_attribute_value (attribute_value) @_value)))
+    (raw_text) @content)
+  (#eq? @_name "lang")
+  (#eq? @_value "scss")
+  (#set! "language" "scss"))
 
 ((raw_text_expr) @content
   (#set! "language" "javascript"))


### PR DESCRIPTION
This PR fixes `<script context="module">` not being highlighted.  
It also adds support for scss.

Release Notes:

- N/A