### PR TITLE
gpui_macros: Disable doctests

### DIFF
--- a/crates/gpui_macros/Cargo.toml
+++ b/crates/gpui_macros/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [lib]
 path = "src/gpui_macros.rs"
 proc-macro = true
+doctest = false
 
 [dependencies]
 proc-macro2 = "1.0.66"

--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -6,17 +6,17 @@ mod test;
 
 use proc_macro::TokenStream;
 
-#[proc_macro]
 /// register_action! can be used to register an action with the GPUI runtime.
 /// You should typically use `gpui::actions!` or `gpui::impl_actions!` instead,
 /// but this can be used for fine grained customization.
+#[proc_macro]
 pub fn register_action(ident: TokenStream) -> TokenStream {
     register_action::register_action_macro(ident)
 }
 
+/// #[derive(IntoElement)] is used to create a Component out of anything that implements
+/// the `RenderOnce` trait.
 #[proc_macro_derive(IntoElement)]
-// #[derive(IntoElement)] is used to create a Component out of anything that implements
-// the `RenderOnce` trait.
 pub fn derive_into_element(input: TokenStream) -> TokenStream {
     derive_into_element::derive_into_element(input)
 }
@@ -27,14 +27,13 @@ pub fn derive_render(input: TokenStream) -> TokenStream {
     derive_render::derive_render(input)
 }
 
-// Used by gpui to generate the style helpers.
+/// Used by gpui to generate the style helpers.
 #[proc_macro]
 #[doc(hidden)]
 pub fn style_helpers(input: TokenStream) -> TokenStream {
     style_helpers::style_helpers(input)
 }
 
-#[proc_macro_attribute]
 /// #[gpui::test] can be used to annotate test functions that run with GPUI support.
 /// it supports both synchronous and asynchronous tests, and can provide you with
 /// as many `TestAppContext` instances as you need.
@@ -57,6 +56,7 @@ pub fn style_helpers(input: TokenStream) -> TokenStream {
 /// - `#[gpui::test(retries=3)]` will run the test up to four times if it fails to try and make it pass.
 /// - `#[gpui::test(on_failure="crate::test::report_failure")]` will call the specified function after the
 ///    tests fail so that you can write out more detail about the failure.
+#[proc_macro_attribute]
 pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
     test::test(args, function)
 }


### PR DESCRIPTION
This PR disables the doctests in the `gpui_macros` crate, as they depend on `gpui` to run.

Since `gpui` depends on `gpui_macros`, we don't really want to add a dependency on `gpui` (even though it _appears_ to work as a dev dependency).

Also did some minor stylistic cleanup of some doc comments.

Release Notes:

- N/A
