### PR TITLE
project_panel: Don't show file icon during rename when file icons are otherwise hidden

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1947,7 +1947,7 @@ impl ProjectPanel {
             entry_git_aware_label_color(details.git_status, details.is_ignored, is_marked);
         let file_name = details.filename.clone();
         let mut icon = details.icon.clone();
-        if show_editor && details.kind.is_file() {
+        if settings.file_icons && show_editor && details.kind.is_file() {
             let filename = self.filename_editor.read(cx).text(cx);
             if filename.len() > 2 {
                 icon = FileIcons::get_icon(Path::new(&filename), cx);


### PR DESCRIPTION
This PR fixes an instance where the file icon for a project panel entry would be shown during a rename even when the `project_panel.file_icons` setting was set to `false`.

Resolves #12905.

Release Notes:

- Fixed an issue where file icons were displayed in the project panel during a rename even when `project_panel.file_icons` was set to `false` ([#12905](https://github.com/zed-industries/zed/issues/12905)).
