### PR TITLE
Upsell built-in features on the extensions page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,6 +4005,7 @@ dependencies = [
  "theme_selector",
  "ui",
  "util",
+ "vim",
  "workspace",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3985,6 +3985,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "client",
+ "collections",
  "db",
  "editor",
  "extension",

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -17,6 +17,7 @@ test-support = []
 [dependencies]
 anyhow.workspace = true
 client.workspace = true
+collections.workspace = true
 db.workspace = true
 editor.workspace = true
 extension.workspace = true

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -37,6 +37,7 @@ theme.workspace = true
 theme_selector.workspace = true
 ui.workspace = true
 util.workspace = true
+vim.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/extensions_ui/src/components.rs
+++ b/crates/extensions_ui/src/components.rs
@@ -1,3 +1,5 @@
 mod extension_card;
+mod feature_upsell;
 
 pub use extension_card::*;
+pub use feature_upsell::*;

--- a/crates/extensions_ui/src/components/feature_upsell.rs
+++ b/crates/extensions_ui/src/components/feature_upsell.rs
@@ -49,7 +49,7 @@ impl RenderOnce for FeatureUpsell {
             .p_4()
             .justify_between()
             .border_color(cx.theme().colors().border)
-            .child(Label::new(self.text))
+            .child(v_flex().overflow_hidden().child(Label::new(self.text)))
             .child(h_flex().gap_2().children(self.children).when_some(
                 self.docs_url,
                 |el, docs_url| {

--- a/crates/extensions_ui/src/components/feature_upsell.rs
+++ b/crates/extensions_ui/src/components/feature_upsell.rs
@@ -1,19 +1,19 @@
+use gpui::{Div, StyleRefinement};
 use ui::{prelude::*, ButtonLike};
 
-#[derive(IntoElement, Clone)]
+#[derive(IntoElement)]
 pub struct FeatureUpsell {
+    base: Div,
     text: SharedString,
     docs_url: Option<SharedString>,
-    /// Whether this is the first upsell being displayed.
-    is_first: bool,
 }
 
 impl FeatureUpsell {
     pub fn new(text: impl Into<SharedString>) -> Self {
         Self {
+            base: h_flex(),
             text: text.into(),
             docs_url: None,
-            is_first: false,
         }
     }
 
@@ -21,20 +21,24 @@ impl FeatureUpsell {
         self.docs_url = Some(docs_url.into());
         self
     }
+}
 
-    pub fn is_first(mut self, is_first: bool) -> Self {
-        self.is_first = is_first;
-        self
+// Style methods.
+impl FeatureUpsell {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
     }
+
+    gpui::border_style_methods!({
+        visibility: pub
+    });
 }
 
 impl RenderOnce for FeatureUpsell {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
-        h_flex()
+        self.base
             .p_4()
             .justify_between()
-            .when(!self.is_first, |el| el.border_t_1())
-            .border_b_1()
             .border_color(cx.theme().colors().border)
             .child(Label::new(self.text))
             .when_some(self.docs_url, |el, docs_url| {

--- a/crates/extensions_ui/src/components/feature_upsell.rs
+++ b/crates/extensions_ui/src/components/feature_upsell.rs
@@ -49,7 +49,8 @@ impl RenderOnce for FeatureUpsell {
             .p_4()
             .justify_between()
             .border_color(cx.theme().colors().border)
-            .child(h_flex().gap_2().child(Label::new(self.text)).when_some(
+            .child(Label::new(self.text))
+            .child(h_flex().gap_2().children(self.children).when_some(
                 self.docs_url,
                 |el, docs_url| {
                     el.child(
@@ -67,6 +68,5 @@ impl RenderOnce for FeatureUpsell {
                     )
                 },
             ))
-            .child(h_flex().children(self.children))
     }
 }

--- a/crates/extensions_ui/src/components/feature_upsell.rs
+++ b/crates/extensions_ui/src/components/feature_upsell.rs
@@ -1,0 +1,56 @@
+use ui::{prelude::*, ButtonLike};
+
+#[derive(IntoElement, Clone)]
+pub struct FeatureUpsell {
+    text: SharedString,
+    docs_url: Option<SharedString>,
+    /// Whether this is the first upsell being displayed.
+    is_first: bool,
+}
+
+impl FeatureUpsell {
+    pub fn new(text: impl Into<SharedString>) -> Self {
+        Self {
+            text: text.into(),
+            docs_url: None,
+            is_first: false,
+        }
+    }
+
+    pub fn docs_url(mut self, docs_url: impl Into<SharedString>) -> Self {
+        self.docs_url = Some(docs_url.into());
+        self
+    }
+
+    pub fn is_first(mut self, is_first: bool) -> Self {
+        self.is_first = is_first;
+        self
+    }
+}
+
+impl RenderOnce for FeatureUpsell {
+    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+        h_flex()
+            .p_4()
+            .justify_between()
+            .when(!self.is_first, |el| el.border_t_1())
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(Label::new(self.text))
+            .when_some(self.docs_url, |el, docs_url| {
+                el.child(
+                    ButtonLike::new("open_docs")
+                        .child(
+                            h_flex()
+                                .gap_2()
+                                .child(Label::new("View docs"))
+                                .child(Icon::new(IconName::ArrowUpRight)),
+                        )
+                        .on_click({
+                            let docs_url = docs_url.clone();
+                            move |_event, cx| cx.open_url(&docs_url)
+                        }),
+                )
+            })
+    }
+}

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -134,6 +134,7 @@ enum Feature {
     LanguageC,
     LanguageCpp,
     LanguagePython,
+    LanguageRust,
 }
 
 fn keywords_by_feature() -> &'static BTreeMap<Feature, Vec<&'static str>> {
@@ -145,6 +146,7 @@ fn keywords_by_feature() -> &'static BTreeMap<Feature, Vec<&'static str>> {
             (Feature::LanguageC, vec!["c", "clang"]),
             (Feature::LanguageCpp, vec!["c++", "cpp", "clang"]),
             (Feature::LanguagePython, vec!["python", "py"]),
+            (Feature::LanguageRust, vec!["rust", "rs"]),
         ])
     })
 }
@@ -971,6 +973,8 @@ impl ExtensionsPage {
                     .docs_url("https://zed.dev/docs/languages/cpp"),
                 Feature::LanguagePython => FeatureUpsell::new("Python support is built-in to Zed!")
                     .docs_url("https://zed.dev/docs/languages/python"),
+                Feature::LanguageRust => FeatureUpsell::new("Rust support is built-in to Zed!")
+                    .docs_url("https://zed.dev/docs/languages/rust"),
             };
 
             upsell.when(ix < upsells_count, |upsell| upsell.border_b_1())

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -21,7 +21,8 @@ use num_format::{Locale, ToFormattedString};
 use release_channel::ReleaseChannel;
 use settings::Settings;
 use theme::ThemeSettings;
-use ui::{prelude::*, ContextMenu, PopoverMenu, ToggleButton, Tooltip};
+use ui::{prelude::*, CheckboxWithLabel, ContextMenu, PopoverMenu, ToggleButton, Tooltip};
+use vim::VimModeSetting;
 use workspace::item::TabContentParams;
 use workspace::{
     item::{Item, ItemEvent},
@@ -891,14 +892,53 @@ impl ExtensionsPage {
         Label::new(message)
     }
 
-    fn render_feature_upsells(&self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn update_settings<T: Settings>(
+        &mut self,
+        selection: &Selection,
+        cx: &mut ViewContext<Self>,
+        callback: impl 'static + Send + Fn(&mut T::FileContent, bool),
+    ) {
+        if let Some(workspace) = self.workspace.upgrade() {
+            let fs = workspace.read(cx).app_state().fs.clone();
+            let selection = *selection;
+            settings::update_settings_file::<T>(fs, cx, move |settings| {
+                let value = match selection {
+                    Selection::Unselected => false,
+                    Selection::Selected => true,
+                    _ => return,
+                };
+
+                callback(settings, value)
+            });
+        }
+    }
+
+    fn render_feature_upsells(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let upsells_count = self.upsells.len();
 
         v_flex().children(self.upsells.iter().enumerate().map(|(ix, feature)| {
             let upsell = match feature {
                 Feature::Git => FeatureUpsell::new("Git support is built-in to Zed!"),
                 Feature::Vim => FeatureUpsell::new("Vim support is built-in to Zed!")
-                    .docs_url("https://zed.dev/docs/vim"),
+                    .docs_url("https://zed.dev/docs/vim")
+                    .child(CheckboxWithLabel::new(
+                        "enable-vim",
+                        Label::new("Enable vim mode"),
+                        if VimModeSetting::get_global(cx).0 {
+                            ui::Selection::Selected
+                        } else {
+                            ui::Selection::Unselected
+                        },
+                        cx.listener(move |this, selection, cx| {
+                            this.telemetry
+                                .report_app_event("extensions: toggle vim".to_string());
+                            this.update_settings::<VimModeSetting>(
+                                selection,
+                                cx,
+                                |setting, value| *setting = Some(value),
+                            );
+                        }),
+                    )),
             };
 
             upsell.when(ix < upsells_count, |upsell| upsell.border_b_1())

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -130,6 +130,7 @@ impl ExtensionFilter {
 enum Feature {
     Git,
     Vim,
+    Python,
 }
 
 pub struct ExtensionsPage {
@@ -817,6 +818,12 @@ impl ExtensionsPage {
                 } else {
                     self.upsells.remove(&Feature::Vim);
                 }
+
+                if search.contains("python") {
+                    self.upsells.insert(Feature::Python);
+                } else {
+                    self.upsells.remove(&Feature::Python);
+                }
             } else {
                 self.upsells.clear();
             }
@@ -939,6 +946,8 @@ impl ExtensionsPage {
                             );
                         }),
                     )),
+                Feature::Python => FeatureUpsell::new("Python support is built-in to Zed!")
+                    .docs_url("https://zed.dev/docs/languages/python"),
             };
 
             upsell.when(ix < upsells_count, |upsell| upsell.border_b_1())

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -944,7 +944,7 @@ impl ExtensionsPage {
 
         v_flex().children(self.upsells.iter().enumerate().map(|(ix, feature)| {
             let upsell = match feature {
-                Feature::Git => FeatureUpsell::new("Git support is built-in to Zed!"),
+                Feature::Git => FeatureUpsell::new("Zed comes with basic Git support for diffs and branches. More Git features are coming in the future."),
                 Feature::Vim => FeatureUpsell::new("Vim support is built-in to Zed!")
                     .docs_url("https://zed.dev/docs/vim")
                     .child(CheckboxWithLabel::new(

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -892,19 +892,17 @@ impl ExtensionsPage {
     }
 
     fn render_feature_upsells(&self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
-        v_flex()
-            .gap_2()
-            .children(self.upsells.iter().enumerate().map(|(ix, feature)| {
-                let upsell = match feature {
-                    Feature::Git => FeatureUpsell::new("Git support is built-in to Zed!"),
-                    Feature::Vim => FeatureUpsell::new("Vim support is built-in to Zed!")
-                        .docs_url("https://zed.dev/docs/vim"),
-                };
+        let upsells_count = self.upsells.len();
 
-                upsell
-                    .when(ix > 0, |upsell| upsell.border_t_1())
-                    .border_b_1()
-            }))
+        v_flex().children(self.upsells.iter().enumerate().map(|(ix, feature)| {
+            let upsell = match feature {
+                Feature::Git => FeatureUpsell::new("Git support is built-in to Zed!"),
+                Feature::Vim => FeatureUpsell::new("Vim support is built-in to Zed!")
+                    .docs_url("https://zed.dev/docs/vim"),
+            };
+
+            upsell.when(ix < upsells_count, |upsell| upsell.border_b_1())
+        }))
     }
 }
 

--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -353,7 +353,7 @@ pub fn border_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the border color of the element.
         #visibility fn border_color<C>(mut self, border_color: C) -> Self
         where
-            C: Into<Hsla>,
+            C: Into<gpui::Hsla>,
             Self: Sized,
         {
             self.style().border_color = Some(border_color.into());


### PR DESCRIPTION
This PR extends the extensions page with support for upselling built-in Zed features when certain keywords are searched for.

This should help inform users about features that Zed has out-of-the-box when they go looking for them as extensions.

For example, when someone searches "vim":

<img width="1341" alt="Screenshot 2024-07-15 at 4 58 44 PM" src="https://github.com/user-attachments/assets/b256d07a-559a-43c2-b491-3eca5bff436e">

Here are more examples of what the upsells can look like:

<img width="1341" alt="Screenshot 2024-07-15 at 4 54 39 PM" src="https://github.com/user-attachments/assets/1f453132-ac14-4884-afc4-7c12db47ad1d">

Release Notes:

- Added banners for built-in Zed features when corresponding keywords are used in the extension search.
