### PR TITLE
Remove invalid symlink in title bar crate

### DIFF
--- a/crates/title_bar/LICENSE_-GPL
+++ b/crates/title_bar/LICENSE_-GPL
@@ -1,1 +1,0 @@
-../../LICENSE_-GPL


### PR DESCRIPTION
This removes an invalid symlink to a non-existing license file, which was added in #13597.

Release Notes:

- N/A
