### PR TITLE
Update windows doc to mention rust-lld linker error

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -89,4 +89,8 @@ Try `cargo clean` and `cargo build`.
 
 ### `STATUS_ACCESS_VIOLATION`
 
-This error can happen if you are using the "rust-lld.exe" linker. Consider trying a different linker. If you are using a global config. Consider putting zed in a nested directory and add a .cargo/config.toml with a custom linker config in the parent directory. See this issue for more information https://github.com/zed-industries/zed/issues/12041
+This error can happen if you are using the "rust-lld.exe" linker. Consider trying a different linker.
+
+If you are using a global config. Consider putting zed in a nested directory and add a `.cargo/config.toml` with a custom linker config in the parent directory.
+
+See this issue for more information https://github.com/zed-industries/zed/issues/12041

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -93,4 +93,4 @@ This error can happen if you are using the "rust-lld.exe" linker. Consider tryin
 
 If you are using a global config, consider moving the Zed repository to a nested directory and add a `.cargo/config.toml` with a custom linker config in the parent directory.
 
-See this issue for more information https://github.com/zed-industries/zed/issues/12041
+See this issue for more information [#12041](https://github.com/zed-industries/zed/issues/12041)

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -91,6 +91,6 @@ Try `cargo clean` and `cargo build`.
 
 This error can happen if you are using the "rust-lld.exe" linker. Consider trying a different linker.
 
-If you are using a global config. Consider putting zed in a nested directory and add a `.cargo/config.toml` with a custom linker config in the parent directory.
+If you are using a global config. Consider moving zed to a nested directory and add a `.cargo/config.toml` with a custom linker config in the parent directory.
 
 See this issue for more information https://github.com/zed-industries/zed/issues/12041

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -89,4 +89,4 @@ Try `cargo clean` and `cargo build`.
 
 ### `STATUS_ACCESS_VIOLATION`
 
-This error can happen if you are using the "rust-lld.exe" linker. Consider trying a different linker. See this issue for more information https://github.com/zed-industries/zed/issues/12041
+This error can happen if you are using the "rust-lld.exe" linker. Consider trying a different linker. If you are using a global config. Consider putting zed in a nested directory and add a .cargo/config.toml with a custom linker config in the parent directory. See this issue for more information https://github.com/zed-industries/zed/issues/12041

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -91,6 +91,6 @@ Try `cargo clean` and `cargo build`.
 
 This error can happen if you are using the "rust-lld.exe" linker. Consider trying a different linker.
 
-If you are using a global config. Consider moving zed to a nested directory and add a `.cargo/config.toml` with a custom linker config in the parent directory.
+If you are using a global config, consider moving the Zed repository to a nested directory and add a `.cargo/config.toml` with a custom linker config in the parent directory.
 
 See this issue for more information https://github.com/zed-industries/zed/issues/12041

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -86,3 +86,7 @@ Before reporting the issue, make sure that you have the latest rustc version wit
 ### Cargo errors claiming that a dependency is using unstable features
 
 Try `cargo clean` and `cargo build`.
+
+### `STATUS_ACCESS_VIOLATION`
+
+This error can happen if you are using the "rust-lld.exe" linker. Consider trying a different linker. See this issue for more information https://github.com/zed-industries/zed/issues/12041


### PR DESCRIPTION
Release Notes:

- N/A

## Description

When using rust-lld it's possible to get a `STATUS_ACCESS_VIOLATION` error at compile time. I added a bit of information about it in the build guide for windows to recommend using a different linker when building `zed`.
