### PR TITLE
vim: Allow toggling command palette on empty diagnostics view

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -672,7 +672,7 @@
     }
   },
   {
-    "context": "EmptyPane || SharedScreen",
+    "context": "EmptyPane || SharedScreen || Workspace",
     "bindings": {
       ":": "command_palette::Toggle"
     }


### PR DESCRIPTION
On an empty diagnostics view, `:` didn't trigger the command palette in Vim mode. This fixes it.

cc @ConradIrwin
 
Release Notes:

- N/A
