### PR TITLE
linux: Fix icon not being associated with app window

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -6,6 +6,7 @@ GenericName=Text Editor
 Comment=A high-performance, multiplayer code editor.
 TryExec=$APP_CLI
 StartupNotify=$DO_STARTUP_NOTIFY
+StartupWMClass=$APP_ID
 Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
 Categories=Utility;TextEditor;Development;IDE;


### PR DESCRIPTION
This commit fixes the app icon not being correctly associated with the app window. For example, the app icon is not correctly shown in the dock (Gnome on Wayland) when Zed is running.

Release Notes:

- N/A
