### PR TITLE
Rust: Execute tasks from files ZED_DIRNAME

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -420,12 +420,14 @@ impl ContextProvider for RustContextProvider {
                     "-p".into(),
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
                 label: "cargo check --workspace --all-targets".into(),
                 command: "cargo".into(),
                 args: vec!["check".into(), "--workspace".into(), "--all-targets".into()],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
@@ -444,6 +446,7 @@ impl ContextProvider for RustContextProvider {
                     "--nocapture".into(),
                 ],
                 tags: vec!["rust-test".to_owned()],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
@@ -460,6 +463,7 @@ impl ContextProvider for RustContextProvider {
                     VariableName::Stem.template_value(),
                 ],
                 tags: vec!["rust-mod-test".to_owned()],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
@@ -476,6 +480,7 @@ impl ContextProvider for RustContextProvider {
                     "--bin".into(),
                     RUST_BIN_NAME_TASK_VARIABLE.template_value(),
                 ],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 tags: vec!["rust-main".to_owned()],
                 ..TaskTemplate::default()
             },
@@ -490,18 +495,21 @@ impl ContextProvider for RustContextProvider {
                     "-p".into(),
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
                 label: "cargo run".into(),
                 command: "cargo".into(),
                 args: vec!["run".into()],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
                 label: "cargo clean".into(),
                 command: "cargo".into(),
                 args: vec!["clean".into()],
+                cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
         ]))


### PR DESCRIPTION
Fixes #13267

Release Notes:

- Fixed Rust tests not working when crates Cargo.toml is not at the root of a worktree.
