### PR TITLE
zig: Revert `464a4439f7c71e867da481e99e22ad99cc23807e`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13891,7 +13891,7 @@ dependencies = [
 name = "zed_zig"
 version = "0.1.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.0.7",
 ]
 
 [[package]]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/zig.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = { path = "../../crates/extension_api" }

--- a/extensions/zig/src/zig.rs
+++ b/extensions/zig/src/zig.rs
@@ -43,15 +43,7 @@ impl ZigExtension {
         // them, at time of writing.
         //
         // ZLS tracking issue: https://github.com/zigtools/zls/issues/1879
-        // let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
-
-        let release = zed::latest_github_release(
-            "zigtools/zls",
-            zed::GithubReleaseOptions {
-                require_assets: true,
-                pre_release: false,
-            },
-        )?;
+        let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(


### PR DESCRIPTION
This PR reverts the changes from #13709, now that we've published a new version of the Zig extension with them.

This reverts commit 464a4439f7c71e867da481e99e22ad99cc23807e.

Release Notes:

- N/A
