### PR TITLE
Add keyboard shortcuts to center scrolling around current line

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -83,7 +83,7 @@
       "ctrl-n": "editor::MoveDown",
       "ctrl-b": "editor::MoveLeft",
       "ctrl-f": "editor::MoveRight",
-      "ctrl-l": "editor::NextScreen",
+      "ctrl-l": "editor::ScrollCursorCenter",
       "alt-left": "editor::MoveToPreviousWordStart",
       "alt-b": "editor::MoveToPreviousWordStart",
       "alt-right": "editor::MoveToNextWordEnd",

--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -13,6 +13,7 @@
       "ctrl-shift-j": "editor::JoinLines",
       "ctrl-d": "editor::DuplicateLineDown",
       "ctrl-y": "editor::DeleteLine",
+      "ctrl-m": "editor::ScrollCursorCenter",
       "ctrl-pagedown": "editor::MovePageDown",
       "ctrl-pageup": "editor::MovePageUp",
       // "ctrl-alt-shift-b": "editor::SelectToPreviousWordStart",


### PR DESCRIPTION
- MacOS: Center the cursor in the visible area. `ctrl-l` (matches MacOS)
- Linux JetBrains: Scroll so cursor is at the Middle `ctrl-m`
- `editor::NextScreen` is not longer bound in any keymap by default (was `ctrl-l` on MacOS)

Fixes #5247

Release Notes:

- Added "Center the cursor in the visible area." to match MacOS `ctrl-l`; Added `ctrl-m` for JetBrain on Linux for the same ([#5247](https://github.com/zed-industries/zed/issues/5247)).
