### PR TITLE
Fix context in command palette from application menu

### DIFF
--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -13,9 +13,10 @@ impl RenderOnce for ApplicationMenu {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
         PopoverMenu::new("application-menu")
             .menu(move |cx| {
-                ContextMenu::build(cx, move |menu, _cx| {
+                ContextMenu::build(cx, move |menu, cx| {
                     menu.header("Workspace")
                         .action("Open Command Palette", Box::new(command_palette::Toggle))
+                        .when_some(cx.focused(), |menu, focused| menu.context(focused))
                         .custom_row(move |cx| {
                             h_flex()
                                 .gap_2()


### PR DESCRIPTION
Supercedes #14468

Release Notes:

- linux: Fixed the command palette when opened from the application menu
