### PR TITLE
Remove stray `println!` for window-side decorations

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6491,8 +6491,6 @@ pub fn client_side_decorations(element: impl IntoElement, cx: &mut WindowContext
         cx.set_client_inset(theme::CLIENT_SIDE_DECORATION_SHADOW);
     }
 
-    println!("decorations: {:?}", decorations);
-
     struct GlobalResizeEdge(ResizeEdge);
     impl Global for GlobalResizeEdge {}
 


### PR DESCRIPTION
This PR removes a stray `println!` that was spamming stdout with the window decorations in use.

Release Notes:

- N/A
