### PR TITLE
Silence error logs in `zed` tests

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3121,7 +3121,7 @@ mod tests {
 
     fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
         cx.update(|cx| {
-            env_logger::try_init().ok();
+            env_logger::builder().is_test(true).try_init().ok();
 
             let mut app_state = AppState::test(cx);
 


### PR DESCRIPTION
This PR silences the remaining error logs in the `zed` crate tests by initializing `env_logger` in test mode.

This means that the logs will no longer be shown unless `--nocapture` is passed to `cargo test`.

Release Notes:

- N/A
