### PR TITLE
gpui: Add mouse selection support to Input example

### DIFF
--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -235,7 +235,7 @@ impl TextInput {
             return;
         }
 
-        if !hitbox.contains(&event.position) {
+        if !self.focus_handle.is_focused(cx) {
             return;
         }
 

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -141,11 +141,6 @@ impl TextInput {
         cx.notify()
     }
 
-    fn unselect(&mut self, cx: &mut ViewContext<Self>) {
-        self.selected_range = self.cursor_offset()..self.cursor_offset();
-        cx.notify()
-    }
-
     fn offset_from_utf16(&self, offset: usize) -> usize {
         let mut utf8_offset = 0;
         let mut utf16_count = 0;


### PR DESCRIPTION
Release Notes:

- N/A

---

Continue rest of #13534, extract from https://github.com/huacnlee/gpui-component/pull/26

## Demo

```bash
cargo run -p gpui --example input    
```

https://github.com/user-attachments/assets/2a674023-af58-4a63-9677-5843e4f35281

> The video is looks like response slow, but it is actully fast.


