### PR TITLE
Add cross-compilation support from MacOS to Windows

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -81,6 +81,9 @@ collections = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
 http = { workspace = true, features = ["test-support"] }
 
+[build-dependencies]
+embed-resource = "2.4"
+
 [target.'cfg(target_os = "macos")'.build-dependencies]
 bindgen = "0.65.1"
 cbindgen = "0.26.0"
@@ -142,9 +145,6 @@ x11-clipboard = "0.9.2"
 windows.workspace = true
 windows-core = "0.57"
 clipboard-win = "3.1.1"
-
-[target.'cfg(windows)'.build-dependencies]
-embed-resource = "2.4"
 
 [[example]]
 name = "hello_world"

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -3,18 +3,25 @@
 //TODO: consider generating shader code for WGSL
 //TODO: deprecate "runtime-shaders" and "macos-blade"
 
-fn main() {
-    #[cfg(target_os = "macos")]
-    macos::build();
+use std::env;
 
-    #[cfg(target_os = "windows")]
-    {
-        let manifest = std::path::Path::new("resources/windows/gpui.manifest.xml");
-        let rc_file = std::path::Path::new("resources/windows/gpui.rc");
-        println!("cargo:rerun-if-changed={}", manifest.display());
-        println!("cargo:rerun-if-changed={}", rc_file.display());
-        embed_resource::compile(rc_file, embed_resource::NONE);
-    }
+fn main() {
+    let target = env::var("CARGO_CFG_TARGET_OS");
+
+    match target.as_deref() {
+        Ok("macos") => {
+            #[cfg(target_os = "macos")]
+            macos::build();
+        }
+        Ok("windows") => {
+            let manifest = std::path::Path::new("resources/windows/gpui.manifest.xml");
+            let rc_file = std::path::Path::new("resources/windows/gpui.rc");
+            println!("cargo:rerun-if-changed={}", manifest.display());
+            println!("cargo:rerun-if-changed={}", rc_file.display());
+            embed_resource::compile(rc_file, embed_resource::NONE);
+        }
+        _ => (),
+    };
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
- Modify `build.rs` to use environment variables instead of `cfg` directive to make cross-compilation to Windows possible
- Make `embed-resource` a global build-dependency for cross-compilation

Release Notes:

- N/A
