### PR TITLE
Slightly improve project panel ergonomics

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -557,8 +557,7 @@ impl OutlinePanel {
                     })
                 }
             }
-            excerpt_entry @ EntryOwned::Excerpt(_, excerpt_id, excerpt_range) => {
-                self.toggle_expanded(excerpt_entry, cx);
+            EntryOwned::Excerpt(_, excerpt_id, excerpt_range) => {
                 let scroll_target = multi_buffer_snapshot
                     .anchor_in_excerpt(*excerpt_id, excerpt_range.context.start);
                 if let Some(anchor) = scroll_target {
@@ -2680,10 +2679,20 @@ impl Render for OutlinePanel {
                     h_flex()
                         .pt(Spacing::Small.rems(cx))
                         .justify_center()
-                        .child(Label::new(format!(
-                            "Toggle this panel with {}",
-                            cx.keystroke_text_for(&ToggleFocus)
-                        ))),
+                        .child({
+                            let keystroke = match self.position(cx) {
+                                DockPosition::Left => {
+                                    cx.keystroke_text_for(&workspace::ToggleLeftDock)
+                                }
+                                DockPosition::Bottom => {
+                                    cx.keystroke_text_for(&workspace::ToggleBottomDock)
+                                }
+                                DockPosition::Right => {
+                                    cx.keystroke_text_for(&workspace::ToggleRightDock)
+                                }
+                            };
+                            Label::new(format!("Toggle this panel with {keystroke}",))
+                        }),
                 )
         } else {
             h_flex()


### PR DESCRIPTION
* properly fetch outlines from channel notes and other project-less external files
* show better messages when for no contents
* make file entries collapsible (hiding all excerpts and outlines beneath), keep the initial panel state unfolded up to file level


Release Notes:

- Slightly improved project panel ergonomics