### PR TITLE
YAML: set auto_indent_using_last_non_empty_line to false (fix wonky formatting)

### DIFF
--- a/crates/languages/src/yaml/config.toml
+++ b/crates/languages/src/yaml/config.toml
@@ -9,6 +9,7 @@ brackets = [
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
 ]
 
+auto_indent_using_last_non_empty_line = false
 increase_indent_pattern = ":\\s*[|>]?\\s*$"
 prettier_parser_name = "yaml"
 tab_size = 2


### PR DESCRIPTION
This makes us treat yaml like other indentation-sensitive languages (e.g. Python) and not reformat it on pasting and what not.

Fixes #12236
Fixes #13338

Release Notes:

- Fixed spurious appliance of auto-formatting to YAML blocks.
