### PR TITLE
linux/x11: Only create ModifiersChanged event if they changed

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -524,15 +524,20 @@ impl X11Client {
                     0,
                     event.locked_group.into(),
                 );
-                let modifiers = Modifiers::from_xkb(&state.xkb);
-                let focused_window_id = state.focused_window?;
-                state.modifiers = modifiers;
-                drop(state);
 
-                let focused_window = self.get_window(focused_window_id)?;
-                focused_window.handle_input(PlatformInput::ModifiersChanged(
-                    ModifiersChangedEvent { modifiers },
-                ));
+                let modifiers = Modifiers::from_xkb(&state.xkb);
+                if state.modifiers == modifiers {
+                    drop(state);
+                } else {
+                    let focused_window_id = state.focused_window?;
+                    state.modifiers = modifiers;
+                    drop(state);
+
+                    let focused_window = self.get_window(focused_window_id)?;
+                    focused_window.handle_input(PlatformInput::ModifiersChanged(
+                        ModifiersChangedEvent { modifiers },
+                    ));
+                }
             }
             Event::KeyPress(event) => {
                 let window = self.get_window(event.event)?;


### PR DESCRIPTION
I noticed that when I use my mouse wheel, we get a ton of the `XkbStateNotify` events, but the modifiers don't change, so we add a ton of useless input events for the window.

Release Notes:

- N/A
