### PR TITLE
assistant: Show a warning indicator when the user needs to run `cargo doc`

### DIFF
--- a/crates/indexed_docs/src/providers/rustdoc.rs
+++ b/crates/indexed_docs/src/providers/rustdoc.rs
@@ -158,6 +158,11 @@ impl RustdocProvider for LocalProvider {
     ) -> Result<Option<String>> {
         let mut local_cargo_doc_path = self.cargo_workspace_root.join("target/doc");
         local_cargo_doc_path.push(crate_name.as_ref());
+
+        if !self.fs.is_dir(&local_cargo_doc_path).await {
+            bail!("docs directory for '{crate_name}' does not exist. run `cargo doc`");
+        }
+
         if let Some(item) = item {
             local_cargo_doc_path.push(item.url_path());
         } else {


### PR DESCRIPTION
This PR updates the `/docs` slash command to show a warning to the user if a crate's docs cannot be indexed due to the target directory not containing docs:

<img width="782" alt="Screenshot 2024-07-11 at 5 11 46 PM" src="https://github.com/user-attachments/assets/2f54f7a1-97f4-4d2d-b51f-57ba31e50a2f">

Release Notes:

- N/A
