### PR TITLE
Make `AssistantProviderContent::OpenAi.available_models` default to None

### DIFF
--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -275,7 +275,7 @@ impl AssistantSettingsContent {
                         default_model: settings.default_open_ai_model.clone(),
                         api_url: Some(open_ai_api_url.clone()),
                         low_speed_timeout_in_seconds: None,
-                        available_models: Some(Default::default()),
+                        available_models: None,
                     })
                 } else {
                     settings.default_open_ai_model.clone().map(|open_ai_model| {
@@ -283,7 +283,7 @@ impl AssistantSettingsContent {
                             default_model: Some(open_ai_model),
                             api_url: None,
                             low_speed_timeout_in_seconds: None,
-                            available_models: Some(Default::default()),
+                            available_models: None,
                         }
                     })
                 },
@@ -350,7 +350,7 @@ impl AssistantSettingsContent {
                                 default_model: Some(model),
                                 api_url: None,
                                 low_speed_timeout_in_seconds: None,
-                                available_models: Some(Default::default()),
+                                available_models: None,
                             })
                         }
                         LanguageModel::Anthropic(model) => {


### PR DESCRIPTION
This is a follow-up for:
+ #13276 

I noticed that `AssistantProviderContent::OpenAi.available_models` should default to None, otherwise, an empty available_models would be filled in user settings, which might be confusing for users.

Release Notes:

- N/A
