### PR TITLE
Add icon to the tabbar title 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3608,6 +3608,7 @@ dependencies = [
  "db",
  "emojis",
  "env_logger",
+ "file_icons",
  "futures 0.3.28",
  "fuzzy",
  "git",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -76,6 +76,7 @@ ui.workspace = true
 url.workspace = true
 util.workspace = true
 workspace.workspace = true
+file_icons.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::HashSet;
+use file_icons::FileIcons;
 use futures::future::try_join_all;
 use git::repository::GitFileStatus;
 use gpui::{
@@ -622,21 +623,26 @@ impl Item for Editor {
 
             Some(util::truncate_and_trailoff(&description, MAX_TAB_TITLE_LEN))
         });
+        let title = format!(" {}", self.title(cx));
+        let icon_path = Path::new(&title);
+        let icon_file = FileIcons::get_icon(icon_path, cx);
 
         h_flex()
             .gap_2()
             .child(
-                Label::new(self.title(cx).to_string())
-                    .color(label_color)
-                    .italic(params.preview),
+                h_flex()
+                    .when_some(icon_file, |this, icon_file| {
+                        this.child(Icon::from_path(icon_file).color(label_color))
+                    })
+                    .child(Label::new(title).color(label_color).italic(params.preview))
+                    .when_some(description, |this, description| {
+                        this.child(
+                            Label::new(description)
+                                .size(LabelSize::XSmall)
+                                .color(Color::Muted),
+                        )
+                    }),
             )
-            .when_some(description, |this, description| {
-                this.child(
-                    Label::new(description)
-                        .size(LabelSize::XSmall)
-                        .color(Color::Muted),
-                )
-            })
             .into_any_element()
     }
 


### PR DESCRIPTION
There is a nice icon in terminal tab, but editor tab are without icons. Here is a PR to add them.

Just one question: 
A margin between an icon and text is a space character at the beginning of the label. Is this done on purpose? 

Beautiful codebase BTW ;)

Release Notes:
 - Added tabbar title icon


<img width="842" alt="Screenshot 2024-07-13 at 17 08 56" src="https://github.com/user-attachments/assets/79baed32-8ca4-4a4d-8e33-5d1f8262a0b0">