### PR TITLE
Allow rpc_url to be assigned on Client with test-support feature

### DIFF
--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     let mut build = prost_build::Config::new();
     build
-        .type_attribute(".", "#[derive(serde::Serialize)]")
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .compile_protos(&["proto/zed.proto"], &["proto"])
         .unwrap();
 }

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -8,7 +8,7 @@ pub use error::*;
 pub use typed_envelope::*;
 
 use collections::HashMap;
-pub use prost::Message;
+pub use prost::{DecodeError, Message};
 use serde::Serialize;
 use std::any::{Any, TypeId};
 use std::time::Instant;


### PR DESCRIPTION
Also, allow proto messages to be deserialized. This is to support translating these messages JS types in a new server implementation based on CloudFlare durable objects.

Release Notes:

- N/A
