### PR TITLE
linux/x11: Set transparency to false by default

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -204,8 +204,7 @@ pub struct X11WindowState {
 
 impl X11WindowState {
     fn is_transparent(&self) -> bool {
-        self.decorations == WindowDecorations::Client
-            || self.background_appearance != WindowBackgroundAppearance::Opaque
+        self.background_appearance != WindowBackgroundAppearance::Opaque
     }
 }
 
@@ -441,8 +440,11 @@ impl X11WindowState {
             // Note: this has to be done after the GPU init, or otherwise
             // the sizes are immediately invalidated.
             size: query_render_extent(xcb_connection, x_window),
-            // In case we have window decorations to render
-            transparent: true,
+            // We set it to transparent by default, even if we have client-side
+            // decorations, since those seem to work on X11 even without `true` here.
+            // If the window appearance changes, then the renderer will get updated
+            // too
+            transparent: false,
         };
         xcb_connection.map_window(x_window).unwrap();
 


### PR DESCRIPTION
The previous code lead to a ton of error messages from Blade on my X11 machine, even with *client-side decorations working well!*

As @someone13574 pointed out [here](https://github.com/zed-industries/zed/pull/13611#issuecomment-2201685030) things still work with this being false. And if someone changes a theme with transparent background, then it will get set anyway. We just don't do it by default.

And as @jansol pointed out [here](https://github.com/zed-industries/zed/issues/5040#issuecomment-2096560629):

> On X11 it may be possible to configure a compositor to blur window backgrounds but Zed has no way to influence that.

So we don't lose anything, I think, but get rid of a ton of error messages in the logs.

Proof of shadows etc. still working:

![Screenshot from 2024-07-05 10-17-38](https://github.com/zed-industries/zed/assets/1185253/1216b38b-8011-46e7-b86f-c0f5fc3f6f64)



Release Notes:

- N/A
