### PR TITLE
Fix a stupid bug that was dropping system prompts for Claude

### DIFF
--- a/crates/assistant/src/completion_provider/anthropic.rs
+++ b/crates/assistant/src/completion_provider/anthropic.rs
@@ -236,7 +236,7 @@ pub fn preprocess_anthropic_request(request: &mut LanguageModelRequest) {
     }
 
     if !system_message.is_empty() {
-        request.messages.insert(
+        new_messages.insert(
             0,
             LanguageModelRequestMessage {
                 role: Role::System,


### PR DESCRIPTION
Release Notes:

- Fixed a bug that was causing system prompts to be dropped for Anthropic models.

@JosephTLyons @notpeter We probably need to hot-fix this as I'm pretty sure this affects the regular anthropic provider in addition to just the feature-flagged cloud stuff. Wouldn't mind confirming that first so we can communicate around it. 😬 
