### PR TITLE
GitHub Issue Templates: Hide Zed Logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/0_feature_request.yml
@@ -2,23 +2,23 @@ name: Feature Request
 description: "Tip: open this issue template from within Zed with the `request feature` command palette action"
 labels: ["admin read", "triage", "enhancement"]
 body:
-    - type: checkboxes
-      attributes:
-          label: Check for existing issues
-          description: Check the backlog of issues to reduce the chances of creating duplicates; if an issue already exists, place a `+1` (👍) on it.
-          options:
-              - label: Completed
-                required: true
-    - type: textarea
-      attributes:
-          label: Describe the feature
-          description: A clear and concise description of what you want to happen.
-      validations:
+  - type: checkboxes
+    attributes:
+      label: Check for existing issues
+      description: Check the backlog of issues to reduce the chances of creating duplicates; if an issue already exists, place a `+1` (👍) on it.
+      options:
+        - label: Completed
           required: true
-    - type: textarea
-      attributes:
-          label: |
-              If applicable, add mockups / screenshots to help present your vision of the feature
-          description: Drag images into the text input below
-      validations:
-          required: false
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: |
+        If applicable, add mockups / screenshots to help present your vision of the feature
+      description: Drag images into the text input below
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -36,5 +36,10 @@ body:
       description: |
         Drag Zed.log into the text input below.
         If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
+      value: |
+        <details><summary>Zed.log</summary><pre>
+        <!-- Click below this line and paste or drag-and-drop your log-->
+
+        <!-- Click above this line and paste or drag-and-drop your log--></pre></details>
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,40 +1,40 @@
 name: Bug Report
 description: |
-    Use this template for **non-crash-related** bug reports.
-    Tip: open this issue template from within Zed with the `file bug report` command palette action.
+  Use this template for **non-crash-related** bug reports.
+  Tip: open this issue template from within Zed with the `file bug report` command palette action.
 labels: ["admin read", "triage", "defect"]
 body:
-    - type: checkboxes
-      attributes:
-          label: Check for existing issues
-          description: Check the backlog of issues to reduce the chances of creating duplicates; if an issue already exists, place a `+1` (👍) on it.
-          options:
-              - label: Completed
-                required: true
-    - type: textarea
-      attributes:
-          label: Describe the bug / provide steps to reproduce it
-          description: A clear and concise description of what the bug is.
-      validations:
+  - type: checkboxes
+    attributes:
+      label: Check for existing issues
+      description: Check the backlog of issues to reduce the chances of creating duplicates; if an issue already exists, place a `+1` (👍) on it.
+      options:
+        - label: Completed
           required: true
-    - type: textarea
-      id: environment
-      attributes:
-          label: Environment
-          description: Run the `copy system specs into clipboard` command palette action and paste the output in the field below.
-      validations:
-          required: true
-    - type: textarea
-      attributes:
-          label: If applicable, add mockups / screenshots to help explain present your vision of the feature
-          description: Drag issues into the text input below
-      validations:
-          required: false
-    - type: textarea
-      attributes:
-          label: If applicable, attach your `~/Library/Logs/Zed/Zed.log` file to this issue.
-          description: |
-              Drag Zed.log into the text input below.
-              If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
-      validations:
-          required: false
+  - type: textarea
+    attributes:
+      label: Describe the bug / provide steps to reproduce it
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Run the `copy system specs into clipboard` command palette action and paste the output in the field below.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: If applicable, add mockups / screenshots to help explain present your vision of the feature
+      description: Drag issues into the text input below
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: If applicable, attach your `~/Library/Logs/Zed/Zed.log` file to this issue.
+      description: |
+        Drag Zed.log into the text input below.
+        If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2_crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_crash_report.yml
@@ -29,5 +29,10 @@ body:
       description: |
         Drag Zed.log into the text input below.
         If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
+      value: |
+        <details><summary>Zed.log</summary><pre>
+        <!-- Click below this line and paste or drag-and-drop your log-->
+
+        <!-- Click above this line and paste or drag-and-drop your log--></pre></details>
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/2_crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_crash_report.yml
@@ -1,33 +1,33 @@
 name: Crash Report
 description: |
-    Use this template for crash reports.
+  Use this template for crash reports.
 labels: ["admin read", "triage", "defect", "panic / crash"]
 body:
-    - type: checkboxes
-      attributes:
-          label: Check for existing issues
-          description: Check the backlog of issues to reduce the chances of creating duplicates; if an issue already exists, place a `+1` (👍) on it.
-          options:
-              - label: Completed
-                required: true
-    - type: textarea
-      attributes:
-          label: Describe the bug / provide steps to reproduce it
-          description: A clear and concise description of what the bug is.
-      validations:
+  - type: checkboxes
+    attributes:
+      label: Check for existing issues
+      description: Check the backlog of issues to reduce the chances of creating duplicates; if an issue already exists, place a `+1` (👍) on it.
+      options:
+        - label: Completed
           required: true
-    - type: textarea
-      id: environment
-      attributes:
-          label: Environment
-          description: Run the `copy system specs into clipboard` command palette action and paste the output in the field below.
-      validations:
-          required: true
-    - type: textarea
-      attributes:
-          label: If applicable, attach your `~/Library/Logs/Zed/Zed.log` file to this issue.
-          description: |
-              Drag Zed.log into the text input below.
-              If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
-      validations:
-          required: false
+  - type: textarea
+    attributes:
+      label: Describe the bug / provide steps to reproduce it
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Run the `copy system specs into clipboard` command palette action and paste the output in the field below.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: If applicable, attach your `~/Library/Logs/Zed/Zed.log` file to this issue.
+      description: |
+        Drag Zed.log into the text input below.
+        If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
+    validations:
+      required: false


### PR DESCRIPTION
Add details/summary block to GitHub issue templates so zed.log can be hidden by default.

The diff for this is messy because the existing files were not correctly auto-formatted.  So I created two commits, one for autoformat and the other for the changes.

I tested it on a private repo. When you first open the issue it looks like this:
<img width="879" alt="image" src="https://github.com/zed-industries/zed/assets/145113/07cda992-4d62-4c27-abaa-5c272ff65345">

Then when you double-click inside it becomes editable:
<img width="880" alt="image" src="https://github.com/zed-industries/zed/assets/145113/970c6669-84da-41d1-9119-d3eb9b090066">
 

Release Notes:

- N/A
