### PR TITLE
Add support for .markdown extension

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -94,6 +94,7 @@
     "lua": "lua",
     "m4a": "audio",
     "m4v": "video",
+    "markdown": "document",
     "md": "document",
     "mdb": "storage",
     "mdf": "storage",

--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -1,6 +1,6 @@
 name = "Markdown"
 grammar = "markdown"
-path_suffixes = ["md", "mdx", "mdwn"]
+path_suffixes = ["md", "mdx", "mdwn", "markdown"]
 word_characters = ["-"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
Fixes #13608

Release Notes:

- Added recognizing *.markdown files as Markdown ([#13608](https://github.com/zed-industries/zed/issues/13608)).