### PR TITLE
Remove never-used client parameter from message handler functions

### DIFF
--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -114,7 +114,6 @@ impl ActiveCall {
     async fn handle_incoming_call(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::IncomingCall>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::Ack> {
         let user_store = this.update(&mut cx, |this, _| this.user_store.clone())?;
@@ -142,7 +141,6 @@ impl ActiveCall {
     async fn handle_call_canceled(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::CallCanceled>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {

--- a/crates/call/src/room.rs
+++ b/crates/call/src/room.rs
@@ -697,7 +697,6 @@ impl Room {
     async fn handle_room_updated(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::RoomUpdated>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let room = envelope

--- a/crates/channel/src/channel_buffer.rs
+++ b/crates/channel/src/channel_buffer.rs
@@ -138,7 +138,6 @@ impl ChannelBuffer {
     async fn handle_update_channel_buffer(
         this: Model<Self>,
         update_channel_buffer: TypedEnvelope<proto::UpdateChannelBuffer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let ops = update_channel_buffer
@@ -160,7 +159,6 @@ impl ChannelBuffer {
     async fn handle_update_channel_buffer_collaborators(
         this: Model<Self>,
         message: TypedEnvelope<proto::UpdateChannelBufferCollaborators>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -528,7 +528,6 @@ impl ChannelChat {
     async fn handle_message_sent(
         this: Model<Self>,
         message: TypedEnvelope<proto::ChannelMessageSent>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let user_store = this.update(&mut cx, |this, _| this.user_store.clone())?;
@@ -553,7 +552,6 @@ impl ChannelChat {
     async fn handle_message_removed(
         this: Model<Self>,
         message: TypedEnvelope<proto::RemoveChannelMessage>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -565,7 +563,6 @@ impl ChannelChat {
     async fn handle_message_updated(
         this: Model<Self>,
         message: TypedEnvelope<proto::ChannelMessageUpdate>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let user_store = this.update(&mut cx, |this, _| this.user_store.clone())?;

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -888,7 +888,6 @@ impl ChannelStore {
     async fn handle_update_channels(
         this: Model<Self>,
         message: TypedEnvelope<proto::UpdateChannels>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {
@@ -902,7 +901,6 @@ impl ChannelStore {
     async fn handle_update_user_channels(
         this: Model<Self>,
         message: TypedEnvelope<proto::UpdateUserChannels>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -242,7 +242,6 @@ impl UserStore {
     async fn handle_update_invite_info(
         this: Model<Self>,
         message: TypedEnvelope<proto::UpdateInviteInfo>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -258,7 +257,6 @@ impl UserStore {
     async fn handle_show_contacts(
         this: Model<Self>,
         _: TypedEnvelope<proto::ShowContacts>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |_, cx| cx.emit(Event::ShowContacts))?;
@@ -272,7 +270,6 @@ impl UserStore {
     async fn handle_update_contacts(
         this: Model<Self>,
         message: TypedEnvelope<proto::UpdateContacts>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {

--- a/crates/dev_server_projects/src/dev_server_projects.rs
+++ b/crates/dev_server_projects/src/dev_server_projects.rs
@@ -124,7 +124,6 @@ impl Store {
     async fn handle_dev_server_projects_update(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::DevServerProjectsUpdate>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {

--- a/crates/headless/src/headless.rs
+++ b/crates/headless/src/headless.rs
@@ -119,7 +119,6 @@ impl DevServer {
     async fn handle_dev_server_instructions(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::DevServerInstructions>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let (added_projects, removed_projects_ids) = this.read_with(&mut cx, |this, _| {
@@ -162,7 +161,6 @@ impl DevServer {
     async fn handle_validate_dev_server_project_request(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::ValidateDevServerProjectRequest>,
-        _: Arc<Client>,
         cx: AsyncAppContext,
     ) -> Result<proto::Ack> {
         let expanded = shellexpand::tilde(&envelope.payload.path).to_string();
@@ -180,7 +178,6 @@ impl DevServer {
     async fn handle_shutdown(
         this: Model<Self>,
         _envelope: TypedEnvelope<proto::ShutdownDevServer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {

--- a/crates/notifications/src/notification_store.rs
+++ b/crates/notifications/src/notification_store.rs
@@ -209,7 +209,6 @@ impl NotificationStore {
     async fn handle_new_notification(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::AddNotification>,
-        _: Arc<Client>,
         cx: AsyncAppContext,
     ) -> Result<()> {
         Self::add_notifications(
@@ -228,7 +227,6 @@ impl NotificationStore {
     async fn handle_delete_notification(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::DeleteNotification>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -240,7 +238,6 @@ impl NotificationStore {
     async fn handle_update_notification(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateNotification>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4028,7 +4028,6 @@ impl Project {
     async fn handle_restart_language_servers(
         project: Model<Self>,
         envelope: TypedEnvelope<proto::RestartLanguageServers>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::Ack> {
         project.update(&mut cx, |project, cx| {
@@ -8561,7 +8560,6 @@ impl Project {
     async fn handle_blame_buffer(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::BlameBuffer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::BlameBufferResponse> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
@@ -8592,7 +8590,6 @@ impl Project {
     async fn handle_multi_lsp_query(
         project: Model<Self>,
         envelope: TypedEnvelope<proto::MultiLspQuery>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::MultiLspQueryResponse> {
         let sender_id = envelope.original_sender_id()?;
@@ -8704,7 +8701,6 @@ impl Project {
     async fn handle_unshare_project(
         this: Model<Self>,
         _: TypedEnvelope<proto::UnshareProject>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -8720,7 +8716,6 @@ impl Project {
     async fn handle_add_collaborator(
         this: Model<Self>,
         mut envelope: TypedEnvelope<proto::AddProjectCollaborator>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let collaborator = envelope
@@ -8744,7 +8739,6 @@ impl Project {
     async fn handle_update_project_collaborator(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateProjectCollaborator>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let old_peer_id = envelope
@@ -8793,7 +8787,6 @@ impl Project {
     async fn handle_remove_collaborator(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::RemoveProjectCollaborator>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -8822,7 +8815,6 @@ impl Project {
     async fn handle_update_project(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateProject>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -8837,7 +8829,6 @@ impl Project {
     async fn handle_update_worktree(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateWorktree>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -8855,7 +8846,6 @@ impl Project {
     async fn handle_update_worktree_settings(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateWorktreeSettings>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -8879,7 +8869,6 @@ impl Project {
     async fn handle_create_project_entry(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::CreateProjectEntry>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ProjectEntryResponse> {
         let worktree = this.update(&mut cx, |this, cx| {
@@ -8893,7 +8882,6 @@ impl Project {
     async fn handle_rename_project_entry(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::RenameProjectEntry>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
@@ -8907,7 +8895,6 @@ impl Project {
     async fn handle_copy_project_entry(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::CopyProjectEntry>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
@@ -8921,7 +8908,6 @@ impl Project {
     async fn handle_delete_project_entry(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::DeleteProjectEntry>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
@@ -8936,7 +8922,6 @@ impl Project {
     async fn handle_expand_project_entry(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::ExpandProjectEntry>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ExpandProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
@@ -8949,7 +8934,6 @@ impl Project {
     async fn handle_update_diagnostic_summary(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateDiagnosticSummary>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -8997,7 +8981,6 @@ impl Project {
     async fn handle_start_language_server(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::StartLanguageServer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let server = envelope
@@ -9022,7 +9005,6 @@ impl Project {
     async fn handle_update_language_server(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateLanguageServer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -9085,7 +9067,6 @@ impl Project {
     async fn handle_update_buffer(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateBuffer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::Ack> {
         this.update(&mut cx, |this, cx| {
@@ -9123,7 +9104,6 @@ impl Project {
     async fn handle_create_buffer_for_peer(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::CreateBufferForPeer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -9209,7 +9189,6 @@ impl Project {
     async fn handle_update_diff_base(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateDiffBase>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
@@ -9232,7 +9211,6 @@ impl Project {
     async fn handle_update_buffer_file(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateBufferFile>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let buffer_id = envelope.payload.buffer_id;
@@ -9263,7 +9241,6 @@ impl Project {
     async fn handle_save_buffer(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::SaveBuffer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::BufferSaved> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
@@ -9305,7 +9282,6 @@ impl Project {
     async fn handle_reload_buffers(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::ReloadBuffers>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ReloadBuffersResponse> {
         let sender_id = envelope.original_sender_id()?;
@@ -9335,7 +9311,6 @@ impl Project {
     async fn handle_synchronize_buffers(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::SynchronizeBuffers>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::SynchronizeBuffersResponse> {
         let project_id = envelope.payload.project_id;
@@ -9426,7 +9401,6 @@ impl Project {
     async fn handle_format_buffers(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::FormatBuffers>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::FormatBuffersResponse> {
         let sender_id = envelope.original_sender_id()?;
@@ -9457,7 +9431,6 @@ impl Project {
     async fn handle_apply_additional_edits_for_completion(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::ApplyCompletionAdditionalEdits>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ApplyCompletionAdditionalEditsResponse> {
         let (buffer, completion) = this.update(&mut cx, |this, _| {
@@ -9509,7 +9482,6 @@ impl Project {
     async fn handle_resolve_completion_documentation(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::ResolveCompletionDocumentation>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ResolveCompletionDocumentationResponse> {
         let lsp_completion = serde_json::from_slice(&envelope.payload.lsp_completion)?;
@@ -9577,7 +9549,6 @@ impl Project {
     async fn handle_apply_code_action(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::ApplyCodeAction>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ApplyCodeActionResponse> {
         let sender_id = envelope.original_sender_id()?;
@@ -9609,7 +9580,6 @@ impl Project {
     async fn handle_on_type_formatting(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::OnTypeFormatting>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::OnTypeFormattingResponse> {
         let on_type_formatting = this.update(&mut cx, |this, cx| {
@@ -9642,7 +9612,6 @@ impl Project {
     async fn handle_inlay_hints(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::InlayHints>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::InlayHintsResponse> {
         let sender_id = envelope.original_sender_id()?;
@@ -9691,7 +9660,6 @@ impl Project {
     async fn handle_resolve_inlay_hint(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::ResolveInlayHint>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::ResolveInlayHintResponse> {
         let proto_hint = envelope
@@ -9726,7 +9694,6 @@ impl Project {
     async fn handle_task_context_for_location(
         project: Model<Self>,
         envelope: TypedEnvelope<proto::TaskContextForLocation>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::TaskContext> {
         let location = envelope
@@ -9769,7 +9736,6 @@ impl Project {
     async fn handle_task_templates(
         project: Model<Self>,
         envelope: TypedEnvelope<proto::TaskTemplates>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::TaskTemplatesResponse> {
         let worktree = envelope.payload.worktree_id.map(WorktreeId::from_proto);
@@ -9935,7 +9901,6 @@ impl Project {
     async fn handle_refresh_inlay_hints(
         this: Model<Self>,
         _: TypedEnvelope<proto::RefreshInlayHints>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::Ack> {
         this.update(&mut cx, |_, cx| {
@@ -9947,7 +9912,6 @@ impl Project {
     async fn handle_lsp_command<T: LspCommand>(
         this: Model<Self>,
         envelope: TypedEnvelope<T::ProtoRequest>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<<T::ProtoRequest as proto::RequestMessage>::Response>
     where
@@ -9993,7 +9957,6 @@ impl Project {
     async fn handle_get_project_symbols(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::GetProjectSymbols>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::GetProjectSymbolsResponse> {
         let symbols = this
@@ -10010,7 +9973,6 @@ impl Project {
     async fn handle_search_project(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::SearchProject>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::SearchProjectResponse> {
         let peer_id = envelope.original_sender_id()?;
@@ -10050,7 +10012,6 @@ impl Project {
     async fn handle_open_buffer_for_symbol(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::OpenBufferForSymbol>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::OpenBufferForSymbolResponse> {
         let peer_id = envelope.original_sender_id()?;
@@ -10116,7 +10077,6 @@ impl Project {
     async fn handle_open_buffer_by_id(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::OpenBufferById>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::OpenBufferResponse> {
         let peer_id = envelope.original_sender_id()?;
@@ -10130,7 +10090,6 @@ impl Project {
     async fn handle_open_buffer_by_path(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::OpenBufferByPath>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::OpenBufferResponse> {
         let peer_id = envelope.original_sender_id()?;
@@ -10152,7 +10111,6 @@ impl Project {
     async fn handle_open_new_buffer(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::OpenNewBuffer>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::OpenBufferResponse> {
         let buffer = this.update(&mut cx, |this, cx| this.create_local_buffer("", None, cx))?;
@@ -10547,7 +10505,6 @@ impl Project {
     async fn handle_buffer_saved(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::BufferSaved>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let version = deserialize_version(&envelope.payload.version);
@@ -10572,7 +10529,6 @@ impl Project {
     async fn handle_buffer_reloaded(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::BufferReloaded>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let payload = envelope.payload;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4350,7 +4350,6 @@ impl WorkspaceStore {
     pub async fn handle_follow(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::Follow>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<proto::FollowResponse> {
         this.update(&mut cx, |this, cx| {
@@ -4396,7 +4395,6 @@ impl WorkspaceStore {
     async fn handle_update_followers(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateFollowers>,
-        _: Arc<Client>,
         mut cx: AsyncAppContext,
     ) -> Result<()> {
         let leader_id = envelope.original_sender_id()?;


### PR DESCRIPTION
Every single client-side RPC message handler function took an unused `Arc<Client>` parameter. This removes that.

Release Notes:

- N/A
