### PR TITLE
Fix a `cargo doc` warning in the `zed` crate

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -857,7 +857,7 @@ struct Args {
     /// Use `path:line:row` syntax to open a file at a specific location.
     /// Non-existing paths and directories will ignore `:line:row` suffix.
     ///
-    /// URLs can either be file:// or zed:// scheme, or relative to https://zed.dev.
+    /// URLs can either be `file://` or `zed://` scheme, or relative to <https://zed.dev>.
     paths_or_urls: Vec<String>,
 
     /// Instructs zed to run as a dev server on this machine. (not implemented)


### PR DESCRIPTION
This PR fixes a warning I observed when running `cargo doc` against the `zed` crate:

```
 Documenting zed v0.141.0 (/Users/maxdeviant/projects/zed/crates/zed)
warning: this URL is not a hyperlink
   --> crates/zed/src/main.rs:860:69
    |
860 |     /// URLs can either be file:// or zed:// scheme, or relative to https://zed.dev.
    |                                                                     ^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://zed.dev.>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `#[warn(rustdoc::bare_urls)]` on by default
```

Release Notes:

- N/A
