### PR TITLE
Revert Windows normal window title style to `WS_EX_APPWINDOW`

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -268,7 +268,7 @@ impl WindowsWindow {
             (WS_EX_TOOLWINDOW, WINDOW_STYLE(0x0))
         } else {
             (
-                WS_EX_OVERLAPPEDWINDOW,
+                WS_EX_APPWINDOW,
                 WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX,
             )
         };


### PR DESCRIPTION
Release Notes:

- N/A

@ConradIrwin we must revert this little change.

https://github.com/zed-industries/zed/pull/14063#issuecomment-2221867379