### PR TITLE
Jetbrains Keybind: Stop binding shift-shift by default

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -63,7 +63,7 @@
     "bindings": {
       "ctrl-shift-n": "file_finder::Toggle",
       "ctrl-shift-a": "command_palette::Toggle",
-      "shift shift": "command_palette::Toggle",
+      // "shift shift": "command_palette::Toggle",
       "ctrl-alt-shift-n": "project_symbols::Toggle",
       "alt-1": "workspace::ToggleLeftDock",
       "ctrl-e": "tab_switcher::Toggle",

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -63,7 +63,7 @@
     "bindings": {
       "cmd-shift-o": "file_finder::Toggle",
       "cmd-shift-a": "command_palette::Toggle",
-      "shift shift": "command_palette::Toggle",
+      // "shift shift": "command_palette::Toggle",
       "cmd-alt-o": "project_symbols::Toggle",
       "cmd-1": "workspace::ToggleLeftDock",
       "cmd-6": "diagnostics::Deploy"


### PR DESCRIPTION
Release Notes:

- Removed "shift shift" from Jetbrains default keybinds.
