### PR TITLE
windows: Fix and simplify title bar padding

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -662,8 +662,8 @@ fn handle_calc_client_size(
     if state_ptr.state.borrow().is_maximized() {
         requested_client_rect[0].top += frame_y + padding;
     } else {
-        // Extra pixel from the top border
-        requested_client_rect[0].top += 1;
+        // Magic number that calculates the width of the border
+        requested_client_rect[0].top += frame_y - 3;
     }
 
     Some(0)

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -828,16 +828,13 @@ fn handle_hit_test_msg(
 
     let dpi = unsafe { GetDpiForWindow(handle) };
     let frame_y = unsafe { GetSystemMetricsForDpi(SM_CYFRAME, dpi) };
-    let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi) };
 
     let mut cursor_point = POINT {
         x: lparam.signed_loword().into(),
         y: lparam.signed_hiword().into(),
     };
     unsafe { ScreenToClient(handle, &mut cursor_point).ok().log_err() };
-    if !state_ptr.state.borrow().is_maximized()
-        && cursor_point.y > 0
-        && cursor_point.y < frame_y + padding
+    if !state_ptr.state.borrow().is_maximized() && cursor_point.y >= 0 && cursor_point.y <= frame_y
     {
         return Some(HTTOP as _);
     }

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -659,6 +659,13 @@ fn handle_calc_client_size(
     requested_client_rect[0].left += frame_x + padding;
     requested_client_rect[0].bottom -= frame_y + padding;
 
+    if state_ptr.state.borrow().is_maximized() {
+        requested_client_rect[0].top += frame_y + padding;
+    } else {
+        // Extra pixel from the top border
+        requested_client_rect[0].top += 1;
+    }
+
     Some(0)
 }
 
@@ -828,7 +835,10 @@ fn handle_hit_test_msg(
         y: lparam.signed_hiword().into(),
     };
     unsafe { ScreenToClient(handle, &mut cursor_point).ok().log_err() };
-    if cursor_point.y > 0 && cursor_point.y < frame_y + padding {
+    if !state_ptr.state.borrow().is_maximized()
+        && cursor_point.y > 0
+        && cursor_point.y < frame_y + padding
+    {
         return Some(HTTOP as _);
     }
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -75,8 +75,7 @@ impl Render for TitleBar {
         h_flex()
             .id("titlebar")
             .w_full()
-            .pt(Self::top_padding(cx))
-            .h(height + Self::top_padding(cx))
+            .h(height)
             .map(|this| {
                 if cx.is_fullscreen() {
                     this.pl_2()
@@ -438,28 +437,6 @@ impl TitleBar {
     pub fn height(_cx: &mut WindowContext) -> Pixels {
         // todo(windows) instead of hard coded size report the actual size to the Windows platform API
         px(32.)
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn top_padding(_cx: &WindowContext) -> Pixels {
-        px(0.)
-    }
-
-    #[cfg(target_os = "windows")]
-    fn top_padding(cx: &WindowContext) -> Pixels {
-        use windows::Win32::UI::{
-            HiDpi::GetSystemMetricsForDpi,
-            WindowsAndMessaging::{SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI},
-        };
-
-        // This top padding is not dependent on the title bar style and is instead a quirk of maximized windows on Windows:
-        // https://devblogs.microsoft.com/oldnewthing/20150304-00/?p=44543
-        let padding = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, USER_DEFAULT_SCREEN_DPI) };
-        if cx.is_maximized() {
-            px((padding * 2) as f32)
-        } else {
-            px(0.)
-        }
     }
 
     /// Sets the platform style.


### PR DESCRIPTION
This PR fixes the off by one pixel of the top client rect when not maximized due to the added border. It also simplifies and properly fixes the title bar padding problem when maximized, it is now properly taken care of in GPUI rather then adding the padding in the UI.

Release Notes:

- N/A
