### PR TITLE
linux/x11: Fix gap when tiling windows side by side

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6491,6 +6491,8 @@ pub fn client_side_decorations(element: impl IntoElement, cx: &mut WindowContext
         cx.set_client_inset(theme::CLIENT_SIDE_DECORATION_SHADOW);
     }
 
+    println!("decorations: {:?}", decorations);
+
     struct GlobalResizeEdge(ResizeEdge);
     impl Global for GlobalResizeEdge {}
 


### PR DESCRIPTION
By leveraging the `_GTK_EDGE_CONSTRAINTS` atom we can get all four booleans for the `Tiling` struct and figure out which side is free when the window is tiled to half of the screen.

For the logic behind the `_GTK_EDGE_CONSTRAINTS` see:
- https://github.com/GNOME/mutter/blob/8e9d13aa3b3baa099ca32bbcb10afb4d9eea4460/src/x11/window-x11.c#L65-L75
- https://github.com/GNOME/mutter/blob/8e9d13aa3b3baa099ca32bbcb10afb4d9eea4460/src/x11/window-x11.c#L1205-L1231

(I used Claude 3.5 Sonnet with our code and these pieces from `mutter` to generate the Rust code, that was pretty sweet)

This fixes the gap in the middle when a GPUI window is tiled to the left and another window to the right.

It's not _perfect_ but it looks a lot better.

Here's a diff that makes it look better:

```diff
diff --git a/crates/gpui/examples/window_shadow.rs b/crates/gpui/examples/window_shadow.rs
index 122231f6b..7fa29dadc 100644
--- a/crates/gpui/examples/window_shadow.rs
+++ b/crates/gpui/examples/window_shadow.rs
@@ -72,8 +72,8 @@ impl Render for WindowShadow {
                     .when(!(tiling.top || tiling.left), |div| div.rounded_tl(rounding))
                     .when(!tiling.top, |div| div.pt(shadow_size))
                     .when(!tiling.bottom, |div| div.pb(shadow_size))
-                    .when(!tiling.left, |div| div.pl(shadow_size))
-                    .when(!tiling.right, |div| div.pr(shadow_size))
+                    .when(!tiling.left, |div| div.pl(shadow_size - border_size))
+                    .when(!tiling.right, |div| div.pr(shadow_size - border_size))
                     .on_mouse_move(|_e, cx| cx.refresh())
                     .on_mouse_down(MouseButton::Left, move |e, cx| {
                         let size = cx.window_bounds().get_bounds().size;
```

But that makes it look weird on Wayland, so I didn't do it.

I think it's fine for now. Chromium looks bad and has a gap, so we're already better.

## Before
![before_1](https://github.com/zed-industries/zed/assets/1185253/875c5cdd-c0be-4295-beb0-bb9ba5beaa52)

![before_2](https://github.com/zed-industries/zed/assets/1185253/0b96be70-4c34-4e99-aeb2-ab741171ad14)

## After
![after_1](https://github.com/zed-industries/zed/assets/1185253/aa51da77-daf1-4ef8-a33f-a83731e0c7e1)
![after_2](https://github.com/zed-industries/zed/assets/1185253/8ce7902d-90b6-4f06-ba2c-626e643abe56)


Release Notes:

- N/A
