### PR TITLE
Python: Fix auto close for single quotes

### DIFF
--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -9,7 +9,7 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
-    { start = "'", end = "'", close = false, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
 ]
 
 auto_indent_using_last_non_empty_line = false


### PR DESCRIPTION
Fixes #13972

Release Notes:

- Fixed auto close for single quotes in Python ([#13972](https://github.com/zed-industries/zed/issues/13972)).
