### PR TITLE
gpui_macros: Extract `border_style_methods` macro

### DIFF
--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -24,8 +24,8 @@ pub trait Styled: Sized {
     gpui_macros::position_style_methods!();
     gpui_macros::overflow_style_methods!();
     gpui_macros::cursor_style_methods!();
-    gpui_macros::box_shadow_style_methods!();
     gpui_macros::border_style_methods!();
+    gpui_macros::box_shadow_style_methods!();
 
     /// Sets the display type of the element to `block`.
     /// [Docs](https://tailwindcss.com/docs/display)

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -5,8 +5,9 @@ use crate::{
     SharedString, StyleRefinement, WhiteSpace,
 };
 pub use gpui_macros::{
-    box_shadow_style_methods, cursor_style_methods, margin_style_methods, overflow_style_methods,
-    padding_style_methods, position_style_methods, visibility_style_methods,
+    border_style_methods, box_shadow_style_methods, cursor_style_methods, margin_style_methods,
+    overflow_style_methods, padding_style_methods, position_style_methods,
+    visibility_style_methods,
 };
 use taffy::style::{AlignContent, Display};
 
@@ -24,6 +25,7 @@ pub trait Styled: Sized {
     gpui_macros::overflow_style_methods!();
     gpui_macros::cursor_style_methods!();
     gpui_macros::box_shadow_style_methods!();
+    gpui_macros::border_style_methods!();
 
     /// Sets the display type of the element to `block`.
     /// [Docs](https://tailwindcss.com/docs/display)
@@ -300,16 +302,6 @@ pub trait Styled: Sized {
         Self: Sized,
     {
         self.style().background = Some(fill.into());
-        self
-    }
-
-    /// Sets the border color of the element.
-    fn border_color<C>(mut self, border_color: C) -> Self
-    where
-        C: Into<Hsla>,
-        Self: Sized,
-    {
-        self.style().border_color = Some(border_color.into());
         self
     }
 

--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -70,6 +70,12 @@ pub fn cursor_style_methods(input: TokenStream) -> TokenStream {
     styles::cursor_style_methods(input)
 }
 
+/// Generates methods for border styles.
+#[proc_macro]
+pub fn border_style_methods(input: TokenStream) -> TokenStream {
+    styles::border_style_methods(input)
+}
+
 /// Generates methods for box shadow styles.
 #[proc_macro]
 pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
This PR extracts a separate `border_style_methods` macro so that it can be used independently from `style_helpers!`.

Release Notes:

- N/A
