### PR TITLE
Revert `hold: true` for macOS tasks

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -346,7 +346,11 @@ impl TerminalBuilder {
             alacritty_terminal::tty::Options {
                 shell: alac_shell,
                 working_directory: working_directory.clone(),
+                #[cfg(target_os = "linux")]
                 hold: !matches!(shell.clone(), Shell::System),
+                // with hold: true, macOS gets tasks stuck on ctrl-c interrupts periodically
+                #[cfg(not(target_os = "linux"))]
+                hold: false,
                 env: env.into_iter().collect(),
             }
         };


### PR DESCRIPTION
Otherwise, ctrl-c makes them stuck being held from time to time

Follow-up of https://github.com/zed-industries/zed/pull/13898 that reverts the macOS-related part of the PR.

Release Notes:

- N/A
