### PR TITLE
Flatpak fixes

### DIFF
--- a/crates/zed/resources/flatpak/zed.metainfo.xml.in
+++ b/crates/zed/resources/flatpak/zed.metainfo.xml.in
@@ -54,27 +54,32 @@
     <screenshots>
         <screenshot type="default">
             <caption>Zed with a large project open, showing language server and gitblame support</caption>
-            <image type="source" width="1122" height="859" xml:lang="en">https://zed.dev/img/flatpak/flatpak-1.png</image>
+            <image>https://zed.dev/img/flatpak/flatpak-1.png</image>
         </screenshot>
         <screenshot>
             <caption>Zed with a file open and a channel message thread in the right sidebar</caption>
-            <image type="source" width="1122" height="859" xml:lang="en">https://zed.dev/img/flatpak/flatpak-2.png</image>
+            <image>https://zed.dev/img/flatpak/flatpak-2.png</image>
         </screenshot>
         <screenshot>
             <caption>Example of a channel's shared document</caption>
-            <image type="source" width="1122" height="859" xml:lang="en">https://zed.dev/img/flatpak/flatpak-3.png</image>
+            <image>https://zed.dev/img/flatpak/flatpak-3.png</image>
         </screenshot>
         <screenshot>
             <caption>Zed's extension list</caption>
-            <image type="source" width="1122" height="859" xml:lang="en">https://zed.dev/img/flatpak/flatpak-4.png</image>
+            <image>https://zed.dev/img/flatpak/flatpak-4.png</image>
         </screenshot>
         <screenshot>
             <caption>Theme switcher UI and example theme</caption>
-            <image type="source" width="1122" height="859" xml:lang="en">https://zed.dev/img/flatpak/flatpak-5.png</image>
+            <image>https://zed.dev/img/flatpak/flatpak-5.png</image>
         </screenshot>
     </screenshots>
 
     <releases>
-        @release_info@
+		@release_info@
+		<release version="0.0.0" date="1970-01-01">
+			<description>
+				<p>Dummy release to keep flatpak-builder AppStream metadata validation from complaining</p>
+			</description>
+		</release>
     </releases>
 </component>

--- a/script/flatpak/bundle-flatpak
+++ b/script/flatpak/bundle-flatpak
@@ -12,19 +12,19 @@ channel=$(<crates/zed/RELEASE_CHANNEL)
 export CHANNEL="$channel"
 export ARCHIVE="$archive"
 if [[ "$channel" == "dev" ]]; then
-    export APP_ID="dev.zed.Zed-Dev"
+    export APP_ID="dev.zed.ZedDev"
     export APP_NAME="Zed Devel"
     export BRANDING_LIGHT="#99c1f1"
     export BRANDING_DARK="#1a5fb4"
     export ICON_FILE="app-icon-dev"
 elif [[ "$channel" == "nightly" ]]; then
-    export APP_ID="dev.zed.Zed-Nightly"
+    export APP_ID="dev.zed.ZedNightly"
     export APP_NAME="Zed Nightly"
     export BRANDING_LIGHT="#e9aa6a"
     export BRANDING_DARK="#1a5fb4"
     export ICON_FILE="app-icon-nightly"
 elif [[ "$channel" == "preview" ]]; then
-    export APP_ID="dev.zed.Zed-Preview"
+    export APP_ID="dev.zed.ZedPreview"
     export APP_NAME="Zed Preview"
     export BRANDING_LIGHT="#99c1f1"
     export BRANDING_DARK="#1a5fb4"


### PR DESCRIPTION
The Flatpak was failing to build because of AppStream metadata linting errors. It also complained about the hyphen in the cid.

Release Notes:
 
     * N/A