### PR TITLE
WIP: Disable binary downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6797,6 +6797,7 @@ dependencies = [
  "async_zip",
  "futures 0.3.28",
  "http 0.1.0",
+ "language",
  "log",
  "paths",
  "semver",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -83,6 +83,9 @@
   "confirm_quit": false,
   // Whether to restore last closed project when fresh Zed instance is opened.
   "restore_on_startup": "last_workspace",
+  // Whether zed should automatically download binaries to run
+  // language servers if they are missing.
+  "download_missing_binaries": true,
   // Size of the drop target in the editor.
   "drop_target_size": 0.2,
   // Whether the window should be closed when using 'close active item' on a window with no tabs.
@@ -128,14 +131,7 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": [
-    "**/.env*",
-    "**/*.pem",
-    "**/*.key",
-    "**/*.cert",
-    "**/*.crt",
-    "**/secrets.yml"
-  ],
+  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,

--- a/crates/extension/src/wasm_host/wit/since_v0_0_7.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_0_7.rs
@@ -198,6 +198,10 @@ impl nodejs::Host for WasmState {
         package_name: String,
         version: String,
     ) -> wasmtime::Result<Result<(), String>> {
+        if !self.host.enable_binary_downloads.get() {
+            return Err("binary downloads are disabled".into()).to_wasmtime_result();
+        }
+
         self.host
             .node_runtime
             .npm_install_packages(&self.work_dir(), &[(&package_name, &version)])
@@ -372,6 +376,10 @@ impl ExtensionImports for WasmState {
         file_type: DownloadedFileType,
     ) -> wasmtime::Result<Result<(), String>> {
         maybe!(async {
+            if !self.host.enable_binary_downloads.get() {
+                return Err("binary downloads are disabled".into()).to_wasmtime_result();
+            }
+
             let path = PathBuf::from(path);
             let extension_work_dir = self.host.work_dir.join(self.manifest.id.as_ref());
 
@@ -435,6 +443,10 @@ impl ExtensionImports for WasmState {
     }
 
     async fn make_file_executable(&mut self, path: String) -> wasmtime::Result<Result<(), String>> {
+        if !self.host.enable_binary_downloads.get() {
+            return Err("binary downloads are disabled".into()).to_wasmtime_result();
+        }
+
         #[allow(unused)]
         let path = self
             .host

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -27,6 +27,27 @@ impl<'a> Into<SettingsLocation<'a>> for &'a dyn File {
 /// Initializes the language settings.
 pub fn init(cx: &mut AppContext) {
     AllLanguageSettings::register(cx);
+    DownloadConfiguration::register(cx);
+}
+
+#[derive(Default, Serialize, Deserialize, Clone)]
+pub struct DownloadConfiguration {
+    enable_binary_downloads: bool,
+}
+
+#[derive(Deserialize)]
+struct DownloadConfigurationContent {
+    enable_binary_downloads: Option<bool>,
+}
+
+impl settings::Settings for DownloadConfiguration {
+    const KEY: Option<&'static str> = None;
+
+    type FileContent = DownloadConfigurationContent;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
+    }
 }
 
 /// Returns the settings for the specified language from the provided file.

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -24,6 +24,7 @@ async_zip.workspace = true
 futures.workspace = true
 http.workspace = true
 log.workspace = true
+language.workspace = true
 paths.workspace = true
 semver.workspace = true
 serde.workspace = true

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -14,6 +14,7 @@ pub struct WorkspaceSettings {
     pub restore_on_startup: RestoreOnStartupBehaviour,
     pub drop_target_size: f32,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
+    pub download_missing_binaries: bool,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
fixes https://github.com/zed-industries/zed/issues/12589 https://github.com/zed-industries/zed/issues/12354

follow up to https://github.com/zed-industries/zed/pull/12703

TODO:

- [ ] Implement a setting for globally enabling / disabling binary downloads
  - [ ] Node
  - [ ] Supermaven & Copilot
  - [ ] Built in and extension LSP binaries
- [ ] Report appropriate errors to the user when downloads are blocked this way
- [ ] Add this setting to the welcome page, so users have a chance to disable it before continuing.

Release Notes:

- TODO