### PR TITLE
vim: Surround in visual mode

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -287,7 +287,10 @@ impl EditorState {
                 .unwrap_or_else(|| "none"),
         );
 
-        if self.mode == Mode::Replace {
+        if self.mode == Mode::Replace
+            || (matches!(active_operator, Some(Operator::AddSurrounds { .. }))
+                && self.mode.is_visual())
+        {
             context.add("VimWaiting");
         }
         context

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -39,7 +39,7 @@ use serde_derive::Serialize;
 use settings::{update_settings_file, Settings, SettingsSources, SettingsStore};
 use state::{EditorState, Mode, Operator, RecordedSelection, Register, WorkspaceState};
 use std::{ops::Range, sync::Arc};
-use surrounds::{add_surrounds, change_surrounds, delete_surrounds};
+use surrounds::{add_surrounds, change_surrounds, delete_surrounds, SurroundsType};
 use ui::BorrowAppContext;
 use visual::{visual_block_motion, visual_replace};
 use workspace::{self, Workspace};
@@ -860,6 +860,10 @@ impl Vim {
                         add_surrounds(text, target, cx);
                         Vim::update(cx, |vim, cx| vim.clear_operator(cx));
                     }
+                }
+                Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                    add_surrounds(text, SurroundsType::Selection, cx);
+                    Vim::update(cx, |vim, cx| vim.clear_operator(cx));
                 }
                 _ => Vim::update(cx, |vim, cx| vim.clear_operator(cx)),
             },

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -293,6 +293,22 @@ Subword motion is not enabled by default. To enable it, add these bindings to yo
   },
 ```
 
+Surrounding the selection in visual mode is also not enabled by default (`shift-s` normally behaves like `c`). To enable it, add the following to your keymap.
+
+```json
+  {
+    "context": "Editor && vim_mode == visual && !VimWaiting && !VimObject",
+    "bindings": {
+      "shift-s": [
+        "vim::PushOperator",
+        {
+          "AddSurrounds": {}
+        }
+      ]
+    }
+  }
+```
+
 ## Supported plugins
 
 Zed has nascent support for some Vim plugins:


### PR DESCRIPTION
Adds support for surrounding text in visual/visual-line/visual-block mode by re-using the `AddSurrounds` operator. There is no default binding though so the user must follow the instructions to enable it.

Note that the behaviour varies slightly for the visual-line and visual-block modes. In visual-line mode the surrounds are placed on separate lines (the vim-surround extension also indents the contents but I opted not to as that behaviour is less important with the use of code formatters). In visual-block mode each of the selected regions is surrounded and the cursor returns to the beginning of the selection after the action is complete.

Release Notes:

- Added action to surround text in visual mode (no default binding).

Fixes #13122 