### PR TITLE
editor: Ensure allocation reuse

### DIFF
--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -103,9 +103,12 @@ impl TabMap {
                 }
             }
 
+            let _old_alloc_ptr = fold_edits.as_ptr();
             // Combine any edits that overlap due to the expansion.
             let mut fold_edits = fold_edits.into_iter();
             let fold_edits = if let Some(mut first_edit) = fold_edits.next() {
+                // This code relies on reusing allocations from the Vec<_> - at the time of writing .flatten() prevents them.
+                #[allow(clippy::filter_map_identity)]
                 let mut v: Vec<_> = fold_edits
                     .scan(&mut first_edit, |state, edit| {
                         if state.old.end >= edit.old.start {
@@ -119,10 +122,10 @@ impl TabMap {
                             result
                         }
                     })
-                    .flatten()
+                    .filter_map(|x| x)
                     .collect();
                 v.push(first_edit);
-
+                debug_assert_eq!(v.as_ptr(), _old_alloc_ptr, "Fold edits were reallocated");
                 v
             } else {
                 vec![]


### PR DESCRIPTION
In #14567 I claimed that the underlying allocation is reused. And it was. At the time I've submitted a PR I was using `.filter_map(|x| x)`, which got flagged by clippy as something that could be simplified to `.flatten()` - that however broke the allocation reuse promise.

Thus, this PR goes back to using `filter_map` and additionally in debug builds it performs checks for allocation reuse. With .flatten in place, a bunch of unit test fail on that branch, so the checks do work.



Release Notes:

- N/A