### PR TITLE
gpui example: Fix SVG not showing up when running from root

### DIFF
--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -23,6 +23,11 @@ impl AssetSource for Assets {
     }
 }
 
+const ARROW_CIRCLE_SVG: &'static str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/image/arrow_circle.svg"
+);
+
 struct AnimationExample {}
 
 impl Render for AnimationExample {
@@ -42,7 +47,7 @@ impl Render for AnimationExample {
                     .child(
                         svg()
                             .size_8()
-                            .path("examples/image/arrow_circle.svg")
+                            .path(ARROW_CIRCLE_SVG)
                             .text_color(black())
                             .with_animation(
                                 "image_circle",


### PR DESCRIPTION
Took me a while to figure out that I can't run

    cargo run -p gpui --example animation

and that it has to run in the `gpui` crate.

So I thought I'd fix this.

Release Notes:

- N/A
