### PR TITLE
gpui: Fix `cx.bounds`, `cx.open_window` position on macOS

### DIFF
--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -7,22 +7,23 @@ struct WindowContent {
 }
 
 impl Render for WindowContent {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let window_bounds = cx.bounds();
+
         div()
             .flex()
             .flex_col()
-            .gap_2()
             .bg(self.bg)
             .size_full()
             .items_center()
-            .text_xl()
             .text_color(rgb(0xffffff))
             .child(self.text.clone())
             .child(
                 div()
                     .flex()
-                    .text_base()
-                    .justify_center()
+                    .flex_col()
+                    .text_sm()
+                    .items_center()
                     .size_full()
                     .child(format!(
                         "origin: {}, {} size: {}, {}",
@@ -30,6 +31,13 @@ impl Render for WindowContent {
                         self.bounds.origin.y,
                         self.bounds.size.width,
                         self.bounds.size.height
+                    ))
+                    .child(format!(
+                        "cx.bounds() origin: {}, {} size {}, {}",
+                        window_bounds.origin.x,
+                        window_bounds.origin.y,
+                        window_bounds.size.width,
+                        window_bounds.size.height
                     )),
             )
     }
@@ -57,8 +65,8 @@ fn main() {
     App::new().run(|cx: &mut AppContext| {
         // Create several new windows, positioned in the top right corner of each screen
         let size = Size {
-            width: px(400.),
-            height: px(72.),
+            width: px(350.),
+            height: px(75.),
         };
         let margin_offset = px(150.);
 

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -79,7 +79,7 @@ fn main() {
 
             let bounds = Bounds {
                 origin: screen.bounds().upper_right()
-                    - point(size.width + margin_offset, margin_offset),
+                    - point(size.width + margin_offset, -margin_offset),
                 size,
             };
 
@@ -93,7 +93,7 @@ fn main() {
             .unwrap();
 
             let bounds = Bounds {
-                origin: screen.bounds().lower_left() + point(margin_offset, margin_offset),
+                origin: screen.bounds().lower_left() + point(margin_offset, -margin_offset),
                 size,
             };
 

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -2,63 +2,200 @@ use gpui::*;
 
 struct WindowContent {
     text: SharedString,
+    bounds: Bounds<Pixels>,
+    bg: Hsla,
 }
 
 impl Render for WindowContent {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
         div()
             .flex()
-            .bg(rgb(0x1e2025))
+            .flex_col()
+            .gap_2()
+            .bg(self.bg)
             .size_full()
-            .justify_center()
             .items_center()
             .text_xl()
             .text_color(rgb(0xffffff))
             .child(self.text.clone())
+            .child(
+                div()
+                    .flex()
+                    .text_base()
+                    .justify_center()
+                    .size_full()
+                    .child(format!(
+                        "origin: {}, {} size: {}, {}",
+                        self.bounds.origin.x,
+                        self.bounds.origin.y,
+                        self.bounds.size.width,
+                        self.bounds.size.height
+                    )),
+            )
+    }
+}
+
+fn build_window_options(display_id: DisplayId, bounds: Bounds<Pixels>) -> WindowOptions {
+    WindowOptions {
+        // Set the bounds of the window in screen coordinates
+        window_bounds: Some(WindowBounds::Windowed(bounds)),
+        // Specify the display_id to ensure the window is created on the correct screen
+        display_id: Some(display_id),
+        titlebar: None,
+        window_background: WindowBackgroundAppearance::Transparent,
+        focus: false,
+        show: true,
+        kind: WindowKind::PopUp,
+        is_movable: false,
+        app_id: None,
+        window_min_size: None,
+        window_decorations: None,
     }
 }
 
 fn main() {
     App::new().run(|cx: &mut AppContext| {
         // Create several new windows, positioned in the top right corner of each screen
+        let size = Size {
+            width: px(400.),
+            height: px(72.),
+        };
+        let margin_offset = px(150.);
 
         for screen in cx.displays() {
-            let options = {
-                let margin_right = px(16.);
-                let margin_height = px(-48.);
-
-                let size = Size {
-                    width: px(400.),
-                    height: px(72.),
-                };
-
-                let bounds = gpui::Bounds::<Pixels> {
-                    origin: screen.bounds().upper_right()
-                        - point(size.width + margin_right, margin_height),
-                    size,
-                };
-
-                WindowOptions {
-                    // Set the bounds of the window in screen coordinates
-                    window_bounds: Some(WindowBounds::Windowed(bounds)),
-                    // Specify the display_id to ensure the window is created on the correct screen
-                    display_id: Some(screen.id()),
-
-                    titlebar: None,
-                    window_background: WindowBackgroundAppearance::default(),
-                    focus: false,
-                    show: true,
-                    kind: WindowKind::PopUp,
-                    is_movable: false,
-                    app_id: None,
-                    window_min_size: None,
-                    window_decorations: None,
-                }
+            let bounds = Bounds {
+                origin: point(margin_offset, margin_offset),
+                size,
             };
 
-            cx.open_window(options, |cx| {
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
                 cx.new_view(|_| WindowContent {
-                    text: format!("{:?}", screen.id()).into(),
+                    text: format!("Top Left {:?}", screen.id()).into(),
+                    bg: gpui::red(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: screen.bounds().upper_right()
+                    - point(size.width + margin_offset, margin_offset),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Top Right {:?}", screen.id()).into(),
+                    bg: gpui::red(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: screen.bounds().lower_left() + point(margin_offset, margin_offset),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Bottom Left {:?}", screen.id()).into(),
+                    bg: gpui::blue(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: screen.bounds().lower_right()
+                    - point(size.width + margin_offset, margin_offset),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Bottom Right {:?}", screen.id()).into(),
+                    bg: gpui::blue(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: point(screen.bounds().center().x - size.center().x, margin_offset),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Top Center {:?}", screen.id()).into(),
+                    bg: gpui::black(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: point(margin_offset, screen.bounds().center().y - size.center().y),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Left Center {:?}", screen.id()).into(),
+                    bg: gpui::black(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: point(
+                    screen.bounds().center().x - size.center().x,
+                    screen.bounds().center().y - size.center().y,
+                ),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Center {:?}", screen.id()).into(),
+                    bg: gpui::black(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: point(
+                    screen.bounds().size.width - size.width - margin_offset,
+                    screen.bounds().center().y - size.center().y,
+                ),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Right Center {:?}", screen.id()).into(),
+                    bg: gpui::black(),
+                    bounds,
+                })
+            })
+            .unwrap();
+
+            let bounds = Bounds {
+                origin: point(
+                    screen.bounds().center().x - size.center().x,
+                    screen.bounds().size.height - margin_offset,
+                ),
+                size,
+            };
+
+            cx.open_window(build_window_options(screen.id(), bounds), |cx| {
+                cx.new_view(|_| WindowContent {
+                    text: format!("Bottom Center {:?}", screen.id()).into(),
+                    bg: gpui::black(),
+                    bounds,
                 })
             })
             .unwrap();

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -101,7 +101,8 @@ fn main() {
             .unwrap();
 
             let bounds = Bounds {
-                origin: screen.bounds().lower_left() + point(margin_offset, -margin_offset),
+                origin: screen.bounds().lower_left()
+                    - point(-margin_offset, size.height + margin_offset),
                 size,
             };
 
@@ -116,7 +117,7 @@ fn main() {
 
             let bounds = Bounds {
                 origin: screen.bounds().lower_right()
-                    - point(size.width + margin_offset, margin_offset),
+                    - point(size.width + margin_offset, size.height + margin_offset),
                 size,
             };
 
@@ -194,7 +195,7 @@ fn main() {
             let bounds = Bounds {
                 origin: point(
                     screen.bounds().center().x - size.center().x,
-                    screen.bounds().size.height - margin_offset,
+                    screen.bounds().size.height - size.height - margin_offset,
                 ),
                 size,
             };

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -452,7 +452,7 @@ impl MacWindowState {
         let bounds = Bounds::new(
             point(
                 px((window_frame.origin.x - screen_frame.origin.x) as f32),
-                px((window_frame.origin.y - screen_frame.origin.y) as f32),
+                px((window_frame.origin.y + screen_frame.origin.y) as f32),
             ),
             size(
                 px(window_frame.size.width as f32),

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -546,7 +546,7 @@ impl MacWindow {
             let count: u64 = cocoa::foundation::NSArray::count(screens);
             for i in 0..count {
                 let screen = cocoa::foundation::NSArray::objectAtIndex(screens, i);
-                let frame = NSScreen::visibleFrame(screen);
+                let frame = NSScreen::frame(screen);
                 let display_id = display_id_for_screen(screen);
                 if display_id == display.0 {
                     screen_frame = Some(frame);
@@ -557,7 +557,7 @@ impl MacWindow {
             let screen_frame = screen_frame.unwrap_or_else(|| {
                 let screen = NSScreen::mainScreen(nil);
                 target_screen = screen;
-                NSScreen::visibleFrame(screen)
+                NSScreen::frame(screen)
             });
 
             let window_rect = NSRect::new(


### PR DESCRIPTION
Release Notes:

- gpui: Fixed `cx.bounds` method to get correct `y` position on macOS.
- gpui: Fixed `cx.open_window` position when macOS Dock is existed.
- Fixed call notification and reopen window position.

## Before

![image](https://github.com/zed-industries/zed/assets/5518/4a435ffd-d7ef-4de7-a7de-44d21db4a719)

https://github.com/zed-industries/zed/assets/5518/ab925779-4253-4b27-9084-01023888087f


## After

<img width="533" alt="image" src="https://github.com/zed-industries/zed/assets/5518/142e9aaa-ae82-4a72-9acf-04097c545bf0">

https://github.com/zed-industries/zed/assets/5518/8793824a-8b74-4913-8204-7b39649aeeed


---

The case is I have made a Popover by use child window, the coordinate of the window is always can't placement a right position.

So, I make this example to test the `cx.bounds` and set bounds to window.

---

By this test, is the `cx.bounds` have a bug?

For example the **Top Left** window, we give it origin (150,150), but it `cx.bounds()` returns (150,262)

> On the window label, middle line is the `bounds` that we set to the window, last line is `cx.bounds()` result.

Display 1:

<img width="1512" alt="CleanShot 2024-07-10 at 14 52 26@2x" src="https://github.com/zed-industries/zed/assets/5518/3adf9e79-f237-431a-a72b-02face7b2361">


---

Or is there something I missed. Is it correct to use `cx.bounds` method to get the bounds of the current window?

At the same time, I also found that when there are multiple screens, the information obtained by cx.bounds is very different on different screens, and it seems that the origin is not relative to the screen.

Display 2:

<img width="2560" alt="SCR-20240710-nkmq" src="https://github.com/zed-industries/zed/assets/5518/d87d4151-0562-4bf8-b3b3-5da3b4d09d82">


