### PR TITLE
docs: Document `buffer_line_height`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -156,7 +156,7 @@ You can also set other OpenType features, like setting `cv01` to `7`:
 
 - Description: The default line height for text in the editor.
 - Setting: `buffer_line_height`
-- Default: `"standard"`
+- Default: `"comfortable"`
 
 **Options**
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -152,6 +152,16 @@ You can also set other OpenType features, like setting `cv01` to `7`:
 
 `integer` values between `100` and `900`
 
+## Buffer Line Height
+
+- Description: The default line height for text in the editor.
+- Setting: `buffer_line_height`
+- Default: `"standard"`
+
+**Options**
+
+`"standard"`, `"comfortable"` or `{"custom": float}` (`1` is very compact, `2` very loose)
+
 ## Confirm Quit
 
 - Description: Whether or not to prompt the user to confirm before closing the application.


### PR DESCRIPTION
`buffer_line_height` has been requested in #5590 and implemented in #2718, however the documentation was still lacking.

Release Notes:

- N/A
