### PR TITLE
Fix Prettier parser values when formatting files with paths

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -8,7 +8,7 @@
   "theme": {
     "mode": "system",
     "light": "One Light",
-    "dark": "One Dark",
+    "dark": "One Dark"
   },
   // The name of a base set of key bindings to use.
   // This setting can take four values, each named after another
@@ -783,6 +783,11 @@
       }
     },
     "JSON": {
+      "prettier": {
+        "allowed": true
+      }
+    },
+    "JSONC": {
       "prettier": {
         "allowed": true
       }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -128,14 +128,7 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": [
-    "**/.env*",
-    "**/*.pem",
-    "**/*.key",
-    "**/*.cert",
-    "**/*.crt",
-    "**/secrets.yml"
-  ],
+  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -406,9 +399,7 @@
   // The list of language servers to use (or disable) for all languages.
   //
   // This is typically customized on a per-language basis.
-  "language_servers": [
-    "..."
-  ],
+  "language_servers": ["..."],
   // When to automatically save edited buffers. This setting can
   // take four values.
   //
@@ -543,9 +534,7 @@
   },
   "inline_completions": {
     // A list of globs representing files that inline completions should be disabled for.
-    "disabled_globs": [
-      ".env"
-    ]
+    "disabled_globs": [".env"]
   },
   // Settings specific to journaling
   "journal": {
@@ -656,12 +645,7 @@
         // Default directories to search for virtual environments, relative
         // to the current working directory. We recommend overriding this
         // in your project's settings, rather than globally.
-        "directories": [
-          ".env",
-          "env",
-          ".venv",
-          "venv"
-        ],
+        "directories": [".env", "env", ".venv", "venv"],
         // Can also be `csh`, `fish`, and `nushell`
         "activate_script": "default"
       }
@@ -695,10 +679,7 @@
   // }
   //
   "file_types": {
-    "JSONC": [
-      "**/.zed/**/*.json",
-      "**/zed/**/*.json"
-    ]
+    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json"]
   },
   // The extensions that Zed should automatically install on startup.
   //
@@ -712,9 +693,7 @@
     "Astro": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-astro"
-        ]
+        "plugins": ["prettier-plugin-astro"]
       }
     },
     "Blade": {
@@ -734,12 +713,7 @@
       }
     },
     "Elixir": {
-      "language_servers": [
-        "elixir-ls",
-        "!next-ls",
-        "!lexical",
-        "..."
-      ]
+      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
     "Go": {
       "code_actions_on_format": {
@@ -752,12 +726,7 @@
       }
     },
     "HEEX": {
-      "language_servers": [
-        "elixir-ls",
-        "!next-ls",
-        "!lexical",
-        "..."
-      ]
+      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
     "HTML": {
       "prettier": {
@@ -767,17 +736,11 @@
     "Java": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-java"
-        ]
+        "plugins": ["prettier-plugin-java"]
       }
     },
     "JavaScript": {
-      "language_servers": [
-        "!typescript-language-server",
-        "vtsls",
-        "..."
-      ],
+      "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
         "allowed": true
       }
@@ -801,17 +764,11 @@
     "PHP": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "@prettier/plugin-php"
-        ]
+        "plugins": ["@prettier/plugin-php"]
       }
     },
     "Ruby": {
-      "language_servers": [
-        "solargraph",
-        "!ruby-lsp",
-        "..."
-      ]
+      "language_servers": ["solargraph", "!ruby-lsp", "..."]
     },
     "SCSS": {
       "prettier": {
@@ -821,25 +778,17 @@
     "SQL": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-sql"
-        ]
+        "plugins": ["prettier-plugin-sql"]
       }
     },
     "Svelte": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "prettier-plugin-svelte"
-        ]
+        "plugins": ["prettier-plugin-svelte"]
       }
     },
     "TSX": {
-      "language_servers": [
-        "!typescript-language-server",
-        "vtsls",
-        "..."
-      ],
+      "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
         "allowed": true
       }
@@ -850,11 +799,7 @@
       }
     },
     "TypeScript": {
-      "language_servers": [
-        "!typescript-language-server",
-        "vtsls",
-        "..."
-      ],
+      "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
         "allowed": true
       }
@@ -867,9 +812,7 @@
     "XML": {
       "prettier": {
         "allowed": true,
-        "plugins": [
-          "@prettier/plugin-xml"
-        ]
+        "plugins": ["@prettier/plugin-xml"]
       }
     },
     "YAML": {

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -317,11 +317,14 @@ impl Prettier {
                             })
                             .collect();
 
-                        let prettier_parser = prettier_settings.parser.as_deref().or_else(|| buffer_language.and_then(|language| language.prettier_parser_name()));
+                        let mut prettier_parser = prettier_settings.parser.as_deref();
+                        if buffer_path.is_none() {
+                            prettier_parser = prettier_parser.or_else(|| buffer_language.and_then(|language| language.prettier_parser_name()));
+                            if prettier_parser.is_none() {
+                                log::error!("Formatting unsaved file with prettier failed. No prettier parser configured for language {buffer_language:?}");
+                                return Err(anyhow!("Cannot determine prettier parser for unsaved file"));
+                            }
 
-                        if prettier_parser.is_none() && buffer_path.is_none() {
-                            log::error!("Formatting unsaved file with prettier failed. No prettier parser configured for language {buffer_language:?}");
-                            return Err(anyhow!("Cannot determine prettier parser for unsaved file"));
                         }
 
                         log::debug!(


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/13660

Now, as intended, the parser value is passed only if configured in the language settings.

Also, allows to format JSONC by default with Prettier and reformats Zed settings.

Release Notes:

- Fixed Zed Prettier integration always passing parser value for files with paths ([13660](https://github.com/zed-industries/zed/issues/13660))