### PR TITLE
Add support for labelDetails in the completion popup

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1126,8 +1126,7 @@ impl CompletionsMenu {
                                         StyledText::new(completion.label.text.clone())
                                     ).when_some(completion.lsp_completion.label_details.as_ref(), |this, ld| {
                                             this.when_some(ld.detail.as_ref(), |this2, d| {
-                                                    this2.gap_1()
-                                                        .items_start()
+                                                    this2.items_start()
                                                         .child(Label::new(d.clone()).color(Color::Hidden))
                                                     }
                                                 ).when_some(ld.description.as_ref(), |this2, d| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1028,6 +1028,16 @@ impl CompletionsMenu {
                 let documentation = &completion.documentation;
 
                 let mut len = completion.label.text.chars().count();
+
+                if let Some(label_details) = completion.lsp_completion.label_details.as_ref() {
+                    if let Some(d) = label_details.detail.as_ref() {
+                        len += d.chars().count();
+                    }
+                    if let Some(d) = label_details.description.as_ref() {
+                        len += d.chars().count();
+                    }
+                }
+
                 if let Some(Documentation::SingleLine(text)) = documentation {
                     if show_completion_documentation {
                         len += text.chars().count();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1118,8 +1118,25 @@ impl CompletionsMenu {
                                 },
                             ),
                         );
-                        let completion_label = StyledText::new(completion.label.text.clone())
-                            .with_highlights(&style.text, highlights);
+
+                        let completion_label = div()
+                                    .flex()
+                                    .items_start()
+                                    .child(
+                                        StyledText::new(completion.label.text.clone())
+                                    ).when_some(completion.lsp_completion.label_details.as_ref(), |this, ld| {
+                                            this.when_some(ld.detail.as_ref(), |this2, d| {
+                                                    this2.items_start()
+                                                        .child(StyledText::new(d.clone()))
+                                                    }
+                                                ).when_some(ld.description.as_ref(), |this2, d| {
+                                                    this2.items_end()
+                                                        .child(StyledText::new(d.clone()))
+                                                    }
+                                                )
+                                        }
+                                    );
+
                         let documentation_label =
                             if let Some(Documentation::SingleLine(text)) = documentation {
                                 if text.trim().is_empty() {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1126,12 +1126,13 @@ impl CompletionsMenu {
                                         StyledText::new(completion.label.text.clone())
                                     ).when_some(completion.lsp_completion.label_details.as_ref(), |this, ld| {
                                             this.when_some(ld.detail.as_ref(), |this2, d| {
-                                                    this2.items_start()
-                                                        .child(StyledText::new(d.clone()))
+                                                    this2.gap_1()
+                                                        .items_start()
+                                                        .child(Label::new(d.clone()).color(Color::Hidden))
                                                     }
                                                 ).when_some(ld.description.as_ref(), |this2, d| {
                                                     this2.items_end()
-                                                        .child(StyledText::new(d.clone()))
+                                                        .child(Label::new(d.clone()).color(Color::Default))
                                                     }
                                                 )
                                         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1093,7 +1093,6 @@ impl CompletionsMenu {
             move |_editor, range, cx| {
                 let start_ix = range.start;
                 let completions_guard = completions.read();
-
                 matches[range]
                     .iter()
                     .enumerate()
@@ -1131,17 +1130,26 @@ impl CompletionsMenu {
 
                         let completion_label = div()
                                     .flex()
+                                    .flex_grow()
                                     .items_start()
                                     .child(
                                         StyledText::new(completion.label.text.clone())
                                     ).when_some(completion.lsp_completion.label_details.as_ref(), |this, ld| {
                                             this.when_some(ld.detail.as_ref(), |this2, d| {
-                                                    this2.items_start()
-                                                        .child(Label::new(d.clone()).color(Color::Hidden))
+                                                    this2.child(div()
+                                                        .flex_grow()
+                                                        .child(Label::new(d.clone()).color(Color::Hidden)))
                                                     }
-                                                ).when_some(ld.description.as_ref(), |this2, d| {
-                                                    this2.items_end()
-                                                        .child(Label::new(d.clone()).color(Color::Default))
+                                                )
+                                        }
+                                    );
+
+                        let completion_desciption = div()
+                                    .when_some(completion.lsp_completion.label_details.as_ref(), |this, ld| {
+                                            this.when_some(ld.description.as_ref(), |this2, d| {
+                                                    this2.child(div()
+                                                        .items_end()
+                                                        .child(Label::new(d.clone()).color(Color::Default)))
                                                     }
                                                 )
                                         }
@@ -1179,7 +1187,8 @@ impl CompletionsMenu {
                                         task.detach_and_log_err(cx)
                                     }
                                 }))
-                                .child(h_flex().overflow_hidden().child(completion_label))
+                                .child(h_flex().flex_grow().overflow_hidden().child(completion_label))
+                                .child(h_flex().child(completion_desciption))
                                 .end_slot::<Div>(documentation_label),
                         )
                     })


### PR DESCRIPTION
Release Notes:

- Added support for LSP's labelDetails in the completion popup

Before:

![image](https://github.com/zed-industries/zed/assets/44361234/0d860098-cdf8-45aa-b92c-4330f2764e93)

After:

![image](https://github.com/zed-industries/zed/assets/44361234/0bb5c796-d33d-4fd2-a1a5-3b548ce2650b)





Questions:

- Is this the right way to layout the completion popup?
- What about themes? I'm not familiar with this code base, and I don't know rust, so i'll perhaps leave that task for someone else