### PR TITLE
vim: Switch to insert mode when renaming

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9413,6 +9413,8 @@ impl Editor {
         });
         drop(snapshot);
 
+        cx.emit(EditorEvent::Renaming);
+
         Some(cx.spawn(|this, mut cx| async move {
             let rename_range = if let Some(range) = prepare_rename.await? {
                 Some(range)
@@ -12234,6 +12236,7 @@ pub enum EditorEvent {
     Edited {
         transaction_id: clock::Lamport,
     },
+    Renaming,
     Reparsed(BufferId),
     Focused,
     Blurred,

--- a/crates/vim/src/editor_events.rs
+++ b/crates/vim/src/editor_events.rs
@@ -9,6 +9,7 @@ pub fn init(cx: &mut AppContext) {
         cx.subscribe(&editor, |_, editor, event: &EditorEvent, cx| match event {
             EditorEvent::Focused => cx.window_context().defer(|cx| focused(editor, cx)),
             EditorEvent::Blurred => cx.window_context().defer(|cx| blurred(editor, cx)),
+            EditorEvent::Renaming => cx.window_context().defer(|cx| renaming(cx)),
             _ => {}
         })
         .detach();
@@ -57,6 +58,16 @@ fn blurred(editor: View<Editor>, cx: &mut WindowContext) {
                 editor.set_cursor_shape(language::CursorShape::Hollow, cx);
             }
         });
+    });
+}
+
+fn renaming(cx: &mut WindowContext) {
+    Vim::update(cx, |vim, cx| {
+        if !vim.enabled {
+            return;
+        }
+        // when renaming, we want to switch to insert mode
+        vim.switch_mode(crate::state::Mode::Insert, true, cx);
     });
 }
 


### PR DESCRIPTION

Release Notes:

- Fixed renaming not working in vim normal or visual mode [#14292](https://github.com/zed-industries/zed/issues/14292).

Before:

https://github.com/user-attachments/assets/b50014ee-0c8c-4919-acda-3cba94db1e0a

After:

https://github.com/user-attachments/assets/d0792dc2-c888-4fd0-a7b9-987206407d89
