### PR TITLE
windows: Fix font clipping issue

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -49,7 +49,8 @@ struct DirectWriteComponent {
 
 struct GlyphRenderContext {
     params: IDWriteRenderingParams3,
-    dc_target: ID2D1DeviceContext4,
+    normal_dc_target: ID2D1DeviceContext4,
+    emoji_dc_target: ID2D1DeviceContext4,
 }
 
 // All use of the IUnknown methods should be "thread-safe".
@@ -127,7 +128,16 @@ impl GlyphRenderContext {
                 DWRITE_RENDERING_MODE1_NATURAL_SYMMETRIC,
                 grid_fit_mode,
             )?;
-            let dc_target = {
+            let normal_dc_target = {
+                let target = d2d1_factory.CreateDCRenderTarget(&get_render_target_property(
+                    DXGI_FORMAT_A8_UNORM,
+                    D2D1_ALPHA_MODE_STRAIGHT,
+                ))?;
+                let target = target.cast::<ID2D1DeviceContext4>()?;
+                target.SetTextRenderingParams(&params);
+                target
+            };
+            let emoji_dc_target = {
                 let target = d2d1_factory.CreateDCRenderTarget(&get_render_target_property(
                     DXGI_FORMAT_B8G8R8A8_UNORM,
                     D2D1_ALPHA_MODE_PREMULTIPLIED,
@@ -137,7 +147,11 @@ impl GlyphRenderContext {
                 target
             };
 
-            Ok(Self { params, dc_target })
+            Ok(Self {
+                params,
+                normal_dc_target,
+                emoji_dc_target,
+            })
         }
     }
 }
@@ -557,7 +571,7 @@ impl DirectWriteState {
     }
 
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
-        let render_target = &self.components.render_context.dc_target;
+        let render_target = &self.components.render_context.emoji_dc_target;
         unsafe {
             render_target.SetUnitMode(D2D1_UNIT_MODE_DIPS);
             render_target.SetDpi(96.0 * params.scale_factor, 96.0 * params.scale_factor);

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -571,7 +571,11 @@ impl DirectWriteState {
     }
 
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
-        let render_target = &self.components.render_context.emoji_dc_target;
+        let render_target = if params.is_emoji {
+            &self.components.render_context.emoji_dc_target
+        } else {
+            &self.components.render_context.normal_dc_target
+        };
         unsafe {
             render_target.SetUnitMode(D2D1_UNIT_MODE_DIPS);
             render_target.SetDpi(96.0 * params.scale_factor, 96.0 * params.scale_factor);


### PR DESCRIPTION
Closes #12737 . Left before this PR, right after.

![Screenshot 2024-07-05 180308](https://github.com/zed-industries/zed/assets/14981363/437baec3-2672-4b19-8595-17a6c564506e)


Release Notes:

- Fixed font rendering clipping issue on Windows.(#12737 )
