### PR TITLE
PlainText language: Default to SoftWrap::EditorWidth

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -122,7 +122,7 @@ lazy_static! {
     pub static ref PLAIN_TEXT: Arc<Language> = Arc::new(Language::new(
         LanguageConfig {
             name: "Plain Text".into(),
-            soft_wrap: Some(SoftWrap::PreferredLineLength),
+            soft_wrap: Some(SoftWrap::EditorWidth),
             ..Default::default()
         },
         None,


### PR DESCRIPTION
- Remove wrap guide / vertical ruler in untitled buffers
- Fixes https://github.com/zed-industries/zed/issues/12473

Release Notes:

- Fixed untitled buffers displaying a soft-wrap wrap-guide at `preferred_line_length` by default. ([#12473](https://github.com/zed-industries/zed/issues/12473)).