### PR TITLE
Combine multiple buffer update count fields into one

### DIFF
--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -462,11 +462,8 @@ impl InlayMap {
 
         if buffer_edits.is_empty() {
             if snapshot.buffer.edit_count() != buffer_snapshot.edit_count()
-                || snapshot.buffer.parse_count() != buffer_snapshot.parse_count()
-                || snapshot.buffer.diagnostics_update_count()
-                    != buffer_snapshot.diagnostics_update_count()
-                || snapshot.buffer.git_diff_update_count()
-                    != buffer_snapshot.git_diff_update_count()
+                || snapshot.buffer.non_text_state_update_count()
+                    != buffer_snapshot.non_text_state_update_count()
                 || snapshot.buffer.trailing_excerpt_update_count()
                     != buffer_snapshot.trailing_excerpt_update_count()
             {


### PR DESCRIPTION
Buffers carry several pieces of state besides their text: syntax tree, diagnostics, git diff, and file data. Previously, the buffer maintained a separate integer version number for each of these four pieces of state, incrementing it every time that piece of state is updated. This is used by MultiBuffers to detect when they need to update excerpts.

Previously, for a given buffer, these four version numbers were stored on the buffer itself, on every snapshot of the buffer,  in any multi-buffer that referenced that buffer,  **and** on snapshots of that multi-buffer. But the only use for the version numbers was reduced down to a single boolean predicate: whether or not the buffer's state has changed.

In this PR, I've combined those 4 version numbers into one. I've called it `non_text_state_update_count` because it tracks all state updates outside of the text itself. This removes a bunch of unnecessary code, and reduces the size of buffer snapshots and multi-buffer snapshots.

Release Notes:

- N/A
