### PR TITLE
Publish `html_to_markdown`

### DIFF
--- a/crates/html_to_markdown/Cargo.toml
+++ b/crates/html_to_markdown/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "html_to_markdown"
 version = "0.1.0"
+description = "Convert HTML to Markdown"
+repository = "https://github.com/zed-industries/zed"
+documentation = "https://docs.rs/html_to_markdown"
+keywords = ["html", "markdown", "html-to-markdown"]
 edition = "2021"
-publish = false
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 
 [lints]
 workspace = true

--- a/crates/html_to_markdown/LICENSE-APACHE
+++ b/crates/html_to_markdown/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/html_to_markdown/LICENSE-GPL
+++ b/crates/html_to_markdown/LICENSE-GPL
@@ -1,1 +1,0 @@
-../../LICENSE-GPL

--- a/crates/html_to_markdown/src/html_to_markdown.rs
+++ b/crates/html_to_markdown/src/html_to_markdown.rs
@@ -1,4 +1,4 @@
-//! Provides conversion from rustdoc's HTML output to Markdown.
+//! Convert HTML to Markdown.
 
 mod html_element;
 pub mod markdown;


### PR DESCRIPTION
This PR updates the `html_to_markdown` crate with the necessary changes to publish it to crates.io.

Publishing it makes it available for use within extensions when implementing functionality for the Assistant.

Release Notes:

- N/A
