### PR TITLE
linux/x11: Reset and restore window cursor depending on focus state

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -570,7 +570,7 @@ impl X11Client {
 
                 // Restore previously set cursor style for the window once it gains focus.
                 if let Some(cursor_style) = cursor_style {
-                    self.set_cursor_style(cursor_style.clone());
+                    self.set_cursor_style(cursor_style);
                 }
 
                 self.enable_ime();


### PR DESCRIPTION
This fixes https://github.com/zed-industries/zed/issues/13897 by resetting the cursor to an `Arrow` whenever we lose focus of a window and restoring it when we gain focus back.

What I'm a bit unsure about is this: we seem to be getting 3 events when clicking - `FocusIn`, `FocusOut`, `FocusIn` - even though the window was focused the whole time.

cc @apricotbucket28 since you worked on the cursor style handling.

I think the change is relatively innocent, so might go ahead and merge, but still am curiousa bout thoughts.

Release Notes:

- N/A
