### PR TITLE
Ignore whitespace commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,23 @@
+# .git-blame-ignore-revs
+#
+# This file consists of a list of commits which should be ignored for
+# `git blame` purposes. This is useful for ignore commits which only
+# changed whitespace / indentation / formatting, but did not change
+# the underlying syntax tree.
+#
+# GitHub will pickup this automatically for blame views:
+#   https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+# To use this file locally, run:
+#   git blame --ignore-revs-file .git-blame-ignore-revs
+# To always use this file by-default, run:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Comments are optional, but may provide helpful context.
+
+# 2023-04-20 Set default tab_size for JSON to 2 and apply new formatting
+# https://github.com/zed-industries/zed/pull/2394
+eca93c124a488b4e538946cd2d313bd571aa2b86
+
+# 2024-07-05 Improved formatting of default keymaps (single line per bind)
+# https://github.com/zed-industries/zed/pull/13887
+813cc3f5e537372fc86720b5e71b6e1c815440ab

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,15 +1,15 @@
 # .git-blame-ignore-revs
 #
-# This file consists of a list of commits which should be ignored for
-# `git blame` purposes. This is useful for ignore commits which only
+# This file consists of a list of commits that should be ignored for
+# `git blame` purposes. This is useful for ignoring commits that only
 # changed whitespace / indentation / formatting, but did not change
 # the underlying syntax tree.
 #
-# GitHub will pickup this automatically for blame views:
+# GitHub will pick this up automatically for blame views:
 #   https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
 # To use this file locally, run:
 #   git blame --ignore-revs-file .git-blame-ignore-revs
-# To always use this file by-default, run:
+# To always use this file by default, run:
 #   git config --local blame.ignoreRevsFile .git-blame-ignore-revs
 # To disable this functionality, run:
 #   git config --local blame.ignoreRevsFile ""

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,8 +10,9 @@
 # To use this file locally, run:
 #   git blame --ignore-revs-file .git-blame-ignore-revs
 # To always use this file by-default, run:
-#   git config blame.ignoreRevsFile .git-blame-ignore-revs
-#
+#   git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+# To disable this functionality, run:
+#   git config --local blame.ignoreRevsFile ""
 # Comments are optional, but may provide helpful context.
 
 # 2023-04-20 Set default tab_size for JSON to 2 and apply new formatting


### PR DESCRIPTION
This let's GitHub and the Git cli optionally "skip" certain revs when generating `git blame`.

Here's an example of a diff of `assets/keymaps/default-macos.json` before this file and after:
![image](https://github.com/zed-industries/zed/assets/145113/d8f71150-f072-4a78-aa5c-c360c4de0007)

You can see it bypasses eca93c124a488b4e538946cd2d313bd571aa2b86 and 813cc3f5e537372fc86720b5e71b6e1c815440ab (commits that only changed whitespace) and displays a richer git blame.

In cases where the "ignored" revs in this file introduced purely new changes, e.g. these [changes to .zed/settings.json](https://github.com/zed-industries/zed/commit/813cc3f5e537372fc86720b5e71b6e1c815440ab#diff-abb804d570c3104a261c81b34f0ad1c1d5edb2f62e1318fa5030dbe6ffbdf3d4R17-R22), the git blame still shows the correct commit (813cc3f5e537372fc86720b5e71b6e1c815440ab) despite it's inclusion in this `.git-blame-ignore-revs` file.

Release Notes:

- N/A
