### PR TITLE
assistant: Add `diagnostics` slash command

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -25,8 +25,8 @@ use semantic_index::{CloudEmbeddingProvider, SemanticIndex};
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
 use slash_command::{
-    active_command, default_command, fetch_command, file_command, now_command, project_command,
-    prompt_command, rustdoc_command, search_command, tabs_command,
+    active_command, default_command, diagnostics_command, fetch_command, file_command, now_command,
+    project_command, prompt_command, rustdoc_command, search_command, tabs_command,
 };
 use std::{
     fmt::{self, Display},
@@ -308,6 +308,7 @@ fn register_slash_commands(cx: &mut AppContext) {
     slash_command_registry.register_command(prompt_command::PromptSlashCommand, true);
     slash_command_registry.register_command(default_command::DefaultSlashCommand, true);
     slash_command_registry.register_command(now_command::NowSlashCommand, true);
+    slash_command_registry.register_command(diagnostics_command::DiagnosticsCommand, true);
     slash_command_registry.register_command(rustdoc_command::RustdocSlashCommand, false);
     slash_command_registry.register_command(fetch_command::FetchSlashCommand, false);
 }

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -18,6 +18,7 @@ use workspace::Workspace;
 
 pub mod active_command;
 pub mod default_command;
+pub mod diagnostics_command;
 pub mod fetch_command;
 pub mod file_command;
 pub mod now_command;

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -1,0 +1,88 @@
+use super::{SlashCommand, SlashCommandOutput};
+use anyhow::{anyhow, Result};
+use assistant_slash_command::SlashCommandOutputSection;
+use fuzzy::PathMatch;
+use gpui::{AppContext, RenderOnce, SharedString, Task, View, WeakView};
+use language::{LineEnding, LspAdapterDelegate};
+use project::PathMatchCandidateSet;
+use std::{
+    ops::Range,
+    path::{Path, PathBuf},
+    sync::{atomic::AtomicBool, Arc},
+};
+use ui::{prelude::*, ButtonLike, ElevationIndex};
+use workspace::Workspace;
+
+pub(crate) struct DiagnosticsCommand;
+
+impl SlashCommand for DiagnosticsCommand {
+    fn name(&self) -> String {
+        "diagnostics".into()
+    }
+
+    fn description(&self) -> String {
+        "Insert diagnostics".into()
+    }
+
+    fn menu_text(&self) -> String {
+        "Insert Diagnostics".into()
+    }
+
+    fn requires_argument(&self) -> bool {
+        false
+    }
+
+    fn complete_argument(
+        &self,
+        query: String,
+        cancellation_flag: Arc<AtomicBool>,
+        workspace: Option<WeakView<Workspace>>,
+        cx: &mut AppContext,
+    ) -> Task<Result<Vec<String>>> {
+        Task::ready(Err(anyhow!("this command does not require argument")))
+    }
+
+    fn run(
+        self: Arc<Self>,
+        argument: Option<&str>,
+        workspace: WeakView<Workspace>,
+        _delegate: Arc<dyn LspAdapterDelegate>,
+        cx: &mut WindowContext,
+    ) -> Task<Result<SlashCommandOutput>> {
+        let Some(workspace) = workspace.upgrade() else {
+            return Task::ready(Err(anyhow!("workspace was dropped")));
+        };
+
+        let text = "Diagnostics".to_string();
+        let range = 0..text.len();
+        Task::Ready(Some(Ok(SlashCommandOutput {
+            text,
+            sections: vec![SlashCommandOutputSection {
+                range,
+                render_placeholder: Arc::new(move |id, unfold, _cx| {
+                    DiagnosticsPlaceholder { id, unfold }.into_any_element()
+                }),
+            }],
+            run_commands_in_text: false,
+        })))
+    }
+}
+
+#[derive(IntoElement)]
+pub struct DiagnosticsPlaceholder {
+    pub id: ElementId,
+    pub unfold: Arc<dyn Fn(&mut WindowContext)>,
+}
+
+impl RenderOnce for DiagnosticsPlaceholder {
+    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
+        let unfold = self.unfold;
+
+        ButtonLike::new(self.id)
+            .style(ButtonStyle::Filled)
+            .layer(ElevationIndex::ElevatedSurface)
+            .child(Icon::new(IconName::File))
+            .child(Label::new("Some file"))
+            .on_click(move |_, cx| unfold(cx))
+    }
+}

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -58,7 +58,7 @@ impl DiagnosticsCommand {
                             .root_entry()
                             .map_or(false, |entry| entry.is_ignored),
                         include_root_name: false,
-                        allowed_candidates: project::AllowedCandidates::Entries,
+                        candidates: project::Candidates::Entries,
                     }
                 })
                 .collect::<Vec<_>>();

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -1,13 +1,10 @@
 use super::{SlashCommand, SlashCommandOutput};
 use anyhow::{anyhow, Result};
 use assistant_slash_command::SlashCommandOutputSection;
