### PR TITLE
Show location of log file when using `zed: open log`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -552,6 +552,7 @@ pub struct Editor {
     tasks_update_task: Option<Task<()>>,
     previous_search_ranges: Option<Arc<[Range<Anchor>]>>,
     file_header_size: u8,
+    breadcrumb_header: Option<String>,
 }
 
 #[derive(Clone)]
@@ -1863,6 +1864,7 @@ impl Editor {
             tasks_update_task: None,
             linked_edit_ranges: Default::default(),
             previous_search_ranges: None,
+            breadcrumb_header: None,
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));
         this._subscriptions.extend(project_subscriptions);
@@ -10503,6 +10505,10 @@ impl Editor {
             |colors| colors.editor_document_highlight_read_background,
             cx,
         )
+    }
+
+    pub fn set_breadcrumb_header(&mut self, new_header: String) {
+        self.breadcrumb_header = Some(new_header);
     }
 
     pub fn clear_search_within_ranges(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -816,22 +816,24 @@ impl Item for Editor {
         let buffer = multibuffer.buffer(buffer_id)?;
 
         let buffer = buffer.read(cx);
-        let filename = buffer
-            .snapshot()
-            .resolve_file_path(
-                cx,
-                self.project
-                    .as_ref()
-                    .map(|project| project.read(cx).visible_worktrees(cx).count() > 1)
-                    .unwrap_or_default(),
-            )
-            .map(|path| path.to_string_lossy().to_string())
-            .unwrap_or_else(|| "untitled".to_string());
+        let text = self.breadcrumb_header.clone().unwrap_or_else(|| {
+            buffer
+                .snapshot()
+                .resolve_file_path(
+                    cx,
+                    self.project
+                        .as_ref()
+                        .map(|project| project.read(cx).visible_worktrees(cx).count() > 1)
+                        .unwrap_or_default(),
+                )
+                .map(|path| path.to_string_lossy().to_string())
+                .unwrap_or_else(|| "untitled".to_string())
+        });
 
         let settings = ThemeSettings::get_global(cx);
 
         let mut breadcrumbs = vec![BreadcrumbText {
-            text: filename,
+            text,
             highlights: None,
             font: Some(settings.buffer_font.clone()),
         }];

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -633,7 +633,14 @@ fn open_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
                             MultiBuffer::singleton(buffer, cx).with_title("Log".into())
                         });
                         let editor = cx.new_view(|cx| {
-                            Editor::for_multibuffer(buffer, Some(project), true, cx)
+                            let mut editor =
+                                Editor::for_multibuffer(buffer, Some(project), true, cx);
+                            editor.set_breadcrumb_header(format!(
+                                "Last {} lines in {}",
+                                MAX_LINES,
+                                paths::log_file().display()
+                            ));
+                            editor
                         });
 
                         editor.update(cx, |editor, cx| {


### PR DESCRIPTION
This changes the breadcrumb header from "untitled" to "Last 1000 lines in <location of log file>".

Reason is that it's been incredibly frustrating not seeing the location of the log file there and not seeing that it's actually a truncated version of the logs.

This is one remedy for that.

Other options considered:

1. Opening the actual log file. Turns out that is huge. On Linux right now it's 5 megabyte after 5 minutes.
2. Opening the file and adding it on the buffer. That is tricky and weird, because you have to modify the underlying buffer and set the file, after having to add it to the workspace and getting its entry, etc.
3. Setting a `display_file_path` on Buffer. That would require also adding it on `BufferSnapshot` and then threading that through so that it gets returned by the multi-buffer and then in the editor. And ultimately this here is a "view concern", so we thought we just add it as such.

So yes, not the best change possible, but it's not that invasive and makes it clear that it's a view-only concern.

Release Notes:

- N/A
