### PR TITLE
typescript: Make VTSLS the default language server for Typescript

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -131,7 +131,14 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.cert",
+    "**/*.crt",
+    "**/secrets.yml"
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -722,7 +729,7 @@
       }
     },
     "JavaScript": {
-      "language_servers": ["typescript-language-server", "!vtsls", "..."],
+      "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
         "allowed": true
       }
@@ -765,7 +772,7 @@
       }
     },
     "TSX": {
-      "language_servers": ["typescript-language-server", "!vtsls", "..."],
+      "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
         "allowed": true
       }
@@ -776,7 +783,7 @@
       }
     },
     "TypeScript": {
-      "language_servers": ["typescript-language-server", "!vtsls", "..."],
+      "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
         "allowed": true
       }

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -174,8 +174,60 @@ impl LspAdapter for VtslsLspAdapter {
                         "enabled": "all",
                         "suppressWhenArgumentMatchesName": false,
 
-                    }
                     },
+
+                    "parameterTypes":
+                    {
+                        "enabled": true
+                    },
+                    "variableTypes": {
+                        "enabled": true,
+                        "suppressWhenTypeMatchesName": false,
+                    },
+                    "propertyDeclarationTypes":{
+                        "enabled": true,
+                    },
+                    "functionLikeReturnTypes": {
+                        "enabled": true,
+                    },
+                    "enumMemberValues":{
+                        "enabled": true,
+                    }
+                }
+            },
+            "vtsls":
+            {"experimental": {
+                "completion": {
+                    "enableServerSideFuzzyMatch": true,
+                    "entriesLimit": 5000,
+                }
+            }
+            }
+        })))
+    }
+
+    async fn workspace_configuration(
+        self: Arc<Self>,
+        _: &Arc<dyn LspAdapterDelegate>,
+        _cx: &mut AsyncAppContext,
+    ) -> Result<Value> {
+        Ok(json!({
+            "typescript": {
+                "suggest": {
+                    "completeFunctionCalls": true
+                },
+                "tsdk": "node_modules/typescript/lib",
+                "format": {
+                    "enable": true
+                },
+                "inlayHints":{
+                    "parameterNames":
+                    {
+                        "enabled": "all",
+                        "suppressWhenArgumentMatchesName": false,
+
+                    },
+
                     "parameterTypes":
                     {
                         "enabled": true
@@ -194,19 +246,14 @@ impl LspAdapter for VtslsLspAdapter {
                         "enabled": true,
                     }
             }
-        })))
-    }
-
-    async fn workspace_configuration(
-        self: Arc<Self>,
-        _: &Arc<dyn LspAdapterDelegate>,
-        _cx: &mut AsyncAppContext,
-    ) -> Result<Value> {
-        Ok(json!({
-            "typescript": {
-                "suggest": {
-                    "completeFunctionCalls": true
+            },
+            "vtsls":
+            {"experimental": {
+                "completion": {
+                    "enableServerSideFuzzyMatch": true,
+                    "entriesLimit": 5000,
                 }
+            }
             }
         }))
     }

--- a/crates/lsp/src/input_handler.rs
+++ b/crates/lsp/src/input_handler.rs
@@ -99,9 +99,7 @@ impl LspStdoutHandler {
                 }
             }
 
-            if let Ok(msg) = serde_json::from_slice::<AnyNotification>(&buffer) {
-                notifications_sender.unbounded_send(msg)?;
-            } else if let Ok(AnyResponse {
+            if let Ok(AnyResponse {
                 id, error, result, ..
             }) = serde_json::from_slice(&buffer)
             {
@@ -119,6 +117,8 @@ impl LspStdoutHandler {
                         handler(Ok("null".into()));
                     }
                 }
+            } else if let Ok(msg) = serde_json::from_slice::<AnyNotification>(&buffer) {
+                notifications_sender.unbounded_send(msg)?;
             } else {
                 warn!(
                     "failed to deserialize LSP message:\n{}",

--- a/crates/lsp/src/input_handler.rs
+++ b/crates/lsp/src/input_handler.rs
@@ -99,7 +99,9 @@ impl LspStdoutHandler {
                 }
             }
 
-            if let Ok(AnyResponse {
+            if let Ok(msg) = serde_json::from_slice::<AnyNotification>(&buffer) {
+                notifications_sender.unbounded_send(msg)?;
+            } else if let Ok(AnyResponse {
                 id, error, result, ..
             }) = serde_json::from_slice(&buffer)
             {
@@ -117,8 +119,6 @@ impl LspStdoutHandler {
                         handler(Ok("null".into()));
                     }
                 }
-            } else if let Ok(msg) = serde_json::from_slice::<AnyNotification>(&buffer) {
-                notifications_sender.unbounded_send(msg)?;
             } else {
                 warn!(
                     "failed to deserialize LSP message:\n{}",


### PR DESCRIPTION
Additionally, limit # of returned completion items + use fuzzy filtering on VTSLS side. Prime LSP handler for response handling.


Release Notes:

- VTSLS is now a default language server for TypeScript, TSX, and JavaScript.
