### PR TITLE
assistant: Put rustdoc indexing behind a staff flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "ctor",
  "editor",
  "env_logger",
+ "feature_flags",
  "file_icons",
  "fs",
  "futures 0.3.28",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/assistant.rs"
 doctest = false
 
 [dependencies]
-anyhow.workspace = true
 anthropic = { workspace = true, features = ["schemars"] }
+anyhow.workspace = true
 assistant_slash_command.workspace = true
 cargo_toml.workspace = true
 chrono.workspace = true
@@ -22,6 +22,7 @@ client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
 editor.workspace = true
+feature_flags.workspace = true
 file_icons.workspace = true
 fs.workspace = true
 futures.workspace = true
@@ -39,6 +40,7 @@ ollama = { workspace = true, features = ["schemars"] }
 open_ai = { workspace = true, features = ["schemars"] }
 ordered-float.workspace = true
 parking_lot.workspace = true
+picker.workspace = true
 project.workspace = true
 regex.workspace = true
 rope.workspace = true
@@ -61,7 +63,6 @@ ui.workspace = true
 util.workspace = true
 uuid.workspace = true
 workspace.workspace = true
-picker.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true


### PR DESCRIPTION
This PR puts the indexing for the `/rustdoc` command behind a staff flag, as it's not ready to be shipped to end users.

Release Notes:

- N/A
