### PR TITLE
windows: Update `windows-rs` crate and better error handling in `DirectWrite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,7 +4238,7 @@ dependencies = [
  "text",
  "time",
  "util",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -4558,7 +4558,7 @@ dependencies = [
  "unindent",
  "url",
  "util",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -4781,8 +4781,8 @@ dependencies = [
  "wayland-cursor",
  "wayland-protocols",
  "wayland-protocols-plasma",
- "windows 0.56.0",
- "windows-core 0.56.0",
+ "windows 0.57.0",
+ "windows-core 0.57.0",
  "x11rb",
  "xim",
  "xkbcommon",
@@ -6096,7 +6096,7 @@ dependencies = [
  "serde_json",
  "smol",
  "util",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -6592,7 +6592,7 @@ dependencies = [
  "tempfile",
  "util",
  "walkdir",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -10440,7 +10440,7 @@ dependencies = [
  "theme",
  "thiserror",
  "util",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -11368,7 +11368,7 @@ dependencies = [
  "story",
  "strum",
  "theme",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -12512,11 +12512,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.56.0",
+ "windows-core 0.57.0",
  "windows-targets 0.52.5",
 ]
 
@@ -12531,9 +12531,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -12543,9 +12543,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12554,9 +12554,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,7 +410,7 @@ wit-component = "0.201"
 sys-locale = "0.3.1"
 
 [workspace.dependencies.windows]
-version = "0.56.0"
+version = "0.57"
 features = [
     "implement",
     "Foundation_Numerics",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -139,7 +139,7 @@ xim = { git = "https://github.com/npmania/xim-rs", rev = "27132caffc5b9bc9c432ca
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
-windows-core = "0.56"
+windows-core = "0.57"
 
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "2.4"

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -350,11 +350,15 @@ impl DirectWriteState {
 
     unsafe fn update_system_font_collection(&mut self) {
         let mut collection = std::mem::zeroed();
-        self.components
+        if self
+            .components
             .factory
             .GetSystemFontCollection(false, &mut collection, true)
-            .unwrap();
-        self.system_font_collection = collection.unwrap();
+            .log_err()
+            .is_some()
+        {
+            self.system_font_collection = collection.unwrap();
+        }
     }
 
     fn select_font(&mut self, target_font: &Font) -> FontId {

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1140,7 +1140,7 @@ fn get_font_names_from_collection(
             let Some(localized_family_name) = font_family.GetFamilyNames().log_err() else {
                 continue;
             };
-            let Some(family_name) = get_name(localized_family_name, locale) else {
+            let Some(family_name) = get_name(localized_family_name, locale).log_err() else {
                 continue;
             };
             result.push(family_name);
@@ -1160,7 +1160,7 @@ fn get_font_identifier_and_font_struct(
     let Some(localized_family_name) = (unsafe { font_face.GetFamilyNames().log_err() }) else {
         return None;
     };
-    let Some(family_name) = get_name(localized_family_name, locale) else {
+    let Some(family_name) = get_name(localized_family_name, locale).log_err() else {
         return None;
     };
     let weight = unsafe { font_face.GetWeight() };
@@ -1208,7 +1208,7 @@ fn get_postscript_name(font_face: &IDWriteFontFace3, locale: &str) -> Option<Str
         return None;
     }
 
-    get_name(info.unwrap(), locale)
+    get_name(info.unwrap(), locale).log_err()
 }
 
 // https://learn.microsoft.com/en-us/windows/win32/api/dwrite/ne-dwrite-dwrite_font_feature_tag

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -303,20 +303,15 @@ impl DirectWriteState {
         } else {
             &self.custom_font_collection
         };
-        let Some(fontset) = collection.GetFontSet().log_err() else {
-            return None;
-        };
-        let Some(font) = fontset
+        let fontset = collection.GetFontSet().log_err()?;
+        let font = fontset
             .GetMatchingFonts(
                 &HSTRING::from(family_name),
                 font_weight.into(),
                 DWRITE_FONT_STRETCH_NORMAL,
                 font_style.into(),
             )
-            .log_err()
-        else {
-            return None;
-        };
+            .log_err()?;
         let total_number = font.GetFontCount();
         for index in 0..total_number {
             let Some(font_face_ref) = font.GetFontFaceReference(index).log_err() else {
@@ -977,7 +972,6 @@ impl IDWriteTextRenderer_Impl for TextRenderer {
             let Some((font_identifier, font_struct, is_emoji)) =
                 get_font_identifier_and_font_struct(font_face, &self.locale)
             else {
-                log::error!("none postscript name found");
                 return Ok(());
             };
 

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1154,15 +1154,9 @@ fn get_font_identifier_and_font_struct(
     font_face: &IDWriteFontFace3,
     locale: &str,
 ) -> Option<(FontIdentifier, Font, bool)> {
-    let Some(postscript_name) = get_postscript_name(font_face, locale) else {
-        return None;
-    };
-    let Some(localized_family_name) = (unsafe { font_face.GetFamilyNames().log_err() }) else {
-        return None;
-    };
-    let Some(family_name) = get_name(localized_family_name, locale).log_err() else {
-        return None;
-    };
+    let postscript_name = get_postscript_name(font_face, locale)?;
+    let localized_family_name = unsafe { font_face.GetFamilyNames().log_err() }?;
+    let family_name = get_name(localized_family_name, locale).log_err()?;
     let weight = unsafe { font_face.GetWeight() };
     let style = unsafe { font_face.GetStyle() };
     let identifier = FontIdentifier {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -162,16 +162,11 @@ impl Platform for WindowsPlatform {
 
     fn run(&self, on_finish_launching: Box<dyn 'static + FnOnce()>) {
         on_finish_launching();
-        let vsync_event = create_event().unwrap();
-        begin_vsync(vsync_event.to_raw());
+        let vsync_event = unsafe { Owned::new(CreateEventW(None, false, false, None).unwrap()) };
+        begin_vsync(*vsync_event);
         'a: loop {
             let wait_result = unsafe {
-                MsgWaitForMultipleObjects(
-                    Some(&[vsync_event.to_raw()]),
-                    false,
-                    INFINITE,
-                    QS_ALLINPUT,
-                )
+                MsgWaitForMultipleObjects(Some(&[*vsync_event]), false, INFINITE, QS_ALLINPUT)
             };
 
             match wait_result {

--- a/crates/gpui/src/platform/windows/util.rs
+++ b/crates/gpui/src/platform/windows/util.rs
@@ -1,7 +1,7 @@
 use std::sync::OnceLock;
 
 use ::util::ResultExt;
-use windows::Win32::{Foundation::*, System::Threading::*, UI::WindowsAndMessaging::*};
+use windows::Win32::{Foundation::*, UI::WindowsAndMessaging::*};
 
 use crate::*;
 
@@ -72,34 +72,6 @@ pub(crate) unsafe fn set_window_long(
     unsafe {
         SetWindowLongW(hwnd, nindex, dwnewlong as i32) as isize
     }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct OwnedHandle(HANDLE);
-
-impl OwnedHandle {
-    pub(crate) fn new(handle: HANDLE) -> Self {
-        Self(handle)
-    }
-
-    #[inline(always)]
-    pub(crate) fn to_raw(&self) -> HANDLE {
-        self.0
-    }
-}
-
-impl Drop for OwnedHandle {
-    fn drop(&mut self) {
-        if !self.0.is_invalid() {
-            unsafe { CloseHandle(self.0) }.log_err();
-        }
-    }
-}
-
-pub(crate) fn create_event() -> windows::core::Result<OwnedHandle> {
-    Ok(OwnedHandle::new(unsafe {
-        CreateEventW(None, false, false, None)?
-    }))
 }
 
 pub(crate) fn windows_credentials_target_name(url: &str) -> String {


### PR DESCRIPTION
- Update `windows-rs` from `0.56` to `0.57`
- Use the newly introduced `Owned` struct in `0.57` to handle the RAII stuff of `HANDLE`
- Better error handling in `DirectWrite`

Release Notes:

- N/A
