### PR TITLE
ocaml: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13841,7 +13841,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ocaml"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/ocaml/Cargo.toml
+++ b/extensions/ocaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ocaml"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/ocaml/extension.toml
+++ b/extensions/ocaml/extension.toml
@@ -1,7 +1,7 @@
 id = "ocaml"
 name = "OCaml"
 description = "OCaml support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Rashid Almheiri <69181766+huwaireb@users.noreply.github.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the OCaml extension to v0.0.2.

Changes:

- https://github.com/zed-industries/zed/pull/13834

Release Notes:

- N/A
