### PR TITLE
Use a human-readable date format for the `now` command's label

### DIFF
--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -46,7 +46,7 @@ impl SlashCommand for NowSlashCommand {
         _cx: &mut WindowContext,
     ) -> Task<Result<SlashCommandOutput>> {
         let now = Local::now();
-        let text = format!("Today is {now}.", now = now.to_rfc3339());
+        let text = format!("Today is {now}.", now = now.to_rfc2822());
         let range = 0..text.len();
 
         Task::ready(Ok(SlashCommandOutput {
@@ -54,7 +54,7 @@ impl SlashCommand for NowSlashCommand {
             sections: vec![SlashCommandOutputSection {
                 range,
                 icon: IconName::CountdownTimer,
-                label: now.to_rfc3339().into(),
+                label: now.to_rfc2822().into(),
             }],
             run_commands_in_text: false,
         }))


### PR DESCRIPTION
Before:
![image](https://github.com/zed-industries/zed/assets/2690773/063887fb-1a28-4922-afd1-b2dc4117a03d)

After:
<img width="435" alt="Screenshot 2024-06-28 at 18 52 08" src="https://github.com/zed-industries/zed/assets/2690773/8e9fd285-1991-4088-a93a-5ea3259d364a">
<img width="480" alt="Screenshot 2024-06-28 at 18 52 10" src="https://github.com/zed-industries/zed/assets/2690773/7853fc90-6a63-4e66-bb83-2ed37d41b1b9">


Release Notes:

- N/A
