### PR TITLE
Add language-agnostic snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,7 +3340,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
 dependencies = [
- "dirs-sys 0.3.7",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -3349,16 +3349,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -3380,18 +3371,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7091,12 +7070,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -13563,7 +13536,6 @@ dependencies = [
 name = "zed_snippets"
 version = "0.0.1"
 dependencies = [
- "dirs 5.0.1",
  "serde_json",
  "zed_extension_api 0.0.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13533,6 +13533,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed_snippets"
+version = "0.0.1"
+dependencies = [
+ "serde_json",
+ "zed_extension_api 0.0.6",
+]
+
+[[package]]
 name = "zed_svelte"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,7 +3340,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -3349,7 +3349,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -3371,6 +3380,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7070,6 +7091,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -13536,6 +13563,7 @@ dependencies = [
 name = "zed_snippets"
 version = "0.0.1"
 dependencies = [
+ "dirs 5.0.1",
  "serde_json",
  "zed_extension_api 0.0.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ members = [
     "extensions/prisma",
     "extensions/purescript",
     "extensions/ruby",
+    "extensions/snippets",
     "extensions/svelte",
     "extensions/terraform",
     "extensions/toml",

--- a/extensions/snippets/Cargo.toml
+++ b/extensions/snippets/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "zed_snippets"
+version = "0.0.1"
+edition = "2021"
+publish = false
+license = "Apache-2.0"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/snippets.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.0.6"
+serde_json = "1.0"

--- a/extensions/snippets/Cargo.toml
+++ b/extensions/snippets/Cargo.toml
@@ -15,4 +15,3 @@ crate-type = ["cdylib"]
 [dependencies]
 zed_extension_api = "0.0.6"
 serde_json = "1.0"
-dirs = "5.0"

--- a/extensions/snippets/Cargo.toml
+++ b/extensions/snippets/Cargo.toml
@@ -15,3 +15,4 @@ crate-type = ["cdylib"]
 [dependencies]
 zed_extension_api = "0.0.6"
 serde_json = "1.0"
+dirs = "5.0"

--- a/extensions/snippets/LICENSE-APACHE
+++ b/extensions/snippets/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/extensions/snippets/extension.toml
+++ b/extensions/snippets/extension.toml
@@ -8,5 +8,5 @@ repository = "https://github.com/zed-extensions/svelte"
 
 [language_servers.snippet-completion-server]
 name = "Snippet Completion Server"
-languages = ["TypeScript", "TSX", "JavaScript", "JSDoc"]
+languages = ["TypeScript", "TSX", "JavaScript", "JSDoc", "Go", "Markdown", "Rust", "C", "C++", "PHP", "Python", "Ruby", "Shell"]
 language_ids = { "TypeScript" = "typescript", "TSX" = "typescriptreact", "JavaScript" = "javascript" }

--- a/extensions/snippets/extension.toml
+++ b/extensions/snippets/extension.toml
@@ -1,0 +1,12 @@
+id = "snippets"
+name = "Snippets"
+description = "Support for language-agnostic snippets, provided by simple-completion-language-server"
+version = "0.0.1"
+schema_version = 1
+authors = []
+repository = "https://github.com/zed-extensions/svelte"
+
+[language_servers.snippet-completion-server]
+name = "Snippet Completion Server"
+languages = ["TypeScript", "TSX", "JavaScript", "JSDoc"]
+language_ids = { "TypeScript" = "typescript", "TSX" = "typescriptreact", "JavaScript" = "javascript" }

--- a/extensions/snippets/src/snippets.rs
+++ b/extensions/snippets/src/snippets.rs
@@ -1,8 +1,6 @@
 use serde_json::json;
 use std::fs;
-use std::path::PathBuf;
-use zed::lsp::CompletionKind;
-use zed::{CodeLabel, CodeLabelSpan, LanguageServerId};
+use zed::LanguageServerId;
 use zed_extension_api::{self as zed, Result};
 
 struct SnippetExtension {
@@ -58,7 +56,7 @@ impl SnippetExtension {
             .find(|asset| asset.name == asset_name)
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
-        let version_dir = format!("simple-completion-language-server");
+        let version_dir = "simple-completion-language-server".to_owned();
         let binary_path = format!("{version_dir}/simple-completion-language-server");
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
@@ -113,14 +111,6 @@ impl zed::Extension for SnippetExtension {
                 ("LOG_FILE".to_owned(), "/tmp/completion1.log".to_owned()),
             ],
         })
-    }
-
-    fn label_for_completion(
-        &self,
-        _language_server_id: &LanguageServerId,
-        completion: zed::lsp::Completion,
-    ) -> Option<zed::CodeLabel> {
-        None
     }
 
     fn language_server_initialization_options(

--- a/extensions/snippets/src/snippets.rs
+++ b/extensions/snippets/src/snippets.rs
@@ -101,22 +101,11 @@ impl zed::Extension for SnippetExtension {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let home_dir = worktree
-            .shell_env()
-            .into_iter()
-            .find(|(k, _)| k == "HOME")
-            .ok_or_else(|| format!("HOME is not in path"))
-            .unwrap()
-            .1;
-        let abs_config_path = PathBuf::from(home_dir).join(".config/zed/snippets");
         Ok(zed::Command {
             command: self.language_server_binary_path(language_server_id, worktree)?,
             args: vec![],
             env: vec![
-                (
-                    "SNIPPETS_PATH".to_owned(),
-                    abs_config_path.to_string_lossy().into_owned(),
-                ),
+                ("SCLS_CONFIG_SUBDIRECTORY".to_owned(), "zed".to_owned()),
                 (
                     "RUST_LOG".to_owned(),
                     "info,simple-completion-language-server=info".to_owned(),

--- a/extensions/snippets/src/snippets.rs
+++ b/extensions/snippets/src/snippets.rs
@@ -1,0 +1,150 @@
+use serde_json::json;
+use std::fs;
+use zed::lsp::CompletionKind;
+use zed::{CodeLabel, CodeLabelSpan, LanguageServerId};
+use zed_extension_api::{self as zed, Result};
+
+struct SnippetExtension {
+    cached_binary_path: Option<String>,
+}
+
+impl SnippetExtension {
+    fn language_server_binary_path(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<String> {
+        if let Some(path) = worktree.which("simple-completion-language-server") {
+            return Ok(path);
+        }
+
+        if let Some(path) = &self.cached_binary_path {
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+                return Ok(path.clone());
+            }
+        }
+
+        zed::set_language_server_installation_status(
+            &language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let release = zed::latest_github_release(
+            "zed-industries/simple-completion-language-server",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let (platform, arch) = zed::current_platform();
+        let asset_name = format!(
+            "simple-completion-language-server-{arch}-{os}.tar.gz",
+            arch = match arch {
+                zed::Architecture::Aarch64 => "aarch64",
+                zed::Architecture::X86 => "x86",
+                zed::Architecture::X8664 => "x86_64",
+            },
+            os = match platform {
+                zed::Os::Mac => "apple-darwin",
+                zed::Os::Linux => "unknown-linux-musl",
+                zed::Os::Windows => "pc-windows-msvc",
+            },
+        );
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+
+        let version_dir = format!("simple-completion-language-server");
+        let binary_path = format!("{version_dir}/simple-completion-language-server");
+
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                &language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(
+                &asset.download_url,
+                &version_dir,
+                zed::DownloadedFileType::GzipTar,
+            )
+            .map_err(|e| format!("failed to download file: {e}"))?;
+
+            let entries =
+                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+                if entry.file_name().to_str() != Some(&version_dir) {
+                    fs::remove_dir_all(&entry.path()).ok();
+                }
+            }
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
+    }
+}
+
+impl zed::Extension for SnippetExtension {
+    fn new() -> Self {
+        Self {
+            cached_binary_path: None,
+        }
+    }
+
+    fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        Ok(zed::Command {
+            command: self.language_server_binary_path(language_server_id, worktree)?,
+            args: vec![],
+            env: vec![(
+                "SNIPPETS_PATH".to_owned(),
+                "~/.config/zed/snippets".to_owned(),
+            )],
+        })
+    }
+
+    fn label_for_completion(
+        &self,
+        _language_server_id: &LanguageServerId,
+        completion: zed::lsp::Completion,
+    ) -> Option<zed::CodeLabel> {
+        None
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        _worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
+        Ok(Some(json!({
+            "max_completion_items": 20,
+            "snippets_first": true,
+            "feature_words": true,
+            "feature_snippets": true,
+            "feature_paths": true
+        })))
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        _worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
+        Ok(Some(json!({
+            "max_completion_items": 20,
+            "snippets_first": true,
+            "feature_words": true,
+            "feature_snippets": true,
+            "feature_paths": true
+        })))
+    }
+}
+
+zed::register_extension!(SnippetExtension);

--- a/extensions/snippets/src/snippets.rs
+++ b/extensions/snippets/src/snippets.rs
@@ -56,7 +56,7 @@ impl SnippetExtension {
             .find(|asset| asset.name == asset_name)
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
-        let version_dir = "simple-completion-language-server".to_owned();
+        let version_dir = format!("simple-completion-language-server-{}", release.version);
         let binary_path = format!("{version_dir}/simple-completion-language-server");
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
@@ -102,14 +102,7 @@ impl zed::Extension for SnippetExtension {
         Ok(zed::Command {
             command: self.language_server_binary_path(language_server_id, worktree)?,
             args: vec![],
-            env: vec![
-                ("SCLS_CONFIG_SUBDIRECTORY".to_owned(), "zed".to_owned()),
-                (
-                    "RUST_LOG".to_owned(),
-                    "info,simple-completion-language-server=info".to_owned(),
-                ),
-                ("LOG_FILE".to_owned(), "/tmp/completion1.log".to_owned()),
-            ],
+            env: vec![("SCLS_CONFIG_SUBDIRECTORY".to_owned(), "zed".to_owned())],
         })
     }
 


### PR DESCRIPTION
Note that right now we can't attach a language server to arbitrary buffer, which is why I've listed a bunch of languages verbatim. 
See https://github.com/zed-industries/simple-completion-language-server/tree/main for docs on how to define your snippets. They should be placed in ~/.config/zed/snippets ; `snippets.(toml|json)` file can be used to define language-agnostic snippets, and any other name (e.g. `python.toml`) will apply only to buffers of that particular type.

There's https://github.com/rafamadriz/friendly-snippets you can use as a repository of snippets, for your convenience.

Fixes https://github.com/zed-industries/zed/issues/4611

Release Notes:
- Added support for snippets via simple-completion-language-server
