### PR TITLE
windows: Fix JSON schema validation

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -249,5 +249,5 @@ fn schema_file_match(path: &Path) -> String {
         .unwrap()
         .display()
         .to_string()
-        .replace("\\", "/")
+        .replace('\\', "/")
 }

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -21,7 +21,7 @@ use std::{
 use task::{TaskTemplate, TaskTemplates, VariableName};
 use util::{maybe, ResultExt};
 
-const SERVER_PATH: &str = "node_modules/vscode-json-languageserver/bin/vscode-json-languageserver";
+const SERVER_PATH: &str = "node_modules/.bin/vscode-json-language-server";
 
 // Origin: https://github.com/SchemaStore/schemastore
 const TSCONFIG_SCHEMA: &str = include_str!("json/schemas/tsconfig.json");
@@ -133,7 +133,7 @@ impl LspAdapter for JsonLspAdapter {
     ) -> Result<Box<dyn 'static + Send + Any>> {
         Ok(Box::new(
             self.node
-                .npm_package_latest_version("vscode-json-languageserver")
+                .npm_package_latest_version("vscode-langservers-extracted")
                 .await?,
         ) as Box<_>)
     }
@@ -145,8 +145,9 @@ impl LspAdapter for JsonLspAdapter {
         _: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
         let latest_version = latest_version.downcast::<String>().unwrap();
+        println!("==> Latest ver: {}", latest_version);
         let server_path = container_dir.join(SERVER_PATH);
-        let package_name = "vscode-json-languageserver";
+        let package_name = "vscode-langservers-extracted";
 
         let should_install_language_server = self
             .node
@@ -158,6 +159,8 @@ impl LspAdapter for JsonLspAdapter {
                 .npm_install_packages(&container_dir, &[(package_name, latest_version.as_str())])
                 .await?;
         }
+
+        // panic!();
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -146,7 +146,6 @@ impl LspAdapter for JsonLspAdapter {
         _: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
         let latest_version = latest_version.downcast::<String>().unwrap();
-        println!("==> Latest ver: {}", latest_version);
         let server_path = container_dir.join(SERVER_PATH);
         let package_name = "vscode-langservers-extracted";
 
@@ -156,14 +155,11 @@ impl LspAdapter for JsonLspAdapter {
             .await;
 
         if should_install_language_server {
-            let ret = self
-                .node
+            self.node
                 .npm_install_packages(&container_dir, &[(package_name, latest_version.as_str())])
-                .await;
-            println!("==>{:#?}", ret);
+                .await
+                .log_err();
         }
-
-        // panic!();
 
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -155,6 +155,7 @@ impl LspAdapter for JsonLspAdapter {
             .await;
 
         if should_install_language_server {
+            // TODO: the postinstall fails on Windows
             self.node
                 .npm_install_packages(&container_dir, &[(package_name, latest_version.as_str())])
                 .await

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -244,17 +244,9 @@ async fn get_cached_server_binary(
 
 #[inline]
 fn schema_file_match(path: &Path) -> String {
-    #[cfg(not(target_os = "windows"))]
-    return path
-        .strip_prefix(path.parent().unwrap().parent().unwrap())
-        .unwrap()
-        .display()
-        .to_string();
-    #[cfg(target_os = "windows")]
-    return path
-        .strip_prefix(path.parent().unwrap().parent().unwrap())
+    path.strip_prefix(path.parent().unwrap().parent().unwrap())
         .unwrap()
         .display()
         .to_string()
-        .replace("\\", "/");
+        .replace("\\", "/")
 }

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -155,9 +155,11 @@ impl LspAdapter for JsonLspAdapter {
             .await;
 
         if should_install_language_server {
-            self.node
+            let ret = self
+                .node
                 .npm_install_packages(&container_dir, &[(package_name, latest_version.as_str())])
-                .await?;
+                .await;
+            println!("==>{:#?}", ret);
         }
 
         // panic!();

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -21,7 +21,8 @@ use std::{
 use task::{TaskTemplate, TaskTemplates, VariableName};
 use util::{maybe, ResultExt};
 
-const SERVER_PATH: &str = "node_modules/.bin/vscode-json-language-server";
+const SERVER_PATH: &str =
+    "node_modules/vscode-langservers-extracted/bin/vscode-json-language-server";
 
 // Origin: https://github.com/SchemaStore/schemastore
 const TSCONFIG_SCHEMA: &str = include_str!("json/schemas/tsconfig.json");

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -246,7 +246,19 @@ async fn get_cached_server_binary(
     .log_err()
 }
 
-fn schema_file_match(path: &Path) -> &Path {
-    path.strip_prefix(path.parent().unwrap().parent().unwrap())
+#[inline]
+fn schema_file_match(path: &Path) -> String {
+    #[cfg(not(target_os = "windows"))]
+    return path
+        .strip_prefix(path.parent().unwrap().parent().unwrap())
         .unwrap()
+        .display()
+        .to_string();
+    #[cfg(target_os = "windows")]
+    return path
+        .strip_prefix(path.parent().unwrap().parent().unwrap())
+        .unwrap()
+        .display()
+        .to_string()
+        .replace("\\", "/");
 }


### PR DESCRIPTION
This PR needs suggestions, especially from the Zed team. As I mentioned in a previous issue #13394 , the `vscode-json-languageserver` that Zed originally relied on has some issues with JSON schema validation on Windows, and it hasn't been updated for a long time. This PR uses the more frequently updated `vscode-langservers-extracted`, which resolves this issue.

Currently, `vscode-langservers-extracted` includes not only the JSON LSP server but also LSP servers for other languages. I think we might need a package specifically for the JSON LSP server, such as something like `vscode-json-langserver-extracted`, or we could consider using the LSP servers for other languages from this package as well. 

And, there are some issues with installing `vscode-langservers-extracted` on Windows, causing the `postinstall` script to fail. However, this does not seem to affect any functionality. Therefore, I think the best solution is for the Zed team to maintain a package like `vscode-json-langserver-extracted` or something else. This way, we can update it promptly and address the installation issues on Windows.

Any suggestions or advices are welcome.


#### JSON vaildation on Winodws


https://github.com/zed-industries/zed/assets/14981363/8cd7ff54-28ec-4601-b2e5-183e2fae2051



Closes #13394 

Release Notes:

- Fixed JSON schema validation issue on Windows.(#13394 )
