### PR TITLE
collab: Fix exact extension filtering

### DIFF
--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -67,7 +67,10 @@ async fn get_extensions(
                 .first()
                 .cloned();
         }
-        extensions.splice(0..0, exact_match);
+
+        if let Some(exact_match) = exact_match {
+            extensions.insert(0, exact_match);
+        }
     };
 
     if let Some(query) = params.filter.as_deref() {

--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -48,11 +48,6 @@ async fn get_extensions(
         .get_extensions(params.filter.as_deref(), params.max_schema_version, 500)
         .await?;
 
-    if let Some(query) = params.filter.as_deref() {
-        let count = extensions.len();
-        tracing::info!(query, count, "extension_search")
-    }
-
     if let Some(filter) = params.filter.as_deref() {
         let extension_id = filter.to_lowercase();
         let mut exact_match = None;
@@ -74,6 +69,11 @@ async fn get_extensions(
         }
         extensions.splice(0..0, exact_match);
     };
+
+    if let Some(query) = params.filter.as_deref() {
+        let count = extensions.len();
+        tracing::info!(query, count, "extension_search")
+    }
 
     Ok(Json(GetExtensionsResponse { data: extensions }))
 }


### PR DESCRIPTION
This PR fixes the exact extension filtering introduced in #14588.

As we traversed the extensions we were always updating `exact_match`, regardless of whether it matched the extension ID from the filter.

Release Notes:

- N/A
