### PR TITLE
Docs: Specify the location of the tasks.json files

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -88,7 +88,7 @@ A common request is to be able to map from one sequence of keys to another. As o
   {
     "context": "Editor && vim_mode == insert",
     "bindings": {
-      "j k": ["workspace::SendKeystrokes", "escape"],
+      "j k": ["workspace::SendKeystrokes", "escape"]
     }
   }
 ]
@@ -116,6 +116,11 @@ For example, `ctrl-n` creates a new tab in Zed on Linux. If you want to send `ct
   }
 }
 ```
+
+### Task Key bindings
+
+You can also bind keys to launch Zed Tasks defined in your tasks.json.
+See the [tasks documentation](/docs/tasks#custom-keybindings-for-tasks) for more.
 
 ### All key bindings
 

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -31,8 +31,9 @@ There are two actions that drive the workflow of using tasks: `task: spawn` and 
 ## Task templates
 
 Tasks can be defined:
-- in global `tasks.json` file; such tasks are available in all Zed projects you work on. You can edit them by using `zed: open tasks` action.
-- in worktree-specific (local) `tasks.json` file; such tasks are available only when working on a project with that worktree included. You can edit worktree-specific tasks by using `zed: open local tasks`.
+
+- in global `tasks.json` file; such tasks are available in all Zed projects you work on. This file is usually located in `~/.config/tasks.json`. You can edit them by using `zed: open tasks` action.
+- in worktree-specific (local) `.zed/tasks.json` file; such tasks are available only when working on a project with that worktree included. You can edit worktree-specific tasks by using `zed: open local tasks`.
 - on the fly with [oneshot tasks](#oneshot-tasks). These tasks are project-specific and do not persist across sections.
 - by language extension.
 


### PR DESCRIPTION
- Docs: Tasks: Explicitly note the location of `tasks.json` files.
- Docs: Keybindings: Add link to task docs showing example of binding to a specific task.

Release Notes:

- N/A
