### PR TITLE
Include stable package in docs, mention UM, and link to sources for the Fedora package

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -30,7 +30,7 @@ There are several third-party Zed packages for various Linux distributions and p
 * Arch (AUR): [`zed-git`](https://aur.archlinux.org/packages/zed-git), [`zed-preview`](https://aur.archlinux.org/packages/zed-preview),  [`zed-preview-bin`](https://aur.archlinux.org/packages/zed-preview-bin)
 * Alpine: `zed` ([aarch64](https://pkgs.alpinelinux.org/package/edge/testing/aarch64/zed)) ([x86_64](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zed))
 * Nix: `zed-editor` ([stable](https://search.nixos.org/packages?show=zed-editor)), ([unstable](https://search.nixos.org/packages?channel=unstable&show=zed-editor))
-* Fedora 39 & 40 (Terra): `zed-nightly` ([aarch64](https://fedora.pkgs.org/40/terra/zed-nightly-0:0.142.0%5e20240619.0129d4e-1.fc40.aarch64.rpm.html)) ([x86_64](https://fedora.pkgs.org/40/terra/zed-nightly-0:0.142.0%5e20240619.0129d4e-1.fc40.x86_64.rpm.html)) `zed-preview` ([aarch64](https://fedora.pkgs.org/40/terra/zed-preview-0:0.142.1-pre1.fc40.aarch64.rpm.html)) ([x86_64](https://fedora.pkgs.org/40/terra/zed-nightly-0:0.142.0%5e20240619.0129d4e-1.fc40.x86_64.rpm.html))
+* Fedora/Ultramarine (Terra): [`zed`](https://github.com/terrapkg/packages/tree/frawhide/anda/devs/zed/stable), [`zed-preview`](https://github.com/terrapkg/packages/tree/frawhide/anda/devs/zed/preview), [`zed-nightly`](https://github.com/terrapkg/packages/tree/frawhide/anda/devs/zed/nightly)
 * Solus: [`zed`](https://github.com/getsolus/packages/tree/main/packages/z/zed)
 * Parabola: [`zed`](https://www.parabola.nu/packages/extra/x86_64/zed/)
 * Manjaro: [`zed`](https://packages.manjaro.org/?query=zed)


### PR DESCRIPTION
Hello, I'm one of the maintainers of the Zed package on Terra. I made the following changes:

- Mention the Terra stable package, instead of only preview and nightly.
- Link to sources for Terra packages instead of pkgs.org.
- Mention Ultramarine in addition to Fedora (one of Terra's targets).

Release Notes:

- N/A
