### PR TITLE
zig: Revert changes dependent on new `zed_extension_api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13950,7 +13950,7 @@ dependencies = [
 name = "zed_zig"
 version = "0.1.3"
 dependencies = [
- "zed_extension_api 0.0.7",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/zig.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = { path = "../../crates/extension_api" }
+zed_extension_api = "0.0.6"

--- a/extensions/zig/src/zig.rs
+++ b/extensions/zig/src/zig.rs
@@ -56,11 +56,21 @@ impl ZigExtension {
             &language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
+        // TODO: Once we're ready to release v0.0.7 of the Zed extension API we want to pin
+        // ZLS to a specific version with `zed::github_release_by_tag_name`.
         // We're pinning ZLS to a release that has `.tar.gz` assets, since the latest release does not have
         // them, at time of writing.
         //
         // ZLS tracking issue: https://github.com/zigtools/zls/issues/1879
-        let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
+        // let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
+
+        let release = zed::latest_github_release(
+            "zigtools/zls",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(


### PR DESCRIPTION
This PR reverts the changes to the Zig extension dependent on the new `zed_extension_api` version so that we can publish the Zig extension.

Release Notes:

- N/A
