### PR TITLE
linux/x11: Fix closing of GPUI windows not working

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -475,9 +475,8 @@ impl X11Client {
                 if atom == state.atoms.WM_DELETE_WINDOW {
                     // window "x" button clicked by user
                     if window.should_close() {
-                        let window_ref = state.windows.remove(&event.window)?;
-                        state.loop_handle.remove(window_ref.refresh_event_token);
                         // Rest of the close logic is handled in drop_window()
+                        window.close();
                     }
                 }
             }


### PR DESCRIPTION
This fixes everything but the main Zed window (GPUI examples, prompt library, etc.) not being closable by clicking on the X in X11.

We had a dangling reference before: we would remove the window from the X11 state, but GPUI itself would still have the window in its references.

In order to fix this we have to call `window.close()`, which ends up calling `cx.remove_window()`, which removes the reference.

That in turn then causes the reference to be dropped, which cleans up the X11 state for the window.

Release Notes:

- N/A