-use fuzzy::PathMatch;
-use gpui::{AppContext, RenderOnce, SharedString, Task, View, WeakView};
-use language::{LineEnding, LspAdapterDelegate};
-use project::PathMatchCandidateSet;
+use gpui::{AppContext, RenderOnce, Task, WeakView};
+use language::LspAdapterDelegate;
 use std::{
     ops::Range,
-    path::{Path, PathBuf},
     sync::{atomic::AtomicBool, Arc},
 };
 use ui::{prelude::*, ButtonLike, ElevationIndex};
@@ -34,17 +31,17 @@ impl SlashCommand for DiagnosticsCommand {
 
     fn complete_argument(
         &self,
-        query: String,
-        cancellation_flag: Arc<AtomicBool>,
-        workspace: Option<WeakView<Workspace>>,
-        cx: &mut AppContext,
+        _query: String,
+        _cancellation_flag: Arc<AtomicBool>,
+        _workspace: Option<WeakView<Workspace>>,
+        _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {
         Task::ready(Err(anyhow!("this command does not require argument")))
     }
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        _argument: Option<&str>,
         workspace: WeakView<Workspace>,
         _delegate: Arc<dyn LspAdapterDelegate>,
         cx: &mut WindowContext,
@@ -53,24 +50,55 @@ impl SlashCommand for DiagnosticsCommand {
             return Task::ready(Err(anyhow!("workspace was dropped")));
         };
 
-        let text = "Diagnostics".to_string();
-        let range = 0..text.len();
+        let project = workspace.read(cx).project().read(cx);
+        let mut text = String::new();
+        text.push_str("Diagnostics:\n");
+        let mut sections: Vec<(Range<usize>, PlaceholderType)> = Vec::new();
+        for (file, _, diagnostics) in project.diagnostic_summaries(false, cx) {
+            let last_end = text.len();
+            let file_path = file.path.to_string_lossy().to_string();
+            text.push_str(&file_path);
+            text.push('\n');
+            sections.push((
+                last_end..last_end + file_path.len(),
+                PlaceholderType::File(file_path),
+            ))
+        }
+        sections.push((0..text.len(), PlaceholderType::Root));
+
+        //TODO move to background thread
+
         Task::Ready(Some(Ok(SlashCommandOutput {
             text,
-            sections: vec![SlashCommandOutputSection {
-                range,
-                render_placeholder: Arc::new(move |id, unfold, _cx| {
-                    DiagnosticsPlaceholder { id, unfold }.into_any_element()
-                }),
-            }],
+            sections: sections
+                .into_iter()
+                .map(|(range, placeholder_type)| SlashCommandOutputSection {
+                    range,
+                    render_placeholder: Arc::new(move |id, unfold, _cx| {
+                        DiagnosticsPlaceholder {
+                            id,
+                            unfold,
+                            placeholder_type: placeholder_type.clone(),
+                        }
+                        .into_any_element()
+                    }),
+                })
+                .collect(),
             run_commands_in_text: false,
         })))
     }
 }
 
+#[derive(Clone)]
+pub enum PlaceholderType {
+    Root,
+    File(String),
+}
+
 #[derive(IntoElement)]
 pub struct DiagnosticsPlaceholder {
     pub id: ElementId,
+    pub placeholder_type: PlaceholderType,
     pub unfold: Arc<dyn Fn(&mut WindowContext)>,
 }
 
