### PR TITLE
Add Markdown Preview shortcut to Atom keymap

### DIFF
--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -25,7 +25,8 @@
       ],
       "ctrl-shift-down": "editor::AddSelectionBelow",
       "ctrl-shift-up": "editor::AddSelectionAbove",
-      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine"
+      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine",
+      "ctrl-shift-m": "markdown::OpenPreviewToTheSide"
     }
   },
   {


### PR DESCRIPTION
This patch maps `Ctrl+Shift+M` to "Open Markdown Preview to the side".

That's what it used to be in Atom: https://github.com/atom/markdown-preview

Release Notes:

- Added Markdown Preview shortcut for the Atom keymap