### PR TITLE
assistant: Fix loading local crate docs

### DIFF
--- a/crates/assistant/src/slash_command/rustdoc_command.rs
+++ b/crates/assistant/src/slash_command/rustdoc_command.rs
@@ -189,7 +189,14 @@ impl SlashCommand for RustdocSlashCommand {
             let item_path = item_path.clone();
             async move {
                 let item_docs = rustdoc_store
-                    .load(crate_name.clone(), Some(item_path.join("::")))
+                    .load(
+                        crate_name.clone(),
+                        if item_path.is_empty() {
+                            None
+                        } else {
+                            Some(item_path.join("::"))
+                        },
+                    )
                     .await;
 
                 if let Ok(item_docs) = item_docs {


### PR DESCRIPTION
This PR fixes an issue where loading the crate-level docs with `/rustdoc` wasn't working as expected.

Release Notes:

- N/A
