### PR TITLE
project: Disable `project_tests::test_rescan_and_remote_updates` on Linux

### DIFF
--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -16,7 +16,6 @@ use std::task::Poll;
 use task::{ResolvedTask, TaskContext, TaskTemplate, TaskTemplates};
 use unindent::Unindent as _;
 use util::{assert_set_eq, paths::PathMatcher, test::temp_tree};
-use worktree::WorktreeModelHandle as _;
 
 #[gpui::test]
 async fn test_block_via_channel(cx: &mut gpui::TestAppContext) {
@@ -2982,6 +2981,8 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
 #[cfg(not(target_os = "linux"))]
 #[gpui::test(retries = 5)]
 async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
+    use worktree::WorktreeModelHandle as _;
+
     init_test(cx);
     cx.executor().allow_parking();
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2978,6 +2978,8 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
     assert_eq!(opened_buffer, buffer);
 }
 
+// This test is currently disabled on Linux as it fails fails pretty consistently on that target.
+#[cfg(not(target_os = "linux"))]
 #[gpui::test(retries = 5)]
 async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
     init_test(cx);


### PR DESCRIPTION
This PR disables the `project::project_tests::test_rescan_and_remote_updates` test on Linux, as we've been seeing it fail quite consistently in CI.

We can re-enable it once we've had a chance to investigate and fix.

Release Notes:

- N/A
