### PR TITLE
linux: Treat fullscreen as tiled on X11 and prevent resizing while maximized

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1241,7 +1241,9 @@ impl PlatformWindow for X11Window {
         match state.decorations {
             WindowDecorations::Server => Decorations::Server,
             WindowDecorations::Client => {
-                let tiling = if let Some(edge_constraints) = &state.edge_constraints {
+                let tiling = if state.fullscreen {
+                    Tiling::tiled()
+                } else if let Some(edge_constraints) = &state.edge_constraints {
                     edge_constraints.to_tiling()
                 } else {
                     // https://source.chromium.org/chromium/chromium/src/+/main:ui/ozone/platform/x11/x11_window.cc;l=2519;drc=1f14cc876cc5bf899d13284a12c451498219bb2d
@@ -1252,7 +1254,6 @@ impl PlatformWindow for X11Window {
                         right: state.maximized_horizontal,
                     }
                 };
-
                 Decorations::Client { tiling }
             }
         }
@@ -1263,7 +1264,9 @@ impl PlatformWindow for X11Window {
 
         let dp = (inset.0 * state.scale_factor) as u32;
 
-        let insets = if let Some(edge_constraints) = &state.edge_constraints {
+        let insets = if state.fullscreen {
+            [0, 0, 0, 0]
+        } else if let Some(edge_constraints) = &state.edge_constraints {
             let left = if edge_constraints.left_tiled { 0 } else { dp };
             let top = if edge_constraints.top_tiled { 0 } else { dp };
             let right = if edge_constraints.right_tiled { 0 } else { dp };

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6658,7 +6658,7 @@ fn resize_edge(
 
     let corner_size = size(shadow_size * 1.5, shadow_size * 1.5);
     let top_left_bounds = Bounds::new(Point::new(px(0.), px(0.)), corner_size);
-    if top_left_bounds.contains(&pos) {
+    if !tiling.top && top_left_bounds.contains(&pos) {
         return Some(ResizeEdge::TopLeft);
     }
 
@@ -6666,7 +6666,7 @@ fn resize_edge(
         Point::new(window_size.width - corner_size.width, px(0.)),
         corner_size,
     );
-    if top_right_bounds.contains(&pos) {
+    if !tiling.top && top_right_bounds.contains(&pos) {
         return Some(ResizeEdge::TopRight);
     }
 
@@ -6674,7 +6674,7 @@ fn resize_edge(
         Point::new(px(0.), window_size.height - corner_size.height),
         corner_size,
     );
-    if bottom_left_bounds.contains(&pos) {
+    if !tiling.bottom && bottom_left_bounds.contains(&pos) {
         return Some(ResizeEdge::BottomLeft);
     }
 
@@ -6685,7 +6685,7 @@ fn resize_edge(
         ),
         corner_size,
     );
-    if bottom_right_bounds.contains(&pos) {
+    if !tiling.bottom && bottom_right_bounds.contains(&pos) {
         return Some(ResizeEdge::BottomRight);
     }
 


### PR DESCRIPTION
Two quick fixes for issues I noticed:

1. Fullscreening an unmaximized X11 window still showed rounded window corners and allowed resizing
2. Maximized windows still allowed for resizing on corners due to missing checks
![image](https://github.com/zed-industries/zed/assets/71973804/47df4de2-4013-4e51-88c3-d33b52a909f5)


Release Notes:

- N/A
