### PR TITLE
Dealing with missing arm architectures

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -18,7 +18,7 @@ main() {
     fi
 
     case "$platform-$arch" in
-        macos-arm64* | linux-arm64* | linux-armhf)
+        macos-arm64* | linux-arm64* | linux-armhf | linux-aarch64)
             arch="aarch64"
             ;;
         macos-x86* | linux-x86* | linux-i686*)


### PR DESCRIPTION
Release Notes:

- N/A

![image](https://github.com/zed-industries/zed/assets/19868292/341bf8c6-4586-4d51-8889-2c706dc98f6f)

"AArch64" and "ARM64" refer to the same thing.

AArch64 is the 64-bit state introduced in the [Armv8-A architecture](https://en.wikipedia.org/wiki/ARM_architecture_family#Armv8-A). The 32-bit state which is backwards compatible with Armv7-A and previous 32-bit Arm architectures is referred to as AArch32. Therefore the GNU triplet for the 64-bit ISA is aarch64. The Linux kernel community [chose](https://lkml.org/lkml/2012/7/6/624) to call their port of the kernel to this architecture arm64 rather than aarch64, so that's where some of the arm64 usage comes from.

The Apple-developed backend for AArch64 was called "ARM64" whereas the LLVM community-developed backend was called "AArch64" (as it is the canonical name for the 64-bit ISA). The two were merged [in 2014](https://www.phoronix.com/news/MTY5ODk) and the backend now is called "AArch64".

Remote Normal

![image](https://github.com/zed-industries/zed/assets/19868292/f8c5505a-f455-45a6-83bd-230054f8aebd)
