### PR TITLE
Fix Cmd+\ for workspace::ToggleLeftDock for Atom base keymap

### DIFF
--- a/assets/keymaps/linux/atom.json
+++ b/assets/keymaps/linux/atom.json
@@ -25,6 +25,7 @@
       "ctrl-shift-d": "editor::DuplicateLineDown", // editor:duplicate-lines
       "ctrl-up": "editor::MoveLineUp", // editor:move-line-up
       "ctrl-down": "editor::MoveLineDown", // editor:move-line-down
+      "ctrl-\\": "workspace::ToggleLeftDock", // tree-view:toggle
       "ctrl-shift-m": "markdown::OpenPreviewToTheSide" // markdown-preview:toggle
     }
   },

--- a/assets/keymaps/macos/atom.json
+++ b/assets/keymaps/macos/atom.json
@@ -26,8 +26,8 @@
       "cmd-shift-d": "editor::DuplicateLineDown",
       "ctrl-cmd-up": "editor::MoveLineUp",
       "ctrl-cmd-down": "editor::MoveLineDown",
-      "ctrl-shift-m": "markdown::OpenPreviewToTheSide",
-      "cmd-\\": "workspace::ToggleLeftDock"
+      "cmd-\\": "workspace::ToggleLeftDock",
+      "ctrl-shift-m": "markdown::OpenPreviewToTheSide"
     }
   },
   {

--- a/assets/keymaps/macos/atom.json
+++ b/assets/keymaps/macos/atom.json
@@ -26,7 +26,8 @@
       "cmd-shift-d": "editor::DuplicateLineDown",
       "ctrl-cmd-up": "editor::MoveLineUp",
       "ctrl-cmd-down": "editor::MoveLineDown",
-      "ctrl-shift-m": "markdown::OpenPreviewToTheSide"
+      "ctrl-shift-m": "markdown::OpenPreviewToTheSide",
+      "cmd-\\": "workspace::ToggleLeftDock"
     }
   },
   {


### PR DESCRIPTION
On macOS, with the Atom base keymap, pressing `Cmd+\` no longer toggles the Left Dock.

Possibly because the macOS default keymap now has an `Editor` command for `Cmd+\`
https://github.com/zed-industries/zed/blob/d32e9f759c289a111f4a104b40f258c00fd4727b/assets/keymaps/default-macos.json#L342
In the Atom base keymap, its set only on `Workspace`
https://github.com/zed-industries/zed/blob/d32e9f759c289a111f4a104b40f258c00fd4727b/assets/keymaps/macos/atom.json#L48

Can be fixed by adding the following for `Editor` to your user`keymap.json`:
```json
[
  {
    "context": "Editor",
    "bindings": {
      "cmd-\\": "workspace::ToggleLeftDock"
    }
  }
]
```

Wanted to report the issue. Also made the change quickly as a PR, although I haven't tested it yet.

---

Release Notes:

- Fixed Cmd+\ did not toggle Left Dock when using Atom base keymap on macOS ([#14098](https://github.com/zed-industries/zed/pull/14098))