### PR TITLE
Add payload limit for Gemini script

### DIFF
--- a/script/gemini.py
+++ b/script/gemini.py
@@ -25,6 +25,7 @@ def get_file_contents(file):
 
 
 def main():
+    MAX_PAYLOAD_SIZE = 1024 * 1024 
     GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY')
 
     # Your prompt
@@ -45,6 +46,10 @@ def main():
             }]
         }]
     })
+
+    if len(payload.encode('utf-8')) > MAX_PAYLOAD_SIZE:
+        print("Payload size exceeds the limit.")
+        return
 
     # Prepare the HTTP connection
     conn = http.client.HTTPSConnection("generativelanguage.googleapis.com")


### PR DESCRIPTION
resolved problem where the request was sent without a payload limit, which could cause the request to fail if something very large was sent as previously the payload size was not checked before sending it

Release Notes:

- N/A