### PR TITLE
snippets: Read user settings for workspace configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13587,7 +13587,7 @@ dependencies = [
 
 [[package]]
 name = "zed_snippets"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde_json",
  "zed_extension_api 0.0.6",

--- a/extensions/snippets/Cargo.toml
+++ b/extensions/snippets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_snippets"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/snippets/extension.toml
+++ b/extensions/snippets/extension.toml
@@ -1,15 +1,15 @@
 id = "snippets"
 name = "Snippets"
 description = "Support for language-agnostic snippets, provided by simple-completion-language-server"
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = []
 repository = "https://github.com/zed-industries/zed"
 
 [language_servers.snippet-completion-server]
 name = "Snippet Completion Server"
-languages = ["Astro", "Clojure", "C", "C++", "C#", "Dart", "Elixir", "Elm", "ERB", "Erlang",
-    "Gleam","GLSL", "Go",  "Haskell", "HCL", "HEEX", "HTML", "JavaScript","JSDoc","Lua",
+languages = ["Astro", "Clojure", "C", "C++", "C#", "Dart", "Dockerfile", "Elixir", "Elm", "ERB", "Erlang",
+    "Gleam","GLSL", "Go",  "Haskell", "HCL", "HEEX", "HTML", "JavaScript","JSDoc", "JSON", "Lua",
     "Markdown","OCaml", "PHP", "Python", "Prisma", "PureScript", "Racket", "Ruby", "Rust", "Scheme",
     "Shell Script", "Svelte", "Terraform", "TOML", "TypeScript", "TSX", "Uiua", "Vue.js", "Zig"]
 language_ids = { TypeScript = "typescript", TSX = "typescriptreact", JavaScript = "javascript", "Vue.js" = "vue", Terraform = "terraform", "Terraform Vars" = "terraform-vars", PHP = "php", HTML = "html", CSS = "css" }


### PR DESCRIPTION
Fixes #13334

Use `settings` field in `lsp` subsettings to fix up the settings as wish:
```
  "lsp": {
    "snippet-completion-server": {
      "settings": {
        "max_completion_items": 20, 
        "snippets_first": false,
        "feature_words": true,
        "feature_snippets": true,
        "feature_paths": true,
        "feature_unicode_input": false
      }
    }
  }
```


Release Notes:

- N/A
