### PR TITLE
outline_panel: Fix outline panel should autoscroll when selection has changed

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -1207,6 +1207,7 @@ impl OutlinePanel {
 
         self.selected_entry = Some(entry_with_selection);
         self.update_cached_entries(None, cx);
+        self.autoscroll(cx);
     }
 
     fn render_excerpt(


### PR DESCRIPTION
Fixed selection changed, outline panel not autoscroll.

Release Notes:

- N/A
