### PR TITLE
zed_extension_api: Add default implementation for `language_server_command`

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -66,9 +66,11 @@ pub trait Extension: Send + Sync {
     /// language.
     fn language_server_command(
         &mut self,
-        language_server_id: &LanguageServerId,
-        worktree: &Worktree,
-    ) -> Result<Command>;
+        _language_server_id: &LanguageServerId,
+        _worktree: &Worktree,
+    ) -> Result<Command> {
+        Err(format!("no language server command was provided"))
+    }
 
     /// Returns the initialization options to pass to the specified language server.
     fn language_server_initialization_options(

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -69,7 +69,7 @@ pub trait Extension: Send + Sync {
         _language_server_id: &LanguageServerId,
         _worktree: &Worktree,
     ) -> Result<Command> {
-        Err(format!("no language server command was provided"))
+        Err("`language_server_command` not implemented".to_string())
     }
 
     /// Returns the initialization options to pass to the specified language server.


### PR DESCRIPTION
This PR adds a default implementation for the `language_server_command` method on the `Extension` trait.

This will allow for extensions to be defined without having to implement this method, which will be useful for extensions that may just want to provide slash commands.

Release Notes:

- N/A
