### PR TITLE
lsp: Revert URL type change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,15 +4126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
 
 [[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "flume"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6171,7 +6162,6 @@ dependencies = [
  "log",
  "lsp-types",
  "parking_lot",
- "pct-str",
  "postage",
  "release_channel",
  "serde",
@@ -6183,14 +6173,14 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.97.0"
-source = "git+https://github.com/zed-industries/lsp-types?branch=zed-main#258db672ceab9e66c6da3883d37c4dcf1094c6ac"
+version = "0.95.1"
+source = "git+https://github.com/zed-industries/lsp-types?branch=apply-snippet-edit#853c7881d200777e20799026651ca36727144646"
 dependencies = [
  "bitflags 1.3.2",
- "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -7429,16 +7419,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
-]
-
-[[package]]
-name = "pct-str"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1bdcc492c285a50bed60860dfa00b50baf1f60c73c7d6b435b01a2a11fd6ff"
-dependencies = [
- "thiserror",
- "utf8-decode",
 ]
 
 [[package]]
@@ -11703,12 +11683,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-decode"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6174,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.95.1"
-source = "git+https://github.com/zed-industries/lsp-types?branch=apply-snippet-edit#853c7881d200777e20799026651ca36727144646"
+source = "git+https://github.com/zed-industries/lsp-types?rev=72357d6f6d212bdffba3b5ef4b31d8ca856058e7#72357d6f6d212bdffba3b5ef4b31d8ca856058e7"
 dependencies = [
  "bitflags 1.3.2",
  "serde",

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -344,7 +344,7 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
         .handle_request::<lsp::request::Completion, _, _>(|params, _| async move {
             assert_eq!(
                 params.text_document_position.text_document.uri,
-                lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                lsp::Url::from_file_path("/a/main.rs").unwrap(),
             );
             assert_eq!(
                 params.text_document_position.position,
@@ -461,7 +461,7 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
         .handle_request::<lsp::request::Completion, _, _>(|params, _| async move {
             assert_eq!(
                 params.text_document_position.text_document.uri,
-                lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                lsp::Url::from_file_path("/a/main.rs").unwrap(),
             );
             assert_eq!(
                 params.text_document_position.position,
@@ -585,7 +585,7 @@ async fn test_collaborating_with_code_actions(
         .handle_request::<lsp::request::CodeActionRequest, _, _>(|params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                lsp::Url::from_file_path("/a/main.rs").unwrap(),
             );
             assert_eq!(params.range.start, lsp::Position::new(0, 0));
             assert_eq!(params.range.end, lsp::Position::new(0, 0));
@@ -607,7 +607,7 @@ async fn test_collaborating_with_code_actions(
         .handle_request::<lsp::request::CodeActionRequest, _, _>(|params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                lsp::Url::from_file_path("/a/main.rs").unwrap(),
             );
             assert_eq!(params.range.start, lsp::Position::new(1, 31));
             assert_eq!(params.range.end, lsp::Position::new(1, 31));
@@ -619,7 +619,7 @@ async fn test_collaborating_with_code_actions(
                         changes: Some(
                             [
                                 (
-                                    lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                                    lsp::Url::from_file_path("/a/main.rs").unwrap(),
                                     vec![lsp::TextEdit::new(
                                         lsp::Range::new(
                                             lsp::Position::new(1, 22),
@@ -629,7 +629,7 @@ async fn test_collaborating_with_code_actions(
                                     )],
                                 ),
                                 (
-                                    lsp::Uri::from_file_path("/a/other.rs").unwrap().into(),
+                                    lsp::Url::from_file_path("/a/other.rs").unwrap(),
                                     vec![lsp::TextEdit::new(
                                         lsp::Range::new(
                                             lsp::Position::new(0, 0),
@@ -689,7 +689,7 @@ async fn test_collaborating_with_code_actions(
                     changes: Some(
                         [
                             (
-                                lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                                lsp::Url::from_file_path("/a/main.rs").unwrap(),
                                 vec![lsp::TextEdit::new(
                                     lsp::Range::new(
                                         lsp::Position::new(1, 22),
@@ -699,7 +699,7 @@ async fn test_collaborating_with_code_actions(
                                 )],
                             ),
                             (
-                                lsp::Uri::from_file_path("/a/other.rs").unwrap().into(),
+                                lsp::Url::from_file_path("/a/other.rs").unwrap(),
                                 vec![lsp::TextEdit::new(
                                     lsp::Range::new(
                                         lsp::Position::new(0, 0),
@@ -897,14 +897,14 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
                 changes: Some(
                     [
                         (
-                            lsp::Uri::from_file_path("/dir/one.rs").unwrap().into(),
+                            lsp::Url::from_file_path("/dir/one.rs").unwrap(),
                             vec![lsp::TextEdit::new(
                                 lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
                                 "THREE".to_string(),
                             )],
                         ),
                         (
-                            lsp::Uri::from_file_path("/dir/two.rs").unwrap().into(),
+                            lsp::Url::from_file_path("/dir/two.rs").unwrap(),
                             vec![
                                 lsp::TextEdit::new(
                                     lsp::Range::new(
@@ -1314,7 +1314,7 @@ async fn test_on_input_format_from_host_to_guest(
         |params, _| async move {
             assert_eq!(
                 params.text_document_position.text_document.uri,
-                lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                lsp::Url::from_file_path("/a/main.rs").unwrap(),
             );
             assert_eq!(
                 params.text_document_position.position,
@@ -1442,7 +1442,7 @@ async fn test_on_input_format_from_guest_to_host(
         .handle_request::<lsp::request::OnTypeFormatting, _, _>(|params, _| async move {
             assert_eq!(
                 params.text_document_position.text_document.uri,
-                lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                lsp::Url::from_file_path("/a/main.rs").unwrap(),
             );
             assert_eq!(
                 params.text_document_position.position,
@@ -1611,7 +1611,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
             async move {
                 assert_eq!(
                     params.text_document.uri,
-                    lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                    lsp::Url::from_file_path("/a/main.rs").unwrap(),
                 );
                 let edits_made = task_edits_made.load(atomic::Ordering::Acquire);
                 Ok(Some(vec![lsp::InlayHint {
@@ -1874,7 +1874,7 @@ async fn test_inlay_hint_refresh_is_forwarded(
             async move {
                 assert_eq!(
                     params.text_document.uri,
-                    lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                    lsp::Url::from_file_path("/a/main.rs").unwrap(),
                 );
                 let other_hints = task_other_hints.load(atomic::Ordering::Acquire);
                 let character = if other_hints { 0 } else { 2 };

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -3897,7 +3897,7 @@ async fn test_collaborating_with_diagnostics(
         .await;
     fake_language_server.notify::<lsp::notification::PublishDiagnostics>(
         lsp::PublishDiagnosticsParams {
-            uri: lsp::Uri::from_file_path("/a/a.rs").unwrap().into(),
+            uri: lsp::Url::from_file_path("/a/a.rs").unwrap(),
             version: None,
             diagnostics: vec![lsp::Diagnostic {
                 severity: Some(lsp::DiagnosticSeverity::WARNING),
@@ -3917,7 +3917,7 @@ async fn test_collaborating_with_diagnostics(
         .unwrap();
     fake_language_server.notify::<lsp::notification::PublishDiagnostics>(
         lsp::PublishDiagnosticsParams {
-            uri: lsp::Uri::from_file_path("/a/a.rs").unwrap().into(),
+            uri: lsp::Url::from_file_path("/a/a.rs").unwrap(),
             version: None,
             diagnostics: vec![lsp::Diagnostic {
                 severity: Some(lsp::DiagnosticSeverity::ERROR),
@@ -3991,7 +3991,7 @@ async fn test_collaborating_with_diagnostics(
     // Simulate a language server reporting more errors for a file.
     fake_language_server.notify::<lsp::notification::PublishDiagnostics>(
         lsp::PublishDiagnosticsParams {
-            uri: lsp::Uri::from_file_path("/a/a.rs").unwrap().into(),
+            uri: lsp::Url::from_file_path("/a/a.rs").unwrap(),
             version: None,
             diagnostics: vec![
                 lsp::Diagnostic {
@@ -4085,7 +4085,7 @@ async fn test_collaborating_with_diagnostics(
     // Simulate a language server reporting no errors for a file.
     fake_language_server.notify::<lsp::notification::PublishDiagnostics>(
         lsp::PublishDiagnosticsParams {
-            uri: lsp::Uri::from_file_path("/a/a.rs").unwrap().into(),
+            uri: lsp::Url::from_file_path("/a/a.rs").unwrap(),
             version: None,
             diagnostics: vec![],
         },
@@ -4189,9 +4189,7 @@ async fn test_collaborating_with_lsp_progress_updates_and_diagnostics_ordering(
     for file_name in file_names {
         fake_language_server.notify::<lsp::notification::PublishDiagnostics>(
             lsp::PublishDiagnosticsParams {
-                uri: lsp::Uri::from_file_path(Path::new("/test").join(file_name))
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path(Path::new("/test").join(file_name)).unwrap(),
                 version: None,
                 diagnostics: vec![lsp::Diagnostic {
                     severity: Some(lsp::DiagnosticSeverity::WARNING),
@@ -4609,7 +4607,7 @@ async fn test_definition(
     fake_language_server.handle_request::<lsp::request::GotoDefinition, _, _>(|_, _| async move {
         Ok(Some(lsp::GotoDefinitionResponse::Scalar(
             lsp::Location::new(
-                lsp::Uri::from_file_path("/root/dir-2/b.rs").unwrap().into(),
+                lsp::Url::from_file_path("/root/dir-2/b.rs").unwrap(),
                 lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
             ),
         )))
@@ -4638,7 +4636,7 @@ async fn test_definition(
     fake_language_server.handle_request::<lsp::request::GotoDefinition, _, _>(|_, _| async move {
         Ok(Some(lsp::GotoDefinitionResponse::Scalar(
             lsp::Location::new(
-                lsp::Uri::from_file_path("/root/dir-2/b.rs").unwrap().into(),
+                lsp::Url::from_file_path("/root/dir-2/b.rs").unwrap(),
                 lsp::Range::new(lsp::Position::new(1, 6), lsp::Position::new(1, 11)),
             ),
         )))
@@ -4674,7 +4672,7 @@ async fn test_definition(
             );
             Ok(Some(lsp::GotoDefinitionResponse::Scalar(
                 lsp::Location::new(
-                    lsp::Uri::from_file_path("/root/dir-2/c.rs").unwrap().into(),
+                    lsp::Url::from_file_path("/root/dir-2/c.rs").unwrap(),
                     lsp::Range::new(lsp::Position::new(0, 5), lsp::Position::new(0, 7)),
                 ),
             )))
@@ -4786,21 +4784,15 @@ async fn test_references(
     lsp_response_tx
         .unbounded_send(Ok(Some(vec![
             lsp::Location {
-                uri: lsp::Uri::from_file_path("/root/dir-1/two.rs")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/root/dir-1/two.rs").unwrap(),
                 range: lsp::Range::new(lsp::Position::new(0, 24), lsp::Position::new(0, 27)),
             },
             lsp::Location {
-                uri: lsp::Uri::from_file_path("/root/dir-1/two.rs")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/root/dir-1/two.rs").unwrap(),
                 range: lsp::Range::new(lsp::Position::new(0, 35), lsp::Position::new(0, 38)),
             },
             lsp::Location {
-                uri: lsp::Uri::from_file_path("/root/dir-2/three.rs")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/root/dir-2/three.rs").unwrap(),
                 range: lsp::Range::new(lsp::Position::new(0, 37), lsp::Position::new(0, 40)),
             },
         ])))
@@ -5300,9 +5292,7 @@ async fn test_project_symbols(
             lsp::SymbolInformation {
                 name: "TWO".into(),
                 location: lsp::Location {
-                    uri: lsp::Uri::from_file_path("/code/crate-2/two.rs")
-                        .unwrap()
-                        .into(),
+                    uri: lsp::Url::from_file_path("/code/crate-2/two.rs").unwrap(),
                     range: lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
                 },
                 kind: lsp::SymbolKind::CONSTANT,
@@ -5392,7 +5382,7 @@ async fn test_open_buffer_while_getting_definition_pointing_to_it(
     fake_language_server.handle_request::<lsp::request::GotoDefinition, _, _>(|_, _| async move {
         Ok(Some(lsp::GotoDefinitionResponse::Scalar(
             lsp::Location::new(
-                lsp::Uri::from_file_path("/root/b.rs").unwrap().into(),
+                lsp::Url::from_file_path("/root/b.rs").unwrap(),
                 lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
             ),
         )))

--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -1101,7 +1101,7 @@ impl RandomizedTest for ProjectCollaborationTest {
                                         files
                                             .into_iter()
                                             .map(|file| lsp::Location {
-                                                uri: lsp::Uri::from_file_path(file).unwrap().into(),
+                                                uri: lsp::Url::from_file_path(file).unwrap(),
                                                 range: Default::default(),
                                             })
                                             .collect(),

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -188,7 +188,7 @@ impl Status {
 }
 
 struct RegisteredBuffer {
-    uri: lsp::RawUri,
+    uri: lsp::Url,
     language_id: String,
     snapshot: BufferSnapshot,
     snapshot_version: i32,
@@ -644,7 +644,7 @@ impl Copilot {
             registered_buffers
                 .entry(buffer.entity_id())
                 .or_insert_with(|| {
-                    let uri = uri_for_buffer(buffer, cx);
+                    let uri: lsp::Url = uri_for_buffer(buffer, cx);
                     let language_id = id_for_language(buffer.read(cx).language());
                     let snapshot = buffer.read(cx).snapshot();
                     server
@@ -959,9 +959,9 @@ fn id_for_language(language: Option<&Arc<Language>>) -> String {
         .unwrap_or_else(|| "plaintext".to_string())
 }
 
-fn uri_for_buffer(buffer: &Model<Buffer>, cx: &AppContext) -> lsp::RawUri {
+fn uri_for_buffer(buffer: &Model<Buffer>, cx: &AppContext) -> lsp::Url {
     if let Some(file) = buffer.read(cx).file().and_then(|file| file.as_local()) {
-        lsp::Uri::from_file_path(file.abs_path(cx)).unwrap().into()
+        lsp::Url::from_file_path(file.abs_path(cx)).unwrap()
     } else {
         format!("buffer://{}", buffer.entity_id()).parse().unwrap()
     }
@@ -1042,8 +1042,6 @@ async fn get_copilot_lsp(http: Arc<dyn HttpClient>) -> anyhow::Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
     use gpui::TestAppContext;
 
@@ -1052,8 +1050,9 @@ mod tests {
         let (copilot, mut lsp) = Copilot::fake(cx);
 
         let buffer_1 = cx.new_model(|cx| Buffer::local("Hello", cx));
-        let buffer_1_uri =
-            lsp::RawUri::from_str(&format!("buffer://{}", buffer_1.entity_id().as_u64())).unwrap();
+        let buffer_1_uri: lsp::Url = format!("buffer://{}", buffer_1.entity_id().as_u64())
+            .parse()
+            .unwrap();
         copilot.update(cx, |copilot, cx| copilot.register_buffer(&buffer_1, cx));
         assert_eq!(
             lsp.receive_notification::<lsp::notification::DidOpenTextDocument>()
@@ -1069,8 +1068,9 @@ mod tests {
         );
 
         let buffer_2 = cx.new_model(|cx| Buffer::local("Goodbye", cx));
-        let buffer_2_uri =
-            lsp::RawUri::from_str(&format!("buffer://{}", buffer_2.entity_id().as_u64())).unwrap();
+        let buffer_2_uri: lsp::Url = format!("buffer://{}", buffer_2.entity_id().as_u64())
+            .parse()
+            .unwrap();
         copilot.update(cx, |copilot, cx| copilot.register_buffer(&buffer_2, cx));
         assert_eq!(
             lsp.receive_notification::<lsp::notification::DidOpenTextDocument>()
@@ -1119,9 +1119,7 @@ mod tests {
                 text_document: lsp::TextDocumentIdentifier::new(buffer_1_uri),
             }
         );
-        let buffer_1_uri: lsp::RawUri = lsp::Uri::from_file_path("/root/child/buffer-1")
-            .unwrap()
-            .into();
+        let buffer_1_uri = lsp::Url::from_file_path("/root/child/buffer-1").unwrap();
         assert_eq!(
             lsp.receive_notification::<lsp::notification::DidOpenTextDocument>()
                 .await,

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -1121,10 +1121,7 @@ mod tests {
             cx.handle_request::<lsp::request::Completion, _, _>(move |url, params, _| {
                 let completions = completions.clone();
                 async move {
-                    assert_eq!(
-                        params.text_document_position.text_document.uri,
-                        url.clone().into()
-                    );
+                    assert_eq!(params.text_document_position.text_document.uri, url.clone());
                     assert_eq!(
                         params.text_document_position.position,
                         complete_from_position

--- a/crates/copilot/src/request.rs
+++ b/crates/copilot/src/request.rs
@@ -102,7 +102,7 @@ pub struct GetCompletionsDocument {
     pub tab_size: u32,
     pub indent_size: u32,
     pub insert_spaces: bool,
-    pub uri: lsp::RawUri,
+    pub uri: lsp::Url,
     pub relative_path: String,
     pub position: lsp::Position,
     pub version: usize,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8971,7 +8971,7 @@ impl Editor {
                         });
                     language_server_name.map(|language_server_name| {
                         project.open_local_buffer_via_lsp(
-                            lsp::Uri::from(lsp_location.uri.clone()),
+                            lsp_location.uri.clone(),
                             server_id,
                             language_server_name,
                             cx,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5861,7 +5861,7 @@ async fn test_document_format_during_save(cx: &mut gpui::TestAppContext) {
         .handle_request::<lsp::request::Formatting, _, _>(move |params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/file.rs").unwrap().into()
+                lsp::Url::from_file_path("/file.rs").unwrap()
             );
             assert_eq!(params.options.tab_size, 4);
             Ok(Some(vec![lsp::TextEdit::new(
@@ -5887,7 +5887,7 @@ async fn test_document_format_during_save(cx: &mut gpui::TestAppContext) {
     fake_server.handle_request::<lsp::request::Formatting, _, _>(move |params, _| async move {
         assert_eq!(
             params.text_document.uri,
-            lsp::Uri::from_file_path("/file.rs").unwrap().into()
+            lsp::Url::from_file_path("/file.rs").unwrap()
         );
         futures::future::pending::<()>().await;
         unreachable!()
@@ -5936,7 +5936,7 @@ async fn test_document_format_during_save(cx: &mut gpui::TestAppContext) {
         .handle_request::<lsp::request::Formatting, _, _>(move |params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/file.rs").unwrap().into()
+                lsp::Url::from_file_path("/file.rs").unwrap()
             );
             assert_eq!(params.options.tab_size, 8);
             Ok(Some(vec![]))
@@ -6139,7 +6139,7 @@ async fn test_multibuffer_format_during_save(cx: &mut gpui::TestAppContext) {
         .on_request::<lsp::request::Formatting, _, _>(move |params, _| async move {
             Ok(Some(vec![lsp::TextEdit::new(
                 lsp::Range::new(lsp::Position::new(0, 3), lsp::Position::new(1, 0)),
-                format!("[{} formatted]", params.text_document.uri.as_str()),
+                format!("[{} formatted]", params.text_document.uri),
             )]))
         })
         .detach();
@@ -6213,7 +6213,7 @@ async fn test_range_format_during_save(cx: &mut gpui::TestAppContext) {
         .handle_request::<lsp::request::RangeFormatting, _, _>(move |params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/file.rs").unwrap().into()
+                lsp::Url::from_file_path("/file.rs").unwrap()
             );
             assert_eq!(params.options.tab_size, 4);
             Ok(Some(vec![lsp::TextEdit::new(
@@ -6239,7 +6239,7 @@ async fn test_range_format_during_save(cx: &mut gpui::TestAppContext) {
         move |params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/file.rs").unwrap().into()
+                lsp::Url::from_file_path("/file.rs").unwrap()
             );
             futures::future::pending::<()>().await;
             unreachable!()
@@ -6289,7 +6289,7 @@ async fn test_range_format_during_save(cx: &mut gpui::TestAppContext) {
         .handle_request::<lsp::request::RangeFormatting, _, _>(move |params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/file.rs").unwrap().into()
+                lsp::Url::from_file_path("/file.rs").unwrap()
             );
             assert_eq!(params.options.tab_size, 8);
             Ok(Some(vec![]))
@@ -6363,7 +6363,7 @@ async fn test_document_format_manual_trigger(cx: &mut gpui::TestAppContext) {
         .handle_request::<lsp::request::Formatting, _, _>(move |params, _| async move {
             assert_eq!(
                 params.text_document.uri,
-                lsp::Uri::from_file_path("/file.rs").unwrap().into()
+                lsp::Url::from_file_path("/file.rs").unwrap()
             );
             assert_eq!(params.options.tab_size, 4);
             Ok(Some(vec![lsp::TextEdit::new(
@@ -6385,7 +6385,7 @@ async fn test_document_format_manual_trigger(cx: &mut gpui::TestAppContext) {
     fake_server.handle_request::<lsp::request::Formatting, _, _>(move |params, _| async move {
         assert_eq!(
             params.text_document.uri,
-            lsp::Uri::from_file_path("/file.rs").unwrap().into()
+            lsp::Url::from_file_path("/file.rs").unwrap()
         );
         futures::future::pending::<()>().await;
         unreachable!()
@@ -8028,7 +8028,7 @@ async fn go_to_prev_overlapping_diagnostic(
                 .update_diagnostics(
                     LanguageServerId(0),
                     lsp::PublishDiagnosticsParams {
-                        uri: lsp::Uri::from_file_path("/root/file").unwrap().into(),
+                        uri: lsp::Url::from_file_path("/root/file").unwrap(),
                         version: None,
                         diagnostics: vec![
                             lsp::Diagnostic {
@@ -8400,7 +8400,7 @@ async fn test_on_type_formatting_not_triggered(cx: &mut gpui::TestAppContext) {
     fake_server.handle_request::<lsp::request::OnTypeFormatting, _, _>(|params, _| async move {
         assert_eq!(
             params.text_document_position.text_document.uri,
-            lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+            lsp::Url::from_file_path("/a/main.rs").unwrap(),
         );
         assert_eq!(
             params.text_document_position.position,
@@ -12151,10 +12151,7 @@ pub fn handle_completion_request(
         let completions = completions.clone();
         counter.fetch_add(1, atomic::Ordering::Release);
         async move {
-            assert_eq!(
-                params.text_document_position.text_document.uri,
-                url.clone().into()
-            );
+            assert_eq!(params.text_document_position.text_document.uri, url.clone());
             assert_eq!(
                 params.text_document_position.position,
                 complete_from_position

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -741,7 +741,7 @@ mod tests {
                 Ok(Some(lsp::GotoTypeDefinitionResponse::Link(vec![
                     lsp::LocationLink {
                         origin_selection_range: Some(symbol_range),
-                        target_uri: url.clone().into(),
+                        target_uri: url.clone(),
                         target_range,
                         target_selection_range: target_range,
                     },
@@ -815,7 +815,7 @@ mod tests {
             Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
                 lsp::LocationLink {
                     origin_selection_range: Some(symbol_range),
-                    target_uri: url.clone().into(),
+                    target_uri: url.clone(),
                     target_range,
                     target_selection_range: target_range,
                 },
@@ -841,7 +841,7 @@ mod tests {
             Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
                 lsp::LocationLink {
                     origin_selection_range: Some(symbol_range),
-                    target_uri: url.clone().into(),
+                    target_uri: url.clone(),
                     target_range,
                     target_selection_range: target_range,
                 },
@@ -904,7 +904,7 @@ mod tests {
             Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
                 lsp::LocationLink {
                     origin_selection_range: Some(symbol_range),
-                    target_uri: url.into(),
+                    target_uri: url,
                     target_range,
                     target_selection_range: target_range,
                 },
@@ -980,7 +980,7 @@ mod tests {
             Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
                 lsp::LocationLink {
                     origin_selection_range: None,
-                    target_uri: url.into(),
+                    target_uri: url,
                     target_range,
                     target_selection_range: target_range,
                 },
@@ -1008,7 +1008,7 @@ mod tests {
             Ok(Some(lsp::GotoDefinitionResponse::Link(vec![
                 lsp::LocationLink {
                     origin_selection_range: None,
-                    target_uri: url.into(),
+                    target_uri: url,
                     target_range,
                     target_selection_range: target_range,
                 },
@@ -1088,7 +1088,7 @@ mod tests {
         let hint_label = ": TestStruct";
         cx.lsp
             .handle_request::<lsp::request::InlayHintRequest, _, _>(move |params, _| {
-                let expected_uri = expected_uri.clone().into();
+                let expected_uri = expected_uri.clone();
                 async move {
                     assert_eq!(params.text_document.uri, expected_uri);
                     Ok(Some(vec![lsp::InlayHint {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1376,7 +1376,7 @@ mod tests {
         let closure_uri = uri.clone();
         cx.lsp
             .handle_request::<lsp::request::InlayHintRequest, _, _>(move |params, _| {
-                let task_uri = closure_uri.clone().into();
+                let task_uri = closure_uri.clone();
                 async move {
                     assert_eq!(params.text_document.uri, task_uri);
                     Ok(Some(vec![lsp::InlayHint {
@@ -1467,7 +1467,7 @@ mod tests {
                             lsp::InlayHintLabelPart {
                                 value: new_type_label.to_string(),
                                 location: Some(lsp::Location {
-                                    uri: task_uri.clone().into(),
+                                    uri: task_uri.clone(),
                                     range: new_type_target_range,
                                 }),
                                 tooltip: Some(lsp::InlayHintLabelPartTooltip::String(format!(
@@ -1482,7 +1482,7 @@ mod tests {
                             lsp::InlayHintLabelPart {
                                 value: struct_label.to_string(),
                                 location: Some(lsp::Location {
-                                    uri: task_uri.into(),
+                                    uri: task_uri,
                                     range: struct_target_range,
                                 }),
                                 tooltip: Some(lsp::InlayHintLabelPartTooltip::MarkupContent(

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -1307,7 +1307,7 @@ pub mod tests {
                 async move {
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path(file_with_hints).unwrap().into(),
+                        lsp::Url::from_file_path(file_with_hints).unwrap(),
                     );
                     let current_call_id =
                         Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::SeqCst);
@@ -1439,7 +1439,7 @@ pub mod tests {
                 async move {
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path(file_with_hints).unwrap().into(),
+                        lsp::Url::from_file_path(file_with_hints).unwrap(),
                     );
                     let current_call_id =
                         Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::SeqCst);
@@ -1613,7 +1613,7 @@ pub mod tests {
                 async move {
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                        lsp::Url::from_file_path("/a/main.rs").unwrap(),
                     );
                     let i = Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::SeqCst);
                     Ok(Some(vec![lsp::InlayHint {
@@ -1666,7 +1666,7 @@ pub mod tests {
                 async move {
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path("/a/other.md").unwrap().into(),
+                        lsp::Url::from_file_path("/a/other.md").unwrap(),
                     );
                     let i = Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::SeqCst);
                     Ok(Some(vec![lsp::InlayHint {
@@ -1790,7 +1790,7 @@ pub mod tests {
                     Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::SeqCst);
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path(file_with_hints).unwrap().into(),
+                        lsp::Url::from_file_path(file_with_hints).unwrap(),
                     );
                     Ok(Some(vec![
                         lsp::InlayHint {
@@ -2136,7 +2136,7 @@ pub mod tests {
                     let i = Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::SeqCst) + 1;
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path(file_with_hints).unwrap().into(),
+                        lsp::Url::from_file_path(file_with_hints).unwrap(),
                     );
                     Ok(Some(vec![lsp::InlayHint {
                         position: lsp::Position::new(0, i),
@@ -2305,7 +2305,7 @@ pub mod tests {
                 async move {
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                        lsp::Url::from_file_path("/a/main.rs").unwrap(),
                     );
 
                     task_lsp_request_ranges.lock().push(params.range);
@@ -2673,11 +2673,11 @@ pub mod tests {
                 let task_editor_edited = Arc::clone(&closure_editor_edited);
                 async move {
                     let hint_text = if params.text_document.uri
-                        == lsp::Uri::from_file_path("/a/main.rs").unwrap().into()
+                        == lsp::Url::from_file_path("/a/main.rs").unwrap()
                     {
                         "main hint"
                     } else if params.text_document.uri
-                        == lsp::Uri::from_file_path("/a/other.rs").unwrap().into()
+                        == lsp::Url::from_file_path("/a/other.rs").unwrap()
                     {
                         "other hint"
                     } else {
@@ -2981,11 +2981,11 @@ pub mod tests {
                 let task_editor_edited = Arc::clone(&closure_editor_edited);
                 async move {
                     let hint_text = if params.text_document.uri
-                        == lsp::Uri::from_file_path("/a/main.rs").unwrap().into()
+                        == lsp::Url::from_file_path("/a/main.rs").unwrap()
                     {
                         "main hint"
                     } else if params.text_document.uri
-                        == lsp::Uri::from_file_path("/a/other.rs").unwrap().into()
+                        == lsp::Url::from_file_path("/a/other.rs").unwrap()
                     {
                         "other hint"
                     } else {
@@ -3177,7 +3177,7 @@ pub mod tests {
                 async move {
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path("/a/main.rs").unwrap().into(),
+                        lsp::Url::from_file_path("/a/main.rs").unwrap(),
                     );
                     let query_start = params.range.start;
                     let i = Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::Release) + 1;
@@ -3244,7 +3244,7 @@ pub mod tests {
                 async move {
                     assert_eq!(
                         params.text_document.uri,
-                        lsp::Uri::from_file_path(file_with_hints).unwrap().into(),
+                        lsp::Url::from_file_path(file_with_hints).unwrap(),
                     );
 
                     let i = Arc::clone(&task_lsp_request_count).fetch_add(1, Ordering::SeqCst) + 1;

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -27,7 +27,7 @@ pub struct EditorLspTestContext {
     pub cx: EditorTestContext,
     pub lsp: lsp::FakeLanguageServer,
     pub workspace: View<Workspace>,
-    pub buffer_lsp_url: lsp::Uri,
+    pub buffer_lsp_url: lsp::Url,
 }
 
 impl EditorLspTestContext {
@@ -113,7 +113,7 @@ impl EditorLspTestContext {
             },
             lsp,
             workspace,
-            buffer_lsp_url: lsp::Uri::from_file_path(format!("/root/dir/{file_name}")).unwrap(),
+            buffer_lsp_url: lsp::Url::from_file_path(format!("/root/dir/{file_name}")).unwrap(),
         }
     }
 
@@ -299,7 +299,7 @@ impl EditorLspTestContext {
     where
         T: 'static + request::Request,
         T::Params: 'static + Send,
-        F: 'static + Send + FnMut(lsp::Uri, T::Params, gpui::AsyncAppContext) -> Fut,
+        F: 'static + Send + FnMut(lsp::Url, T::Params, gpui::AsyncAppContext) -> Fut,
         Fut: 'static + Send + Future<Output = Result<T::Result>>,
     {
         let url = self.buffer_lsp_url.clone();

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -533,7 +533,7 @@ mod tests {
     #[gpui::test]
     async fn test_process_rust_diagnostics() {
         let mut params = lsp::PublishDiagnosticsParams {
-            uri: lsp::Uri::from_file_path("/a").unwrap().into(),
+            uri: lsp::Url::from_file_path("/a").unwrap(),
             version: None,
             diagnostics: vec![
                 // no newlines

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -22,7 +22,7 @@ collections.workspace = true
 futures.workspace = true
 gpui.workspace = true
 log.workspace = true
-lsp-types = { git = "https://github.com/zed-industries/lsp-types", branch = "apply-snippet-edit" }
+lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "72357d6f6d212bdffba3b5ef4b31d8ca856058e7" }
 parking_lot.workspace = true
 postage.workspace = true
 serde.workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -22,9 +22,8 @@ collections.workspace = true
 futures.workspace = true
 gpui.workspace = true
 log.workspace = true
-lsp-types = { git = "https://github.com/zed-industries/lsp-types", branch = "zed-main" }
+lsp-types = { git = "https://github.com/zed-industries/lsp-types", branch = "apply-snippet-edit" }
 parking_lot.workspace = true
-pct-str = "2.0"
 postage.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -3,9 +3,7 @@ mod input_handler;
 pub use lsp_types::request::*;
 pub use lsp_types::*;
 
-pub use lsp_types::Uri as RawUri;
-
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use collections::HashMap;
 use futures::{channel::oneshot, io::BufWriter, select, AsyncRead, AsyncWrite, Future, FutureExt};
 use gpui::{AppContext, AsyncAppContext, BackgroundExecutor, Task};
@@ -23,13 +21,11 @@ use smol::{
 use smol::process::windows::CommandExt;
 
 use std::{
-    borrow::Cow,
     ffi::OsString,
     fmt,
     io::Write,
     path::PathBuf,
     pin::Pin,
-    str::FromStr,
     sync::{
         atomic::{AtomicI32, Ordering::SeqCst},
         Arc, Weak,
@@ -58,61 +54,6 @@ pub enum IoKind {
     StdErr,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq)]
-pub struct Uri(lsp_types::Uri);
-
-const FILE_SCHEME: &str = "file://";
-impl Uri {
-    pub fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let mut uri = FILE_SCHEME.to_owned();
-        for part in path.as_ref().components() {
-            let part: Cow<_> = match part {
-                std::path::Component::Prefix(prefix) => prefix.as_os_str().to_string_lossy(),
-                std::path::Component::RootDir => "/".into(),
-                std::path::Component::CurDir => ".".into(),
-                std::path::Component::ParentDir => "..".into(),
-                std::path::Component::Normal(component) => {
-                    let as_str = component.to_string_lossy();
-                    pct_str::PctString::encode(as_str.chars(), pct_str::URIReserved)
-                        .to_string()
-                        .into()
-                }
-            };
-            if !uri.ends_with('/') {
-                uri.push('/');
-            }
-            uri.push_str(&part);
-        }
-        Ok(lsp_types::Uri::from_str(&uri)?.into())
-    }
-    pub fn to_file_path(self) -> Result<PathBuf> {
-        if self
-            .0
-            .scheme()
-            .map_or(true, |scheme| !scheme.eq_lowercase("file"))
-        {
-            bail!("file path does not have a file scheme");
-        }
-        Ok(self.0.path().as_str().into())
-    }
-}
-
-impl PartialEq<lsp_types::Uri> for Uri {
-    fn eq(&self, other: &lsp_types::Uri) -> bool {
-        self.0.eq(other)
-    }
-}
-impl From<lsp_types::Uri> for Uri {
-    fn from(uri: lsp_types::Uri) -> Self {
-        Self(uri)
-    }
-}
-
-impl From<Uri> for lsp_types::Uri {
-    fn from(uri: Uri) -> Self {
-        uri.0
-    }
-}
 /// Represents a launchable language server. This can either be a standalone binary or the path
 /// to a runtime with arguments to instruct it to launch the actual language server file.
 #[derive(Debug, Clone, Deserialize)]
@@ -582,12 +523,12 @@ impl LanguageServer {
         options: Option<Value>,
         cx: &AppContext,
     ) -> Task<Result<Arc<Self>>> {
-        let root_uri = Uri::from_file_path(&self.working_dir).unwrap();
+        let root_uri = Url::from_file_path(&self.working_dir).unwrap();
         #[allow(deprecated)]
         let params = InitializeParams {
             process_id: None,
             root_path: None,
-            root_uri: Some(root_uri.clone().into()),
+            root_uri: Some(root_uri.clone()),
             initialization_options: options,
             capabilities: ClientCapabilities {
                 workspace: Some(WorkspaceClientCapabilities {
@@ -714,11 +655,10 @@ impl LanguageServer {
                     ..Default::default()
                 }),
                 general: None,
-                notebook_document: None,
             },
             trace: None,
             workspace_folders: Some(vec![WorkspaceFolder {
-                uri: root_uri.into(),
+                uri: root_uri,
                 name: Default::default(),
             }]),
             client_info: release_channel::ReleaseChannel::try_global(cx).map(|release_channel| {
@@ -1384,6 +1324,7 @@ impl FakeLanguageServer {
 mod tests {
     use super::*;
     use gpui::{SemanticVersion, TestAppContext};
+    use std::str::FromStr;
 
     #[ctor::ctor]
     fn init_logger() {
@@ -1426,7 +1367,7 @@ mod tests {
         server
             .notify::<notification::DidOpenTextDocument>(DidOpenTextDocumentParams {
                 text_document: TextDocumentItem::new(
-                    RawUri::from_str("file://a/b").unwrap(),
+                    Url::from_str("file://a/b").unwrap(),
                     "rust".to_string(),
                     0,
                     "".to_string(),
@@ -1447,7 +1388,7 @@ mod tests {
             message: "ok".to_string(),
         });
         fake.notify::<notification::PublishDiagnostics>(PublishDiagnosticsParams {
-            uri: RawUri::from_str("file://b/c").unwrap(),
+            uri: Url::from_str("file://b/c").unwrap(),
             version: Some(5),
             diagnostics: vec![],
         });

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -187,7 +187,7 @@ impl LspCommand for PrepareRename {
     ) -> lsp::TextDocumentPositionParams {
         lsp::TextDocumentPositionParams {
             text_document: lsp::TextDocumentIdentifier {
-                uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                uri: lsp::Url::from_file_path(path).unwrap(),
             },
             position: point_to_lsp(self.position),
         }
@@ -311,7 +311,7 @@ impl LspCommand for PerformRename {
         lsp::RenameParams {
             text_document_position: lsp::TextDocumentPositionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
@@ -430,7 +430,7 @@ impl LspCommand for GetDefinition {
         lsp::GotoDefinitionParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
@@ -523,7 +523,7 @@ impl LspCommand for GetImplementation {
         lsp::GotoImplementationParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
@@ -624,7 +624,7 @@ impl LspCommand for GetTypeDefinition {
         lsp::GotoTypeDefinitionParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
@@ -820,7 +820,7 @@ async fn location_links_from_lsp(
         let target_buffer_handle = project
             .update(&mut cx, |this, cx| {
                 this.open_local_buffer_via_lsp(
-                    target_uri.into(),
+                    target_uri,
                     language_server.server_id(),
                     lsp_adapter.name.clone(),
                     cx,
@@ -927,7 +927,7 @@ impl LspCommand for GetReferences {
         lsp::ReferenceParams {
             text_document_position: lsp::TextDocumentPositionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
@@ -956,7 +956,7 @@ impl LspCommand for GetReferences {
                 let target_buffer_handle = project
                     .update(&mut cx, |this, cx| {
                         this.open_local_buffer_via_lsp(
-                            lsp_location.uri.into(),
+                            lsp_location.uri,
                             language_server.server_id(),
                             lsp_adapter.name.clone(),
                             cx,
@@ -1094,7 +1094,7 @@ impl LspCommand for GetDocumentHighlights {
         lsp::DocumentHighlightParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
@@ -1241,7 +1241,7 @@ impl LspCommand for GetHover {
         lsp::HoverParams {
             text_document_position_params: lsp::TextDocumentPositionParams {
                 text_document: lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(path).unwrap(),
                 },
                 position: point_to_lsp(self.position),
             },
@@ -1463,7 +1463,7 @@ impl LspCommand for GetCompletions {
     ) -> lsp::CompletionParams {
         lsp::CompletionParams {
             text_document_position: lsp::TextDocumentPositionParams::new(
-                lsp::TextDocumentIdentifier::new(lsp::Uri::from_file_path(path).unwrap().into()),
+                lsp::TextDocumentIdentifier::new(lsp::Url::from_file_path(path).unwrap()),
                 point_to_lsp(self.position),
             ),
             context: Some(self.context.clone()),
@@ -1768,7 +1768,7 @@ impl LspCommand for GetCodeActions {
 
         lsp::CodeActionParams {
             text_document: lsp::TextDocumentIdentifier::new(
-                lsp::Uri::from_file_path(path).unwrap().into(),
+                lsp::Url::from_file_path(path).unwrap(),
             ),
             range: range_to_lsp(self.range.to_point_utf16(buffer)),
             work_done_progress_params: Default::default(),
@@ -1940,7 +1940,7 @@ impl LspCommand for OnTypeFormatting {
     ) -> lsp::DocumentOnTypeFormattingParams {
         lsp::DocumentOnTypeFormattingParams {
             text_document_position: lsp::TextDocumentPositionParams::new(
-                lsp::TextDocumentIdentifier::new(lsp::Uri::from_file_path(path).unwrap().into()),
+                lsp::TextDocumentIdentifier::new(lsp::Url::from_file_path(path).unwrap()),
                 point_to_lsp(self.position),
             ),
             ch: self.trigger.clone(),
@@ -2282,9 +2282,8 @@ impl InlayHints {
                                     Some(((uri, range), server_id)) => Some((
                                         LanguageServerId(server_id as usize),
                                         lsp::Location {
-                                            uri: lsp::Uri::from_file_path(&uri)
-                                                .context("invalid uri in hint part {part:?}")?
-                                                .into(),
+                                            uri: lsp::Url::parse(&uri)
+                                                .context("invalid uri in hint part {part:?}")?,
                                             range: lsp::Range::new(
                                                 point_to_lsp(PointUtf16::new(
                                                     range.start.row,
@@ -2444,7 +2443,7 @@ impl LspCommand for InlayHints {
     ) -> lsp::InlayHintParams {
         lsp::InlayHintParams {
             text_document: lsp::TextDocumentIdentifier {
-                uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                uri: lsp::Url::from_file_path(path).unwrap(),
             },
             range: range_to_lsp(self.range.to_point_utf16(buffer)),
             work_done_progress_params: Default::default(),
@@ -2600,7 +2599,7 @@ impl LspCommand for LinkedEditingRange {
         let position = self.position.to_point_utf16(&buffer.snapshot());
         lsp::LinkedEditingRangeParams {
             text_document_position_params: lsp::TextDocumentPositionParams::new(
-                lsp::TextDocumentIdentifier::new(lsp::Uri::from_file_path(path).unwrap().into()),
+                lsp::TextDocumentIdentifier::new(lsp::Url::from_file_path(path).unwrap()),
                 point_to_lsp(position),
             ),
             work_done_progress_params: Default::default(),

--- a/crates/project/src/lsp_ext_command.rs
+++ b/crates/project/src/lsp_ext_command.rs
@@ -58,7 +58,7 @@ impl LspCommand for ExpandMacro {
     ) -> ExpandMacroParams {
         ExpandMacroParams {
             text_document: lsp::TextDocumentIdentifier {
-                uri: lsp::Uri::from_file_path(path).unwrap().into(),
+                uri: lsp::Url::from_file_path(path).unwrap(),
             },
             position: point_to_lsp(self.position),
         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -61,8 +61,7 @@ use lsp::{
     CompletionContext, DiagnosticSeverity, DiagnosticTag, DidChangeWatchedFilesRegistrationOptions,
     DocumentHighlightKind, Edit, FileSystemWatcher, InsertTextFormat, LanguageServer,
     LanguageServerBinary, LanguageServerId, LspRequestFuture, MessageActionItem, OneOf,
-    ServerCapabilities, ServerHealthStatus, ServerStatus, TextEdit, Uri,
-    WorkDoneProgressCancelParams,
+    ServerCapabilities, ServerHealthStatus, ServerStatus, TextEdit, WorkDoneProgressCancelParams,
 };
 use lsp_command::*;
 use node_runtime::NodeRuntime;
@@ -2141,7 +2140,7 @@ impl Project {
     /// LanguageServerName is owned, because it is inserted into a map
     pub fn open_local_buffer_via_lsp(
         &mut self,
-        abs_path: lsp::Uri,
+        abs_path: lsp::Url,
         language_server_id: LanguageServerId,
         language_server_name: LanguageServerName,
         cx: &mut ModelContext<Self>,
@@ -2441,15 +2440,13 @@ impl Project {
         cx.observe_release(buffer, |this, buffer, cx| {
             if let Some(file) = File::from_dyn(buffer.file()) {
                 if file.is_local() {
-                    let uri = lsp::Uri::from_file_path(file.abs_path(cx)).unwrap();
+                    let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
                     for server in this.language_servers_for_buffer(buffer, cx) {
                         server
                             .1
                             .notify::<lsp::notification::DidCloseTextDocument>(
                                 lsp::DidCloseTextDocumentParams {
-                                    text_document: lsp::TextDocumentIdentifier::new(
-                                        uri.clone().into(),
-                                    ),
+                                    text_document: lsp::TextDocumentIdentifier::new(uri.clone()),
                                 },
                             )
                             .log_err();
@@ -2481,7 +2478,7 @@ impl Project {
             }
 
             let abs_path = file.abs_path(cx);
-            let Some(uri) = lsp::Uri::from_file_path(&abs_path).log_err() else {
+            let Some(uri) = lsp::Url::from_file_path(&abs_path).log_err() else {
                 return;
             };
             let initial_snapshot = buffer.text_snapshot();
@@ -2519,7 +2516,7 @@ impl Project {
                         .notify::<lsp::notification::DidOpenTextDocument>(
                             lsp::DidOpenTextDocumentParams {
                                 text_document: lsp::TextDocumentItem::new(
-                                    uri.clone().into(),
+                                    uri.clone(),
                                     adapter.language_id(&language),
                                     0,
                                     initial_snapshot.text(),
@@ -2577,14 +2574,12 @@ impl Project {
             }
 
             self.buffer_snapshots.remove(&buffer.remote_id());
-            let file_url = lsp::Uri::from_file_path(old_path).unwrap();
+            let file_url = lsp::Url::from_file_path(old_path).unwrap();
             for (_, language_server) in self.language_servers_for_buffer(buffer, cx) {
                 language_server
                     .notify::<lsp::notification::DidCloseTextDocument>(
                         lsp::DidCloseTextDocumentParams {
-                            text_document: lsp::TextDocumentIdentifier::new(
-                                file_url.clone().into(),
-                            ),
+                            text_document: lsp::TextDocumentIdentifier::new(file_url.clone()),
                         },
                     )
                     .log_err();
@@ -2743,7 +2738,7 @@ impl Project {
                 let buffer = buffer.read(cx);
                 let file = File::from_dyn(buffer.file())?;
                 let abs_path = file.as_local()?.abs_path(cx);
-                let uri = lsp::Uri::from_file_path(abs_path).unwrap();
+                let uri = lsp::Url::from_file_path(abs_path).unwrap();
                 let next_snapshot = buffer.text_snapshot();
 
                 let language_servers: Vec<_> = self
@@ -2824,7 +2819,7 @@ impl Project {
                         .notify::<lsp::notification::DidChangeTextDocument>(
                             lsp::DidChangeTextDocumentParams {
                                 text_document: lsp::VersionedTextDocumentIdentifier::new(
-                                    uri.clone().into(),
+                                    uri.clone(),
                                     next_version,
                                 ),
                                 content_changes,
@@ -2839,7 +2834,7 @@ impl Project {
                 let worktree_id = file.worktree_id(cx);
                 let abs_path = file.as_local()?.abs_path(cx);
                 let text_document = lsp::TextDocumentIdentifier {
-                    uri: lsp::Uri::from_file_path(abs_path).unwrap().into(),
+                    uri: lsp::Url::from_file_path(abs_path).unwrap(),
                 };
 
                 for (_, _, server) in self.language_servers_for_worktree(worktree_id) {
@@ -3879,11 +3874,11 @@ impl Project {
                 let snapshot = versions.last().unwrap();
                 let version = snapshot.version;
                 let initial_snapshot = &snapshot.snapshot;
-                let uri = lsp::Uri::from_file_path(file.abs_path(cx)).unwrap();
+                let uri = lsp::Url::from_file_path(file.abs_path(cx)).unwrap();
                 language_server.notify::<lsp::notification::DidOpenTextDocument>(
                     lsp::DidOpenTextDocumentParams {
                         text_document: lsp::TextDocumentItem::new(
-                            uri.into(),
+                            uri,
                             adapter.language_id(&language),
                             version,
                             initial_snapshot.text(),
@@ -4507,13 +4502,10 @@ impl Project {
                                         lsp::OneOf::Left(workspace_folder) => &workspace_folder.uri,
                                         lsp::OneOf::Right(base_uri) => base_uri,
                                     };
-                                    lsp::Uri::from(base_uri.clone())
-                                        .to_file_path()
-                                        .ok()
-                                        .and_then(|file_path| {
-                                            (file_path.to_str() == Some(abs_path))
-                                                .then_some(rp.pattern.as_str())
-                                        })
+                                    base_uri.to_file_path().ok().and_then(|file_path| {
+                                        (file_path.to_str() == Some(abs_path))
+                                            .then_some(rp.pattern.as_str())
+                                    })
                                 }
                             };
                             if let Some(relative_glob_pattern) = relative_glob_pattern {
@@ -4602,9 +4594,10 @@ impl Project {
         disk_based_sources: &[String],
         cx: &mut ModelContext<Self>,
     ) -> Result<()> {
-        let abs_path = Uri::from(params.uri.clone())
+        let abs_path = params
+            .uri
             .to_file_path()
-            .map_err(|_| anyhow!("URI `{}` is not a file", params.uri.as_str()))?;
+            .map_err(|_| anyhow!("URI is not a file"))?;
         let mut diagnostics = Vec::default();
         let mut primary_diagnostic_group_ids = HashMap::default();
         let mut sources_by_group_id = HashMap::default();
@@ -5285,9 +5278,9 @@ impl Project {
         tab_size: NonZeroU32,
         cx: &mut AsyncAppContext,
     ) -> Result<Vec<(Range<Anchor>, String)>> {
-        let uri = lsp::Uri::from_file_path(abs_path)
+        let uri = lsp::Url::from_file_path(abs_path)
             .map_err(|_| anyhow!("failed to convert abs path to uri"))?;
-        let text_document = lsp::TextDocumentIdentifier::new(uri.into());
+        let text_document = lsp::TextDocumentIdentifier::new(uri);
         let capabilities = &language_server.capabilities();
 
         let formatting_provider = capabilities.document_formatting_provider.as_ref();
@@ -5592,8 +5585,7 @@ impl Project {
                         lsp_symbols
                             .into_iter()
                             .filter_map(|(symbol_name, symbol_kind, symbol_location)| {
-                                let abs_path: lsp::Uri = symbol_location.uri.into();
-                                let abs_path = abs_path.to_file_path().ok()?;
+                                let abs_path = symbol_location.uri.to_file_path().ok()?;
                                 let source_worktree = source_worktree.upgrade()?;
                                 let source_worktree_id = source_worktree.read(cx).id();
 
@@ -5695,7 +5687,7 @@ impl Project {
             };
 
             let symbol_abs_path = resolve_path(&worktree_abs_path, &symbol.path.path);
-            let symbol_uri = if let Ok(uri) = lsp::Uri::from_file_path(symbol_abs_path) {
+            let symbol_uri = if let Ok(uri) = lsp::Url::from_file_path(symbol_abs_path) {
                 uri
             } else {
                 return Task::ready(Err(anyhow!("invalid symbol path")));
@@ -6628,7 +6620,8 @@ impl Project {
         for operation in operations {
             match operation {
                 lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Create(op)) => {
-                    let abs_path = Uri::from(op.uri)
+                    let abs_path = op
+                        .uri
                         .to_file_path()
                         .map_err(|_| anyhow!("can't convert URI to path"))?;
 
@@ -6652,10 +6645,12 @@ impl Project {
                 }
 
                 lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(op)) => {
-                    let source_abs_path = Uri::from(op.old_uri)
+                    let source_abs_path = op
+                        .old_uri
                         .to_file_path()
                         .map_err(|_| anyhow!("can't convert URI to path"))?;
-                    let target_abs_path = Uri::from(op.new_uri)
+                    let target_abs_path = op
+                        .new_uri
                         .to_file_path()
                         .map_err(|_| anyhow!("can't convert URI to path"))?;
                     fs.rename(
@@ -6672,7 +6667,8 @@ impl Project {
                 }
 
                 lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Delete(op)) => {
-                    let abs_path: PathBuf = Uri::from(op.uri)
+                    let abs_path = op
+                        .uri
                         .to_file_path()
                         .map_err(|_| anyhow!("can't convert URI to path"))?;
                     let options = op
@@ -6693,7 +6689,7 @@ impl Project {
                     let buffer_to_edit = this
                         .update(cx, |this, cx| {
                             this.open_local_buffer_via_lsp(
-                                op.text_document.uri.clone().into(),
+                                op.text_document.uri.clone(),
                                 language_server.server_id(),
                                 lsp_adapter.name.clone(),
                                 cx,
@@ -8008,9 +8004,7 @@ impl Project {
                                     PathChange::AddedOrUpdated => lsp::FileChangeType::CHANGED,
                                 };
                                 Some(lsp::FileEvent {
-                                    uri: lsp::Uri::from_file_path(abs_path.join(path))
-                                        .unwrap()
-                                        .into(),
+                                    uri: lsp::Url::from_file_path(abs_path.join(path)).unwrap(),
                                     typ,
                                 })
                             })

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -378,9 +378,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::TextDocumentItem {
-            uri: lsp::Uri::from_file_path("/the-root/test.rs")
-                .unwrap()
-                .into(),
+            uri: lsp::Url::from_file_path("/the-root/test.rs").unwrap(),
             version: 0,
             text: "const A: i32 = 1;".to_string(),
             language_id: "rust".to_string(),
@@ -406,9 +404,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::VersionedTextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/test.rs")
-                .unwrap()
-                .into(),
+            lsp::Url::from_file_path("/the-root/test.rs").unwrap(),
             1
         )
     );
@@ -429,9 +425,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::TextDocumentItem {
-            uri: lsp::Uri::from_file_path("/the-root/package.json")
-                .unwrap()
-                .into(),
+            uri: lsp::Url::from_file_path("/the-root/package.json").unwrap(),
             version: 0,
             text: "{\"a\": 1}".to_string(),
             language_id: "json".to_string(),
@@ -470,9 +464,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::VersionedTextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/test2.rs")
-                .unwrap()
-                .into(),
+            lsp::Url::from_file_path("/the-root/test2.rs").unwrap(),
             1
         )
     );
@@ -487,22 +479,14 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .receive_notification::<lsp::notification::DidSaveTextDocument>()
             .await
             .text_document,
-        lsp::TextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/Cargo.toml")
-                .unwrap()
-                .into()
-        )
+        lsp::TextDocumentIdentifier::new(lsp::Url::from_file_path("/the-root/Cargo.toml").unwrap())
     );
     assert_eq!(
         fake_json_server
             .receive_notification::<lsp::notification::DidSaveTextDocument>()
             .await
             .text_document,
-        lsp::TextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/Cargo.toml")
-                .unwrap()
-                .into()
-        )
+        lsp::TextDocumentIdentifier::new(lsp::Url::from_file_path("/the-root/Cargo.toml").unwrap())
     );
 
     // Renames are reported only to servers matching the buffer's language.
@@ -518,11 +502,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .receive_notification::<lsp::notification::DidCloseTextDocument>()
             .await
             .text_document,
-        lsp::TextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/test2.rs")
-                .unwrap()
-                .into()
-        ),
+        lsp::TextDocumentIdentifier::new(lsp::Url::from_file_path("/the-root/test2.rs").unwrap()),
     );
     assert_eq!(
         fake_rust_server
@@ -530,9 +510,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::TextDocumentItem {
-            uri: lsp::Uri::from_file_path("/the-root/test3.rs")
-                .unwrap()
-                .into(),
+            uri: lsp::Url::from_file_path("/the-root/test3.rs").unwrap(),
             version: 0,
             text: rust_buffer2.update(cx, |buffer, _| buffer.text()),
             language_id: "rust".to_string(),
@@ -574,11 +552,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .receive_notification::<lsp::notification::DidCloseTextDocument>()
             .await
             .text_document,
-        lsp::TextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/test3.rs")
-                .unwrap()
-                .into(),
-        ),
+        lsp::TextDocumentIdentifier::new(lsp::Url::from_file_path("/the-root/test3.rs").unwrap(),),
     );
     assert_eq!(
         fake_json_server
@@ -586,9 +560,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::TextDocumentItem {
-            uri: lsp::Uri::from_file_path("/the-root/test3.json")
-                .unwrap()
-                .into(),
+            uri: lsp::Url::from_file_path("/the-root/test3.json").unwrap(),
             version: 0,
             text: rust_buffer2.update(cx, |buffer, _| buffer.text()),
             language_id: "json".to_string(),
@@ -614,9 +586,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::VersionedTextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/test3.json")
-                .unwrap()
-                .into(),
+            lsp::Url::from_file_path("/the-root/test3.json").unwrap(),
             1
         )
     );
@@ -645,9 +615,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
             .await
             .text_document,
         lsp::TextDocumentItem {
-            uri: lsp::Uri::from_file_path("/the-root/test.rs")
-                .unwrap()
-                .into(),
+            uri: lsp::Url::from_file_path("/the-root/test.rs").unwrap(),
             version: 0,
             text: rust_buffer.update(cx, |buffer, _| buffer.text()),
             language_id: "rust".to_string(),
@@ -668,17 +636,13 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
         ],
         [
             lsp::TextDocumentItem {
-                uri: lsp::Uri::from_file_path("/the-root/package.json")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/the-root/package.json").unwrap(),
                 version: 0,
                 text: json_buffer.update(cx, |buffer, _| buffer.text()),
                 language_id: "json".to_string(),
             },
             lsp::TextDocumentItem {
-                uri: lsp::Uri::from_file_path("/the-root/test3.json")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/the-root/test3.json").unwrap(),
                 version: 0,
                 text: rust_buffer2.update(cx, |buffer, _| buffer.text()),
                 language_id: "json".to_string(),
@@ -690,9 +654,7 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
     cx.update(|_| drop(json_buffer));
     let close_message = lsp::DidCloseTextDocumentParams {
         text_document: lsp::TextDocumentIdentifier::new(
-            lsp::Uri::from_file_path("/the-root/package.json")
-                .unwrap()
-                .into(),
+            lsp::Url::from_file_path("/the-root/package.json").unwrap(),
         ),
     };
     assert_eq!(
@@ -882,21 +844,15 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
         &*file_changes.lock(),
         &[
             lsp::FileEvent {
-                uri: lsp::Uri::from_file_path("/the-root/src/b.rs")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/the-root/src/b.rs").unwrap(),
                 typ: lsp::FileChangeType::DELETED,
             },
             lsp::FileEvent {
-                uri: lsp::Uri::from_file_path("/the-root/src/c.rs")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/the-root/src/c.rs").unwrap(),
                 typ: lsp::FileChangeType::CREATED,
             },
             lsp::FileEvent {
-                uri: lsp::Uri::from_file_path("/the-root/target/y/out/y2.rs")
-                    .unwrap()
-                    .into(),
+                uri: lsp::Url::from_file_path("/the-root/target/y/out/y2.rs").unwrap(),
                 typ: lsp::FileChangeType::CREATED,
             },
         ]
@@ -933,7 +889,7 @@ async fn test_single_file_worktrees_diagnostics(cx: &mut gpui::TestAppContext) {
             .update_diagnostics(
                 LanguageServerId(0),
                 lsp::PublishDiagnosticsParams {
-                    uri: Uri::from_file_path("/dir/a.rs").unwrap().into(),
+                    uri: Url::from_file_path("/dir/a.rs").unwrap(),
                     version: None,
                     diagnostics: vec![lsp::Diagnostic {
                         range: lsp::Range::new(lsp::Position::new(0, 4), lsp::Position::new(0, 5)),
@@ -950,7 +906,7 @@ async fn test_single_file_worktrees_diagnostics(cx: &mut gpui::TestAppContext) {
             .update_diagnostics(
                 LanguageServerId(0),
                 lsp::PublishDiagnosticsParams {
-                    uri: Uri::from_file_path("/dir/b.rs").unwrap().into(),
+                    uri: Url::from_file_path("/dir/b.rs").unwrap(),
                     version: None,
                     diagnostics: vec![lsp::Diagnostic {
                         range: lsp::Range::new(lsp::Position::new(0, 4), lsp::Position::new(0, 5)),
@@ -1039,7 +995,7 @@ async fn test_omitted_diagnostics(cx: &mut gpui::TestAppContext) {
             .update_diagnostics(
                 server_id,
                 lsp::PublishDiagnosticsParams {
-                    uri: Uri::from_file_path("/root/dir/b.rs").unwrap().into(),
+                    uri: Url::from_file_path("/root/dir/b.rs").unwrap(),
                     version: None,
                     diagnostics: vec![lsp::Diagnostic {
                         range: lsp::Range::new(lsp::Position::new(0, 4), lsp::Position::new(0, 5)),
@@ -1056,7 +1012,7 @@ async fn test_omitted_diagnostics(cx: &mut gpui::TestAppContext) {
             .update_diagnostics(
                 server_id,
                 lsp::PublishDiagnosticsParams {
-                    uri: Uri::from_file_path("/root/other.rs").unwrap().into(),
+                    uri: Url::from_file_path("/root/other.rs").unwrap(),
                     version: None,
                     diagnostics: vec![lsp::Diagnostic {
                         range: lsp::Range::new(lsp::Position::new(0, 8), lsp::Position::new(0, 9)),
@@ -1191,7 +1147,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     );
 
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: Url::from_file_path("/dir/a.rs").unwrap(),
         version: None,
         diagnostics: vec![lsp::Diagnostic {
             range: lsp::Range::new(lsp::Position::new(0, 9), lsp::Position::new(0, 10)),
@@ -1243,7 +1199,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
 
     // Ensure publishing empty diagnostics twice only results in one update event.
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: Url::from_file_path("/dir/a.rs").unwrap(),
         version: None,
         diagnostics: Default::default(),
     });
@@ -1256,7 +1212,7 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     );
 
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: Url::from_file_path("/dir/a.rs").unwrap(),
         version: None,
         diagnostics: Default::default(),
     });
@@ -1365,7 +1321,7 @@ async fn test_restarting_server_with_diagnostics_published(cx: &mut gpui::TestAp
     // Publish diagnostics
     let fake_server = fake_servers.next().await.unwrap();
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: Url::from_file_path("/dir/a.rs").unwrap(),
         version: None,
         diagnostics: vec![lsp::Diagnostic {
             range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 0)),
@@ -1445,7 +1401,7 @@ async fn test_restarted_server_reporting_invalid_buffer_version(cx: &mut gpui::T
     // Before restarting the server, report diagnostics with an unknown buffer version.
     let fake_server = fake_servers.next().await.unwrap();
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: lsp::Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: lsp::Url::from_file_path("/dir/a.rs").unwrap(),
         version: Some(10000),
         diagnostics: Vec::new(),
     });
@@ -1684,7 +1640,7 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
 
     // Report some diagnostics for the initial version of the buffer
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: lsp::Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: lsp::Url::from_file_path("/dir/a.rs").unwrap(),
         version: Some(open_notification.text_document.version),
         diagnostics: vec![
             lsp::Diagnostic {
@@ -1770,7 +1726,7 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
 
     // Ensure overlapping diagnostics are highlighted correctly.
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: lsp::Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: lsp::Url::from_file_path("/dir/a.rs").unwrap(),
         version: Some(open_notification.text_document.version),
         diagnostics: vec![
             lsp::Diagnostic {
@@ -1862,7 +1818,7 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
 
     // Handle out-of-order diagnostics
     fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
-        uri: lsp::Uri::from_file_path("/dir/a.rs").unwrap().into(),
+        uri: lsp::Url::from_file_path("/dir/a.rs").unwrap(),
         version: Some(change_notification_2.text_document.version),
         diagnostics: vec![
             lsp::Diagnostic {
@@ -2456,14 +2412,14 @@ async fn test_definition(cx: &mut gpui::TestAppContext) {
     fake_server.handle_request::<lsp::request::GotoDefinition, _, _>(|params, _| async move {
         let params = params.text_document_position_params;
         assert_eq!(
-            Uri::from(params.text_document.uri).to_file_path().unwrap(),
+            params.text_document.uri.to_file_path().unwrap(),
             Path::new("/dir/b.rs"),
         );
         assert_eq!(params.position, lsp::Position::new(0, 22));
 
         Ok(Some(lsp::GotoDefinitionResponse::Scalar(
             lsp::Location::new(
-                lsp::Uri::from_file_path("/dir/a.rs").unwrap().into(),
+                lsp::Url::from_file_path("/dir/a.rs").unwrap(),
                 lsp::Range::new(lsp::Position::new(0, 9), lsp::Position::new(0, 10)),
             ),
         )))
@@ -2771,7 +2727,7 @@ async fn test_apply_code_actions_with_commands(cx: &mut gpui::TestAppContext) {
                                 edit: lsp::WorkspaceEdit {
                                     changes: Some(
                                         [(
-                                            lsp::Uri::from_file_path("/dir/a.ts").unwrap().into(),
+                                            lsp::Url::from_file_path("/dir/a.ts").unwrap(),
                                             vec![lsp::TextEdit {
                                                 range: lsp::Range::new(
                                                     lsp::Position::new(0, 0),
@@ -3604,9 +3560,9 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
         .await
         .unwrap();
 
-    let buffer_uri = Uri::from_file_path("/the-dir/a.rs").unwrap();
+    let buffer_uri = Url::from_file_path("/the-dir/a.rs").unwrap();
     let message = lsp::PublishDiagnosticsParams {
-        uri: buffer_uri.clone().into(),
+        uri: buffer_uri.clone(),
         diagnostics: vec![
             lsp::Diagnostic {
                 range: lsp::Range::new(lsp::Position::new(1, 8), lsp::Position::new(1, 9)),
@@ -3614,7 +3570,7 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
                 message: "error 1".to_string(),
                 related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                     location: lsp::Location {
-                        uri: buffer_uri.clone().into(),
+                        uri: buffer_uri.clone(),
                         range: lsp::Range::new(lsp::Position::new(1, 8), lsp::Position::new(1, 9)),
                     },
                     message: "error 1 hint 1".to_string(),
@@ -3627,7 +3583,7 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
                 message: "error 1 hint 1".to_string(),
                 related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                     location: lsp::Location {
-                        uri: buffer_uri.clone().into(),
+                        uri: buffer_uri.clone(),
                         range: lsp::Range::new(lsp::Position::new(1, 8), lsp::Position::new(1, 9)),
                     },
                     message: "original diagnostic".to_string(),
@@ -3641,7 +3597,7 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
                 related_information: Some(vec![
                     lsp::DiagnosticRelatedInformation {
                         location: lsp::Location {
-                            uri: buffer_uri.clone().into(),
+                            uri: buffer_uri.clone(),
                             range: lsp::Range::new(
                                 lsp::Position::new(1, 13),
                                 lsp::Position::new(1, 15),
@@ -3651,7 +3607,7 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
                     },
                     lsp::DiagnosticRelatedInformation {
                         location: lsp::Location {
-                            uri: buffer_uri.clone().into(),
+                            uri: buffer_uri.clone(),
                             range: lsp::Range::new(
                                 lsp::Position::new(1, 13),
                                 lsp::Position::new(1, 15),
@@ -3668,7 +3624,7 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
                 message: "error 2 hint 1".to_string(),
                 related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                     location: lsp::Location {
-                        uri: buffer_uri.clone().into(),
+                        uri: buffer_uri.clone(),
                         range: lsp::Range::new(lsp::Position::new(2, 8), lsp::Position::new(2, 17)),
                     },
                     message: "original diagnostic".to_string(),
@@ -3681,7 +3637,7 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
                 message: "error 2 hint 2".to_string(),
                 related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                     location: lsp::Location {
-                        uri: buffer_uri.into(),
+                        uri: buffer_uri,
                         range: lsp::Range::new(lsp::Position::new(2, 8), lsp::Position::new(2, 17)),
                     },
                     message: "original diagnostic".to_string(),
@@ -3899,14 +3855,14 @@ async fn test_rename(cx: &mut gpui::TestAppContext) {
                 changes: Some(
                     [
                         (
-                            lsp::Uri::from_file_path("/dir/one.rs").unwrap().into(),
+                            lsp::Url::from_file_path("/dir/one.rs").unwrap(),
                             vec![lsp::TextEdit::new(
                                 lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
                                 "THREE".to_string(),
                             )],
                         ),
                         (
-                            lsp::Uri::from_file_path("/dir/two.rs").unwrap().into(),
+                            lsp::Url::from_file_path("/dir/two.rs").unwrap(),
                             vec![
                                 lsp::TextEdit::new(
                                     lsp::Range::new(

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -412,7 +412,7 @@ mod tests {
             deprecated: None,
             container_name: None,
             location: lsp::Location::new(
-                lsp::Uri::from_file_path(path.as_ref()).unwrap().into(),
+                lsp::Url::from_file_path(path.as_ref()).unwrap(),
                 lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 0)),
             ),
         }

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -893,7 +893,7 @@ async fn test_rename(cx: &mut gpui::TestAppContext) {
             Ok(Some(lsp::WorkspaceEdit {
                 changes: Some(
                     [(
-                        url.clone().into(),
+                        url.clone(),
                         vec![
                             lsp::TextEdit::new(def_range, params.new_name.clone()),
                             lsp::TextEdit::new(tgt_range, params.new_name),


### PR DESCRIPTION
This reverts URI changes made in https://github.com/zed-industries/zed/pull/12928 while keeping the perf goodies in tact. We should keep an eye out for https://github.com/gluon-lang/lsp-types/issues/284
Fixes: https://github.com/zed-industries/zed/issues/13135
Fixes: https://github.com/zed-industries/zed/issues/13131
Release Notes:

- N/A
