### PR TITLE
Add Nix/NixOS dev-shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.direnv
 .idea
 **/target
 **/cargo-target

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718895438,
+        "narHash": "sha256-k3JqJrkdoYwE3fHE6xGDY676AYmyh4U2Zw+0Bwe5DLU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d603719ec6e294f034936c0d0dc06f689d91b6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718895438,
-        "narHash": "sha256-k3JqJrkdoYwE3fHE6xGDY676AYmyh4U2Zw+0Bwe5DLU=",
+        "lastModified": 1719690277,
+        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d603719ec6e294f034936c0d0dc06f689d91b6c3",
+        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (self) outputs;
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = import ./shell.nix { inherit pkgs; };
+        }
+      );
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,64 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  nativeBuildInputs =
+    with pkgs;
+    [
+      copyDesktopItems
+      curl
+      perl
+      pkg-config
+      protobuf
+      rustPlatform.bindgenHook
+    ]
+    ++ lib.optionals stdenv.isDarwin [ pkgs.xcbuild.xcrun ];
+
+  buildInputs =
+    with pkgs;
+    [
+      curl
+      fontconfig
+      freetype
+      libgit2
+      openssl
+      sqlite
+      zlib
+      zstd
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      alsa-lib
+      libxkbcommon
+      wayland
+      xorg.libxcb
+    ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        AppKit
+        CoreAudio
+        CoreFoundation
+        CoreGraphics
+        CoreMedia
+        CoreServices
+        CoreText
+        Foundation
+        IOKit
+        Metal
+        Security
+        SystemConfiguration
+        VideoToolbox
+      ]
+    );
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+    FONTCONFIG_FILE = pkgs.makeFontsConf {
+      fontDirectories = [
+        "assets/fonts/zed-mono"
+        "assets/fonts/zed-sans"
+      ];
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -5,43 +5,52 @@
 let
   stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.llvmPackages_18.stdenv;
 in
-(pkgs.mkShell.override { inherit stdenv; }) rec {
-  nativeBuildInputs = with pkgs; [
-    copyDesktopItems
-    curl
-    perl
-    pkg-config
-    protobuf
-    rustPlatform.bindgenHook
-  ];
+if pkgs.stdenv.isDarwin then
+  # See https://github.com/NixOS/nixpkgs/issues/320084
+  throw "zed: nix dev-shell isn't supported on darwin yet."
+else
+  (pkgs.mkShell.override { inherit stdenv; }) rec {
+    nativeBuildInputs = with pkgs; [
+      copyDesktopItems
+      curl
+      perl
+      pkg-config
+      protobuf
+      rustPlatform.bindgenHook
+    ];
 
-  buildInputs = with pkgs; [
-    curl
-    fontconfig
-    freetype
-    libgit2
-    openssl
-    sqlite
-    zlib
-    zstd
+    buildInputs = with pkgs; [
+      curl
+      fontconfig
+      freetype
+      libgit2
+      openssl
+      sqlite
+      zlib
+      zstd
 
-    alsa-lib
-    libxkbcommon
-    wayland
-    xorg.libxcb
-  ];
+      alsa-lib
+      libxkbcommon
+      wayland
+      xorg.libxcb
+    ];
 
-  env = {
-    LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath (buildInputs ++ [
-      stdenv.cc.cc.lib
-      vulkan-loader
-    ]);
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-    FONTCONFIG_FILE = pkgs.makeFontsConf {
-      fontDirectories = [
-        "assets/fonts/zed-mono"
-        "assets/fonts/zed-sans"
-      ];
+    env = {
+      LD_LIBRARY_PATH =
+        with pkgs;
+        lib.makeLibraryPath (
+          buildInputs
+          ++ [
+            stdenv.cc.cc.lib
+            vulkan-loader
+          ]
+        );
+      ZSTD_SYS_USE_PKG_CONFIG = true;
+      FONTCONFIG_FILE = pkgs.makeFontsConf {
+        fontDirectories = [
+          "assets/fonts/zed-mono"
+          "assets/fonts/zed-sans"
+        ];
+      };
     };
-  };
-}
+  }


### PR DESCRIPTION
This PR adds a Nix/NixOS development-shell (`shell.nix`), which is based on the upstream [nixpkgs](https://github.com/NixOS/nixpkgs/blob/c5d4d458115263ec3ee0efd974e6aeb2f787a0ed/pkgs/by-name/ze/zed-editor/package.nix), as well as its corresponding `flake.nix` file.

To use it, run either the `nix-shell` command (uses the `shell.nix` file), or the newer but experimental `nix develop` command (uses `flake.nix`)

~~This has not been tested on macOS, tho preliminary code is there to try and support it, feel free to report any issues.~~ Zed unfortunately doesn't build on nix-darwin (see https://github.com/NixOS/nixpkgs/issues/320084), so this PR doesn't aim to add darwin support.

---

Release Notes:

- N/A
