### PR TITLE
docs: Fix casing of "REPL" in sidebar

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,7 +22,7 @@
 - [Collaboration](./collaboration.md)
 - [Tasks](./tasks.md)
 - [Remote Development](./remote-development.md)
-- [Repl](./repl.md)
+- [REPL](./repl.md)
 
 # Language Support
 


### PR DESCRIPTION
This PR fixes the casing of the REPL link in the sidebar.

Release Notes:

- N/A
