### PR TITLE
Fix default sublime tab navigation

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -5,8 +5,8 @@
       "ctrl-shift-]": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
       "ctrl-pagedown": "pane::ActivateNextItem",
-      "ctrl-tab": "pane::ActivateNextItem"
-      "ctrl-shift-tab": "pane::ActivatePrevItem",
+      "ctrl-tab": "pane::ActivateNextItem",
+      "ctrl-shift-tab": "pane::ActivatePrevItem"
     }
   },
   {

--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -3,10 +3,10 @@
     "bindings": {
       "ctrl-shift-[": "pane::ActivatePrevItem",
       "ctrl-shift-]": "pane::ActivateNextItem",
-      "ctrl-pagedown": "pane::ActivatePrevItem",
-      "ctrl-pageup": "pane::ActivateNextItem",
-      "ctrl-shift-tab": "pane::ActivateNextItem",
-      "ctrl-tab": "pane::ActivatePrevItem"
+      "ctrl-pageup": "pane::ActivatePrevItem",
+      "ctrl-pagedown": "pane::ActivateNextItem",
+      "ctrl-tab": "pane::ActivateNextItem"
+      "ctrl-shift-tab": "pane::ActivatePrevItem",
     }
   },
   {

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -3,10 +3,10 @@
     "bindings": {
       "cmd-shift-[": "pane::ActivatePrevItem",
       "cmd-shift-]": "pane::ActivateNextItem",
-      "ctrl-pagedown": "pane::ActivatePrevItem",
-      "ctrl-pageup": "pane::ActivateNextItem",
-      "ctrl-shift-tab": "pane::ActivateNextItem",
-      "ctrl-tab": "pane::ActivatePrevItem"
+      "ctrl-pageup": "pane::ActivatePrevItem",
+      "ctrl-pagedown": "pane::ActivateNextItem",
+      "ctrl-tab": "pane::ActivateNextItem",
+      "ctrl-shift-tab": "pane::ActivatePrevItem"
     }
   },
   {


### PR DESCRIPTION
The default sublime bindings are:

{ "keys": ["ctrl+pagedown"], "command": "next_view" },
{ "keys": ["ctrl+pageup"], "command": "prev_view" },
{ "keys": ["ctrl+tab"], "command": "next_view_in_stack" },
{ "keys": ["ctrl+shift+tab"], "command": "prev_view_in_stack" },

This matches zed to do the same:

pagedown = tab = NextItem
pageup = shift_tab = PrevItem

Release Notes:

- Fixed Sublime tab navigation (unintentionally reversed directions) 