### PR TITLE
extension_cli: Allow building without dynamically linking WebRTC

### DIFF
--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/call.rs"
 doctest = false
 
 [features]
+no-webrtc = ["live_kit_client/no-webrtc"]
 test-support = [
     "client/test-support",
     "collections/test-support",

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -12,6 +12,9 @@ workspace = true
 path = "src/extension_store.rs"
 doctest = false
 
+[features]
+no-webrtc = ["workspace/no-webrtc"]
+
 [dependencies]
 anyhow.workspace = true
 assistant_slash_command.workspace = true

--- a/crates/extension_cli/Cargo.toml
+++ b/crates/extension_cli/Cargo.toml
@@ -17,7 +17,7 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 env_logger.workspace = true
 fs.workspace = true
-extension.workspace = true
+extension = { workspace = true, features = ["no-webrtc"] }
 language.workspace = true
 log.workspace = true
 rpc.workspace = true

--- a/crates/live_kit_client/Cargo.toml
+++ b/crates/live_kit_client/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 name = "test_app"
 
 [features]
+no-webrtc = []
 test-support = [
     "async-trait",
     "collections/test-support",

--- a/crates/live_kit_client/build.rs
+++ b/crates/live_kit_client/build.rs
@@ -37,7 +37,7 @@ const MACOS_TARGET_VERSION: &str = "10.15.7";
 fn main() {
     if cfg!(all(
         target_os = "macos",
-        not(any(test, feature = "test-support"))
+        not(any(test, feature = "test-support", feature = "no-webrtc")),
     )) {
         let swift_target = get_swift_target();
 

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/workspace.rs"
 doctest = false
 
 [features]
+no-webrtc = ["call/no-webrtc"]
 test-support = [
     "call/test-support",
     "client/test-support",


### PR DESCRIPTION
This PR fixes an issue where the `zed-extension` CLI could no longer be run as a static binary due to the following error:

```
dyld[36964]: Library not loaded: @rpath/WebRTC.framework/WebRTC
  Referenced from: <56332E1D-292E-3F9B-97B9-8A9962D21599> /Users/maxdeviant/projects/zed-extensions/zed-extension
  Reason: no LC_RPATH's found
fish: Job 1, './zed-extension --scratch-dir .…' terminated by signal SIGABRT (Abort)
```

This is the result of the addition of a dependency on `workspace` to the `extension` crate (and thus, the `extension_cli` crate) in #12360.

Since we don't actually _need_ WebRTC in the extension CLI, we don't care about dynamically linking it.

To resolve this, a new `no-webrtc` feature has been added to the `live_kit_client` client crate and threaded through all of the crates between it and the `extension_cli`.

Enabling the `no-webrtc` feature will prevent linking to the LiveKit Swift SDK as well as linking the WebRTC framework.

Release Notes:

- N/A
