### PR TITLE
Assign GOOGLE_AI_API_KEY from a Kubernetes secret

### DIFF
--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -122,6 +122,11 @@ spec:
                 secretKeyRef:
                   name: anthropic
                   key: api_key
+            - name: GOOGLE_AI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google_ai
+                  key: api_key
             - name: BLOB_STORE_ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Release Notes:

- N/A
