### PR TITLE
assistant: Feature flag terminal inline assistant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "ctor",
  "editor",
  "env_logger",
+ "feature_flags",
  "file_icons",
  "fs",
  "futures 0.3.28",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -23,6 +23,7 @@ client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
 editor.workspace = true
+feature_flags.workspace = true
 file_icons.workspace = true
 fs.workspace = true
 futures.workspace = true

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -462,6 +462,11 @@ impl AssistantPanel {
                 .focus_handle(cx)
                 .contains_focused(cx)
             {
+                use feature_flags::FeatureFlagAppExt;
+                if !cx.has_flag::<feature_flags::TerminalInlineAssist>() {
+                    return None;
+                }
+
                 if let Some(terminal_view) = terminal_panel
                     .read(cx)
                     .pane()

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -29,6 +29,11 @@ impl FeatureFlag for Remoting {
     const NAME: &'static str = "remoting";
 }
 
+pub struct TerminalInlineAssist {}
+impl FeatureFlag for TerminalInlineAssist {
+    const NAME: &'static str = "terminal-inline-assist";
+}
+
 pub trait FeatureFlagViewExt<V: 'static> {
     fn observe_flag<T: FeatureFlag, F>(&mut self, callback: F) -> Subscription
     where


### PR DESCRIPTION
This PR adds a feature flag for the terminal inline assistant because we want to keep it internal for now.

Release Notes:

- N/A
