### PR TITLE
Remove `copilot` and `show_copilot_suggestions` setting aliases

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -145,9 +145,9 @@
   // Otherwise(when `true`), the closing characters are always skipped over and auto-removed
   // no matter how they were inserted.
   "always_treat_brackets_as_autoclosed": false,
-  // Controls whether copilot provides suggestion immediately
-  // or waits for a `copilot::Toggle`
-  "show_copilot_suggestions": true,
+  // Controls whether inline completions are shown immediately (true)
+  // or manually by triggering `editor::ShowInlineCompletion` (false).
+  "show_inline_completions": true,
   // Whether to show tabs and spaces in the editor.
   // This setting can take three values:
   //
@@ -516,9 +516,8 @@
       // "delay_ms": 600
     }
   },
-  "copilot": {
-    // The set of glob patterns for which copilot should be disabled
-    // in any matching file.
+  "inline_completions": {
+    // A list of globs representing files that inline completions should be disabled for.
     "disabled_globs": [".env"]
   },
   // Settings specific to journaling

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -194,7 +194,7 @@ pub struct AllLanguageSettingsContent {
     #[serde(default)]
     pub features: Option<FeaturesContent>,
     /// The inline completion settings.
-    #[serde(default, alias = "copilot")]
+    #[serde(default)]
     pub inline_completions: Option<InlineCompletionSettingsContent>,
     /// The default language settings.
     #[serde(flatten)]
@@ -297,7 +297,7 @@ pub struct LanguageSettingsContent {
     /// or manually by triggering `editor::ShowInlineCompletion` (false).
     ///
     /// Default: true
-    #[serde(default, alias = "show_copilot_suggestions")]
+    #[serde(default)]
     pub show_inline_completions: Option<bool>,
     /// Whether to show tabs and spaces in the editor.
     #[serde(default)]


### PR DESCRIPTION
This PR removes the Copilot-specific aliases for the `inline_completions` and `show_inline_completions` settings.

While these aliases were added to maintain backward-compatibility, the aliasing behavior here can lead to a confusing experience when both keys end up in the `settings.json`.

Release Notes:

- Breaking Change: Removed the `copilot` alias for the `inline_completions` setting. If you have settings under `copilot` they should get moved to `inline_completions`.
- Breaking Change: Removed the `show_copilot_suggestions` alias for the `show_inline_completions` setting.
