### PR TITLE
tailwind: Check user settings for `classAttributes`

### DIFF
--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -158,26 +158,25 @@ impl LspAdapter for TailwindLspAdapter {
                 .unwrap_or_default()
         })?;
 
-        // We need to set this to null if it's not set, because tailwindcss-languageserver
-        // will check whether it's an object and if it is (even if it's empty) it will
-        // ignore the `userLanguages` from the initialization options.
-        let include_languages = tailwind_user_settings
-            .get("includeLanguages")
-            .cloned()
-            .unwrap_or(Value::Null);
-
-        let experimental = tailwind_user_settings
-            .get("experimental")
-            .cloned()
-            .unwrap_or_else(|| json!([]));
-
-        Ok(json!({
+        let mut configuration = json!({
             "tailwindCSS": {
                 "emmetCompletions": true,
-                "includeLanguages": include_languages,
-                "experimental": experimental,
             }
-        }))
+        });
+
+        if let Some(experimental) = tailwind_user_settings.get("experimental").cloned() {
+            configuration["tailwindCSS"]["experimental"] = experimental;
+        }
+
+        if let Some(class_attributes) = tailwind_user_settings.get("classAttributes").cloned() {
+            configuration["tailwindCSS"]["classAttributes"] = class_attributes;
+        }
+
+        if let Some(include_languages) = tailwind_user_settings.get("includeLanguages").cloned() {
+            configuration["tailwindCSS"]["includeLanguages"] = include_languages;
+        }
+
+        Ok(configuration)
     }
 
     fn language_ids(&self) -> HashMap<String, String> {


### PR DESCRIPTION
This addresses the question in [this
comment](https://github.com/zed-industries/zed/issues/5830#issuecomment-2211942554) by adding support for `classAttributes` to the settings.

Meaning that the following Zed `settings.json` now works:

```jsonc
{
  "lsp": {
    "tailwindcss-language-server": {
      "settings": {
        "classAttributes": [
          "class",
          "className",
          "ngClass",

          // add styles so will give intellisense to styles constant.
          "styles"
        ]
        // Optional:
        // "includeLanguages": {
        //   "erb": "html",
        //   "ruby": "html"
        // },
        // "experimental": {
        //   "classRegex": ["\\bclass:\\s*['\"]([^'\"]*)['\"]"]
        // }
      }
    }
  }
}
```



Release Notes:

- Added support for setting `classAttributes` in the configuration for `tailwindcss-language-server`. Example: `{ "lsp": { "tailwindcss-language-server": { "settings": { "classAttributes": [ "class", "className", "ngClass", "styles" ] } } } }`