### PR TITLE
repl: Add missing LICENSE file

### DIFF
--- a/crates/repl/LICENSE-GPL
+++ b/crates/repl/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL


### PR DESCRIPTION
This PR adds a missing LICENSE file to the `repl` crate.

Release Notes:

- N/A
