### PR TITLE
Use regex to properly select Go test runnable

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -518,7 +518,7 @@ impl ContextProvider for GoContextProvider {
                     "test".into(),
                     GO_PACKAGE_TASK_VARIABLE.template_value(),
                     "-run".into(),
-                    VariableName::Symbol.template_value(),
+                    format!("^{}$", VariableName::Symbol.template_value(),),
                 ],
                 tags: vec!["go-test".to_owned()],
                 ..TaskTemplate::default()


### PR DESCRIPTION
This is already done when selecting a subtest; by wrapping the test name with `^{}$` the runnable will avoid selecting additional tests with the same prefix.

Without this fix, selecting the runnable for `TestExample` will also run `TestExample2`.



Release Notes:

- Fixed #13784

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

### Or...

Release Notes:

- N/A
