### PR TITLE
windows: Fix `package-version-server`

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -317,11 +317,11 @@ impl LspAdapter for NodeVersionAdapter {
         delegate: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
         let version = latest_version.downcast::<GitHubLspBinaryVersion>().unwrap();
-        #[cfg(target_os = "windows")]
-        let executable_name = format!("package-version-server-{}.exe", version.name);
-        #[cfg(not(target_os = "windows"))]
-        let executable_name = format!("package-version-server-{}", version.name);
-        let destination_path = container_dir.join(executable_name);
+        let destination_path = container_dir.join(format!(
+            "package-version-server-{}{}",
+            version.name,
+            std::env::consts::EXE_SUFFIX
+        ));
         let destination_container_path =
             container_dir.join(format!("package-version-server-{}-tmp", version.name));
         if fs::metadata(&destination_path).await.is_err() {
@@ -341,23 +341,14 @@ impl LspAdapter for NodeVersionAdapter {
                 let archive = Archive::new(decompressed_bytes);
                 archive.unpack(&destination_container_path).await?;
             }
-
-            #[cfg(not(target_os = "windows"))]
-            {
-                fs::copy(
-                    destination_container_path.join("package-version-server"),
-                    &destination_path,
-                )
-                .await?;
-            }
-            #[cfg(target_os = "windows")]
-            {
-                fs::copy(
-                    destination_container_path.join("package-version-server.exe"),
-                    &destination_path,
-                )
-                .await?;
-            }
+            fs::copy(
+                destination_container_path.join(format!(
+                    "package-version-server{}",
+                    std::env::consts::EXE_SUFFIX
+                )),
+                &destination_path,
+            )
+            .await?;
             // todo("windows")
             #[cfg(not(windows))]
             {

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -341,6 +341,7 @@ impl LspAdapter for NodeVersionAdapter {
                 let archive = Archive::new(decompressed_bytes);
                 archive.unpack(&destination_container_path).await?;
             }
+
             fs::copy(
                 destination_container_path.join(format!(
                     "package-version-server{}",


### PR DESCRIPTION
Now, it can run on windows.

![Screenshot 2024-07-04 173832](https://github.com/zed-industries/zed/assets/14981363/d3c17fe3-6e79-46cd-b9a3-f6655109463c)


Release Notes:

- N/A
