### PR TITLE
Fix IME delete misalignment

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12183,9 +12183,7 @@ impl ViewInputHandler for Editor {
                     .collect::<Vec<_>>()
             };
 
-            if text.is_empty() {
-                this.unmark_text(cx);
-            } else {
+            if !text.is_empty() {
                 this.highlight_text::<InputComposition>(
                     marked_ranges.clone(),
                     HighlightStyle {


### PR DESCRIPTION
I noticed that when deleting the last letter in the IME, an additional character in the editor is also deleted.

I looked into it and figured out that the only difference between deleting the last letter and others is that the text was empty. After that, I noticed a special logic for `text.is_empty()`. Everything worked fine after I removed it.

I'm not sure what `this.unmark_text(cx)` is for, so this change might break other things. I would appreciate it if someone could provide some guidance.

Before(from the linked issue):

https://private-user-images.githubusercontent.com/45585937/338304719-9909fe45-d6c1-45f1-a60b-89bd2102f827.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg5NDc1MDgsIm5iZiI6MTcxODk0NzIwOCwicGF0aCI6Ii80NTU4NTkzNy8zMzgzMDQ3MTktOTkwOWZlNDUtZDZjMS00NWYxLWE2MGItODliZDIxMDJmODI3Lm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjIxVDA1MjAwOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTMwZjA3OWQzMWNmZDhlYjkwNjczNTQ4NmE0N2NmYjEyYTRjZGVhNmJjYmI1NzhlMjUyZTg1Mzg3YmZmNDdkNzEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.tF9Rsr1AKkk0yJ8MsQdVeRkcAI5uRKCjmyjKgjMdnHQ

After:

![20240621131933_rec_](https://github.com/zed-industries/zed/assets/32017007/d2d2a2c5-c22d-4e70-b7c5-db19a2b8af50)

Closes #12862.

Release Notes:

- Fixed IME delete misalignment ([#12862](https://github.com/zed-industries/zed/issues/12862)).
