### PR TITLE
linux: Fix missing licenses in binary causing panics

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -121,9 +121,6 @@ jobs:
           echo "Publishing version: ${version} on release channel nightly"
           echo "nightly" > crates/zed/RELEASE_CHANNEL
 
-      - name: Generate license file
-        run: script/generate-licenses
-
       - name: Create Linux .tar.gz bundle
         run: script/bundle-linux
 

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -38,6 +38,9 @@ version_info=$(rustc --version --verbose)
 host_line=$(echo "$version_info" | grep host)
 target_triple=${host_line#*: }
 
+# Generate the licenses first, so they can be baked into the binaries
+script/generate-licenses
+
 # Build binary in release mode
 export RUSTFLAGS="-C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
 cargo build --release --target "${target_triple}" --package zed --package cli
@@ -97,8 +100,7 @@ fi
 mkdir -p "${zed_dir}/share/applications"
 envsubst < "crates/zed/resources/zed.desktop.in" > "${zed_dir}/share/applications/zed$suffix.desktop"
 
-# Licenses
-script/generate-licenses
+# Copy generated licenses so they'll end up in archive too
 cp "assets/licenses.md" "${zed_dir}/licenses.md"
 
 # Create archive out of everything that's in the temp directory


### PR DESCRIPTION
Turns out that the existing CI step for Nightly did create the licenses and they have been baked into X86 builds ever since, because our builders are stateful.

On ARM machines, the licenses wouldn't exist in the binary because we called `script/generate-licenses` too late in `scripts/bundle-linux`, after the binary had been created.

This removes the duplication and generates the licenses once, before the binary is created.

Fixes #14302.

Release Notes:

- Fixed "View Dependency Licenses" (or `zed: open licenses`) crashing on Linux ARM machines. ([#14302](https://github.com/zed-industries/zed/issues/14302)