### PR TITLE
Add jq as a dependency for Linux script for Arch Linux

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -109,6 +109,7 @@ if [[ -n $pacman ]]; then
     pkgconf
     mold
     sqlite
+    jq
   )
   $maysudo "$pacman" -S --needed --noconfirm "${deps[@]}"
   exit 0


### PR DESCRIPTION
## Error
```sh
./script/install-linux 

+ [[ 0 -gt 0 ]]
+ export ZED_CHANNEL=dev
+ ZED_CHANNEL=dev
++ pwd
+ export 'ZED_UPDATE_EXPLANATION=You need to fetch and rebuild zed in /home/adityakrcodes/repos/zed'
+ ZED_UPDATE_EXPLANATION='You need to fetch and rebuild zed in /home/adityakrcodes/repos/zed'
+ script/bundle-linux
+ getopts h flag
+ export ZED_BUNDLE=true
+ ZED_BUNDLE=true
+ channel=dev
++ script/get-crate-version zed
script/get-crate-version: line 16: jq: command not found <-- ERROR
+ version=
```
The script fails to install zed on Arch Linux due to a missing dependency, `jq`.
## My machine info
OS: Arch Linux
Kernel: 6.6.34-1-lts 
WM: dwm 
Terminal: kitty
CPU: Ryzen 5 5500U with Radeon Graphics
GPU: AMD ATI 04:00.0 Lucienne 
Memory: 16 GB

## Error Description
The error occurs when running the script in `script/install-linux`, which is unable to find the `jq` package, which is not installed by default on the machine.
## Solution
To resolve this issue, you can install `jq` independently by running `sudo pacman -S jq`. Alternatively, I have updated script `script/linux` to include `jq` as a dependency ([link to the commit](https://github.com/adityakrcodes/zed/commit/2349ad111f48bf8c571e3710bdb317ee151fabdb)), ensuring it is installed automatically when running the initial script for system libraries.

Release Notes:

- N/A