### PR TITLE
Fix nushell local env detection by using direnv export

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -540,9 +540,11 @@
     }
   },
   // Configuration for how direnv configuration should be loaded. May take 2 values:
-  // 1. Load direnv configuration through the shell hook
+  // 1. Load direnv configuration through the shell hook, works for POSIX shells and fish.
   //      "direnv": "shell_hook"
-  // 2. Load direnv configuration using `direnv export json` directly
+  // 2. Load direnv configuration using `direnv export json` directly.
+  //    This can help with some shells that otherwise would not detect
+  //    the direnv environment, such as nushell or elvish.
   //      "direnv": "direct"
   "direnv": "shell_hook",
   "inline_completions": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -539,6 +539,12 @@
       // "delay_ms": 600
     }
   },
+  // Configuration for how direnv configuration should be loaded. May take 2 values:
+  // 1. Load direnv configuration through the shell hook
+  //      "direnv": "shell_hook"
+  // 2. Load direnv configuraton using `direnv export json` directly
+  //      "direnv": "direct"
+  "direnv": "shell_hook",
   "inline_completions": {
     // A list of globs representing files that inline completions should be disabled for.
     "disabled_globs": [".env"]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -542,7 +542,7 @@
   // Configuration for how direnv configuration should be loaded. May take 2 values:
   // 1. Load direnv configuration through the shell hook
   //      "direnv": "shell_hook"
-  // 2. Load direnv configuraton using `direnv export json` directly
+  // 2. Load direnv configuration using `direnv export json` directly
   //      "direnv": "direct"
   "direnv": "shell_hook",
   "inline_completions": {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -11727,7 +11727,6 @@ async fn load_shell_environment(
     dir: &Path,
     load_direnv: &DirenvSettings,
 ) -> Result<HashMap<String, String>> {
-    // Start by loading the direnv environment
     let direnv_environment = match load_direnv {
         DirenvSettings::ShellHook => None,
         DirenvSettings::Direct => load_direnv_environment(dir).await?,
@@ -11743,6 +11742,11 @@ async fn load_shell_environment(
     // the project directory to get the env in there as if the user
     // `cd`'d into it. We do that because tools like direnv, asdf, ...
     // hook into `cd` and only set up the env after that.
+    //
+    // If the user selects `Direct` for direnv, it would set an environment
+    // variable that later uses to know that it should not run the hook.
+    // We would include in `.envs` call so it is okay to run the hook
+    // even if direnv direct mode is enabled.
     //
     // In certain shells we need to execute additional_command in order to
     // trigger the behavior of direnv, etc.

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -11701,11 +11701,12 @@ async fn load_direnv_environment(dir: &Path) -> Result<Option<HashMap<String, St
 
     let direnv_output = match direnv_res {
         Ok(output) => output,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(None);
-        }
-        Err(err) => {
-            return Err(err).context("failed to spawn direnv to get local environment variables")
+        Err(e) => {
+            return if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(None)
+            } else {
+                Err(e).context("failed to spawn direnv to get local environment variables")
+            }
         }
     };
 
@@ -11721,8 +11722,7 @@ async fn load_direnv_environment(dir: &Path) -> Result<Option<HashMap<String, St
     }
 
     Ok(Some(
-        serde_json::from_str(&output)
-            .context("failed to parse direnv output")?,
+        serde_json::from_str(&output).context("failed to parse direnv output")?,
     ))
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -11479,9 +11479,9 @@ impl ProjectLspAdapterDelegate {
         })
     }
 
-    async fn load_shell_env(&self, load_direnv: &DirenvSettings) {
+    async fn load_shell_env(&self) {
         let worktree_abs_path = self.worktree.abs_path();
-        let shell_env = load_shell_environment(&worktree_abs_path, &load_direnv)
+        let shell_env = load_shell_environment(&worktree_abs_path, &self.load_direnv)
             .await
             .with_context(|| {
                 format!("failed to determine load login shell environment in {worktree_abs_path:?}")
@@ -11513,14 +11513,14 @@ impl LspAdapterDelegate for ProjectLspAdapterDelegate {
     }
 
     async fn shell_env(&self) -> HashMap<String, String> {
-        self.load_shell_env(&self.load_direnv).await;
+        self.load_shell_env().await;
         self.shell_env.lock().as_ref().cloned().unwrap_or_default()
     }
 
     #[cfg(not(target_os = "windows"))]
     async fn which(&self, command: &OsStr) -> Option<PathBuf> {
         let worktree_abs_path = self.worktree.abs_path();
-        self.load_shell_env(&self.load_direnv).await;
+        self.load_shell_env().await;
         let shell_path = self
             .shell_env
             .lock()

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -20,6 +20,23 @@ pub struct ProjectSettings {
     /// Configuration for Git-related features
     #[serde(default)]
     pub git: GitSettings,
+
+    /// Configuration for how direnv configuration should be loaded
+    #[serde(default)]
+    pub load_direnv: DirenvSettings,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DirenvSettings {
+    /// Load direnv configuration through a shell hook
+    #[default]
+    ShellHook,
+    /// Load direnv configuration directly using `direnv export json`
+    ///
+    /// Warning: This option is experimental and might cause some inconsistent behaviour compared to using the shell hook.
+    /// If it does, please report it to GitHub
+    Direct,
 }
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -182,7 +182,7 @@ left and right padding of the central pane from the workspace when the centered 
 
 ## Direnv Integration
 
-- Description: Settings for direnv integration.
+- Description: Settings for [direnv](https://direnv.net/) integration. Requires `direnv` to be installed. `direnv` integration currently only means that the environment variables set by a `direnv` configuration can be used to detect some language servers in `$PATH` instead of installing them.
 - Setting: `direnv`
 - Default:
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -180,6 +180,22 @@ You can also set other OpenType features, like setting `cv01` to `7`:
 The `left_padding` and `right_padding` options define the relative width of the
 left and right padding of the central pane from the workspace when the centered layout mode is activated. Valid values range is from `0` to `0.4`.
 
+## Direnv Integration
+
+- Description: Settings for direnv integration.
+- Setting: `direnv`
+- Default:
+
+```json
+"direnv": "shell_hook"
+```
+
+**Options**
+There are two options to choose from:
+
+1. `shell_hook`: Use the shell hook to load direnv. This relies on direnv to activate upon entering the directory. Supports POSIX shells and fish.
+2. `direct`: Use `direnv export json` to load direnv. This will load direnv directly without relying on the shell hook and might cause some inconsistencies. This allows direnv to work with any shell.
+
 ## Inline Completions
 
 - Description: Settings for inline completions.


### PR DESCRIPTION
I don't intend fully on getting this merged, this is just an experiment on using `direnv` directly without relying on shell-specific behaviours. It works though, so this finally closes #8633
Release Notes:

- Fixed nushell not picking up `direnv` environments by directly interfacing with it using `direnv export`