### PR TITLE
Show extension download counts with thousands separators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,6 +3833,7 @@ dependencies = [
  "fuzzy",
  "gpui",
  "language",
+ "num-format",
  "picker",
  "project",
  "release_channel",
@@ -6733,6 +6734,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,6 +307,7 @@ log = { version = "0.4.16", features = ["kv_unstable_serde"] }
 markup5ever_rcdom = "0.3.0"
 nanoid = "0.4"
 nix = "0.28"
+num-format = "0.4.4"
 once_cell = "1.19.0"
 ordered-float = "2.1.1"
 palette = { version = "0.7.5", default-features = false, features = ["std"] }

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -24,6 +24,7 @@ fs.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 language.workspace = true
+num-format.workspace = true
 picker.workspace = true
 project.workspace = true
 release_channel.workspace = true

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -16,6 +16,7 @@ use gpui::{
     InteractiveElement, KeyContext, ParentElement, Render, Styled, Task, TextStyle,
     UniformListScrollHandle, View, ViewContext, VisualContext, WeakView, WhiteSpace, WindowContext,
 };
+use num_format::{Locale, ToFormattedString};
 use release_channel::ReleaseChannel;
 use settings::Settings;
 use std::ops::DerefMut;
@@ -487,8 +488,11 @@ impl ExtensionsPage {
                         .size(LabelSize::Small),
                     )
                     .child(
-                        Label::new(format!("Downloads: {}", extension.download_count))
-                            .size(LabelSize::Small),
+                        Label::new(format!(
+                            "Downloads: {}",
+                            extension.download_count.to_formatted_string(&Locale::en)
+                        ))
+                        .size(LabelSize::Small),
                     ),
             )
             .child(


### PR DESCRIPTION
This PR adjusts the extension download counts to be displayed using thousands separators.

Release Notes:

- Adjusted extension download counts to display with thousands separators (e.g., `1,000,000`).
