### PR TITLE
windows: Refactor clipboard implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,16 +2407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clipboard-win"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342"
-dependencies = [
- "lazy-bytes-cast",
- "winapi",
-]
-
-[[package]]
 name = "clock"
 version = "0.1.0"
 dependencies = [
@@ -4883,7 +4873,6 @@ dependencies = [
  "calloop",
  "calloop-wayland-source",
  "cbindgen",
- "clipboard-win",
  "cocoa",
  "collections",
  "core-foundation",
@@ -6067,12 +6056,6 @@ dependencies = [
  "util",
  "workspace",
 ]
-
-[[package]]
-name = "lazy-bytes-cast"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,6 +452,7 @@ features = [
     "Win32_System_Com_StructuredStorage",
     "Win32_System_DataExchange",
     "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
     "Win32_System_Ole",
     "Win32_System_SystemInformation",
     "Win32_System_SystemServices",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -134,18 +134,22 @@ x11rb = { version = "0.13.0", features = [
     "resource_manager",
     "sync",
 ] }
-xkbcommon = { git = "https://github.com/ConradIrwin/xkbcommon-rs", rev = "2d4c4439160c7846ede0f0ece93bf73b1e613339", features = ["wayland", "x11"] }
+xkbcommon = { git = "https://github.com/ConradIrwin/xkbcommon-rs", rev = "2d4c4439160c7846ede0f0ece93bf73b1e613339", features = [
+    "wayland",
+    "x11",
+] }
 xim = { git = "https://github.com/npmania/xim-rs", rev = "27132caffc5b9bc9c432ca4afad184ab6e7c16af", features = [
     "x11rb-xcb",
     "x11rb-client",
 ] }
-font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "5a5c4d4", features = ["source-fontconfig-dlopen"] }
+font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "5a5c4d4", features = [
+    "source-fontconfig-dlopen",
+] }
 x11-clipboard = "0.9.2"
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
 windows-core = "0.57"
-clipboard-win = "3.1.1"
 
 [[example]]
 name = "hello_world"

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -406,6 +406,8 @@ pub(crate) trait PlatformTextSystem: Send + Sync {
         raster_bounds: Bounds<DevicePixels>,
     ) -> Result<(Size<DevicePixels>, Vec<u8>)>;
     fn layout_line(&self, text: &str, font_size: Pixels, runs: &[FontRun]) -> LineLayout;
+    #[cfg(target_os = "windows")]
+    fn destory(&self);
 }
 
 #[derive(PartialEq, Eq, Hash, Clone)]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -407,7 +407,7 @@ pub(crate) trait PlatformTextSystem: Send + Sync {
     ) -> Result<(Size<DevicePixels>, Vec<u8>)>;
     fn layout_line(&self, text: &str, font_size: Pixels, runs: &[FontRun]) -> LineLayout;
     #[cfg(target_os = "windows")]
-    fn destory(&self);
+    fn destroy(&self);
 }
 
 #[derive(PartialEq, Eq, Hash, Clone)]

--- a/crates/gpui/src/platform/cosmic_text/text_system.rs
+++ b/crates/gpui/src/platform/cosmic_text/text_system.rs
@@ -177,6 +177,8 @@ impl PlatformTextSystem for CosmicTextSystem {
     fn layout_line(&self, text: &str, font_size: Pixels, runs: &[FontRun]) -> LineLayout {
         self.0.write().layout_line(text, font_size, runs)
     }
+
+    fn destory(&self) {}
 }
 
 impl CosmicTextSystemState {

--- a/crates/gpui/src/platform/cosmic_text/text_system.rs
+++ b/crates/gpui/src/platform/cosmic_text/text_system.rs
@@ -178,7 +178,7 @@ impl PlatformTextSystem for CosmicTextSystem {
         self.0.write().layout_line(text, font_size, runs)
     }
 
-    fn destory(&self) {}
+    fn destroy(&self) {}
 }
 
 impl CosmicTextSystemState {

--- a/crates/gpui/src/platform/cosmic_text/text_system.rs
+++ b/crates/gpui/src/platform/cosmic_text/text_system.rs
@@ -178,6 +178,7 @@ impl PlatformTextSystem for CosmicTextSystem {
         self.0.write().layout_line(text, font_size, runs)
     }
 
+    #[cfg(target_os = "windows")]
     fn destroy(&self) {}
 }
 

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -240,7 +240,7 @@ impl PlatformTextSystem for DirectWriteTextSystem {
             })
     }
 
-    fn destory(&self) {
+    fn destroy(&self) {
         let mut lock = self.0.write();
         unsafe { ManuallyDrop::drop(&mut lock.components.bitmap_factory) };
     }

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, mem::ManuallyDrop, sync::Arc};
 
 use ::util::ResultExt;
 use anyhow::{anyhow, Result};
