### PR TITLE
Add toggle hunk diff and expand all hunk diffs key bindings

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -268,6 +268,8 @@ See the [tasks documentation](/docs/tasks#custom-keybindings-for-tasks) for more
 | Redo selection                   | Editor     | `⌘ + Shift + U`                 |
 | Rename                           | Editor     | `F2`                            |
 | Reveal in File Manager           | Editor     | `Alt + ⌘ + R`                   |
+| Toggle hunk diff                 | Editor     | `⌘ + '`                         |
+| Expand all hunk diffs            | Editor     | `⌘ + "`                         |
 | Revert selected hunks            | Editor     | `⌘ + Alt + Z`                   |
 | Select all                       | Editor     | `⌘ + A`                         |
 | Select all matches               | Editor     | `⌘ + Shift + L`                 |


### PR DESCRIPTION
Noticed these were missing when I was reading through the docs.

Release Notes:

- Add toggle hunk diff and expand all hunk diffs key bindings
