### PR TITLE
Send telemetry events for pnpm usage

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -203,6 +203,10 @@ impl Telemetry {
             max_queue_size: MAX_QUEUE_LEN,
             worktree_id_map: WorktreeIdMap(HashMap::from_iter([
                 (
+                    "pnpm-lock.yaml".to_string(),
+                    ProjectCache::new("pnpm".to_string()),
+                ),
+                (
                     "yarn.lock".to_string(),
                     ProjectCache::new("yarn".to_string()),
                 ),


### PR DESCRIPTION
This PR adds telemetry events for pnpm usage, similar to what we did for Yarn in #12785.

Seems like useful information to have.

Release Notes:

- N/A
