### PR TITLE
Pass `hold: true` to Alacritty for tasks

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -340,7 +340,7 @@ impl TerminalBuilder {
             alacritty_terminal::tty::Options {
                 shell: alac_shell,
                 working_directory: working_directory.clone(),
-                hold: false,
+                hold: !matches!(shell.clone(), Shell::System),
                 env: env.into_iter().collect(),
             }
         };


### PR DESCRIPTION
It seems `hold: false` causes alacritty to close the channel earlier, without waiting for the output from the child command to go to Zed.

Fixes [#13683](https://github.com/zed-industries/zed/issues/13683)

Release Notes:

- Fixed loosing output of a spawned task ([#13683](https://github.com/zed-industries/zed/issues/13683)).

[Screencast from 2024-07-06 18-28-56.webm](https://github.com/zed-industries/zed/assets/39293/4ebef8b5-7c0d-46be-9341-4ac0d809458d)

