### PR TITLE
Fix missing IME keys when no input handler is set

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -310,7 +310,7 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
 }
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum ImeInput {
     InsertText(String, Option<Range<usize>>),
     SetMarkedText(String, Option<Range<usize>>, Option<Range<usize>>),
@@ -1911,7 +1911,7 @@ fn send_to_input_handler(window: &Object, ime: ImeInput) {
         let mut lock = window_state.lock();
 
         if let Some(mut input_handler) = lock.input_handler.take() {
-            match ime.clone() {
+            match ime {
                 ImeInput::InsertText(text, range) => {
                     if let Some(ime_input) = lock.last_ime_inputs.as_mut() {
                         ime_input.push((text, range));
@@ -1931,6 +1931,15 @@ fn send_to_input_handler(window: &Object, ime: ImeInput) {
                 }
             }
             window_state.lock().input_handler = Some(input_handler);
+        } else {
+            match ime {
+                ImeInput::InsertText(text, range) => {
+                    if let Some(ime_input) = lock.last_ime_inputs.as_mut() {
+                        ime_input.push((text, range));
+                    }
+                }
+                _ => {}
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/zed-industries/zed/pull/12702, where GPUI would only generate the correct key events if you had an input handler set.

Release Notes:

- N/A