### PR TITLE
docs: Update language pages to indicate whether they are native or from an extension

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -1,7 +1,6 @@
 # Elixir
 
-- Tree Sitter: [tree-sitter-elixir](https://github.com/elixir-lang/tree-sitter-elixir)
-- Language Server: [elixir-ls](https://github.com/elixir-lsp/elixir-ls)
+Elixir support is available through the [Elixir extension](https://github.com/zed-industries/zed/tree/main/extensions/elixir).
 
 ## Choosing a language server
 

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -1,5 +1,7 @@
 # Go
 
+Go support is available natively in Zed.
+
 - Tree Sitter: [tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go)
 - Language Server: [gopls](https://github.com/golang/tools/tree/master/gopls)
 

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -1,5 +1,7 @@
 # JavaScript
 
+JavaScript support is available natively in Zed.
+
 - Tree Sitter: [tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript)
 - Language Server: [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
 

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -1,5 +1,7 @@
 # Python
 
+Python support is available natively in Zed.
+
 - Tree Sitter: [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python)
 - Language Server: [pyright](https://github.com/microsoft/pyright)
 

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -1,7 +1,6 @@
 # Ruby
 
-- Tree Sitter: [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby)
-- Language Servers: [solargraph](https://github.com/castwide/solargraph), [ruby-lsp](https://github.com/Shopify/ruby-lsp)
+Ruby support is available through the [Ruby extension](https://github.com/zed-industries/zed/tree/main/extensions/ruby).
 
 ## Choosing a language server
 
@@ -81,7 +80,6 @@ Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell 
   }
 }
 ```
-
 
 ## Using the Tailwind CSS Language Server with Ruby
 

--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -1,5 +1,7 @@
 # Rust
 
+Rust support is available natively in Zed.
+
 - Tree Sitter: [tree-sitter-rust](https://github.com/tree-sitter/tree-sitter-rust)
 - Language Server: [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 


### PR DESCRIPTION
This PR updates the language pages in the docs to indicate whether the support is available natively or provided by an extension.

Release Notes:

- N/A
