### PR TITLE
windows: Return client size and position from `window_bounds`

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -732,7 +732,10 @@ fn handle_dpi_changed_msg(
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
     let new_dpi = wparam.loword() as f32;
-    state_ptr.state.borrow_mut().scale_factor = new_dpi / USER_DEFAULT_SCREEN_DPI as f32;
+    let mut lock = state_ptr.state.borrow_mut();
+    lock.scale_factor = new_dpi / USER_DEFAULT_SCREEN_DPI as f32;
+    lock.border_offset.udpate(handle).log_err();
+    drop(lock);
 
     let rect = unsafe { &*(lparam.0 as *const RECT) };
     let width = rect.right - rect.left;

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -82,7 +82,7 @@ pub(crate) fn handle_msg(
         WM_IME_STARTCOMPOSITION => handle_ime_position(handle, state_ptr),
         WM_IME_COMPOSITION => handle_ime_composition(handle, lparam, state_ptr),
         WM_SETCURSOR => handle_set_cursor(lparam, state_ptr),
-        WM_SETTINGCHANGE => handle_system_settings_changed(state_ptr),
+        WM_SETTINGCHANGE => handle_system_settings_changed(handle, state_ptr),
         CURSOR_STYLE_CHANGED => handle_cursor_changed(lparam, state_ptr),
         _ => None,
     };
@@ -1050,12 +1050,17 @@ fn handle_set_cursor(lparam: LPARAM, state_ptr: Rc<WindowsWindowStatePtr>) -> Op
     Some(1)
 }
 
-fn handle_system_settings_changed(state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
+fn handle_system_settings_changed(
+    handle: HWND,
+    state_ptr: Rc<WindowsWindowStatePtr>,
+) -> Option<isize> {
     let mut lock = state_ptr.state.borrow_mut();
     // mouse wheel
     lock.system_settings.mouse_wheel_settings.update();
     // mouse double click
     lock.click_state.system_update();
+    // window size offset
+    lock.size_offset.udpate(handle).log_err();
     Some(0)
 }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1059,7 +1059,7 @@ fn handle_system_settings_changed(
     lock.system_settings.mouse_wheel_settings.update();
     // mouse double click
     lock.click_state.system_update();
-    // window size offset
+    // window border offset
     lock.border_offset.udpate(handle).log_err();
     Some(0)
 }

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1060,7 +1060,7 @@ fn handle_system_settings_changed(
     // mouse double click
     lock.click_state.system_update();
     // window size offset
-    lock.size_offset.udpate(handle).log_err();
+    lock.border_offset.udpate(handle).log_err();
     Some(0)
 }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -313,7 +313,6 @@ impl WindowsWindow {
         let state_ptr = Rc::clone(context.inner.as_ref().unwrap());
         register_drag_drop(state_ptr.clone());
 
-        let mut lock = state_ptr.state.borrow_mut();
         unsafe {
             let mut placement = WINDOWPLACEMENT {
                 length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
@@ -326,12 +325,13 @@ impl WindowsWindow {
             } else {
                 display.default_bounds()
             };
+            let mut lock = state_ptr.state.borrow_mut();
             let bounds = bounds.to_device_pixels(lock.scale_factor);
             lock.border_offset.udpate(raw_hwnd).unwrap();
             placement.rcNormalPosition = calcualte_window_rect(bounds, lock.border_offset);
+            drop(lock);
             SetWindowPlacement(raw_hwnd, &placement).log_err();
         }
-        drop(lock);
         unsafe { ShowWindow(raw_hwnd, SW_SHOW).ok().log_err() };
 
         Self(state_ptr)

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -986,6 +986,13 @@ fn register_drag_drop(state_ptr: Rc<WindowsWindowStatePtr>) {
 }
 
 fn calcualte_window_rect(bounds: Bounds<DevicePixels>, border_offset: WindowBorderOffset) -> RECT {
+    // NOTE:
+    // The reason that not using `AdjustWindowRectEx()` here is
+    // that the size reported by this function is incorrect.
+    // You can test it, and there are similar discussions online.
+    // See: https://stackoverflow.com/questions/12423584/how-to-set-exact-client-size-for-overlapped-window-winapi
+    //
+    // So we manually calculate these values here.
     let mut rect = RECT {
         left: bounds.left().0,
         top: bounds.top().0,
@@ -1008,13 +1015,6 @@ fn calculate_client_rect(
     border_offset: WindowBorderOffset,
     scale_factor: f32,
 ) -> Bounds<Pixels> {
-    // NOTE:
-    // The reason that not using `AdjustWindowRectEx()` here is
-    // that the size reported by this function is incorrect.
-    // You can test it, and there are similar discussions online.
-    // See: https://stackoverflow.com/questions/12423584/how-to-set-exact-client-size-for-overlapped-window-winapi
-    //
-    // So we manually calculate these values here.
     let left_offset = border_offset.width_offset / 2;
     let top_offset = border_offset.height_offset / 2;
     let right_offset = border_offset.width_offset - left_offset;

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -127,7 +127,7 @@ impl WindowsWindowState {
         }
     }
 
-    // Calculate the bounds used for saving and bool for if window is maximized
+    // Calculate the bounds used for saving and whether the window is maximized.
     fn calculate_window_bounds(&self) -> (Bounds<Pixels>, bool) {
         let placement = unsafe {
             let mut placement = WINDOWPLACEMENT {
@@ -1008,6 +1008,13 @@ fn calculate_client_rect(
     border_offset: WindowBorderOffset,
     scale_factor: f32,
 ) -> Bounds<Pixels> {
+    // NOTE:
+    // The reason that not using `AdjustWindowRectEx()` here is
+    // that the size reported by this function is incorrect.
+    // You can test it, and there are similar discussions online.
+    // See: https://stackoverflow.com/questions/12423584/how-to-set-exact-client-size-for-overlapped-window-winapi
+    //
+    // So we manually calculate these values here.
     let left_offset = border_offset.width_offset / 2;
     let top_offset = border_offset.height_offset / 2;
     let right_offset = border_offset.width_offset - left_offset;

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -128,7 +128,7 @@ impl WindowsWindowState {
         }
     }
 
-    // Get the bounds used for saving and bool for if window is maximized
+    // Calculate the bounds used for saving and bool for if window is maximized
     fn calculate_window_bounds(&self) -> (Bounds<Pixels>, bool) {
         let placement = unsafe {
             let mut placement = WINDOWPLACEMENT {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -865,13 +865,13 @@ struct StyleAndBounds {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-struct WindowSizeOffset {
+pub(crate) struct WindowSizeOffset {
     width_offset: i32,
     height_offset: i32,
 }
 
 impl WindowSizeOffset {
-    pub fn udpate(&mut self, hwnd: HWND) -> anyhow::Result<()> {
+    pub(crate) fn udpate(&mut self, hwnd: HWND) -> anyhow::Result<()> {
         let window_rect = unsafe {
             let mut rect = std::mem::zeroed();
             GetWindowRect(hwnd, &mut rect)?;


### PR DESCRIPTION
This is a follow up of #14218 , since we open the window based on the size of the client area, `window_bounds` should also return the size of the client area to maintain consistency.

Release Notes:

- N/A
