### PR TITLE
docs: Fix typo in Svelte docs

### DIFF
--- a/docs/src/languages/svelte.md
+++ b/docs/src/languages/svelte.md
@@ -22,7 +22,7 @@ Zed sets the following initialization options for inlay Hints:
   "propertyDeclarationTypes": {
     "enabled": true
   },
-  "functionLikeReturnType": {
+  "functionLikeReturnTypes": {
     "enabled": true
   },
   "enumMemberValues": {


### PR DESCRIPTION
This PR fixes a typo in the Svelte docs to reflect the fixes from #14614.

Release Notes:

- N/A
