### PR TITLE
linux: Quiet some noisy logs when logging to file

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -705,11 +705,19 @@ fn init_logger() {
             .open(paths::log_file())
         {
             Ok(log_file) => {
-                let config = ConfigBuilder::new()
-                    .set_time_format_str("%Y-%m-%dT%T%:z")
-                    .set_time_to_local(true)
-                    .build();
+                let mut config_builder = ConfigBuilder::new();
 
+                config_builder.set_time_format_str("%Y-%m-%dT%T%:z");
+                config_builder.set_time_to_local(true);
+
+                #[cfg(target_os = "linux")]
+                {
+                    config_builder.add_filter_ignore_str("zbus");
+                    config_builder.add_filter_ignore_str("blade_graphics::hal::resource");
+                    config_builder.add_filter_ignore_str("naga::back::spv::writer");
+                }
+
+                let config = config_builder.build();
                 simplelog::WriteLogger::init(level, config, log_file)
                     .expect("could not initialize logger");
             }


### PR DESCRIPTION
zbus, naga, and some parts of blade are pretty noisy at the INFO level. zbus especially dumps large debug dumps into the logs.

So on Linux, when logging to a file, we reduce that noise. That means one still gets the full firehose when doing `RUST_LOG=info cargo run`, but not in the logs.


Release Notes:

- N/A
