### PR TITLE
Improve code folding to exclude folding line breaks in whitespace-sensitive languages

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -984,7 +984,18 @@ impl DisplaySnapshot {
                 }
             }
             let end = end.unwrap_or(max_point);
-            Some((start..end, self.fold_placeholder.clone()))
+
+            // Adjust end point to exclude folding line break if present
+            let adjusted_end = if self.buffer_snapshot.is_line_blank(MultiBufferRow(end.row)) {
+                Point::new(
+                    end.row - 1,
+                    self.buffer_snapshot.line_len(MultiBufferRow(end.row - 1)),
+                )
+            } else {
+                end
+            };
+
+            Some((start..adjusted_end, self.fold_placeholder.clone()))
         } else {
             None
         }

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -985,7 +985,7 @@ impl DisplaySnapshot {
             }
 
             let mut row_before_line_breaks = end.unwrap_or(max_point);
-            while row_before_line_breaks.row > 0
+            while row_before_line_breaks.row > start.row
                 && self
                     .buffer_snapshot
                     .is_line_blank(MultiBufferRow(row_before_line_breaks.row))

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -983,17 +983,21 @@ impl DisplaySnapshot {
                     break;
                 }
             }
-            let end = end.unwrap_or(max_point);
+            let mut adjusted_end = end.unwrap_or(max_point);
 
-            // Adjust end point to exclude folding line break if present
-            let adjusted_end = if self.buffer_snapshot.is_line_blank(MultiBufferRow(end.row)) {
-                Point::new(
-                    end.row - 1,
-                    self.buffer_snapshot.line_len(MultiBufferRow(end.row - 1)),
-                )
-            } else {
-                end
-            };
+            // Adjust end point to exclude folding any line breaks if present
+            while adjusted_end.row > 0
+                && self
+                    .buffer_snapshot
+                    .is_line_blank(MultiBufferRow(adjusted_end.row))
+            {
+                // Keep searching upwards until we find a non-blank line
+                adjusted_end = Point::new(
+                    adjusted_end.row - 1,
+                    self.buffer_snapshot
+                        .line_len(MultiBufferRow(adjusted_end.row - 1)),
+                );
+            }
 
             Some((start..adjusted_end, self.fold_placeholder.clone()))
         } else {

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -983,23 +983,23 @@ impl DisplaySnapshot {
                     break;
                 }
             }
-            let mut adjusted_end = end.unwrap_or(max_point);
 
-            // Adjust end point to exclude folding any line breaks if present
-            while adjusted_end.row > 0
+            let mut row_before_line_breaks = end.unwrap_or(max_point);
+            while row_before_line_breaks.row > 0
                 && self
                     .buffer_snapshot
-                    .is_line_blank(MultiBufferRow(adjusted_end.row))
+                    .is_line_blank(MultiBufferRow(row_before_line_breaks.row))
             {
-                // Keep searching upwards until we find a non-blank line
-                adjusted_end = Point::new(
-                    adjusted_end.row - 1,
-                    self.buffer_snapshot
-                        .line_len(MultiBufferRow(adjusted_end.row - 1)),
-                );
+                row_before_line_breaks.row -= 1;
             }
 
-            Some((start..adjusted_end, self.fold_placeholder.clone()))
+            row_before_line_breaks = Point::new(
+                row_before_line_breaks.row,
+                self.buffer_snapshot
+                    .line_len(MultiBufferRow(row_before_line_breaks.row)),
+            );
+
+            Some((start..row_before_line_breaks, self.fold_placeholder.clone()))
         } else {
             None
         }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -938,6 +938,96 @@ fn test_fold_action_whitespace_sensitive_language(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_fold_action_multiple_line_breaks(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let view = cx.add_window(|cx| {
+        let buffer = MultiBuffer::build_simple(
+            &"
+                class Foo:
+                    # Hello!
+
+                    def a():
+                        print(1)
+
+                    def b():
+                        print(2)
+
+
+                    def c():
+                        print(3)
+
+
+            "
+            .unindent(),
+            cx,
+        );
+        build_editor(buffer.clone(), cx)
+    });
+
+    _ = view.update(cx, |view, cx| {
+        view.change_selections(None, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(7), 0)..DisplayPoint::new(DisplayRow(11), 0)
+            ]);
+        });
+        view.fold(&Fold, cx);
+        assert_eq!(
+            view.display_text(cx),
+            "
+                class Foo:
+                    # Hello!
+
+                    def a():
+                        print(1)
+
+                    def b():⋯
+
+
+                    def c():⋯
+
+
+            "
+            .unindent(),
+        );
+
+        view.fold(&Fold, cx);
+        assert_eq!(
+            view.display_text(cx),
+            "
+                class Foo:⋯
+
+
+            "
+            .unindent(),
+        );
+
+        view.unfold_lines(&UnfoldLines, cx);
+        assert_eq!(
+            view.display_text(cx),
+            "
+                class Foo:
+                    # Hello!
+
+                    def a():
+                        print(1)
+
+                    def b():⋯
+
+
+                    def c():⋯
+
+
+            "
+            .unindent(),
+        );
+
+        view.unfold_lines(&UnfoldLines, cx);
+        assert_eq!(view.display_text(cx), view.buffer.read(cx).read(cx).text());
+    });
+}
+
+#[gpui::test]
 fn test_move_cursor(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -859,6 +859,85 @@ fn test_fold_action(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_fold_action_whitespace_sensitive_language(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let view = cx.add_window(|cx| {
+        let buffer = MultiBuffer::build_simple(
+            &"
+                class Foo:
+                    # Hello!
+
+                    def a():
+                        print(1)
+
+                    def b():
+                        print(2)
+
+                    def c():
+                        print(3)
+            "
+            .unindent(),
+            cx,
+        );
+        build_editor(buffer.clone(), cx)
+    });
+
+    _ = view.update(cx, |view, cx| {
+        view.change_selections(None, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(7), 0)..DisplayPoint::new(DisplayRow(10), 0)
+            ]);
+        });
+        view.fold(&Fold, cx);
+        assert_eq!(
+            view.display_text(cx),
+            "
+                class Foo:
+                    # Hello!
+
+                    def a():
+                        print(1)
+
+                    def b():⋯
+
+                    def c():⋯
+            "
+            .unindent(),
+        );
+
+        view.fold(&Fold, cx);
+        assert_eq!(
+            view.display_text(cx),
+            "
+                class Foo:⋯
+            "
+            .unindent(),
+        );
+
+        view.unfold_lines(&UnfoldLines, cx);
+        assert_eq!(
+            view.display_text(cx),
+            "
+                class Foo:
+                    # Hello!
+
+                    def a():
+                        print(1)
+
+                    def b():⋯
+
+                    def c():⋯
+            "
+            .unindent(),
+        );
+
+        view.unfold_lines(&UnfoldLines, cx);
+        assert_eq!(view.display_text(cx), view.buffer.read(cx).read(cx).text());
+    });
+}
+
+#[gpui::test]
 fn test_move_cursor(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Updated the foldable_range method to exclude folding line breaks during code folding in whitespace-sensitive languages like Python and YAML. This adjustment ensures that folding behaves as expected, similar to other code editors.

Ref #11614

Release Notes:

- Fixed #11614

<img width="1219" alt="Screenshot 2024-06-16 at 15 43 31" src="https://github.com/zed-industries/zed/assets/87859239/dd05de16-7f20-4c88-9e95-021555b8b78b">
<img width="1219" alt="Screenshot 2024-06-16 at 15 45 10" src="https://github.com/zed-industries/zed/assets/87859239/b1b78cdd-f34d-4ea3-9728-4741727a9643">

