### PR TITLE
Hide old linux panics

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -308,13 +308,12 @@ pub async fn post_panic(
         .map_err(|_| Error::Http(StatusCode::BAD_REQUEST, "invalid json".into()))?;
     let panic = report.panic;
 
-    // better OS reporting for linux (because linux is hard):
-    // - Remove os_version/app_version/os_name from the gpui platform trait
-    // - Move platform processing data into client/telemetry
-    // - Duplicate some small code in macOS platform for a version check
-    // - Add GPUI API for reporting the selected platform integration
-    //  - macos-blade, macos-metal, linux-X11, linux-headless
-    // if cfg(macos( { "Macos" } else { "Linux-{cx.compositor_name()"} ))
+    if panic.os_name == "Linux" && panic.os_version == Some("1.0.0".to_string()) {
+        return Err(Error::Http(
+            StatusCode::BAD_REQUEST,
+            "invalid os version".into(),
+        ))?;
+    }
 
     tracing::error!(
         service = "client",


### PR DESCRIPTION
Remove noise from the #panics channel by excluding any linux build before
0.139.x. We filter on the os_version and os_name because evern older versions
of linux set app_version = 1.0.0.

Release Notes:

- N/A
