### PR TITLE
Register Markdown language in some tests to silence error logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13336,6 +13336,7 @@ dependencies = [
  "terminal_view",
  "theme",
  "theme_selector",
+ "tree-sitter-markdown",
  "tree-sitter-rust",
  "urlencoding",
  "util",

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use channel::{ChannelChat, ChannelStore, MessageParams};
 use client::{UserId, UserStore};
 use collections::HashSet;
@@ -133,7 +133,7 @@ impl MessageEditor {
 
         let markdown = language_registry.language_for_name("Markdown");
         cx.spawn(|_, mut cx| async move {
-            let markdown = markdown.await?;
+            let markdown = markdown.await.context("failed to load Markdown language")?;
             buffer.update(&mut cx, |buffer, cx| {
                 buffer.set_language(Some(markdown), cx)
             })

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -113,6 +113,7 @@ editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
+tree-sitter-markdown.workspace = true
 tree-sitter-rust.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 


### PR DESCRIPTION
This PR registers the Markdown language in some of the tests in the `zed` crate to silence the error logs about the language not being found when the chat panel attempts to load it.

Release Notes:

- N/A
