### PR TITLE
Allow completing slash command arguments from extensions

### DIFF
--- a/crates/assistant/src/slash_command/active_command.rs
+++ b/crates/assistant/src/slash_command/active_command.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use editor::Editor;
 use gpui::{AppContext, Task, WeakView};
 use language::LspAdapterDelegate;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use ui::WindowContext;
 use workspace::Workspace;
@@ -26,9 +27,9 @@ impl SlashCommand for ActiveSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         _query: String,
-        _cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut AppContext,
     ) -> Task<Result<Vec<String>>> {

--- a/crates/assistant/src/slash_command/default_command.rs
+++ b/crates/assistant/src/slash_command/default_command.rs
@@ -31,7 +31,7 @@ impl SlashCommand for DefaultSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         _query: String,
         _cancellation_flag: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -98,7 +98,7 @@ impl SlashCommand for DiagnosticsCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         query: String,
         cancellation_flag: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -113,7 +113,7 @@ impl SlashCommand for FetchSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         _query: String,
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -101,7 +101,7 @@ impl SlashCommand for FileSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         query: String,
         cancellation_flag: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -29,7 +29,7 @@ impl SlashCommand for NowSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         _query: String,
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -102,7 +102,7 @@ impl SlashCommand for ProjectSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         _query: String,
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -28,7 +28,7 @@ impl SlashCommand for PromptSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         query: String,
         _cancellation_flag: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/rustdoc_command.rs
+++ b/crates/assistant/src/slash_command/rustdoc_command.rs
@@ -107,7 +107,7 @@ impl SlashCommand for RustdocSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         query: String,
         _cancel: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -47,7 +47,7 @@ impl SlashCommand for SearchSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         _query: String,
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant/src/slash_command/tabs_command.rs
+++ b/crates/assistant/src/slash_command/tabs_command.rs
@@ -31,7 +31,7 @@ impl SlashCommand for TabsSlashCommand {
     }
 
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         _query: String,
         _cancel: Arc<std::sync::atomic::AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -23,7 +23,7 @@ pub trait SlashCommand: 'static + Send + Sync {
     fn description(&self) -> String;
     fn menu_text(&self) -> String;
     fn complete_argument(
-        &self,
+        self: Arc<Self>,
         query: String,
         cancel: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -268,9 +268,7 @@ impl Extension {
                 ext.call_complete_slash_command_argument(store, command, query)
                     .await
             }
-            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Err(anyhow!(
-                "`complete_slash_command_argument` not available prior to v0.0.7"
-            )),
+            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Ok(Ok(Vec::new())),
         }
     }
 

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -257,6 +257,23 @@ impl Extension {
         }
     }
 
+    pub async fn call_complete_slash_command_argument(
+        &self,
+        store: &mut Store<WasmState>,
+        command: &SlashCommand,
+        query: &str,
+    ) -> Result<Result<Vec<String>, String>> {
+        match self {
+            Extension::V007(ext) => {
+                ext.call_complete_slash_command_argument(store, command, query)
+                    .await
+            }
+            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Err(anyhow!(
+                "`complete_slash_command_argument` not available prior to v0.0.7"
+            )),
+        }
+    }
+
     pub async fn call_run_slash_command(
         &self,
         store: &mut Store<WasmState>,

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -108,7 +108,16 @@ pub trait Extension: Send + Sync {
         None
     }
 
-    /// Runs the given slash command.
+    /// Returns the completions that should be shown when completing the provided slash command with the given query
+    fn complete_slash_command_argument(
+        &self,
+        _command: SlashCommand,
+        _query: String,
+    ) -> Result<Vec<String>, String> {
+        Ok(Vec::new())
+    }
+
+    /// Returns the output from running the provided slash command.
     fn run_slash_command(
         &self,
         _command: SlashCommand,
@@ -223,6 +232,13 @@ impl wit::Guest for Component {
             }
         }
         Ok(labels)
+    }
+
+    fn complete_slash_command_argument(
+        command: SlashCommand,
+        query: String,
+    ) -> Result<Vec<String>, String> {
+        extension().complete_slash_command_argument(command, query)
     }
 
     fn run_slash_command(

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -108,7 +108,7 @@ pub trait Extension: Send + Sync {
         None
     }
 
-    /// Returns the completions that should be shown when completing the provided slash command with the given query
+    /// Returns the completions that should be shown when completing the provided slash command with the given query.
     fn complete_slash_command_argument(
         &self,
         _command: SlashCommand,

--- a/crates/extension_api/wit/since_v0.0.7/extension.wit
+++ b/crates/extension_api/wit/since_v0.0.7/extension.wit
@@ -122,6 +122,9 @@ world extension {
     export labels-for-completions: func(language-server-id: string, completions: list<completion>) -> result<list<option<code-label>>, string>;
     export labels-for-symbols: func(language-server-id: string, symbols: list<symbol>) -> result<list<option<code-label>>, string>;
 
-    /// Runs the provided slash command.
+    /// Returns the completions that should be shown when completing the provided slash command with the given query.
+    export complete-slash-command-argument: func(command: slash-command, query: string) -> result<list<string>, string>;
+
+    /// Returns the output from running the provided slash command.
     export run-slash-command: func(command: slash-command, argument: option<string>, worktree: borrow<worktree>) -> result<slash-command-output, string>;
 }

--- a/extensions/gleam/src/gleam.rs
+++ b/extensions/gleam/src/gleam.rs
@@ -146,6 +146,21 @@ impl zed::Extension for GleamExtension {
         })
     }
 
+    fn complete_slash_command_argument(
+        &self,
+        command: SlashCommand,
+        _query: String,
+    ) -> Result<Vec<String>, String> {
+        match command.name.as_str() {
+            "gleam-project" => Ok(vec![
+                "apple".to_string(),
+                "banana".to_string(),
+                "cherry".to_string(),
+            ]),
+            _ => Ok(Vec::new()),
+        }
+    }
+
     fn run_slash_command(
         &self,
         command: SlashCommand,


### PR DESCRIPTION
This PR extends the extension API with support for completing slash command arguments for slash commands defined in extensions.

Release Notes:

- N/A
