### PR TITLE
Improve extension search functionality to Include description field

### DIFF
--- a/crates/collab/src/db/queries/extensions.rs
+++ b/crates/collab/src/db/queries/extensions.rs
@@ -23,7 +23,7 @@ impl Database {
                 .add(extension_version::Column::SchemaVersion.lte(max_schema_version));
             if let Some(filter) = filter {
                 let fuzzy_name_filter = Self::fuzzy_like_string(filter);
-                condition = condition.add(Expr::cust_with_expr("name ILIKE $1", fuzzy_name_filter));
+                condition = condition.add(Expr::cust_with_expr("name ILIKE $1 OR description ILIKE $1",, fuzzy_name_filter));
             }
 
             self.get_extensions_where(condition, Some(limit as u64), &tx)

--- a/crates/collab/src/db/queries/extensions.rs
+++ b/crates/collab/src/db/queries/extensions.rs
@@ -23,7 +23,10 @@ impl Database {
                 .add(extension_version::Column::SchemaVersion.lte(max_schema_version));
             if let Some(filter) = filter {
                 let fuzzy_name_filter = Self::fuzzy_like_string(filter);
-                condition = condition.add(Expr::cust_with_expr("name ILIKE $1 OR description ILIKE $1",, fuzzy_name_filter));
+                condition = condition.add(Expr::cust_with_expr(
+                    "name ILIKE $1 OR description ILIKE $1",
+                    fuzzy_name_filter,
+                ));
             }
 
             self.get_extensions_where(condition, Some(limit as u64), &tx)


### PR DESCRIPTION
Release Notes:

- Improved extension search  ([#10340](https://github.com/zed-industries/zed/issues/10340)).

 Changes 
- Modified the search condition to use `name ILIKE $1 OR description ILIKE $1`, ensuring that the search term is applied to both the name and description fields


NOTE: I haven’t tested this as there’s no support for extension when running the collar server locally(if I'm correct) https://github.com/zed-industries/zed/blob/main/docs/src/development/local-collaboration.md#running-a-local-collab-server