### PR TITLE
Alias `ctrl-shift-~` with `ctrl-~` on Linux to fix default `ctrl-~` keybind

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -31,7 +31,9 @@
       "ctrl-0": "zed::ResetBufferFontSize",
       "ctrl-,": "zed::OpenSettings",
       "ctrl-q": "zed::Quit",
-      "f11": "zed::ToggleFullScreen"
+      "f11": "zed::ToggleFullScreen",
+      // On US keyboards, distributions may send `ctrl-~` as `ctrl-shift-~`
+      "ctrl-shift-~": ["workspace::SendKeystrokes", "ctrl-~"]
     }
   },
   {


### PR DESCRIPTION
In certain Linux distributions when using a US keyboard, `ctrl-~` may be sent as `ctrl-shift-~`. This causes the default `ctrl-~` keybind to not function. This PR aliases `ctrl-shift-~` to `ctrl-~` by default under Linux. 

Although I am unsure as to if this would have a negative impact on international layouts or if this is an underlying issue with how zed parses keyboard input.

I was able to reproduce this on Fedora 39 running Gnome in Wayland mode.

Release Notes:

- Fixed `ctrl-~` keybind not working under certain Linux distributions 

