### PR TITLE
Fix reverse selections always being cleared

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -49,13 +49,11 @@ fn display_ranges<'a>(
         .pending
         .as_ref()
         .map(|pending| &pending.selection);
-    selections.disjoint.iter().chain(pending).map(move |s| {
-        if s.reversed {
-            s.end.to_display_point(&display_map)..s.start.to_display_point(&display_map)
-        } else {
-            s.start.to_display_point(&display_map)..s.end.to_display_point(&display_map)
-        }
-    })
+    selections
+        .disjoint
+        .iter()
+        .chain(pending)
+        .map(move |s| s.start.to_display_point(&display_map)..s.end.to_display_point(&display_map))
 }
 
 pub fn deploy_context_menu(


### PR DESCRIPTION
When I implemented #13701, I kinda messed up with the reversed selections, thinking that their anchors are flipped, so I flipped them again. This caused the reverse selections to always be cleared

Release Notes:

- Fix reverse selections always being cleared, even if the right click was performed inside
