### PR TITLE
Keymap changes for `editor::JoinLines`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -397,7 +397,7 @@
     "bindings": {
       "ctrl-shift-k": "editor::DeleteLine",
       "ctrl-shift-d": "editor::DuplicateLineDown",
-      "ctrl-j": "editor::JoinLines",
+      "ctrl-shift-j": "editor::JoinLines",
       "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -432,6 +432,7 @@
     "context": "Editor",
     "bindings": {
       "ctrl-j": "editor::JoinLines",
+      "cmd-shift-j": "editor::JoinLines",
       "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -432,7 +432,6 @@
     "context": "Editor",
     "bindings": {
       "ctrl-j": "editor::JoinLines",
-      "cmd-shift-j": "editor::JoinLines",
       "ctrl-alt-backspace": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-h": "editor::DeleteToPreviousSubwordStart",
       "ctrl-alt-delete": "editor::DeleteToNextSubwordEnd",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -27,6 +27,7 @@
       "ctrl-,": "editor::GoToPrevHunk",
       "cmd-k cmd-u": "editor::ConvertToUpperCase",
       "cmd-k cmd-l": "editor::ConvertToLowerCase",
+      "cmd-shift-j": "editor::JoinLines",
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
       "ctrl-delete": "editor::DeleteToNextWordEnd"


### PR DESCRIPTION
- Linux (default) add ctrl-shift-j
- Linux (default) remove ctrl-j
  - Conflicted with: `"ctrl-j": "workspace::ToggleBottomDock",`
- MacOS (sublime) add cmd-shift-j

JetBrains/Sublime on Windows/Linux already use `ctrl-shift-j`

Reported here:
- https://github.com/zed-industries/zed/issues/14085#issuecomment-2221604905
- https://discord.com/channels/869392257814519848/873292398204170290/1260706111611207843

Release Notes:

- Keymap: Move `editor::JoinLines` to ctrl-shift-j (Linux)
