### PR TITLE
lsp: Add support for label_details in completions

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -138,9 +138,16 @@ impl LspAdapter for VtslsLspAdapter {
             _ => None,
         }?;
 
-        let text = match &item.detail {
-            Some(detail) => format!("{} {}", item.label, detail),
-            None => item.label.clone(),
+        let text = if let Some(description) = item
+            .label_details
+            .as_ref()
+            .and_then(|label_details| label_details.description.as_ref())
+        {
+            format!("{} {}", item.label, description)
+        } else if let Some(detail) = &item.detail {
+            format!("{} {}", item.label, detail)
+        } else {
+            item.label.clone()
         };
 
         Some(language::CodeLabel {

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -660,6 +660,7 @@ impl LanguageServer {
                                 ],
                             }),
                             insert_replace_support: Some(true),
+                            label_details_support: Some(true),
                             ..Default::default()
                         }),
                         completion_list: Some(CompletionListCapability {
@@ -670,6 +671,7 @@ impl LanguageServer {
                                 "data".to_owned(),
                             ]),
                         }),
+                        context_support: Some(true),
                         ..Default::default()
                     }),
                     rename: Some(RenameClientCapabilities {


### PR DESCRIPTION
This fixes an issue reported by @Spoutnik97 in https://github.com/zed-industries/zed/issues/12711#issuecomment-2163785111 - vtsls returns auxiliary docs via .label_details and not plain .details field.

Release Notes:

- Improved quality of auxiliary details in completions returned by VTSLS
