### PR TITLE
Fix scrolling sticking to top

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3660,6 +3660,8 @@ impl EditorElement {
                         if scroll_position != current_scroll_position {
                             editor.scroll(scroll_position, axis, cx);
                             cx.stop_propagation();
+                        } else {
+                            cx.notify();
                         }
                     });
                 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3660,7 +3660,7 @@ impl EditorElement {
                         if scroll_position != current_scroll_position {
                             editor.scroll(scroll_position, axis, cx);
                             cx.stop_propagation();
-                        } else {
+                        } else if y < 0. {
                             cx.notify();
                         }
                     });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3661,6 +3661,9 @@ impl EditorElement {
                             editor.scroll(scroll_position, axis, cx);
                             cx.stop_propagation();
                         } else if y < 0. {
+                            // Due to clamping, we may fail to detect cases of overscroll to the top;
+                            // We want the scroll manager to get an update in such cases and detect the change of direction
+                            // on the next frame.
                             cx.notify();
                         }
                     });


### PR DESCRIPTION
The problem seemingly was that scrolling only started after autoscroll has finished. I have added a function to forcefully stop it, which I call when scroll event happens 
Release Notes:

- Fixed delay when changing scrolling direction (#13720)
