### PR TITLE
Allow Zed Nightly to use v0.0.7 of the Zed extension API

### DIFF
--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -49,10 +49,9 @@ pub fn is_supported_wasm_api_version(
 /// Returns the Wasm API version range that is supported by the Wasm host.
 #[inline(always)]
 pub fn wasm_api_version_range(release_channel: ReleaseChannel) -> RangeInclusive<SemanticVersion> {
-    let max_version = if release_channel == ReleaseChannel::Dev {
-        latest::MAX_VERSION
-    } else {
-        since_v0_0_6::MAX_VERSION
+    let max_version = match release_channel {
+        ReleaseChannel::Dev | ReleaseChannel::Nightly => latest::MAX_VERSION,
+        ReleaseChannel::Stable | ReleaseChannel::Preview => since_v0_0_6::MAX_VERSION,
     };
 
     since_v0_0_1::MIN_VERSION..=max_version


### PR DESCRIPTION
This PR updates the Wasm API compatibility check to allow Nightly to load extensions using v0.0.7 of the Zed extension API.

Release Notes:

- N/A
