### PR TITLE
Add libstdc++-12-dev for linux

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -20,6 +20,7 @@ if [[ -n $apt ]]; then
     libwayland-dev
     libxkbcommon-x11-dev
     libssl-dev
+    libstdc++-12-dev
     libzstd-dev
     libvulkan1
     libgit2-dev


### PR DESCRIPTION
Release Notes:

- N/A

PS: :wave: Congrats on the release :confetti_ball:  and hey from discussing CRDTs at the [GitPod/DevX conference last year](https://www.youtube.com/watch?v=wXT73bBr83s)! Just read the [blog post](https://zed.dev/blog/zed-decoded-linux-when) and thought I'd finally try zed out (I have a linux laptop). This was the only snag I ran into :clap: 
