### PR TITLE
Dim the shared screen tab's icon when it is inactive

### DIFF
--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -96,7 +96,11 @@ impl Item for SharedScreen {
     fn tab_content(&self, params: TabContentParams, _: &WindowContext<'_>) -> gpui::AnyElement {
         h_flex()
             .gap_1()
-            .child(Icon::new(IconName::Screen))
+            .child(Icon::new(IconName::Screen).color(if params.selected {
+                Color::Default
+            } else {
+                Color::Muted
+            }))
             .child(
                 Label::new(format!("{}'s screen", self.user.github_login)).color(
                     if params.selected {


### PR DESCRIPTION
This PR makes it so the icon of the shared screen tab is properly dimmed when the tab is inactive.

Release Notes:

- Fixed an issue where the shared screen tab's icon would not render as dimmed when the tab was inactive.
