### PR TITLE
rustdoc: Fix duplicated item path

### DIFF
--- a/crates/rustdoc/src/indexer.rs
+++ b/crates/rustdoc/src/indexer.rs
@@ -193,7 +193,7 @@ impl RustdocIndexer {
 
             self.database
                 .insert(
-                    format!("{crate_name}::{}", item.display()),
+                    crate_name.clone(),
                     Some(item),
                     markdown,
                 )

--- a/crates/rustdoc/src/indexer.rs
+++ b/crates/rustdoc/src/indexer.rs
@@ -192,11 +192,7 @@ impl RustdocIndexer {
             let (markdown, referenced_items) = convert_rustdoc_to_markdown(result.as_bytes())?;
 
             self.database
-                .insert(
-                    crate_name.clone(),
-                    Some(item),
-                    markdown,
-                )
+                .insert(crate_name.clone(), Some(item), markdown)
                 .await?;
 
             let parent_item = item;


### PR DESCRIPTION
This PR fixes a bug that was introduced in #13011 where the item path would get duplicated twice in the database key.

Release Notes:

- N/A
