### PR TITLE
Mute mic by default on channel join

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -166,8 +166,8 @@
   "show_whitespaces": "selection",
   // Settings related to calls in Zed
   "calls": {
-    // Join calls with the microphone live by default
-    "mute_on_join": false,
+    // Mute microphone when joining new calls
+    "mute_on_join": true,
     // Share your project when you are the first to join a channel
     "share_on_join": false
   },

--- a/crates/call/src/call_settings.rs
+++ b/crates/call/src/call_settings.rs
@@ -15,7 +15,7 @@ pub struct CallSettings {
 pub struct CallSettingsContent {
     /// Whether the microphone should be muted when joining a channel or a call.
     ///
-    /// Default: false
+    /// Default: true
     pub mute_on_join: Option<bool>,
 
     /// Whether your current project should be shared when joining an empty channel.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1565,8 +1565,8 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 
 ```json
 "calls": {
-  // Join calls with the microphone live by default
-  "mute_on_join": false,
+  // Mute microphone when joining new calls
+  "mute_on_join": true,
   // Share your project when you are the first to join a channel
   "share_on_join": false
 },


### PR DESCRIPTION
Release Notes:

- Mute mic by default when joining a collaboration channel.