### PR TITLE
Allow Ollama Model KeepAlive to be None, defaulting to indefinite

### DIFF
--- a/crates/assistant/src/completion_provider/ollama.rs
+++ b/crates/assistant/src/completion_provider/ollama.rs
@@ -240,7 +240,7 @@ impl OllamaCompletionProvider {
                     },
                 })
                 .collect(),
-            keep_alive: model.keep_alive,
+            keep_alive: model.keep_alive.unwrap_or_default(),
             stream: true,
             options: Some(ChatOptions {
                 num_ctx: Some(model.max_tokens),

--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -66,7 +66,7 @@ impl Default for KeepAlive {
 pub struct Model {
     pub name: String,
     pub max_tokens: usize,
-    pub keep_alive: KeepAlive,
+    pub keep_alive: Option<KeepAlive>,
 }
 
 impl Model {
@@ -74,7 +74,7 @@ impl Model {
         Self {
             name: name.to_owned(),
             max_tokens: 2048,
-            keep_alive: KeepAlive::indefinite(),
+            keep_alive: Some(KeepAlive::indefinite()),
         }
     }
 


### PR DESCRIPTION
Putting this back to `Option<KeepAlive>` to make existing configs keep working.

Release Notes:

- N/A
