### PR TITLE
Don't override environment's locale

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -320,10 +320,6 @@ impl TerminalBuilder {
         window: AnyWindowHandle,
         completion_tx: Sender<()>,
     ) -> Result<TerminalBuilder> {
-        // TODO: Properly set the current locale,
-        env.entry("LC_ALL".to_string())
-            .or_insert_with(|| "en_US.UTF-8".to_string());
-
         env.insert("ZED_TERM".to_string(), "true".to_string());
 
         let pty_options = {


### PR DESCRIPTION
Previously `LC_ALL` was being set to `en_US.UTF-8` if it wasn't set (which it normally isn't). This would case it to override more specific locale environment variables in addition to `LANG` due to `LC_ALL` being higher on the [locale priority order](https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html). The correct thing to due to not touch any locale environment variables because they will be inherited from the environment, and fallback to `LANG` automatically if unset.

This also prevents the warning messages which are displayed if you don't have the `en_US.UTF-8` locale enabled:
```
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

Release Notes:

- N/A.
