### PR TITLE
wayland: Implement `activate()` API and use portals to open URLs and paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,8 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093"
+version = "0.9.0"
+source = "git+https://github.com/bilelmoussaoui/ashpd?rev=29f2e1a#29f2e1a6f4b0911f504658f5f4630c02e01b13f2"
 dependencies = [
  "async-fs 2.1.1",
  "async-net 2.0.0",
@@ -4893,7 +4892,6 @@ dependencies = [
  "num_cpus",
  "objc",
  "oo7",
- "open",
  "parking",
  "parking_lot",
  "pathfinder_geometry",
@@ -5704,25 +5702,6 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
-
-[[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
 
 [[package]]
 name = "isahc"
@@ -7224,17 +7203,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "open"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32"
-dependencies = [
- "is-wsl",
- "libc",
- "pathdiff",
-]
 
 [[package]]
 name = "open_ai"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,9 +272,9 @@ zed_actions = { path = "crates/zed_actions" }
 alacritty_terminal = "0.23"
 any_vec = "0.13"
 anyhow = "1.0.57"
-ashpd = "0.8.0"
+ashpd = { git = "https://github.com/bilelmoussaoui/ashpd", rev = "29f2e1a" }
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
-async-dispatcher = { version = "0.1"}
+async-dispatcher = { version = "0.1" }
 async-fs = "1.6"
 async-recursion = "1.0.0"
 async-tar = "0.4.2"
@@ -315,7 +315,9 @@ image = "0.25.1"
 indexmap = { version = "1.6.2", features = ["serde"] }
 indoc = "1"
 # We explicitly disable http2 support in isahc.
-isahc = { version = "1.7.2", default-features = false, features = [ "text-decoding" ] }
+isahc = { version = "1.7.2", default-features = false, features = [
+    "text-decoding",
+] }
 itertools = "0.11.0"
 lazy_static = "1.4.0"
 libc = "0.2"
@@ -341,7 +343,9 @@ rand = "0.8.5"
 refineable = { path = "./crates/refineable" }
 regex = "1.5"
 repair_json = "0.1.0"
-runtimelib = { version="0.12", default-features = false, features = ["async-dispatcher-runtime"] }
+runtimelib = { version = "0.12", default-features = false, features = [
+    "async-dispatcher-runtime",
+] }
 rusqlite = { version = "0.29.0", features = ["blob", "array", "modern_sqlite"] }
 rust-embed = { version = "8.4", features = ["include-exclude"] }
 schemars = "0.8"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -124,7 +124,6 @@ wayland-protocols = { version = "0.31.2", features = [
 ] }
 wayland-protocols-plasma = { version = "0.2.0", features = ["client"] }
 oo7 = "0.3.0"
-open = "5.1.2"
 filedescriptor = "0.8.2"
 x11rb = { version = "0.13.0", features = [
     "allow-unsafe-code",

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -81,6 +81,8 @@ impl LinuxClient for HeadlessClient {
 
     fn open_uri(&self, _uri: &str) {}
 
+    fn reveal_path(&self, _path: std::path::PathBuf) {}
+
     fn write_to_primary(&self, _item: crate::ClipboardItem) {}
 
     fn write_to_clipboard(&self, _item: crate::ClipboardItem) {}

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -61,7 +61,6 @@ use wayland_protocols_plasma::blur::client::{org_kde_kwin_blur, org_kde_kwin_blu
 use xkbcommon::xkb::ffi::XKB_KEYMAP_FORMAT_TEXT_V1;
 use xkbcommon::xkb::{self, Keycode, KEYMAP_COMPILE_NO_FLAGS};
 
-use super::super::{open_uri_internal, read_fd, DOUBLE_CLICK_INTERVAL};
 use super::display::WaylandDisplay;
 use super::window::{ImeInput, WaylandWindowStatePtr};
 use crate::platform::linux::wayland::clipboard::{
@@ -72,11 +71,14 @@ use crate::platform::linux::wayland::serial::{SerialKind, SerialTracker};
 use crate::platform::linux::wayland::window::WaylandWindow;
 use crate::platform::linux::xdg_desktop_portal::{Event as XDPEvent, XDPEventSource};
 use crate::platform::linux::LinuxClient;
-use crate::platform::linux::{get_xkb_compose_state, is_within_click_distance};
+use crate::platform::linux::{
+    get_xkb_compose_state, is_within_click_distance, open_uri_internal, read_fd,
+    reveal_path_internal,
+};
 use crate::platform::PlatformWindow;
 use crate::{
     point, px, size, Bounds, DevicePixels, FileDropEvent, ForegroundExecutor, MouseExitEvent, Size,
-    SCROLL_LINES,
+    DOUBLE_CLICK_INTERVAL, SCROLL_LINES,
 };
 use crate::{
     AnyWindowHandle, CursorStyle, DisplayId, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers,
@@ -220,7 +222,7 @@ pub(crate) struct WaylandClientState {
     data_offers: Vec<DataOffer<WlDataOffer>>,
     primary_data_offer: Option<DataOffer<ZwpPrimarySelectionOfferV1>>,
     cursor: Cursor,
-    pending_open_uri: Option<String>,
+    pending_activation: Option<PendingActivation>,
     event_loop: Option<EventLoop<'static, WaylandClientStatePtr>>,
     common: LinuxCommon,
 }
@@ -242,6 +244,13 @@ pub(crate) struct KeyRepeat {
     delay: Duration,
     current_id: u64,
     current_keycode: Option<xkb::Keycode>,
+}
+
+pub(crate) enum PendingActivation {
+    /// URI to open in the web browser.
+    Uri(String),
+    /// Path to open in the file explorer.
+    Path(PathBuf),
 }
 
 /// This struct is required to conform to Rust's orphan rules, so we can dispatch on the state but hand the
@@ -530,7 +539,7 @@ impl WaylandClient {
             data_offers: Vec::new(),
             primary_data_offer: None,
             cursor,
-            pending_open_uri: None,
+            pending_activation: None,
             event_loop: Some(event_loop),
         }));
 
@@ -629,14 +638,33 @@ impl LinuxClient for WaylandClient {
             state.globals.activation.clone(),
             state.mouse_focused_window.clone(),
         ) {
-            state.pending_open_uri = Some(uri.to_owned());
+            state.pending_activation = Some(PendingActivation::Uri(uri.to_string()));
             let token = activation.get_activation_token(&state.globals.qh, ());
             let serial = state.serial_tracker.get(SerialKind::MousePress);
             token.set_serial(serial, &state.wl_seat);
             token.set_surface(&window.surface());
             token.commit();
         } else {
-            open_uri_internal(uri, None);
+            let executor = state.common.background_executor.clone();
+            open_uri_internal(executor, uri, None);
+        }
+    }
+
+    fn reveal_path(&self, path: PathBuf) {
+        let mut state = self.0.borrow_mut();
+        if let (Some(activation), Some(window)) = (
+            state.globals.activation.clone(),
+            state.mouse_focused_window.clone(),
+        ) {
+            state.pending_activation = Some(PendingActivation::Path(path));
+            let token = activation.get_activation_token(&state.globals.qh, ());
+            let serial = state.serial_tracker.get(SerialKind::MousePress);
+            token.set_serial(serial, &state.wl_seat);
+            token.set_surface(&window.surface());
+            token.commit();
+        } else {
+            let executor = state.common.background_executor.clone();
+            reveal_path_internal(executor, path, None);
         }
     }
 
@@ -954,13 +982,18 @@ impl Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ()> for WaylandClie
     ) {
         let client = this.get_client();
         let mut state = client.borrow_mut();
+
         if let xdg_activation_token_v1::Event::Done { token } = event {
-            if let Some(uri) = state.pending_open_uri.take() {
-                open_uri_internal(&uri, Some(&token));
-            } else {
-                log::error!("called while pending_open_uri is None");
+            let executor = state.common.background_executor.clone();
+            match state.pending_activation.take() {
+                Some(PendingActivation::Uri(uri)) => open_uri_internal(executor, &uri, Some(token)),
+                Some(PendingActivation::Path(path)) => {
+                    reveal_path_internal(executor, path, Some(token))
+                }
+                None => log::error!("activation token received with no pending activation"),
             }
         }
+
         token.destroy();
     }
 }


### PR DESCRIPTION
This PR consists of two main changes:
1. The first commit changes the `open` crate for opening URLs/paths for the `OpenURI` desktop portal. This fixes the activation token not being passed to programs (at least on KDE).
2. The second commit implements the window `activate()` API on Wayland. This allows KWin and Mutter to show a visual indicator when the window is requesting attention. (see https://github.com/zed-industries/zed/issues/12557)
![image](https://github.com/zed-industries/zed/assets/71973804/ce148f8e-28fd-4249-8f8d-3a5828ed6f83)


Release Notes:

- N/A