@@ -78,11 +106,19 @@ impl RenderOnce for DiagnosticsPlaceholder {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
         let unfold = self.unfold;
 
+        let (icon, content) = match self.placeholder_type {
+            PlaceholderType::Root => (
+                Icon::new(IconName::CopilotDisabled),
+                Label::new("Diagnostics"),
+            ),
+            PlaceholderType::File(file) => (Icon::new(IconName::File), Label::new(file)),
+        };
+
         ButtonLike::new(self.id)
             .style(ButtonStyle::Filled)
             .layer(ElevationIndex::ElevatedSurface)
-            .child(Icon::new(IconName::File))
-            .child(Label::new("Some file"))
+            .child(icon)
+            .child(content)
             .on_click(move |_, cx| unfold(cx))
     }
 }

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -1,13 +1,15 @@
 use super::{SlashCommand, SlashCommandOutput};
 use anyhow::{anyhow, Result};
 use assistant_slash_command::SlashCommandOutputSection;
-use gpui::{svg, AppContext, RenderOnce, Task, WeakView};
-use language::LspAdapterDelegate;
+use gpui::{svg, AppContext, Model, RenderOnce, Task, WeakView};
+use language::{BufferSnapshot, DiagnosticSeverity, LspAdapterDelegate};
+use project::{DiagnosticSummary, Project};
 use std::{
     ops::Range,
     sync::{atomic::AtomicBool, Arc},
 };
 use ui::{prelude::*, ButtonLike, ElevationIndex};
+use util::ResultExt;
 use workspace::Workspace;
 
 pub(crate) struct DiagnosticsCommand;
@@ -50,36 +52,63 @@ impl SlashCommand for DiagnosticsCommand {
             return Task::ready(Err(anyhow!("workspace was dropped")));
         };
 
