### PR TITLE
Configurable window decorations

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6491,8 +6491,6 @@ pub fn client_side_decorations(element: impl IntoElement, cx: &mut WindowContext
         cx.set_client_inset(theme::CLIENT_SIDE_DECORATION_SHADOW);
     }
 
-    println!("decorations: {:?}", decorations);
-
     struct GlobalResizeEdge(ResizeEdge);
     impl Global for GlobalResizeEdge {}
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -90,6 +90,11 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
             .find(|display| display.uuid().ok() == Some(uuid))
     });
     let app_id = ReleaseChannel::global(cx).app_id();
+    let window_decorations = match std::env::var("ZED_WINDOW_DECORATIONS") {
+        Ok(val) if val == "server" => gpui::WindowDecorations::Server,
+        Ok(val) if val == "client" => gpui::WindowDecorations::Client,
+        _ => gpui::WindowDecorations::Client,
+    };
 
     WindowOptions {
         titlebar: Some(TitlebarOptions {
@@ -105,7 +110,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         display_id: display.map(|display| display.id()),
         window_background: cx.theme().window_background_appearance(),
         app_id: Some(app_id.to_owned()),
-        window_decorations: Some(gpui::WindowDecorations::Client),
+        window_decorations: Some(window_decorations),
         window_min_size: Some(gpui::Size {
             width: px(360.0),
             height: px(240.0),


### PR DESCRIPTION
Introduces the `ZED_WINDOW_DECORATIONS` env variable.

- Not set, defaulting to client-side decorations
- Value is "client": client-side decorations
- Value is "server": server-side decorations

I think it's good to have this escape-hatch next to all possible
detection mechanisms.

Release Notes:

- N/A
