### PR TITLE
Do not bind cmd-enter for repl::Run when in AssistantContext

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -569,7 +569,7 @@
     }
   },
   {
-    "context": "Editor && jupyter",
+    "context": "Editor && jupyter && !ContextEditor",
     "bindings": {
       "cmd-enter": "repl::Run"
     }


### PR DESCRIPTION
Don't pollute cmd-enter in the Assistant's `ContextEditor`.

Release Notes:

- N/A
