### PR TITLE
rustdoc: Automatically index crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8723,6 +8723,7 @@ dependencies = [
  "http 0.1.0",
  "indexmap 1.9.3",
  "indoc",
+ "parking_lot",
  "pretty_assertions",
  "serde",
  "strum",

--- a/crates/rustdoc/Cargo.toml
+++ b/crates/rustdoc/Cargo.toml
@@ -23,6 +23,7 @@ heed.workspace = true
 html_to_markdown.workspace = true
 http.workspace = true
 indexmap.workspace = true
+parking_lot.workspace = true
 serde.workspace = true
 strum.workspace = true
 util.workspace = true

--- a/crates/rustdoc/src/indexer.rs
+++ b/crates/rustdoc/src/indexer.rs
@@ -56,8 +56,6 @@ impl RustdocProvider for LocalProvider {
             local_cargo_doc_path.push("index.html");
         }
 
-        println!("Fetching {}", local_cargo_doc_path.display());
-
         let Ok(contents) = self.fs.load(&local_cargo_doc_path).await else {
             return Ok(None);
         };
@@ -90,8 +88,6 @@ impl RustdocProvider for DocsDotRsProvider {
                 .map(|item| format!("/{}", item.url_path()))
                 .unwrap_or_default()
         );
-
-        println!("Fetching {}", &format!("https://docs.rs/{path}"));
 
         let mut response = self
             .http_client
@@ -164,8 +160,6 @@ impl RustdocIndexer {
 
         while let Some(item_with_history) = items_to_visit.pop_front() {
             let item = &item_with_history.item;
-
-            println!("Visiting {:?} {:?} {}", &item.kind, &item.path, &item.name);
 
             let Some(result) = self
                 .provider

--- a/crates/rustdoc/src/indexer.rs
+++ b/crates/rustdoc/src/indexer.rs
@@ -193,7 +193,7 @@ impl RustdocIndexer {
 
             self.database
                 .insert(
-                    format!("{crate_name}::{}", item.display()),
+                    crate_name.clone(),
                     Some(item),
                     markdown,
                 )

--- a/crates/rustdoc/src/indexer.rs
+++ b/crates/rustdoc/src/indexer.rs
@@ -192,11 +192,7 @@ impl RustdocIndexer {
             let (markdown, referenced_items) = convert_rustdoc_to_markdown(result.as_bytes())?;
 
             self.database
-                .insert(
-                    crate_name.clone(),
-                    Some(item),
-                    markdown,
-                )
+                .insert(crate_name.clone(), Some(item), markdown)
                 .await?;
 
             let parent_item = item;

--- a/crates/rustdoc/src/store.rs
+++ b/crates/rustdoc/src/store.rs
@@ -3,12 +3,14 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use collections::HashMap;
 use futures::future::{self, BoxFuture, Shared};
 use futures::FutureExt;
 use fuzzy::StringMatchCandidate;
 use gpui::{AppContext, BackgroundExecutor, Global, ReadGlobal, Task, UpdateGlobal};
 use heed::types::SerdeBincode;
 use heed::Database;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use util::paths::SUPPORT_DIR;
 use util::ResultExt;
@@ -23,6 +25,7 @@ impl Global for GlobalRustdocStore {}
 pub struct RustdocStore {
     executor: BackgroundExecutor,
     database_future: Shared<BoxFuture<'static, Result<Arc<RustdocDatabase>, Arc<anyhow::Error>>>>,
+    indexing_tasks_by_crate: RwLock<HashMap<String, Shared<Task<Result<(), Arc<anyhow::Error>>>>>>,
 }
 
 impl RustdocStore {
@@ -52,6 +55,7 @@ impl RustdocStore {
         Self {
             executor,
             database_future,
+            indexing_tasks_by_crate: RwLock::new(HashMap::default()),
         }
     }
 
@@ -69,17 +73,45 @@ impl RustdocStore {
     }
 
     pub fn index(
-        &self,
+        self: Arc<Self>,
         crate_name: String,
         provider: Box<dyn RustdocProvider + Send + Sync + 'static>,
-    ) -> Task<Result<()>> {
-        let database_future = self.database_future.clone();
-        self.executor.spawn(async move {
-            let database = database_future.await.map_err(|err| anyhow!(err))?;
-            let indexer = RustdocIndexer::new(database, provider);
+    ) -> Shared<Task<Result<(), Arc<anyhow::Error>>>> {
+        let indexing_task = self
+            .executor
+            .spawn({
+                let this = self.clone();
+                let crate_name = crate_name.clone();
+                async move {
+                    let _finally = util::defer({
+                        let this = this.clone();
+                        let crate_name = crate_name.clone();
+                        move || {
+                            this.indexing_tasks_by_crate.write().remove(&crate_name);
+                        }
+                    });
 
-            indexer.index(crate_name.clone()).await
-        })
+                    let index_task = async {
+                        let database = this
+                            .database_future
+                            .clone()
+                            .await
+                            .map_err(|err| anyhow!(err))?;
+                        let indexer = RustdocIndexer::new(database, provider);
+
+                        indexer.index(crate_name.clone()).await
+                    };
+
+                    index_task.await.map_err(Arc::new)
+                }
+            })
+            .shared();
+
+        self.indexing_tasks_by_crate
+            .write()
+            .insert(crate_name, indexing_task.clone());
+
+        indexing_task
     }
 
     pub fn search(&self, query: String) -> Task<Vec<String>> {


### PR DESCRIPTION
This PR removes the need to use `/rustdoc --index <CRATE_NAME>` and instead indexes the crates once they are referenced.

As soon as the first `:` is added after the crate name, the indexing will kick off in the background and update the index as it goes.

Release Notes:

- N/A
