### PR TITLE
Don't panic on unknown cursor style on x11

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1169,10 +1169,13 @@ impl LinuxClient for X11Client {
         let cursor = match state.cursor_cache.get(&style) {
             Some(cursor) => *cursor,
             None => {
-                let cursor = state
+                let Some(cursor) = state
                     .cursor_handle
                     .load_cursor(&state.xcb_connection, &style.to_icon_name())
-                    .expect("failed to load cursor");
+                    .log_err()
+                else {
+                    return;
+                };
                 state.cursor_cache.insert(style, cursor);
                 cursor
             }


### PR DESCRIPTION
Release Notes:

- linux: Fixed a panic if we request a cursor style your system doesn't support
