### PR TITLE
deno: wire up LSP settings

### DIFF
--- a/extensions/deno/src/deno.rs
+++ b/extensions/deno/src/deno.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use zed::lsp::CompletionKind;
 use zed::{serde_json, CodeLabel, CodeLabelSpan, LanguageServerId};
+use zed_extension_api::settings::LspSettings;
 use zed_extension_api::{self as zed, Result};
 
 struct DenoExtension {

--- a/extensions/deno/src/deno.rs
+++ b/extensions/deno/src/deno.rs
@@ -117,6 +117,18 @@ impl zed::Extension for DenoExtension {
         })))
     }
 
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree("deno", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+
     fn label_for_completion(
         &self,
         _language_server_id: &LanguageServerId,


### PR DESCRIPTION
It can be used like this

```json
{
  "lsp": {
    "deno": {
      "settings": {
        "deno": {
          "enable": true
        }
      }
    }
  }
}
```

Currently deno lsp only works because deno have a workaround when it detects deno.json it gets activated, but without a deno.json it won't work
With this change now it works correctly regardless of a deno.json presence, it only require enable:true

Release Notes:

- Added/Fixed/Improved ... ([#NNNNN](https://github.com/zed-industries/zed/issues/NNNNN)).

Optionally, include screenshots / media showcasing your addition that can be included in the release notes.

### Or...

Release Notes:

- N/A
