### PR TITLE
prisma: Bump to v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13840,7 +13840,7 @@ dependencies = [
 
 [[package]]
 name = "zed_prisma"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.4",
 ]

--- a/extensions/prisma/Cargo.toml
+++ b/extensions/prisma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_prisma"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/prisma/extension.toml
+++ b/extensions/prisma/extension.toml
@@ -1,7 +1,7 @@
 id = "prisma"
 name = "Prisma"
 description = "Prisma support."
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = ["Matthew Gramigna <matthewgramigna@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Prisma extension to v0.0.3.

Changes:

- https://github.com/zed-industries/zed/pull/13738

Release Notes:

- N/A
