### PR TITLE
Disable inline assist button when assistant is disabled

### DIFF
--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -282,9 +282,11 @@ impl Render for QuickActionBar {
                     .gap_1p5()
                     .children(search_button)
                     .children(editor_selections_dropdown)
-                    .when(AssistantSettings::get_global(cx).enabled && AssistantSettings::get_global(cx).button, |bar| {
-                        bar.child(assistant_button)
-                    }),
+                    .when(
+                        AssistantSettings::get_global(cx).enabled
+                            && AssistantSettings::get_global(cx).button,
+                        |bar| bar.child(assistant_button),
+                    ),
             )
             .child(editor_settings_dropdown)
             .when_some(

--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -282,7 +282,7 @@ impl Render for QuickActionBar {
                     .gap_1p5()
                     .children(search_button)
                     .children(editor_selections_dropdown)
-                    .when(AssistantSettings::get_global(cx).button, |bar| {
+                    .when(AssistantSettings::get_global(cx).enabled && AssistantSettings::get_global(cx).button, |bar| {
                         bar.child(assistant_button)
                     }),
             )


### PR DESCRIPTION
Release Notes:

- Hide inline assist button when assistant is disabled ([#13289](https://github.com/zed-industries/zed/issues/13289)).
