### PR TITLE
Update install CLI message for linux

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -293,8 +293,8 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
                     if cfg!(target_os = "linux") {
                         let prompt = cx.prompt(
                             PromptLevel::Warning,
-                            "Could not install the CLI",
-                            Some("If you installed Zed from our official release add ~/.local/bin to your PATH.\n\nIf you installed Zed from a different source you may need to create an alias/symlink manually."),
+                            "CLI should already be installed",
+                            Some("If you installed Zed from our official release add ~/.local/bin to your PATH.\n\nIf you installed Zed from a different source like your package manager, then you may need to create an alias/symlink manually.\n\nDepending on your package manager, the CLI might be named zeditor, zedit, zed-editor or something else."),
                             &["Ok"],
                         );
                         cx.background_executor().spawn(prompt).detach();


### PR DESCRIPTION
This PR updates the `cli: install` message for Linux. It initially threw me off thinking that because `path_for_auxiliary_executable` is not implemented for Linux it's failing and I thought it's a bug. Turns out the CLI gets installed by the package manager and it's just named something else.

I ended up only updating the message so it's more clear. If you don't like the message, let me know :)

The old message:
![image](https://github.com/zed-industries/zed/assets/829535/1a02d08d-2c7a-452a-bfee-dc55d29c0c10)

The new message:
![image](https://github.com/user-attachments/assets/82052a43-1cf5-4b86-88e8-1c1f01a0ae3c)

@ConradIrwin thank you for taking the time and explaining it to me.

closes: #14118

Release Notes:

- N/A
