### PR TITLE
Rust: Prefer completion.label_details over completion.details

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -203,12 +203,10 @@ impl LspAdapter for RustLspAdapter {
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         let detail = completion
-            .detail
+            .label_details
             .as_ref()
-            .or(completion
-                .label_details
-                .as_ref()
-                .and_then(|detail| detail.detail.as_ref()))
+            .and_then(|detail| detail.detail.as_ref())
+            .or(completion.detail.as_ref())
             .map(ToOwned::to_owned);
         match completion.kind {
             Some(lsp::CompletionItemKind::FIELD) if detail.is_some() => {


### PR DESCRIPTION
In doing so we get to surface origin packages more prominently.

Fixes #13494  (again)

Release Notes:

- Fixed origin packages not being surfaced in Rust completions
