### PR TITLE
Remove extra `cargo install cargo-about`

### DIFF
--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+CARGO_ABOUT_VERSION="0.6.1"
 OUTPUT_FILE="${1:-$(pwd)/assets/licenses.md}"
 
 > $OUTPUT_FILE
@@ -14,7 +15,12 @@ cat assets/icons/LICENSES >> $OUTPUT_FILE
 
 echo -e "# ###### CODE LICENSES ######\n" >> $OUTPUT_FILE
 
-[[ "$(cargo about --version)" == "cargo-about 0.6.1" ]] || cargo install cargo-about@0.6.1
+if ! cargo install --list | grep "cargo-about v$CARGO_ABOUT_VERSION" > /dev/null; then
+  echo "Installing cargo-about@$CARGO_ABOUT_VERSION..."
+  cargo install "cargo-about@$CARGO_ABOUT_VERSION"
+else
+  echo "cargo-about@$CARGO_ABOUT_VERSION is already installed."
+fi
 
 echo "Generating cargo licenses"
 cargo about generate --fail -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md >> $OUTPUT_FILE

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -17,7 +17,6 @@ echo -e "# ###### CODE LICENSES ######\n" >> $OUTPUT_FILE
 [[ "$(cargo about --version)" == "cargo-about 0.6.1" ]] || cargo install cargo-about@0.6.1
 
 echo "Generating cargo licenses"
-cargo install cargo-about
 cargo about generate --fail -c script/licenses/zed-licenses.toml script/licenses/template.hbs.md >> $OUTPUT_FILE
 
 


### PR DESCRIPTION
This PR removes an extra `cargo install cargo-about` in the `generate-licenses` script, as we already install a specific version of `cargo-about`.

It also improves the way we detect if `cargo-about` is already installed, to avoid logging an error when it is not installed.

Resolves #13075.

Release Notes:

- N/A
