### PR TITLE
ui: Don't show tooltip when ButtonLike is selected

### DIFF
--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -507,8 +507,10 @@ impl RenderOnce for ButtonLike {
                         })
                 },
             )
-            .when_some(self.tooltip, |this, tooltip| {
-                this.tooltip(move |cx| tooltip(cx))
+            .when(!self.selected, |this| {
+                this.when_some(self.tooltip, |this, tooltip| {
+                    this.tooltip(move |cx| tooltip(cx))
+                })
             })
             .children(self.children)
     }


### PR DESCRIPTION
This fixes the issue of a tooltip covering the thing that the button has revealed.

It also mirrors what other UI frameworks do. Chrome on Linux behaves the same, and Safari does the same thing on macOS.

It fixes this:

![Screenshot from 2024-07-05 12-39-22](https://github.com/zed-industries/zed/assets/1185253/51ce4347-d12f-463a-9adb-da031fe2f751)


Release Notes:

- N/A
