### PR TITLE
fix font fallback

### DIFF
--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 use std::ops::Range;
 
 use gpui::*;
@@ -93,7 +92,7 @@ impl TextInput {
 
     fn paste(&mut self, _: &Paste, cx: &mut ViewContext<Self>) {
         if let Some(item) = cx.read_from_clipboard() {
-            self.replace_text_in_range(None, &item.text().replace("\n", ""), cx);
+            self.replace_text_in_range(None, &item.text().replace('\n', ""), cx);
         }
     }
 
@@ -479,7 +478,7 @@ fn main() {
                 .into(),
         ];
 
-        cx.text_system().add_fonts(fonts);
+        cx.text_system().add_fonts(fonts).unwrap();
         cx.bind_keys([
             KeyBinding::new("backspace", Backspace, None),
             KeyBinding::new("delete", Delete, None),

--- a/crates/gpui/src/platform/cosmic_text/text_system.rs
+++ b/crates/gpui/src/platform/cosmic_text/text_system.rs
@@ -379,7 +379,6 @@ impl CosmicTextSystemState {
                 offs..(offs + run.len),
                 Attrs::new()
                     .family(Family::Name(&font.families.first().unwrap().0))
-                    .stretch(font.stretch)
                     .style(font.style)
                     .weight(font.weight),
             );


### PR DESCRIPTION
Fixes font fallbacks on linux by neglecting to tell cosmic text the stretch.
Zed Mono/Sans have the stretch set to "Expanded", but the entire (hardcoded)
fallback stack is "Standard".

Let's fallback to something instead of nothing (until we can replace this
system with a fontconfig backed one)

Fixes: #9310

### Or...

Release Notes:

- N/A
