### PR TITLE
Fix panic in worktree scanning

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2504,8 +2504,9 @@ impl Project {
             }
 
             let abs_path = file.abs_path(cx);
-            let uri = lsp::Uri::from_file_path(&abs_path)
-                .unwrap_or_else(|_| panic!("Failed to register file {abs_path:?}"));
+            let Some(uri) = lsp::Uri::from_file_path(&abs_path).log_err() else {
+                return;
+            };
             let initial_snapshot = buffer.text_snapshot();
             let language = buffer.language().cloned();
             let worktree_id = file.worktree_id(cx);


### PR DESCRIPTION
Release Notes:

- Fixed a panic when worktree paths are incorrectly relative.
