### PR TITLE
Added TSX test runnables

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -141,7 +141,8 @@ pub fn init(
         vec![
             Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone())),
             Arc::new(vtsls::VtslsLspAdapter::new(node_runtime.clone()))
-        ]
+        ],
+        typescript_task_context()
     );
     language!(
         "typescript",

--- a/crates/languages/src/tsx/runnables.scm
+++ b/crates/languages/src/tsx/runnables.scm
@@ -1,0 +1,14 @@
+; Add support for (node:test, bun:test and Jest) runnable
+; Function expression that has `it`, `test` or `describe` as the function name
+(
+    (call_expression
+        function: (_) @_name
+        (#any-of? @_name "it" "test" "describe")
+        arguments: (
+            arguments . (string
+                (string_fragment) @run
+            )
+        )
+    ) @tsx-test
+    (#set! tag tsx-test)
+)

--- a/crates/languages/src/tsx/runnables.scm
+++ b/crates/languages/src/tsx/runnables.scm
@@ -9,6 +9,6 @@
                 (string_fragment) @run
             )
         )
-    ) @tsx-test
+    ) @_tsx-test
     (#set! tag tsx-test)
 )

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -37,7 +37,7 @@ pub(super) fn typescript_task_context() -> ContextProviderWithTasks {
                 VariableName::Symbol.template_value(),
                 VariableName::File.template_value(),
             ],
-            tags: vec!["ts-test".into(), "js-test".into()],
+            tags: vec!["ts-test".into(), "js-test".into(), "tsx-test".into()],
             ..TaskTemplate::default()
         },
         TaskTemplate {


### PR DESCRIPTION
Fix #12884

Release Notes:

- Added runnable tests for TSX files.

---
Runnable tests can be customized via `tsx-test` tag