### PR TITLE
Prevent rendering of system title bar when window is not maximized

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -268,12 +268,13 @@ impl WindowsWindow {
                 .map(|title| title.as_ref())
                 .unwrap_or(""),
         );
-        let (dwexstyle, dwstyle) = if params.kind == WindowKind::PopUp {
-            (WS_EX_TOOLWINDOW, WINDOW_STYLE(0x0))
+        let (dwexstyle, dwstyle, gwlstyle) = if params.kind == WindowKind::PopUp {
+            (WS_EX_TOOLWINDOW, WINDOW_STYLE(0x0), None)
         } else {
             (
                 WS_EX_APPWINDOW,
                 WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX,
+                Some((WS_BORDER.0 | WS_THICKFRAME.0) as i32),
             )
         };
         let hinstance = get_module_handle();
@@ -310,6 +311,11 @@ impl WindowsWindow {
                 lpparam,
             )
         };
+        if let Some(s) = gwlstyle {
+            unsafe {
+                SetWindowLongW(raw_hwnd, GWL_STYLE, s);
+            }
+        }
         let state_ptr = Rc::clone(context.inner.as_ref().unwrap());
         register_drag_drop(state_ptr.clone());
 


### PR DESCRIPTION
Before this fix a system title bar appeared on top of the zed's one when the window was not maximized.

The system title bar was not usable as clicks went through it to an underlying window if any.

The solution was inspired by [this thread on Stackoverflow](https://stackoverflow.com/questions/7442939/opening-a-window-that-has-no-title-bar-with-win32).

It seems like this PR addresses the same issue as #14190. However I believe this one avoids calculation of adjustments for different Windows versions.

Release Notes:

- Fixed Duplicate title bar when the window is not maximized (on Windows)

### Before
![zed-double-title-bar-on-windows-10](https://github.com/user-attachments/assets/df10f117-96b0-451b-9cdf-4d8e535c03d5)

### After
![zed-without-system-title-bar](https://github.com/user-attachments/assets/2ffd2a22-3ce3-4e4f-9322-a0fb7412625d)

