### PR TITLE
linux/x11: Fix bugs related to unflushed commands

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1072,7 +1072,9 @@ impl LinuxClient for X11Client {
                     ..Default::default()
                 },
             )
-            .expect("failed to change window cursor");
+            .expect("failed to change window cursor")
+            .check()
+            .unwrap();
     }
 
     fn open_uri(&self, uri: &str) {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -607,6 +607,8 @@ impl X11Window {
                 EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
                 message,
             )
+            .unwrap()
+            .check()
             .unwrap();
     }
 
@@ -994,6 +996,7 @@ impl PlatformWindow for X11Window {
                 xproto::Time::CURRENT_TIME,
             )
             .log_err();
+        self.0.xcb_connection.flush().unwrap();
     }
 
     fn is_active(&self) -> bool {
@@ -1022,6 +1025,7 @@ impl PlatformWindow for X11Window {
                 title.as_bytes(),
             )
             .unwrap();
+        self.0.xcb_connection.flush().unwrap();
     }
 
     fn set_app_id(&mut self, app_id: &str) {
@@ -1039,6 +1043,8 @@ impl PlatformWindow for X11Window {
                 xproto::AtomEnum::STRING,
                 &data,
             )
+            .unwrap()
+            .check()
             .unwrap();
     }
 
@@ -1074,6 +1080,8 @@ impl PlatformWindow for X11Window {
                 EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
                 message,
             )
+            .unwrap()
+            .check()
             .unwrap();
     }
 
@@ -1164,6 +1172,8 @@ impl PlatformWindow for X11Window {
                 EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
                 message,
             )
+            .unwrap()
+            .check()
             .unwrap();
     }
 
@@ -1226,6 +1236,8 @@ impl PlatformWindow for X11Window {
                     4,
                     bytemuck::cast_slice::<u32, u8>(&insets),
                 )
+                .unwrap()
+                .check()
                 .unwrap();
         }
     }
@@ -1250,6 +1262,8 @@ impl PlatformWindow for X11Window {
                 5,
                 bytemuck::cast_slice::<u32, u8>(&hints_data),
             )
+            .unwrap()
+            .check()
             .unwrap();
 
         match decorations {


### PR DESCRIPTION
**Edit**:

This PR adds flushes to functions which should have an immediate affect. I've observed it fixing the following bugs (but there are probably more):

- The cursor not updating when just hovering.
- The window not maximising after clicking the full-screen button until you move the mouse.
- The window not minimising after clicking the minimise button until you move the mouse.

---

**Original content**:

Following #13646, the cursor style wouldn't change because the `change_window_attributes` command wasn't being flushed. I guess it was working before because something else was flushing it somewhere else so it was never noticed. 

I just added `check()` which flushes the command so that the cursor will actually update when just hovering. Before you would need to interact with the window so that something else could flush the command.

Release Notes:

- N/A
