### PR TITLE
Store starts open state of outline panel

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -272,6 +272,7 @@ pub enum Event {
 #[derive(Serialize, Deserialize)]
 struct SerializedOutlinePanel {
     width: Option<Pixels>,
+    active: Option<bool>,
 }
 
 pub fn init_settings(cx: &mut AppContext) {
@@ -312,6 +313,7 @@ impl OutlinePanel {
             if let Some(serialized_panel) = serialized_panel {
                 panel.update(cx, |panel, cx| {
                     panel.width = serialized_panel.width.map(|px| px.round());
+                    panel.active = serialized_panel.active.unwrap_or(false);
                     cx.notify();
                 });
             }
@@ -407,12 +409,13 @@ impl OutlinePanel {
 
     fn serialize(&mut self, cx: &mut ViewContext<Self>) {
         let width = self.width;
+        let active = Some(self.active);
         self.pending_serialization = cx.background_executor().spawn(
             async move {
                 KEY_VALUE_STORE
                     .write_kvp(
                         OUTLINE_PANEL_KEY.into(),
-                        serde_json::to_string(&SerializedOutlinePanel { width })?,
+                        serde_json::to_string(&SerializedOutlinePanel { width, active })?,
                     )
                     .await?;
                 anyhow::Ok(())
@@ -2522,7 +2525,7 @@ impl Panel for OutlinePanel {
     }
 
     fn starts_open(&self, _: &WindowContext) -> bool {
-        self.active_item.is_some()
+        self.active
     }
 
     fn set_active(&mut self, active: bool, cx: &mut ViewContext<Self>) {
@@ -2551,6 +2554,7 @@ impl Panel for OutlinePanel {
                 }
             }
         }
+        self.serialize(cx);
     }
 }
 


### PR DESCRIPTION

### Release Notes:

- Fixed issue where outline panel remains open despite being closed before window close.

Before the release of Outline Panel feature, everything works fine. But after that, the outline panel keeps open. It's very annoy that I only want to edit a simple file. Event I close it before I close the window. The active state of this panel didn't stored.

### Description:
Before the introduction of the Outline Panel feature, the application behaved as expected. However, with the addition of the Outline Panel, an issue arose where the panel would persistently remain open. This behavior was observed even when manually closing the panel before closing the application window. The problem stemmed from the inactive state of the panel not being stored properly. This fix addresses the issue by ensuring that the panel's active state is correctly stored and retrieved, thereby improving user experience and preventing unnecessary persistence of the panel's visibility.

### Screen Records

#### Before Release of Outline Panel

https://github.com/zed-industries/zed/assets/704762/2a222c70-c6d7-4472-9f27-7868d1786a5f


#### After Release of Outline Panel

https://github.com/zed-industries/zed/assets/704762/69c16a5d-beed-4d4a-8341-83c53f6a6713


#### After Fixing This Issue

https://github.com/zed-industries/zed/assets/704762/f51c5df7-54e3-4a62-ac54-b5d12cfe69d1


