### PR TITLE
Add active_line_width setting to increase the thickness of the active indent guide

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -233,6 +233,8 @@
     "enabled": true,
     /// The width of the indent guides in pixels, between 1 and 10.
     "line_width": 1,
+    /// The width of the active indent guide in pixels, between 1 and 10.
+    "active_line_width": 2,
     /// Determines how indent guides are colored.
     /// This setting can take the following three values:
     ///
@@ -245,9 +247,7 @@
     ///
     /// 1. "disabled"
     /// 2. "indent_aware"
-    "background_coloring": "disabled",
-    /// Whether to make an active indent guide thicker than the others.
-    "thicken_active": true
+    "background_coloring": "disabled"
   },
   // The number of lines to keep above/below the cursor when scrolling.
   "vertical_scroll_margin": 3,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -234,7 +234,7 @@
     /// The width of the indent guides in pixels, between 1 and 10.
     "line_width": 1,
     /// The width of the active indent guide in pixels, between 1 and 10.
-    "active_line_width": 2,
+    "active_line_width": 1,
     /// Determines how indent guides are colored.
     /// This setting can take the following three values:
     ///

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -131,7 +131,14 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.cert",
+    "**/*.crt",
+    "**/secrets.yml"
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -238,7 +245,9 @@
     ///
     /// 1. "disabled"
     /// 2. "indent_aware"
-    "background_coloring": "disabled"
+    "background_coloring": "disabled",
+    /// Whether to make an active indent guide thicker than the others.
+    "thicken_active": true
   },
   // The number of lines to keep above/below the cursor when scrolling.
   "vertical_scroll_margin": 3,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11603,6 +11603,7 @@ fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -
         settings: IndentGuideSettings {
             enabled: true,
             line_width: 1,
+            active_line_width: 2,
             ..Default::default()
         },
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11603,7 +11603,7 @@ fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -
         settings: IndentGuideSettings {
             enabled: true,
             line_width: 1,
-            active_line_width: 2,
+            active_line_width: 1,
             ..Default::default()
         },
     }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2782,6 +2782,12 @@ impl EditorElement {
             };
 
             let requested_line_width = settings.line_width.clamp(1, 10);
