### PR TITLE
assistant: Use a more generic icon for the `/docs` command

### DIFF
--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -216,7 +216,7 @@ impl SlashCommand for DocsSlashCommand {
                 text,
                 sections: vec![SlashCommandOutputSection {
                     range,
-                    icon: IconName::FileRust,
+                    icon: IconName::FileDoc,
                     label: format!("docs ({provider}): {path}",).into(),
                 }],
                 run_commands_in_text: false,


### PR DESCRIPTION
This PR updates the `/docs` slash command to use a more generic icon to convey docs.

It was still using the Rust icon, a relic of when it was still `/rustdoc`.

Release Notes:

- N/A
