### PR TITLE
collab_ui: Re-enable deafening and screen share on Mac

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -276,7 +276,7 @@ impl Render for CollabTitlebarItem {
                             .selected_style(ButtonStyle::Tinted(TintColor::Negative))
                             .icon_size(IconSize::Small)
                             .selected(is_deafened)
-                            .disabled(cfg!(not(target_os = "linux")))
+                            .disabled(!platform_supported)
                             .tooltip(move |cx| {
                                 if !platform_supported {
                                     Tooltip::text("Cannot share microphone", cx)
@@ -299,7 +299,7 @@ impl Render for CollabTitlebarItem {
                                     .style(ButtonStyle::Subtle)
                                     .icon_size(IconSize::Small)
                                     .selected(is_screen_sharing)
-                                    .disabled(cfg!(not(target_os = "linux")))
+                                    .disabled(!platform_supported)
                                     .selected_style(ButtonStyle::Tinted(TintColor::Accent))
                                     .tooltip(move |cx| {
                                         Tooltip::text(


### PR DESCRIPTION
Fixes regression from https://github.com/zed-industries/zed/pull/12994
Release Notes:

- N/A
