### PR TITLE
Fix GoForward shortcut on non-US keyboard layouts

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -326,7 +326,7 @@
       "alt-9": ["pane::ActivateItem", 8],
       "alt-0": "pane::ActivateLastItem",
       "ctrl-alt--": "pane::GoBack",
-      "ctrl-alt-shift--": "pane::GoForward",
+      "ctrl-alt-_": "pane::GoForward",
       "ctrl-shift-t": "pane::ReopenClosedItem",
       "f3": "search::SelectNextMatch",
       "shift-f3": "search::SelectPrevMatch",


### PR DESCRIPTION
Fixes #14418
 
Originally broken by 
- #13946

Release Notes:

- Fixed GoForward shortcut on non-US keyboard layouts ([14418](https://github.com/zed-industries/zed/issues/14418)).
