### PR TITLE
Wrap JS/TS runnables in quotes

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -34,7 +34,8 @@ pub(super) fn typescript_task_context() -> ContextProviderWithTasks {
             label: "jest test $ZED_SYMBOL".to_owned(),
             command: "npx jest".to_owned(),
             args: vec![
-                VariableName::Symbol.template_value(),
+                "--testNamePattern".into(),
+                format!("\"{}\"", VariableName::Symbol.template_value()),
                 VariableName::File.template_value(),
             ],
             tags: vec!["ts-test".into(), "js-test".into(), "tsx-test".into()],
@@ -43,7 +44,10 @@ pub(super) fn typescript_task_context() -> ContextProviderWithTasks {
         TaskTemplate {
             label: "execute selection $ZED_SELECTED_TEXT".to_owned(),
             command: "node".to_owned(),
-            args: vec!["-e".into(), VariableName::SelectedText.template_value()],
+            args: vec![
+                "-e".into(),
+                format!("\"{}\"", VariableName::SelectedText.template_value()),
+            ],
             ..TaskTemplate::default()
         },
     ]))


### PR DESCRIPTION
Some of the runnables added in #12118 don't work for tests (or code) that contain spaces. In other words, the runnable for a test like
```js
it('does the thing', () => ...)
```
would end up w/ something like `npx jest does the thing /path/to/file.spec.js`, but what we really want is `npx jest --testNamePattern "does the thing" /path/to/file.spec.js`. A similar thing was happening for the "node execute selection" runnable: selecting `let foo = 1` would run `node -e let foo = 1`, not `node -e "let foo = 1"`.

In my (somewhat limited?) experience, it's very common for tests like these to include spaces, and of course a code selection is almost certain to contain whitespace.

Not covered: 
- this just blindly wraps quotes around the symbol/code; in the future it may make sense to try to figure out *what type of quote* to use. (eg `it('does the "thing"', () => ...)` is a valid test name, but `--testNamePattern "does the "thing""` would not work. Note the doubled quotes.)
- I did not wrap the filenames in quotes to escape those for the shell, nor did I test if that's actually an issue. In my experience, I've not seen many (any?) test files that contain spaces in the name, but I suspect that it would be an issue if a containing dir includes spaces. (eg `npx jest ... /path/to/My Documents/Code/file.spec.js`

/cc @RemcoSmitsDev 

Release Notes:

- Fixed some runnables in Javascript/Typescript
