### PR TITLE
zig: Bump to v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13889,7 +13889,7 @@ dependencies = [
 
 [[package]]
 name = "zed_zig"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_zig"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -1,7 +1,7 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Zig extension to v0.1.3 so we can republish with #13709.

Release Notes:

- N/A
