### PR TITLE
Confirm context menu selection on enter

### DIFF
--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -160,7 +160,7 @@ impl ContextMenu {
             Some(
                 ContextMenuItem::Entry { handler, .. }
                 | ContextMenuItem::CustomEntry { handler, .. },
-            ) => (handler)(cx),
+            ) => (handler)(cx), // Default handler is responsible for dismissing on confirmation.
             _ => {
                 cx.emit(DismissEvent);
             }

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -161,10 +161,10 @@ impl ContextMenu {
                 ContextMenuItem::Entry { handler, .. }
                 | ContextMenuItem::CustomEntry { handler, .. },
             ) => (handler)(cx),
-            _ => {}
+            _ => {
+                cx.emit(DismissEvent);
+            }
         }
-
-        cx.emit(DismissEvent);
     }
 
     pub fn cancel(&mut self, _: &menu::Cancel, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
Release Notes:

- Fixed context menu selection confirmation with keyboard on macOS. [#12796](https://github.com/zed-industries/zed/issues/12796)

## Demonstration

Sorry, only later did I notice that neither the cursor/arrow nor the key stroke overlays visible during the recording made it into the video 🙏 

### Before

https://github.com/zed-industries/zed/assets/59080/9a270405-79f9-4025-930a-f954a362e674 

### After

https://github.com/zed-industries/zed/assets/59080/7527db03-34d5-43b2-84bd-3e6e1b57505a
