### PR TITLE
Change the default shortcut for git blame on Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -130,7 +130,7 @@
       "ctrl-k ctrl-r": "editor::RevertSelectedHunks",
       "ctrl-'": "editor::ToggleHunkDiff",
       "ctrl-\"": "editor::ExpandAllHunkDiffs",
-      "ctrl-alt-g b": "editor::ToggleGitBlame"
+      "alt-g b": "editor::ToggleGitBlame"
     }
   },
   {


### PR DESCRIPTION
Zed already has a shortcut assigned to ctrl-alt-g and it's mapped to `search::SelectNextMatch`. Having another multi shortcut with the same prefix makes `ctrl-alt-g` to have a very noticeable delay when pressed.

This commit changes the default shortcut for git blame to `alt-g b`

Release Notes:

- N/A
