### PR TITLE
Finely scope repl events for runs and output clearing

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -171,7 +171,6 @@
       "enter": "editor::Newline",
       "shift-enter": "editor::Newline",
       "cmd-shift-enter": "editor::NewlineAbove",
-      "cmd-enter": "editor::NewlineBelow",
       "alt-z": "editor::ToggleSoftWrap",
       "cmd-f": "buffer_search::Deploy",
       "cmd-alt-f": [
@@ -195,6 +194,12 @@
       "cmd->": "assistant::QuoteSelection",
       "cmd-<": "assistant::InsertIntoEditor",
       "cmd-alt-e": "editor::SelectEnclosingSymbol"
+    }
+  },
+  {
+    "context": "Editor && mode == full && !jupyter",
+    "bindings": {
+      "cmd-enter": "editor::NewlineBelow"
     }
   },
   {
@@ -635,6 +640,12 @@
     "context": "ProjectPanel && not_editing",
     "bindings": {
       "space": "project_panel::Open"
+    }
+  },
+  {
+    "context": "Editor && jupyter",
+    "bindings": {
+      "cmd-enter": "repl::Run"
     }
   },
   {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1927,6 +1927,11 @@ impl Editor {
             EditorMode::AutoHeight { .. } => "auto_height",
             EditorMode::Full => "full",
         };
+
+        if EditorSettings::get_global(cx).jupyter.enabled {
+            key_context.add("jupyter");
+        }
+
         key_context.set("mode", mode);
         if self.pending_rename.is_some() {
             key_context.add("renaming");

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -25,6 +25,8 @@ pub struct EditorSettings {
     pub expand_excerpt_lines: u32,
     #[serde(default)]
     pub double_click_in_multibuffer: DoubleClickInMultibuffer,
+    #[serde(default)]
+    pub jupyter: Jupyter,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -62,6 +64,15 @@ pub enum DoubleClickInMultibuffer {
     /// Open the excerpt clicked as a new buffer in the new tab, if no `alt` modifier was pressed during double click.
     /// Otherwise, behave as a regular buffer and select the whole word.
     Open,
+}
+
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct Jupyter {
+    /// Whether the Jupyter feature is enabled.
+    ///
+    /// Default: `false`
+    pub enabled: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -217,6 +228,9 @@ pub struct EditorSettingsContent {
     ///
     /// Default: select
     pub double_click_in_multibuffer: Option<DoubleClickInMultibuffer>,
+
+    /// Jupyter REPL settings.
+    pub jupyter: Option<Jupyter>,
 }
 
 // Toolbar related settings

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -35,6 +35,7 @@ theme.workspace = true
 terminal_view.workspace = true
 ui.workspace = true
 uuid.workspace = true
+util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/repl/src/jupyter_settings.rs
+++ b/crates/repl/src/jupyter_settings.rs
@@ -110,6 +110,7 @@ mod tests {
         let store = settings::SettingsStore::test(cx);
         cx.set_global(store);
 
+        EditorSettings::register(cx);
         JupyterSettings::register(cx);
 
         assert_eq!(JupyterSettings::enabled(cx), false);

--- a/crates/repl/src/jupyter_settings.rs
+++ b/crates/repl/src/jupyter_settings.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use editor::EditorSettings;
+use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
@@ -16,18 +18,22 @@ pub enum JupyterDockPosition {
 
 #[derive(Debug, Default)]
 pub struct JupyterSettings {
-    pub enabled: bool,
     pub dock: JupyterDockPosition,
     pub default_width: Pixels,
     pub kernel_selections: HashMap<String, String>,
 }
 
+impl JupyterSettings {
+    pub fn enabled(cx: &AppContext) -> bool {
+        // In order to avoid a circular dependency between `editor` and `repl` crates,
+        // we put the `enable` flag on its settings.
+        // This allows the editor to set up context for key bindings/actions.
+        EditorSettings::get_global(cx).jupyter.enabled
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct JupyterSettingsContent {
-    /// Whether the Jupyter feature is enabled.
-    ///
-    /// Default: `false`
-    enabled: Option<bool>,
     /// Where to dock the Jupyter panel.
     ///
     /// Default: `right`
@@ -51,7 +57,6 @@ impl JupyterSettingsContent {
 impl Default for JupyterSettingsContent {
     fn default() -> Self {
         JupyterSettingsContent {
-            enabled: Some(false),
             dock: Some(JupyterDockPosition::Right),
             default_width: Some(640.0),
             kernel_selections: Some(HashMap::new()),
@@ -74,9 +79,6 @@ impl Settings for JupyterSettings {
         let mut settings = JupyterSettings::default();
 
         for value in sources.defaults_and_customizations() {
-            if let Some(enabled) = value.enabled {
-                settings.enabled = enabled;
-            }
             if let Some(dock) = value.dock {
                 settings.dock = dock;
             }
@@ -110,7 +112,7 @@ mod tests {
 
         JupyterSettings::register(cx);
 
-        assert_eq!(JupyterSettings::get_global(cx).enabled, false);
+        assert_eq!(JupyterSettings::enabled(cx), false);
         assert_eq!(
             JupyterSettings::get_global(cx).dock,
             JupyterDockPosition::Right
@@ -136,7 +138,7 @@ mod tests {
                 .unwrap();
         });
 
-        assert_eq!(JupyterSettings::get_global(cx).enabled, true);
+        assert_eq!(JupyterSettings::enabled(cx), true);
         assert_eq!(
             JupyterSettings::get_global(cx).dock,
             JupyterDockPosition::Left

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -161,9 +161,9 @@ impl RunningKernel {
             };
 
             let runtime_dir = dirs::runtime_dir();
-            fs.create_dir(&runtime_dir).await.with_context(|| {
-                format!("Failed to createa a jupyter runtime dir {runtime_dir:?}")
-            })?;
+            fs.create_dir(&runtime_dir)
+                .await
+                .with_context(|| format!("Failed to create jupyter runtime dir {runtime_dir:?}"))?;
             let connection_path = runtime_dir.join(format!("kernel-zed-{entity_id}.json"));
             let content = serde_json::to_string(&connection_info)?;
             // write out file to disk for kernel

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -160,7 +160,11 @@ impl RunningKernel {
                 kernel_name: Some(format!("zed-{}", kernel_specification.name)),
             };
 
-            let connection_path = dirs::runtime_dir().join(format!("kernel-zed-{entity_id}.json"));
+            let runtime_dir = dirs::runtime_dir();
+            fs.create_dir(&runtime_dir).await.with_context(|| {
+                format!("Failed to createa a jupyter runtime dir {runtime_dir:?}")
+            })?;
+            let connection_path = runtime_dir.join(format!("kernel-zed-{entity_id}.json"));
             let content = serde_json::to_string(&connection_info)?;
             // write out file to disk for kernel
             fs.atomic_write(connection_path.clone(), content).await?;

--- a/crates/repl/src/runtime_panel.rs
+++ b/crates/repl/src/runtime_panel.rs
@@ -62,12 +62,11 @@ impl RuntimePanel {
                         cx.on_focus_in(&focus_handle, Self::focus_in),
                         cx.on_focus_out(&focus_handle, Self::focus_out),
                         cx.observe_global::<SettingsStore>(move |this, cx| {
-                            let settings = JupyterSettings::get_global(cx);
-                            this.set_enabled(settings.enabled, cx);
+                            this.set_enabled(JupyterSettings::enabled(cx), cx);
                         }),
                     ];
 
-                    let enabled = JupyterSettings::get_global(cx).enabled;
+                    let enabled = JupyterSettings::enabled(cx);
 
                     Self {
                         fs,
@@ -273,8 +272,7 @@ impl RuntimePanel {
 }
 
 pub fn run(workspace: &mut Workspace, _: &Run, cx: &mut ViewContext<Workspace>) {
-    let settings = JupyterSettings::get_global(cx);
-    if !settings.enabled {
+    if !JupyterSettings::enabled(cx) {
         return;
     }
 
@@ -292,8 +290,7 @@ pub fn run(workspace: &mut Workspace, _: &Run, cx: &mut ViewContext<Workspace>) 
 }
 
 pub fn clear_outputs(workspace: &mut Workspace, _: &ClearOutputs, cx: &mut ViewContext<Workspace>) {
-    let settings = JupyterSettings::get_global(cx);
-    if !settings.enabled {
+    if !JupyterSettings::enabled(cx) {
         return;
     }
 


### PR DESCRIPTION
Sets up the `cmd-enter` keybinding for the jupyter repl to only apply when enabled.

Release Notes:

- N/A
