### PR TITLE
Fix modality indicators in user menu

### DIFF
--- a/crates/collab_ui/src/collab_titlebar_item.rs
+++ b/crates/collab_ui/src/collab_titlebar_item.rs
@@ -911,8 +911,8 @@ impl CollabTitlebarItem {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
-                            .action("Themes", theme_selector::Toggle::default().boxed_clone())
-                            .action("Extensions...", extensions_ui::Extensions.boxed_clone())
+                            .action("Themes…", theme_selector::Toggle::default().boxed_clone())
+                            .action("Extensions", extensions_ui::Extensions.boxed_clone())
                             .separator()
                             .action("Sign Out", client::SignOut.boxed_clone())
                     })
@@ -940,8 +940,8 @@ impl CollabTitlebarItem {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
-                            .action("Themes", theme_selector::Toggle::default().boxed_clone())
-                            .action("Extensions...", extensions_ui::Extensions.boxed_clone())
+                            .action("Themes…", theme_selector::Toggle::default().boxed_clone())
+                            .action("Extensions", extensions_ui::Extensions.boxed_clone())
                     })
                     .into()
                 })


### PR DESCRIPTION
This PR updates the modality indicators in the user menu after #12940.

We use the ellipsis throughout the app to indicate that a menu action will open a modal (e.g., the theme selector), so "Themes" needs the trailing ellipsis.

Whereas the "Extensions" entry opens up a new tab, which we don't indicate that same way.

Release Notes:

- N/A
