### PR TITLE
Rename Linux desktop icon to match application name

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -64,9 +64,9 @@ ln -sf ~/.local/zed.app/bin/zed ~/.local/bin/zed
 If you'd like integration with an XDG-compatible desktop environment, you will also need to install the `.desktop` file:
 
 ```sh
-cp ~/.local/zed.app/share/applications/zed.desktop ~/.local/share/applications/zed.desktop
-sed -i "s|Icon=zed|Icon=$HOME/.local/zed.app/share/icons/hicolor/512x512/apps/zed.png|g" ~/.local/share/applications/zed.desktop
-sed -i "s|Exec=zed|Exec=$HOME/.local/zed.app/libexec/zed-editor|g" ~/.local/share/applications/zed.desktop
+cp ~/.local/zed.app/share/applications/zed.desktop ~/.local/share/applications/dev.zed.Zed.desktop
+sed -i "s|Icon=zed|Icon=$HOME/.local/zed.app/share/icons/hicolor/512x512/apps/zed.png|g" ~/.local/share/applications/dev.zed.Zed.desktop
+sed -i "s|Exec=zed|Exec=$HOME/.local/zed.app/libexec/zed-editor|g" ~/.local/share/applications/dev.zed.Zed.desktop
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Release Notes:

- Updated the Linux manual installation docs to fix windows not matching with desktop icons ([#14435](https://github.com/zed-industries/zed/issues/14435)).

The automated `curl | bash` installation script already renames the `zed.desktop` file to match the window, so most users will not be facing this issue.  This is only affecting users who have downloaded and extracted the files following the manual instructions.

Since the app ID and the desktop file name are not the same, open windows are not being matched with the desktop icons, therefore showing a default one.  This PR changes the documentation to tell users they should rename the `.desktop` file to `dev.zed.Zed.desktop`, and therefore match the automated install script.

Before:
![image](https://github.com/user-attachments/assets/324b91e6-dae1-4902-b59c-b4f124a29820)

After:
![image](https://github.com/user-attachments/assets/169a4e8c-5c84-4400-8f0d-30cf478ca272)


