### PR TITLE
svelte: Add `-` `:` `.` to word_characters set to fix linked edit

### DIFF
--- a/extensions/svelte/languages/svelte/config.toml
+++ b/extensions/svelte/languages/svelte/config.toml
@@ -13,6 +13,7 @@ brackets = [
     { start = "`", end = "`", close = true, newline = false, not_in = ["string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
+word_characters = ["-", ":", "."]
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "svelte"
 prettier_plugins = ["prettier-plugin-svelte"]


### PR DESCRIPTION
Fixed linked edit for Svelte HTML tags

Before:
[before.webm](https://github.com/user-attachments/assets/55f7d105-9b6d-46ed-99ae-a5d5953cb2fd)

After:
[after.webm](https://github.com/user-attachments/assets/5181940e-6398-4156-8055-7f69250344e6)

Release Notes:

- N/A
