### PR TITLE
zig: Temporarily roll back changes depending on new extension API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13891,7 +13891,7 @@ dependencies = [
 name = "zed_zig"
 version = "0.1.2"
 dependencies = [
- "zed_extension_api 0.0.7",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/zig.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = { path = "../../crates/extension_api" }
+zed_extension_api = "0.0.6"

--- a/extensions/zig/src/zig.rs
+++ b/extensions/zig/src/zig.rs
@@ -43,7 +43,15 @@ impl ZigExtension {
         // them, at time of writing.
         //
         // ZLS tracking issue: https://github.com/zigtools/zls/issues/1879
-        let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
+        // let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
+
+        let release = zed::latest_github_release(
+            "zigtools/zls",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(


### PR DESCRIPTION
This PR temporarily rolls back the changes in #12173 so that we can publish a new version of the Zig extension.

There was a problem stemming from #12614 that caused v0.1.2 of the Zig extension to get re-published with unreleased `zed_extension_api` changes.

Once we publish v0.1.3 we'll be able to revert this change.

Release Notes:

- N/A
