### PR TITLE
docs: Update the example to set up black formatter in Python

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -58,12 +58,13 @@ A common tool for formatting python code is [Black](https://black.readthedocs.io
 {
   "languages": {
     "Python": {
-      "format_on_save": {
-        "external": {
+      "formatter": {
+         "external": {
           "command": "black",
           "arguments": ["-"]
         }
-      }
+      },
+      "format_on_save": "on"
     }
   }
 }


### PR DESCRIPTION
As titled. The new example is consistent with the instructions in "Configuring Zed". I verified that the example works as expected.

Release Notes:

- N/A
