### PR TITLE
windows: Fix title bar font for Windows 10

### DIFF
--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -2,6 +2,7 @@ use gpui::{prelude::*, Rgba, WindowAppearance};
 
 use crate::prelude::*;
 
+#[cfg(target_os = "windows")]
 #[derive(IntoElement)]
 pub struct WindowsWindowControls {
     button_height: Pixels,
@@ -95,7 +96,6 @@ impl WindowsCaptionButton {
         }
     }
 
-    #[cfg(target_os = "windows")]
     pub fn get_font() -> &'static str {
         use windows::Wdk::System::SystemServices::RtlGetVersion;
 

--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -111,9 +111,10 @@ impl RenderOnce for WindowsCaptionButton {
             .w(width)
             .h_full()
             .font_family({
+                use windows::Wdk::System::SystemServices::RtlGetVersion;
+
                 let mut version = unsafe { std::mem::zeroed() };
-                let status =
-                    unsafe { windows::Wdk::System::SystemServices::RtlGetVersion(&mut version) };
+                let status = unsafe { RtlGetVersion(&mut version) };
 
                 if status.is_ok() && version.dwBuildNumber >= 22000 {
                     "Segoe Fluent Icons"

--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -110,7 +110,17 @@ impl RenderOnce for WindowsCaptionButton {
             .content_center()
             .w(width)
             .h_full()
-            .font_family("Segoe Fluent Icons")
+            .font_family({
+                let mut version = unsafe { std::mem::zeroed() };
+                let status =
+                    unsafe { windows::Wdk::System::SystemServices::RtlGetVersion(&mut version) };
+
+                if status.is_ok() && version.dwBuildNumber >= 22000 {
+                    "Segoe Fluent Icons"
+                } else {
+                    "Segoe MDL2 Assets"
+                }
+            })
             .text_size(px(10.0))
             .hover(|style| style.bg(self.hover_background_color))
             .active(|style| {

--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -2,7 +2,6 @@ use gpui::{prelude::*, Rgba, WindowAppearance};
 
 use crate::prelude::*;
 
-#[cfg(target_os = "windows")]
 #[derive(IntoElement)]
 pub struct WindowsWindowControls {
     button_height: Pixels,
@@ -96,6 +95,12 @@ impl WindowsCaptionButton {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
+    pub fn get_font() -> &'static str {
+        "Segoe Fluent Icons"
+    }
+
+    #[cfg(target_os = "windows")]
     pub fn get_font() -> &'static str {
         use windows::Wdk::System::SystemServices::RtlGetVersion;
 

--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -5,15 +5,11 @@ use crate::prelude::*;
 #[derive(IntoElement)]
 pub struct WindowsWindowControls {
     button_height: Pixels,
-    font: SharedString,
 }
 
 impl WindowsWindowControls {
     pub fn new(button_height: Pixels) -> Self {
-        Self {
-            button_height,
-            font: SharedString::from(Self::get_font()),
-        }
+        Self { button_height }
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -62,6 +58,7 @@ impl RenderOnce for WindowsWindowControls {
 
         div()
             .id("windows-window-controls")
+            .font_family(Self::get_font())
             .flex()
             .flex_row()
             .justify_center()
@@ -72,7 +69,6 @@ impl RenderOnce for WindowsWindowControls {
                 "minimize",
                 WindowsCaptionButtonIcon::Minimize,
                 button_hover_color,
-                self.font.clone(),
             ))
             .child(WindowsCaptionButton::new(
                 "maximize-or-restore",
@@ -82,13 +78,11 @@ impl RenderOnce for WindowsWindowControls {
                     WindowsCaptionButtonIcon::Maximize
                 },
                 button_hover_color,
-                self.font.clone(),
             ))
             .child(WindowsCaptionButton::new(
                 "close",
                 WindowsCaptionButtonIcon::Close,
                 close_button_hover_color,
-                self.font.clone(),
             ))
     }
 }
@@ -106,7 +100,6 @@ struct WindowsCaptionButton {
     id: ElementId,
     icon: WindowsCaptionButtonIcon,
     hover_background_color: Rgba,
-    font: SharedString,
 }
 
 impl WindowsCaptionButton {
@@ -114,13 +107,11 @@ impl WindowsCaptionButton {
         id: impl Into<ElementId>,
         icon: WindowsCaptionButtonIcon,
         hover_background_color: Rgba,
-        font: SharedString,
     ) -> Self {
         Self {
             id: id.into(),
             icon,
             hover_background_color,
-            font,
         }
     }
 }
@@ -139,7 +130,6 @@ impl RenderOnce for WindowsCaptionButton {
             .content_center()
             .w(width)
             .h_full()
-            .font_family(self.font)
             .text_size(px(10.0))
             .hover(|style| style.bg(self.hover_background_color))
             .active(|style| {

--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -96,12 +96,12 @@ impl WindowsCaptionButton {
     }
 
     #[cfg(not(target_os = "windows"))]
-    pub fn get_font() -> &'static str {
+    fn get_font() -> &'static str {
         "Segoe Fluent Icons"
     }
 
     #[cfg(target_os = "windows")]
-    pub fn get_font() -> &'static str {
+    fn get_font() -> &'static str {
         use windows::Wdk::System::SystemServices::RtlGetVersion;
 
         let mut version = unsafe { std::mem::zeroed() };

--- a/crates/ui/src/components/title_bar/windows_window_controls.rs
+++ b/crates/ui/src/components/title_bar/windows_window_controls.rs
@@ -94,6 +94,20 @@ impl WindowsCaptionButton {
             hover_background_color,
         }
     }
+
+    #[cfg(target_os = "windows")]
+    pub fn get_font() -> &'static str {
+        use windows::Wdk::System::SystemServices::RtlGetVersion;
+
+        let mut version = unsafe { std::mem::zeroed() };
+        let status = unsafe { RtlGetVersion(&mut version) };
+
+        if status.is_ok() && version.dwBuildNumber >= 22000 {
+            "Segoe Fluent Icons"
+        } else {
+            "Segoe MDL2 Assets"
+        }
+    }
 }
 
 impl RenderOnce for WindowsCaptionButton {
@@ -110,18 +124,7 @@ impl RenderOnce for WindowsCaptionButton {
             .content_center()
             .w(width)
             .h_full()
-            .font_family({
-                use windows::Wdk::System::SystemServices::RtlGetVersion;
-
-                let mut version = unsafe { std::mem::zeroed() };
-                let status = unsafe { RtlGetVersion(&mut version) };
-
-                if status.is_ok() && version.dwBuildNumber >= 22000 {
-                    "Segoe Fluent Icons"
-                } else {
-                    "Segoe MDL2 Assets"
-                }
-            })
+            .font_family(Self::get_font())
             .text_size(px(10.0))
             .hover(|style| style.bg(self.hover_background_color))
             .active(|style| {


### PR DESCRIPTION
This should fix the title bar font for Windows 10 as `Segoe Fluent Icons` is only for Windows 11 and Windows 10 should be using `Segoe MDL2 Assets`, I haven't tested this myself on a Windows 10 machine but the fonts work fine.

Release Notes:

- N/A
