### PR TITLE
gleam: Include a package name suffix for docs entries

### DIFF
--- a/extensions/gleam/src/hexdocs.rs
+++ b/extensions/gleam/src/hexdocs.rs
@@ -28,7 +28,7 @@ pub fn index(package: String, database: &KeyValueStore) -> Result<()> {
 
         let (markdown, _modules) = convert_hexdocs_to_markdown(response.body.as_bytes())?;
 
-        database.insert(&module, &markdown)?;
+        database.insert(&format!("{module} ({package})"), &markdown)?;
     }
 
     Ok(())


### PR DESCRIPTION
This PR updates the Gleam docs provider to include the package name as a suffix for docs entries:

<img width="639" alt="Screenshot 2024-07-03 at 5 48 28 PM" src="https://github.com/zed-industries/zed/assets/1486634/0d98ffba-fbab-4511-ae16-e1e742d56f93">

This will help disambiguate modules with the same names from different packages, as well as help out with providing better completions when the package name and top-level module name do not match.

Release Notes:

- N/A
