### PR TITLE
x11: Properly update XKB group state

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -585,8 +585,8 @@ impl X11Client {
                     event.base_mods.into(),
                     event.latched_mods.into(),
                     event.locked_mods.into(),
-                    0,
-                    0,
+                    event.base_group as u32,
+                    event.latched_group as u32,
                     event.locked_group.into(),
                 );
 


### PR DESCRIPTION
Pass on all the XkbStateNotify information to XKB.

> "All parameters must always be passed, or the resulting state may be incoherent."
> https://docs.rs/xkbcommon/latest/xkbcommon/xkb/struct.State.html#method.update_mask

Previously, many keymaps using multiple groups/layers would not work and remain in group0.

Release Notes:

- Fixed handling of Xkb keymap groups on X11.