### PR TITLE
Fix FS-related issues that were causing a test failure on linux

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -457,6 +457,8 @@ impl Fs for RealFs {
         Pin<Box<dyn Send + Stream<Item = Vec<PathBuf>>>>,
         Arc<dyn Watcher>,
     ) {
+        use parking_lot::Mutex;
+
         let (tx, rx) = smol::channel::unbounded();
 
         let file_watcher = notify::recommended_watcher({

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -492,6 +492,10 @@ impl Fs for RealFs {
                         paths.sort();
                         let paths_buffer = paths_buffer.clone();
                         futures::stream::once(Box::pin(async move {
+                            if paths.is_empty() {
+                                return None;
+                            }
+
                             {
                                 let mut lock = paths_buffer.lock();
                                 if let Some(paths_buffer) = lock.as_mut() {
@@ -508,13 +512,7 @@ impl Fs for RealFs {
                             }
 
                             smol::Timer::after(latency).await;
-
-                            let paths = paths_buffer.lock().take()?;
-                            if paths.is_empty() {
-                                None
-                            } else {
-                                Some(paths)
-                            }
+                            paths_buffer.lock().take()
                         }))
                     }
                 })

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2977,8 +2977,6 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
     assert_eq!(opened_buffer, buffer);
 }
 
-// This test is currently disabled on Linux as it fails fails pretty consistently on that target.
-#[cfg(not(target_os = "linux"))]
 #[gpui::test(retries = 5)]
 async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
     use worktree::WorktreeModelHandle as _;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -303,7 +303,7 @@ struct BackgroundScannerState {
     /// as part of the current update. These entry ids may be re-used
     /// if the same inode is discovered at a new path, or if the given
     /// path is re-created after being deleted.
-    removed_entry_ids: HashMap<u64, ProjectEntryId>,
+    removed_entry_ids: HashMap<(u64, SystemTime), ProjectEntryId>,
     changed_paths: Vec<Arc<Path>>,
     prev_snapshot: Snapshot,
 }
@@ -2638,10 +2638,13 @@ impl BackgroundScannerState {
     }
 
     fn reuse_entry_id(&mut self, entry: &mut Entry) {
-        if let Some(removed_entry_id) = self.removed_entry_ids.remove(&entry.inode) {
-            entry.id = removed_entry_id;
-        } else if let Some(existing_entry) = self.snapshot.entry_for_path(&entry.path) {
-            entry.id = existing_entry.id;
+        if let Some(mtime) = entry.mtime {
+            if let Some(removed_entry_id) = self.removed_entry_ids.remove(&(entry.inode, mtime)) {
+                eprintln!("detected that entry {entry:?} was renamed from inode and mtime reusing id {removed_entry_id:?}");
+                entry.id = removed_entry_id;
+            } else if let Some(existing_entry) = self.snapshot.entry_for_path(&entry.path) {
+                entry.id = existing_entry.id;
+            }
         }
     }
 
@@ -2732,11 +2735,13 @@ impl BackgroundScannerState {
 
         let mut entries_by_id_edits = Vec::new();
         for entry in removed_entries.cursor::<()>() {
-            let removed_entry_id = self
-                .removed_entry_ids
-                .entry(entry.inode)
-                .or_insert(entry.id);
-            *removed_entry_id = cmp::max(*removed_entry_id, entry.id);
+            if let Some(mtime) = entry.mtime {
+                let removed_entry_id = self
+                    .removed_entry_ids
+                    .entry((entry.inode, mtime))
+                    .or_insert(entry.id);
+                *removed_entry_id = cmp::max(*removed_entry_id, entry.id);
+            }
             entries_by_id_edits.push(Edit::Remove(entry.id));
         }
         self.snapshot.entries_by_id.edit(entries_by_id_edits, &());


### PR DESCRIPTION
This fixes `project_tests::rescan_and_remote_updates` .

That test was actually correctly failing, revealing two bugs on Linux.

Release Notes:

- Fixed an issue where file renames were not detected on Linux.
- Fixed performance problems caused by excessive file system events on Linux.