@@ -39,7 +39,7 @@ pub(crate) struct DirectWriteTextSystem(RwLock<DirectWriteState>);
 struct DirectWriteComponent {
     locale: String,
     factory: IDWriteFactory5,
-    bitmap_factory: IWICImagingFactory2,
+    bitmap_factory: ManuallyDrop<IWICImagingFactory2>,
     d2d1_factory: ID2D1Factory,
     in_memory_loader: IDWriteInMemoryFontFileLoader,
     builder: IDWriteFontSetBuilder1,
@@ -79,6 +79,7 @@ impl DirectWriteComponent {
             let factory: IDWriteFactory5 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
             let bitmap_factory: IWICImagingFactory2 =
                 CoCreateInstance(&CLSID_WICImagingFactory2, None, CLSCTX_INPROC_SERVER)?;
+            let bitmap_factory = ManuallyDrop::new(bitmap_factory);
             let d2d1_factory: ID2D1Factory =
                 D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None)?;
             // The `IDWriteInMemoryFontFileLoader` here is supported starting from
@@ -237,6 +238,11 @@ impl PlatformTextSystem for DirectWriteTextSystem {
                 font_size,
                 ..Default::default()
             })
+    }
+
+    fn destory(&self) {
+        let mut lock = self.0.write();
+        unsafe { ManuallyDrop::drop(&mut lock.components.bitmap_factory) };
     }
 }
 

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -791,8 +791,8 @@ fn read_metadata_from_clipboard(metadata_format: u32) -> Option<String> {
 }
 
 // clipboard
-pub const CLIPBOARD_HASH_FORMAT: PCWSTR = windows::core::w!("ZedTextHash");
-pub const CLIPBOARD_METADATA_FORMAT: PCWSTR = windows::core::w!("ZedMetadata");
+pub const CLIPBOARD_HASH_FORMAT: PCWSTR = windows::core::w!("zed-text-hash");
+pub const CLIPBOARD_METADATA_FORMAT: PCWSTR = windows::core::w!("zed-metadata");
 
 #[cfg(test)]
 mod tests {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -222,7 +222,6 @@ impl Platform for WindowsPlatform {
         if let Some(ref mut callback) = self.state.borrow_mut().callbacks.quit {
             callback();
         }
-        unsafe { OleUninitialize() };
     }
 
     fn quit(&self) {
@@ -599,6 +598,13 @@ impl Platform for WindowsPlatform {
 
     fn register_url_scheme(&self, _: &str) -> Task<anyhow::Result<()>> {
         Task::ready(Err(anyhow!("register_url_scheme unimplemented")))
+    }
+}
+
+impl Drop for WindowsPlatform {
+    fn drop(&mut self) {
+        self.text_system.destory();
+        unsafe { OleUninitialize() };
     }
 }
 

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -603,7 +603,7 @@ impl Platform for WindowsPlatform {
 
 impl Drop for WindowsPlatform {
     fn drop(&mut self) {
-        self.text_system.destory();
+        self.text_system.destroy();
         unsafe { OleUninitialize() };
     }
 }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -12,7 +12,6 @@ use std::{
 
 use ::util::ResultExt;
 use anyhow::{anyhow, Context, Result};
-use clipboard_win::{get_clipboard_string, set_clipboard_string};
 use futures::channel::oneshot::{self, Receiver};
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -220,10 +219,10 @@ impl Platform for WindowsPlatform {
             }
         }
 
-        unsafe { OleUninitialize() };
         if let Some(ref mut callback) = self.state.borrow_mut().callbacks.quit {
             callback();
         }
+        unsafe { OleUninitialize() };
     }
 
     fn quit(&self) {
@@ -603,15 +602,6 @@ impl Platform for WindowsPlatform {
     }
 }
 
-impl Drop for WindowsPlatform {
-    fn drop(&mut self) {
-        unsafe {
-            // OleUninitialize();
-            // CoUninitialize();
-        }
-    }
-}
-
 fn open_target(target: &str) {
     unsafe {
         let ret = ShellExecuteW(
@@ -807,17 +797,14 @@ mod tests {
         let platform = WindowsPlatform::new();
         let item = ClipboardItem::new("你好".to_string());
         platform.write_to_clipboard(item.clone());
-        // assert_eq!(platform.read_from_clipboard(), Some(item));
-        println!("{:#?}", platform.read_from_clipboard());
+        assert_eq!(platform.read_from_clipboard(), Some(item));
 
         let item = ClipboardItem::new("12345".to_string());
         platform.write_to_clipboard(item.clone());
-        // assert_eq!(platform.read_from_clipboard(), Some(item));
-        println!("{:#?}", platform.read_from_clipboard());
+        assert_eq!(platform.read_from_clipboard(), Some(item));
 
         let item = ClipboardItem::new("abcdef".to_string()).with_metadata(vec![3, 4]);
         platform.write_to_clipboard(item.clone());
-        // assert_eq!(platform.read_from_clipboard(), Some(item));
-        println!("{:#?}", platform.read_from_clipboard());
+        assert_eq!(platform.read_from_clipboard(), Some(item));
     }
 }


### PR DESCRIPTION
This PR provides a similar implementation to the macOS clipboard implementation, adds support for metadata and includes tests.

Release Notes:

- N/A
