### PR TITLE
windows: Remove unnecessary `Send` and `Sync` implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -447,7 +447,6 @@ features = [
     "Win32_Security",
     "Win32_Security_Credentials",
     "Win32_Storage_FileSystem",
-    "Win32_System_LibraryLoader",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_DataExchange",

--- a/crates/gpui/src/platform/windows/dispatcher.rs
+++ b/crates/gpui/src/platform/windows/dispatcher.rs
@@ -31,9 +31,6 @@ pub(crate) struct WindowsDispatcher {
     main_thread_id: ThreadId,
 }
 
-unsafe impl Send for WindowsDispatcher {}
-unsafe impl Sync for WindowsDispatcher {}
-
 impl WindowsDispatcher {
     pub(crate) fn new() -> Self {
         let controller = unsafe {


### PR DESCRIPTION
After a update to `windows-rs 0.57`, these two implementations are no longer needed.

Release Notes:

- N/A
