### PR TITLE
Change the context menu and Copilot settings icon

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -286,7 +286,7 @@ impl InlineCompletionButton {
             self.build_language_settings_menu(menu, cx)
                 .separator()
                 .link(
-                    "Copilot Settings",
+                    "Go to Copilot Settings",
                     OpenBrowser {
                         url: COPILOT_SETTINGS_URL.to_string(),
                     }

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -178,7 +178,7 @@ impl ContextMenu {
 
             action: Some(action.boxed_clone()),
             handler: Rc::new(move |_, cx| cx.dispatch_action(action.boxed_clone())),
-            icon: Some(IconName::Link),
+            icon: Some(IconName::ArrowUpRight),
         });
         self
     }
@@ -360,7 +360,7 @@ impl Render for ContextMenu {
                                         h_flex()
                                             .gap_1()
                                             .child(Label::new(label.clone()))
-                                            .child(Icon::new(*icon))
+                                            .child(Icon::new(*icon).size(IconSize::Small))
                                             .into_any_element()
                                     } else {
                                         Label::new(label.clone()).into_any_element()


### PR DESCRIPTION
Felt the link we were using for menu items that open a browser page was not the best. That one is most typically used for attachments within scope, as opposed to opening external links. Noticed that via the "Copilot Settings" menu, which also felt like it could have a bit more descriptive label. Also reduced the size of the rendered icon in this component.

| Before | After |
|--------|--------|
| <img width="271" alt="Screenshot 2024-07-15 at 12 16 15" src="https://github.com/user-attachments/assets/33f1a462-2413-4987-a621-86e46d844904"> | <img width="271" alt="Screenshot 2024-07-15 at 12 16 23" src="https://github.com/user-attachments/assets/b1ad7f2e-81da-4839-92da-45141134dbd9"> | 

---

Release Notes:

- N/A
