### PR TITLE
Add Upper/LowerCase binds to Linux Sublime Text keybinds

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -24,6 +24,8 @@
       "ctrl-shift-f12": "editor::FindAllReferences",
       "ctrl-.": "editor::GoToHunk",
       "ctrl-,": "editor::GoToPrevHunk",
+      "ctrl-k ctrl-u": "editor::ConvertToUpperCase",
+      "ctrl-k ctrl-l": "editor::ConvertToLowerCase",
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
       "ctrl-delete": "editor::DeleteToNextWordEnd"


### PR DESCRIPTION
- Discovered missing in https://github.com/zed-industries/zed/issues/14019

Release Notes:

- N/A
