### PR TITLE
Disrupt blink for immediate feedback on cursor shape changes

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2156,6 +2156,10 @@ impl Editor {
 
     pub fn set_cursor_shape(&mut self, cursor_shape: CursorShape, cx: &mut ViewContext<Self>) {
         self.cursor_shape = cursor_shape;
+
+        // Disrupt blink for immediate user feedback that the cursor shape has changed
+        self.blink_manager.update(cx, BlinkManager::show_cursor);
+
         cx.notify();
     }
 


### PR DESCRIPTION
# Issue

When a user does something that changes the cursor shape, such as when switching between vim modes, there may be an up to 500ms (cursor blink interval) delay until the user receives feedback for their action. This happens when the shape change happens during the invisible phase of a blink - the user will not see the cursor shape change until the next phase, which could be 500ms away.

# Solution

Cursor shape changes should disrupt blinking by forcing the cursor to be shown, this results in immediate feedback for shape changes. This is in line with the behavior of other editors I've tried.

Release Notes:

- vim: Improved visual feedback when changing cursor shape