### PR TITLE
wayland: Set window urgency hint when `activate` is called

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -345,7 +345,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093"
 dependencies = [
- "async-fs 2.1.1",
+ "async-fs 2.1.2",
  "async-net 2.0.0",
  "enumflags2",
  "futures-channel",
@@ -481,7 +481,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258b52a1aa741b9f09783b2d86cf0aeeb617bbf847f6933340a39644227acbdb"
 dependencies = [
- "event-listener 5.1.0",
+ "event-listener 5.3.1",
  "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
@@ -505,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.1.0",
+ "event-listener 5.3.1",
  "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
@@ -550,15 +550,14 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
 dependencies = [
- "async-lock 2.8.0",
  "async-task",
  "concurrent-queue",
- "fastrand 1.9.0",
- "futures-lite 1.13.0",
+ "fastrand 2.0.0",
+ "futures-lite 2.2.0",
  "slab",
 ]
 
@@ -576,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
  "async-lock 3.3.0",
  "blocking",
@@ -622,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
 dependencies = [
  "async-lock 3.3.0",
  "cfg-if",
@@ -701,7 +700,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
- "async-io 2.3.1",
+ "async-io 2.3.3",
  "blocking",
  "futures-lite 2.2.0",
 ]
@@ -735,19 +734,21 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.1.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451e3cf68011bd56771c79db04a9e333095ab6349f7e47592b788e9b98720cc8"
+checksum = "f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a"
 dependencies = [
  "async-channel 2.2.0",
- "async-io 2.3.1",
+ "async-io 2.3.3",
  "async-lock 3.3.0",
  "async-signal",
+ "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.1.0",
+ "event-listener 5.3.1",
  "futures-lite 2.2.0",
  "rustix 0.38.32",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -764,13 +765,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -779,7 +780,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io 2.3.1",
+ "async-io 2.3.3",
  "async-lock 2.8.0",
  "atomic-waker",
  "cfg-if",
@@ -838,7 +839,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -857,19 +858,19 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1572,7 +1573,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.59",
+ "syn 2.0.67",
  "which 4.4.2",
 ]
 
@@ -1667,7 +1668,7 @@ source = "git+https://github.com/kvark/blade?rev=21a56f780e21e4cb42c70a1dcf4b598
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1716,18 +1717,15 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
  "async-channel 2.2.0",
- "async-lock 3.3.0",
  "async-task",
- "fastrand 2.0.0",
  "futures-io",
  "futures-lite 2.2.0",
  "piper",
- "tracing",
 ]
 
 [[package]]
@@ -1850,7 +1848,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2263,7 +2261,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2661,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3203,7 +3201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
 dependencies = [
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3723,7 +3721,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3844,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.1.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ad6fd685ce13acd6d9541a30f6db6567a7a24c9ffd4ba2955d29e3f22c8b27"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -3869,7 +3867,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
 dependencies = [
- "event-listener 5.1.0",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -4298,7 +4296,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4552,7 +4550,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4932,6 +4930,7 @@ dependencies = [
  "x11rb",
  "xim",
  "xkbcommon",
+ "zbus",
 ]
 
 [[package]]
@@ -5225,7 +5224,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -5556,7 +5555,7 @@ checksum = "ce243b1bfa62ffc028f1cc3b6034ec63d649f3031bc8a4fbbb004e1ac17d1f68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -5641,7 +5640,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -6225,7 +6224,7 @@ checksum = "ba125974b109d512fccbc6c0244e7580143e460895dfd6ea7f8bbb692fd94396"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -6434,7 +6433,7 @@ name = "markdown_preview"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion 1.0.5",
+ "async-recursion 1.1.1",
  "collections",
  "editor",
  "gpui",
@@ -6798,18 +6797,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
@@ -6818,6 +6805,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -7009,7 +6997,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -7191,8 +7179,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37558cac1af63a81fd2ff7f3469c02a4da06b163c5671791553b8dac10f07c82"
 dependencies = [
  "aes",
- "async-fs 2.1.1",
- "async-io 2.3.1",
+ "async-fs 2.1.2",
+ "async-io 2.3.3",
  "async-lock 3.3.0",
  "blocking",
  "cbc",
@@ -7273,7 +7261,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -7365,7 +7353,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -7468,7 +7456,7 @@ checksum = "e8890702dbec0bad9116041ae586f84805b13eecd1d8b1df27c29998a9969d6d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -7674,7 +7662,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -7734,7 +7722,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -7959,7 +7947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -8016,9 +8004,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -8039,7 +8027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -8321,9 +8309,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -9007,7 +8995,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.59",
+ "syn 2.0.67",
  "walkdir",
 ]
 
@@ -9275,7 +9263,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -9316,7 +9304,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.59",
+ "syn 2.0.67",
  "unicode-ident",
 ]
 
@@ -9507,7 +9495,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -9566,13 +9554,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -10362,7 +10350,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -10530,9 +10518,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10915,7 +10903,7 @@ checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -11141,7 +11129,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -11366,7 +11354,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -12168,7 +12156,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
  "wasm-bindgen-shared",
 ]
 
@@ -12202,7 +12190,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -12339,7 +12327,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -12500,7 +12488,7 @@ checksum = "6d6d967f01032da7d4c6303da32f6a00d5efe1bac124b156e7342d8ace6ffdfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -12770,7 +12758,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand 2.1.2",
- "syn 2.0.59",
+ "syn 2.0.67",
  "witx",
 ]
 
