### PR TITLE
linux/x11: Resize on GTK_EDGE_CONSTRAINTS atom

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -54,6 +54,7 @@ x11rb::atom_manager! {
         _MOTIF_WM_HINTS,
         _GTK_SHOW_WINDOW_MENU,
         _GTK_FRAME_EXTENTS,
+        _GTK_EDGE_CONSTRAINTS,
     }
 }
 
@@ -681,7 +682,9 @@ impl X11WindowStatePtr {
 
     pub fn property_notify(&self, event: xproto::PropertyNotifyEvent) {
         let mut state = self.state.borrow_mut();
-        if event.atom == state.atoms._NET_WM_STATE {
+        if event.atom == state.atoms._NET_WM_STATE
+            || event.atom == state.atoms._GTK_EDGE_CONSTRAINTS
+        {
             self.set_wm_properties(state);
         }
     }


### PR DESCRIPTION
With the new window decorations resizing was _really_ laggy on my X11 machine.

Before:
- Click on window border (hitbox doesn't work properly, but that's another issue)
- Drag and resize
- 4-5s nothing happens
- Window is resized

After:
- Click on window border
- Drag and resize
- Window is resized

I'm still not 100% sure on why this happens on my machine and not Conrad's/Mikayla's, but seems like that GTK_EDGE_CONSTRAINTS atom is sent when resizing.

The other thing that I can't explain is that we get a `ConfigureNotify` when resizing, with the right size, but maybe not often enough?

Anyway, for now we'll go with this.

Release Notes:

- N/A
