### PR TITLE
assistant: Add `/now` slash command

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -35,6 +35,8 @@ use std::{
 pub(crate) use streaming_diff::*;
 use util::paths::EMBEDDINGS_DIR;
 
+use crate::slash_command::now_command;
+
 actions!(
     assistant,
     [
@@ -307,6 +309,7 @@ fn register_slash_commands(cx: &mut AppContext) {
     slash_command_registry.register_command(search_command::SearchSlashCommand, true);
     slash_command_registry.register_command(prompt_command::PromptSlashCommand, true);
     slash_command_registry.register_command(default_command::DefaultSlashCommand, true);
+    slash_command_registry.register_command(now_command::NowSlashCommand, true);
     slash_command_registry.register_command(rustdoc_command::RustdocSlashCommand, false);
     slash_command_registry.register_command(fetch_command::FetchSlashCommand, false);
 }

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -25,8 +25,8 @@ use semantic_index::{CloudEmbeddingProvider, SemanticIndex};
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
 use slash_command::{
-    active_command, default_command, fetch_command, file_command, project_command, prompt_command,
-    rustdoc_command, search_command, tabs_command,
+    active_command, default_command, fetch_command, file_command, now_command, project_command,
+    prompt_command, rustdoc_command, search_command, tabs_command,
 };
 use std::{
     fmt::{self, Display},
@@ -34,8 +34,6 @@ use std::{
 };
 pub(crate) use streaming_diff::*;
 use util::paths::EMBEDDINGS_DIR;
-
-use crate::slash_command::now_command;
 
 actions!(
     assistant,

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -20,6 +20,7 @@ pub mod active_command;
 pub mod default_command;
 pub mod fetch_command;
 pub mod file_command;
+pub mod now_command;
 pub mod project_command;
 pub mod prompt_command;
 pub mod rustdoc_command;

--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -1,0 +1,83 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use anyhow::Result;
+use assistant_slash_command::{SlashCommand, SlashCommandOutput, SlashCommandOutputSection};
+use chrono::{DateTime, Local};
+use gpui::{AppContext, Task, WeakView};
+use language::LspAdapterDelegate;
+use ui::{prelude::*, ButtonLike, ElevationIndex};
+use workspace::Workspace;
+
+pub(crate) struct NowSlashCommand;
+
+impl SlashCommand for NowSlashCommand {
+    fn name(&self) -> String {
+        "now".into()
+    }
+
+    fn description(&self) -> String {
+        "insert the current date and time".into()
+    }
+
+    fn menu_text(&self) -> String {
+        "Insert current date and time".into()
+    }
+
+    fn requires_argument(&self) -> bool {
+        false
+    }
+
+    fn complete_argument(
+        &self,
+        _query: String,
+        _cancel: Arc<AtomicBool>,
+        _workspace: Option<WeakView<Workspace>>,
+        _cx: &mut AppContext,
+    ) -> Task<Result<Vec<String>>> {
+        Task::ready(Ok(Vec::new()))
+    }
+
+    fn run(
+        self: Arc<Self>,
+        _argument: Option<&str>,
+        _workspace: WeakView<Workspace>,
+        _delegate: Arc<dyn LspAdapterDelegate>,
+        _cx: &mut WindowContext,
+    ) -> Task<Result<SlashCommandOutput>> {
+        let now = Local::now();
+        let text = format!("Today is {now}.", now = now.to_rfc3339());
+        let range = 0..text.len();
+
+        Task::ready(Ok(SlashCommandOutput {
+            text,
+            sections: vec![SlashCommandOutputSection {
+                range,
+                render_placeholder: Arc::new(move |id, unfold, _cx| {
+                    NowPlaceholder { id, unfold, now }.into_any_element()
+                }),
+            }],
+            run_commands_in_text: false,
+        }))
+    }
+}
+
+#[derive(IntoElement)]
+struct NowPlaceholder {
+    pub id: ElementId,
+    pub unfold: Arc<dyn Fn(&mut WindowContext)>,
+    pub now: DateTime<Local>,
+}
+
+impl RenderOnce for NowPlaceholder {
+    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
+        let unfold = self.unfold;
+
+        ButtonLike::new(self.id)
+            .style(ButtonStyle::Filled)
+            .layer(ElevationIndex::ElevatedSurface)
+            .child(Icon::new(IconName::CountdownTimer))
+            .child(Label::new(self.now.to_rfc3339()))
+            .on_click(move |_, cx| unfold(cx))
+    }
+}


### PR DESCRIPTION
This PR adds a `/now` command to the Assistant for indicating the current date and time to the model.

Release Notes:

- Added `/now` command to the Assistant for getting the current date and time.

