### PR TITLE
linux/x11: Fix CPU being pinned at 100% in X11 loop

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -291,7 +291,7 @@ impl X11Client {
             .insert_source(
                 Generic::new_with_error::<EventHandlerError>(
                     fd,
-                    calloop::Interest::BOTH,
+                    calloop::Interest::READ,
                     calloop::Mode::Level,
                 ),
                 {


### PR DESCRIPTION
This was part of https://github.com/zed-industries/zed/pull/13355 to fix the problem of XIM events not waking up the loop. Problem is that it seems to pin a single CPU at 100%.

Luckily, it looks like the change is not necessary anymore after we refactored the improvements in #13355.

This fixes https://github.com/zed-industries/zed/issues/13409.

Release Notes:

- N/A
