### PR TITLE
assistant: Remove unused `NowPlaceholder`

### DIFF
--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use assistant_slash_command::{SlashCommand, SlashCommandOutput, SlashCommandOutputSection};
-use chrono::{DateTime, Local};
+use chrono::Local;
 use gpui::{AppContext, Task, WeakView};
 use language::LspAdapterDelegate;
-use ui::{prelude::*, ButtonLike, ElevationIndex};
+use ui::prelude::*;
 use workspace::Workspace;
 
 pub(crate) struct NowSlashCommand;
@@ -58,25 +58,5 @@ impl SlashCommand for NowSlashCommand {
             }],
             run_commands_in_text: false,
         }))
-    }
-}
-
-#[derive(IntoElement)]
-struct NowPlaceholder {
-    pub id: ElementId,
-    pub unfold: Arc<dyn Fn(&mut WindowContext)>,
-    pub now: DateTime<Local>,
-}
-
-impl RenderOnce for NowPlaceholder {
-    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
-        let unfold = self.unfold;
-
-        ButtonLike::new(self.id)
-            .style(ButtonStyle::Filled)
-            .layer(ElevationIndex::ElevatedSurface)
-            .child(Icon::new(IconName::CountdownTimer))
-            .child(Label::new(self.now.to_rfc3339()))
-            .on_click(move |_, cx| unfold(cx))
     }
 }


### PR DESCRIPTION
This PR removes the `NowPlaceholder` component, as it was no longer used.

Release Notes:

- N/A
