### PR TITLE
Quiet excess output in tests 

### DIFF
--- a/crates/extension/src/extension_store_test.rs
+++ b/crates/extension/src/extension_store_test.rs
@@ -280,7 +280,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
 
         assert_eq!(
             language_registry.language_names(),
-            ["ERB", "Plain Text", "Ruby"]
+            ["ERB", "Markdown", "Plain Text", "Ruby"]
         );
         assert_eq!(
             theme_registry.list_names(false),
@@ -398,7 +398,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
         assert_eq!(store.extension_index, expected_index);
         assert_eq!(
             language_registry.language_names(),
-            ["ERB", "Plain Text", "Ruby"]
+            ["ERB", "Markdown", "Plain Text", "Ruby"]
         );
         assert_eq!(
             language_registry.grammar_names(),
@@ -433,7 +433,10 @@ async fn test_extension_store(cx: &mut TestAppContext) {
 
     store.read_with(cx, |store, _| {
         assert_eq!(store.extension_index, expected_index);
-        assert_eq!(language_registry.language_names(), ["Plain Text"]);
+        assert_eq!(
+            language_registry.language_names(),
+            ["Markdown", "Plain Text"]
+        );
         assert_eq!(language_registry.grammar_names(), []);
     });
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1736,6 +1736,7 @@ mod tests {
             languages.language_names(),
             &[
                 "JSON".to_string(),
+                "Markdown".to_string(),
                 "Plain Text".to_string(),
                 "Rust".to_string(),
             ]
@@ -1749,6 +1750,7 @@ mod tests {
             languages.language_names(),
             &[
                 "JSON".to_string(),
+                "Markdown".to_string(),
                 "Plain Text".to_string(),
                 "Rust".to_string(),
             ]
@@ -1762,6 +1764,7 @@ mod tests {
             languages.language_names(),
             &[
                 "JSON".to_string(),
+                "Markdown".to_string(),
                 "Plain Text".to_string(),
                 "Rust".to_string(),
             ]

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -180,6 +180,19 @@ impl LanguageRegistry {
     pub fn test(executor: BackgroundExecutor) -> Self {
         let mut this = Self::new(Task::ready(()), executor);
         this.language_server_download_dir = Some(Path::new("/the-download-dir").into());
+
+        this.add(Arc::new(crate::Language::new(
+            crate::LanguageConfig {
+                name: "Markdown".into(),
+                matcher: crate::LanguageMatcher {
+                    path_suffixes: vec!["md".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            None,
+        )));
+
         this
     }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -910,6 +910,8 @@ mod tests {
 
     #[gpui::test]
     async fn test_open_non_existing_file(cx: &mut TestAppContext) {
+        // TODO: This tests prints an error in the console:
+        // "failed to canonicalize root path: path does not exist: /root/a/new"
         let app_state = init_test(cx);
         app_state
             .fs
@@ -1697,6 +1699,8 @@ mod tests {
 
     #[gpui::test]
     async fn test_opening_excluded_paths(cx: &mut TestAppContext) {
+        // TODO: This outputs and error message (not failure) to the console:
+        // "failed to get git blame data: Failed to blame ".git/HEAD"
         let app_state = init_test(cx);
         cx.update(|cx| {
             cx.update_global::<SettingsStore, _>(|store, cx| {
@@ -1784,6 +1788,8 @@ mod tests {
                 .collect::<Vec<_>>()
         });
         opened_paths.sort();
+        // TODO: This test outputs a error (not failure) when run
+        // "failed to get git blame data: Failed to blame ".git/HEAD""
         assert_eq!(
             opened_paths,
             vec![


### PR DESCRIPTION
There were a bunch of errors being output to the console when running `cargo test`.

This fixes them or adds comments to the test which will cause errors.

Paired with @bennetbo 

<img width="1249" alt="image" src="https://github.com/zed-industries/zed/assets/145113/3b91aa8e-f138-4fcd-9695-b6de7581c48a">

Release Notes:

- N/A
