### PR TITLE
vim: Switch to normal mode after toggling comments

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -612,13 +612,13 @@
   {
     "context": "Editor && vim_mode == normal && !VimWaiting",
     "bindings": {
-      "g c c": "editor::ToggleComments"
+      "g c c": "vim::ToggleComments"
     }
   },
   {
     "context": "Editor && vim_mode == visual",
     "bindings": {
-      "g c": "editor::ToggleComments"
+      "g c": "vim::ToggleComments"
     }
   },
   {


### PR DESCRIPTION

Release Notes:

- vim: Fixed switching to normal mode after `g c`(vim::ToggleComments)  in visual mode ([#4439](https://github.com/zed-industries/zed/issues/4439))



