### PR TITLE
windows: Fix title bar misrendering after #13420

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -661,9 +661,6 @@ fn handle_calc_client_size(
 
     if state_ptr.state.borrow().is_maximized() {
         requested_client_rect[0].top += frame_y + padding;
-    } else {
-        // Magic number that calculates the width of the border
-        requested_client_rect[0].top += frame_y - 3;
     }
 
     Some(0)


### PR DESCRIPTION
This commit fix the title bar rendering issue left in #13420 .

before:
![image](https://github.com/zed-industries/zed/assets/54507071/7260eb4a-149d-48f3-a679-277d0d10dcf4)

after:
![image](https://github.com/zed-industries/zed/assets/54507071/4157e27c-ba39-4471-89d1-fdbc754fd5d6)

thanks for @MatinAniss for telling me how to fix this


Release Notes:

- N/A