### PR TITLE
Fix headless mode

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -500,6 +500,7 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
         let app_state = app_state.clone();
         cx.spawn(move |cx| handle_cli_connection(connection, app_state, cx))
             .detach();
+        return;
     }
 
     if let Err(e) = init_ui(app_state.clone(), cx) {

--- a/script/install.sh
+++ b/script/install.sh
@@ -47,7 +47,7 @@ main() {
 }
 
 linux() {
-    if [[ -n "${ZED_BUNDLE_PATH:-}" ]]; then
+    if [ -n "${ZED_BUNDLE_PATH:-}" ]; then
         cp "$ZED_BUNDLE_PATH" "$temp/zed-linux-$arch.tar.gz"
     else
         echo "Downloading Zed"


### PR DESCRIPTION
This was broken by two things:
1. A merge conflict in the install.sh script leading to bad sh syntax
2. A return removed by accident when we refactored main

Release Notes:

- N/A
