### PR TITLE
Fix Hide Copilot context menu item

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -440,7 +440,9 @@ fn toggle_inline_completions_for_language(
 
 fn hide_copilot(fs: Arc<dyn Fs>, cx: &mut AppContext) {
     update_settings_file::<AllLanguageSettings>(fs, cx, move |file| {
-        file.features.get_or_insert(Default::default()).copilot = Some(false);
+        file.features
+            .get_or_insert(Default::default())
+            .inline_completion_provider = Some(InlineCompletionProvider::None);
     });
 }
 


### PR DESCRIPTION
The `features.copilot` setting appears to have been replaced by `"inline_completion_provider": "none"` at some point, but the Hide Copilot context menu was never updated to reflect that.

Release Notes:

- Fixed the Hide Copilot context menu item to modify the appropriate setting.