### PR TITLE
Add missing LICENSE file to `ollama` crate

### DIFF
--- a/crates/ollama/Cargo.toml
+++ b/crates/ollama/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/ollama.rs"
 

--- a/crates/ollama/LICENSE-GPL
+++ b/crates/ollama/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL


### PR DESCRIPTION
This PR adds a missing LICENSE file to the recently-added `ollama` crate.

Also added the missing `lints.workspace = true` to the `Cargo.toml`.

Release Notes:

- N/A