-        let project = workspace.read(cx).project().read(cx);
+        let task = collect_diagnostics(workspace.read(cx).project().clone(), cx);
+        cx.spawn(move |_| async move {
+            let (text, sections) = task.await?;
+            Ok(SlashCommandOutput {
+                text,
+                sections: sections
+                    .into_iter()
+                    .map(|(range, placeholder_type)| SlashCommandOutputSection {
+                        range,
+                        render_placeholder: Arc::new(move |id, unfold, _cx| {
+                            DiagnosticsPlaceholder {
+                                id,
+                                unfold,
+                                placeholder_type: placeholder_type.clone(),
+                            }
+                            .into_any_element()
+                        }),
+                    })
+                    .collect(),
+                run_commands_in_text: false,
+            })
+        })
+    }
+}
+
+fn collect_diagnostics(
+    project: Model<Project>,
+    cx: &mut AppContext,
+) -> Task<Result<(String, Vec<(Range<usize>, PlaceholderType)>)>> {
+    let project_handle = project.downgrade();
+    let diagnostic_summaries: Vec<_> = project.read(cx).diagnostic_summaries(false, cx).collect();
+
+    cx.spawn(|mut cx| async move {
         let mut text = String::new();
         text.push_str("Diagnostics:\n");
         let mut sections: Vec<(Range<usize>, PlaceholderType)> = Vec::new();
-        for (file, _, diagnostics) in project.diagnostic_summaries(false, cx) {
+
+        let mut project_summary = DiagnosticSummary::default();
+        for (project_path, _, summary) in diagnostic_summaries {
+            project_summary.error_count += summary.error_count;
+            project_summary.warning_count += summary.warning_count;
+
             let last_end = text.len();
-            let file_path = file.path.to_string_lossy().to_string();
+            let file_path = project_path.path.to_string_lossy().to_string();
             text.push_str(&file_path);
             text.push('\n');
 
-            for error in 0..diagnostics.error_count {
-                let prev_len = text.len();
-                text.push_str("Error ");
-                text.push_str(&error.to_string());
-                text.push('\n');
-                sections.push((
-                    prev_len..text.len().saturating_sub(1),
-                    PlaceholderType::Diagnostic(DiagnosticType::Error, "Error".to_string()),
-                ))
-            }
-
-            for warning in 0..diagnostics.warning_count {
-                let prev_len = text.len();
-                text.push_str("Warning ");
-                text.push_str(&warning.to_string());
-                text.push('\n');
-                sections.push((
-                    prev_len..text.len().saturating_sub(1),
-                    PlaceholderType::Diagnostic(DiagnosticType::Warning, "Warning".to_string()),
-                ))
+            if let Some(buffer) = project_handle
+                .update(&mut cx, |project, cx| project.open_buffer(project_path, cx))?
+                .await
+                .log_err()
+            {
+                collect_buffer_diagnostics(
+                    &mut text,
+                    &mut sections,
+                    cx.read_model(&buffer, |buffer, _| buffer.snapshot())?,
+                );
             }
 
             sections.push((
@@ -87,39 +116,47 @@ impl SlashCommand for DiagnosticsCommand {
                 PlaceholderType::File(file_path),
             ))
         }
-        sections.push((0..text.len(), PlaceholderType::Root));
+        sections.push((0..text.len(), PlaceholderType::Root(project_summary)));
 
-        //TODO move to background thread
+        Ok((text, sections))
+    })
+}
 
-        Task::Ready(Some(Ok(SlashCommandOutput {
-            text,
-            sections: sections
-                .into_iter()
-                .map(|(range, placeholder_type)| SlashCommandOutputSection {
-                    range,
-                    render_placeholder: Arc::new(move |id, unfold, _cx| {
-                        DiagnosticsPlaceholder {
-                            id,
-                            unfold,
-                            placeholder_type: placeholder_type.clone(),
-                        }
-                        .into_any_element()
-                    }),
-                })
-                .collect(),
-            run_commands_in_text: false,
-        })))
+fn collect_buffer_diagnostics(
+    text: &mut String,
+    sections: &mut Vec<(Range<usize>, PlaceholderType)>,
+    snapshot: BufferSnapshot,
+) {
+    for (_, group) in snapshot.diagnostic_groups(None) {
+        //TODO Find to link related diagnostics together (primary diagnostic)
+        for entry in group.entries {
+            let ty = match entry.diagnostic.severity {
+                DiagnosticSeverity::WARNING => DiagnosticType::Warning,
+                DiagnosticSeverity::ERROR => DiagnosticType::Error,
+                _ => continue,
+            };
+            let prev_len = text.len();
+            text.push_str(&entry.diagnostic.message);
+            text.push('\n');
+            sections.push((
+                prev_len..text.len().saturating_sub(1),
+                PlaceholderType::Diagnostic(
+                    ty,
+                    util::truncate_and_trailoff(&entry.diagnostic.message, 50).replace('\n', " "),
+                ),
+            ))
+        }
     }
 }
 
 #[derive(Clone)]
 pub enum PlaceholderType {
-    Root,
+    Root(DiagnosticSummary),
     File(String),
     Diagnostic(DiagnosticType, String),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, IntoElement)]
 pub enum DiagnosticType {
     Warning,
     Error,
@@ -133,33 +170,30 @@ pub struct DiagnosticsPlaceholder {
 }
 
 impl RenderOnce for DiagnosticsPlaceholder {
-    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
         let unfold = self.unfold;
-
         let (icon, content) = match self.placeholder_type {
-            PlaceholderType::Root => (
-                Icon::new(IconName::CopilotDisabled).into_any_element(),
+            PlaceholderType::Root(summary) => (
+                h_flex()
+                    .gap_0p5()
+                    .when(summary.error_count > 0, |this| {
+                        this.child(DiagnosticType::Error)
+                            .child(Label::new(summary.error_count.to_string()))
+                    })
+                    .when(summary.warning_count > 0, |this| {
+                        this.child(DiagnosticType::Warning)
+                            .child(Label::new(summary.warning_count.to_string()))
+                    })
+                    .into_any_element(),
                 Label::new("Diagnostics"),
             ),
             PlaceholderType::File(file) => (
                 Icon::new(IconName::File).into_any_element(),
                 Label::new(file),
             ),
-            PlaceholderType::Diagnostic(diagnostic_type, message) => (
-                svg()
-                    .size(cx.text_style().font_size)
-                    .flex_none()
-                    .map(|icon| match diagnostic_type {
-                        DiagnosticType::Warning => icon
-                            .path(IconName::XCircle.path())
-                            .text_color(Color::Error.color(cx)),
-                        DiagnosticType::Error => icon
-                            .path(IconName::ExclamationTriangle.path())
-                            .text_color(Color::Warning.color(cx)),
-                    })
-                    .into_any_element(),
-                Label::new(message),
-            ),
+            PlaceholderType::Diagnostic(diagnostic_type, message) => {
+                (diagnostic_type.into_any_element(), Label::new(message))
+            }
         };
 
         ButtonLike::new(self.id)
@@ -168,5 +202,21 @@ impl RenderOnce for DiagnosticsPlaceholder {
             .child(icon)
             .child(content)
             .on_click(move |_, cx| unfold(cx))
+    }
+}
+
+impl RenderOnce for DiagnosticType {
+    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+        svg()
+            .size(cx.text_style().font_size)
+            .flex_none()
+            .map(|icon| match self {
+                DiagnosticType::Warning => icon
+                    .path(IconName::XCircle.path())
+                    .text_color(Color::Error.color(cx)),
+                DiagnosticType::Error => icon
+                    .path(IconName::ExclamationTriangle.path())
+                    .text_color(Color::Warning.color(cx)),
+            })
     }
 }

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -58,7 +58,7 @@ impl FileSlashCommand {
                             .root_entry()
                             .map_or(false, |entry| entry.is_ignored),
                         include_root_name: true,
-                        allowed_candidates: project::AllowedCandidates::Files,
+                        candidates: project::Candidates::Files,
                     }
                 })
                 .collect::<Vec<_>>();

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -58,7 +58,7 @@ impl FileSlashCommand {
                             .root_entry()
                             .map_or(false, |entry| entry.is_ignored),
                         include_root_name: true,
-                        directories_only: false,
+                        allowed_candidates: project::AllowedCandidates::Files,
                     }
                 })
                 .collect::<Vec<_>>();

