### PR TITLE
linux: Fix dropping action when action is just started

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1194,7 +1194,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                                         && state.repeat.current_keycode.is_some()
                                         && state.keyboard_focused_window.is_some();
 
-                                    if !is_repeating {
+                                    if !is_repeating || rate == 0 {
                                         return TimeoutAction::Drop;
                                     }
 


### PR DESCRIPTION
```
Thread "main" panicked with "divide by zero error when dividing duration by scalar" at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/time.rs:1172:31
   0: zed::reliability::init_panic_hook::{{closure}}
             at crates/zed/src/reliability.rs:58:29
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/alloc/src/boxed.rs:2036:9
      std::panicking::rust_panic_with_hook
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:799:13
   2: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:664:13
   3: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:171:18
   4: rust_begin_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5
   5: core::panicking::panic_fmt
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:72:14
   6: core::panicking::panic_display
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:263:5
   7: core::option::expect_failed
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/option.rs:1994:5
   8: core::option::Option<T>::expect
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/option.rs:895:21
      <core::time::Duration as core::ops::arith::Div<u32>>::div
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/time.rs:1172:31
   9: <gpui::platform::linux::wayland::client::WaylandClientStatePtr as wayland_client::event_queue::Dispatch<wayland_client::protocol::wl_keyboard::WlKeyboard,()>>::event::{{closure}}
             at crates/gpui/src/platform/linux/wayland/client.rs:1211:63
  10: <core::cell::RefCell<calloop::sources::DispatcherInner<S,F>> as calloop::sources::EventDispatcher<Data>>::process_events::{{closure}}
             at /home/atassis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/calloop-0.13.0/src/sources/mod.rs:327:61
  11: <calloop::sources::timer::Timer as calloop::sources::EventSource>::process_events
             at /home/atassis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/calloop-0.13.0/src/sources/timer.rs:122:38
  12: <core::cell::RefCell<calloop::sources::DispatcherInner<S,F>> as calloop::sources::EventDispatcher<Data>>::process_events
             at /home/atassis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/calloop-0.13.0/src/sources/mod.rs:326:9
  13: calloop::loop_logic::EventLoop<Data>::dispatch_events
             at /home/atassis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/calloop-0.13.0/src/loop_logic.rs:445:31
  14: calloop::loop_logic::EventLoop<Data>::dispatch
             at /home/atassis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/calloop-0.13.0/src/loop_logic.rs:559:9
  15: calloop::loop_logic::EventLoop<Data>::run
             at /home/atassis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/calloop-0.13.0/src/loop_logic.rs:596:13
  16: <gpui::platform::linux::wayland::client::WaylandClient as gpui::platform::linux::platform::LinuxClient>::run
             at crates/gpui/src/platform/linux/wayland/client.rs:655:9
  17: gpui::platform::linux::platform::<impl gpui::platform::Platform for P>::run
             at crates/gpui/src/platform/linux/platform.rs:153:9
  18: gpui::app::App::run
             at crates/gpui/src/app.rs:140:9
  19: zed::main
             at crates/zed/src/main.rs:382:5
  20: core::ops::function::FnOnce::call_once
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:250:5
  21: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:155:18
  22: std::rt::lang_start::{{closure}}
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:159:18
  23: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:284:13
      std::panicking::try::do_call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40
      std::panicking::try
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19
      std::panic::catch_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:141:48
      std::panicking::try::do_call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40
      std::panicking::try
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19
      std::panic::catch_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14
      std::rt::lang_start_internal
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:141:20
  24: std::rt::lang_start
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:158:17
  25: main
  26: __libc_start_call_main
  27: __libc_start_main_impl
  28: _start
```
This error was happening when I started typing. This PR fixes this error.
Fedora 40, latest kernel, gnome 46, wayland.


Release Notes:

- Fixed an error on linux platform, which happens on typing start.

