### PR TITLE
Fix diagnostic popover not overflowing when necessary

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -636,8 +636,6 @@ impl DiagnosticPopover {
             .when(window_is_transparent(cx), |this| {
                 this.bg(gpui::transparent_black())
             })
-            .max_w(max_size.width)
-            .max_h(max_size.height)
             .cursor(CursorStyle::PointingHand)
             .tooltip(move |cx| Tooltip::for_action("Go To Diagnostic", &crate::GoToDiagnostic, cx))
             // Prevent a mouse move on the popover from being propagated to the editor,
@@ -651,6 +649,8 @@ impl DiagnosticPopover {
                 div()
                     .id("diagnostic-inner")
                     .overflow_y_scroll()
+                    .max_w(max_size.width)
+                    .max_h(max_size.height)
                     .px_2()
                     .py_1()
                     .bg(diagnostic_colors.background)


### PR DESCRIPTION
It was broken after #13996 moved rendering text one level deeper, causing `max_h` and `overflow_y_scroll` to apply to different widgets
Release Notes:

- Fixed large diagnostic popovers not overflowing when nessesary

Before:
<img width="814" alt="Screenshot 2024-07-12 at 15 25 46" src="https://github.com/user-attachments/assets/4f615600-2857-4470-8b77-864e3a9e38d5">

After:
<img width="813" alt="Screenshot 2024-07-12 at 15 26 10" src="https://github.com/user-attachments/assets/83c1f344-b3b1-4929-8197-4b24a0e9c65e">
