### PR TITLE
terminal: Prevent extra character on handled meta keystrokes

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -864,10 +864,13 @@ impl TerminalView {
         self.pause_cursor_blinking(cx);
 
         self.terminal.update(cx, |term, cx| {
-            term.try_keystroke(
+            let handled = term.try_keystroke(
                 &event.keystroke,
                 TerminalSettings::get_global(cx).option_as_meta,
-            )
+            );
+            if handled {
+                cx.stop_propagation();
+            }
         });
     }
 


### PR DESCRIPTION
On macOS, when `terminal.option_as_meta` is enabled, pressing key combinations like `option+b` and `option+f` would lead to both an escape sequence being sent to the terminal (the expected behavior with `option_as_meta == true`) AND a character being inserted (the behavior when `option_as_meta == false`). Prevent the latter by stopping propagation of the key-down event if it corresponds to a terminal escape sequence and `option_as_meta` is enabled.

Fixes #7728

Release Notes:

- Fixed insertion of extra characters for some keystrokes if `terminal.option_as_meta` is enabled ([#7728](https://github.com/zed-industries/zed/issues/7728)).