### PR TITLE
fix: auto close <> in Rust

### DIFF
--- a/crates/languages/src/rust/config.toml
+++ b/crates/languages/src/rust/config.toml
@@ -7,7 +7,7 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "<", end = ">", close = false, newline = true, not_in = ["string", "comment"] },
+    { start = "<", end = ">", close = true, newline = true, not_in = ["string", "comment"] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]


### PR DESCRIPTION
fix #12898.

Release Notes:

- Fixed auto close <> in Rust ([#12898](https://github.com/zed-industries/zed/issues/12898)).
![20240618141248_rec_](https://github.com/zed-industries/zed/assets/32017007/1859ebc4-4037-41c3-8968-b428ac555d93)
