### PR TITLE
Respect user preference for JS/TS on_type formatting

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -180,8 +180,8 @@ impl LspAdapter for VtslsLspAdapter {
         Ok(Some(json!({
             "typescript": {
                 "tsdk": tsdk_path,
-                "format": {
-                    "enable": true
+                "suggest": {
+                    "completeFunctionCalls": true
                 },
                 "inlayHints": {
                     "parameterNames": {
@@ -204,6 +204,11 @@ impl LspAdapter for VtslsLspAdapter {
                     "enumMemberValues": {
                         "enabled": true,
                     }
+                }
+            },
+            "javascript": {
+                "suggest": {
+                    "completeFunctionCalls": true
                 }
             },
             "vtsls": {
@@ -232,49 +237,9 @@ impl LspAdapter for VtslsLspAdapter {
         if let Some(options) = override_options {
             return Ok(options);
         }
-        let tsdk_path = Self::tsdk_path(&adapter).await;
-        Ok(json!({
-            "typescript": {
-                "suggest": {
-                    "completeFunctionCalls": true
-                },
-                "tsdk": tsdk_path,
-                "format": {
-                    "enable": true
-                },
-                "inlayHints": {
-                    "parameterNames": {
-                        "enabled": "all",
-                        "suppressWhenArgumentMatchesName": false,
-                    },
-                    "parameterTypes": {
-                        "enabled": true
-                    },
-                    "variableTypes": {
-                        "enabled": true,
-                        "suppressWhenTypeMatchesName": false,
-                    },
-                    "propertyDeclarationTypes": {
-                        "enabled": true,
-                    },
-                    "functionLikeReturnTypes": {
-                        "enabled": true,
-                    },
-                    "enumMemberValues": {
-                        "enabled": true,
-                    }
-                }
-            },
-            "vtsls": {
-                "experimental": {
-                    "completion": {
-                        "enableServerSideFuzzyMatch": true,
-                        "entriesLimit": 5000,
-                    }
-                },
-                "autoUseWorkspaceTsdk": true
-            }
-        }))
+        self.initialization_options(adapter)
+            .await
+            .map(|o| o.unwrap())
     }
 
     fn language_ids(&self) -> HashMap<String, String> {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -43,6 +43,7 @@ use itertools::Itertools;
 use language::{
     language_settings::{
         language_settings, AllLanguageSettings, FormatOnSave, Formatter, InlayHintKind,
+        LanguageSettings,
     },
     markdown, point_to_lsp, prepare_completion_documentation,
     proto::{
@@ -92,7 +93,6 @@ use std::{
     ffi::OsStr,
     hash::Hash,
     iter, mem,
-    num::NonZeroU32,
     ops::Range,
     path::{self, Component, Path, PathBuf},
     process::Stdio,
@@ -4920,7 +4920,6 @@ impl Project {
 
             let remove_trailing_whitespace = settings.remove_trailing_whitespace_on_save;
             let ensure_final_newline = settings.ensure_final_newline_on_save;
-            let tab_size = settings.tab_size;
 
             // First, format buffer's whitespace according to the settings.
             let trailing_whitespace_diff = if remove_trailing_whitespace {
@@ -5005,7 +5004,7 @@ impl Project {
                                 buffer,
                                 buffer_abs_path,
                                 language_server,
-                                tab_size,
+                                &settings,
                                 &mut cx,
                             )
                             .await
@@ -5054,7 +5053,7 @@ impl Project {
                                 buffer,
                                 buffer_abs_path,
                                 language_server,
-                                tab_size,
+                                &settings,
                                 &mut cx,
                             )
                             .await
@@ -5124,7 +5123,7 @@ impl Project {
         buffer: &Model<Buffer>,
         abs_path: &Path,
         language_server: &Arc<LanguageServer>,
-        tab_size: NonZeroU32,
+        settings: &LanguageSettings,
         cx: &mut AsyncAppContext,
     ) -> Result<Vec<(Range<Anchor>, String)>> {
         let uri = lsp::Url::from_file_path(abs_path)
@@ -5139,7 +5138,7 @@ impl Project {
             language_server
                 .request::<lsp::request::Formatting>(lsp::DocumentFormattingParams {
                     text_document,
-                    options: lsp_command::lsp_formatting_options(tab_size.get()),
+                    options: lsp_command::lsp_formatting_options(settings),
                     work_done_progress_params: Default::default(),
                 })
                 .await?
@@ -5151,7 +5150,7 @@ impl Project {
                 .request::<lsp::request::RangeFormatting>(lsp::DocumentRangeFormattingParams {
                     text_document,
                     range: lsp::Range::new(buffer_start, buffer_end),
-                    options: lsp_command::lsp_formatting_options(tab_size.get()),
+                    options: lsp_command::lsp_formatting_options(settings),
                     work_done_progress_params: Default::default(),
                 })
                 .await?
@@ -6784,8 +6783,12 @@ impl Project {
         push_to_history: bool,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<Option<Transaction>>> {
-        let tab_size = buffer.update(cx, |buffer, cx| {
-            language_settings(buffer.language_at(position).as_ref(), buffer.file(), cx).tab_size
+        let options = buffer.update(cx, |buffer, cx| {
+            lsp_command::lsp_formatting_options(language_settings(
+                buffer.language_at(position).as_ref(),
+                buffer.file(),
+                cx,
+            ))
         });
         self.request_lsp(
             buffer.clone(),
@@ -6793,7 +6796,7 @@ impl Project {
             OnTypeFormatting {
                 position,
                 trigger,
-                options: lsp_command::lsp_formatting_options(tab_size.get()).into(),
+                options,
                 push_to_history,
             },
             cx,


### PR DESCRIPTION

Release Notes:

- Fix respect user preference for JS/TS on_type formatting ([#13733](https://github.com/zed-industries/zed/issues/13733), [#14499](https://github.com/zed-industries/zed/issues/14499))
