### PR TITLE
assistant: Handle `http://` links in `/fetch`

### DIFF
--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -27,7 +27,7 @@ pub(crate) struct FetchSlashCommand;
 impl FetchSlashCommand {
     async fn build_message(http_client: Arc<HttpClientWithUrl>, url: &str) -> Result<String> {
         let mut url = url.to_owned();
-        if !url.starts_with("https://") {
+        if !url.starts_with("https://") && !url.starts_with("http://") {
             url = format!("https://{url}");
         }
 


### PR DESCRIPTION
Previously http://google.com would get modified to https://http://google.com which doesn't work. I assume http links should be supported.

Release Notes:

- N/A