### PR TITLE
linux: Hide Install CLI from welcome

### DIFF
--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -123,20 +123,22 @@ impl Render for WelcomePage {
                                             .ok();
                                     })),
                             )
-                            .child(
-                                Button::new("install-cli", "Install the CLI")
-                                    .full_width()
-                                    .on_click(cx.listener(|this, _, cx| {
-                                        this.telemetry.report_app_event(
-                                            "welcome page: install cli".to_string(),
-                                        );
-                                        cx.app_mut()
-                                            .spawn(|cx| async move {
-                                                install_cli::install_cli(&cx).await
-                                            })
-                                            .detach_and_log_err(cx);
-                                    })),
-                            )
+                            .when(cfg!(target_os = "macos"), |el| {
+                                el.child(
+                                    Button::new("install-cli", "Install the CLI")
+                                        .full_width()
+                                        .on_click(cx.listener(|this, _, cx| {
+                                            this.telemetry.report_app_event(
+                                                "welcome page: install cli".to_string(),
+                                            );
+                                            cx.app_mut()
+                                                .spawn(|cx| async move {
+                                                    install_cli::install_cli(&cx).await
+                                                })
+                                                .detach_and_log_err(cx);
+                                        })),
+                                )
+                            })
                             .child(
                                 Button::new("sign-in-to-copilot", "Sign in to GitHub Copilot")
                                     .full_width()


### PR DESCRIPTION
Release Notes:

- linux: Remove "Install CLI" from welcome, it is not necessary
