### PR TITLE
Change `window_min_size` from `Size<Pixels>` to `Option<Size<Pixels>>`

### DIFF
--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -124,6 +124,6 @@ fn notification_window_options(
         display_id: Some(screen.id()),
         window_background: WindowBackgroundAppearance::default(),
         app_id: Some(app_id.to_owned()),
-        window_min_size: Size::default(),
+        window_min_size: None,
     }
 }

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -51,7 +51,7 @@ fn main() {
                     kind: WindowKind::PopUp,
                     is_movable: false,
                     app_id: None,
-                    window_min_size: Size::default(),
+                    window_min_size: None,
                 }
             };
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -569,7 +569,7 @@ pub struct WindowOptions {
     pub app_id: Option<String>,
 
     /// Window minimum size
-    pub window_min_size: Size<Pixels>,
+    pub window_min_size: Option<Size<Pixels>>,
 }
 
 /// The variables that can be configured when creating a new window
@@ -599,7 +599,7 @@ pub(crate) struct WindowParams {
     pub window_background: WindowBackgroundAppearance,
 
     #[cfg_attr(target_os = "linux", allow(dead_code))]
-    pub window_min_size: Size<Pixels>,
+    pub window_min_size: Option<Size<Pixels>>,
 }
 
 /// Represents the status of how a window should be opened.
@@ -648,7 +648,7 @@ impl Default for WindowOptions {
             display_id: None,
             window_background: WindowBackgroundAppearance::default(),
             app_id: None,
-            window_min_size: Size::default(),
+            window_min_size: None,
         }
     }
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -647,10 +647,12 @@ impl MacWindow {
 
             native_window.setMovable_(is_movable as BOOL);
 
-            native_window.setContentMinSize_(NSSize {
-                width: window_min_size.width.to_f64(),
-                height: window_min_size.height.to_f64(),
-            });
+            if let Some(window_min_size) = window_min_size {
+                native_window.setContentMinSize_(NSSize {
+                    width: window_min_size.width.to_f64(),
+                    height: window_min_size.height.to_f64(),
+                });
+            }
 
             if titlebar.map_or(true, |titlebar| titlebar.appears_transparent) {
                 native_window.setTitlebarAppearsTransparent_(YES);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -105,10 +105,10 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         display_id: display.map(|display| display.id()),
         window_background: cx.theme().window_background_appearance(),
         app_id: Some(app_id.to_owned()),
-        window_min_size: gpui::Size {
+        window_min_size: Some(gpui::Size {
             width: px(360.0),
             height: px(240.0),
-        },
+        }),
     }
 }
 


### PR DESCRIPTION
Now we can set `window_min_size` to `None` instead of `Size::default()`. I think this makes more sense.

Release Notes:

- N/A
