### PR TITLE
Adjust list item & pickers spacing

### DIFF
--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -766,6 +766,7 @@ impl PromptLibrary {
             .capture_action(cx.listener(Self::focus_active_prompt))
             .bg(cx.theme().colors().panel_background)
             .h_full()
+            .px_1()
             .w_1_3()
             .overflow_x_hidden()
             .child(

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -268,7 +268,7 @@ impl PickerDelegate for PromptPickerDelegate {
             .flex_none()
             .py_1()
             .px_2()
-            .mx_2()
+            .mx_1()
             .child(editor.clone())
     }
 }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -110,7 +110,7 @@ pub trait PickerDelegate: Sized + 'static {
                     .overflow_hidden()
                     .flex_none()
                     .h_9()
-                    .px_4()
+                    .px_3()
                     .child(editor.clone()),
             )
             .child(Divider::horizontal())
@@ -527,7 +527,7 @@ impl<D: PickerDelegate> Picker<D> {
             )
             .with_sizing_behavior(sizing_behavior)
             .flex_grow()
-            .py_2()
+            .py_1()
             .track_scroll(scroll_handle.clone())
             .into_any_element(),
             ElementContainer::List(state) => list(state.clone())

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -162,7 +162,7 @@ impl RenderOnce for ListItem {
             // When an item is inset draw the indent spacing outside of the item
             .when(self.inset, |this| {
                 this.ml(self.indent_level as f32 * self.indent_step_size)
-                    .px_2()
+                    .px_1()
             })
             .when(!self.inset && !self.disabled, |this| {
                 this

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -273,6 +273,7 @@ impl PickerDelegate for BranchListDelegate {
         let label = if self.last_query.is_empty() {
             Label::new("Recent Branches")
                 .size(LabelSize::Small)
+                .mt_1()
                 .ml_3()
                 .into_any_element()
         } else {


### PR DESCRIPTION
This PR's goal is to fix the bigger horizontal than vertical padding in list items and pickers. Couldn't find any instance where my changes dramatically worsened different flavors of these components.

| Before | After |
|--------|--------|
| <img width="527" alt="Screenshot 2024-07-11 at 16 42 33" src="https://github.com/user-attachments/assets/7fb7c6c6-83d4-47e3-a60c-a816967b36ad"> | <img width="527" alt="Screenshot 2024-07-11 at 16 42 44" src="https://github.com/user-attachments/assets/6203adb3-18b4-40d5-8e53-c54a848405ce"> | 
| <img width="228" alt="Screenshot 2024-07-11 at 16 43 19" src="https://github.com/user-attachments/assets/5071005a-ac07-4e64-8f62-fbd3ee6d684c"> | <img width="228" alt="Screenshot 2024-07-11 at 16 43 00" src="https://github.com/user-attachments/assets/dcbfb35b-6160-4da6-a05a-3b87a701f3c3"> | 
| <img width="530" alt="Screenshot 2024-07-11 at 16 43 31" src="https://github.com/user-attachments/assets/1039366f-e60c-4671-a33f-c7a24f0111ed"> | <img width="530" alt="Screenshot 2024-07-11 at 16 43 45" src="https://github.com/user-attachments/assets/8b111ff3-da99-47df-8bcd-ab36ab4cec55"> | 
| <img width="530" alt="Screenshot 2024-07-11 at 16 43 59" src="https://github.com/user-attachments/assets/e21313c4-a2fc-47a7-939c-86c4d56ef7e9"> | <img width="530" alt="Screenshot 2024-07-11 at 16 44 12" src="https://github.com/user-attachments/assets/47105834-8ab3-4df2-906c-2e1fce27b074"> |

---

Release Notes:
- N/A
