### PR TITLE
vim: (BREAKING) clean up keymap contexts

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -430,7 +430,7 @@
     }
   },
   {
-    "context": "Editor && (vim_mode == insert_operator || vim_mode == replace_operator || vim_mode = visual_operator)",
+    "context": "Editor && (vim_mode == insert_operator || vim_mode == replace_operator || vim_mode == visual_operator)",
     "bindings": {
       "escape": "vim::ClearOperators",
       "ctrl-c": "vim::ClearOperators",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -197,6 +197,12 @@
     }
   },
   {
+    "context": "VimControl && VimCount",
+    "bindings": {
+      "0": ["vim::Number", 0]
+    }
+  },
+  {
     "context": "vim_mode == normal",
     "bindings": {
       "escape": "editor::Cancel",
@@ -246,102 +252,6 @@
       "] c": "editor::GoToHunk",
       "[ c": "editor::GoToPrevHunk",
       "g c c": "vim::ToggleComments"
-    }
-  },
-  {
-    "context": "vim_mode == visual",
-    "bindings": {}
-  },
-  {
-    "context": "VimCount && vim_mode != insert",
-    "bindings": {
-      "0": ["vim::Number", 0]
-    }
-  },
-  {
-    "context": "vim_operator == c",
-    "bindings": {
-      "c": "vim::CurrentLine",
-      "d": "editor::Rename", // zed specific
-      "s": ["vim::PushOperator", { "ChangeSurrounds": {} }]
-    }
-  },
-  {
-    "context": "vim_operator == d",
-    "bindings": {
-      "d": "vim::CurrentLine",
-      "s": ["vim::PushOperator", "DeleteSurrounds"]
-    }
-  },
-  {
-    "context": "vim_operator == gu",
-    "bindings": {
-      "g u": "vim::CurrentLine",
-      "u": "vim::CurrentLine"
-    }
-  },
-  {
-    "context": "vim_operator == gU",
-    "bindings": {
-      "g shift-u": "vim::CurrentLine",
-      "shift-u": "vim::CurrentLine"
-    }
-  },
-  {
-    "context": "vim_operator == g~",
-    "bindings": {
-      "g ~": "vim::CurrentLine",
-      "~": "vim::CurrentLine"
-    }
-  },
-  {
-    "context": "vim_operator == y",
-    "bindings": {
-      "y": "vim::CurrentLine",
-      "s": ["vim::PushOperator", { "AddSurrounds": {} }]
-    }
-  },
-  {
-    "context": "vim_operator == ys",
-    "bindings": {
-      "s": "vim::CurrentLine"
-    }
-  },
-  {
-    "context": "vim_operator == >",
-    "bindings": {
-      ">": "vim::CurrentLine"
-    }
-  },
-  {
-    "context": "vim_operator == <",
-    "bindings": {
-      "<": "vim::CurrentLine"
-    }
-  },
-  {
-    "context": "vim_mode != waiting && (vim_operator == a || vim_operator == i || vim_operator == cs)",
-    "bindings": {
-      "w": "vim::Word",
-      "shift-w": ["vim::Word", { "ignorePunctuation": true }],
-      "t": "vim::Tag",
-      "s": "vim::Sentence",
-      "p": "vim::Paragraph",
-      "'": "vim::Quotes",
-      "`": "vim::BackQuotes",
-      "\"": "vim::DoubleQuotes",
-      "|": "vim::VerticalBars",
-      "(": "vim::Parentheses",
-      ")": "vim::Parentheses",
-      "b": "vim::Parentheses",
-      "[": "vim::SquareBrackets",
-      "]": "vim::SquareBrackets",
-      "{": "vim::CurlyBrackets",
-      "}": "vim::CurlyBrackets",
-      "shift-b": "vim::CurlyBrackets",
-      "<": "vim::AngleBrackets",
-      ">": "vim::AngleBrackets",
-      "a": "vim::Argument"
     }
   },
   {
@@ -408,14 +318,6 @@
     }
   },
   {
-    "context": "vim_mode == insert_operator || vim_mode == replace_operator || vim_mode == visual_operator",
-    "bindings": {
-      "escape": "vim::ClearOperators",
-      "ctrl-c": "vim::ClearOperators",
-      "ctrl-[": "vim::ClearOperators"
-    }
-  },
-  {
     "context": "vim_mode == replace",
     "bindings": {
       "escape": "vim::NormalBefore",
@@ -431,6 +333,100 @@
     "bindings": {
       "tab": "vim::Tab",
       "enter": "vim::Enter"
+    }
+  },
+  {
+    "context": "vim_mode == insert_operator || vim_mode == replace_operator || vim_mode == visual_operator",
+    "bindings": {
+      "escape": "vim::ClearOperators",
+      "ctrl-c": "vim::ClearOperators",
+      "ctrl-[": "vim::ClearOperators"
+    }
+  },
+  {
+    "context": "vim_operator == a || vim_operator == i || vim_operator == cs",
+    "bindings": {
+      "w": "vim::Word",
+      "shift-w": ["vim::Word", { "ignorePunctuation": true }],
+      "t": "vim::Tag",
+      "s": "vim::Sentence",
+      "p": "vim::Paragraph",
+      "'": "vim::Quotes",
+      "`": "vim::BackQuotes",
+      "\"": "vim::DoubleQuotes",
+      "|": "vim::VerticalBars",
+      "(": "vim::Parentheses",
+      ")": "vim::Parentheses",
+      "b": "vim::Parentheses",
+      "[": "vim::SquareBrackets",
+      "]": "vim::SquareBrackets",
+      "{": "vim::CurlyBrackets",
+      "}": "vim::CurlyBrackets",
+      "shift-b": "vim::CurlyBrackets",
+      "<": "vim::AngleBrackets",
+      ">": "vim::AngleBrackets",
+      "a": "vim::Argument"
+    }
+  },
+  {
+    "context": "vim_operator == c",
+    "bindings": {
+      "c": "vim::CurrentLine",
+      "d": "editor::Rename", // zed specific
+      "s": ["vim::PushOperator", { "ChangeSurrounds": {} }]
+    }
+  },
+  {
+    "context": "vim_operator == d",
+    "bindings": {
+      "d": "vim::CurrentLine",
+      "s": ["vim::PushOperator", "DeleteSurrounds"]
+    }
+  },
+  {
+    "context": "vim_operator == gu",
+    "bindings": {
+      "g u": "vim::CurrentLine",
+      "u": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "vim_operator == gU",
+    "bindings": {
+      "g shift-u": "vim::CurrentLine",
+      "shift-u": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "vim_operator == g~",
+    "bindings": {
+      "g ~": "vim::CurrentLine",
+      "~": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "vim_operator == y",
+    "bindings": {
+      "y": "vim::CurrentLine",
+      "s": ["vim::PushOperator", { "AddSurrounds": {} }]
+    }
+  },
+  {
+    "context": "vim_operator == ys",
+    "bindings": {
+      "s": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "vim_operator == >",
+    "bindings": {
+      ">": "vim::CurrentLine"
+    }
+  },
+  {
+    "context": "vim_operator == <",
+    "bindings": {
+      "<": "vim::CurrentLine"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -203,14 +203,14 @@
   },
   {
     // escape is in its own section so that it cancels a pending count.
-    "context": "Editor && vim_mode == normal && vim_operator == none && !VimWaiting",
+    "context": "Editor && vim_mode == normal && !VimWaiting",
     "bindings": {
       "escape": "editor::Cancel",
       "ctrl-[": "editor::Cancel"
     }
   },
   {
-    "context": "Editor && vim_mode == normal && vim_operator == none && !VimWaiting",
+    "context": "Editor && vim_mode == normal && !VimWaiting",
     "bindings": {
       ".": "vim::Repeat",
       "c": ["vim::PushOperator", "Change"],
@@ -259,7 +259,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == visual && vim_operator == none && !VimWaiting",
+    "context": "Editor && vim_mode == visual && !VimWaiting",
     "bindings": {
       "\"": ["vim::PushOperator", "Register"],
       // tree-sitter related commands
@@ -277,19 +277,15 @@
     "context": "Editor && vim_operator == c",
     "bindings": {
       "c": "vim::CurrentLine",
-      "d": "editor::Rename" // zed specific
-    }
-  },
-  {
-    "context": "Editor && vim_mode == normal && vim_operator == c",
-    "bindings": {
+      "d": "editor::Rename", // zed specific
       "s": ["vim::PushOperator", { "ChangeSurrounds": {} }]
     }
   },
   {
     "context": "Editor && vim_operator == d",
     "bindings": {
-      "d": "vim::CurrentLine"
+      "d": "vim::CurrentLine",
+      "s": ["vim::PushOperator", "DeleteSurrounds"]
     }
   },
   {
@@ -314,20 +310,9 @@
     }
   },
   {
-    "context": "Editor && vim_mode == normal && vim_operator == d",
-    "bindings": {
-      "s": ["vim::PushOperator", "DeleteSurrounds"]
-    }
-  },
-  {
     "context": "Editor && vim_operator == y",
     "bindings": {
-      "y": "vim::CurrentLine"
-    }
-  },
-  {
-    "context": "Editor && vim_mode == normal && vim_operator == y",
-    "bindings": {
+      "y": "vim::CurrentLine",
       "s": ["vim::PushOperator", { "AddSurrounds": {} }]
     }
   },
@@ -445,6 +430,14 @@
     }
   },
   {
+    "context": "Editor && (vim_mode == insert_operator || vim_mode == replace_operator || vim_mode = visual_operator)",
+    "bindings": {
+      "escape": "vim::ClearOperators",
+      "ctrl-c": "vim::ClearOperators",
+      "ctrl-[": "vim::ClearOperators"
+    }
+  },
+  {
     "context": "Editor && vim_mode == replace",
     "bindings": {
       "escape": "vim::NormalBefore",
@@ -459,13 +452,11 @@
     "context": "Editor && vim_mode != replace && VimWaiting",
     "bindings": {
       "tab": "vim::Tab",
-      "enter": "vim::Enter",
-      "escape": ["vim::SwitchMode", "Normal"],
-      "ctrl-[": ["vim::SwitchMode", "Normal"]
+      "enter": "vim::Enter"
     }
   },
   {
-    "context": "Editor && vim_mode == insert && VimWaiting",
+    "context": "Editor && vim_mode == insert && VimWaiting",;
     "bindings": {
       "escape": "vim::NormalBefore",
       "ctrl-[": "vim::NormalBefore"

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -336,7 +336,7 @@
     }
   },
   {
-    "context": "vim_mode == insert_operator || vim_mode == replace_operator || vim_mode == visual_operator",
+    "context": "vim_mode == operator",
     "bindings": {
       "escape": "vim::ClearOperators",
       "ctrl-c": "vim::ClearOperators",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -202,16 +202,10 @@
     }
   },
   {
-    // escape is in its own section so that it cancels a pending count.
-    "context": "Editor && vim_mode == normal && !VimWaiting",
+    "context": "Editor && vim_mode == normal",
     "bindings": {
       "escape": "editor::Cancel",
-      "ctrl-[": "editor::Cancel"
-    }
-  },
-  {
-    "context": "Editor && vim_mode == normal && !VimWaiting",
-    "bindings": {
+      "ctrl-[": "editor::Cancel",
       ".": "vim::Repeat",
       "c": ["vim::PushOperator", "Change"],
       "shift-c": "vim::ChangeToEndOfLine",
@@ -259,7 +253,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == visual && !VimWaiting",
+    "context": "Editor && vim_mode == visual",
     "bindings": {
       "\"": ["vim::PushOperator", "Register"],
       // tree-sitter related commands
@@ -360,7 +354,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == visual && !VimWaiting && !VimObject",
+    "context": "Editor && vim_mode == visual && !VimObject",
     "bindings": {
       "u": "vim::ConvertToLowerCase",
       "U": "vim::ConvertToUpperCase",
@@ -399,7 +393,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == normal && !VimWaiting",
+    "context": "Editor && vim_mode == normal",
     "bindings": {
       "g c c": "vim::ToggleComments"
     }
@@ -443,23 +437,14 @@
       "escape": "vim::NormalBefore",
       "ctrl-c": "vim::NormalBefore",
       "ctrl-[": "vim::NormalBefore",
-      "tab": "vim::Tab",
-      "enter": "vim::Enter",
       "backspace": "vim::UndoReplace"
     }
   },
   {
-    "context": "Editor && vim_mode != replace && VimWaiting",
+    "context": "Editor && VimWaiting",
     "bindings": {
       "tab": "vim::Tab",
       "enter": "vim::Enter"
-    }
-  },
-  {
-    "context": "Editor && vim_mode == insert && VimWaiting",
-    "bindings": {
-      "escape": "vim::NormalBefore",
-      "ctrl-[": "vim::NormalBefore"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,12 +1,6 @@
 [
   {
-    "context": "ProjectPanel || Editor",
-    "bindings": {
-      "ctrl-6": "pane::AlternateFile"
-    }
-  },
-  {
-    "context": "Editor && VimControl && (vim_mode != waiting && vim_mode != replace) && !menu",
+    "context": "VimControl && !menu",
     "bindings": {
       "i": ["vim::PushOperator", { "Object": { "around": false } }],
       "a": ["vim::PushOperator", { "Object": { "around": true } }],
@@ -198,11 +192,12 @@
       "ctrl-w g shift-d": "editor::GoToTypeDefinitionSplit",
       "ctrl-w space": "editor::OpenExcerptsSplit",
       "ctrl-w g space": "editor::OpenExcerptsSplit",
-      "-": "pane::RevealInProjectPanel"
+      "-": "pane::RevealInProjectPanel",
+      "ctrl-6": "pane::AlternateFile"
     }
   },
   {
-    "context": "Editor && vim_mode == normal",
+    "context": "vim_mode == normal",
     "bindings": {
       "escape": "editor::Cancel",
       "ctrl-[": "editor::Cancel",
@@ -249,26 +244,22 @@
       "] d": "editor::GoToDiagnostic",
       "[ d": "editor::GoToPrevDiagnostic",
       "] c": "editor::GoToHunk",
-      "[ c": "editor::GoToPrevHunk"
+      "[ c": "editor::GoToPrevHunk",
+      "g c c": "vim::ToggleComments"
     }
   },
   {
-    "context": "Editor && vim_mode == visual",
-    "bindings": {
-      "\"": ["vim::PushOperator", "Register"],
-      // tree-sitter related commands
-      "[ x": "editor::SelectLargerSyntaxNode",
-      "] x": "editor::SelectSmallerSyntaxNode"
-    }
+    "context": "vim_mode == visual",
+    "bindings": {}
   },
   {
-    "context": "Editor && VimCount && vim_mode != insert",
+    "context": "VimCount && vim_mode != insert",
     "bindings": {
       "0": ["vim::Number", 0]
     }
   },
   {
-    "context": "Editor && vim_operator == c",
+    "context": "vim_operator == c",
     "bindings": {
       "c": "vim::CurrentLine",
       "d": "editor::Rename", // zed specific
@@ -276,60 +267,60 @@
     }
   },
   {
-    "context": "Editor && vim_operator == d",
+    "context": "vim_operator == d",
     "bindings": {
       "d": "vim::CurrentLine",
       "s": ["vim::PushOperator", "DeleteSurrounds"]
     }
   },
   {
-    "context": "Editor && vim_operator == gu",
+    "context": "vim_operator == gu",
     "bindings": {
       "g u": "vim::CurrentLine",
       "u": "vim::CurrentLine"
     }
   },
   {
-    "context": "Editor && vim_operator == gU",
+    "context": "vim_operator == gU",
     "bindings": {
       "g shift-u": "vim::CurrentLine",
       "shift-u": "vim::CurrentLine"
     }
   },
   {
-    "context": "Editor && vim_operator == g~",
+    "context": "vim_operator == g~",
     "bindings": {
       "g ~": "vim::CurrentLine",
       "~": "vim::CurrentLine"
     }
   },
   {
-    "context": "Editor && vim_operator == y",
+    "context": "vim_operator == y",
     "bindings": {
       "y": "vim::CurrentLine",
       "s": ["vim::PushOperator", { "AddSurrounds": {} }]
     }
   },
   {
-    "context": "Editor && vim_operator == ys",
+    "context": "vim_operator == ys",
     "bindings": {
       "s": "vim::CurrentLine"
     }
   },
   {
-    "context": "Editor && vim_operator == >",
+    "context": "vim_operator == >",
     "bindings": {
       ">": "vim::CurrentLine"
     }
   },
   {
-    "context": "Editor && vim_operator == <",
+    "context": "vim_operator == <",
     "bindings": {
       "<": "vim::CurrentLine"
     }
   },
   {
-    "context": "Editor && VimObject",
+    "context": "vim_mode != waiting && (vim_operator == a || vim_operator == i || vim_operator == cs)",
     "bindings": {
       "w": "vim::Word",
       "shift-w": ["vim::Word", { "ignorePunctuation": true }],
@@ -354,7 +345,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == visual && !VimObject",
+    "context": "vim_mode == visual",
     "bindings": {
       "u": "vim::ConvertToLowerCase",
       "U": "vim::ConvertToUpperCase",
@@ -389,23 +380,16 @@
       ">": "vim::Indent",
       "<": "vim::Outdent",
       "i": ["vim::PushOperator", { "Object": { "around": false } }],
-      "a": ["vim::PushOperator", { "Object": { "around": true } }]
+      "a": ["vim::PushOperator", { "Object": { "around": true } }],
+      "g c": "vim::ToggleComments",
+      "\"": ["vim::PushOperator", "Register"],
+      // tree-sitter related commands
+      "[ x": "editor::SelectLargerSyntaxNode",
+      "] x": "editor::SelectSmallerSyntaxNode"
     }
   },
   {
-    "context": "Editor && vim_mode == normal",
-    "bindings": {
-      "g c c": "vim::ToggleComments"
-    }
-  },
-  {
-    "context": "Editor && vim_mode == visual",
-    "bindings": {
-      "g c": "vim::ToggleComments"
-    }
-  },
-  {
-    "context": "Editor && vim_mode == insert",
+    "context": "vim_mode == insert",
     "bindings": {
       "escape": "vim::NormalBefore",
       "ctrl-c": "vim::NormalBefore",
@@ -424,7 +408,7 @@
     }
   },
   {
-    "context": "Editor && (vim_mode == insert_operator || vim_mode == replace_operator || vim_mode == visual_operator)",
+    "context": "vim_mode == insert_operator || vim_mode == replace_operator || vim_mode == visual_operator",
     "bindings": {
       "escape": "vim::ClearOperators",
       "ctrl-c": "vim::ClearOperators",
@@ -432,7 +416,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == replace",
+    "context": "vim_mode == replace",
     "bindings": {
       "escape": "vim::NormalBefore",
       "ctrl-c": "vim::NormalBefore",
@@ -443,7 +427,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == waiting",
+    "context": "vim_mode == waiting",
     "bindings": {
       "tab": "vim::Tab",
       "enter": "vim::Enter"
@@ -486,7 +470,8 @@
       "x": "project_panel::RevealInFileManager",
       "shift-g": "menu::SelectLast",
       "g g": "menu::SelectFirst",
-      "-": "project_panel::SelectParent"
+      "-": "project_panel::SelectParent",
+      "ctrl-6": "pane::AlternateFile"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -6,7 +6,7 @@
     }
   },
   {
-    "context": "Editor && VimControl && !VimWaiting && !menu",
+    "context": "Editor && VimControl && (vim_mode != waiting && vim_mode != replace) && !menu",
     "bindings": {
       "i": ["vim::PushOperator", { "Object": { "around": false } }],
       "a": ["vim::PushOperator", { "Object": { "around": true } }],
@@ -437,11 +437,13 @@
       "escape": "vim::NormalBefore",
       "ctrl-c": "vim::NormalBefore",
       "ctrl-[": "vim::NormalBefore",
-      "backspace": "vim::UndoReplace"
+      "backspace": "vim::UndoReplace",
+      "tab": "vim::Tab",
+      "enter": "vim::Enter"
     }
   },
   {
-    "context": "Editor && VimWaiting",
+    "context": "Editor && vim_mode == waiting",
     "bindings": {
       "tab": "vim::Tab",
       "enter": "vim::Enter"

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -456,7 +456,7 @@
     }
   },
   {
-    "context": "Editor && vim_mode == insert && VimWaiting",;
+    "context": "Editor && vim_mode == insert && VimWaiting",
     "bindings": {
       "escape": "vim::NormalBefore",
       "ctrl-[": "vim::NormalBefore"

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -263,14 +263,6 @@ impl EditorState {
     pub fn keymap_context_layer(&self) -> KeyContext {
         let mut context = KeyContext::new_with_defaults();
 
-        let active_operator = self.active_operator();
-
-        if active_operator.is_none() && self.pre_count.is_some()
-            || active_operator.is_some() && self.post_count.is_some()
-        {
-            context.add("VimCount");
-        }
-
         let mut mode = match self.mode {
             Mode::Normal => "normal",
             Mode::Visual | Mode::VisualLine | Mode::VisualBlock => "visual",
@@ -281,13 +273,20 @@ impl EditorState {
 
         let mut operator_id = "none";
 
-        if let Some(active_operator) = active_operator.clone() {
+        let active_operator = self.active_operator();
+        if active_operator.is_none() && self.pre_count.is_some()
+            || active_operator.is_some() && self.post_count.is_some()
+        {
+            context.add("VimCount");
+        }
+
+        if let Some(active_operator) = active_operator {
             if active_operator.is_waiting(self.mode) {
                 mode = "waiting".to_owned();
             } else {
                 mode = format!("{}_operator", mode);
+                operator_id = active_operator.id();
             }
-            operator_id = active_operator.id();
         }
 
         if mode != "waiting" && mode != "insert" && mode != "replace" {

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -264,15 +264,6 @@ impl EditorState {
 
     pub fn keymap_context_layer(&self) -> KeyContext {
         let mut context = KeyContext::new_with_defaults();
-        context.set(
-            "vim_mode",
-            match self.mode {
-                Mode::Normal => "normal",
-                Mode::Visual | Mode::VisualLine | Mode::VisualBlock => "visual",
-                Mode::Insert => "insert",
-                Mode::Replace => "replace",
-            },
-        );
 
         if self.vim_controlled() {
             context.add("VimControl");
@@ -284,13 +275,23 @@ impl EditorState {
             context.add("VimCount");
         }
 
+        let mut mode = match self.mode {
+            Mode::Normal => "normal",
+            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => "visual",
+            Mode::Insert => "insert",
+            Mode::Replace => "replace",
+        }
+        .to_owned();
+
         let active_operator = self.active_operator();
 
         if let Some(active_operator) = active_operator.clone() {
+            mode += "_operator";
             for context_flag in active_operator.context_flags().into_iter() {
                 context.add(*context_flag);
             }
         }
+        context.set("vim_mode", mode);
 
         context.set(
             "vim_operator",

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -269,7 +269,7 @@ impl EditorState {
             Mode::Insert => "insert",
             Mode::Replace => "replace",
         }
-        .to_owned();
+        .to_string();
 
         let mut operator_id = "none";
 
@@ -282,9 +282,9 @@ impl EditorState {
 
         if let Some(active_operator) = active_operator {
             if active_operator.is_waiting(self.mode) {
-                mode = "waiting".to_owned();
+                mode = "waiting".to_string();
             } else {
-                mode = "operator".to_owned();
+                mode = "operator".to_string();
                 operator_id = active_operator.id();
             }
         }

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -284,12 +284,7 @@ impl EditorState {
             Mode::Replace => "replace",
         };
 
-        if self.mode == Mode::Replace {
-            context.add("VimWaiting");
-        }
-
         if let Some(active_operator) = active_operator.clone() {
-            context.set("vim_mode", format!("{}_operator", mode));
             context.set("vim_operator", active_operator.id());
 
             match active_operator {
@@ -298,7 +293,7 @@ impl EditorState {
                 }
                 Operator::AddSurrounds { target } => {
                     if target.is_some() || self.mode.is_visual() {
-                        context.add("VimWaiting");
+                        context.set("vim_mode", "waiting");
                     }
                 }
                 Operator::FindForward { .. }
@@ -310,7 +305,7 @@ impl EditorState {
                 | Operator::ReplayRegister
                 | Operator::Replace
                 | Operator::ChangeSurrounds { .. }
-                | Operator::DeleteSurrounds => context.add("VimWaiting"),
+                | Operator::DeleteSurrounds => context.set("vim_mode", "waiting"),
                 Operator::Change
                 | Operator::Delete
                 | Operator::Yank
@@ -318,7 +313,7 @@ impl EditorState {
                 | Operator::Outdent
                 | Operator::Lowercase
                 | Operator::Uppercase
-                | Operator::OppositeCase => {}
+                | Operator::OppositeCase => context.set("vim_mode", format!("{}_operator", mode)),
             }
         } else {
             context.set("vim_mode", mode);

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -284,7 +284,7 @@ impl EditorState {
             if active_operator.is_waiting(self.mode) {
                 mode = "waiting".to_owned();
             } else {
-                mode = format!("{}_operator", mode);
+                mode = "operator".to_owned();
                 operator_id = active_operator.id();
             }
         }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -131,7 +131,6 @@ fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
         },
     );
     workspace.register_action(|_: &mut Workspace, _: &ClearOperators, cx| {
-        println!("------ CLEAR OPERATORS! -------");
         Vim::update(cx, |vim, cx| vim.clear_operator(cx))
     });
     workspace.register_action(|_: &mut Workspace, n: &Number, cx: _| {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -87,7 +87,7 @@ actions!(
 );
 
 // in the workspace namespace so it's not filtered out when vim is disabled.
-actions!(workspace, [ToggleVimMode]);
+actions!(workspace, [ToggleVimMode, ClearOperators]);
 
 impl_actions!(vim, [SwitchMode, PushOperator, Number, SelectRegister]);
 
@@ -129,6 +129,10 @@ fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
             Vim::update(cx, |vim, cx| vim.push_operator(operator.clone(), cx))
         },
     );
+    workspace.register_action(|_: &mut Workspace, _: &ClearOperators, cx| {
+        println!("------ CLEAR OPERATORS! -------");
+        Vim::update(cx, |vim, cx| vim.clear_operator(cx))
+    });
     workspace.register_action(|_: &mut Workspace, n: &Number, cx: _| {
         Vim::update(cx, |vim, cx| vim.push_count_digit(n.0, cx));
     });
@@ -169,6 +173,7 @@ fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
 /// Called whenever an keystroke is typed so vim can observe all actions
 /// and keystrokes accordingly.
 fn observe_keystrokes(keystroke_event: &KeystrokeEvent, cx: &mut WindowContext) {
+    dbg!(&keystroke_event);
     if let Some(action) = keystroke_event
         .action
         .as_ref()

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -173,7 +173,6 @@ fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
 /// Called whenever an keystroke is typed so vim can observe all actions
 /// and keystrokes accordingly.
 fn observe_keystrokes(keystroke_event: &KeystrokeEvent, cx: &mut WindowContext) {
-    dbg!(&keystroke_event);
     if let Some(action) = keystroke_event
         .action
         .as_ref()

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -978,7 +978,7 @@ impl Vim {
             editor.set_cursor_shape(state.cursor_shape(), cx);
             editor.set_clip_at_line_ends(state.clip_at_line_ends(), cx);
             editor.set_collapse_matches(true);
-            editor.set_input_enabled(!state.vim_controlled());
+            editor.set_input_enabled(state.editor_input_enabled());
             editor.set_autoindent(state.should_autoindent());
             editor.selections.line_mode = matches!(state.mode, Mode::VisualLine);
             if editor.is_focused(cx) || editor.mouse_menu_is_focused(cx) {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -76,6 +76,7 @@ struct SelectRegister(String);
 actions!(
     vim,
     [
+        ClearOperators,
         Tab,
         Enter,
         Object,
@@ -87,7 +88,7 @@ actions!(
 );
 
 // in the workspace namespace so it's not filtered out when vim is disabled.
-actions!(workspace, [ToggleVimMode, ClearOperators]);
+actions!(workspace, [ToggleVimMode]);
 
 impl_actions!(vim, [SwitchMode, PushOperator, Number, SelectRegister]);
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -85,7 +85,9 @@ Finally, Vim mode's search and replace functionality is backed by Zed's. This me
 ## Custom key bindings
 
 You can edit your personal key bindings with `:keymap`.
-For vim-specific shortcuts, you may find the following template a good place to start:
+For vim-specific shortcuts, you may find the following template a good place to start.
+
+> **Note:** We made some breaking changes in Zed version `0.145.0`. For older versions, see [the previous version of this document](https://github.com/zed-industries/zed/blob/c67aeaa9c58619a58708722ac7d7a78c75c29336/docs/src/vim.md#L90).
 
 ```json
 [
@@ -96,25 +98,9 @@ For vim-specific shortcuts, you may find the following template a good place to 
     }
   },
   {
-    "context": "vim_mode == normal && !menu",
+    "context": "vim_mode == insert",
     "bindings": {
-      // put key-bindings here if you want them to work only in normal mode
-      // "down": ["workspace::SendKeystrokes", "4 j"]
-      // "up": ["workspace::SendKeystrokes", "4 k"]
-    }
-  },
-  {
-    "context": "vim_mode == visual && !menu",
-    "bindings": {
-      // visual, visual line & visual block modes
-    }
-  },
-  {
-    "context": "vim_mode == insert && !menu",
-    "bindings": {
-      // put key-bindings here if you want them to work in insert mode
-      // e.g.
-      // "j j": "vim::NormalBefore" // remap jj in insert mode to escape.
+      // "j k": "vim::NormalBefore" // remap jk in insert mode to escape.
     }
   },
   {
@@ -122,7 +108,6 @@ For vim-specific shortcuts, you may find the following template a good place to 
     "bindings": {
       // put key-bindings here (in addition to above) if you want them to
       // work when no editor exists
-      // e.g.
       // "space f": "file_finder::Toggle"
     }
   }
@@ -133,20 +118,15 @@ If you would like to emulate vim's `map` (`nmap` etc.) commands you can bind to 
 
 You can see the bindings that are enabled by default in vim mode [here](https://github.com/zed-industries/zed/blob/main/assets/keymaps/vim.json).
 
-The details of the context are a little out of scope for this doc, but suffice to say that `menu` is true when a menu is open (e.g. the completions menu), `VimWaiting` is true after you type `f` or `t` when we’re waiting for a new key (and you probably don’t want bindings to happen). Please reach out on [GitHub](https://github.com/zed-industries/zed) if you want help making a key bindings work.
+#### Contexts
 
-### Examples
+Zed's keyboard bindings are evaluated only when the `"context"` matches the location you are in on the screen. Locations are nested, so when you're editing you're in the `"Workspace"` location is at the top, containing a `"Pane"` which contains an `"Editor"`. Contexts are matched only on one level at a time. So it is possible to combine `Editor && vim_mode == normal`, but `Workspace && vim_mode == normal` will never match because we set the vim context at the `Editor` level.
 
-Binding `jk` to exit insert mode and go to normal mode:
+Vim mode adds several contexts to the `Editor`:
 
-```
-{
-  "context": "Editor && vim_mode == insert && !menu",
-  "bindings": {
-    "j k": ["vim::SwitchMode", "Normal"]
-  }
-}
-```
+* `vim_mode` is similar to, but not identical to, the current mode. It starts as one of `normal`, `visual`, `insert` or `replace` (depending on your mode). If you are mid-way through typing a sequence, `vim_mode` will be either `waiting` if it's waiting for an arbitrary key (for example after typing `f` or `t`), or `operator` if it's waiting for another binding to trigger (for example after typing `c` or `d`).
+* `vim_operator` is set to `none` unless `vim_mode == operator` in which case it is set to the current operator's default keybinding (for example after typing `d`, `vim_operator == d`).
+* `"VimControl"` indicates that vim keybindings should work. It is currently an alias for `vim_mode == normal || vim_mode == visual || vim_mode == operator`, but the definition may change over time.
 
 ### Restoring some sense of normality
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -90,13 +90,13 @@ For vim-specific shortcuts, you may find the following template a good place to 
 ```json
 [
   {
-    "context": "Editor && (vim_mode == normal || vim_mode == visual) && !VimWaiting && !menu",
+    "context": "VimControl && !menu",
     "bindings": {
       // put key-bindings here if you want them to work in normal & visual mode
     }
   },
   {
-    "context": "Editor && vim_mode == normal && !VimWaiting && !menu",
+    "context": "vim_mode == normal && !menu",
     "bindings": {
       // put key-bindings here if you want them to work only in normal mode
       // "down": ["workspace::SendKeystrokes", "4 j"]
@@ -104,13 +104,13 @@ For vim-specific shortcuts, you may find the following template a good place to 
     }
   },
   {
-    "context": "Editor && vim_mode == visual && !VimWaiting && !menu",
+    "context": "vim_mode == visual && !menu",
     "bindings": {
       // visual, visual line & visual block modes
     }
   },
   {
-    "context": "Editor && vim_mode == insert && !menu",
+    "context": "vim_mode == insert && !menu",
     "bindings": {
       // put key-bindings here if you want them to work in insert mode
       // e.g.
@@ -155,7 +155,7 @@ that you can't live without. You can restore them to their defaults by copying t
 
 ```
 {
-  "context": "Editor && !VimWaiting && !menu",
+  "context": "Editor && !menu",
   "bindings": {
     "ctrl-c": "editor::Copy",          // vim default: return to normal mode
     "ctrl-x": "editor::Cut",           // vim default: increment
@@ -304,7 +304,7 @@ Subword motion is not enabled by default. To enable it, add these bindings to yo
 
 ```json
   {
-    "context": "Editor && VimControl && !VimWaiting && !menu",
+    "context": "VimControl && !menu",
     "bindings": {
       "w": "vim::NextSubwordStart",
       "b": "vim::PreviousSubwordStart",
@@ -318,7 +318,7 @@ Surrounding the selection in visual mode is also not enabled by default (`shift-
 
 ```json
   {
-    "context": "Editor && vim_mode == visual && !VimWaiting && !VimObject",
+    "context": "vim_mode == visual",
     "bindings": {
       "shift-s": [
         "vim::PushOperator",


### PR DESCRIPTION
Release Notes:

- vim: (BREAKING) Improved vim keymap contexts.

    Previously `vim_mode == normal` was true even when operators were pending, which led to bugs like #13789 and a requirement for custom keymaps to exclude various conditions like (`!VimObject` and `!VimWaiting`) to avoid bugs.

    Now `vim_mode` will be set to `operator` or `waiting` in these cases as described in [the docs](https://zed.dev/docs/vim#keybindings). For most custom keymaps this change will be a no-op or an improvement, but if you were deliberately relying on the old behaviour (if you were relying on `VimObject` or `VimWaiting` becoming true) you will need to update your keymap.

