### PR TITLE
windows: Fix executable display name

### DIFF
--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -57,6 +57,8 @@ fn main() {
 
         let mut res = winresource::WindowsResource::new();
         res.set_icon(icon.to_str().unwrap());
+        res.set("FileDescription", "Zed");
+        res.set("ProductName", "Zed");
 
         if let Err(e) = res.compile() {
             eprintln!("{}", e);


### PR DESCRIPTION
Closes #12907 

**Note:** To actually take effect, delete the registered key of `Zed` in `HKEY_CLASSES_ROOT\Local Settings\Software\Microsoft\Windows\Shell\MuiCache`, for example, delete this:

![Screenshot 2024-06-15 180939](https://github.com/zed-industries/zed/assets/14981363/8da94188-a869-48bb-9ecf-18a0a2cd3061)


### Before

1. In Taskmanager

![Screenshot 2024-06-15 175146](https://github.com/zed-industries/zed/assets/14981363/bb58a136-9f28-4f7f-9079-d83bc8b27580)

2. Right click taskbar

![Screenshot 2024-06-15 175211](https://github.com/zed-industries/zed/assets/14981363/113797c5-fa38-494e-a939-7a05adfa6d9e)

### After

![Screenshot 2024-06-15 174800](https://github.com/zed-industries/zed/assets/14981363/a1e9c1f5-da05-4a47-a97f-bd297f22ae37)

![Screenshot 2024-06-15 175847](https://github.com/zed-industries/zed/assets/14981363/692ed3ac-6ad0-4804-894e-1fae375ebd3d)

Release Notes:

- N/A

