### PR TITLE
Release notes upload fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
             target/aarch64-apple-darwin/release/Zed-aarch64.dmg
             target/x86_64-apple-darwin/release/Zed-x86_64.dmg
             target/release/Zed.dmg
-          body_file: target/release-notes.md
+          body_path: target/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
I ran a Preview Release build today and saw this in the actions output:

<img width="950" alt="image" src="https://github.com/zed-industries/zed/assets/145113/89846bb7-6c5c-4981-b9c3-9e527dbefa3d">

My assumption is that this job is supposed to pre-populate the release notes for the newly created draft release (it did not).

Release Notes:

- N/A
