### PR TITLE
svelte: Bump to v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13906,7 +13906,7 @@ dependencies = [
 
 [[package]]
 name = "zed_svelte"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/svelte/Cargo.toml
+++ b/extensions/svelte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_svelte"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/svelte/extension.toml
+++ b/extensions/svelte/extension.toml
@@ -1,7 +1,7 @@
 id = "svelte"
 name = "Svelte"
 description = "Svelte support"
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = []
 repository = "https://github.com/zed-extensions/svelte"


### PR DESCRIPTION
This PR bumps the Svelte extension to v0.0.3.

Changes:

- #14614

Release Notes:

- N/A
