### PR TITLE
Change minimum version of xdg_wm_base wayland protocol to fix WSLg

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -140,7 +140,7 @@ impl Globals {
             primary_selection_manager: globals.bind(&qh, 1..=1, ()).ok(),
             shm: globals.bind(&qh, 1..=1, ()).unwrap(),
             seat,
-            wm_base: globals.bind(&qh, 2..=5, ()).unwrap(),
+            wm_base: globals.bind(&qh, 1..=5, ()).unwrap(),
             viewporter: globals.bind(&qh, 1..=1, ()).ok(),
             fractional_scale_manager: globals.bind(&qh, 1..=1, ()).ok(),
             decoration_manager: globals.bind(&qh, 1..=1, ()).ok(),


### PR DESCRIPTION
I searched code base and didn't find any usages of the xdg_wm_base that were needed version 2+.

In case someone else runs into something similar `wayland-info` was helpful to know what protocols are supported by WSLg.

Release Notes:

- Fixed running on WSLg ([#14126](https://github.com/zed-industries/zed/issues/14126)).
