### PR TITLE
Reorganize Quick Action Bar

### DIFF
--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -210,7 +210,7 @@ impl Render for QuickActionBar {
                         let menu = ContextMenu::build(cx, |mut menu, _| {
                             if supports_inlay_hints {
                                 menu = menu.toggleable_entry(
-                                    "Show Inlay Hints",
+                                    "Inlay Hints",
                                     inlay_hints_enabled,
                                     Some(editor::actions::ToggleInlayHints.boxed_clone()),
                                     {
@@ -228,7 +228,7 @@ impl Render for QuickActionBar {
                             }
 
                             menu = menu.toggleable_entry(
-                                "Show Git Blame Inline",
+                                "Inline Git Blame",
                                 git_blame_inline_enabled,
                                 Some(editor::actions::ToggleGitBlameInline.boxed_clone()),
                                 {
@@ -245,7 +245,7 @@ impl Render for QuickActionBar {
                             );
 
                             menu = menu.toggleable_entry(
-                                "Show Selection Menu",
+                                "Selection Menu",
                                 selection_menu_enabled,
                                 Some(editor::actions::ToggleSelectionMenu.boxed_clone()),
                                 {
@@ -276,19 +276,23 @@ impl Render for QuickActionBar {
 
         h_flex()
             .id("quick action bar")
-            .gap_3()
+            .gap(Spacing::XLarge.rems(cx))
             .child(
                 h_flex()
-                    .gap_1p5()
+                    .gap(Spacing::Medium.rems(cx))
                     .children(search_button)
-                    .children(editor_selections_dropdown)
                     .when(
                         AssistantSettings::get_global(cx).enabled
                             && AssistantSettings::get_global(cx).button,
                         |bar| bar.child(assistant_button),
                     ),
             )
-            .child(editor_settings_dropdown)
+            .child(
+                h_flex()
+                    .gap(Spacing::Medium.rems(cx))
+                    .children(editor_selections_dropdown)
+                    .child(editor_settings_dropdown),
+            )
             .when_some(
                 self.toggle_settings_menu.as_ref(),
                 |el, toggle_settings_menu| {


### PR DESCRIPTION
This PR:

- Moves the selection menu to the end with the editor settings menu
- Tidies up labels in the settings menu
- Minor spacing updates

Release Notes:

- Improved organization in the Quick Action Bar