### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
  "tiny_http",
  "url",
  "util",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates `Cargo.lock`, since it was missed in #12818.

Release Notes:

- N/A
