### PR TITLE
gpui: Fix hide titlebar on Windows, with `titlebar: None` option

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -252,7 +252,7 @@ impl WindowsWindow {
             .titlebar
             .as_ref()
             .map(|titlebar| titlebar.appears_transparent)
-            .unwrap_or(false);
+            .unwrap_or(true);
         let windowname = HSTRING::from(
             params
                 .titlebar


### PR DESCRIPTION
Release Notes:

- N/A

Ref the macOS Window:

When the `titlebar` is none, the titlebar should be hidden.

https://github.com/zed-industries/zed/blob/adaa4831766cde63b408909cf65cdeb1641e5888/crates/gpui/src/platform/mac/window.rs#L516-L528

```
cargo run -p gpui --example window_positioning
```

## Before

![img_v3_02ck_939c23d0-acc6-40c1-aaf7-c6dd73ddf7ag](https://github.com/zed-industries/zed/assets/5518/f2c7aa02-a102-4f24-8243-74219957d16b)

## After

<img width="466" alt="image" src="https://github.com/zed-industries/zed/assets/5518/176ce4ea-14e9-44c8-8f2d-01e20ff3e543">

