### PR TITLE
worktree: Fix race condition when a root of worktree is .git directory

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3988,7 +3988,10 @@ impl BackgroundScanner {
                     }
 
                     if let (Some(scan_queue_tx), true) = (&scan_queue_tx, fs_entry.is_dir()) {
-                        if state.should_scan_directory(&fs_entry) {
+                        if state.should_scan_directory(&fs_entry)
+                            || (fs_entry.path.as_os_str().is_empty()
+                                && abs_path.file_name() == Some(*DOT_GIT))
+                        {
                             state.enqueue_scan_dir(abs_path, &fs_entry, scan_queue_tx);
                         } else {
                             fs_entry.kind = EntryKind::UnloadedDir;


### PR DESCRIPTION
It was possible to unload a root of worktree when it was a .git directory; due to that, test_fs_events_in_dot_git_worktree was sometimes stuck in an infinite loop on CI.

The gist of an issue is that when .git dir is a root dir, then modifying a file within this directory could sometimes unload the .git dir; the test went into an infinite loop when the first event in an filesystem stream was not the event for the file creation, but for a dir modification. In that case we'd unload the root directory and a subsequent event for file creation would never be registered, leading to the test being stuck waiting for it to happen.

This commit alleviates it by special-casing worktrees rooted in .git directories.



Release Notes:

- Fixed a possible hang when opening a worktree in .git directory.