### PR TITLE
JSON: Fix validation being disabled following #13459

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -95,6 +95,10 @@ impl JsonLspAdapter {
                 "format": {
                     "enable": true,
                 },
+                "validate":
+                {
+                    "enable": true,
+                },
                 "schemas": [
                     {
                         "fileMatch": ["tsconfig.json"],


### PR DESCRIPTION
The problem with #13459 was the bump to a newer JSON LS version, which requires explicitly opting into validation.

Release Notes:

- Fixed JSON validation being disabled by default (Preview only)
