### PR TITLE
chore: Take down codegen-units in dev builds to 16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,6 +464,7 @@ pathfinder_simd = { git = "https://github.com/servo/pathfinder.git", rev = "4968
 [profile.dev]
 split-debuginfo = "unpacked"
 debug = "limited"
+codegen-units = 16
 
 [profile.dev.package]
 taffy = { opt-level = 3 }


### PR DESCRIPTION
codegen-units determines how many object files are used when building a single crate. By default it is set to 256 in dev builds and to 16 in release builds. Higher values can get in the way of optimizations, but they should help when performing an incremental build (as higher granularity means that it's less likely we'd have to rebuild the whole crate). When we were tinkering with Linux builds we found that we're spreading ourselves too thin at times; large values of codegen-units were making builds of smaller crates, such as file_finder, redundantly long, where some CGs were miniscule. This PR significantly reduces the # of CGs we use in dev builds. This means that an incremental build of a crate might have to rebuild a bit more, but overall, we should be spending *less* time in multicrate builds.

As a result of this change, incremental build of gpui (`cargo build; touch crates/gpui/src/gpui.rs; cargo build`) goes down from 29-32s to 22s on my machine. Same scenario for editor: 13s to 11s. I've ran `cargo clean` before executing each run



Release Notes:

- N/A
