### PR TITLE
zed_extension_api: Return structured slash command completions

### DIFF
--- a/crates/extension/src/extension_slash_command.rs
+++ b/crates/extension/src/extension_slash_command.rs
@@ -63,9 +63,9 @@ impl SlashCommand for ExtensionSlashCommand {
                                 completions
                                     .into_iter()
                                     .map(|completion| ArgumentCompletion {
-                                        label: completion.clone(),
-                                        new_text: completion,
-                                        run_command: true,
+                                        label: completion.label,
+                                        new_text: completion.new_text,
+                                        run_command: completion.run_command,
                                     })
                                     .collect(),
                             )

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -20,7 +20,7 @@ use wasmtime::{
 pub use latest::CodeLabelSpanLiteral;
 pub use latest::{
     zed::extension::lsp::{Completion, CompletionKind, InsertTextFormat, Symbol, SymbolKind},
-    zed::extension::slash_command::SlashCommandOutput,
+    zed::extension::slash_command::{SlashCommandArgumentCompletion, SlashCommandOutput},
     CodeLabel, CodeLabelSpan, Command, Range, SlashCommand,
 };
 pub use since_v0_0_4::LanguageServerConfig;
@@ -263,7 +263,7 @@ impl Extension {
         store: &mut Store<WasmState>,
         command: &SlashCommand,
         query: &str,
-    ) -> Result<Result<Vec<String>, String>> {
+    ) -> Result<Result<Vec<SlashCommandArgumentCompletion>, String>> {
         match self {
             Extension::V007(ext) => {
                 ext.call_complete_slash_command_argument(store, command, query)

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -25,7 +25,9 @@ pub use wit::{
         npm_package_latest_version,
     },
     zed::extension::platform::{current_platform, Architecture, Os},
-    zed::extension::slash_command::{SlashCommand, SlashCommandOutput, SlashCommandOutputSection},
+    zed::extension::slash_command::{
+        SlashCommand, SlashCommandArgumentCompletion, SlashCommandOutput, SlashCommandOutputSection,
+    },
     CodeLabel, CodeLabelSpan, CodeLabelSpanLiteral, Command, DownloadedFileType, EnvVars,
     KeyValueStore, LanguageServerInstallationStatus, Range, Worktree,
 };
@@ -114,7 +116,7 @@ pub trait Extension: Send + Sync {
         &self,
         _command: SlashCommand,
         _query: String,
-    ) -> Result<Vec<String>, String> {
+    ) -> Result<Vec<SlashCommandArgumentCompletion>, String> {
         Ok(Vec::new())
     }
 
@@ -247,7 +249,7 @@ impl wit::Guest for Component {
     fn complete_slash_command_argument(
         command: SlashCommand,
         query: String,
-    ) -> Result<Vec<String>, String> {
+    ) -> Result<Vec<SlashCommandArgumentCompletion>, String> {
         extension().complete_slash_command_argument(command, query)
     }
 

--- a/crates/extension_api/wit/since_v0.0.7/extension.wit
+++ b/crates/extension_api/wit/since_v0.0.7/extension.wit
@@ -8,7 +8,7 @@ world extension {
 
     use common.{range};
     use lsp.{completion, symbol};
-    use slash-command.{slash-command, slash-command-output};
+    use slash-command.{slash-command, slash-command-argument-completion, slash-command-output};
 
     /// Initializes the extension.
     export init-extension: func();
@@ -130,7 +130,7 @@ world extension {
     export labels-for-symbols: func(language-server-id: string, symbols: list<symbol>) -> result<list<option<code-label>>, string>;
 
     /// Returns the completions that should be shown when completing the provided slash command with the given query.
-    export complete-slash-command-argument: func(command: slash-command, query: string) -> result<list<string>, string>;
+    export complete-slash-command-argument: func(command: slash-command, query: string) -> result<list<slash-command-argument-completion>, string>;
 
     /// Returns the output from running the provided slash command.
     export run-slash-command: func(command: slash-command, argument: option<string>, worktree: borrow<worktree>) -> result<slash-command-output, string>;

--- a/crates/extension_api/wit/since_v0.0.7/slash-command.wit
+++ b/crates/extension_api/wit/since_v0.0.7/slash-command.wit
@@ -28,4 +28,14 @@ interface slash-command {
         /// The label to display in the placeholder for this section.
         label: string,
     }
+
+    /// A completion for a slash command argument.
+    record slash-command-argument-completion {
+        /// The label to display for this completion.
+        label: string,
+        /// The new text that should be inserted into the command when this completion is accepted.
+        new-text: string,
+        /// Whether the command should be run when accepting this completion.
+        run-command: bool,
+    }
 }

--- a/extensions/gleam/src/gleam.rs
+++ b/extensions/gleam/src/gleam.rs
@@ -4,7 +4,7 @@ use std::fs;
 use zed::lsp::CompletionKind;
 use zed::{
     CodeLabel, CodeLabelSpan, HttpRequest, KeyValueStore, LanguageServerId, SlashCommand,
-    SlashCommandOutput, SlashCommandOutputSection,
+    SlashCommandArgumentCompletion, SlashCommandOutput, SlashCommandOutputSection,
 };
 use zed_extension_api::{self as zed, Result};
 
@@ -154,12 +154,24 @@ impl zed::Extension for GleamExtension {
         &self,
         command: SlashCommand,
         _query: String,
-    ) -> Result<Vec<String>, String> {
+    ) -> Result<Vec<SlashCommandArgumentCompletion>, String> {
         match command.name.as_str() {
             "gleam-project" => Ok(vec![
-                "apple".to_string(),
-                "banana".to_string(),
-                "cherry".to_string(),
+                SlashCommandArgumentCompletion {
+                    label: "apple".to_string(),
+                    new_text: "Apple".to_string(),
+                    run_command: false,
+                },
+                SlashCommandArgumentCompletion {
+                    label: "banana".to_string(),
+                    new_text: "Banana".to_string(),
+                    run_command: false,
+                },
+                SlashCommandArgumentCompletion {
+                    label: "cherry".to_string(),
+                    new_text: "Cherry".to_string(),
+                    run_command: true,
+                },
             ]),
             _ => Ok(Vec::new()),
         }


### PR DESCRIPTION
This PR updates the extension API to use structured slash command completions instead of plain strings.

This allows slash commands defined in extensions to take advantage of the improvements made in #13876.

Release Notes:

- N/A
