### PR TITLE
workspace: Add clear notifications command

### DIFF
--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -191,6 +191,11 @@ impl Workspace {
         self.dismiss_notification(id, cx);
     }
 
+    pub fn clear_all_notifications(&mut self, cx: &mut ViewContext<Self>) {
+        self.notifications.clear();
+        cx.notify();
+    }
+
     fn dismiss_notification_internal(&mut self, id: &NotificationId, cx: &mut ViewContext<Self>) {
         self.notifications.retain(|(existing_id, _)| {
             if existing_id == id {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -115,6 +115,7 @@ actions!(
         ActivateNextPane,
         ActivatePreviousPane,
         AddFolderToProject,
+        ClearAllNotifications,
         CloseAllDocks,
         CloseWindow,
         Feedback,
@@ -3894,6 +3895,11 @@ impl Workspace {
             .on_action(
                 cx.listener(|workspace: &mut Workspace, _: &CloseAllDocks, cx| {
                     workspace.close_all_docks(cx);
+                }),
+            )
+            .on_action(
+                cx.listener(|workspace: &mut Workspace, _: &ClearAllNotifications, cx| {
+                    workspace.clear_all_notifications(cx);
                 }),
             )
             .on_action(cx.listener(Workspace::open))


### PR DESCRIPTION
Release Notes:

- Added the `workspace: clear all notifications` command to clear notifications ([#10761](https://github.com/zed-industries/zed/issues/10761))

https://github.com/zed-industries/zed/assets/30776250/36f2c3f3-5b5e-4f98-9418-8806ce311504

