### PR TITLE
auto-updates: Do not poll for updates on dev channel

### DIFF
--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -118,6 +118,14 @@ impl ReleaseChannel {
             .map(|channel| channel.0)
     }
 
+    /// Returns whether we want to poll for updates for this [`ReleaseChannel`]
+    pub fn poll_for_updates(&self) -> bool {
+        match self {
+            ReleaseChannel::Dev => false,
+            _ => true,
+        }
+    }
+
     /// Returns the display name for this [`ReleaseChannel`].
     pub fn display_name(&self) -> &'static str {
         match self {


### PR DESCRIPTION
Our dev builds don't have updates and will never have updates, so instead of polling our servers every time we start a dev instance, let's disable it for the dev channel.

Release Notes:

- N/A
