### PR TITLE
Minor breadcrumb style updates

### DIFF
--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -72,7 +72,7 @@ impl Render for Breadcrumbs {
                 .into_any()
         });
         let breadcrumbs = Itertools::intersperse_with(highlighted_segments, || {
-            Label::new("›").color(Color::Muted).into_any_element()
+            Label::new("›").color(Color::Placeholder).into_any_element()
         });
 
         let breadcrumbs_stack = h_flex().gap_1().children(breadcrumbs);
@@ -83,7 +83,7 @@ impl Render for Breadcrumbs {
             Some(editor) => element.child(
                 ButtonLike::new("toggle outline view")
                     .child(breadcrumbs_stack)
-                    .style(ButtonStyle::Subtle)
+                    .style(ButtonStyle::Transparent)
                     .on_click(move |_, cx| {
                         if let Some(editor) = editor.upgrade() {
                             outline::toggle(editor, &editor::actions::ToggleOutline, cx)


### PR DESCRIPTION
Minor breadcrumb style updates

Before:

![CleanShot 2024-07-10 at 12 42 46@2x](https://github.com/zed-industries/zed/assets/1714999/9e1d4fb7-7549-4749-85f8-797f59d06c4d)

After:

![CleanShot 2024-07-10 at 12 42 36@2x](https://github.com/zed-industries/zed/assets/1714999/f448eb0a-deac-4a8e-b26e-67d559c4c679)


Release Notes:

- N/A
