### PR TITLE
ruby: Add support for "rubocop" language server

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -798,7 +798,7 @@
       }
     },
     "Ruby": {
-      "language_servers": ["solargraph", "!ruby-lsp", "..."]
+      "language_servers": ["solargraph", "!ruby-lsp", "!rubocop", "..."]
     },
     "SCSS": {
       "prettier": {

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -1,8 +1,7 @@
 # Ruby
 
-Ruby support is available through the [Ruby extension](https://github.com/zed-industries/zed/tree/main/extensions/ruby).
-
-The Ruby extension also provides support for ERB files.
+- Tree Sitter: [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby)
+- Language Servers: [solargraph](https://github.com/castwide/solargraph), [ruby-lsp](https://github.com/Shopify/ruby-lsp)
 
 ## Choosing a language server
 
@@ -16,7 +15,20 @@ To switch to `ruby-lsp`, add the following to your `settings.json`:
 {
   "languages": {
     "Ruby": {
-      "language_servers": ["ruby-lsp", "!solargraph", "..."]
+      "language_servers": ["ruby-lsp", "!solargraph", "!rubocop", "..."]
+    }
+  }
+}
+```
+
+The Ruby extension also provides support for `rubocop` language server for offense detection and autocorrection. To enable it, add the following to your
+`settings.json`:
+
+```json
+{
+  "languages": {
+    "Ruby": {
+      "language_servers": ["rubocop", "ruby-lsp", "!solargraph", "..."]
     }
   }
 }
@@ -77,6 +89,30 @@ Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell 
         "enabledFeatures": {
           "diagnostics": false
         }
+      }
+    }
+  }
+}
+```
+
+## Setting up `rubocop` LSP
+
+Zed currently doesn't install `rubocop` automatically. To use `rubocop`, you need to install the gem. Zed just looks for an executable called `rubocop` on your `PATH`.
+
+You can install the gem manually with the following command:
+
+```shell
+gem install rubocop
+```
+
+Rubocop has unsafe autocorrection disabled by default. We can tell Zed to enable it by adding the following to your `settings.json`:
+
+```json
+{
+  "lsp": {
+    "rubocop": {
+      "initialization_options": {
+        "safeAutocorrect": false
       }
     }
   }

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -1,7 +1,8 @@
 # Ruby
 
-- Tree Sitter: [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby)
-- Language Servers: [solargraph](https://github.com/castwide/solargraph), [ruby-lsp](https://github.com/Shopify/ruby-lsp)
+Ruby support is available through the [Ruby extension](https://github.com/zed-industries/zed/tree/main/extensions/ruby).
+
+The Ruby extension also provides support for ERB files.
 
 ## Choosing a language server
 

--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -14,6 +14,10 @@ language = "Ruby"
 name = "Ruby LSP"
 language = "Ruby"
 
+[language_servers.rubocop]
+name = "Rubocop"
+language = "Ruby"
+
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
 commit = "dc2d7d6b50f9975bc3c35bbec0ba11b2617b736b"

--- a/extensions/ruby/src/language_servers.rs
+++ b/extensions/ruby/src/language_servers.rs
@@ -1,5 +1,7 @@
+mod rubocop;
 mod ruby_lsp;
 mod solargraph;
 
+pub use rubocop::*;
 pub use ruby_lsp::*;
 pub use solargraph::*;

--- a/extensions/ruby/src/language_servers/rubocop.rs
+++ b/extensions/ruby/src/language_servers/rubocop.rs
@@ -1,0 +1,19 @@
+use zed_extension_api::{self as zed, Result};
+
+pub struct Rubocop {}
+
+impl Rubocop {
+    pub const LANGUAGE_SERVER_ID: &'static str = "rubocop";
+
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn server_script_path(&mut self, worktree: &zed::Worktree) -> Result<String> {
+        let path = worktree.which("rubocop").ok_or_else(|| {
+            "rubocop must be installed manually. Install it with `gem install rubocop` or specify the 'binary' path to it via local settings.".to_string()
+        })?;
+
+        Ok(path)
+    }
+}

--- a/extensions/ruby/src/ruby.rs
+++ b/extensions/ruby/src/ruby.rs
@@ -5,11 +5,12 @@ use zed::settings::LspSettings;
 use zed::{serde_json, CodeLabel, LanguageServerId};
 use zed_extension_api::{self as zed, Result};
 
-use crate::language_servers::{RubyLsp, Solargraph};
+use crate::language_servers::{Rubocop, RubyLsp, Solargraph};
 
 struct RubyExtension {
     solargraph: Option<Solargraph>,
     ruby_lsp: Option<RubyLsp>,
+    rubocop: Option<Rubocop>,
 }
 
 impl zed::Extension for RubyExtension {
@@ -17,6 +18,7 @@ impl zed::Extension for RubyExtension {
         Self {
             solargraph: None,
             ruby_lsp: None,
+            rubocop: None,
         }
     }
 
@@ -41,6 +43,15 @@ impl zed::Extension for RubyExtension {
                 Ok(zed::Command {
                     command: ruby_lsp.server_script_path(worktree)?,
                     args: vec![],
+                    env: worktree.shell_env(),
+                })
+            }
+            Rubocop::LANGUAGE_SERVER_ID => {
+                let rubocop = self.rubocop.get_or_insert_with(|| Rubocop::new());
+
+                Ok(zed::Command {
+                    command: rubocop.server_script_path(worktree)?,
+                    args: vec!["--lsp".into()],
                     env: worktree.shell_env(),
                 })
             }


### PR DESCRIPTION
Hi, this pull request adds support for `rubocop` language server. I noticed that `ruby-lsp` LS is becoming more popular but it still lacks diagnostics support in Zed. To cover that missing feature, it could be good to use `rubocop` LS to show diagnostics alongside with the running Ruby LSP.

Release Notes:

- N/A

