### PR TITLE
Add "copy (absolute) path" menu items for tabs

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     toolbar::Toolbar,
     workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings},
-    CloseWindow, CopyAbsolutePath, CopyPath, NewFile, NewTerminal, OpenInTerminal, OpenTerminal,
+    CloseWindow, CopyAbsolutePath, CopyRelativePath, NewFile, NewTerminal, OpenInTerminal, OpenTerminal,
     OpenVisible, SplitDirection, ToggleFileFinder, ToggleProjectSymbols, ToggleZoom, Workspace,
 };
 use anyhow::Result;
@@ -1797,8 +1797,8 @@ impl Pane {
                             )
                             .when_some(rel_path, |menu, path| {
                                 menu.entry(
-                                    "Copy Path",
-                                    Some(Box::new(CopyPath)),
+                                    "Copy Relative Path",
+                                    Some(Box::new(CopyRelativePath)),
                                     cx.handler_for(&pane, move |_, cx| {
                                         cx.write_to_clipboard(ClipboardItem::new(
                                             path.to_string_lossy().into_owned(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -120,6 +120,8 @@ actions!(
         ClearAllNotifications,
         CloseAllDocks,
         CloseWindow,
+        CopyPath,
+        CopyAbsolutePath,
         Feedback,
         FollowNextCollaborator,
         NewCenterTerminal,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -120,7 +120,7 @@ actions!(
         ClearAllNotifications,
         CloseAllDocks,
         CloseWindow,
-        CopyPath,
+        CopyRelativePath,
         CopyAbsolutePath,
         Feedback,
         FollowNextCollaborator,


### PR DESCRIPTION
So far we have the basic functionality, but it doesn't work on all tabs because some of them don't properly implement for_each_project_item, most notably the image viewer.

Closes #13970. Related to #11181.

Release Notes:

- Added context menu items for tabs to copy the file's path ([#13970](https://github.com/zed-industries/zed/issues/13970)).

![An example of the updated context menu showing "Copy path" and "Copy absolute path"](https://github.com/zed-industries/zed/assets/58113890/80a5e545-63b7-472a-94c4-e923d40df279)
