### PR TITLE
gpui: Fix TextStyle default font_family crash on Windows, use `Segoe UI` for Windows

### DIFF
--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -212,6 +212,8 @@ impl Default for TextStyle {
             // todo(linux) make this configurable or choose better default
             font_family: if cfg!(target_os = "linux") {
                 "FreeMono".into()
+            } else if cfg!(target_os = "windows") {
+                "Segoe UI".into()
             } else {
                 "Helvetica".into()
             },

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -66,6 +66,7 @@ impl TextSystem {
                 // We should allow GPUI users to provide their own fallback font stack.
                 font("Zed Plex Mono"),
                 font("Helvetica"),
+                font("Segoe UI"),  // Windows
                 font("Cantarell"), // Gnome
                 font("Ubuntu"),    // Gnome (Ubuntu)
                 font("Noto Sans"), // KDE


### PR DESCRIPTION
Release Notes:

- Fixed default font_family crash on Windows, use `Segoe UI`.

## Crash error message

```
thread 'main' panicked at crates\gpui\src\text_system.rs:150:9:
failed to resolve font 'Helvetica' or any of the fallbacks: 
Zed Plex Mono, Helvetica, Cantarell, Ubuntu, Noto Sans, DejaVu Sans
```