### PR TITLE
Fix focusing terminal when running tasks

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -371,7 +371,6 @@ impl TerminalPanel {
         spawn_task.args = user_args;
         let spawn_task = spawn_task;
 
-        let reveal = spawn_task.reveal;
         let allow_concurrent_runs = spawn_in_terminal.allow_concurrent_runs;
         let use_new_terminal = spawn_in_terminal.use_new_terminal;
 
@@ -420,20 +419,6 @@ impl TerminalPanel {
                         .ok();
                 }),
             );
-
-            match reveal {
-                RevealStrategy::Always => {
-                    self.activate_terminal_view(existing_item_index, cx);
-                    let task_workspace = self.workspace.clone();
-                    cx.spawn(|_, mut cx| async move {
-                        task_workspace
-                            .update(&mut cx, |workspace, cx| workspace.focus_panel::<Self>(cx))
-                            .ok()
-                    })
-                    .detach();
-                }
-                RevealStrategy::Never => {}
-            }
         }
     }
 


### PR DESCRIPTION
When running tasks, the terminal was not focused when the terminal had to be replaced. This is because the code for revealing the terminal had been executed twise: once inside `replace_terminal` function and also at the end of `spawn_task`.

Fixes #13674

Release Notes:

- Fixed focusing the terminal when re-spawning a task ([#13674](https://github.com/zed-industries/zed/issues/13674)).

After removing the unnecessary reveal strategy handling:


[focus-task-fix.webm](https://github.com/zed-industries/zed/assets/39293/93afd332-8f22-47f5-914d-5bc040e24029)


