### PR TITLE
Fix most vim tests on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,7 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "assets",
  "client",
  "clock",
  "collections",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -30,6 +30,7 @@ test-support = [
 [dependencies]
 aho-corasick = "1.1"
 anyhow.workspace = true
+assets.workspace = true
 client.workspace = true
 clock.workspace = true
 collections.workspace = true

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9,7 +9,9 @@ use crate::{
     JoinLines,
 };
 use futures::StreamExt;
-use gpui::{div, TestAppContext, UpdateGlobal, VisualTestContext, WindowBounds, WindowOptions};
+use gpui::{
+    div, AssetSource, TestAppContext, UpdateGlobal, VisualTestContext, WindowBounds, WindowOptions,
+};
 use indoc::indoc;
 use language::{
     language_settings::{
@@ -12184,6 +12186,12 @@ pub(crate) fn update_test_project_settings(
 
 pub(crate) fn init_test(cx: &mut TestAppContext, f: fn(&mut AllLanguageSettingsContent)) {
     _ = cx.update(|cx| {
+        cx.text_system()
+            .add_fonts(vec![assets::Assets
+                .load("fonts/zed-mono/zed-mono-extended.ttf")
+                .unwrap()
+                .unwrap()])
+            .unwrap();
         let store = SettingsStore::test(cx);
         cx.set_global(store);
         theme::init(theme::LoadThemes::JustBase, cx);

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use crate::{Editor, ToPoint};
 use collections::HashSet;
 use futures::Future;
-use gpui::{View, ViewContext, VisualTestContext};
+use gpui::{AssetSource, View, ViewContext, VisualTestContext};
 use indoc::indoc;
 use language::{
     point_to_lsp, FakeLspAdapter, Language, LanguageConfig, LanguageMatcher, LanguageQueries,
@@ -39,6 +39,12 @@ impl EditorLspTestContext {
         let app_state = cx.update(AppState::test);
 
         cx.update(|cx| {
+            cx.text_system()
+                .add_fonts(vec![assets::Assets
+                    .load("fonts/zed-mono/zed-mono-extended.ttf")
+                    .unwrap()
+                    .unwrap()])
+                .unwrap();
             language::init(cx);
             crate::init(cx);
             workspace::init(app_state.clone(), cx);


### PR DESCRIPTION
Fixes most vim tests on linux (and a few editor ones) by loading Zed Mono
instead of relying on the system fallback stack.

Release Notes:

- N/A
