### PR TITLE
Apply `terminal.foreground` and `terminal.background` from theme

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -661,7 +661,7 @@ impl Element for TerminalElement {
                     // These are going to be overridden per-cell
                     underline: None,
                     strikethrough: None,
-                    color: theme.colors().text,
+                    color: theme.colors().terminal_foreground,
                 };
 
                 let text_system = cx.text_system();
@@ -1141,7 +1141,7 @@ pub fn convert_color(fg: &terminal::alacritty_terminal::vte::ansi::Color, theme:
             NamedColor::BrightMagenta => colors.terminal_ansi_bright_magenta,
             NamedColor::BrightCyan => colors.terminal_ansi_bright_cyan,
             NamedColor::BrightWhite => colors.terminal_ansi_bright_white,
-            NamedColor::Foreground => colors.text,
+            NamedColor::Foreground => colors.terminal_foreground,
             NamedColor::Background => colors.background,
             NamedColor::Cursor => theme.players().local().cursor,
             NamedColor::DimBlack => colors.terminal_ansi_dim_black,

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -656,7 +656,7 @@ impl Element for TerminalElement {
                     font_size: font_size.into(),
                     font_style: FontStyle::Normal,
                     line_height: line_height.into(),
-                    background_color: None,
+                    background_color: Some(theme.colors().terminal_background),
                     white_space: WhiteSpace::Normal,
                     // These are going to be overridden per-cell
                     underline: None,
@@ -1142,7 +1142,7 @@ pub fn convert_color(fg: &terminal::alacritty_terminal::vte::ansi::Color, theme:
             NamedColor::BrightCyan => colors.terminal_ansi_bright_cyan,
             NamedColor::BrightWhite => colors.terminal_ansi_bright_white,
             NamedColor::Foreground => colors.terminal_foreground,
-            NamedColor::Background => colors.background,
+            NamedColor::Background => colors.terminal_background,
             NamedColor::Cursor => theme.players().local().cursor,
             NamedColor::DimBlack => colors.terminal_ansi_dim_black,
             NamedColor::DimRed => colors.terminal_ansi_dim_red,


### PR DESCRIPTION
Release Notes:

- Fixed terminal colors not respecting the theme ([#11418](https://github.com/zed-industries/zed/discussions/11418)).