### PR TITLE
Explicitly specify php files' formatter for prettier

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -775,7 +775,8 @@
     "PHP": {
       "prettier": {
         "allowed": true,
-        "plugins": ["@prettier/plugin-php"]
+        "plugins": ["@prettier/plugin-php"],
+        "parser": "php"
       }
     },
     "Ruby": {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/13878

Seems that all regular files types are being recognized by Prettier from their paths, but the PHP one does not despite the PHP plugin used when formatting.


Release Notes:

- Fixed PHP prettier formatting, by including `php` parser name into formatting queries ([13878](https://github.com/zed-industries/zed/issues/13878))