### PR TITLE
Fix Command Palette when opened from application menu

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -366,7 +366,9 @@ impl PickerDelegate for CommandPaletteDelegate {
             *hit_counts.0.entry(command.name).or_default() += 1;
         });
         let action = command.action;
-        cx.focus(&self.previous_focus_handle);
+        if cx.focus_handle_in_tree(&self.previous_focus_handle) {
+            cx.focus(&self.previous_focus_handle);
+        }
         self.dismissed(cx);
         cx.dispatch_action(action);
     }
@@ -379,6 +381,12 @@ impl PickerDelegate for CommandPaletteDelegate {
     ) -> Option<Self::ListItem> {
         let r#match = self.matches.get(ix)?;
         let command = self.commands.get(r#match.candidate_id)?;
+        let focus_handle = if cx.focus_handle_in_tree(&self.previous_focus_handle) {
+            &self.previous_focus_handle
+        } else {
+            &cx.focused()?
+        };
+
         Some(
             ListItem::new(ix)
                 .inset(true)
@@ -395,7 +403,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                         ))
                         .children(KeyBinding::for_action_in(
                             &*command.action,
-                            &self.previous_focus_handle,
+                            focus_handle,
                             cx,
                         )),
                 ),

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -975,6 +975,15 @@ impl<'a> WindowContext<'a> {
         self.refresh();
     }
 
+    /// Check if the provided focus handle is in the dispatch tree
+    pub fn focus_handle_in_tree(&self, handle: &FocusHandle) -> bool {
+        self.window
+            .rendered_frame
+            .dispatch_tree
+            .focusable_node_id(handle.id)
+            .is_some()
+    }
+
     /// Remove focus from all elements within this context's window.
     pub fn blur(&mut self) {
         if !self.window.focus_enabled {


### PR DESCRIPTION
The command palette relies on a `previous_focus_handle` to determine the applicable commands for the element that was focused before the command palette was opened. However, it seems the "Open Command Palette" button in the application menu is the last focused element when the command palette is opened, but is then destroyed when the menu closes so the focus_handle is invalid.
The command palette determines the available commands before the menu is closed (which is why the list of commands is visible when opening the palette from the menu), but the keymaps for those commands are determined in the render method after the menu is closed, and when a command is confirmed the `dispatch_path` is built from the root to the node referenced by `previous_focus_handle`.
MacOS does not see this bug because the "Open Command Palette" menu option is in the OS's app menu, which does not take focus, so the `previous_focus_handle` is not set to the menu before the command palette opens. However, the bug _can_ be reproduced in MacOS by using the hotkeys to open the command palette when a different menu is open (like the git branch menu).
I _believe_ this bug also affects Windows, but I have not verified this myself yet.

Release Notes:

- Fixes the command palette when opened from the application menu.

[Screencast from 2024-07-14 22-51-17.webm](https://github.com/user-attachments/assets/48c32020-bf4f-49c0-8dae-0219362b9a5e)
