### PR TITLE
Remove textDocument/diagnostic capability

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -704,10 +704,6 @@ impl LanguageServer {
                     on_type_formatting: Some(DynamicRegistrationClientCapabilities {
                         dynamic_registration: None,
                     }),
-                    diagnostic: Some(DiagnosticClientCapabilities {
-                        related_document_support: Some(true),
-                        dynamic_registration: None,
-                    }),
                     ..Default::default()
                 }),
                 experimental: Some(json!({


### PR DESCRIPTION
Zed currently does not support pull diagnostics, yet still has the capability for it (`textDocument/diagnostic`) (added in https://github.com/zed-industries/zed/commit/14993e087669c7103df2239a2628ee0d3ce38596). Some language servers therefore assume Zed will use pull diagnostics, which leads to there being no diagnostics at all. This PR removes this capability, making it possible to get diagnostics with more language servers.