### PR TITLE
Add mouse context action to copy permalink

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -1,7 +1,5 @@
 use crate::{
-    Copy, Cut, DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition,
-    GoToImplementation, GoToTypeDefinition, Paste, Rename, RevealInFinder, SelectMode,
-    ToggleCodeActions,
+    Copy, CopyPermalinkToLine, Cut, DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition, GoToImplementation, GoToTypeDefinition, Paste, Rename, RevealInFinder, SelectMode, ToggleCodeActions
 };
 use gpui::{DismissEvent, Pixels, Point, Subscription, View, ViewContext};
 use workspace::OpenInTerminal;
@@ -91,7 +89,8 @@ pub fn deploy_context_menu(
                 .action("Paste", Box::new(Paste))
                 .separator()
                 .action("Reveal in Finder", Box::new(RevealInFinder))
-                .action("Open in Terminal", Box::new(OpenInTerminal));
+                .action("Open in Terminal", Box::new(OpenInTerminal))
+                .action("Copy Permalink", Box::new(CopyPermalinkToLine));
             match focus {
                 Some(focus) => builder.context(focus),
                 None => builder,

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -1,5 +1,7 @@
 use crate::{
-    Copy, CopyPermalinkToLine, Cut, DisplayPoint, Editor, EditorMode, FindAllReferences, GoToDefinition, GoToImplementation, GoToTypeDefinition, Paste, Rename, RevealInFinder, SelectMode, ToggleCodeActions
+    Copy, CopyPermalinkToLine, Cut, DisplayPoint, Editor, EditorMode, FindAllReferences,
+    GoToDefinition, GoToImplementation, GoToTypeDefinition, Paste, Rename, RevealInFinder,
+    SelectMode, ToggleCodeActions,
 };
 use gpui::{DismissEvent, Pixels, Point, Subscription, View, ViewContext};
 use workspace::OpenInTerminal;


### PR DESCRIPTION

Release Notes:

- Added mouse context action to copy permalink to line

<img width="977" alt="Screenshot 2024-06-19 at 00 24 21" src="https://github.com/zed-industries/zed/assets/5855806/8bdb46ad-2d81-45d0-853b-c1d0cc0fc037">

Selecting the item results in the following link https://github.com/zed-industries/zed/blob/a8c19ab8958a932fc9b7b66e8a0659bf3e3ebcc2/crates/assets/Cargo.toml#L12 for me.

## Summary

Switching from PyCharm, my number one most missed feature is "Copy Github link" provided by the Gitlink plugin (https://plugins.jetbrains.com/plugin/8183-gitlink / https://github.com/ben-gibson/GitLink). I use this a lot to quickly send code pointers to teammates.

While digging around, I found that this is basically already implemented, but wasn't able to find this action exposed anywhere in the UI.

https://github.com/zed-industries/zed/blob/a8c19ab8958a932fc9b7b66e8a0659bf3e3ebcc2/crates/editor/src/editor.rs#L10343-L10367