### PR TITLE
linux: Show warning if file picker portal is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,8 +341,9 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.9.0"
-source = "git+https://github.com/bilelmoussaoui/ashpd?rev=29f2e1a#29f2e1a6f4b0911f504658f5f4630c02e01b13f2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe7e0dd0ac5a401dc116ed9f9119cf9decc625600474cb41f0fc0a0050abc9a"
 dependencies = [
  "async-fs 2.1.1",
  "async-net 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ zed_actions = { path = "crates/zed_actions" }
 alacritty_terminal = "0.23"
 any_vec = "0.13"
 anyhow = "1.0.57"
-ashpd = { git = "https://github.com/bilelmoussaoui/ashpd", rev = "29f2e1a" }
+ashpd = "0.9.1"
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
 async-dispatcher = { version = "0.1" }
 async-fs = "1.6"

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -612,10 +612,11 @@ impl AppContext {
     /// Displays a platform modal for selecting paths.
     /// When one or more paths are selected, they'll be relayed asynchronously via the returned oneshot channel.
     /// If cancelled, a `None` will be relayed instead.
+    /// May return an error on Linux if the file picker couldn't be opened.
     pub fn prompt_for_paths(
         &self,
         options: PathPromptOptions,
-    ) -> oneshot::Receiver<Option<Vec<PathBuf>>> {
+    ) -> oneshot::Receiver<Result<Option<Vec<PathBuf>>>> {
         self.platform.prompt_for_paths(options)
     }
 
@@ -623,7 +624,11 @@ impl AppContext {
     /// The provided directory will be used to set the initial location.
     /// When a path is selected, it is relayed asynchronously via the returned oneshot channel.
     /// If cancelled, a `None` will be relayed instead.
-    pub fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>> {
+    /// May return an error on Linux if the file picker couldn't be opened.
+    pub fn prompt_for_new_path(
+        &self,
+        directory: &Path,
+    ) -> oneshot::Receiver<Result<Option<PathBuf>>> {
         self.platform.prompt_for_new_path(directory)
     }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -137,8 +137,8 @@ pub(crate) trait Platform: 'static {
     fn prompt_for_paths(
         &self,
         options: PathPromptOptions,
-    ) -> oneshot::Receiver<Option<Vec<PathBuf>>>;
-    fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>>;
+    ) -> oneshot::Receiver<Result<Option<Vec<PathBuf>>>>;
+    fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Result<Option<PathBuf>>>;
     fn reveal_path(&self, path: &Path);
 
     fn on_quit(&self, callback: Box<dyn FnMut()>);

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -602,7 +602,7 @@ impl Platform for MacPlatform {
     fn prompt_for_paths(
         &self,
         options: PathPromptOptions,
-    ) -> oneshot::Receiver<Option<Vec<PathBuf>>> {
+    ) -> oneshot::Receiver<Result<Option<Vec<PathBuf>>>> {
         let (done_tx, done_rx) = oneshot::channel();
         self.foreground_executor()
             .spawn(async move {
@@ -632,7 +632,7 @@ impl Platform for MacPlatform {
                         };
 
                         if let Some(done_tx) = done_tx.take() {
-                            let _ = done_tx.send(result);
+                            let _ = done_tx.send(Ok(result));
                         }
                     });
                     let block = block.copy();
@@ -643,7 +643,7 @@ impl Platform for MacPlatform {
         done_rx
     }
 
-    fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Option<PathBuf>> {
+    fn prompt_for_new_path(&self, directory: &Path) -> oneshot::Receiver<Result<Option<PathBuf>>> {
         let directory = directory.to_owned();
         let (done_tx, done_rx) = oneshot::channel();
         self.foreground_executor()
@@ -665,7 +665,7 @@ impl Platform for MacPlatform {
                         }
 
                         if let Some(done_tx) = done_tx.take() {
-                            let _ = done_tx.send(result);
+                            let _ = done_tx.send(Ok(result));
                         }
                     });
                     let block = block.copy();

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -34,7 +34,7 @@ pub(crate) struct TestPlatform {
 #[derive(Default)]
 pub(crate) struct TestPrompts {
     multiple_choice: VecDeque<oneshot::Sender<usize>>,
-    new_path: VecDeque<(PathBuf, oneshot::Sender<Option<PathBuf>>)>,
+    new_path: VecDeque<(PathBuf, oneshot::Sender<Result<Option<PathBuf>>>)>,
 }
 
 impl TestPlatform {
@@ -80,7 +80,7 @@ impl TestPlatform {
             .new_path
             .pop_front()
             .expect("no pending new path prompt");
-        tx.send(select_path(&path)).ok();
+        tx.send(Ok(select_path(&path))).ok();
     }
 
     pub(crate) fn simulate_prompt_answer(&self, response_ix: usize) {
@@ -216,14 +216,14 @@ impl Platform for TestPlatform {
     fn prompt_for_paths(
         &self,
         _options: crate::PathPromptOptions,
-    ) -> oneshot::Receiver<Option<Vec<std::path::PathBuf>>> {
+    ) -> oneshot::Receiver<Result<Option<Vec<std::path::PathBuf>>>> {
         unimplemented!()
     }
 
     fn prompt_for_new_path(
         &self,
         directory: &std::path::Path,
-    ) -> oneshot::Receiver<Option<std::path::PathBuf>> {
+    ) -> oneshot::Receiver<Result<Option<std::path::PathBuf>>> {
         let (tx, rx) = oneshot::channel();
         self.prompts
             .borrow_mut()

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -160,12 +160,21 @@ impl Workspace {
         self.show_notification(
             NotificationId::unique::<WorkspaceErrorNotification>(),
             cx,
-            |cx| {
-                cx.new_view(|_cx| {
-                    simple_message_notification::MessageNotification::new(format!("Error: {err:#}"))
-                })
-            },
+            |cx| cx.new_view(|_cx| ErrorMessagePrompt::new(format!("Error: {err:#}"))),
         );
+    }
+
+    pub fn show_portal_error(&mut self, err: String, cx: &mut ViewContext<Self>) {
+        struct PortalError;
+
+        self.show_notification(NotificationId::unique::<PortalError>(), cx, |cx| {
+            cx.new_view(|_cx| {
+                ErrorMessagePrompt::new(err.to_string()).with_link_button(
+                    "See docs",
+                    "https://zed.dev/docs/linux#i-cant-open-any-files",
+                )
+            })
+        });
     }
 
     pub fn dismiss_notification(&mut self, id: &NotificationId, cx: &mut ViewContext<Self>) {
@@ -361,6 +370,84 @@ impl Render for LanguageServerPrompt {
 }
 
 impl EventEmitter<DismissEvent> for LanguageServerPrompt {}
+
+pub struct ErrorMessagePrompt {
+    message: SharedString,
+    label_and_url_button: Option<(SharedString, SharedString)>,
+}
+
+impl ErrorMessagePrompt {
+    pub fn new<S>(message: S) -> Self
+    where
+        S: Into<SharedString>,
+    {
+        Self {
+            message: message.into(),
+            label_and_url_button: None,
+        }
+    }
+
+    pub fn with_link_button<S>(mut self, label: S, url: S) -> Self
+    where
+        S: Into<SharedString>,
+    {
+        self.label_and_url_button = Some((label.into(), url.into()));
+        self
+    }
+}
+
+impl Render for ErrorMessagePrompt {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        h_flex()
+            .id("error_message_prompt_notification")
+            .occlude()
+            .elevation_3(cx)
+            .items_start()
+            .justify_between()
+            .p_2()
+            .gap_2()
+            .w_full()
+            .child(
+                v_flex()
+                    .w_full()
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .justify_between()
+                            .child(
+                                svg()
+                                    .size(cx.text_style().font_size)
+                                    .flex_none()
+                                    .mr_2()
+                                    .mt(px(-2.0))
+                                    .map(|icon| {
+                                        icon.path(IconName::ExclamationTriangle.path())
+                                            .text_color(Color::Error.color(cx))
+                                    }),
+                            )
+                            .child(
+                                ui::IconButton::new("close", ui::IconName::Close)
+                                    .on_click(cx.listener(|_, _, cx| cx.emit(gpui::DismissEvent))),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .max_w_80()
+                            .child(Label::new(self.message.clone()).size(LabelSize::Small)),
+                    )
+                    .when_some(self.label_and_url_button.clone(), |elm, (label, url)| {
+                        elm.child(
+                            div().mt_2().child(
+                                ui::Button::new("error_message_prompt_notification_button", label)
+                                    .on_click(move |_, cx| cx.open_url(&url)),
+                            ),
+                        )
+                    }),
+            )
+    }
+}
+
+impl EventEmitter<DismissEvent> for ErrorMessagePrompt {}
 
 pub mod simple_message_notification {
     use gpui::{

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -30,10 +30,10 @@ use gpui::{
     action_as, actions, canvas, impl_action_as, impl_actions, point, relative, size,
     transparent_black, Action, AnyElement, AnyView, AnyWeakView, AppContext, AsyncAppContext,
     AsyncWindowContext, Bounds, CursorStyle, Decorations, DragMoveEvent, Entity as _, EntityId,
-    EventEmitter, FocusHandle, FocusableView, Global, Hsla, KeyContext, Keystroke, ManagedView,
-    Model, ModelContext, MouseButton, PathPromptOptions, Point, PromptLevel, Render, ResizeEdge,
-    Size, Stateful, Subscription, Task, Tiling, View, WeakView, WindowBounds, WindowHandle,
-    WindowOptions,
+    EventEmitter, Flatten, FocusHandle, FocusableView, Global, Hsla, KeyContext, Keystroke,
+    ManagedView, Model, ModelContext, MouseButton, PathPromptOptions, Point, PromptLevel, Render,
+    ResizeEdge, Size, Stateful, Subscription, Task, Tiling, View, WeakView, WindowBounds,
+    WindowHandle, WindowOptions,
 };
 use item::{
     FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, PreviewTabsSettings,
@@ -305,13 +305,31 @@ pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {
 
             if let Some(app_state) = app_state.upgrade() {
                 cx.spawn(move |cx| async move {
-                    if let Some(paths) = paths.await.log_err().flatten() {
-                        cx.update(|cx| {
-                            open_paths(&paths, app_state, OpenOptions::default(), cx)
-                                .detach_and_log_err(cx)
-                        })
-                        .ok();
-                    }
+                    match Flatten::flatten(paths.await.map_err(|e| e.into())) {
+                        Ok(Some(paths)) => {
+                            cx.update(|cx| {
+                                open_paths(&paths, app_state, OpenOptions::default(), cx)
+                                    .detach_and_log_err(cx)
+                            })
+                            .ok();
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            cx.update(|cx| {
+                                if let Some(workspace_window) = cx
+                                    .active_window()
+                                    .and_then(|window| window.downcast::<Workspace>())
+                                {
+                                    workspace_window
+                                        .update(cx, |workspace, cx| {
+                                            workspace.show_portal_error(err.to_string(), cx);
+                                        })
+                                        .ok();
+                                }
+                            })
+                            .ok();
+                        }
+                    };
                 })
                 .detach();
             }
@@ -1294,7 +1312,15 @@ impl Workspace {
             let (tx, rx) = oneshot::channel();
             let abs_path = cx.prompt_for_new_path(&start_abs_path);
             cx.spawn(|this, mut cx| async move {
-                let abs_path = abs_path.await?;
+                let abs_path: Option<PathBuf> =
+                    Flatten::flatten(abs_path.await.map_err(|e| e.into())).map_err(|err| {
+                        this.update(&mut cx, |this, cx| {
+                            this.show_portal_error(err.to_string(), cx);
+                        })
+                        .ok();
+                        err
+                    })?;
+
                 let project_path = abs_path.and_then(|abs_path| {
                     this.update(&mut cx, |this, cx| {
                         this.project.update(cx, |project, cx| {
@@ -1583,8 +1609,16 @@ impl Workspace {
         });
 
         cx.spawn(|this, mut cx| async move {
-            let Some(paths) = paths.await.log_err().flatten() else {
-                return;
+            let paths = match Flatten::flatten(paths.await.map_err(|e| e.into())) {
+                Ok(Some(paths)) => paths,
+                Ok(None) => return,
+                Err(err) => {
+                    this.update(&mut cx, |this, cx| {
+                        this.show_portal_error(err.to_string(), cx);
+                    })
+                    .ok();
+                    return;
+                }
             };
 
             if let Some(task) = this
@@ -1746,7 +1780,14 @@ impl Workspace {
             multiple: true,
         });
         cx.spawn(|this, mut cx| async move {
-            if let Some(paths) = paths.await.log_err().flatten() {
+            let paths = Flatten::flatten(paths.await.map_err(|e| e.into())).map_err(|err| {
+                this.update(&mut cx, |this, cx| {
+                    this.show_portal_error(err.to_string(), cx);
+                })
+                .ok();
+                err
+            })?;
+            if let Some(paths) = paths {
                 let results = this
                     .update(&mut cx, |this, cx| {
                         this.open_paths(paths, OpenVisible::All, None, cx)


### PR DESCRIPTION
This PR adds a warning when the file chooser couldn't be opened on Linux

It's quite confusing when trying to open a file and apparently nothing happens: 

- fixes https://github.com/zed-industries/zed/issues/11089
- fixes https://github.com/zed-industries/zed/issues/14328
- fixes https://github.com/zed-industries/zed/issues/13753#issuecomment-2225812703
- fixes https://github.com/zed-industries/zed/issues/13766
- fixes https://github.com/zed-industries/zed/issues/14384
- fixes https://github.com/zed-industries/zed/issues/14353
- fixes https://github.com/zed-industries/zed/issues/9209

![image](https://github.com/user-attachments/assets/5acabdaa-7a9d-4225-9480-e371d20387c3)


Release Notes:

- N/A
