### PR TITLE
Fix bug with inline assist and indentation on empty lines

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1893,6 +1893,11 @@ impl Codegen {
 
                                         if lines.peek().is_some() {
                                             hunks_tx.send(diff.push_new("\n")).await?;
+                                            if line_indent.is_none() {
+                                                // Don't write out the leading indentation in empty lines on the next line
+                                                // This is the case where the above if statement didn't clear the buffer
+                                                new_text.clear();
+                                            }
                                             line_indent = None;
                                             first_line = false;
                                         }


### PR DESCRIPTION
Fix a minor bug when the inline assistant model spits out an empty line with leading indentation on it. This happens sometimes with Claude 3.5 Sonnet and currently it causes the following line to have the wrong indentation.

Release Notes:

- N/A
