### PR TITLE
windows: Fix title bar appearing when set to None

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -665,11 +665,8 @@ fn handle_calc_client_size(
 ) -> Option<isize> {
     if (state_ptr.title_bar && !state_ptr.transparent_title_bar)
         || state_ptr.state.borrow().is_fullscreen()
+        || wparam.0 == 0
     {
-        return None;
-    }
-
-    if wparam.0 == 0 {
         return None;
     }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -687,9 +687,6 @@ fn handle_calc_client_size(
     requested_client_rect[0].left += frame_x + padding;
     requested_client_rect[0].bottom -= frame_y + padding;
 
-    // Extra pixel not accounted for from the top border
-    requested_client_rect[0].top += 1;
-
     Some(0)
 }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -56,7 +56,8 @@ pub(crate) struct WindowsWindowStatePtr {
     hwnd: HWND,
     pub(crate) state: RefCell<WindowsWindowState>,
     pub(crate) handle: AnyWindowHandle,
-    pub(crate) hide_title_bar: bool,
+    pub(crate) title_bar: bool,
+    pub(crate) transparent_title_bar: bool,
     pub(crate) executor: ForegroundExecutor,
 }
 
@@ -211,7 +212,8 @@ impl WindowsWindowStatePtr {
             state,
             hwnd,
             handle: context.handle,
-            hide_title_bar: context.hide_title_bar,
+            title_bar: context.title_bar,
+            transparent_title_bar: context.transparent_title_bar,
             executor: context.executor.clone(),
         })
     }
@@ -232,7 +234,8 @@ pub(crate) struct Callbacks {
 struct WindowCreateContext {
     inner: Option<Rc<WindowsWindowStatePtr>>,
     handle: AnyWindowHandle,
-    hide_title_bar: bool,
+    title_bar: bool,
+    transparent_title_bar: bool,
     display: WindowsDisplay,
     transparent: bool,
     executor: ForegroundExecutor,
@@ -248,7 +251,7 @@ impl WindowsWindow {
         current_cursor: HCURSOR,
     ) -> Self {
         let classname = register_wnd_class(icon);
-        let hide_title_bar = params
+        let transparent_title_bar = params
             .titlebar
             .as_ref()
             .map(|titlebar| titlebar.appears_transparent)
@@ -272,7 +275,8 @@ impl WindowsWindow {
         let mut context = WindowCreateContext {
             inner: None,
             handle,
-            hide_title_bar,
+            title_bar: params.titlebar.is_some(),
+            transparent_title_bar,
             display,
             transparent: params.window_background != WindowBackgroundAppearance::Opaque,
             executor,


### PR DESCRIPTION
When the `titlebar` option is set to `None` in the `WindowOptions` it currently still displays the title bar of the window on Windows. This PR fixes this issue.

Release Notes:

- N/A
