### PR TITLE
editor: Select first match in "Find all references" editor

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9181,6 +9181,12 @@ impl Editor {
             Editor::for_multibuffer(excerpt_buffer, Some(workspace.project().clone()), true, cx)
         });
         editor.update(cx, |editor, cx| {
+            if let Some(first_range) = ranges_to_highlight.first() {
+                editor.change_selections(None, cx, |selections| {
+                    selections.clear_disjoint();
+                    selections.select_anchor_ranges(std::iter::once(first_range.clone()));
+                });
+            }
             editor.highlight_background::<Self>(
                 &ranges_to_highlight,
                 |theme| theme.editor_highlighted_line_background,


### PR DESCRIPTION
Previously we've placed cursor on the first line of the first excerpt in the multibuffer, but alas, https://x.com/fasterthanlime/status/1804883499809165473 happened (j/k, this feedback is totally valid). With this PR, we're gonna place the cursor past first reference.
As a bonus, with the old configuration `editor: select next` tripped over itself. Now it's possible (& feasible) to do a "select next" in "find all references"; consecutive referenced ranges will be selected.

Fixes #13419



Release Notes:

- Fixed a bug where "Find all references" editor had cursor placed on the first line of the first excerpt in the multibuffer instead of having it on the first reference.
