### PR TITLE
vim: Fix `c` when range ends in a multibyte character

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -890,7 +890,7 @@ impl Motion {
                 }
 
                 if inclusive && selection.end.column() < map.line_len(selection.end.row()) {
-                    *selection.end.column_mut() += 1;
+                    selection.end = movement::saturating_right(map, selection.end)
                 }
             }
             Some(selection.start..selection.end)

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1266,3 +1266,16 @@ async fn test_toggle_comments(cx: &mut gpui::TestAppContext) {
         Mode::Normal,
     );
 }
+
+#[gpui::test]
+async fn test_find_multibyte(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state(r#"<label for="guests">ˇPočet hostů</label>"#)
+        .await;
+
+    cx.simulate_shared_keystrokes("c t < o escape").await;
+    cx.shared_state()
+        .await
+        .assert_eq(r#"<label for="guests">ˇo</label>"#);
+}

--- a/crates/vim/test_data/test_find_multibyte.json
+++ b/crates/vim/test_data/test_find_multibyte.json
@@ -1,0 +1,7 @@
+{"Put":{"state":"<label for=\"guests\">ˇPočet hostů</label>"}}
+{"Key":"c"}
+{"Key":"t"}
+{"Key":"<"}
+{"Key":"o"}
+{"Key":"escape"}
+{"Get":{"state":"<label for=\"guests\">ˇo</label>","mode":"Normal"}}


### PR DESCRIPTION
Release Notes:

- vim: Fixed `c <motion>` omitting trailing multibyte characters ([#13909](https://github.com/zed-industries/zed/issues/13909)).

