### PR TITLE
Better tooltips for back/forward

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -322,7 +322,7 @@
       "alt-9": ["pane::ActivateItem", 8],
       "alt-0": "pane::ActivateLastItem",
       "ctrl-alt--": "pane::GoBack",
-      "ctrl-alt-_": "pane::GoForward",
+      "ctrl-alt-shift--": "pane::GoForward",
       "ctrl-shift-t": "pane::ReopenClosedItem",
       "f3": "search::SelectNextMatch",
       "shift-f3": "search::SelectPrevMatch",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -362,7 +362,7 @@
       "ctrl-9": ["pane::ActivateItem", 8],
       "ctrl-0": "pane::ActivateLastItem",
       "ctrl--": "pane::GoBack",
-      "ctrl-_": "pane::GoForward",
+      "ctrl-shift--": "pane::GoForward",
       "cmd-shift-t": "pane::ReopenClosedItem",
       "cmd-shift-f": "project_search::ToggleFocus"
     }

--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -12,7 +12,7 @@ More themes are available from the Extensions page. You can open the Extensions 
 
 ## Configuring a Theme
 
-Your selected theme is stored in your settings file. You can open your settings file from the command palette with "zed: Open Settings" (bound to `cmd,` on macOS and `ctrl,` on Linux).
+Your selected theme is stored in your settings file. You can open your settings file from the command palette with "zed: Open Settings" (bound to `cmd-,` on macOS and `ctrl-,` on Linux).
 
 By default, Zed maintains two themes: one for light mode and one for dark mode. You can set the mode to `"dark"` or `"light"` to ignore the current system mode.
 


### PR DESCRIPTION
Tooltips for back/forward were kinda confusing.

Fixes #8459

https://github.com/zed-industries/zed/assets/145113/b9d84ca1-e042-4526-9917-0e964d385114

https://github.com/zed-industries/zed/assets/145113/4435befd-e969-410b-9b8e-136c20ff8840


Release Notes:

- Improved back/forward tooltips. ([#8459](https://github.com/zed-industries/zed/issues/8459)).
