### PR TITLE
Fix #14106 Windows title bar broken

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -804,7 +804,7 @@ fn handle_hit_test_msg(
     if !state_ptr.is_movable {
         return None;
     }
-    if state_ptr.hide_title_bar {
+    if !state_ptr.hide_title_bar {
         return None;
     }
 


### PR DESCRIPTION
Release Notes:

- N/A

----

Fix #14106 

Sorry, the previous change in #14063 I have made a mistake. I shouldn't have changed the previous logic.

```diff
- if !state_ptr.hide_title_bar {
+ if state_ptr.hide_title_bar {
```

## Test

https://github.com/zed-industries/zed/assets/5518/e03fbcac-be6b-4a9d-8937-d3b5e236b564

And the popup window limit is still works.

