### PR TITLE
extensions_ui: Add telemetry for docs click-throughs from feature upsells

### DIFF
--- a/crates/extensions_ui/src/components/feature_upsell.rs
+++ b/crates/extensions_ui/src/components/feature_upsell.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use client::telemetry::Telemetry;
 use gpui::{AnyElement, Div, StyleRefinement};
 use smallvec::SmallVec;
 use ui::{prelude::*, ButtonLike};
@@ -5,15 +8,17 @@ use ui::{prelude::*, ButtonLike};
 #[derive(IntoElement)]
 pub struct FeatureUpsell {
     base: Div,
+    telemetry: Arc<Telemetry>,
     text: SharedString,
     docs_url: Option<SharedString>,
     children: SmallVec<[AnyElement; 2]>,
 }
 
 impl FeatureUpsell {
-    pub fn new(text: impl Into<SharedString>) -> Self {
+    pub fn new(telemetry: Arc<Telemetry>, text: impl Into<SharedString>) -> Self {
         Self {
             base: h_flex(),
+            telemetry,
             text: text.into(),
             docs_url: None,
             children: SmallVec::new(),
@@ -62,8 +67,14 @@ impl RenderOnce for FeatureUpsell {
                                     .child(Icon::new(IconName::ArrowUpRight)),
                             )
                             .on_click({
+                                let telemetry = self.telemetry.clone();
                                 let docs_url = docs_url.clone();
-                                move |_event, cx| cx.open_url(&docs_url)
+                                move |_event, cx| {
+                                    telemetry.report_app_event(format!(
+                                        "feature upsell: viewed docs ({docs_url})"
+                                    ));
+                                    cx.open_url(&docs_url)
+                                }
                             }),
                     )
                 },

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -938,10 +938,13 @@ impl ExtensionsPage {
     fn render_feature_upsells(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let upsells_count = self.upsells.len();
 
+        const GIT_UPSELL_TEXT: &str = "Zed comes with basic Git support for diffs and branches. More Git features are coming in the future.";
+
         v_flex().children(self.upsells.iter().enumerate().map(|(ix, feature)| {
+            let telemetry = self.telemetry.clone();
             let upsell = match feature {
-                Feature::Git => FeatureUpsell::new("Zed comes with basic Git support for diffs and branches. More Git features are coming in the future."),
-                Feature::Vim => FeatureUpsell::new("Vim support is built-in to Zed!")
+                Feature::Git => FeatureUpsell::new(telemetry, GIT_UPSELL_TEXT),
+                Feature::Vim => FeatureUpsell::new(telemetry, "Vim support is built-in to Zed!")
                     .docs_url("https://zed.dev/docs/vim")
                     .child(CheckboxWithLabel::new(
                         "enable-vim",
@@ -953,7 +956,7 @@ impl ExtensionsPage {
                         },
                         cx.listener(move |this, selection, cx| {
                             this.telemetry
-                                .report_app_event("extensions: toggle vim".to_string());
+                                .report_app_event("feature upsell: toggle vim".to_string());
                             this.update_settings::<VimModeSetting>(
                                 selection,
                                 cx,
@@ -961,14 +964,22 @@ impl ExtensionsPage {
                             );
                         }),
                     )),
-                Feature::LanguageC => FeatureUpsell::new("C support is built-in to Zed!")
-                    .docs_url("https://zed.dev/docs/languages/c"),
-                Feature::LanguageCpp => FeatureUpsell::new("C++ support is built-in to Zed!")
-                    .docs_url("https://zed.dev/docs/languages/cpp"),
-                Feature::LanguagePython => FeatureUpsell::new("Python support is built-in to Zed!")
-                    .docs_url("https://zed.dev/docs/languages/python"),
-                Feature::LanguageRust => FeatureUpsell::new("Rust support is built-in to Zed!")
-                    .docs_url("https://zed.dev/docs/languages/rust"),
+                Feature::LanguageC => {
+                    FeatureUpsell::new(telemetry, "C support is built-in to Zed!")
+                        .docs_url("https://zed.dev/docs/languages/c")
+                }
+                Feature::LanguageCpp => {
+                    FeatureUpsell::new(telemetry, "C++ support is built-in to Zed!")
+                        .docs_url("https://zed.dev/docs/languages/cpp")
+                }
+                Feature::LanguagePython => {
+                    FeatureUpsell::new(telemetry, "Python support is built-in to Zed!")
+                        .docs_url("https://zed.dev/docs/languages/python")
+                }
+                Feature::LanguageRust => {
+                    FeatureUpsell::new(telemetry, "Rust support is built-in to Zed!")
+                        .docs_url("https://zed.dev/docs/languages/rust")
+                }
             };
 
             upsell.when(ix < upsells_count, |upsell| upsell.border_b_1())


### PR DESCRIPTION
This PR adds some telemetry when the "View docs" button is clicked on a feature upsell.

The goal here is to get a sense for how effective these upsells are at getting users to click through if they can't find what they're looking for.

Release Notes:

- N/A
