### PR TITLE
Fix direnv option being named direnv and not load_direnv in the docs

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -133,7 +133,14 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.cert",
+    "**/*.crt",
+    "**/secrets.yml"
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -133,14 +133,7 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": [
-    "**/.env*",
-    "**/*.pem",
-    "**/*.key",
-    "**/*.cert",
-    "**/*.crt",
-    "**/secrets.yml"
-  ],
+  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -548,12 +541,12 @@
   },
   // Configuration for how direnv configuration should be loaded. May take 2 values:
   // 1. Load direnv configuration through the shell hook, works for POSIX shells and fish.
-  //      "direnv": "shell_hook"
+  //      "load_direnv": "shell_hook"
   // 2. Load direnv configuration using `direnv export json` directly.
   //    This can help with some shells that otherwise would not detect
   //    the direnv environment, such as nushell or elvish.
-  //      "direnv": "direct"
-  "direnv": "shell_hook",
+  //      "load_direnv": "direct"
+  "load_direnv": "shell_hook",
   "inline_completions": {
     // A list of globs representing files that inline completions should be disabled for.
     "disabled_globs": [".env"]

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -193,11 +193,11 @@ left and right padding of the central pane from the workspace when the centered 
 ## Direnv Integration
 
 - Description: Settings for [direnv](https://direnv.net/) integration. Requires `direnv` to be installed. `direnv` integration currently only means that the environment variables set by a `direnv` configuration can be used to detect some language servers in `$PATH` instead of installing them.
-- Setting: `direnv`
+- Setting: `load_direnv`
 - Default:
 
 ```json
-"direnv": "shell_hook"
+"load_direnv": "shell_hook"
 ```
 
 **Options**


### PR DESCRIPTION
This is a quick followup to #13902 that fixes a mistake with the setting naming in the docs, I accidentally made 
Release Notes:

- N/A
