### PR TITLE
scripts/flatpak: Escape XML characters in convert-release-notes.py

### DIFF
--- a/script/flatpak/convert-release-notes.py
+++ b/script/flatpak/convert-release-notes.py
@@ -1,18 +1,18 @@
+import os
 import re
 import requests
 import sys
 import textwrap
-import os
+
+from html import escape
 
 def clean_line(line: str, in_code_fence: bool) -> str:
-    line = re.sub(r"<", "&lt;", line)
-    line = re.sub(r">", "&gt;", line)
     line = re.sub(r"\(\[(#\d+)\]\([\w|\d\:|\/|\.|\-|_]*\)\)", lambda match: f"[{match.group(1)}]", line)
     line = re.sub(r"\[(#\d+)\]\([\w|\d\:|\/|\.|\-|_]*\)", lambda match: f"[{match.group(1)}]", line)
     if not in_code_fence:
         line = line.strip()
 
-    return line
+    return escape(line)
 
 
 def convert_body(body: str) -> str:


### PR DESCRIPTION
Resolves #13791

Release Notes:

- N/A
