### PR TITLE
Fix cursors on some GNOME installations

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/cursor.rs
+++ b/crates/gpui/src/platform/linux/wayland/cursor.rs
@@ -8,6 +8,7 @@ use wayland_cursor::{CursorImageBuffer, CursorTheme};
 
 pub(crate) struct Cursor {
     theme: Option<CursorTheme>,
+    theme_name: Option<String>,
     surface: WlSurface,
     size: u32,
     shm: WlShm,
@@ -25,6 +26,7 @@ impl Cursor {
     pub fn new(connection: &Connection, globals: &Globals, size: u32) -> Self {
         Self {
             theme: CursorTheme::load(&connection, globals.shm.clone(), size).log_err(),
+            theme_name: None,
             surface: globals.compositor.create_surface(&globals.qh, ()),
             shm: globals.shm.clone(),
             connection: connection.clone(),
@@ -32,13 +34,39 @@ impl Cursor {
         }
     }
 
-    pub fn set_theme(&mut self, theme: &str) {
-        self.theme =
-            CursorTheme::load_from_name(&self.connection, self.shm.clone(), theme, self.size)
+    pub fn set_theme(&mut self, theme_name: &str, size: Option<u32>) {
+        if let Some(size) = size {
+            self.size = size;
+        }
+        if let Some(theme) =
+            CursorTheme::load_from_name(&self.connection, self.shm.clone(), theme_name, self.size)
                 .log_err()
-                .or_else(|| {
-                    CursorTheme::load(&self.connection, self.shm.clone(), self.size).log_err()
-                });
+        {
+            self.theme = Some(theme);
+            self.theme_name = Some(theme_name.to_string());
+        } else if let Some(theme) =
+            CursorTheme::load(&self.connection, self.shm.clone(), self.size).log_err()
+        {
+            self.theme = Some(theme);
+            self.theme_name = None;
+        }
+    }
+
+    pub fn set_size(&mut self, size: u32) {
+        self.size = size;
+        self.theme = self
+            .theme_name
+            .as_ref()
+            .and_then(|name| {
+                CursorTheme::load_from_name(
+                    &self.connection,
+                    self.shm.clone(),
+                    name.as_str(),
+                    self.size,
+                )
+                .log_err()
+            })
+            .or_else(|| CursorTheme::load(&self.connection, self.shm.clone(), self.size).log_err());
     }
 
     pub fn set_icon(&mut self, wl_pointer: &WlPointer, serial_id: u32, mut cursor_icon_name: &str) {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -359,8 +359,8 @@ impl X11Client {
                             window.window.set_appearance(appearance);
                         }
                     }
-                    XDPEvent::CursorTheme(_theme) => {
-                        // TODO: Implement GNOME cursor theme switching_
+                    XDPEvent::CursorTheme(_) | XDPEvent::CursorSize(_) => {
+                        // noop, X11 manages this for us.
                     }
                 }
             })

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -359,6 +359,9 @@ impl X11Client {
                             window.window.set_appearance(appearance);
                         }
                     }
+                    XDPEvent::CursorTheme(_theme) => {
+                        // TODO: Implement GNOME cursor theme switching_
+                    }
                 }
             })
             .unwrap();


### PR DESCRIPTION
This PR adds support for `org.gnome.desktop.interface`'s `cursor-theme` setting on Wayland. This should fix cursors not showing up on some GNOME installs. This PR also adds the wiring to watch the current cursor theme value. 

Thanks to @apricotbucket28 for helping debug the issue.

Release Notes:

- N/A