### PR TITLE
docs: Fix the missing shortcut for Go Back

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -347,7 +347,7 @@ The argument to `SendKeystrokes` is a space-separated list of keystrokes (using 
 | Close all items               | Pane           | `⌘ + K, ⌘ + W`          |
 | Close clean items             | Pane           | `⌘ + K, U`              |
 | Close inactive items          | Pane           | `Alt + ⌘ + T`           |
-| Go back                       | Pane           | `Control + `            |
+| Go back                       | Pane           | `Control + -`           |
 | Go forward                    | Pane           | `Control + _`           |
 | Reopen closed item            | Pane           | `⌘ + Shift + T`         |
 | Split down                    | Pane           | `⌘ + K, Down`           |


### PR DESCRIPTION
Hi all. I fixed a typo in the documents of key bindings. The default shortcut of Go Back command is uncompleted.

Release Notes:

- N/A
