### PR TITLE
Don't hide inline assist when editor loses focus

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -32,7 +32,7 @@ use gpui::{
     ClipboardItem, Context as _, Empty, EventEmitter, FocusHandle, FocusableView,
     InteractiveElement, IntoElement, Model, ModelContext, ParentElement, Pixels, Render,
     SharedString, StatefulInteractiveElement, Styled, Subscription, Task, UpdateGlobal, View,
-    ViewContext, VisualContext, WeakView, WindowContext,
+    ViewContext, VisualContext, WeakFocusHandle, WeakView, WindowContext,
 };
 use language::{
     language_settings::SoftWrap, AnchorRangeExt, AutoindentMode, Buffer, LanguageRegistry,
@@ -296,7 +296,7 @@ impl AssistantPanel {
         }
     }
 
-    fn focus_out(&mut self, cx: &mut ViewContext<Self>) {
+    fn focus_out(&mut self, _blurred: WeakFocusHandle, cx: &mut ViewContext<Self>) {
         self.toolbar
             .update(cx, |toolbar, cx| toolbar.focus_changed(false, cx));
         cx.notify();

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -29,10 +29,10 @@ use futures::future::Shared;
 use futures::{FutureExt, StreamExt};
 use gpui::{
     div, point, rems, Action, AnyElement, AnyView, AppContext, AsyncAppContext, AsyncWindowContext,
-    ClipboardItem, Context as _, Empty, EventEmitter, FocusHandle, FocusableView,
+    ClipboardItem, Context as _, Empty, EventEmitter, FocusHandle, FocusOutEvent, FocusableView,
     InteractiveElement, IntoElement, Model, ModelContext, ParentElement, Pixels, Render,
     SharedString, StatefulInteractiveElement, Styled, Subscription, Task, UpdateGlobal, View,
-    ViewContext, VisualContext, WeakFocusHandle, WeakView, WindowContext,
+    ViewContext, VisualContext, WeakView, WindowContext,
 };
 use language::{
     language_settings::SoftWrap, AnchorRangeExt, AutoindentMode, Buffer, LanguageRegistry,
@@ -296,7 +296,7 @@ impl AssistantPanel {
         }
     }
 
-    fn focus_out(&mut self, _blurred: WeakFocusHandle, cx: &mut ViewContext<Self>) {
+    fn focus_out(&mut self, _event: FocusOutEvent, cx: &mut ViewContext<Self>) {
         self.toolbar
             .update(cx, |toolbar, cx| toolbar.focus_changed(false, cx));
         cx.notify();

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -345,10 +345,8 @@ impl InlineAssistant {
 
         match event {
             EditorEvent::SelectionsChanged { local } if *local => {
-                if let Some(decorations) = assist.editor_decorations.as_ref() {
-                    if let CodegenStatus::Idle = &assist.codegen.read(cx).status {
-                        self.finish_inline_assist(assist_id, true, cx);
-                    }
+                if let CodegenStatus::Idle = &assist.codegen.read(cx).status {
+                    self.finish_inline_assist(assist_id, true, cx);
                 }
             }
             EditorEvent::Saved => {

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -277,19 +277,19 @@ impl InlineAssistant {
     ) {
         let assist_id = inline_assist_editor.read(cx).id;
         match event {
-            InlineAssistEditorEvent::Started => {
+            InlineAssistEditorEvent::StartRequested => {
                 self.start_inline_assist(assist_id, cx);
             }
-            InlineAssistEditorEvent::Stopped => {
+            InlineAssistEditorEvent::StopRequested => {
                 self.stop_inline_assist(assist_id, cx);
             }
-            InlineAssistEditorEvent::Confirmed => {
+            InlineAssistEditorEvent::ConfirmRequested => {
                 self.finish_inline_assist(assist_id, false, cx);
             }
-            InlineAssistEditorEvent::Canceled => {
+            InlineAssistEditorEvent::CancelRequested => {
                 self.finish_inline_assist(assist_id, true, cx);
             }
-            InlineAssistEditorEvent::Dismissed => {
+            InlineAssistEditorEvent::DismissRequested => {
                 self.dismiss_inline_assist(assist_id, cx);
             }
             InlineAssistEditorEvent::Resized { height_in_lines } => {
@@ -809,11 +809,11 @@ impl InlineAssistId {
 }
 
 enum InlineAssistEditorEvent {
-    Started,
-    Stopped,
-    Confirmed,
-    Canceled,
-    Dismissed,
+    StartRequested,
+    StopRequested,
+    ConfirmRequested,
+    CancelRequested,
+    DismissRequested,
     Resized { height_in_lines: u8 },
 }
 
@@ -846,15 +846,17 @@ impl Render for InlineAssistEditor {
                         .icon_size(IconSize::XSmall)
                         .tooltip(|cx| Tooltip::for_action("Transform", &menu::Confirm, cx))
                         .on_click(
-                            cx.listener(|_, _, cx| cx.emit(InlineAssistEditorEvent::Started)),
+                            cx.listener(|_, _, cx| {
+                                cx.emit(InlineAssistEditorEvent::StartRequested)
+                            }),
                         ),
                     IconButton::new("cancel", IconName::Close)
                         .icon_color(Color::Muted)
                         .size(ButtonSize::None)
                         .tooltip(|cx| Tooltip::for_action("Cancel Assist", &menu::Cancel, cx))
-                        .on_click(
-                            cx.listener(|_, _, cx| cx.emit(InlineAssistEditorEvent::Canceled)),
-                        ),
+                        .on_click(cx.listener(|_, _, cx| {
+                            cx.emit(InlineAssistEditorEvent::CancelRequested)
+                        })),
                 ]
             }
             CodegenStatus::Pending => {
@@ -872,15 +874,15 @@ impl Render for InlineAssistEditor {
                             )
                         })
                         .on_click(
-                            cx.listener(|_, _, cx| cx.emit(InlineAssistEditorEvent::Stopped)),
+                            cx.listener(|_, _, cx| cx.emit(InlineAssistEditorEvent::StopRequested)),
                         ),
                     IconButton::new("cancel", IconName::Close)
                         .icon_color(Color::Muted)
                         .size(ButtonSize::None)
                         .tooltip(|cx| Tooltip::text("Cancel Assist", cx))
-                        .on_click(
-                            cx.listener(|_, _, cx| cx.emit(InlineAssistEditorEvent::Canceled)),
-                        ),
+                        .on_click(cx.listener(|_, _, cx| {
+                            cx.emit(InlineAssistEditorEvent::CancelRequested)
+                        })),
                 ]
             }
             CodegenStatus::Error(_) | CodegenStatus::Done => {
@@ -899,7 +901,7 @@ impl Render for InlineAssistEditor {
                                 )
                             })
                             .on_click(cx.listener(|_, _, cx| {
-                                cx.emit(InlineAssistEditorEvent::Started);
+                                cx.emit(InlineAssistEditorEvent::StartRequested);
                             }))
                     } else {
                         IconButton::new("confirm", IconName::Check)
@@ -907,16 +909,16 @@ impl Render for InlineAssistEditor {
                             .size(ButtonSize::None)
                             .tooltip(|cx| Tooltip::for_action("Confirm Assist", &menu::Confirm, cx))
                             .on_click(cx.listener(|_, _, cx| {
-                                cx.emit(InlineAssistEditorEvent::Confirmed);
+                                cx.emit(InlineAssistEditorEvent::ConfirmRequested);
                             }))
                     },
                     IconButton::new("cancel", IconName::Close)
                         .icon_color(Color::Muted)
                         .size(ButtonSize::None)
                         .tooltip(|cx| Tooltip::for_action("Cancel Assist", &menu::Cancel, cx))
-                        .on_click(
-                            cx.listener(|_, _, cx| cx.emit(InlineAssistEditorEvent::Canceled)),
-                        ),
+                        .on_click(cx.listener(|_, _, cx| {
+                            cx.emit(InlineAssistEditorEvent::CancelRequested)
+                        })),
                 ]
             }
         };
@@ -1121,10 +1123,10 @@ impl InlineAssistEditor {
     fn cancel(&mut self, _: &editor::actions::Cancel, cx: &mut ViewContext<Self>) {
         match &self.codegen.read(cx).status {
             CodegenStatus::Idle | CodegenStatus::Done | CodegenStatus::Error(_) => {
-                cx.emit(InlineAssistEditorEvent::Canceled);
+                cx.emit(InlineAssistEditorEvent::CancelRequested);
             }
             CodegenStatus::Pending => {
-                cx.emit(InlineAssistEditorEvent::Stopped);
+                cx.emit(InlineAssistEditorEvent::StopRequested);
             }
         }
     }
@@ -1132,16 +1134,16 @@ impl InlineAssistEditor {
     fn confirm(&mut self, _: &menu::Confirm, cx: &mut ViewContext<Self>) {
         match &self.codegen.read(cx).status {
             CodegenStatus::Idle => {
-                cx.emit(InlineAssistEditorEvent::Started);
+                cx.emit(InlineAssistEditorEvent::StartRequested);
             }
             CodegenStatus::Pending => {
-                cx.emit(InlineAssistEditorEvent::Dismissed);
+                cx.emit(InlineAssistEditorEvent::DismissRequested);
             }
             CodegenStatus::Done | CodegenStatus::Error(_) => {
                 if self.edited_since_done {
-                    cx.emit(InlineAssistEditorEvent::Started);
+                    cx.emit(InlineAssistEditorEvent::StartRequested);
                 } else {
-                    cx.emit(InlineAssistEditorEvent::Confirmed);
+                    cx.emit(InlineAssistEditorEvent::ConfirmRequested);
                 }
             }
         }

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -150,7 +150,7 @@ impl ProjectDiagnosticsEditor {
         let focus_handle = cx.focus_handle();
         cx.on_focus_in(&focus_handle, |this, cx| this.focus_in(cx))
             .detach();
-        cx.on_focus_out(&focus_handle, |this, _blurred, cx| this.focus_out(cx))
+        cx.on_focus_out(&focus_handle, |this, _event, cx| this.focus_out(cx))
             .detach();
 
         let excerpts = cx.new_model(|cx| {

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -150,7 +150,7 @@ impl ProjectDiagnosticsEditor {
         let focus_handle = cx.focus_handle();
         cx.on_focus_in(&focus_handle, |this, cx| this.focus_in(cx))
             .detach();
-        cx.on_focus_out(&focus_handle, |this, cx| this.focus_out(cx))
+        cx.on_focus_out(&focus_handle, |this, _blurred, cx| this.focus_out(cx))
             .detach();
 
         let excerpts = cx.new_model(|cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -66,12 +66,12 @@ use git::diff_hunk_to_display;
 use gpui::{
     div, impl_actions, point, prelude::*, px, relative, size, uniform_list, Action, AnyElement,
     AppContext, AsyncWindowContext, AvailableSpace, BackgroundExecutor, Bounds, ClipboardItem,
-    Context, DispatchPhase, ElementId, EventEmitter, FocusHandle, FocusableView, FontId, FontStyle,
-    FontWeight, HighlightStyle, Hsla, InteractiveText, KeyContext, ListSizingBehavior, Model,
-    MouseButton, PaintQuad, ParentElement, Pixels, Render, SharedString, Size, StrikethroughStyle,
-    Styled, StyledText, Subscription, Task, TextStyle, UnderlineStyle, UniformListScrollHandle,
-    View, ViewContext, ViewInputHandler, VisualContext, WeakFocusHandle, WeakView, WhiteSpace,
-    WindowContext,
+    Context, DispatchPhase, ElementId, EventEmitter, FocusHandle, FocusOutEvent, FocusableView,
+    FontId, FontStyle, FontWeight, HighlightStyle, Hsla, InteractiveText, KeyContext,
+    ListSizingBehavior, Model, MouseButton, PaintQuad, ParentElement, Pixels, Render, SharedString,
+    Size, StrikethroughStyle, Styled, StyledText, Subscription, Task, TextStyle, UnderlineStyle,
+    UniformListScrollHandle, View, ViewContext, ViewInputHandler, VisualContext, WeakFocusHandle,
+    WeakView, WhiteSpace, WindowContext,
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HoverState};
@@ -11332,8 +11332,8 @@ impl Editor {
         }
     }
 
-    fn handle_focus_out(&mut self, blurred: WeakFocusHandle, _cx: &mut ViewContext<Self>) {
-        self.last_focused = Some(blurred);
+    fn handle_focus_out(&mut self, event: FocusOutEvent, _cx: &mut ViewContext<Self>) {
+        self.last_focused = Some(event.blurred);
     }
 
     pub fn handle_blur(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11305,19 +11305,6 @@ impl Editor {
     fn handle_focus(&mut self, cx: &mut ViewContext<Self>) {
         cx.emit(EditorEvent::Focused);
 
-        let path = self
-            .buffer
-            .read(cx)
-            .read(cx)
-            .file_at(0)
-            .map_or("untitled".to_string(), |file| {
-                file.path().to_string_lossy().to_string()
-            });
-        println!(
-            "{:?}: handle_focus, last_focused = {:?}",
-            path,
-            self.last_focused.as_ref()
-        );
         if let Some(last_focused) = self
             .last_focused
             .as_ref()
@@ -11347,19 +11334,6 @@ impl Editor {
 
     fn handle_descendant_focus(&mut self, cx: &mut ViewContext<Self>) {
         self.last_focused = cx.focused().map(|focused| focused.downgrade());
-        let path = self
-            .buffer
-            .read(cx)
-            .read(cx)
-            .file_at(0)
-            .map_or("untitled".to_string(), |file| {
-                file.path().to_string_lossy().to_string()
-            });
-        println!(
-            "{:?}: handle_descendant_focus, setting last_focused to {:?}",
-            path,
-            self.last_focused.as_ref()
-        );
     }
 
     pub fn handle_blur(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11305,6 +11305,19 @@ impl Editor {
     fn handle_focus(&mut self, cx: &mut ViewContext<Self>) {
         cx.emit(EditorEvent::Focused);
 
+        let path = self
+            .buffer
+            .read(cx)
+            .read(cx)
+            .file_at(0)
+            .map_or("untitled".to_string(), |file| {
+                file.path().to_string_lossy().to_string()
+            });
+        println!(
+            "{:?}: handle_focus, last_focused = {:?}",
+            path,
+            self.last_focused.as_ref()
+        );
         if let Some(last_focused) = self
             .last_focused
             .as_ref()
@@ -11334,6 +11347,19 @@ impl Editor {
 
     fn handle_descendant_focus(&mut self, cx: &mut ViewContext<Self>) {
         self.last_focused = cx.focused().map(|focused| focused.downgrade());
+        let path = self
+            .buffer
+            .read(cx)
+            .read(cx)
+            .file_at(0)
+            .map_or("untitled".to_string(), |file| {
+                file.path().to_string_lossy().to_string()
+            });
+        println!(
+            "{:?}: handle_descendant_focus, setting last_focused to {:?}",
+            path,
+            self.last_focused.as_ref()
+        );
     }
 
     pub fn handle_blur(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -449,7 +449,7 @@ struct BufferOffset(usize);
 /// See the [module level documentation](self) for more information.
 pub struct Editor {
     focus_handle: FocusHandle,
-    last_focused: Option<WeakFocusHandle>,
+    last_focused_descendant: Option<WeakFocusHandle>,
     /// The text buffer being edited
     buffer: Model<MultiBuffer>,
     /// Map of how text in the buffer should be displayed.
@@ -1749,7 +1749,7 @@ impl Editor {
 
         let mut this = Self {
             focus_handle,
-            last_focused: None,
+            last_focused_descendant: None,
             buffer: buffer.clone(),
             display_map: display_map.clone(),
             selections,
@@ -11306,8 +11306,8 @@ impl Editor {
         cx.emit(EditorEvent::Focused);
 
         if let Some(last_focused) = self
-            .last_focused
-            .as_ref()
+            .last_focused_descendant
+            .take()
             .and_then(|last_focused| last_focused.upgrade())
         {
             cx.focus(&last_focused);
@@ -11333,7 +11333,7 @@ impl Editor {
     }
 
     fn handle_descendant_focus(&mut self, cx: &mut ViewContext<Self>) {
-        self.last_focused = cx.focused().map(|focused| focused.downgrade());
+        self.last_focused_descendant = cx.focused().map(|focused| focused.downgrade());
     }
 
     pub fn handle_blur(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4196,7 +4196,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
             });
     }
 
-    /// Emit an event to be handled any other views that have subscribed via [ViewContext::subscribe].
+    /// Emit an event to be handled by any other views that have subscribed via [ViewContext::subscribe].
     pub fn emit<Evt>(&mut self, event: Evt)
     where
         Evt: 'static,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1389,6 +1389,9 @@ impl<'a> WindowContext<'a> {
         self.window.next_frame.clear();
         let current_focus_path = self.window.rendered_frame.focus_path();
         let current_window_active = self.window.rendered_frame.window_active;
+        if current_focus_path != previous_focus_path {
+            dbg!(&current_focus_path);
+        }
 
         if previous_focus_path != current_focus_path
             || previous_window_active != current_window_active

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1389,9 +1389,6 @@ impl<'a> WindowContext<'a> {
         self.window.next_frame.clear();
         let current_focus_path = self.window.rendered_frame.focus_path();
         let current_window_active = self.window.rendered_frame.window_active;
-        if current_focus_path != previous_focus_path {
-            dbg!(&current_focus_path);
-        }
 
         if previous_focus_path != current_focus_path
             || previous_window_active != current_window_active

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4082,32 +4082,6 @@ impl<'a, V: 'static> ViewContext<'a, V> {
         subscription
     }
 
-    /// Register a listener to be called when a descendant of the given focus handle gains focus.
-    /// Returns a subscription and persists until the subscription is dropped.
-    pub fn on_descendant_focus(
-        &mut self,
-        handle: &FocusHandle,
-        mut listener: impl FnMut(&mut V, &mut ViewContext<V>) + 'static,
-    ) -> Subscription {
-        let view = self.view.downgrade();
-        let focus_id = handle.id;
-        let (subscription, activate) =
-            self.window.new_focus_listener(Box::new(move |event, cx| {
-                view.update(cx, |view, cx| {
-                    let last_current = event.current_focus_path.last();
-                    if event.current_focus_path.contains(&focus_id)
-                        && last_current != Some(&focus_id)
-                        && last_current != event.previous_focus_path.last()
-                    {
-                        listener(view, cx)
-                    }
-                })
-                .is_ok()
-            }));
-        self.app.defer(move |_| activate());
-        subscription
-    }
-
     /// Register a listener to be called when the given focus handle loses focus.
     /// Returns a subscription and persists until the subscription is dropped.
     pub fn on_blur(

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -152,7 +152,7 @@ impl TerminalView {
         let focus_in = cx.on_focus_in(&focus_handle, |terminal_view, cx| {
             terminal_view.focus_in(cx);
         });
-        let focus_out = cx.on_focus_out(&focus_handle, |terminal_view, _blurred, cx| {
+        let focus_out = cx.on_focus_out(&focus_handle, |terminal_view, _event, cx| {
             terminal_view.focus_out(cx);
         });
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -152,7 +152,7 @@ impl TerminalView {
         let focus_in = cx.on_focus_in(&focus_handle, |terminal_view, cx| {
             terminal_view.focus_in(cx);
         });
-        let focus_out = cx.on_focus_out(&focus_handle, |terminal_view, cx| {
+        let focus_out = cx.on_focus_out(&focus_handle, |terminal_view, _blurred, cx| {
             terminal_view.focus_out(cx);
         });
 

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -87,7 +87,7 @@ impl ModalLayer {
                 cx.subscribe(&new_modal, |this, _, _: &DismissEvent, cx| {
                     this.hide_modal(cx);
                 }),
-                cx.on_focus_out(&focus_handle, |this, cx| {
+                cx.on_focus_out(&focus_handle, |this, _blurred, cx| {
                     if this.dismiss_on_focus_lost {
                         this.hide_modal(cx);
                     }

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -87,7 +87,7 @@ impl ModalLayer {
                 cx.subscribe(&new_modal, |this, _, _: &DismissEvent, cx| {
                     this.hide_modal(cx);
                 }),
-                cx.on_focus_out(&focus_handle, |this, _blurred, cx| {
+                cx.on_focus_out(&focus_handle, |this, _event, cx| {
                     if this.dismiss_on_focus_lost {
                         this.hide_modal(cx);
                     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -14,9 +14,10 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use gpui::{
     actions, anchored, deferred, impl_actions, prelude::*, Action, AnchorCorner, AnyElement,
     AppContext, AsyncWindowContext, ClickEvent, DismissEvent, Div, DragMoveEvent, EntityId,
-    EventEmitter, ExternalPaths, FocusHandle, FocusableView, KeyContext, Model, MouseButton,
-    MouseDownEvent, NavigationDirection, Pixels, Point, PromptLevel, Render, ScrollHandle,
-    Subscription, Task, View, ViewContext, VisualContext, WeakFocusHandle, WeakView, WindowContext,
+    EventEmitter, ExternalPaths, FocusHandle, FocusOutEvent, FocusableView, KeyContext, Model,
+    MouseButton, MouseDownEvent, NavigationDirection, Pixels, Point, PromptLevel, Render,
+    ScrollHandle, Subscription, Task, View, ViewContext, VisualContext, WeakFocusHandle, WeakView,
+    WindowContext,
 };
 use itertools::Itertools;
 use parking_lot::Mutex;
@@ -517,7 +518,7 @@ impl Pane {
             .map_or(false, |menu| menu.focus_handle(cx).is_focused(cx))
     }
 
-    fn focus_out(&mut self, _blurred: WeakFocusHandle, cx: &mut ViewContext<Self>) {
+    fn focus_out(&mut self, _event: FocusOutEvent, cx: &mut ViewContext<Self>) {
         self.was_focused = false;
         self.toolbar.update(cx, |toolbar, cx| {
             toolbar.focus_changed(false, cx);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -517,7 +517,7 @@ impl Pane {
             .map_or(false, |menu| menu.focus_handle(cx).is_focused(cx))
     }
 
-    fn focus_out(&mut self, cx: &mut ViewContext<Self>) {
+    fn focus_out(&mut self, _blurred: WeakFocusHandle, cx: &mut ViewContext<Self>) {
         self.was_focused = false;
         self.toolbar.update(cx, |toolbar, cx| {
             toolbar.focus_changed(false, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2174,7 +2174,7 @@ mod tests {
         cx.background_executor.run_until_parked();
 
         window
-            .read_with(cx, |workspace, cx| {
+            .update(cx, |workspace, cx| {
                 assert_eq!(workspace.panes().len(), 1);
                 assert!(workspace.active_item(cx).is_none());
             })


### PR DESCRIPTION
Paired with @as-cii

Release Notes:

- Now when an editor loses focus (e.g. from switching tabs) and then gains focus again, it doesn't close the inline assist. Instead, it only closes when you move the cursor outside of it, e.g. by clicking somewhere else in its parent editor.