### PR TITLE
Project panel: Prevent scrollbar size from scaling with rem size

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2293,7 +2293,7 @@ impl ProjectPanel {
                 .right_0()
                 .top_0()
                 .bottom_0()
-                .w_3()
+                .w(px(12.))
                 .cursor_default()
                 .child(ProjectPanelScrollbar::new(
                     percentage as f32..end_offset as f32,


### PR DESCRIPTION
The underlying container had width of 0.75 rem, which was equal to 12px at default ui_font_size. However, with larger values of ui_font_size the scrollbar would drift towards the center of a project panel, as the scrollbar itself has a fixed width of 12 pixels. This commit moves towards using a fixed width of 12px for scrollbar container. The alternative was to make the scrollbar scale with ui_font_size, but that isn't what the Editor scrollbar does, so I decided against it.



Release Notes:

- Fixed position of scrollbar in project panel with non-default `ui_font_size` values.
