### PR TITLE
linux: Add profiling annotations & extend example

### DIFF
--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -193,6 +193,16 @@ impl TextInput {
             .find_map(|(idx, _)| (idx > offset).then_some(idx))
             .unwrap_or(self.content.len())
     }
+
+    fn reset(&mut self) {
+        self.content = "".into();
+        self.selected_range = 0..0;
+        self.selection_reversed = false;
+        self.marked_range = None;
+        self.last_layout = None;
+        self.last_bounds = None;
+        self.is_selecting = false;
+    }
 }
 
 impl ViewInputHandler for TextInput {
@@ -315,6 +325,7 @@ impl Element for TextElement {
         None
     }
 
+    #[profiling::function]
     fn request_layout(
         &mut self,
         _id: Option<&GlobalElementId>,
@@ -326,6 +337,7 @@ impl Element for TextElement {
         (cx.request_layout(style, []), ())
     }
 
+    #[profiling::function]
     fn prepaint(
         &mut self,
         _id: Option<&GlobalElementId>,
@@ -416,6 +428,7 @@ impl Element for TextElement {
         }
     }
 
+    #[profiling::function]
     fn paint(
         &mut self,
         _id: Option<&GlobalElementId>,
@@ -430,12 +443,14 @@ impl Element for TextElement {
             ElementInputHandler::new(bounds, self.input.clone()),
         );
         if let Some(selection) = prepaint.selection.take() {
+            profiling::scope!("paint_quad selection");
             cx.paint_quad(selection)
         }
         let line = prepaint.line.take().unwrap();
         line.paint(bounds.origin, cx.line_height(), cx).unwrap();
 
         if let Some(cursor) = prepaint.cursor.take() {
+            profiling::scope!("paint_quad cursor");
             cx.paint_quad(cursor);
         }
         self.input.update(cx, |input, _cx| {
@@ -446,6 +461,7 @@ impl Element for TextElement {
 }
 
 impl Render for TextInput {
+    #[profiling::function]
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         div()
             .flex()
@@ -494,13 +510,48 @@ struct InputExample {
     recent_keystrokes: Vec<Keystroke>,
 }
 
+impl InputExample {
+    fn on_reset_click(&mut self, _: &MouseUpEvent, cx: &mut ViewContext<Self>) {
+        self.recent_keystrokes.clear();
+        self.text_input
+            .update(cx, |text_input, _cx| text_input.reset());
+        cx.notify();
+    }
+}
+
 impl Render for InputExample {
-    fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
+    #[profiling::function]
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let num_keystrokes = self.recent_keystrokes.len();
         div()
             .bg(rgb(0xaaaaaa))
             .flex()
             .flex_col()
             .size_full()
+            .child(
+                div()
+                    .bg(white())
+                    .border_b_1()
+                    .border_color(black())
+                    .flex()
+                    .flex_row()
+                    .justify_between()
+                    .child(format!("Keystrokes: {}", num_keystrokes))
+                    .child(
+                        div()
+                            .border_1()
+                            .border_color(black())
+                            .px_2()
+                            .bg(yellow())
+                            .child("Reset")
+                            .hover(|style| {
+                                style
+                                    .bg(yellow().blend(opaque_grey(0.5, 0.5)))
+                                    .cursor_pointer()
+                            })
+                            .on_mouse_up(MouseButton::Left, cx.listener(Self::on_reset_click)),
+                    ),
+            )
             .child(self.text_input.clone())
             .children(self.recent_keystrokes.iter().rev().map(|ks| {
                 format!(

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -387,6 +387,7 @@ impl<E: Element> Drawable<E> {
         }
     }
 
+    #[profiling::function]
     pub(crate) fn layout_as_root(
         &mut self,
         available_space: Size<AvailableSpace>,
@@ -503,6 +504,7 @@ impl AnyElement {
     }
 
     /// Performs layout for this element within the given available space and returns its size.
+    #[profiling::function]
     pub fn layout_as_root(
         &mut self,
         available_space: Size<AvailableSpace>,
@@ -517,6 +519,7 @@ impl AnyElement {
     }
 
     /// Performs layout on this element in the available space, then prepaints it at the given absolute origin.
+    #[profiling::function]
     pub fn prepaint_as_root(
         &mut self,
         origin: Point<Pixels>,
@@ -524,7 +527,10 @@ impl AnyElement {
         cx: &mut WindowContext,
     ) {
         self.layout_as_root(available_space, cx);
-        cx.with_absolute_element_offset(origin, |cx| self.0.prepaint(cx));
+        cx.with_absolute_element_offset(origin, |cx| {
+            profiling::scope!("with_absolute_element_offset prepaint");
+            self.0.prepaint(cx)
+        });
     }
 }
 

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -524,6 +524,7 @@ impl BladeRenderer {
         self.gpu.destroy_command_encoder(&mut self.command_encoder);
     }
 
+    #[profiling::function]
     pub fn draw(&mut self, scene: &Scene) {
         self.command_encoder.start();
         self.atlas.before_frame(&mut self.command_encoder);

--- a/crates/gpui/src/platform/linux/dispatcher.rs
+++ b/crates/gpui/src/platform/linux/dispatcher.rs
@@ -38,6 +38,8 @@ impl LinuxDispatcher {
             .map(|i| {
                 let receiver = background_receiver.clone();
                 std::thread::spawn(move || {
+                    let thread_name = format!("background-{}", i);
+                    profiling::register_thread!(&thread_name);
                     for runnable in receiver {
                         let start = Instant::now();
 
@@ -55,6 +57,8 @@ impl LinuxDispatcher {
 
         let (timer_sender, timer_channel) = calloop::channel::channel::<TimerAfter>();
         let timer_thread = std::thread::spawn(|| {
+            profiling::register_thread!("timer-thread");
+
             let mut event_loop: EventLoop<()> =
                 EventLoop::try_new().expect("Failed to initialize timer loop!");
 

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1182,6 +1182,7 @@ impl PlatformWindow for X11Window {
         self.0.callbacks.borrow_mut().appearance_changed = Some(callback);
     }
 
+    #[profiling::function]
     fn draw(&self, scene: &Scene) {
         let mut inner = self.0.state.borrow_mut();
         inner.renderer.draw(scene);


### PR DESCRIPTION
Run:

```
cargo run -p gpui  --example input --features profiling/profile-with-tracy
```

(Yes, this is a debug build! I think there's data in it, because it's super slow compared to macOS)

Then keep a key pressed. After ~900 keystrokes recorded, things slow down a lot on Linux.

## Linux - debug build, after ~900 keystrokes

Mostly due to layout:

![image](https://github.com/zed-industries/zed/assets/1185253/c96b0c23-ad29-4d56-8d57-1952c55675e1)

When you then lift the finger, the frames get faster again (nothing really to render).

But then each keypress leads to a re-render which takes a long time:

![image](https://github.com/zed-industries/zed/assets/1185253/454ebaaa-44f1-4fe0-9d74-74f72d955b99)

## macOS - debug build, after ~900 keystrokes
![screenshot-2024-07-10-13 28 28@2x](https://github.com/zed-industries/zed/assets/1185253/f2f1c097-c36a-4ea3-bb85-d41a8fa9fce9)


Release Notes:

- N/A