--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -303,7 +303,7 @@ impl RandomizedTest for ProjectCollaborationTest {
                                     .filter(|worktree| {
                                         let worktree = worktree.read(cx);
                                         worktree.is_visible()
-                                            && worktree.entries(false).any(|e| e.is_file())
+                                            && worktree.entries(false, 0).any(|e| e.is_file())
                                             && worktree.root_entry().map_or(false, |e| e.is_dir())
                                     })
                                     .choose(rng)
@@ -425,14 +425,14 @@ impl RandomizedTest for ProjectCollaborationTest {
                                     .filter(|worktree| {
                                         let worktree = worktree.read(cx);
                                         worktree.is_visible()
-                                            && worktree.entries(false).any(|e| e.is_file())
+                                            && worktree.entries(false, 0).any(|e| e.is_file())
                                     })
                                     .choose(rng)
                             });
                             let Some(worktree) = worktree else { continue };
                             let full_path = worktree.read_with(cx, |worktree, _| {
                                 let entry = worktree
-                                    .entries(false)
+                                    .entries(false, 0)
                                     .filter(|e| e.is_file())
                                     .choose(rng)
                                     .unwrap();
@@ -1204,8 +1204,8 @@ impl RandomizedTest for ProjectCollaborationTest {
                                         guest_project.remote_id(),
                                     );
                                     assert_eq!(
-                                        guest_snapshot.entries(false).collect::<Vec<_>>(),
-                                        host_snapshot.entries(false).collect::<Vec<_>>(),
+                                        guest_snapshot.entries(false, 0).collect::<Vec<_>>(),
+                                        host_snapshot.entries(false, 0).collect::<Vec<_>>(),
                                         "{} has different snapshot than the host for worktree {:?} ({:?}) and project {:?}",
                                         client.username,
                                         host_snapshot.abs_path(),

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -483,7 +483,7 @@ impl FileFinderDelegate {
                         .root_entry()
                         .map_or(false, |entry| entry.is_ignored),
                     include_root_name,
-                    directories_only: false,
+                    allowed_candidates: project::AllowedCandidates::Files,
                 }
             })
             .collect::<Vec<_>>();

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -483,7 +483,7 @@ impl FileFinderDelegate {
                         .root_entry()
                         .map_or(false, |entry| entry.is_ignored),
                     include_root_name,
-                    allowed_candidates: project::AllowedCandidates::Files,
+                    candidates: project::Candidates::Files,
                 }
             })
             .collect::<Vec<_>>();

