### PR TITLE
docs: Adjust the note and warning callout design

### DIFF
--- a/docs/theme/css/general.css
+++ b/docs/theme/css/general.css
@@ -212,7 +212,7 @@ blockquote {
 
 blockquote > p {
   margin: 0;
-  padding-left: 2.4rem;
+  padding-left: 2.6rem;
   font-size: 1.4rem;
 }
 
@@ -244,7 +244,7 @@ blockquote .warning:before {
 
 .warning > p {
   margin: 0;
-  padding-left: 2.4rem;
+  padding-left: 2.6rem;
   font-size: 1.4rem;
 }
 

--- a/docs/theme/css/general.css
+++ b/docs/theme/css/general.css
@@ -202,35 +202,65 @@ table tbody tr:nth-child(2n) {
 }
 
 blockquote {
-  margin: 20px 0;
-  padding: 0 20px;
+  margin: auto;
+  margin-top: 1rem;
+  padding: 1rem 1.25rem;
   color: var(--fg);
   background-color: var(--quote-bg);
-  border-block-start: 0.1em solid var(--quote-border);
-  border-block-end: 0.1em solid var(--quote-border);
+  border: 1px solid var(--quote-border);
 }
 
-.warning {
-  margin: 20px;
-  padding: 0 20px;
-  border-inline-start: 2px solid var(--warning-border);
+blockquote > p {
+  margin: 0;
+  padding-left: 2.4rem;
+  font-size: 1.4rem;
 }
 
-.warning:before {
+blockquote:before {
   position: absolute;
-  width: 3rem;
-  height: 3rem;
-  margin-inline-start: calc(-1.5rem - 21px);
   content: "ⓘ";
-  text-align: center;
-  background-color: var(--bg);
-  color: var(--warning-border);
+  margin: 0.3rem 0;
+  width: 1.6rem;
+  height: 1.6rem;
+  font-size: 1.6rem;
   font-weight: bold;
-  font-size: 2rem;
+  color: var(--icons);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.625em;
 }
 
 blockquote .warning:before {
   background-color: var(--quote-bg);
+}
+
+.warning {
+  margin: auto;
+  padding: 1rem 1.25rem;
+  background-color: var(--warning-bg);
+  border: 1px solid var(--warning-border);
+}
+
+.warning > p {
+  margin: 0;
+  padding-left: 2.4rem;
+  font-size: 1.4rem;
+}
+
+.warning:before {
+  position: absolute;
+  content: "ⓘ";
+  margin: 0.3rem 0;
+  width: 1.6rem;
+  height: 1.6rem;
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: var(--warning-icon);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.625em;
 }
 
 kbd {

--- a/docs/theme/css/variables.css
+++ b/docs/theme/css/variables.css
@@ -35,9 +35,11 @@
   --theme-hover: #e6e6e6;
 
   --quote-bg: hsl(197, 37%, 96%);
-  --quote-border: hsl(197, 37%, 91%);
+  --quote-border: hsl(197, 37%, 88%);
 
-  --warning-border: #ff8e00;
+  --warning-border: hsl(25, 100%, 85%);
+  --warning-bg: hsl(42, 100%, 60%, 0.1);
+  --warning-icon: hsl(42, 100%, 30%);
 
   --table-border-color: hsl(219, 93%, 42%, 0.15);
   --table-header-bg: hsl(0, 0%, 80%);


### PR DESCRIPTION
So they're more consistent and polished. Felt like they could be a bit more refined.

| Before | After |
|--------|--------|
| <img width="785" alt="Screenshot 2024-07-16 at 19 34 34" src="https://github.com/user-attachments/assets/b9fff057-3998-4390-b661-74317329df40"> | <img width="785" alt="Screenshot 2024-07-16 at 19 37 18" src="https://github.com/user-attachments/assets/2bcf965d-a44a-42d7-bc87-8e072ce0df8f"> |
| <img width="785" alt="Screenshot 2024-07-16 at 19 37 41" src="https://github.com/user-attachments/assets/3d71a11a-ed63-4baf-8b77-20bd6aa7dece"> | <img width="785" alt="Screenshot 2024-07-16 at 19 37 24" src="https://github.com/user-attachments/assets/7a52d7eb-c5f2-489d-877d-c0a38fd00631"> | 

---

Release Notes:

- N/A
