### PR TITLE
vim: Add ctrl-m binding (equivalent to <CR>)

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -17,6 +17,7 @@
       "j": "vim::Down",
       "down": "vim::Down",
       "enter": "vim::NextLineStart",
+      "ctrl-m": "vim::NextLineStart",
       "tab": "vim::Tab",
       "shift-tab": "vim::Tab",
       "k": "vim::Up",


### PR DESCRIPTION
Now that we have macros I noticed how much I rely on this.

Release Notes:

- vim: `ctrl-m` now is equivalent to `enter` in editor.
