### PR TITLE
add cljd file suffix to the Clojure Extension

### DIFF
--- a/extensions/clojure/extension.toml
+++ b/extensions/clojure/extension.toml
@@ -1,7 +1,7 @@
 id = "clojure"
 name = "Clojure"
 description = "Clojure support."
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = ["Paulo Roberto de Oliveira Castro <p.oliveira.castro@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/clojure/languages/clojure/config.toml
+++ b/extensions/clojure/languages/clojure/config.toml
@@ -1,6 +1,6 @@
 name = "Clojure"
 grammar = "clojure"
-path_suffixes = ["clj", "cljs", "cljc", "edn", "bb"]
+path_suffixes = ["clj", "cljs", "cljc", "cljd","edn", "bb"]
 line_comments = [";; "]
 autoclose_before = "}])"
 brackets = [


### PR DESCRIPTION

Release Notes:

- Added `cljd` file support to the Clojure extension to support ClojureDart