### PR TITLE
Improve experience when themes provide transparent status colors

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -588,14 +588,6 @@ impl DiagnosticPopover {
             .id("diagnostic")
             .block()
             .elevation_2(cx)
-            .overflow_y_scroll()
-            .px_2()
-            .py_1()
-            .bg(diagnostic_colors.background)
-            .text_color(style.text.color)
-            .border_1()
-            .border_color(diagnostic_colors.border)
-            .rounded_md()
             .max_w(max_size.width)
             .max_h(max_size.height)
             .cursor(CursorStyle::PointingHand)
@@ -607,7 +599,19 @@ impl DiagnosticPopover {
             // because that would move the cursor.
             .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
             .on_click(cx.listener(|editor, _, cx| editor.go_to_diagnostic(&Default::default(), cx)))
-            .child(SharedString::from(text))
+            .child(
+                div()
+                    .id("diagnostic-inner")
+                    .overflow_y_scroll()
+                    .px_2()
+                    .py_1()
+                    .bg(diagnostic_colors.background)
+                    .text_color(style.text.color)
+                    .border_1()
+                    .border_color(diagnostic_colors.border)
+                    .rounded_md()
+                    .child(SharedString::from(text)),
+            )
             .into_any_element()
     }
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -587,7 +587,7 @@ impl DiagnosticPopover {
         div()
             .id("diagnostic")
             .block()
-            .elevation_2(cx)
+            .elevation_2_borderless(cx)
             .max_w(max_size.width)
             .max_h(max_size.height)
             .cursor(CursorStyle::PointingHand)
@@ -609,7 +609,7 @@ impl DiagnosticPopover {
                     .text_color(style.text.color)
                     .border_1()
                     .border_color(diagnostic_colors.border)
-                    .rounded_md()
+                    .rounded_lg()
                     .child(SharedString::from(text)),
             )
             .into_any_element()

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -19,7 +19,7 @@ use project::{HoverBlock, HoverBlockKind, InlayHintLabelPart};
 use settings::Settings;
 use smol::stream::StreamExt;
 use std::{ops::Range, sync::Arc, time::Duration};
-use ui::{prelude::*, Tooltip};
+use ui::{prelude::*, window_is_transparent, Tooltip};
 use util::TryFutureExt;
 use workspace::Workspace;
 
@@ -588,6 +588,11 @@ impl DiagnosticPopover {
             .id("diagnostic")
             .block()
             .elevation_2_borderless(cx)
+            // Don't draw the background color if the theme
+            // allows transparent surfaces.
+            .when(window_is_transparent(cx), |this| {
+                this.bg(gpui::transparent_black())
+            })
             .max_w(max_size.width)
             .max_h(max_size.height)
             .cursor(CursorStyle::PointingHand)

--- a/crates/ui/src/styled_ext.rs
+++ b/crates/ui/src/styled_ext.rs
@@ -5,9 +5,15 @@ use crate::ElevationIndex;
 
 fn elevated<E: Styled>(this: E, cx: &mut WindowContext, index: ElevationIndex) -> E {
     this.bg(cx.theme().colors().elevated_surface_background)
-        .rounded(px(8.))
+        .rounded_lg()
         .border_1()
         .border_color(cx.theme().colors().border_variant)
+        .shadow(index.shadow())
+}
+
+fn elevated_borderless<E: Styled>(this: E, cx: &mut WindowContext, index: ElevationIndex) -> E {
+    this.bg(cx.theme().colors().elevated_surface_background)
+        .rounded_lg()
         .shadow(index.shadow())
 }
 
@@ -36,6 +42,13 @@ pub trait StyledExt: Styled + Sized {
         elevated(self, cx, ElevationIndex::Surface)
     }
 
+    /// See [`elevation_1`].
+    ///
+    /// Renders a borderless version [`elevation_1`].
+    fn elevation_1_borderless(self, cx: &mut WindowContext) -> Self {
+        elevated_borderless(self, cx, ElevationIndex::Surface)
+    }
+
     /// Non-Modal Elevated Surfaces appear above the [`Surface`](ElevationIndex::Surface) layer and is used for things that should appear above most UI elements like an editor or panel, but not elements like popovers, context menus, modals, etc.
     ///
     /// Sets `bg()`, `rounded_lg()`, `border()`, `border_color()`, `shadow()`
@@ -43,6 +56,13 @@ pub trait StyledExt: Styled + Sized {
     /// Examples: Notifications, Palettes, Detached/Floating Windows, Detached/Floating Panels
     fn elevation_2(self, cx: &mut WindowContext) -> Self {
         elevated(self, cx, ElevationIndex::ElevatedSurface)
+    }
+
+    /// See [`elevation_2`].
+    ///
+    /// Renders a borderless version [`elevation_2`].
+    fn elevation_2_borderless(self, cx: &mut WindowContext) -> Self {
+        elevated_borderless(self, cx, ElevationIndex::ElevatedSurface)
     }
 
     /// Modal Surfaces are used for elements that should appear above all other UI elements and are located above the wash layer. This is the maximum elevation at which UI elements can be rendered in their default state.
@@ -56,6 +76,13 @@ pub trait StyledExt: Styled + Sized {
     /// Examples: Settings Modal, Channel Management, Wizards/Setup UI, Dialogs
     fn elevation_3(self, cx: &mut WindowContext) -> Self {
         elevated(self, cx, ElevationIndex::ModalSurface)
+    }
+
+    /// See [`elevation_3`].
+    ///
+    /// Renders a borderless version [`elevation_3`].
+    fn elevation_3_borderless(self, cx: &mut WindowContext) -> Self {
+        elevated_borderless(self, cx, ElevationIndex::ModalSurface)
     }
 
     /// The theme's primary border color.

--- a/crates/ui/src/styled_ext.rs
+++ b/crates/ui/src/styled_ext.rs
@@ -1,4 +1,4 @@
-use gpui::{hsla, px, Styled, WindowContext};
+use gpui::{hsla, Styled, WindowContext};
 
 use crate::prelude::*;
 use crate::ElevationIndex;

--- a/crates/ui/src/styles.rs
+++ b/crates/ui/src/styles.rs
@@ -1,3 +1,4 @@
+mod appearance;
 mod color;
 mod elevation;
 mod platform;
@@ -5,6 +6,7 @@ mod spacing;
 mod typography;
 mod units;
 
+pub use appearance::*;
 pub use color::*;
 pub use elevation::*;
 pub use platform::*;

--- a/crates/ui/src/styles/appearance.rs
+++ b/crates/ui/src/styles/appearance.rs
@@ -1,0 +1,26 @@
+use crate::prelude::*;
+use gpui::{WindowBackgroundAppearance, WindowContext};
+use theme::Appearance;
+
+/// Returns the current [Appearance].
+pub fn appearance(cx: &WindowContext) -> Appearance {
+    cx.theme().appearance
+}
+
+/// Returns the [WindowBackgroundAppearance].
+pub fn window_appereance(cx: &WindowContext) -> WindowBackgroundAppearance {
+    cx.theme().styles.window_background_appearance
+}
+
+/// Returns if the window and it's surfaces are expected
+/// to be transparent.
+///
+/// Helps determine if you need to take extra steps to prevent
+/// transparent backgrounds.
+pub fn window_is_transparent(cx: &WindowContext) -> bool {
+    match window_appereance(cx) {
+        WindowBackgroundAppearance::Transparent => true,
+        WindowBackgroundAppearance::Blurred => true,
+        _ => false,
+    }
+}

--- a/crates/ui/src/styles/appearance.rs
+++ b/crates/ui/src/styles/appearance.rs
@@ -8,7 +8,7 @@ pub fn appearance(cx: &WindowContext) -> Appearance {
 }
 
 /// Returns the [WindowBackgroundAppearance].
-pub fn window_appereance(cx: &WindowContext) -> WindowBackgroundAppearance {
+pub fn window_appearance(cx: &WindowContext) -> WindowBackgroundAppearance {
     cx.theme().styles.window_background_appearance
 }
 
@@ -18,7 +18,7 @@ pub fn window_appereance(cx: &WindowContext) -> WindowBackgroundAppearance {
 /// Helps determine if you need to take extra steps to prevent
 /// transparent backgrounds.
 pub fn window_is_transparent(cx: &WindowContext) -> bool {
-    match window_appereance(cx) {
+    match window_appearance(cx) {
         WindowBackgroundAppearance::Transparent => true,
         WindowBackgroundAppearance::Blurred => true,
         _ => false,


### PR DESCRIPTION
We shouldn't assume all themes will give us solid status color backgrounds.

This change makes it so the status color renders on top of a normal elevated surface background.

#### Before | After (Transparent status background color – Fixed)

![CleanShot 2024-07-09 at 10 50 17@2x](https://github.com/zed-industries/zed/assets/1714999/5f4b24c1-335a-4ed8-a1d0-f511e217e4a5)

![CleanShot 2024-07-09 at 10 50 31@2x](https://github.com/zed-industries/zed/assets/1714999/38c06533-bda5-4cfb-822a-ed5a9639fc33)

---

#### Before | After (Solid status background color – No change)

![CleanShot 2024-07-09 at 10 49 43@2x](https://github.com/zed-industries/zed/assets/1714999/bd60c807-a7bb-4f60-ab47-ddba17288e93)

![CleanShot 2024-07-09 at 10 49 58@2x](https://github.com/zed-industries/zed/assets/1714999/6ab27d60-5a77-448c-a23b-569b337f11e1)



Release Notes:

- Improved support for transparent status colors in themes.
