### PR TITLE
indent guides: Fix edge case when line is folded

### DIFF
--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -165,10 +165,16 @@ pub fn indent_guides_in_range(
         .indent_guides_in_range(start_anchor..end_anchor, ignore_disabled_for_language, cx)
         .into_iter()
         .filter(|indent_guide| {
+            let start =
+                MultiBufferRow(indent_guide.multibuffer_row_range.start.0.saturating_sub(1));
             // Filter out indent guides that are inside a fold
-            !snapshot.is_line_folded(MultiBufferRow(
-                indent_guide.multibuffer_row_range.start.0.saturating_sub(1),
-            ))
+            let is_folded = snapshot.is_line_folded(start);
+            let line_indent = snapshot.line_indent_for_buffer_row(start);
+
+            let contained_in_fold =
+                line_indent.len(indent_guide.tab_size) <= indent_guide.indent_level();
+
+            !(is_folded && contained_in_fold)
         })
         .collect()
 }


### PR DESCRIPTION


https://github.com/zed-industries/zed/assets/53836821/6c79cdc8-c0e1-4f5e-807e-be4a4bde32c3



Release Notes:

- Fixed an edge case where some indent guides would disappear when a folded line is the first visible line on screen
