### PR TITLE
Show correct line number for entry placeholders in `/search`

### DIFF
--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -159,7 +159,7 @@ impl SlashCommand for SearchSlashCommand {
                                     id,
                                     path: Some(full_path.clone()),
                                     is_directory: false,
-                                    line_range: Some(start_row..end_row),
+                                    line_range: Some(start_row + 1..end_row + 1),
                                     unfold,
                                 }
                                 .into_any_element()


### PR DESCRIPTION
Release Notes:

- N/A
