### PR TITLE
wayland: Fix drag and drop for paths with spaces

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -11,6 +11,7 @@ use calloop_wayland_source::WaylandSource;
 use collections::HashMap;
 use filedescriptor::Pipe;
 
+use http::Url;
 use smallvec::SmallVec;
 use util::ResultExt;
 use wayland_backend::client::ObjectId;
@@ -1795,7 +1796,8 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
 
                             let paths: SmallVec<[_; 2]> = file_list
                                 .lines()
-                                .map(|path| PathBuf::from(path.replace("file://", "")))
+                                .filter_map(|path| Url::parse(path).log_err())
+                                .filter_map(|url| url.to_file_path().log_err())
                                 .collect();
                             let position = Point::new(x.into(), y.into());
 


### PR DESCRIPTION
This wasn't doing any proper parsing before, so `%20` or similar encoded characters weren't handled correctly.

Release Notes:

- N/A
