### PR TITLE
Exclude dev extensions from auto-updates

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -456,9 +456,9 @@ impl ExtensionStore {
         let extension_ids = self
             .extension_index
             .extensions
-            .keys()
-            .map(|id| id.as_ref())
-            .filter(|id| extension_settings.should_auto_update(id))
+            .iter()
+            .filter(|(id, entry)| !entry.dev && extension_settings.should_auto_update(id))
+            .map(|(id, _)| id.as_ref())
             .collect::<Vec<_>>()
             .join(",");
         let task = self.fetch_extensions_from_api(


### PR DESCRIPTION
This PR makes it so dev extensions that are installed are excluded when checking for extension updates.

We don't want to accidentally clobber dev extensions if the upstream extension is deemed more "up-to-date".

Release Notes:

- Changed dev extensions to be excluded from extension auto-updates.
