### PR TITLE
Remove `language_overrides` setting alias

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -200,7 +200,7 @@ pub struct AllLanguageSettingsContent {
     #[serde(flatten)]
     pub defaults: LanguageSettingsContent,
     /// The settings for individual languages.
-    #[serde(default, alias = "language_overrides")]
+    #[serde(default)]
     pub languages: HashMap<Arc<str>, LanguageSettingsContent>,
     /// Settings for associating file extensions and filenames
     /// with languages.
@@ -754,17 +754,10 @@ impl settings::Settings for AllLanguageSettings {
             .as_mut()
             .unwrap()
             .properties
-            .extend([
-                (
-                    "languages".to_owned(),
-                    Schema::new_ref("#/definitions/Languages".into()),
-                ),
-                // For backward compatibility
-                (
-                    "language_overrides".to_owned(),
-                    Schema::new_ref("#/definitions/Languages".into()),
-                ),
-            ]);
+            .extend([(
+                "languages".to_owned(),
+                Schema::new_ref("#/definitions/Languages".into()),
+            )]);
 
         root_schema
     }


### PR DESCRIPTION
This PR removes the `language_overrides` alias for the `languages` setting.

I've seen a number of people run into issues where they have both `languages` and `language_overrides` in their settings and get confused when their settings don't seem to apply as expected.

This is a breaking change, but I think it is a necessary one to prevent more users from running into issues.

Release Notes:

- Breaking Change: Removed the `language_overrides` alias for the `languages` setting. If you have settings under `language_overrides` they should get moved to `languages`.
