### PR TITLE
docs: Make it clearer how to disable ligatures with `buffer_font_features`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -112,12 +112,21 @@ The name of any font family installed on the user's system
 
 Zed supports all OpenType features that can be enabled or disabled for a given buffer or terminal font, as well as setting values for font features.
 
-For example, to disable ligatures and set `cv01` to `7` for a given font you can add the following to your settings:
+For example, to disable font ligatures, add the following to your settings:
 
 ```json
 {
   "buffer_font_features": {
-    "calt": false,
+    "calt": false
+  }
+}
+```
+
+You can also set other OpenType features, like setting `cv01` to `7`:
+
+```json
+{
+  "buffer_font_features": {
     "cv01": 7
   }
 }


### PR DESCRIPTION
This PR updates the docs around disabling font ligatures to make it clearer which OpenType features need to be changed.

Release Notes:

- N/A
