### PR TITLE
json: Fix package-version-server referencing the wrong path to the binary

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -348,7 +348,7 @@ impl LspAdapter for NodeVersionAdapter {
         }
 
         Ok(LanguageServerBinary {
-            path: destination_path.join("package-version-server"),
+            path: destination_path,
             env: None,
             arguments: Default::default(),
         })


### PR DESCRIPTION
We were trying to access the binary at package-version-server-{VERSION}/package-version-server, whereas the binary itself is placed at package-version-server-{VERSION}

Release Notes:

- Fixed package.json language server failing to start.
