### PR TITLE
assistant: Make including warnings for the diagnostic command more discoverable

### DIFF
--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -3,8 +3,8 @@ use anyhow::Result;
 pub use assistant_slash_command::{SlashCommand, SlashCommandOutput, SlashCommandRegistry};
 use editor::{CompletionProvider, Editor};
 use fuzzy::{match_strings, StringMatchCandidate};
-use gpui::{Model, Task, ViewContext, WeakView, WindowContext};
-use language::{Anchor, Buffer, CodeLabel, Documentation, LanguageServerId, ToPoint};
+use gpui::{AppContext, Model, Task, ViewContext, WeakView, WindowContext};
+use language::{Anchor, Buffer, CodeLabel, Documentation, HighlightId, LanguageServerId, ToPoint};
 use parking_lot::{Mutex, RwLock};
 use rope::Point;
 use std::{
@@ -14,6 +14,7 @@ use std::{
         Arc,
     },
 };
+use ui::ActiveTheme;
 use workspace::Workspace;
 
 pub mod active_command;
@@ -346,4 +347,20 @@ impl SlashCommandLine {
         }
         call
     }
+}
+
+pub fn create_label_for_command(
+    command_name: &str,
+    arguments: &[&str],
+    cx: &AppContext,
+) -> CodeLabel {
+    let mut label = CodeLabel::default();
+    label.push_str(command_name, None);
+    label.push_str(" ", None);
+    label.push_str(
+        &arguments.join(" "),
+        cx.theme().syntax().highlight_id("comment").map(HighlightId),
+    );
+    label.filter_range = 0..command_name.len();
+    label
 }

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -1,4 +1,4 @@
-use super::{SlashCommand, SlashCommandOutput};
+use super::{create_label_for_command, SlashCommand, SlashCommandOutput};
 use anyhow::{anyhow, Result};
 use assistant_slash_command::SlashCommandOutputSection;
 use fuzzy::{PathMatch, StringMatchCandidate};
@@ -83,6 +83,10 @@ impl DiagnosticsCommand {
 impl SlashCommand for DiagnosticsCommand {
     fn name(&self) -> String {
         "diagnostics".into()
+    }
+
+    fn label(&self, cx: &AppContext) -> language::CodeLabel {
+        create_label_for_command("diagnostics", &[INCLUDE_WARNINGS_ARGUMENT], cx)
     }
 
     fn description(&self) -> String {

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -1,11 +1,12 @@
 use super::{
+    create_label_for_command,
     file_command::{build_entry_output_section, codeblock_fence_for_path},
     SlashCommand, SlashCommandOutput,
 };
 use anyhow::Result;
 use assistant_slash_command::SlashCommandOutputSection;
 use gpui::{AppContext, Task, WeakView};
-use language::{CodeLabel, HighlightId, LineEnding, LspAdapterDelegate};
+use language::{CodeLabel, LineEnding, LspAdapterDelegate};
 use semantic_index::SemanticIndex;
 use std::{
     fmt::Write,
@@ -24,14 +25,7 @@ impl SlashCommand for SearchSlashCommand {
     }
 
     fn label(&self, cx: &AppContext) -> CodeLabel {
-        let mut label = CodeLabel::default();
-        label.push_str("search ", None);
-        label.push_str(
-            "--n",
-            cx.theme().syntax().highlight_id("comment").map(HighlightId),
-        );
-        label.filter_range = 0.."search".len();
-        label
+        create_label_for_command("search", &["--n"], cx)
     }
 
     fn description(&self) -> String {


### PR DESCRIPTION
This makes the `--include-warnings` argument more discoverable

<img width="651" alt="image" src="https://github.com/zed-industries/zed/assets/53836821/02d32496-ad7a-4670-85ce-eda945c0f1c2">

Release Notes:

- N/A
