### PR TITLE
Rename `ExtensionDocsIndexer` to `ExtensionIndexedDocsProvider`

### DIFF
--- a/crates/extension/src/extension_indexed_docs_provider.rs
+++ b/crates/extension/src/extension_indexed_docs_provider.rs
@@ -9,14 +9,14 @@ use wasmtime_wasi::WasiView;
 
 use crate::wasm_host::{WasmExtension, WasmHost};
 
-pub struct ExtensionDocsIndexer {
+pub struct ExtensionIndexedDocsProvider {
     pub(crate) extension: WasmExtension,
     pub(crate) host: Arc<WasmHost>,
     pub(crate) id: ProviderId,
 }
 
 #[async_trait]
-impl IndexedDocsProvider for ExtensionDocsIndexer {
+impl IndexedDocsProvider for ExtensionIndexedDocsProvider {
     fn id(&self) -> ProviderId {
         self.id.clone()
     }

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -1,5 +1,5 @@
 pub mod extension_builder;
-mod extension_docs_indexer;
+mod extension_indexed_docs_provider;
 mod extension_lsp_adapter;
 mod extension_manifest;
 mod extension_settings;
@@ -9,7 +9,7 @@ mod wasm_host;
 #[cfg(test)]
 mod extension_store_test;
 
-use crate::extension_docs_indexer::ExtensionDocsIndexer;
+use crate::extension_indexed_docs_provider::ExtensionIndexedDocsProvider;
 use crate::extension_manifest::SchemaVersion;
 use crate::extension_slash_command::ExtensionSlashCommand;
 use crate::{extension_lsp_adapter::ExtensionLspAdapter, wasm_host::wit};
@@ -1202,7 +1202,7 @@ impl ExtensionStore {
 
                     for (provider_id, _provider) in &manifest.indexed_docs_providers {
                         this.indexed_docs_registry.register_provider(Box::new(
-                            ExtensionDocsIndexer {
+                            ExtensionIndexedDocsProvider {
                                 extension: wasm_extension.clone(),
                                 host: this.wasm_host.clone(),
                                 id: ProviderId(provider_id.clone()),


### PR DESCRIPTION
This PR renames `ExtensionDocsIndexer` to `ExtensionIndexedDocsProvider` to better align with the name of the trait it implements.

Release Notes:

- N/A
