### PR TITLE
Document how to enable `vim_mode` in /docs/vim

### DIFF
--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -241,6 +241,16 @@ As any Zed command is available, you may find that it's helpful to remember mnem
 
 ## Settings
 
+Vim mode is not enabled by default. To enable Vim mode, you need to add the following configuration to your settings file:
+
+```json
+{
+  "vim_mode": true
+}
+```
+
+Alternatively, you can enable Vim mode by running the `toggle vim mode` command from the command palette.
+
 Some vim settings are available to modify the default vim behavior:
 
 ```json


### PR DESCRIPTION
## Documents:

- **Added** instructions on how to enable "Vim mode" to the ["Settings"](https://zed.dev/docs/vim#settings) of [/docs/vim](https://zed.dev/docs/vim).

While [/docs/configuring-zed](https://zed.dev/docs/configuring-zed) _does_ mention the `vim_mode` setting, [/docs/vim](https://zed.dev/docs/vim) does not. 

This can be confusing for users like me who went straight to the vim doc, and could not figure out how to enable vim.

## Release Notes:

- N/A
