### PR TITLE
tasks: Allow disabling runnables in the gutter

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -231,6 +231,8 @@
     "line_numbers": true,
     // Whether to show code action buttons in the gutter.
     "code_actions": true,
+    // Whether to show runnables buttons in the gutter.
+    "runnables": true,
     // Whether to show fold buttons in the gutter.
     "folds": true
   },

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -84,6 +84,7 @@ pub struct Scrollbar {
 pub struct Gutter {
     pub line_numbers: bool,
     pub code_actions: bool,
+    pub runnables: bool,
     pub folds: bool,
 }
 
@@ -255,6 +256,10 @@ pub struct GutterContent {
     ///
     /// Default: true
     pub code_actions: Option<bool>,
+    /// Whether to show runnable buttons in the gutter.
+    ///
+    /// Default: true
+    pub runnables: Option<bool>,
     /// Whether to show fold buttons in the gutter.
     ///
     /// Default: true

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4931,14 +4931,18 @@ impl Element for EditorElement {
                         }
                     }
 
-                    let test_indicators = self.layout_run_indicators(
-                        line_height,
-                        scroll_pixel_position,
-                        &gutter_dimensions,
-                        &gutter_hitbox,
-                        &snapshot,
-                        cx,
-                    );
+                    let test_indicators = if gutter_settings.runnables {
+                        self.layout_run_indicators(
+                            line_height,
+                            scroll_pixel_position,
+                            &gutter_dimensions,
+                            &gutter_hitbox,
+                            &snapshot,
+                            cx,
+                        )
+                    } else {
+                        vec![]
+                    };
 
                     if !cx.has_active_drag() {
                         self.layout_hover_popovers(


### PR DESCRIPTION
Runnables can now be disabled with:
```
  "gutter": {
    "runnables": false
  }
```
Fixes #13280



Release Notes:

- Added `gutter.runnables` setting that controls whether runnable indicators are displayed in the gutter.