### PR TITLE
gpui: Make style macros more composable

### DIFF
--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -4,6 +4,7 @@ use crate::{
     JustifyContent, Length, Position, SharedString, StyleRefinement, Visibility, WhiteSpace,
 };
 use crate::{BoxShadow, TextStyleRefinement};
+pub use gpui_macros::{margin_style_methods, padding_style_methods, position_style_methods};
 use smallvec::{smallvec, SmallVec};
 use taffy::style::{AlignContent, Display, Overflow};
 
@@ -17,20 +18,6 @@ pub trait Styled: Sized {
     gpui_macros::margin_style_methods!();
     gpui_macros::padding_style_methods!();
     gpui_macros::position_style_methods!();
-
-    /// Sets the position of the element to `relative`.
-    /// [Docs](https://tailwindcss.com/docs/position)
-    fn relative(mut self) -> Self {
-        self.style().position = Some(Position::Relative);
-        self
-    }
-
-    /// Sets the position of the element to `absolute`.
-    /// [Docs](https://tailwindcss.com/docs/position)
-    fn absolute(mut self) -> Self {
-        self.style().position = Some(Position::Absolute);
-        self
-    }
 
     /// Sets the display type of the element to `block`.
     /// [Docs](https://tailwindcss.com/docs/display)

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -14,6 +14,8 @@ pub trait Styled: Sized {
     fn style(&mut self) -> &mut StyleRefinement;
 
     gpui_macros::style_helpers!();
+    gpui_macros::margin_style_methods!();
+    gpui_macros::padding_style_methods!();
     gpui_macros::position_style_methods!();
 
     /// Sets the position of the element to `relative`.

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -14,6 +14,7 @@ pub trait Styled: Sized {
     fn style(&mut self) -> &mut StyleRefinement;
 
     gpui_macros::style_helpers!();
+    gpui_macros::position_style_methods!();
 
     /// Sets the position of the element to `relative`.
     /// [Docs](https://tailwindcss.com/docs/position)

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,7 +1,7 @@
 use crate::{
     self as gpui, hsla, point, px, relative, rems, AbsoluteLength, AlignItems, CursorStyle,
     DefiniteLength, Fill, FlexDirection, FlexWrap, Font, FontStyle, FontWeight, Hsla,
-    JustifyContent, Length, Position, SharedString, StyleRefinement, Visibility, WhiteSpace,
+    JustifyContent, Length, SharedString, StyleRefinement, Visibility, WhiteSpace,
 };
 use crate::{BoxShadow, TextStyleRefinement};
 pub use gpui_macros::{margin_style_methods, padding_style_methods, position_style_methods};

--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -27,11 +27,18 @@ pub fn derive_render(input: TokenStream) -> TokenStream {
     derive_render::derive_render(input)
 }
 
-/// Used by gpui to generate the style helpers.
+/// Used by GPUI to generate the style helpers.
 #[proc_macro]
 #[doc(hidden)]
 pub fn style_helpers(input: TokenStream) -> TokenStream {
     style_helpers::style_helpers(input)
+}
+
+/// Used by GPUI to generate the methods for position styles.
+#[proc_macro]
+#[doc(hidden)]
+pub fn position_style_methods(input: TokenStream) -> TokenStream {
+    style_helpers::position_style_methods(input)
 }
 
 /// #[gpui::test] can be used to annotate test functions that run with GPUI support.

--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -34,7 +34,21 @@ pub fn style_helpers(input: TokenStream) -> TokenStream {
     style_helpers::style_helpers(input)
 }
 
-/// Used by GPUI to generate the methods for position styles.
+/// Generates methods for margin styles.
+#[proc_macro]
+#[doc(hidden)]
+pub fn margin_style_methods(input: TokenStream) -> TokenStream {
+    style_helpers::margin_style_methods(input)
+}
+
+/// Generates methods for padding styles.
+#[proc_macro]
+#[doc(hidden)]
+pub fn padding_style_methods(input: TokenStream) -> TokenStream {
+    style_helpers::padding_style_methods(input)
+}
+
+/// Generates methods for position styles.
 #[proc_macro]
 #[doc(hidden)]
 pub fn position_style_methods(input: TokenStream) -> TokenStream {

--- a/crates/gpui_macros/src/style_helpers.rs
+++ b/crates/gpui_macros/src/style_helpers.rs
@@ -24,6 +24,26 @@ pub fn style_helpers(input: TokenStream) -> TokenStream {
     output.into()
 }
 
+pub fn margin_style_methods(input: TokenStream) -> TokenStream {
+    let _ = parse_macro_input!(input as StyleableMacroInput);
+    let methods = generate_box_style_methods(margin_box_style_prefixes(), box_style_suffixes());
+    let output = quote! {
+        #(#methods)*
+    };
+
+    output.into()
+}
+
+pub fn padding_style_methods(input: TokenStream) -> TokenStream {
+    let _ = parse_macro_input!(input as StyleableMacroInput);
+    let methods = generate_box_style_methods(padding_box_style_prefixes(), box_style_suffixes());
+    let output = quote! {
+        #(#methods)*
+    };
+
+    output.into()
+}
+
 pub fn position_style_methods(input: TokenStream) -> TokenStream {
     let _ = parse_macro_input!(input as StyleableMacroInput);
     let methods = generate_box_style_methods(position_box_style_prefixes(), box_style_suffixes());
@@ -252,6 +272,110 @@ fn generate_custom_value_setter(
     method
 }
 
+fn margin_box_style_prefixes() -> Vec<BoxStylePrefix> {
+    vec![
+        BoxStylePrefix {
+            prefix: "m",
+            auto_allowed: true,
+            fields: vec![
+                quote! { margin.top },
+                quote! { margin.bottom },
+                quote! { margin.left },
+                quote! { margin.right },
+            ],
+            doc_string_prefix: "Sets the margin of the element. [Docs](https://tailwindcss.com/docs/margin)",
+        },
+        BoxStylePrefix {
+            prefix: "mt",
+            auto_allowed: true,
+            fields: vec![quote! { margin.top }],
+            doc_string_prefix: "Sets the top margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
+        },
+        BoxStylePrefix {
+            prefix: "mb",
+            auto_allowed: true,
+            fields: vec![quote! { margin.bottom }],
+            doc_string_prefix: "Sets the bottom margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
+        },
+        BoxStylePrefix {
+            prefix: "my",
+            auto_allowed: true,
+            fields: vec![quote! { margin.top }, quote! { margin.bottom }],
+            doc_string_prefix: "Sets the vertical margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-vertical-margin)",
+        },
+        BoxStylePrefix {
+            prefix: "mx",
+            auto_allowed: true,
+            fields: vec![quote! { margin.left }, quote! { margin.right }],
+            doc_string_prefix: "Sets the horizontal margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-horizontal-margin)",
+        },
+        BoxStylePrefix {
+            prefix: "ml",
+            auto_allowed: true,
+            fields: vec![quote! { margin.left }],
+            doc_string_prefix: "Sets the left margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
+        },
+        BoxStylePrefix {
+            prefix: "mr",
+            auto_allowed: true,
+            fields: vec![quote! { margin.right }],
+            doc_string_prefix: "Sets the right margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
+        },
+    ]
+}
+
+fn padding_box_style_prefixes() -> Vec<BoxStylePrefix> {
+    vec![
+        BoxStylePrefix {
+            prefix: "p",
+            auto_allowed: false,
+            fields: vec![
+                quote! { padding.top },
+                quote! { padding.bottom },
+                quote! { padding.left },
+                quote! { padding.right },
+            ],
+            doc_string_prefix: "Sets the padding of the element. [Docs](https://tailwindcss.com/docs/padding)",
+        },
+        BoxStylePrefix {
+            prefix: "pt",
+            auto_allowed: false,
+            fields: vec![quote! { padding.top }],
+            doc_string_prefix: "Sets the top padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
+        },
+        BoxStylePrefix {
+            prefix: "pb",
+            auto_allowed: false,
+            fields: vec![quote! { padding.bottom }],
+            doc_string_prefix: "Sets the bottom padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
+        },
+        BoxStylePrefix {
+            prefix: "px",
+            auto_allowed: false,
+            fields: vec![quote! { padding.left }, quote! { padding.right }],
+            doc_string_prefix: "Sets the horizontal padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-horizontal-padding)",
+        },
+        BoxStylePrefix {
+            prefix: "py",
+            auto_allowed: false,
+            fields: vec![quote! { padding.top }, quote! { padding.bottom }],
+            doc_string_prefix: "Sets the vertical padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-vertical-padding)",
+        },
+        BoxStylePrefix {
+            prefix: "pl",
+            auto_allowed: false,
+            fields: vec![quote! { padding.left }],
+            doc_string_prefix: "Sets the left padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
+        },
+        BoxStylePrefix {
+            prefix: "pr",
+            auto_allowed: false,
+            fields: vec![quote! { padding.right }],
+            doc_string_prefix: "Sets the right padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
+        },
+    ]
+}
+
 fn position_box_style_prefixes() -> Vec<BoxStylePrefix> {
     vec![
         BoxStylePrefix {
@@ -343,100 +467,6 @@ fn box_prefixes() -> Vec<BoxStylePrefix> {
             auto_allowed: true,
             fields: vec![quote! { max_size.height }],
             doc_string_prefix: "Sets the maximum height of the element. [Docs](https://tailwindcss.com/docs/max-height)",
-        },
-        BoxStylePrefix {
-            prefix: "m",
-            auto_allowed: true,
-            fields: vec![
-                quote! { margin.top },
-                quote! { margin.bottom },
-                quote! { margin.left },
-                quote! { margin.right },
-            ],
-            doc_string_prefix: "Sets the margin of the element. [Docs](https://tailwindcss.com/docs/margin)",
-        },
-        BoxStylePrefix {
-            prefix: "mt",
-            auto_allowed: true,
-            fields: vec![quote! { margin.top }],
-            doc_string_prefix: "Sets the top margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
-        },
-        BoxStylePrefix {
-            prefix: "mb",
-            auto_allowed: true,
-            fields: vec![quote! { margin.bottom }],
-            doc_string_prefix: "Sets the bottom margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
-        },
-        BoxStylePrefix {
-            prefix: "my",
-            auto_allowed: true,
-            fields: vec![quote! { margin.top }, quote! { margin.bottom }],
-            doc_string_prefix: "Sets the vertical margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-vertical-margin)",
-        },
-        BoxStylePrefix {
-            prefix: "mx",
-            auto_allowed: true,
-            fields: vec![quote! { margin.left }, quote! { margin.right }],
-            doc_string_prefix: "Sets the horizontal margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-horizontal-margin)",
-        },
-        BoxStylePrefix {
-            prefix: "ml",
-            auto_allowed: true,
-            fields: vec![quote! { margin.left }],
-            doc_string_prefix: "Sets the left margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
-        },
-        BoxStylePrefix {
-            prefix: "mr",
-            auto_allowed: true,
-            fields: vec![quote! { margin.right }],
-            doc_string_prefix: "Sets the right margin of the element. [Docs](https://tailwindcss.com/docs/margin#add-margin-to-a-single-side)",
-        },
-        BoxStylePrefix {
-            prefix: "p",
-            auto_allowed: false,
-            fields: vec![
-                quote! { padding.top },
-                quote! { padding.bottom },
-                quote! { padding.left },
-                quote! { padding.right },
-            ],
-            doc_string_prefix: "Sets the padding of the element. [Docs](https://tailwindcss.com/docs/padding)",
-        },
-        BoxStylePrefix {
-            prefix: "pt",
-            auto_allowed: false,
-            fields: vec![quote! { padding.top }],
-            doc_string_prefix: "Sets the top padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
-        },
-        BoxStylePrefix {
-            prefix: "pb",
-            auto_allowed: false,
-            fields: vec![quote! { padding.bottom }],
-            doc_string_prefix: "Sets the bottom padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
-        },
-        BoxStylePrefix {
-            prefix: "px",
-            auto_allowed: false,
-            fields: vec![quote! { padding.left }, quote! { padding.right }],
-            doc_string_prefix: "Sets the horizontal padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-horizontal-padding)",
-        },
-        BoxStylePrefix {
-            prefix: "py",
-            auto_allowed: false,
-            fields: vec![quote! { padding.top }, quote! { padding.bottom }],
-            doc_string_prefix: "Sets the vertical padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-vertical-padding)",
-        },
-        BoxStylePrefix {
-            prefix: "pl",
-            auto_allowed: false,
-            fields: vec![quote! { padding.left }],
-            doc_string_prefix: "Sets the left padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
-        },
-        BoxStylePrefix {
-            prefix: "pr",
-            auto_allowed: false,
-            fields: vec![quote! { padding.right }],
-            doc_string_prefix: "Sets the right padding of the element. [Docs](https://tailwindcss.com/docs/padding#add-padding-to-a-single-side)",
         },
         BoxStylePrefix {
             prefix: "gap",

--- a/crates/gpui_macros/src/style_helpers.rs
+++ b/crates/gpui_macros/src/style_helpers.rs
@@ -63,9 +63,23 @@ pub fn margin_style_methods(input: TokenStream) -> TokenStream {
 
 pub fn padding_style_methods(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as StyleableMacroInput);
-    let visibility = input.method_visibility;
     let methods = generate_box_style_methods(
         padding_box_style_prefixes(),
+        box_style_suffixes(),
+        input.method_visibility,
+    );
+    let output = quote! {
+        #(#methods)*
+    };
+
+    output.into()
+}
+
+pub fn position_style_methods(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as StyleableMacroInput);
+    let visibility = input.method_visibility;
+    let methods = generate_box_style_methods(
+        position_box_style_prefixes(),
         box_style_suffixes(),
         visibility.clone(),
     );
@@ -84,20 +98,6 @@ pub fn padding_style_methods(input: TokenStream) -> TokenStream {
             self
         }
 
-        #(#methods)*
-    };
-
-    output.into()
-}
-
-pub fn position_style_methods(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as StyleableMacroInput);
-    let methods = generate_box_style_methods(
-        position_box_style_prefixes(),
-        box_style_suffixes(),
-        input.method_visibility,
-    );
-    let output = quote! {
         #(#methods)*
     };
 

--- a/crates/ui/src/components/facepile.rs
+++ b/crates/ui/src/components/facepile.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use gpui::AnyElement;
+use gpui::{AnyElement, StyleRefinement};
 use smallvec::SmallVec;
 
 /// A facepile is a collection of faces stacked horizontally–
@@ -23,6 +23,23 @@ impl Facepile {
     }
 }
 
+impl ParentElement for Facepile {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.faces.extend(elements);
+    }
+}
+
+// Style methods.
+impl Facepile {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+
+    gpui::padding_style_methods!({
+        visibility: pub
+    });
+}
+
 impl RenderOnce for Facepile {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
         // Lay the faces out in reverse so they overlap in the desired order (left to right, front to back)
@@ -38,17 +55,5 @@ impl RenderOnce for Facepile {
                     .rev()
                     .map(|(ix, player)| div().when(ix > 0, |div| div.ml_neg_1()).child(player)),
             )
-    }
-}
-
-impl ParentElement for Facepile {
-    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
-        self.faces.extend(elements);
-    }
-}
-
-impl Styled for Facepile {
-    fn style(&mut self) -> &mut gpui::StyleRefinement {
-        self.base.style()
     }
 }


### PR DESCRIPTION
This PR begins the process of breaking up the `style_helpers!` macro into smaller macros that can be used to generate methods for a related subset of styles.

The style method macros also now accept an optional `visibility` parameter to control the visibility of the generated methods. This allows for adding these methods to a struct instead of a just a trait.

For example, to expose just the padding styles on a `Facepile` we can do this:

```rs
impl Facepile {
    fn style(&mut self) -> &mut StyleRefinement {
        self.base.style()
    }

    gpui::padding_style_methods!({
        visibility: pub
    });
}
```

Release Notes:

- N/A
