### PR TITLE
chore: Bump Rust version to 1.79

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 
-FROM rust:1.78-bookworm as builder
+FROM rust:1.79-bookworm as builder
 WORKDIR app
 COPY . .
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.78"
+channel = "1.79"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi" ]


### PR DESCRIPTION
This is blocked on a release of new Docker image for 1.79 (https://github.com/docker-library/official-images/pull/16981)

Release Notes:

- N/A
