### PR TITLE
Fix panel state

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3811,18 +3811,18 @@ impl Workspace {
 
                 let docks = serialized_workspace.docks;
 
-                let right = docks.right.clone();
-                workspace
-                    .right_dock
-                    .update(cx, |dock, _| dock.serialized_dock = Some(right));
-                let left = docks.left.clone();
-                workspace
-                    .left_dock
-                    .update(cx, |dock, _| dock.serialized_dock = Some(left));
-                let bottom = docks.bottom.clone();
-                workspace
-                    .bottom_dock
-                    .update(cx, |dock, _| dock.serialized_dock = Some(bottom));
+                for (dock, serialized_dock) in [
+                    (&mut workspace.right_dock, docks.right),
+                    (&mut workspace.left_dock, docks.left),
+                    (&mut workspace.bottom_dock, docks.bottom),
+                ]
+                .iter_mut()
+                {
+                    dock.update(cx, |dock, cx| {
+                        dock.serialized_dock = Some(serialized_dock.clone());
+                        dock.restore_state(cx);
+                    });
+                }
 
                 cx.notify();
             })?;


### PR DESCRIPTION
In the latest update, panel loading occasionally occurred randomly, either before or after workspace deserialization due to their asynchronous nature. This update addresses the issue by ensuring panels restore their state based on serialized data, synchronizing their loading with workspace deserialization.

Release Notes:

- Fixed [#9638](https://github.com/zed-industries/zed/issues/9638)
- Fixed [#12954](https://github.com/zed-industries/zed/issues/12954)

