### PR TITLE
Fix font feature tag validation

### DIFF
--- a/crates/gpui/src/text_system/font_features.rs
+++ b/crates/gpui/src/text_system/font_features.rs
@@ -144,15 +144,14 @@ impl schemars::JsonSchema for FontFeatures {
 }
 
 fn is_valid_feature_tag(tag: &str) -> bool {
-    let raw_bytes = tag.bytes();
-    if raw_bytes.len() != 4 {
+    if tag.len() != 4 {
         return false;
     }
-    for ch in raw_bytes.into_iter() {
+    for ch in tag.chars() {
         match ch {
-            48..=57 => continue,  // 0 ... 9
-            65..=90 => continue,  // A ... Z
-            97..=122 => continue, // a ... z
+            '0'..='9' => continue,
+            'A'..='Z' => continue,
+            'a'..='z' => continue,
             _ => return false,
         }
     }

--- a/crates/gpui/src/text_system/font_features.rs
+++ b/crates/gpui/src/text_system/font_features.rs
@@ -58,7 +58,7 @@ impl<'de> serde::Deserialize<'de> for FontFeatures {
                 while let Some((key, value)) =
                     access.next_entry::<String, Option<FeatureValue>>()?
                 {
-                    if key.len() != 4 || !key.is_ascii() {
+                    if !is_valid_feature_tag(&key) {
                         log::error!("Incorrect font feature tag: {}", key);
                         continue;
                     }
@@ -141,4 +141,20 @@ impl schemars::JsonSchema for FontFeatures {
         }
         schema.into()
     }
+}
+
+fn is_valid_feature_tag(tag: &str) -> bool {
+    let raw_bytes = tag.bytes();
+    if raw_bytes.len() != 4 {
+        return false;
+    }
+    for ch in raw_bytes.into_iter() {
+        match ch {
+            48..=57 => continue,  // 0 ... 9
+            65..=90 => continue,  // A ... Z
+            97..=122 => continue, // a ... z
+            _ => return false,
+        }
+    }
+    true
 }

--- a/crates/gpui/src/text_system/font_features.rs
+++ b/crates/gpui/src/text_system/font_features.rs
@@ -148,11 +148,8 @@ fn is_valid_feature_tag(tag: &str) -> bool {
         return false;
     }
     for ch in tag.chars() {
-        match ch {
-            '0'..='9' => continue,
-            'A'..='Z' => continue,
-            'a'..='z' => continue,
-            _ => return false,
+        if !ch.is_ascii_alphanumeric() {
+            return false;
         }
     }
     true

--- a/crates/gpui/src/text_system/font_features.rs
+++ b/crates/gpui/src/text_system/font_features.rs
@@ -58,7 +58,7 @@ impl<'de> serde::Deserialize<'de> for FontFeatures {
                 while let Some((key, value)) =
                     access.next_entry::<String, Option<FeatureValue>>()?
                 {
-                    if key.len() != 4 && !key.is_ascii() {
+                    if key.len() != 4 || !key.is_ascii() {
                         log::error!("Incorrect font feature tag: {}", key);
                         continue;
                     }


### PR DESCRIPTION
The previous implementation that I implemented had two issues:
1. It did not throw an error when the user input some invalid values such as "panic".
2. The feature tag for OpenType fonts should be a combination of letters and digits. We only checked if the input was an ASCII character, which could lead to undefined behavior.

Closes #13517 

Release Notes:

- N/A
