### PR TITLE
docs: Correct path to global tasks file

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -32,7 +32,7 @@ There are two actions that drive the workflow of using tasks: `task: spawn` and 
 
 Tasks can be defined:
 
-- in global `tasks.json` file; such tasks are available in all Zed projects you work on. This file is usually located in `~/.config/tasks.json`. You can edit them by using `zed: open tasks` action.
+- in global `tasks.json` file; such tasks are available in all Zed projects you work on. This file is usually located in `~/.config/zed/tasks.json`. You can edit them by using `zed: open tasks` action.
 - in worktree-specific (local) `.zed/tasks.json` file; such tasks are available only when working on a project with that worktree included. You can edit worktree-specific tasks by using `zed: open local tasks`.
 - on the fly with [oneshot tasks](#oneshot-tasks). These tasks are project-specific and do not persist across sections.
 - by language extension.


### PR DESCRIPTION
The documentation lists the path to the global tasks config file as `~/.config/tasks.json`, but it's actually `~/.config/zed/tasks.json`.

thanks

```
Release Notes:

- Fixed path to global tasks config in docs
```