### PR TITLE
Add limit to minimum window size

### DIFF
--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -126,5 +126,6 @@ fn notification_window_options(
         display_id: Some(screen.id()),
         window_background: WindowBackgroundAppearance::default(),
         app_id: Some(app_id.to_owned()),
+        window_min_size: Size::default(),
     }
 }

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -54,6 +54,7 @@ fn main() {
                     kind: WindowKind::PopUp,
                     is_movable: false,
                     app_id: None,
+                    window_min_size: Size::default(),
                 }
             };
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2256,6 +2256,15 @@ impl Pixels {
     pub fn abs(&self) -> Self {
         Self(self.0.abs())
     }
+
+    /// Returns the f64 value of `Pixels`.
+    ///
+    /// # Returns
+    ///
+    /// A f64 value of the `Pixels`.
+    pub fn to_f64(self) -> f64 {
+        self.0 as f64
+    }
 }
 
 impl Mul<Pixels> for Pixels {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -565,6 +565,9 @@ pub struct WindowOptions {
 
     /// Application identifier of the window. Can by used by desktop environments to group applications together.
     pub app_id: Option<String>,
+
+    /// Window minimum size
+    pub window_min_size: Size<Pixels>,
 }
 
 /// The variables that can be configured when creating a new window
@@ -592,6 +595,9 @@ pub(crate) struct WindowParams {
     pub display_id: Option<DisplayId>,
 
     pub window_background: WindowBackgroundAppearance,
+
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
+    pub window_min_size: Size<Pixels>,
 }
 
 /// Represents the status of how a window should be opened.
@@ -640,6 +646,7 @@ impl Default for WindowOptions {
             display_id: None,
             window_background: WindowBackgroundAppearance::default(),
             app_id: None,
+            window_min_size: Size::default(),
         }
     }
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -513,6 +513,7 @@ impl MacWindow {
             focus,
             show,
             display_id,
+            window_min_size,
         }: WindowParams,
         executor: ForegroundExecutor,
         renderer_context: renderer::Context,
@@ -663,8 +664,8 @@ impl MacWindow {
             native_window.setMovable_(is_movable as BOOL);
 
             native_window.setContentMinSize_(NSSize {
-                width: (360f64),
-                height: (240f64),
+                width: window_min_size.width.to_f64(),
+                height: window_min_size.height.to_f64(),
             });
 
             if titlebar.map_or(true, |titlebar| titlebar.appears_transparent) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -662,6 +662,11 @@ impl MacWindow {
 
             native_window.setMovable_(is_movable as BOOL);
 
+            native_window.setContentMinSize_(NSSize {
+                width: (360f64),
+                height: (240f64),
+            });
+
             if titlebar.map_or(true, |titlebar| titlebar.appears_transparent) {
                 native_window.setTitlebarAppearsTransparent_(YES);
                 native_window.setTitleVisibility_(NSWindowTitleVisibility::NSWindowTitleHidden);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -616,6 +616,7 @@ impl Window {
             display_id,
             window_background,
             app_id,
+            window_min_size,
         } = options;
 
         let bounds = window_bounds
@@ -632,6 +633,7 @@ impl Window {
                 show,
                 display_id,
                 window_background,
+                window_min_size,
             },
         );
         let display_id = platform_window.display().map(|display| display.id());

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -107,6 +107,10 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         display_id: display.map(|display| display.id()),
         window_background: cx.theme().window_background_appearance(),
         app_id: Some(app_id.to_owned()),
+        window_min_size: gpui::Size {
+            width: px(360.0),
+            height: px(240.0),
+        },
     }
 }
 


### PR DESCRIPTION
Release Notes:

- Add a limit to the minimum window size on macOS.

Here's the minimum window before change:
<img width="121" alt="image" src="https://github.com/zed-industries/zed/assets/38318044/9e907194-42e5-457e-91ea-96613426b479">

After change:
<img width="410" alt="image" src="https://github.com/zed-industries/zed/assets/38318044/6e9c3057-9860-4f4b-9a73-c158ebac5ba9">

