### PR TITLE
docs: Add Dart

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -30,6 +30,7 @@
 - [C#](./languages/csharp.md)
 - [Clojure](./languages/clojure.md)
 - [CSS](./languages/css.md)
+- [Dart](./languages/dart.md)
 - [Deno](./languages/deno.md)
 - [Elixir](./languages/elixir.md)
 - [Elm](./languages/elm.md)

--- a/docs/src/languages/dart.md
+++ b/docs/src/languages/dart.md
@@ -1,0 +1,3 @@
+# Dart
+
+Dart support is available through the [Dart extension](https://github.com/zed-industries/zed/tree/main/extensions/dart).


### PR DESCRIPTION
This PR adds Dart support to the docs, as it was one of the first-party extensions that wasn't mentioned anywhere.

Release Notes:

- N/A
