### PR TITLE
Support Additional Icons for Repo URLs in Extension Card

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3912,6 +3912,7 @@ dependencies = [
  "num-format",
  "picker",
  "project",
+ "regex",
  "release_channel",
  "semantic_version",
  "serde",

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -27,6 +27,7 @@ language.workspace = true
 num-format.workspace = true
 picker.workspace = true
 project.workspace = true
+regex.workspace = true
 release_channel.workspace = true
 semantic_version.workspace = true
 serde.workspace = true

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -17,6 +17,7 @@ use gpui::{
     UniformListScrollHandle, View, ViewContext, VisualContext, WeakView, WhiteSpace, WindowContext,
 };
 use num_format::{Locale, ToFormattedString};
+use regex::Regex;
 use release_channel::ReleaseChannel;
 use settings::Settings;
 use std::ops::DerefMut;
@@ -405,7 +406,7 @@ impl ExtensionsPage {
                     .children(repository_url.map(|repository_url| {
                         IconButton::new(
                             SharedString::from(format!("repository-{}", extension.id)),
-                            IconName::Github,
+                            Self::get_repository_host_icon(&repository_url),
                         )
                         .icon_color(Color::Accent)
                         .icon_size(IconSize::Small)
@@ -419,6 +420,17 @@ impl ExtensionsPage {
                         .tooltip(move |cx| Tooltip::text(repository_url.clone(), cx))
                     })),
             )
+    }
+
+    fn get_repository_host_icon(url: &str) -> IconName {
+        if Regex::new(r"(?i)github\.com").unwrap().is_match(&url) {
+            IconName::Github
+        } else if Regex::new(r"(?i)gitlab\.com").unwrap().is_match(&url) {
+            // TODO: Add gitlab icon
+            IconName::Link
+        } else {
+            IconName::Link
+        }
     }
 
     fn render_remote_extension(
@@ -512,7 +524,7 @@ impl ExtensionsPage {
                             .child(
                                 IconButton::new(
                                     SharedString::from(format!("repository-{}", extension.id)),
-                                    IconName::Github,
+                                    Self::get_repository_host_icon(&repository_url),
                                 )
                                 .icon_color(Color::Accent)
                                 .icon_size(IconSize::Small)


### PR DESCRIPTION
Currently, Zed adds a `GitHub` icon for every extension repository URL, even if the repository isn't hosted on **GitHub**. This PR addresses that issue by determining the icon based on the repository URL using **regex**. For now, it adds a `Link` icon for all repository URLs except those from GitHub.

As @\maxdeviant mentioned, the Zed team isn't expecting icons from outside. Therefore, I've added a TODO note and temporarily applied the Link icon to the **GitLab** provider as well. Once the Zed team creates the appropriate icon, they can replace the Link icon with it.

Release Notes:

- N/A
