### PR TITLE
clojure: Bump to v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13720,7 +13720,7 @@ dependencies = [
 
 [[package]]
 name = "zed_clojure"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/clojure/Cargo.toml
+++ b/extensions/clojure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_clojure"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/clojure/extension.toml
+++ b/extensions/clojure/extension.toml
@@ -1,7 +1,7 @@
 id = "clojure"
 name = "Clojure"
 description = "Clojure support."
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = ["Paulo Roberto de Oliveira Castro <p.oliveira.castro@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Clojure extension to v0.0.3.

Changes:

- https://github.com/zed-industries/zed/pull/13914
- https://github.com/zed-industries/zed/pull/13933

Release Notes:

- N/A
