### PR TITLE
WIP: Switch to entry IDs instead of entity IDs

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -112,7 +112,7 @@ use ordered_float::OrderedFloat;
 use parking_lot::{Mutex, RwLock};
 use project::project_settings::{GitGutterSetting, ProjectSettings};
 use project::{
-    CodeAction, Completion, FormatTrigger, Item, Location, Project, ProjectPath,
+    CodeAction, Completion, FormatTrigger, Item, Location, Project, ProjectEntryId, ProjectPath,
     ProjectTransaction, TaskSourceKind, WorktreeId,
 };
 use rand::prelude::*;
@@ -10221,6 +10221,10 @@ impl Editor {
                 .expect("you can only call set_text on editors for singleton buffers")
                 .update(cx, |buffer, cx| buffer.set_text(text, cx));
         });
+    }
+
+    pub fn entry_id(&self, cx: &mut ViewContext<Self>) -> Option<ProjectEntryId> {
+        self.buffer.read(cx).as_singleton()?.read(cx).entry_id(cx)
     }
 
     pub fn display_text(&self, cx: &mut AppContext) -> String {

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -14,7 +14,7 @@ use gpui::{
     div, prelude::*, EventEmitter, Model, Render, Subscription, Task, View, ViewContext, WeakView,
 };
 use language::Point;
-use project::Fs;
+use project::{Fs, ProjectEntryId};
 use runtimelib::{
     ExecuteRequest, InterruptRequest, JupyterMessage, JupyterMessageContent, ShutdownRequest,
 };


### PR DESCRIPTION
Opening this as a draft to chat about. I've swapped out the repl kernel to use the `entry_id` rather than the `entity_id`. This has an interesting side effect where only one editor will show the output, no matter which side the code was run on:

![image](https://github.com/user-attachments/assets/73934566-efde-4d1a-b10b-b5581ce461f1)


Release Notes:

- N/A