--- a/crates/file_finder/src/new_path_prompt.rs
+++ b/crates/file_finder/src/new_path_prompt.rs
@@ -278,7 +278,7 @@ impl PickerDelegate for NewPathDelegate {
                         .root_entry()
                         .map_or(false, |entry| entry.is_ignored),
                     include_root_name,
-                    allowed_candidates: project::AllowedCandidates::Directories,
+                    candidates: project::Candidates::Directories,
                 }
             })
             .collect::<Vec<_>>();

--- a/crates/file_finder/src/new_path_prompt.rs
+++ b/crates/file_finder/src/new_path_prompt.rs
@@ -278,7 +278,7 @@ impl PickerDelegate for NewPathDelegate {
                         .root_entry()
                         .map_or(false, |entry| entry.is_ignored),
                     include_root_name,
-                    directories_only: true,
+                    allowed_candidates: project::AllowedCandidates::Directories,
                 }
             })
             .collect::<Vec<_>>();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -11305,10 +11305,10 @@ pub struct PathMatchCandidateSet {
     pub snapshot: Snapshot,
     pub include_ignored: bool,
     pub include_root_name: bool,
-    pub allowed_candidates: AllowedCandidates,
+    pub candidates: Candidates,
 }
 
-pub enum AllowedCandidates {
+pub enum Candidates {
     /// Only consider directories.
     Directories,
     /// Only consider files.
@@ -11344,12 +11344,10 @@ impl<'a> fuzzy::PathMatchCandidateSet<'a> for PathMatchCandidateSet {
 
     fn candidates(&'a self, start: usize) -> Self::Candidates {
         PathMatchCandidateSetIter {
-            traversal: match self.allowed_candidates {
-                AllowedCandidates::Directories => {
-                    self.snapshot.directories(self.include_ignored, start)
-                }
-                AllowedCandidates::Files => self.snapshot.files(self.include_ignored, start),
-                AllowedCandidates::Entries => self.snapshot.entries(self.include_ignored, start),
+            traversal: match self.candidates {
+                Candidates::Directories => self.snapshot.directories(self.include_ignored, start),
+                Candidates::Files => self.snapshot.files(self.include_ignored, start),
+                Candidates::Entries => self.snapshot.entries(self.include_ignored, start),
             },
         }
     }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -728,7 +728,7 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
             worktree
                 .read(cx)
                 .snapshot()
-                .entries(true)
+                .entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_ignored))
                 .collect::<Vec<_>>(),
             &[
@@ -802,7 +802,7 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
             worktree
                 .read(cx)
                 .snapshot()
-                .entries(true)
+                .entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_ignored))
                 .collect::<Vec<_>>(),
             &[

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1196,7 +1196,7 @@ impl ProjectPanel {
         if let Some(worktree) = worktree {
             let worktree = worktree.read(cx);
             let worktree_id = worktree.id();
-            if let Some(last_entry) = worktree.entries(true).last() {
+            if let Some(last_entry) = worktree.entries(true, 0).last() {
                 self.selection = Some(SelectedEntry {
                     worktree_id,
                     entry_id: last_entry.id,
@@ -1575,7 +1575,7 @@ impl ProjectPanel {
             }
 
             let mut visible_worktree_entries = Vec::new();
-            let mut entry_iter = snapshot.entries(true);
+            let mut entry_iter = snapshot.entries(true, 0);
             while let Some(entry) = entry_iter.entry() {
                 if auto_collapse_dirs
                     && entry.kind.is_dir()

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2024,8 +2024,8 @@ impl Snapshot {
         self.traverse_from_offset(false, true, include_ignored, start)
     }
 
-    pub fn entries(&self, include_ignored: bool) -> Traversal {
-        self.traverse_from_offset(true, true, include_ignored, 0)
+    pub fn entries(&self, include_ignored: bool, start: usize) -> Traversal {
+        self.traverse_from_offset(true, true, include_ignored, start)
     }
 
     pub fn repositories(&self) -> impl Iterator<Item = (&Arc<Path>, &RepositoryEntry)> {
@@ -2457,7 +2457,7 @@ impl LocalSnapshot {
         assert_eq!(bfs_paths, dfs_paths_via_iter);
 
         let dfs_paths_via_traversal = self
-            .entries(true)
+            .entries(true, 0)
             .map(|e| e.path.as_ref())
             .collect::<Vec<_>>();
         assert_eq!(dfs_paths_via_traversal, dfs_paths_via_iter);

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -45,7 +45,7 @@ async fn test_traversal(cx: &mut TestAppContext) {
 
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(false)
+            tree.entries(false, 0)
                 .map(|entry| entry.path.as_ref())
                 .collect::<Vec<_>>(),
             vec![
@@ -56,7 +56,7 @@ async fn test_traversal(cx: &mut TestAppContext) {
             ]
         );
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| entry.path.as_ref())
                 .collect::<Vec<_>>(),
             vec![
@@ -110,7 +110,7 @@ async fn test_circular_symlinks(cx: &mut TestAppContext) {
 
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(false)
+            tree.entries(false, 0)
                 .map(|entry| entry.path.as_ref())
                 .collect::<Vec<_>>(),
             vec![
@@ -136,7 +136,7 @@ async fn test_circular_symlinks(cx: &mut TestAppContext) {
     cx.executor().run_until_parked();
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(false)
+            tree.entries(false, 0)
                 .map(|entry| entry.path.as_ref())
                 .collect::<Vec<_>>(),
             vec![
@@ -225,7 +225,7 @@ async fn test_symlinks_pointing_outside(cx: &mut TestAppContext) {
     // The symlinked directories are not scanned by default.
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_external))
                 .collect::<Vec<_>>(),
             vec![
@@ -258,7 +258,7 @@ async fn test_symlinks_pointing_outside(cx: &mut TestAppContext) {
     // not scanned yet.
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_external))
                 .collect::<Vec<_>>(),
             vec![
@@ -295,7 +295,7 @@ async fn test_symlinks_pointing_outside(cx: &mut TestAppContext) {
     // The expanded subdirectory's contents are loaded.
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_external))
                 .collect::<Vec<_>>(),
             vec![
@@ -358,7 +358,7 @@ async fn test_renaming_case_only(cx: &mut TestAppContext) {
         .await;
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| entry.path.as_ref())
                 .collect::<Vec<_>>(),
             vec![Path::new(""), Path::new(OLD_NAME)]
@@ -380,7 +380,7 @@ async fn test_renaming_case_only(cx: &mut TestAppContext) {
 
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| entry.path.as_ref())
                 .collect::<Vec<_>>(),
             vec![Path::new(""), Path::new(NEW_NAME)]
@@ -435,7 +435,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
 
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_ignored))
                 .collect::<Vec<_>>(),
             vec![
@@ -462,7 +462,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
 
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_ignored))
                 .collect::<Vec<_>>(),
             vec![
@@ -502,7 +502,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
 
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|entry| (entry.path.as_ref(), entry.is_ignored))
                 .collect::<Vec<_>>(),
             vec![
@@ -605,7 +605,7 @@ async fn test_dirs_no_longer_ignored(cx: &mut TestAppContext) {
     // Those subdirectories are now loaded.
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|e| (e.path.as_ref(), e.is_ignored))
                 .collect::<Vec<_>>(),
             &[
@@ -637,7 +637,7 @@ async fn test_dirs_no_longer_ignored(cx: &mut TestAppContext) {
     // All of the directories that are no longer ignored are now loaded.
     tree.read_with(cx, |tree, _| {
         assert_eq!(
-            tree.entries(true)
+            tree.entries(true, 0)
                 .map(|e| (e.path.as_ref(), e.is_ignored))
                 .collect::<Vec<_>>(),
             &[
@@ -1203,8 +1203,8 @@ async fn test_create_directory_during_initial_scan(cx: &mut TestAppContext) {
 
     let snapshot2 = tree.update(cx, |tree, _| tree.as_local().unwrap().snapshot());
     assert_eq!(
-        snapshot1.lock().entries(true).collect::<Vec<_>>(),
-        snapshot2.entries(true).collect::<Vec<_>>()
+        snapshot1.lock().entries(true, 0).collect::<Vec<_>>(),
+        snapshot2.entries(true, 0).collect::<Vec<_>>()
     );
 }
 
@@ -1411,8 +1411,8 @@ async fn test_random_worktree_operations_during_initial_scan(
         }
 
         assert_eq!(
-            updated_snapshot.entries(true).collect::<Vec<_>>(),
-            final_snapshot.entries(true).collect::<Vec<_>>(),
+            updated_snapshot.entries(true, 0).collect::<Vec<_>>(),
+            final_snapshot.entries(true, 0).collect::<Vec<_>>(),
             "wrong updates after snapshot {i}: {snapshot:#?} {updates:#?}",
         );
     }
@@ -1545,11 +1545,11 @@ async fn test_random_worktree_changes(cx: &mut TestAppContext, mut rng: StdRng) 
 
         assert_eq!(
             prev_snapshot
-                .entries(true)
+                .entries(true, 0)
                 .map(ignore_pending_dir)
                 .collect::<Vec<_>>(),
             snapshot
-                .entries(true)
+                .entries(true, 0)
                 .map(ignore_pending_dir)
                 .collect::<Vec<_>>(),
             "wrong updates after snapshot {i}: {updates:#?}",
@@ -1568,7 +1568,7 @@ async fn test_random_worktree_changes(cx: &mut TestAppContext, mut rng: StdRng) 
 // The worktree's `UpdatedEntries` event can be used to follow along with
 // all changes to the worktree's snapshot.
 fn check_worktree_change_events(tree: &mut Worktree, cx: &mut ModelContext<Worktree>) {
-    let mut entries = tree.entries(true).cloned().collect::<Vec<_>>();
+    let mut entries = tree.entries(true, 0).cloned().collect::<Vec<_>>();
     cx.subscribe(&cx.handle(), move |tree, _, event, _| {
         if let Event::UpdatedEntries(changes) = event {
             for (path, _, change_type) in changes.iter() {
@@ -1596,7 +1596,7 @@ fn check_worktree_change_events(tree: &mut Worktree, cx: &mut ModelContext<Workt
                 }
             }
 
-            let new_entries = tree.entries(true).cloned().collect::<Vec<_>>();
+            let new_entries = tree.entries(true, 0).cloned().collect::<Vec<_>>();
             assert_eq!(entries, new_entries, "incorrect changes: {:?}", changes);
         }
     })
@@ -1611,7 +1611,7 @@ fn randomly_mutate_worktree(
     log::info!("mutating worktree");
     let worktree = worktree.as_local_mut().unwrap();
     let snapshot = worktree.snapshot();
-    let entry = snapshot.entries(false).choose(rng).unwrap();
+    let entry = snapshot.entries(false, 0).choose(rng).unwrap();
 
     match rng.gen_range(0_u32..100) {
         0..=33 if entry.path.as_ref() != Path::new("") => {
@@ -1619,7 +1619,7 @@ fn randomly_mutate_worktree(
             worktree.delete_entry(entry.id, false, cx).unwrap()
         }
         ..=66 if entry.path.as_ref() != Path::new("") => {
-            let other_entry = snapshot.entries(false).choose(rng).unwrap();
+            let other_entry = snapshot.entries(false, 0).choose(rng).unwrap();
             let new_parent_path = if other_entry.is_dir() {
                 other_entry.path.clone()
             } else {


### PR DESCRIPTION
This adds a `diagnostics` command to the assistant which allows to inject compile errors/warnings into the context.

Release Notes:

- N/A
