### PR TITLE
assistant: Show a message when no docs providers are available

### DIFF
--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -121,7 +121,7 @@ impl SlashCommand for DocsSlashCommand {
             match args {
                 DocsSlashCommandArgs::NoProvider => {
                     let providers = indexed_docs_registry.list_providers();
-                    if true || providers.is_empty() {
+                    if providers.is_empty() {
                         return Ok(vec![ArgumentCompletion {
                             label: "No available docs providers.".to_string(),
                             new_text: String::new(),

--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -121,6 +121,14 @@ impl SlashCommand for DocsSlashCommand {
             match args {
                 DocsSlashCommandArgs::NoProvider => {
                     let providers = indexed_docs_registry.list_providers();
+                    if true || providers.is_empty() {
+                        return Ok(vec![ArgumentCompletion {
+                            label: "No available docs providers.".to_string(),
+                            new_text: String::new(),
+                            run_command: false,
+                        }]);
+                    }
+
                     Ok(providers
                         .into_iter()
                         .map(|provider| ArgumentCompletion {


### PR DESCRIPTION
This PR updates the `/docs` slash command to show a message to more clearly indicate when there are no available docs providers.

<img width="379" alt="Screenshot 2024-07-11 at 10 31 53 AM" src="https://github.com/zed-industries/zed/assets/1486634/d079f87c-4933-4da9-ad82-34dbfe6a284c">

Release Notes:

- N/A
