### PR TITLE
Fix PageUp for context menu

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6812,6 +6812,16 @@ impl Editor {
             return;
         }
 
+        if self
+            .context_menu
+            .write()
+            .as_mut()
+            .map(|menu| menu.select_first(self.project.as_ref(), cx))
+            .unwrap_or(false)
+        {
+            return;
+        }
+
         if matches!(self.mode, EditorMode::SingleLine { .. }) {
             cx.propagate();
             return;


### PR DESCRIPTION
The PageUp key was not working for the context menu. Instead of selecting one of the previous items in the context menu, `MovePageUp` closed the menu and scrolled the editor. `MovePageDown` was working correctly because it has the same fix.



Release Notes:

- Fixed `PageUp` for context menu, it doesn't close a context menu anymore if one is active