@@ -12782,7 +12770,7 @@ checksum = "512d816dbcd0113103b2eb2402ec9018e7f0755202a5b3e67db726f229d8dcae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
  "wiggle-generate",
 ]
 
@@ -12900,7 +12888,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -12911,7 +12899,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -13245,7 +13233,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -13305,7 +13293,7 @@ version = "0.1.0"
 dependencies = [
  "any_vec",
  "anyhow",
- "async-recursion 1.0.5",
+ "async-recursion 1.1.1",
  "bincode",
  "call",
  "client",
@@ -13543,28 +13531,27 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.0.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8e3d6ae3342792a6cc2340e4394334c7402f3d793b390d2c5494a4032b3030"
+checksum = "23915fcb26e7a9a9dc05fd93a9870d336d6d032cd7e8cebf1c5c37666489fdd5"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs 2.1.1",
- "async-io 2.3.1",
+ "async-fs 2.1.2",
+ "async-io 2.3.3",
  "async-lock 3.3.0",
- "async-process 2.1.0",
- "async-recursion 1.0.5",
+ "async-process 2.2.3",
+ "async-recursion 1.1.1",
  "async-task",
  "async-trait",
  "blocking",
- "derivative",
  "enumflags2",
- "event-listener 5.1.0",
+ "event-listener 5.3.1",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hex",
- "nix 0.27.1",
+ "nix 0.28.0",
  "ordered-stream",
  "rand 0.8.5",
  "serde",
@@ -13582,15 +13569,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.0.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a3e850ff1e7217a3b7a07eba90d37fe9bb9e89a310f718afcde5885ca9b6d7"
+checksum = "02bcca0b586d2f8589da32347b4784ba424c4891ed86aa5b50d5e88f6b2c4f5d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "regex",
- "syn 1.0.109",
+ "syn 2.0.67",
  "zvariant_utils",
 ]
 
@@ -13954,7 +13940,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -13974,7 +13960,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -14060,9 +14046,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.0.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b3ca6db667bfada0f1ebfc94b2b1759ba25472ee5373d4551bb892616389a"
+checksum = "9aa6d31a02fbfb602bfde791de7fedeb9c2c18115b3d00f3a36e489f46ffbbc7"
 dependencies = [
  "endi",
  "enumflags2",
@@ -14074,24 +14060,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "4.0.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4b236063316163b69039f77ce3117accb41a09567fd24c168e43491e521bc"
+checksum = "642bf1b6b6d527988b3e8193d20969d53700a36eac734d21ae6639db168701c8"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.67",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bedb16a193cc12451873fee2a1bc6550225acece0e36f333e68326c73c8172"
+checksum = "fc242db087efc22bd9ade7aa7809e4ba828132edc312871584a6b4391bdf8786"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.67",
 ]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -126,6 +126,7 @@ wayland-protocols-plasma = { version = "0.2.0", features = ["client"] }
 oo7 = "0.3.0"
 open = "5.1.2"
 filedescriptor = "0.8.2"
