### PR TITLE
Fix panic clicking on multibyte chars

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -709,18 +709,24 @@ impl EditorElement {
         let Some(hub) = editor.collaboration_hub() else {
             return;
         };
-        let range = DisplayPoint::new(point.row(), point.column().saturating_sub(1))
-            ..DisplayPoint::new(
+        let start = snapshot.display_snapshot.clip_point(
+            DisplayPoint::new(point.row(), point.column().saturating_sub(1)),
+            Bias::Left,
+        );
+        let end = snapshot.display_snapshot.clip_point(
+            DisplayPoint::new(
                 point.row(),
                 (point.column() + 1).min(snapshot.line_len(point.row())),
-            );
+            ),
+            Bias::Right,
+        );
 
         let range = snapshot
             .buffer_snapshot
-            .anchor_at(range.start.to_point(&snapshot.display_snapshot), Bias::Left)
+            .anchor_at(start.to_point(&snapshot.display_snapshot), Bias::Left)
             ..snapshot
                 .buffer_snapshot
-                .anchor_at(range.end.to_point(&snapshot.display_snapshot), Bias::Right);
+                .anchor_at(end.to_point(&snapshot.display_snapshot), Bias::Right);
 
         let Some(selection) = snapshot.remote_selections_in_range(&range, hub, cx).next() else {
             return;


### PR DESCRIPTION
Fixes: #12011

When hovering over a multibyte character in a debug build, Zed would panic.
Follow up to #11296 

Release Notes:

- N/A
