### PR TITLE
AlpineLinux: Fix install.sh and docs typo

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -28,7 +28,7 @@ There are several third-party Zed packages for various Linux distributions and p
 * Homebrew: [`zed`](https://formulae.brew.sh/cask/zed), [`zed@preview`](https://formulae.brew.sh/cask/zed@preview)
 * Arch: [`zed`](https://archlinux.org/packages/extra/x86_64/zed/)
 * Arch (AUR): [`zed-git`](https://aur.archlinux.org/packages/zed-git), [`zed-preview`](https://aur.archlinux.org/packages/zed-preview),  [`zed-preview-bin`](https://aur.archlinux.org/packages/zed-preview-bin)
-* Alpine: `zed` ([aarch64](https://pkgs.alpinelinux.org/package/edge/testing/aarch64/zed)) ([x86_65](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zed))
+* Alpine: `zed` ([aarch64](https://pkgs.alpinelinux.org/package/edge/testing/aarch64/zed)) ([x86_64](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zed))
 * Nix: `zed-editor` ([stable](https://search.nixos.org/packages?show=zed-editor)), ([unstable](https://search.nixos.org/packages?channel=unstable&show=zed-editor))
 * Fedora 39 & 40 (Terra): `zed-nightly` ([aarch64](https://fedora.pkgs.org/40/terra/zed-nightly-0:0.142.0%5e20240619.0129d4e-1.fc40.aarch64.rpm.html)) ([x86_64](https://fedora.pkgs.org/40/terra/zed-nightly-0:0.142.0%5e20240619.0129d4e-1.fc40.x86_64.rpm.html)) `zed-preview` ([aarch64](https://fedora.pkgs.org/40/terra/zed-preview-0:0.142.1-pre1.fc40.aarch64.rpm.html)) ([x86_64](https://fedora.pkgs.org/40/terra/zed-nightly-0:0.142.0%5e20240619.0129d4e-1.fc40.x86_64.rpm.html))
 * Solus: [`zed`](https://github.com/getsolus/packages/tree/main/packages/z/zed)

--- a/script/install.sh
+++ b/script/install.sh
@@ -9,7 +9,7 @@ main() {
     platform="$(uname -s)"
     arch="$(uname -m)"
     channel="${ZED_CHANNEL:-stable}"
-    temp="$(mktemp -d "/tmp/zed-XXXXX")"
+    temp="$(mktemp -d "/tmp/zed-XXXXXX")"
 
     if [ "$platform" = "Darwin" ]; then
         platform="macos"


### PR DESCRIPTION
AlpineLinux uses busybox `mktemp` which requires `mktemp -d` end with six XXXXXX (not five).

Fixes #14082

mktemp on MacOS (BSD) and Ubuntu (GNU) supports `XXXXXX` just fine.  

<img width="866" alt="image" src="https://github.com/zed-industries/zed/assets/145113/cd3340c8-14e6-40dd-8400-ccd8c2ca88a4">

Release Notes:

- N/A
