### PR TITLE
Add `shift shift` to open command palette

### DIFF
--- a/assets/keymaps/jetbrains.json
+++ b/assets/keymaps/jetbrains.json
@@ -78,6 +78,7 @@
     "bindings": {
       "cmd-shift-o": "file_finder::Toggle",
       "cmd-shift-a": "command_palette::Toggle",
+      "shift shift": "command_palette::Toggle",
       "cmd-alt-o": "project_symbols::Toggle",
       "cmd-1": "workspace::ToggleLeftDock",
       "cmd-6": "diagnostics::Deploy"


### PR DESCRIPTION
I've add `shift shift` as a default keybinding to open command palette, when using JetBrains keymap, along with the already existing `cmd-shift-a`. This isn't quite right, as in JetBrains, `cmd-shift-a` opens the actions modal, which would be our command palette, and `shift shift` actually opens up a view for searching everything, commands, actions, settings, etc - we do not have a unified modal for these things, so I think this is the best thing we can do. Some users might want to change this to be our file picker, but I think adding it as the default at least puts it on their radar that they can use this type of binding; they can change it if they want.

Release Notes:

- Added `shift shift` as a default binding to open the command palette in the JetBrains keymap.
