### PR TITLE
Introduce `autosave_before_task` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -419,6 +419,8 @@
   // 4. Save when idle for a certain amount of time:
   //     "autosave": { "after_delay": {"milliseconds": 500} },
   "autosave": "off",
+  // Save all files before execution of a task
+  "autosave_before_task": false,
   // Settings related to the editor's tab bar.
   "tab_bar": {
     // Whether or not to show the tab bar in the editor

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4498,9 +4498,8 @@ impl Editor {
 
         match action {
             CodeActionsItem::Task(task_source_kind, resolved_task) => {
-                workspace.update(cx, |workspace, cx| {
+                workspace.update(cx, |_, cx| {
                     workspace::tasks::schedule_resolved_task(
-                        workspace,
                         task_source_kind,
                         resolved_task,
                         false,

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -38,9 +38,8 @@ pub fn init(cx: &mut AppContext) {
                             cx.spawn(|workspace, mut cx| async move {
                                 let task_context = context_task.await;
                                 workspace
-                                    .update(&mut cx, |workspace, cx| {
+                                    .update(&mut cx, |_workspace, cx| {
                                         schedule_task(
-                                            workspace,
                                             task_source_kind,
                                             &original_task,
                                             &task_context,
@@ -62,7 +61,6 @@ pub fn init(cx: &mut AppContext) {
                             }
 
                             schedule_resolved_task(
-                                workspace,
                                 task_source_kind,
                                 last_scheduled_task,
                                 false,
@@ -123,17 +121,10 @@ fn spawn_task_with_name(
             .await?;
 
         let did_spawn = workspace
-            .update(&mut cx, |workspace, cx| {
+            .update(&mut cx, |_, cx| {
                 let (task_source_kind, target_task) =
                     tasks.into_iter().find(|(_, task)| task.label == name)?;
-                schedule_task(
-                    workspace,
-                    task_source_kind,
-                    &target_task,
-                    &task_context,
-                    false,
-                    cx,
-                );
+                schedule_task(task_source_kind, &target_task, &task_context, false, cx);
                 Some(())
             })?
             .is_some();

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -333,8 +333,8 @@ impl PickerDelegate for TasksModalDelegate {
         };
 
         self.workspace
-            .update(cx, |workspace, cx| {
-                schedule_resolved_task(workspace, task_source_kind, task, omit_history_entry, cx);
+            .update(cx, |_, cx| {
+                schedule_resolved_task(task_source_kind, task, omit_history_entry, cx);
             })
             .ok();
         cx.emit(DismissEvent);
@@ -474,8 +474,8 @@ impl PickerDelegate for TasksModalDelegate {
             return;
         };
         self.workspace
-            .update(cx, |workspace, cx| {
-                schedule_resolved_task(workspace, task_source_kind, task, omit_history_entry, cx);
+            .update(cx, |_, cx| {
+                schedule_resolved_task(task_source_kind, task, omit_history_entry, cx);
             })
             .ok();
         cx.emit(DismissEvent);

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -1,11 +1,14 @@
+use futures::TryFutureExt;
+use gpui::Task;
 use project::TaskSourceKind;
 use task::{ResolvedTask, TaskContext, TaskTemplate};
 use ui::ViewContext;
 
+use crate::workspace_settings::WorkspaceSettings;
 use crate::Workspace;
+use settings::Settings;
 
 pub fn schedule_task(
-    workspace: &Workspace,
     task_source_kind: TaskSourceKind,
     task_to_resolve: &TaskTemplate,
     task_cx: &TaskContext,
@@ -15,32 +18,52 @@ pub fn schedule_task(
     if let Some(spawn_in_terminal) =
         task_to_resolve.resolve_task(&task_source_kind.to_id_base(), task_cx)
     {
-        schedule_resolved_task(
-            workspace,
-            task_source_kind,
-            spawn_in_terminal,
-            omit_history,
-            cx,
-        );
+        schedule_resolved_task(task_source_kind, spawn_in_terminal, omit_history, cx);
     }
 }
 
 pub fn schedule_resolved_task(
-    workspace: &Workspace,
     task_source_kind: TaskSourceKind,
     mut resolved_task: ResolvedTask,
     omit_history: bool,
     cx: &mut ViewContext<'_, Workspace>,
 ) {
-    if let Some(spawn_in_terminal) = resolved_task.resolved.take() {
-        if !omit_history {
-            resolved_task.resolved = Some(spawn_in_terminal.clone());
-            workspace.project().update(cx, |project, cx| {
-                project.task_inventory().update(cx, |inventory, _| {
-                    inventory.task_scheduled(task_source_kind, resolved_task);
+    cx.spawn(|workspace, mut cx| async move {
+        cx.update(|cx| {
+            workspace
+                .update(cx, |workspace, cx| {
+                    WorkspaceSettings::register(cx);
+                    if WorkspaceSettings::get_global(cx).autosave_before_task {
+                        workspace.save_all_internal(crate::SaveIntent::SaveAll, cx)
+                    } else {
+                        Task::ready(Ok(false))
+                    }
                 })
-            });
-        }
-        cx.emit(crate::Event::SpawnTask(spawn_in_terminal));
-    }
+                .unwrap()
+        })
+        .unwrap()
+        .and_then(|_| async {
+            if let Some(workspace) = workspace.upgrade() {
+                cx.update(|cx| {
+                    workspace.update(cx, |workspace, cx| {
+                        if let Some(spawn_in_terminal) = resolved_task.resolved.take() {
+                            if !omit_history {
+                                resolved_task.resolved = Some(spawn_in_terminal.clone());
+                                workspace.project().update(cx, |project, cx| {
+                                    project.task_inventory().update(cx, |inventory, _| {
+                                        inventory.task_scheduled(task_source_kind, resolved_task);
+                                    })
+                                });
+                            }
+                            cx.emit(crate::Event::SpawnTask(spawn_in_terminal));
+                        }
+                    })
+                })
+            } else {
+                Ok(())
+            }
+        })
+        .await
+    })
+    .detach_and_log_err(cx)
 }

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -11,6 +11,7 @@ pub struct WorkspaceSettings {
     pub confirm_quit: bool,
     pub show_call_status_icon: bool,
     pub autosave: AutosaveSetting,
+    pub autosave_before_task: bool,
     pub restore_on_startup: RestoreOnStartupBehaviour,
     pub drop_target_size: f32,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
@@ -70,6 +71,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: off
     pub autosave: Option<AutosaveSetting>,
+    /// Whether to save all files automatically before running any task.
+    ///
+    /// Default: false
+    pub autosave_before_task: Option<bool>,
     /// Controls previous session restoration in freshly launched Zed instance.
     /// Values: none, last_workspace
     /// Default: last_workspace


### PR DESCRIPTION
With this setting set to `true` Zed saves all files before it executes a task. By default, it's false and this represent the current behavior

Release Notes:

- Added `autosave_before_task` setting. With this setting set to `true` Zed saves all files before running a task
