### PR TITLE
assistant: Include worktree name in diagnostics slash command

### DIFF
--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -50,6 +50,7 @@ pub type RenderFoldPlaceholder = Arc<
         + Fn(ElementId, Arc<dyn Fn(&mut WindowContext)>, &mut WindowContext) -> AnyElement,
 >;
 
+#[derive(Default)]
 pub struct SlashCommandOutput {
     pub text: String,
     pub sections: Vec<SlashCommandOutputSection<usize>>,


### PR DESCRIPTION
Files included with the diagnostics command now include the worktree name, making it more consistent with the way other commands work (`/active`, `/tabs`, `/file`). Also, the diagnostics command will now insert nothing when there are no diagnostics.

Release Notes:

- N/A
