### PR TITLE
cargo: Add release-fast profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -482,6 +482,11 @@ codegen-units = 1
 [profile.release.package]
 zed = { codegen-units = 16 }
 
+[profile.release-fast]
+inherits = "release"
+lto = false
+codegen-units = 16
+
 [workspace.lints.clippy]
 dbg_macro = "deny"
 todo = "deny"


### PR DESCRIPTION
This saves us ~1min of linking time on my Linux machine.

Release Notes:

- N/A
