### PR TITLE
Add a way to filter items in the outline panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7355,6 +7355,7 @@ dependencies = [
  "db",
  "editor",
  "file_icons",
+ "fuzzy",
  "gpui",
  "itertools 0.11.0",
  "language",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -502,6 +502,7 @@
   {
     "context": "OutlinePanel",
     "bindings": {
+      "escape": "menu::Cancel",
       "left": "outline_panel::CollapseSelectedEntry",
       "right": "outline_panel::ExpandSelectedEntry",
       "ctrl-alt-c": "outline_panel::CopyPath",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -523,6 +523,7 @@
   {
     "context": "OutlinePanel",
     "bindings": {
+      "escape": "menu::Cancel",
       "left": "outline_panel::CollapseSelectedEntry",
       "right": "outline_panel::ExpandSelectedEntry",
       "cmd-alt-c": "outline_panel::CopyPath",

--- a/crates/language/src/outline.rs
+++ b/crates/language/src/outline.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 use settings::Settings;
 use std::ops::Range;
-use theme::{ActiveTheme, ThemeSettings};
+use theme::{color_alpha, ActiveTheme, ThemeSettings};
 
 /// An outline of all the symbols contained in a buffer.
 #[derive(Debug)]
@@ -146,9 +146,15 @@ impl<T> Outline<T> {
 
 pub fn render_item<T>(
     outline_item: &OutlineItem<T>,
-    custom_highlights: impl IntoIterator<Item = (Range<usize>, HighlightStyle)>,
+    match_ranges: impl IntoIterator<Item = Range<usize>>,
     cx: &AppContext,
 ) -> StyledText {
+    let mut highlight_style = HighlightStyle::default();
+    highlight_style.background_color = Some(color_alpha(cx.theme().colors().text_accent, 0.3));
+    let custom_highlights = match_ranges
+        .into_iter()
+        .map(|range| (range, highlight_style));
+
     let settings = ThemeSettings::get_global(cx);
 
     // TODO: We probably shouldn't need to build a whole new text style here

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -3,9 +3,8 @@ use editor::{
 };
 use fuzzy::StringMatch;
 use gpui::{
-    div, rems, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, HighlightStyle,
-    ParentElement, Point, Render, Styled, Task, View, ViewContext, VisualContext, WeakView,
-    WindowContext,
+    div, rems, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, ParentElement,
+    Point, Render, Styled, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use language::Outline;
 use ordered_float::OrderedFloat;
@@ -15,7 +14,7 @@ use std::{
     sync::Arc,
 };
 
-use theme::{color_alpha, ActiveTheme};
+use theme::ActiveTheme;
 use ui::{prelude::*, ListItem, ListItemSpacing};
 use util::ResultExt;
 use workspace::{DismissDecision, ModalView};
@@ -272,10 +271,6 @@ impl PickerDelegate for OutlineViewDelegate {
         let mat = self.matches.get(ix)?;
         let outline_item = self.outline.items.get(mat.candidate_id)?;
 
-        let mut highlight_style = HighlightStyle::default();
-        highlight_style.background_color = Some(color_alpha(cx.theme().colors().text_accent, 0.3));
-        let custom_highlights = mat.ranges().map(|range| (range, highlight_style));
-
         Some(
             ListItem::new(ix)
                 .inset(true)
@@ -285,7 +280,7 @@ impl PickerDelegate for OutlineViewDelegate {
                     div()
                         .text_ui(cx)
                         .pl(rems(outline_item.depth as f32))
-                        .child(language::render_item(outline_item, custom_highlights, cx)),
+                        .child(language::render_item(outline_item, mat.ranges(), cx)),
                 ),
         )
     }

--- a/crates/outline_panel/Cargo.toml
+++ b/crates/outline_panel/Cargo.toml
@@ -18,6 +18,7 @@ collections.workspace = true
 db.workspace = true
 editor.workspace = true
 file_icons.workspace = true
+fuzzy.workspace = true
 itertools.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -970,22 +970,26 @@ impl OutlinePanel {
                     match fs_entry {
                         FsEntry::ExternalFile(buffer_id, _) => {
                             entries.insert(CollapsedEntry::ExternalFile(*buffer_id));
-                            entries.extend(self.excerpts.get(buffer_id).map(|excerpts| {
-                                excerpts.iter().map(|excerpt_id| {
-                                    CollapsedEntry::Excerpt(*buffer_id, *excerpt_id)
-                                })
-                            }));
+                            entries.extend(self.excerpts.get(buffer_id).into_iter().flat_map(
+                                |excerpts| {
+                                    excerpts.iter().map(|(excerpt_id, _)| {
+                                        CollapsedEntry::Excerpt(*buffer_id, *excerpt_id)
+                                    })
+                                },
+                            ));
                         }
                         FsEntry::Directory(worktree_id, entry) => {
                             entries.insert(CollapsedEntry::Dir(*worktree_id, entry.id));
                         }
                         FsEntry::File(worktree_id, _, buffer_id, _) => {
                             entries.insert(CollapsedEntry::File(*worktree_id, *buffer_id));
-                            entries.extend(self.excerpts.get(buffer_id).map(|excerpts| {
-                                excerpts.iter().map(|excerpt_id| {
-                                    CollapsedEntry::Excerpt(*buffer_id, *excerpt_id)
-                                })
-                            }));
+                            entries.extend(self.excerpts.get(buffer_id).into_iter().flat_map(
+                                |excerpts| {
+                                    excerpts.iter().map(|(excerpt_id, _)| {
+                                        CollapsedEntry::Excerpt(*buffer_id, *excerpt_id)
+                                    })
+                                },
+                            ));
                         }
                     }
                     entries

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2863,9 +2863,8 @@ impl Render for OutlinePanel {
         if self.cached_entries_with_depth.is_empty() {
             let header = if self.updating_fs_entries {
                 Cow::Borrowed("Loading outlines")
-            } else if let Some(query) = query.as_deref() {
-                // TODO kb can be too long, wrap or shorten?
-                Cow::Owned(format!("No matches for query '{query}'"))
+            } else if query.is_some() {
+                Cow::Owned(format!("No matches for query"))
             } else {
                 Cow::Borrowed("No outlines available")
             };
@@ -2875,6 +2874,9 @@ impl Render for OutlinePanel {
                     .justify_center()
                     .size_full()
                     .child(h_flex().justify_center().child(Label::new(header)))
+                    .when_some(query.clone(), |panel, query| {
+                        panel.child(h_flex().justify_center().child(Label::new(query)))
+                    })
                     .child(
                         h_flex()
                             .pt(Spacing::Small.rems(cx))

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -1,7 +1,6 @@
 mod outline_panel_settings;
 
 use std::{
-    borrow::Cow,
     cmp,
     ops::Range,
     path::{Path, PathBuf},
@@ -2437,12 +2436,11 @@ impl OutlinePanel {
                                 let parent_expanded = parent_dirs
                                     .iter()
                                     .rev()
-                                    .skip_while(|(parent_path, ..)| {
-                                        !folded_dirs
+                                    .find(|(parent_path, ..)| {
+                                        folded_dirs
                                             .iter()
-                                            .any(|entry| entry.path.as_ref() == *parent_path)
+                                            .all(|entry| entry.path.as_ref() != *parent_path)
                                     })
-                                    .next()
                                     .map_or(true, |&(_, _, parent_expanded, _)| parent_expanded);
                                 if parent_expanded || query.is_some() {
                                     outline_panel.push_entry(
@@ -2465,12 +2463,11 @@ impl OutlinePanel {
                                 let parent_expanded = parent_dirs
                                     .iter()
                                     .rev()
-                                    .skip_while(|(parent_path, ..)| {
+                                    .find(|(parent_path, ..)| {
                                         folded_dirs
                                             .iter()
-                                            .any(|entry| entry.path.as_ref() == *parent_path)
+                                            .all(|entry| entry.path.as_ref() != *parent_path)
                                     })
-                                    .next()
                                     .map_or(true, |&(_, _, parent_expanded, _)| parent_expanded);
                                 if parent_expanded || query.is_some() {
                                     outline_panel.push_entry(
@@ -2599,12 +2596,11 @@ impl OutlinePanel {
                     let parent_expanded = parent_dirs
                         .iter()
                         .rev()
-                        .skip_while(|(parent_path, ..)| {
+                        .find(|(parent_path, ..)| {
                             folded_dirs
                                 .iter()
-                                .any(|entry| entry.path.as_ref() == *parent_path)
+                                .all(|entry| entry.path.as_ref() != *parent_path)
                         })
-                        .next()
                         .map_or(true, |&(_, _, parent_expanded, _)| parent_expanded);
                     if parent_expanded || query.is_some() {
                         outline_panel.push_entry(
@@ -2914,11 +2910,11 @@ impl Render for OutlinePanel {
 
         if self.cached_entries_with_depth.is_empty() {
             let header = if self.updating_fs_entries {
-                Cow::Borrowed("Loading outlines")
+                "Loading outlines"
             } else if query.is_some() {
-                Cow::Owned(format!("No matches for query"))
+                "No matches for query"
             } else {
-                Cow::Borrowed("No outlines available")
+                "No outlines available"
             };
 
             outline_panel.child(


### PR DESCRIPTION
https://github.com/zed-industries/zed/assets/2690773/145a7cf2-332c-46c9-ab2f-42a77504f54f

Adds a way to filter entries in the outline panel, by showing all entries (even if their parents were collapsed) that fuzzy match a given query.

Release Notes:

- Added a way to filter items in the outline panel