### PR TITLE
Fix text appearing twice after Chinese character input

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1001,7 +1001,6 @@ impl X11Client {
             }));
         }
 
-        window.handle_ime_commit(text);
         Some(())
     }
 


### PR DESCRIPTION
Release Notes:

- Fixed the issue where text appears twice in the editor after Chinese Character input.([linux: Fix IME on fcitx](https://github.com/zed-industries/zed/pull/14508)).

Before：
![zed2](https://github.com/user-attachments/assets/e387d70b-ca91-49c8-93e4-850f9e3ef227)

After Fixed：
![zed](https://github.com/user-attachments/assets/8307c12f-30a7-4e82-8c65-d0b53bb8cf44)
