### PR TITLE
linux: Forward ctrl-w/ctrl-e to terminal

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -296,6 +296,13 @@
       "ctrl-alt-shift-x": "search::ToggleRegex"
     }
   },
+  {
+    "context": "Terminal",
+    "bindings": {
+      "ctrl-w": ["terminal::SendKeystroke", "ctrl-w"],
+      "ctrl-e": ["terminal::SendKeystroke", "ctrl-e"]
+    }
+  },
   // Bindings from VS Code
   {
     "context": "Editor",


### PR DESCRIPTION
This fixes `ctrl-w` and `ctrl-e` not working in the terminal pane but instead triggering Zed actions ("close pane" and "search project files" respectively).

I've added both because I think they're pretty commonly used in terminals, since they're default Emacs-style keybindings.

But I also didn't want to add more, since it's relatively easy for users to define themselves which keybindings should be forwarded to the terminal and which not.

All that's required is adding something like this to the keymap:

```json
{
  "context": "Terminal",
  "bindings": {
    "ctrl-n": ["terminal::SendKeystroke", "ctrl-n"],
    "ctrl-p": ["terminal::SendKeystroke", "ctrl-p"]
  }
}
```
cc @mikayla-maki 

Release Notes:

- N/A
