### PR TITLE
vim: Fix ctrl-d/u going to top bottom

### DIFF
--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -476,7 +476,10 @@ impl Editor {
         }
 
         let cur_position = self.scroll_position(cx);
-        let new_pos = cur_position + point(0., amount.lines(self));
+        let Some(visible_line_count) = self.visible_line_count() else {
+            return;
+        };
+        let new_pos = cur_position + point(0., amount.lines(visible_line_count));
         self.set_scroll_position(new_pos, cx);
     }
 

--- a/crates/editor/src/scroll/scroll_amount.rs
+++ b/crates/editor/src/scroll/scroll_amount.rs
@@ -1,4 +1,3 @@
-use crate::Editor;
 use serde::Deserialize;
 use ui::{px, Pixels};
 
@@ -11,19 +10,16 @@ pub enum ScrollAmount {
 }
 
 impl ScrollAmount {
-    pub fn lines(&self, editor: &mut Editor) -> f32 {
+    pub fn lines(&self, mut visible_line_count: f32) -> f32 {
         match self {
             Self::Line(count) => *count,
-            Self::Page(count) => editor
-                .visible_line_count()
-                .map(|mut l| {
-                    // for full pages subtract one to leave an anchor line
-                    if count.abs() == 1.0 {
-                        l -= 1.0
-                    }
-                    (l * count).trunc()
-                })
-                .unwrap_or(0.),
+            Self::Page(count) => {
+                // for full pages subtract one to leave an anchor line
+                if count.abs() == 1.0 {
+                    visible_line_count -= 1.0
+                }
+                (visible_line_count * count).trunc()
+            }
         }
     }
 

--- a/crates/vim/test_data/test_ctrl_d_u.json
+++ b/crates/vim/test_data/test_ctrl_d_u.json
@@ -20,3 +20,9 @@
 {"Key":"ctrl-u"}
 {"Key":"ctrl-u"}
 {"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nˇhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"g"}
+{"Key":"g"}
+{"Key":"ctrl-d"}
+{"Key":"ctrl-u"}
+{"Key":"ctrl-u"}
+{"Get":{"state":"ˇaa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}


### PR DESCRIPTION

Release Notes:

- vim: Fixed ctrl-d/ctrl-u getting to top/bottom of buffer (#13250)
