### PR TITLE
Don't include prompt titles / "Default Prompt:" in slash command output

### DIFF
--- a/crates/assistant/src/slash_command/default_command.rs
+++ b/crates/assistant/src/slash_command/default_command.rs
@@ -53,13 +53,17 @@ impl SlashCommand for DefaultSlashCommand {
             let prompts = store.default_prompt_metadata();
 
             let mut text = String::new();
-            writeln!(text, "Default Prompt:").unwrap();
+            text.push('\n');
             for prompt in prompts {
                 if let Some(title) = prompt.title {
                     writeln!(text, "/prompt {}", title).unwrap();
                 }
             }
             text.pop();
+
+            if text.is_empty() {
+                text.push('\n');
+            }
 
             Ok(SlashCommandOutput {
                 sections: vec![SlashCommandOutputSection {

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -69,7 +69,10 @@ impl SlashCommand for PromptSlashCommand {
             }
         });
         cx.foreground_executor().spawn(async move {
-            let prompt = prompt.await?;
+            let mut prompt = prompt.await?;
+            if prompt.is_empty() {
+                prompt.push('\n');
+            }
             let range = 0..prompt.len();
             Ok(SlashCommandOutput {
                 text: prompt,


### PR DESCRIPTION
This only includes a newline to ensure there's always something to fold.

Release Notes:

- N/A
