### PR TITLE
Remove non-default wrap setting for markdown

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -13,5 +13,4 @@ brackets = [
 ]
 
 tab_size = 2
-soft_wrap = "preferred_line_length"
 prettier_parser_name = "markdown"


### PR DESCRIPTION
With this setting, markdown files are one of the few that get a line wrap indicator, a vertical line on the right, which confuses people.

See also:
- https://github.com/zed-industries/zed/issues/12473

Release Notes:

- N/A
