### PR TITLE
Stop using xtask for clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Check unused dependencies
         uses: bnjbvr/cargo-machete@main
 
+      - name: Check licenses are present
+        run: script/check-licenses
+
       - name: Check license generation
         run: script/generate-licenses /tmp/zed_licenses_output
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           clean: false
 
       - name: cargo clippy
-        run: cargo xtask clippy
+        run: ./script/clippy
 
       - name: Run tests
         uses: ./.github/actions/run_tests
@@ -114,7 +114,7 @@ jobs:
           clean: false
 
       - name: cargo clippy
-        run: cargo xtask clippy
+        run: ./script/clippy
 
       - name: Run tests
         uses: ./.github/actions/run_tests
@@ -139,7 +139,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: cargo clippy
-        run: cargo xtask clippy
+        run: ./script/clippy
 
       - name: Build Zed
         run: cargo build -p zed

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/check_style
 
       - name: Run clippy
-        run: cargo xtask clippy
+        run: ./script/clippy
 
   tests:
     name: Run tests

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/check_style
 
       - name: Run clippy
-        run: cargo xtask clippy
+        run: ./script/clippy
   tests:
     timeout-minutes: 60
     name: Run tests

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,7 +1,7 @@
 [
   {
     "label": "clippy",
-    "command": "cargo",
-    "args": ["xtask", "clippy"]
+    "command": "./script/clippy",
+    "args": []
   }
 ]

--- a/script/check-licenses
+++ b/script/check-licenses
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+check_license () {
+    for license in "LICENSE-AGPL" "LICENSE-GPL" "LICENSE-APACHE"; do
+        if [[ -L "$1/$license" ]]; then
+            return 0
+        elif [[ -e "$1/$license" ]]; then
+            echo "Error: $1/$license exists but is not a symlink."
+            exit 1
+        fi
+    done
+    echo "Error: $1 does not contain a license symlink"
+    exit 1
+}
+
+git ls-files **/*/Cargo.toml | while read cargo_toml; do
+   check_license $(dirname "$cargo_toml");
+done

--- a/script/clippy
+++ b/script/clippy
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
-cargo xtask clippy
+if [[ ! " $* " == *" -p "* && ! " $* " == *" --package "* ]]; then
+    set -- "$@" --workspace
+fi
+
+set -x
+"${CARGO:-cargo}" clippy "$@" --release --all-targets --all-features -- --deny warnings


### PR DESCRIPTION
This fixes an extra 10 second delay when needing to recompile xtask, and
allows passing arbitrary clippy args (like --allow-dirty)

Release Notes:

- N/A
