### PR TITLE
Add path_lookup field to BinarySettings in extension API

### DIFF
--- a/crates/extension/src/wasm_host/wit/since_v0_0_7.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_0_7.rs
@@ -325,6 +325,7 @@ impl ExtensionImports for WasmState {
                             binary: settings.binary.map(|binary| settings::BinarySettings {
                                 path: binary.path,
                                 arguments: binary.arguments,
+                                path_lookup: binary.path_lookup,
                             }),
                             settings: settings.settings,
                             initialization_options: settings.initialization_options,

--- a/crates/extension_api/wit/since_v0.0.7/settings.rs
+++ b/crates/extension_api/wit/since_v0.0.7/settings.rs
@@ -26,4 +26,6 @@ pub struct BinarySettings {
     pub path: Option<String>,
     /// The arguments to pass to the binary.
     pub arguments: Option<Vec<String>>,
+    /// Whether to look up the path in the system's PATH.
+    pub path_lookup: Option<bool>,
 }


### PR DESCRIPTION
This improves parity between the configuration of natively supported LSPs (currently Rust, C, and Go) and the possible configuration of LSPs added in an extension. For example, this allows us to change the Swift extension as outlined in my comment on zed-extensions/swift#10, so that it can be configured like this:

```json
{
  "lsp": {
    "sourcekit-lsp": {
      "binary": {
        "path_lookup": true
      }
    }
  }
}
```

Release Notes:

- Added `path_lookup` field to `zed_extension_api::settings::types::BinarySettings`.
