### PR TITLE
Add missing clipboard shortcut to default-linux.json

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -44,6 +44,7 @@
       "ctrl-t": "editor::Transpose",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
       "ctrl-delete": "editor::DeleteToNextWordEnd",
+      "shift-delete": "editor::Cut",
       "ctrl-x": "editor::Cut",
       "ctrl-insert": "editor::Copy",
       "ctrl-c": "editor::Copy",


### PR DESCRIPTION
Bind shift-delete to editor::Cut (similar to #11799, which added copy and paste, but not cut)



Release Notes:

- N/A
