### PR TITLE
Clean up `json!` literal for `vtsls` configuration

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -162,46 +162,42 @@ impl LspAdapter for VtslsLspAdapter {
         _: &Arc<dyn LspAdapterDelegate>,
     ) -> Result<Option<serde_json::Value>> {
         Ok(Some(json!({
-            "typescript":
-            {
+            "typescript": {
                 "tsdk": "node_modules/typescript/lib",
                 "format": {
                     "enable": true
                 },
-                "inlayHints":{
-                    "parameterNames":
-                    {
+                "inlayHints": {
+                    "parameterNames": {
                         "enabled": "all",
                         "suppressWhenArgumentMatchesName": false,
 
                     },
-
-                    "parameterTypes":
-                    {
+                    "parameterTypes": {
                         "enabled": true
                     },
                     "variableTypes": {
                         "enabled": true,
                         "suppressWhenTypeMatchesName": false,
                     },
-                    "propertyDeclarationTypes":{
+                    "propertyDeclarationTypes": {
                         "enabled": true,
                     },
                     "functionLikeReturnTypes": {
                         "enabled": true,
                     },
-                    "enumMemberValues":{
+                    "enumMemberValues": {
                         "enabled": true,
                     }
                 }
             },
-            "vtsls":
-            {"experimental": {
-                "completion": {
-                    "enableServerSideFuzzyMatch": true,
-                    "entriesLimit": 5000,
+            "vtsls": {
+                "experimental": {
+                    "completion": {
+                        "enableServerSideFuzzyMatch": true,
+                        "entriesLimit": 5000,
+                    }
                 }
-            }
             }
         })))
     }
@@ -220,40 +216,36 @@ impl LspAdapter for VtslsLspAdapter {
                 "format": {
                     "enable": true
                 },
-                "inlayHints":{
-                    "parameterNames":
-                    {
+                "inlayHints": {
+                    "parameterNames": {
                         "enabled": "all",
                         "suppressWhenArgumentMatchesName": false,
-
                     },
-
-                    "parameterTypes":
-                    {
+                    "parameterTypes": {
                         "enabled": true
                     },
                     "variableTypes": {
                         "enabled": true,
                         "suppressWhenTypeMatchesName": false,
                     },
-                    "propertyDeclarationTypes":{
+                    "propertyDeclarationTypes": {
                         "enabled": true,
                     },
                     "functionLikeReturnTypes": {
                         "enabled": true,
                     },
-                    "enumMemberValues":{
+                    "enumMemberValues": {
                         "enabled": true,
                     }
-            }
-            },
-            "vtsls":
-            {"experimental": {
-                "completion": {
-                    "enableServerSideFuzzyMatch": true,
-                    "entriesLimit": 5000,
                 }
-            }
+            },
+            "vtsls": {
+                "experimental": {
+                    "completion": {
+                        "enableServerSideFuzzyMatch": true,
+                        "entriesLimit": 5000,
+                    }
+                }
             }
         }))
     }


### PR DESCRIPTION
This PR cleans up the formatting of the `json!` literal used to provided `vtsls` configuration.

Release Notes:

- N/A
