### PR TITLE
Remove 'a' from Atom ProjectPanel default keymap

### DIFF
--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -70,10 +70,8 @@
   {
     "context": "ProjectPanel",
     "bindings": {
-      "shift-a": "project_panel::NewDirectory",
       "f2": "project_panel::Rename",
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],
-      "shift-d": "project_panel::Duplicate",
       "cmd-x": "project_panel::Cut",
       "cmd-c": "project_panel::Copy",
       "cmd-v": "project_panel::Paste",
@@ -83,6 +81,14 @@
       "ctrl-]": "project_panel::ExpandSelectedEntry",
       "ctrl-f": "project_panel::ExpandSelectedEntry",
       "ctrl-shift-c": "project_panel::CopyPath"
+    }
+  },
+  {
+    "context": "ProjectPanel && not_editing",
+    "bindings": {
+      "a": "project_panel::NewFile",
+      "shift-a": "project_panel::NewDirectory",
+      "shift-d": "project_panel::Duplicate"
     }
   }
 ]

--- a/assets/keymaps/atom.json
+++ b/assets/keymaps/atom.json
@@ -70,7 +70,6 @@
   {
     "context": "ProjectPanel",
     "bindings": {
-      "a": "project_panel::NewFile",
       "shift-a": "project_panel::NewDirectory",
       "f2": "project_panel::Rename",
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],


### PR DESCRIPTION
Fixes #13647.

Release Notes:

- N/A
