### PR TITLE
Log extension queries to axiom

### DIFF
--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -53,9 +53,17 @@ async fn get_extensions(
     let extensions = if let Some(extension_ids) = extension_ids {
         app.db.get_extensions_by_ids(&extension_ids, None).await?
     } else {
-        app.db
+        let result = app
+            .db
             .get_extensions(params.filter.as_deref(), params.max_schema_version, 500)
-            .await?
+            .await?;
+
+        if let Some(query) = params.filter.as_deref() {
+            let count = result.len();
+            tracing::info!(query, count, "extension_search")
+        }
+
+        result
     };
 
     Ok(Json(GetExtensionsResponse { data: extensions }))


### PR DESCRIPTION
Log extension queries to axiom. Longer term it'd be nice to get this in
clickhouse, but that requires a bit more work.

Release Notes:

- N/A
