### PR TITLE
chore: Clippy fixes for 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -518,7 +518,7 @@ single_range_in_vec_init = "allow"
 
 # There are a bunch of rules currently failing in the `style` group, so
 # allow all of those, for now.
-style = "allow"
+style = { level = "allow", priority = -1 }
 
 # Individual rules that have violations in the codebase:
 almost_complete_range = "allow"

--- a/crates/collab/src/db/tests/db_tests.rs
+++ b/crates/collab/src/db/tests/db_tests.rs
@@ -562,7 +562,7 @@ fn test_fuzzy_like_string() {
     assert_eq!(Database::fuzzy_like_string(" z  "), "%z%");
 }
 
-#[cfg(target = "macos")]
+#[cfg(target_os = "macos")]
 #[gpui::test]
 async fn test_fuzzy_search_users(cx: &mut gpui::TestAppContext) {
     let test_db = tests::TestDb::postgres(cx.executor());

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11094,6 +11094,7 @@ impl Editor {
                 if *singleton_buffer_edited {
                     if let Some(project) = &self.project {
                         let project = project.read(cx);
+                        #[allow(clippy::mutable_key_type)]
                         let languages_affected = multibuffer
                             .read(cx)
                             .all_buffers()

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -7,7 +7,7 @@ use std::env;
 
 fn main() {
     let target = env::var("CARGO_CFG_TARGET_OS");
-
+    println!("cargo::rustc-check-cfg=cfg(gles)");
     match target.as_deref() {
         Ok("macos") => {
             #[cfg(target_os = "macos")]

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -658,26 +658,6 @@ impl Hash for RenderGlyphParams {
     }
 }
 
-/// The parameters for rendering an emoji glyph.
-#[derive(Clone, Debug, PartialEq)]
-pub struct RenderEmojiParams {
-    pub(crate) font_id: FontId,
-    pub(crate) glyph_id: GlyphId,
-    pub(crate) font_size: Pixels,
-    pub(crate) scale_factor: f32,
-}
-
-impl Eq for RenderEmojiParams {}
-
-impl Hash for RenderEmojiParams {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.font_id.0.hash(state);
-        self.glyph_id.0.hash(state);
-        self.font_size.0.to_bits().hash(state);
-        self.scale_factor.to_bits().hash(state);
-    }
-}
-
 /// The configuration details for identifying a specific font.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Font {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4076,6 +4076,7 @@ impl Project {
             return;
         }
 
+        #[allow(clippy::mutable_key_type)]
         let language_server_lookup_info: HashSet<(Model<Worktree>, Arc<Language>)> = buffers
             .into_iter()
             .filter_map(|buffer| {
@@ -11035,6 +11036,7 @@ async fn populate_labels_for_symbols(
     lsp_adapter: Option<Arc<CachedLspAdapter>>,
     output: &mut Vec<Symbol>,
 ) {
+    #[allow(clippy::mutable_key_type)]
     let mut symbols_by_language = HashMap::<Option<Arc<Language>>, Vec<CoreSymbol>>::default();
 
     let mut unknown_path = None;

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -444,11 +444,6 @@ mod test_inventory {
 
     use super::{task_source_kind_preference, TaskSourceKind, UnboundedSender};
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct TestTask {
-        name: String,
-    }
-
     pub(super) fn static_test_source(
         task_names: impl IntoIterator<Item = String>,
         updates: UnboundedSender<()>,


### PR DESCRIPTION
The biggest hurdle turned out to be use of `Arc<Language>` in maps, as `clippy::mutable_key_type` started triggering on it (due to - I suppose - internal mutability on `HighlightMap`?). I switched over to using `LanguageId` as the key type in some of the callsites, as that's what `Language` uses anyways for it's hash/eq, though I've still had to suppress the lint outside of language crate.

/cc @maxdeviant , le clippy guru.

Release Notes:

- N/A
