### PR TITLE
util: Replace `lazy_static!` with `OnceLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11703,7 +11703,6 @@ dependencies = [
  "futures-lite 1.13.0",
  "git2",
  "globset",
- "lazy_static",
  "log",
  "rand 0.8.5",
  "regex",

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use util::paths::HOME;
+pub use util::paths::home_dir;
 
 /// Returns the path to the configuration directory used by Zed.
 pub fn config_dir() -> &'static PathBuf {
@@ -24,7 +24,7 @@ pub fn config_dir() -> &'static PathBuf {
             .join("zed");
         }
 
-        HOME.join(".config").join("zed")
+        home_dir().join(".config").join("zed")
     })
 }
 
@@ -33,7 +33,7 @@ pub fn support_dir() -> &'static PathBuf {
     static SUPPORT_DIR: OnceLock<PathBuf> = OnceLock::new();
     SUPPORT_DIR.get_or_init(|| {
         if cfg!(target_os = "macos") {
-            return HOME.join("Library/Application Support/Zed");
+            return home_dir().join("Library/Application Support/Zed");
         }
 
         if cfg!(target_os = "linux") {
@@ -74,7 +74,7 @@ pub fn temp_dir() -> &'static PathBuf {
             .join("zed");
         }
 
-        HOME.join(".cache").join("zed")
+        home_dir().join(".cache").join("zed")
     })
 }
 
@@ -83,7 +83,7 @@ pub fn logs_dir() -> &'static PathBuf {
     static LOGS_DIR: OnceLock<PathBuf> = OnceLock::new();
     LOGS_DIR.get_or_init(|| {
         if cfg!(target_os = "macos") {
-            HOME.join("Library/Logs/Zed")
+            home_dir().join("Library/Logs/Zed")
         } else {
             support_dir().join("logs")
         }
@@ -112,7 +112,7 @@ pub fn database_dir() -> &'static PathBuf {
 pub fn crashes_dir() -> &'static Option<PathBuf> {
     static CRASHES_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
     CRASHES_DIR.get_or_init(|| {
-        cfg!(target_os = "macos").then_some(HOME.join("Library/Logs/DiagnosticReports"))
+        cfg!(target_os = "macos").then_some(home_dir().join("Library/Logs/DiagnosticReports"))
     })
 }
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -22,7 +22,6 @@ dirs.workspace = true
 futures.workspace = true
 git2 = { workspace = true, optional = true }
 globset.workspace = true
-lazy_static.workspace = true
 log.workspace = true
 rand.workspace = true
 regex.workspace = true

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -58,7 +58,7 @@ use std::{
 };
 use sum_tree::{Bias, Edit, SeekTarget, SumTree, TreeMap, TreeSet};
 use text::{LineEnding, Rope};
-use util::{paths::HOME, ResultExt};
+use util::{paths::home_dir, ResultExt};
 pub use worktree_settings::WorktreeSettings;
 
 #[cfg(feature = "test-support")]
@@ -2968,9 +2968,9 @@ impl language::File for File {
         } else {
             let path = worktree.abs_path();
 
-            if worktree.is_local() && path.starts_with(HOME.as_path()) {
+            if worktree.is_local() && path.starts_with(home_dir().as_path()) {
                 full_path.push("~");
-                full_path.push(path.strip_prefix(HOME.as_path()).unwrap());
+                full_path.push(path.strip_prefix(home_dir().as_path()).unwrap());
             } else {
                 full_path.push(path)
             }


### PR DESCRIPTION
This PR replaces the `lazy_static!` usages in the `util` crate with `OnceLock` from the standard library.

This allows us to drop the `lazy_static` dependency from this crate.

Release Notes:

- N/A
