### PR TITLE
Add missing Linux build dependencies

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -63,7 +63,7 @@ if [[ -n $dnf ]]; then
   exit 0
 fi
 
-# openSUSE Tumbleweed
+# openSUSE
 # https://software.opensuse.org/
 zyp=$(command -v zypper || true)
 if [[ -n $zyp ]]; then

--- a/script/linux
+++ b/script/linux
@@ -63,11 +63,15 @@ if [[ -n $dnf ]]; then
   exit 0
 fi
 
-# openSUSE
+# openSUSE Tumbleweed
 # https://software.opensuse.org/
 zyp=$(command -v zypper || true)
 if [[ -n $zyp ]]; then
   deps=(
+    gcc
+    gcc-c++
+    clang
+    make
     alsa-devel
     fontconfig-devel
     wayland-devel
@@ -86,6 +90,8 @@ fi
 pacman=$(command -v pacman || true)
 if [[ -n $pacman ]]; then
   deps=(
+    gcc
+    clang
     alsa-lib
     fontconfig
     wayland


### PR DESCRIPTION
I found that builds failed on Arch and OpenSUSE so I added missing dependencies. I also found that OpenSUSE Leap is currently not able to install the required dependencies so I added a check to limit the supported distros to Tumbleweed.

Release Notes:

- N/A
