### PR TITLE
linux/x11: Fallback to 800x600 if window bounds size has 0

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -274,6 +274,11 @@ impl X11WindowState {
             );
 
         let mut bounds = params.bounds.to_device_pixels(scale_factor);
+        if bounds.size.width.0 == 0 || bounds.size.height.0 == 0 {
+            log::warn!("Window bounds contain a zero value. height={}, width={}. Falling back to defaults.", bounds.size.height.0, bounds.size.width.0);
+            bounds.size.width = 800.into();
+            bounds.size.height = 600.into();
+        }
 
         xcb_connection
             .create_window(


### PR DESCRIPTION
As reported here https://github.com/zed-industries/zed/issues/13203#issuecomment-2183514518 it seems that sometimes we get 0 values for the window bounds.

Instead of failing to start up, we log a warning and fall back to defaults that let a window show up.


Release Notes:

- N/A
