### PR TITLE
Wait for composition to end before sending InputIgnored

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11708,7 +11708,6 @@ impl ViewInputHandler for Editor {
         cx: &mut ViewContext<Self>,
     ) {
         if !self.input_enabled {
-            cx.emit(EditorEvent::InputIgnored { text: text.into() });
             return;
         }
 


### PR DESCRIPTION
Release Notes:

- vim: Fixed `f`/`t` etc. for keys that require IME (#12522)
