### PR TITLE
Force default MSVC linker when building on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ rustflags = ["-C", "symbol-mangling-version=v0", "--cfg", "tokio_unstable"]
 
 [alias]
 xtask = "run --package xtask --"
+
+[target.x86_64-pc-windows-msvc]
+linker = "link.exe"


### PR DESCRIPTION
Release Notes:

- N/A

## Description

Using `rust-lld.exe` globally on windows is pretty common since it can help speed up compilation. Unfortunately, zed fails to build with that linker. This PR forces the default "link.exe" to be used on windows to avoid this potential error. This is intended as a temporary fix until the reason why it fails to compile with another linker is found.

Changing the linker from the global setting might seem a bit wrong but the alternative right now is just crashing with a `STATUS_ACCESS_VIOLATION` without any explanations as to what went wrong.

See #12041 