### PR TITLE
Fix search/replace start of line anchor

### DIFF
--- a/crates/vim/test_data/test_replace_with_range_at_start.json
+++ b/crates/vim/test_data/test_replace_with_range_at_start.json
@@ -1,0 +1,16 @@
+{"Put":{"state":"ˇa\na\na\na\na\na\na\n "}}
+{"Key":":"}
+{"Key":"2"}
+{"Key":","}
+{"Key":"5"}
+{"Key":"s"}
+{"Key":"/"}
+{"Key":"^"}
+{"Key":"/"}
+{"Key":"b"}
+{"Key":"enter"}
+{"Get":{"state":"a\nba\nba\nba\nˇba\na\na\n ","mode":"Normal"}}
+{"Key":"/"}
+{"Key":"a"}
+{"Key":"enter"}
+{"Get":{"state":"a\nba\nba\nba\nbˇa\na\na\n ","mode":"Normal"}}


### PR DESCRIPTION
This is related to #9428 

I noticed that doing a search and replace for the beginning of a line `^` results in the trailing line being included in the search. This seems to be because of the way the range is generated for generating matches being the up to the start of the trailing line rather than up to the end of the last line.

I added a test and took a stab at fixing it but it is a bit yolo as this is the first time I've seen this codebase.
