### PR TITLE
Treat `flake.lock` files as JSON

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -690,6 +690,7 @@
   // }
   //
   "file_types": {
+    "JSON": ["flake.lock"],
     "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json"]
   },
   // The extensions that Zed should automatically install on startup.


### PR DESCRIPTION
This PR updates the default settings to treat Nix's `flake.lock` files as JSON.

Resolves https://github.com/zed-extensions/nix/issues/2.

Release Notes:

- Nix's `flake.lock` files are now automatically identified as JSON.
