### PR TITLE
docs: Add Git page

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -940,7 +940,10 @@ impl ExtensionsPage {
 
         v_flex().children(self.upsells.iter().enumerate().map(|(ix, feature)| {
             let upsell = match feature {
-                Feature::Git => FeatureUpsell::new("Zed comes with basic Git support for diffs and branches. More Git features are coming in the future."),
+                Feature::Git => FeatureUpsell::new(
+                    "Zed comes with basic Git support. More Git features are coming in the future.",
+                )
+                .docs_url("https://zed.dev/docs/git"),
                 Feature::Vim => FeatureUpsell::new("Vim support is built-in to Zed!")
                     .docs_url("https://zed.dev/docs/vim")
                     .child(CheckboxWithLabel::new(

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Assistant Panel](./assistant-panel.md)
 - [Channels](./channels.md)
 - [Collaboration](./collaboration.md)
+- [Git](./git.md)
 - [Tasks](./tasks.md)
 - [Remote Development](./remote-development.md)
 - [REPL](./repl.md)

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -1,0 +1,10 @@
+# Git
+
+Zed currently supports the following Git features:
+
+- Diff indicators in buffers and editor scrollbars
+- Git status in the project panel
+- Branch creating and switching
+- Git blame viewing
+
+More advanced Git features—like staging and committing changes or viewing history within Zed—will be coming in the future.


### PR DESCRIPTION
This PR adds a basic Git page to the docs so that we have somewhere to link to from the Git upsell within Zed.

Release Notes:

- N/A
