### PR TITLE
ui: Render disclosures with `IconButtonShape::Square`

### DIFF
--- a/crates/ui/src/components/disclosure.rs
+++ b/crates/ui/src/components/disclosure.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use gpui::ClickEvent;
 
-use crate::{prelude::*, Color, IconButton, IconName, IconSize};
+use crate::{prelude::*, Color, IconButton, IconButtonShape, IconName, IconSize};
 
 #[derive(IntoElement)]
 pub struct Disclosure {
@@ -38,6 +38,7 @@ impl RenderOnce for Disclosure {
                 false => IconName::ChevronRight,
             },
         )
+        .shape(IconButtonShape::Square)
         .icon_color(Color::Muted)
         .icon_size(IconSize::Small)
         .when_some(self.on_toggle, move |this, on_toggle| {


### PR DESCRIPTION
This PR adjusts the `Disclosure` component to render using `IconButtonShape::Square`.

This tightens up the hover styles so they aren't quite so massive.

### Before

<img width="116" alt="Screenshot 2024-06-13 at 3 22 43 PM" src="https://github.com/zed-industries/zed/assets/1486634/dea8f8fb-a041-4aa7-89be-0cd2d7889955">

### After

<img width="113" alt="Screenshot 2024-06-13 at 3 23 02 PM" src="https://github.com/zed-industries/zed/assets/1486634/7682cce6-4f83-4f3e-b91f-3023849bd314">

Release Notes:

- Tweaked the style of disclosure controls throughout the UI.
