### PR TITLE
Keep symbol names in bundled linux binaries

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -73,6 +73,7 @@ actions!(
         ShowAll,
         ToggleFullScreen,
         Zoom,
+        TestPanic,
     ]
 );
 
@@ -84,6 +85,10 @@ pub fn init(cx: &mut AppContext) {
     #[cfg(target_os = "macos")]
     cx.on_action(|_: &ShowAll, cx| cx.unhide_other_apps());
     cx.on_action(quit);
+
+    if ReleaseChannel::global(cx) == ReleaseChannel::Dev {
+        cx.on_action(test_panic);
+    }
 }
 
 pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> WindowOptions {
@@ -482,6 +487,10 @@ fn about(_: &mut Workspace, _: &About, cx: &mut gpui::ViewContext<Workspace>) {
             prompt.await.ok();
         })
         .detach();
+}
+
+fn test_panic(_: &TestPanic, _: &mut AppContext) {
+    panic!("Ran the TestPanic action")
 }
 
 fn quit(_: &Quit, cx: &mut AppContext) {

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -43,8 +43,8 @@ cargo build --release --target "${target_triple}" --package zed --package cli
 
 # Strip the binary of all debug symbols
 # Later, we probably want to do something like this: https://github.com/GabrielMajeri/separate-symbols
-strip "target/${target_triple}/release/zed"
-strip "target/${target_triple}/release/cli"
+strip --strip-debug "target/${target_triple}/release/zed"
+strip --strip-debug "target/${target_triple}/release/cli"
 
 suffix=""
 if [ "$channel" != "stable" ]; then


### PR DESCRIPTION
This ensures that linux panics still contain symbol names. It also allows us to profile Zed on linux with `perf` and get symbol names.

Release Notes:

- N/A
