### PR TITLE
Hoist `indexmap` to workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,7 @@ heed = { version = "0.20.1", features = ["read-txn-no-tls"] }
 hex = "0.4.3"
 html5ever = "0.27.0"
 ignore = "0.4.22"
+indexmap = { version = "1.6.2", features = ["serde"] }
 indoc = "1"
 # We explicitly disable http2 support in isahc.
 isahc = { version = "1.7.2", default-features = false, features = [

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -24,7 +24,7 @@ derive_more.workspace = true
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
-indexmap = { version = "1.6.2", features = ["serde"] }
+indexmap.workspace = true
 palette = { workspace = true, default-features = false, features = ["std"] }
 parking_lot.workspace = true
 refineable.workspace = true

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 gpui.workspace = true
-indexmap = { version = "1.6.2", features = ["serde"] }
+indexmap.workspace = true
 log.workspace = true
 palette.workspace = true
 rust-embed.workspace = true


### PR DESCRIPTION
This PR hoists `indexmap` up to a workspace dependency.

Release Notes:

- N/A
