### PR TITLE
Display hint to add PATH for Fish shell too

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -59,6 +59,9 @@ main() {
                 echo "   echo 'export PATH=\$HOME/.local/bin:\$PATH' >> ~/.zshrc"
                 echo "   source ~/.zshrc"
                 ;;
+            *fish)
+                echo "   fish_add_path -U $HOME/.local/bin"
+                ;;
             *)
                 echo "   echo 'export PATH=\$HOME/.local/bin:\$PATH' >> ~/.bashrc"
                 echo "   source ~/.bashrc"


### PR DESCRIPTION
tested on `fish 3.7.1 (released March 19, 2024)`
___

Release Notes:

- N/A