### PR TITLE
Fix Linux search issues

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1641,13 +1641,6 @@ impl ProjectPanel {
                 });
             }
         }
-
-        let any_ignored = self
-            .visible_entries
-            .iter()
-            .flat_map(|entry| entry.1.iter().map(|e| e.is_ignored))
-            .any(|ignored| ignored);
-        dbg!(any_ignored);
     }
 
     fn expand_entry(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1641,6 +1641,13 @@ impl ProjectPanel {
                 });
             }
         }
+
+        let any_ignored = self
+            .visible_entries
+            .iter()
+            .flat_map(|entry| entry.1.iter().map(|e| e.is_ignored))
+            .any(|ignored| ignored);
+        dbg!(any_ignored);
     }
 
     fn expand_entry(

--- a/crates/worktree/src/ignore.rs
+++ b/crates/worktree/src/ignore.rs
@@ -37,11 +37,6 @@ impl IgnoreStack {
             return true;
         }
 
-        if abs_path.ends_with(Path::new("target")) {
-            dbg!(abs_path, is_dir);
-            dbg!(self);
-        }
-
         match self {
             Self::None => false,
             Self::All => true,

--- a/crates/worktree/src/ignore.rs
+++ b/crates/worktree/src/ignore.rs
@@ -1,6 +1,7 @@
 use ignore::gitignore::Gitignore;
 use std::{ffi::OsStr, path::Path, sync::Arc};
 
+#[derive(Debug)]
 pub enum IgnoreStack {
     None,
     Some {
@@ -34,6 +35,11 @@ impl IgnoreStack {
     pub fn is_abs_path_ignored(&self, abs_path: &Path, is_dir: bool) -> bool {
         if is_dir && abs_path.file_name() == Some(OsStr::new(".git")) {
             return true;
+        }
+
+        if abs_path.ends_with(Path::new("target")) {
+            dbg!(abs_path, is_dir);
+            dbg!(self);
         }
 
         match self {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3803,7 +3803,7 @@ impl BackgroundScanner {
         let mut root_canonical_path = None;
         let mut new_entries: Vec<Entry> = Vec::new();
         let mut new_jobs: Vec<Option<ScanJob>> = Vec::new();
-        let mut child_paths = self
+        let child_paths = self
             .fs
             .read_dir(&job.abs_path)
             .await?

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3819,11 +3819,10 @@ impl BackgroundScanner {
             .collect::<Vec<_>>()
             .await;
 
-        if let Some(dot_git_position) = child_paths
+        if let Some(dot_git_path) = child_paths
             .iter()
-            .position(|abs_path| abs_path.file_name().unwrap() == *DOT_GIT)
+            .find(|abs_path| abs_path.file_name().unwrap() == *DOT_GIT)
         {
-            let dot_git_path = child_paths.remove(dot_git_position);
             let dot_git_path: Arc<Path> = job.path.join(dot_git_path.file_name().unwrap()).into();
 
             let repo = self
@@ -3845,11 +3844,10 @@ impl BackgroundScanner {
             self.watcher.add(dot_git_path.as_ref()).log_err();
         }
 
-        if let Some(gitignore_position) = child_paths
+        if let Some(gitignore_path) = child_paths
             .iter()
-            .position(|abs_path| abs_path.file_name().unwrap() == *GITIGNORE)
+            .find(|abs_path| abs_path.file_name().unwrap() == *GITIGNORE)
         {
-            let gitignore_path = child_paths.remove(gitignore_position);
             let child_name = gitignore_path.file_name().unwrap();
             let gitignore_path: Arc<Path> = job.path.join(child_name).into();
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3840,6 +3840,7 @@ impl BackgroundScanner {
             let child_path: Arc<Path> = job.path.join(child_name).into();
 
             if child_name == *DOT_GIT {
+                dbg!("dot git");
                 let repo = self
                     .state
                     .lock()
@@ -3858,6 +3859,7 @@ impl BackgroundScanner {
                 }
                 self.watcher.add(child_abs_path.as_ref()).log_err();
             } else if child_name == *GITIGNORE {
+                dbg!("git ignore");
                 match build_gitignore(&child_abs_path, self.fs.as_ref()).await {
                     Ok(ignore) => {
                         let ignore = Arc::new(ignore);
@@ -3933,12 +3935,12 @@ impl BackgroundScanner {
             }
 
             if child_entry.is_dir() {
+                // ***THIS SHOULD GET IT
                 child_entry.is_ignored = ignore_stack.is_abs_path_ignored(&child_abs_path, true);
 
-                if child_entry.is_ignored {
-                    dbg!("ignored");
+                if child_entry.path.ends_with(Path::new("target")) {
+                    dbg!(&child_entry);
                 }
-
                 // Avoid recursing until crash in the case of a recursive symlink
                 if job.ancestor_inodes.contains(&child_entry.inode) {
                     new_jobs.push(None);

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3439,6 +3439,7 @@ impl BackgroundScanner {
                     .ignore_stack_for_abs_path(&root_abs_path, true);
                 if ignore_stack.is_abs_path_ignored(&root_abs_path, true) {
                     root_entry.is_ignored = true;
+                    dbg!("ignored");
                     state.insert_entry(root_entry.clone(), self.fs.as_ref());
                 }
                 state.enqueue_scan_dir(root_abs_path, &root_entry, &scan_job_tx);
@@ -3934,6 +3935,10 @@ impl BackgroundScanner {
             if child_entry.is_dir() {
                 child_entry.is_ignored = ignore_stack.is_abs_path_ignored(&child_abs_path, true);
 
+                if child_entry.is_ignored {
+                    dbg!("ignored");
+                }
+
                 // Avoid recursing until crash in the case of a recursive symlink
                 if job.ancestor_inodes.contains(&child_entry.inode) {
                     new_jobs.push(None);
@@ -4081,6 +4086,10 @@ impl BackgroundScanner {
 
                     let is_dir = fs_entry.is_dir();
                     fs_entry.is_ignored = ignore_stack.is_abs_path_ignored(&abs_path, is_dir);
+                    if fs_entry.is_ignored {
+                        dbg!("ignored");
+                    }
+
                     fs_entry.is_external = !canonical_path.starts_with(&root_canonical_path);
                     fs_entry.is_private = self.is_path_private(path);
 
@@ -4243,6 +4252,9 @@ impl BackgroundScanner {
             let was_ignored = entry.is_ignored;
             let abs_path: Arc<Path> = snapshot.abs_path().join(&entry.path).into();
             entry.is_ignored = ignore_stack.is_abs_path_ignored(&abs_path, entry.is_dir());
+            if entry.is_ignored {
+                dbg!("ignored");
+            }
             if entry.is_dir() {
                 let child_ignore_stack = if entry.is_ignored {
                     IgnoreStack::all()


### PR DESCRIPTION
In some rare cases, we wouldn't pick up .gitignore files in the right order, causing performance issues for the project search and the file finder  

Release Notes:

- N/A