+zbus = { version = "4.3.0", default-features = false, features = ["async-io"] }
 x11rb = { version = "0.13.0", features = [
     "allow-unsafe-code",
     "xkb",

--- a/crates/gpui/src/platform/linux.rs
+++ b/crates/gpui/src/platform/linux.rs
@@ -1,3 +1,4 @@
+mod dbus;
 mod dispatcher;
 mod headless;
 mod platform;

--- a/crates/gpui/src/platform/linux/dbus/mod.rs
+++ b/crates/gpui/src/platform/linux/dbus/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod unity_launcher;
 
 static SESSION: OnceLock<zbus::Connection> = OnceLock::new();
 
-// TODO: this will spawn a new thread, maybe we could find a way to reuse the ashpd connection?
 pub(crate) async fn connection() -> zbus::Result<zbus::Connection> {
     if let Some(conn) = SESSION.get() {
         Ok(conn.clone())

--- a/crates/gpui/src/platform/linux/dbus/mod.rs
+++ b/crates/gpui/src/platform/linux/dbus/mod.rs
@@ -1,0 +1,15 @@
+use std::sync::OnceLock;
+
+pub(crate) mod unity_launcher;
+
+static SESSION: OnceLock<zbus::Connection> = OnceLock::new();
+
+// TODO: this will spawn a new thread, maybe we could find a way to reuse the ashpd connection?
+pub(crate) async fn connection() -> zbus::Result<zbus::Connection> {
+    if let Some(conn) = SESSION.get() {
+        Ok(conn.clone())
+    } else {
+        let conn = zbus::Connection::session().await?;
+        Ok(SESSION.get_or_init(|| conn).clone())
+    }
+}

--- a/crates/gpui/src/platform/linux/dbus/unity_launcher.rs
+++ b/crates/gpui/src/platform/linux/dbus/unity_launcher.rs
@@ -1,0 +1,82 @@
+//! Implements part of the [Unity Launcher API](https://wiki.ubuntu.com/Unity/LauncherAPI)
+
+use std::hash::Hasher;
+
+use seahash::SeaHasher;
+use zbus::zvariant::{SerializeDict, Type};
+
+use super::connection;
+
+#[derive(SerializeDict, Type, Debug, Default)]
+#[zvariant(signature = "dict")]
+/// Options to pass to [`LauncherEntryProxy::update`]
+pub(crate) struct UpdateOptions {
+    count: Option<u32>,
+    count_visible: Option<bool>,
+    progress: Option<f32>,
+    progress_visible: Option<bool>,
+    urgent: Option<bool>,
+    // Dynamic quicklists are not supported.
+}
+
+#[allow(dead_code)]
+impl UpdateOptions {
+    /// A count badge that will be associated with the icon.
+    pub fn count(mut self, count: impl Into<Option<u32>>) -> Self {
+        self.count = count.into();
+        self
+    }
+
+    /// Sets whether the `count` will be visible.
+    pub fn count_visible(mut self, count_visible: impl Into<Option<bool>>) -> Self {
+        self.count_visible = count_visible.into();
+        self
+    }
+
+    /// Sets the progress to be associated with the icon. The progress value should be between `0.0` and `1.0`.
+    pub fn progress(mut self, progress: impl Into<Option<f32>>) -> Self {
+        self.progress = progress.into();
+        self
+    }
+
+    /// Sets whether the `progress` will be visible.
+    pub fn progress_visible(mut self, progress_visible: impl Into<Option<bool>>) -> Self {
+        self.progress_visible = progress_visible.into();
+        self
+    }
+
+    /// Sets whether the program is asking for user attention.
+    pub fn urgent(mut self, urgent: impl Into<Option<bool>>) -> Self {
+        self.urgent = urgent.into();
+        self
+    }
+}
+
+/// Wrapper for the [LauncherEntry](https://wiki.ubuntu.com/Unity/LauncherAPI#Low_level_DBus_API:_com.canonical.Unity.LauncherEntry) API.
+pub(crate) struct LauncherEntryProxy;
+
+impl LauncherEntryProxy {
+    /// Sends a request to update the launcher entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `app_id` - A URI of the form `application://$desktop_file`
+    /// * `options` - The properties to update (will not override previous properties)
+    pub async fn update(app_uri: &str, options: UpdateOptions) -> zbus::Result<()> {
+        let path = format!(
+            "/com/canonical/unity/launcherentry/{}",
+            hash_app_uri(app_uri)
+        );
+        let msg = zbus::Message::signal(path, "com.canonical.Unity.LauncherEntry", "Update")?
+            .build(&(app_uri, options))?;
+        let conn = connection().await?;
+        conn.send(&msg).await
+    }
+}
+
+// libunity hashes the app_id, and this seems to be enforced by an AppArmor rule
+fn hash_app_uri(app_id: &str) -> u64 {
+    let mut hasher = SeaHasher::new();
+    hasher.write(app_id.as_bytes());
+    hasher.finish()
+}

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -9,6 +9,7 @@ use collections::HashMap;
 use futures::channel::oneshot::Receiver;
 
 use raw_window_handle as rwh;
+use util::ResultExt;
 use wayland_backend::client::ObjectId;
 use wayland_client::WEnum;
 use wayland_client::{protocol::wl_surface, Proxy};
@@ -705,7 +706,7 @@ impl WaylandWindowStatePtr {
                 .spawn(async move {
                     LauncherEntryProxy::update(&app_uri, UpdateOptions::default().urgent(urgent))
                         .await
-                        .ok();
+                        .log_err();
                 })
                 .detach();
         }


### PR DESCRIPTION
This PR adds support for the [LauncherEntry](https://wiki.ubuntu.com/Unity/LauncherAPI) API, which lets a program set various display properties for its task bar icon.

This is mainly about setting the urgency hint when `activate()` is called, e.g. when opening a file from the CLI the icon is easier to distinguish from other programs.
![image](https://github.com/zed-industries/zed/assets/71973804/4f16fb9f-00a4-47ef-ba2a-3426cfa0a4b0)
_(after opening a file from the CLI)_

The API also allows doing other stuff like this:
![image](https://github.com/zed-industries/zed/assets/71973804/d1ca14d7-c153-4e43-ab03-d55f4d4a2eb8)


This should work on KDE and also on Ubuntu (thanks to the dash to dock panel)

Related issue: https://github.com/zed-industries/zed/issues/12557

Release Notes:

- N/A