+            let requested_line_width =
+                if indent_guide.active && indent_guide.settings.thicken_active {
+                    requested_line_width + 1
+                } else {
+                    requested_line_width
+                };
             let mut line_indicator_width = 0.;
             if let Some(color) = line_color {
                 cx.paint_quad(fill(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2781,12 +2781,12 @@ impl EditorElement {
                 )),
             };
 
-            let requested_line_width = settings.line_width.clamp(1, 10);
             let requested_line_width = if indent_guide.active {
-                settings.active_line_width.clamp(1, 10)
+                settings.active_line_width
             } else {
-                requested_line_width
-            };
+                settings.line_width
+            }
+            .clamp(1, 10);
             let mut line_indicator_width = 0.;
             if let Some(color) = line_color {
                 cx.paint_quad(fill(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2782,12 +2782,11 @@ impl EditorElement {
             };
 
             let requested_line_width = settings.line_width.clamp(1, 10);
-            let requested_line_width =
-                if indent_guide.active && indent_guide.settings.thicken_active {
-                    requested_line_width + 1
-                } else {
-                    requested_line_width
-                };
+            let requested_line_width = if indent_guide.active {
+                settings.active_line_width.clamp(1, 10)
+            } else {
+                requested_line_width
+            };
             let mut line_indicator_width = 0.;
             if let Some(color) = line_color {
                 cx.paint_quad(fill(

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -443,11 +443,11 @@ pub struct IndentGuideSettings {
     /// Default: 1
     #[serde(default = "line_width")]
     pub line_width: u32,
-    /// Whether to make an active indent guide thicker than the others.
+    /// The width of the active indent guide in pixels, between 1 and 10.
     ///
-    /// Default: true
-    #[serde(default = "default_true")]
-    pub thicken_active: bool,
+    /// Default: 2
+    #[serde(default = "active_line_width")]
+    pub active_line_width: u32,
     /// Determines how indent guides are colored.
     ///
     /// Default: Fixed
@@ -462,6 +462,10 @@ pub struct IndentGuideSettings {
 
 fn line_width() -> u32 {
     1
+}
+
+fn active_line_width() -> u32 {
+    line_width() + 1
 }
 
 /// Determines how indent guides are colored.

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -445,7 +445,7 @@ pub struct IndentGuideSettings {
     pub line_width: u32,
     /// The width of the active indent guide in pixels, between 1 and 10.
     ///
-    /// Default: 2
+    /// Default: 1
     #[serde(default = "active_line_width")]
     pub active_line_width: u32,
     /// Determines how indent guides are colored.
@@ -465,7 +465,7 @@ fn line_width() -> u32 {
 }
 
 fn active_line_width() -> u32 {
-    line_width() + 1
+    line_width()
 }
 
 /// Determines how indent guides are colored.

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -13,7 +13,7 @@ use schemars::{
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsLocation, SettingsSources};
 use std::{num::NonZeroU32, path::Path, sync::Arc};
-use util::serde::default_true;
+use util::serde::{default_false, default_true};
 
 impl<'a> Into<SettingsLocation<'a>> for &'a dyn File {
     fn into(self) -> SettingsLocation<'a> {
@@ -443,6 +443,11 @@ pub struct IndentGuideSettings {
     /// Default: 1
     #[serde(default = "line_width")]
     pub line_width: u32,
+    /// Whether to make an active indent guide thicker than the others.
+    ///
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub thicken_active: bool,
     /// Determines how indent guides are colored.
     ///
     /// Default: Fixed

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -445,8 +445,8 @@ pub struct IndentGuideSettings {
     pub line_width: u32,
     /// Whether to make an active indent guide thicker than the others.
     ///
-    /// Default: false
-    #[serde(default)]
+    /// Default: true
+    #[serde(default = "default_true")]
     pub thicken_active: bool,
     /// Determines how indent guides are colored.
     ///

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -13,7 +13,7 @@ use schemars::{
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsLocation, SettingsSources};
 use std::{num::NonZeroU32, path::Path, sync::Arc};
-use util::serde::{default_false, default_true};
+use util::serde::default_true;
 
 impl<'a> Into<SettingsLocation<'a>> for &'a dyn File {
     fn into(self) -> SettingsLocation<'a> {
@@ -446,7 +446,7 @@ pub struct IndentGuideSettings {
     /// Whether to make an active indent guide thicker than the others.
     ///
     /// Default: false
-    #[serde(default = "default_false")]
+    #[serde(default)]
     pub thicken_active: bool,
     /// Determines how indent guides are colored.
     ///

--- a/crates/util/src/serde.rs
+++ b/crates/util/src/serde.rs
@@ -1,3 +1,7 @@
 pub const fn default_true() -> bool {
     true
 }
+
+pub const fn default_false() -> bool {
+    false
+}

--- a/crates/util/src/serde.rs
+++ b/crates/util/src/serde.rs
@@ -1,7 +1,3 @@
 pub const fn default_true() -> bool {
     true
 }
-
-pub const fn default_false() -> bool {
-    false
-}

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -725,6 +725,7 @@ To interpret all `.c` files as C++, files called `MyLockFile` as TOML and files 
   "indent_guides": {
     "enabled": true,
     "line_width": 1,
+    "active_line_width": 1,
     "coloring": "fixed",
     "background_coloring": "disabled"
   }
@@ -758,7 +759,7 @@ To interpret all `.c` files as C++, files called `MyLockFile` as TOML and files 
 ```
 
 3. Enable indent aware coloring ("rainbow indentation").
-The colors that are used for different indentation levels are defined in the theme (theme key: `accents`). They can be customized by using theme overrides.
+   The colors that are used for different indentation levels are defined in the theme (theme key: `accents`). They can be customized by using theme overrides.
 
 ```json
 {
@@ -770,7 +771,7 @@ The colors that are used for different indentation levels are defined in the the
 ```
 
 4. Enable indent aware background coloring ("rainbow indentation").
-The colors that are used for different indentation levels are defined in the theme (theme key: `accents`). They can be customized by using theme overrides.
+   The colors that are used for different indentation levels are defined in the theme (theme key: `accents`). They can be customized by using theme overrides.
 
 ```json
 {


### PR DESCRIPTION
Resolves #12312.

Release Notes:

- Added an option to configure the line width of the active indent guide [#12312](https://github.com/zed-industries/zed/issues/12312)