### PR TITLE
ruby: Update tree-sitter grammar version

### DIFF
--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -16,7 +16,7 @@ language = "Ruby"
 
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
-commit = "9d86f3761bb30e8dcc81e754b81d3ce91848477e"
+commit = "dc2d7d6b50f9975bc3c35bbec0ba11b2617b736b"
 
 [grammars.embedded_template]
 repository = "https://github.com/tree-sitter/tree-sitter-embedded-template"


### PR DESCRIPTION
Hi, this pull request just updates the `tree-sitter` version for the Ruby language. I checked the changelog and it doesn't contain breaking changes. Thanks.

tree-sitter/tree-sitter-ruby@9d86f3761bb3 -> tree-sitter/tree-sitter-ruby@dc2d7d6b50f9


Release Notes:

- N/A
