### PR TITLE
Don't generate invalid ranges for C code

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -197,8 +197,16 @@ impl super::LspAdapter for CLspAdapter {
                 let detail = completion.detail.as_ref().unwrap();
                 let text = format!("{} {}", detail, label);
                 let runs = language.highlight_text(&Rope::from(text.as_str()), 0..text.len());
+                let filter_start = detail.len() + 1;
+                let filter_end =
+                    if let Some(end) = text.rfind('(').filter(|end| *end > filter_start) {
+                        end
+                    } else {
+                        text.len()
+                    };
+
                 return Some(CodeLabel {
-                    filter_range: detail.len() + 1..text.rfind('(').unwrap_or(text.len()),
+                    filter_range: filter_start..filter_end,
                     text,
                     runs,
                 });


### PR DESCRIPTION
Fixes: #13128

Release Notes:

- Fixed a panic when editing C code ([#13128](https://github.com/zed-industries/zed/issues/13128)).
