### PR TITLE
Prevent dumping of temporary files in config_dir

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -227,7 +227,7 @@ impl Telemetry {
                 let state = state.clone();
                 async move {
                     if let Some(tempfile) =
-                        NamedTempFile::new_in(paths::config_dir().as_path()).log_err()
+                        NamedTempFile::new_in(paths::logs_dir().as_path()).log_err()
                     {
                         state.lock().log_file = Some(tempfile);
                     }


### PR DESCRIPTION
Move telemetry temp files from `config_dir` to `log_dir`. Fixes #7155 

- On MacOS: from `~/.config/zed` to `~/Library/Logs/Zed`
- On Linux: from `~/.config/zed` to `.local/share/zed/logs` (or `$FLATPAK_XDG_DATA_HOME/zed/logs`).

Release Notes:

- Fixed telemetry putting temporary files in config_dir ([#7155](https://github.com/zed-industries/zed/issues/7155)).