### PR TITLE
csharp: Solve problem of omnisharp server failing to download

### DIFF
--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -54,6 +54,8 @@ wit-component.workspace = true
 workspace.workspace = true
 task.workspace = true
 serde_json_lenient.workspace = true
+async_zip.workspace = true
+smol.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true


### PR DESCRIPTION
Fix issue #9181: https://github.com/zed-industries/zed/issues/9181.

1. The root cause for the issue is that zed downloads the zip files and it used external command utility 'unzip' to extract to zip file. However, not all systems are equipped with it at default. So zed reports error like 'failed to start language server "OmniSharp": No such file or directory (os error 2)'. Once it fails, zed keep constantly downloading the zip file. 
2. The solution is to use async_zip crate to extract the downloaded language zip file instead of calling 'unzip' command. So for any systems without `unzip`, zed should be working fine with it.


Release Notes:

- - Fixed [#9181](https://github.com/zed-industries/zed/issues/9181).

