### PR TITLE
rustdoc: Don't start indexing if a crate is already being indexed

### DIFF
--- a/crates/rustdoc/src/store.rs
+++ b/crates/rustdoc/src/store.rs
@@ -89,6 +89,10 @@ impl RustdocStore {
         crate_name: CrateName,
         provider: Box<dyn RustdocProvider + Send + Sync + 'static>,
     ) -> Shared<Task<Result<(), Arc<anyhow::Error>>>> {
+        if let Some(existing_task) = self.indexing_tasks_by_crate.read().get(&crate_name) {
+            return existing_task.clone();
+        }
+
         let indexing_task = self
             .executor
             .spawn({


### PR DESCRIPTION
This PR updates the rustdoc indexing to not start indexing a crate that is already being indexed.

Currently the indexing of a crate might get continuously interrupted by the user's typing, resulting in thrashing of the indexing task and never indexing the crate in its entirety.

Release Notes:

- N/A
