### PR TITLE
Reveal the selected item when cycling a picker's selection

### DIFF
--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -37,6 +37,7 @@ editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
+picker = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -98,6 +98,13 @@ impl UniformListScrollHandle {
     pub fn scroll_to_item(&mut self, ix: usize) {
         self.deferred_scroll_to_item.replace(Some(ix));
     }
+
+    /// Get the index of the topmost visible child.
+    pub fn logical_scroll_top_index(&self) -> usize {
+        self.deferred_scroll_to_item
+            .borrow()
+            .unwrap_or_else(|| self.base_handle.logical_scroll_top().0)
+    }
 }
 
 impl Styled for UniformList {

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -12,6 +12,9 @@ workspace = true
 path = "src/picker.rs"
 doctest = false
 
+[features]
+test-support = []
+
 [dependencies]
 anyhow.workspace = true
 editor.workspace = true

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -310,7 +310,7 @@ impl<D: PickerDelegate> Picker<D> {
         let count = self.delegate.match_count();
         let index = self.delegate.selected_index();
         let new_index = if index + 1 == count { 0 } else { index + 1 };
-        self.set_selected_index(new_index, false, cx);
+        self.set_selected_index(new_index, true, cx);
         cx.notify();
     }
 
@@ -536,6 +536,16 @@ impl<D: PickerDelegate> Picker<D> {
                 .flex_grow()
                 .py_2()
                 .into_any_element(),
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn logical_scroll_top_index(&self) -> usize {
+        match &self.element_container {
+            ElementContainer::List(state) => state.logical_scroll_top().item_ix,
+            ElementContainer::UniformList(scroll_handle) => {
+                scroll_handle.logical_scroll_top_index()
+            }
         }
     }
 }


### PR DESCRIPTION
Release Notes:

- Fixed a bug where the selected tab was not always shown when cycling between tabs with `ctrl-tab`.