### PR TITLE
Have Danger check the format of GitHub issue links

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -34,12 +34,21 @@ if (!hasReleaseNotes) {
   );
 }
 
-const ISSUE_LINK_PATTERN = /\(#(\d+)\)/g;
-const releaseNotesSection = danger.github.pr.body.match(
-  /Release Notes:\r?\n([\s\S]*?)(?:\r?\n){2}/,
+const INCORRECT_ISSUE_LINK_PATTERN = new RegExp("-.*(#d+)", "g");
+
+const hasIncorrectIssueLinks = INCORRECT_ISSUE_LINK_PATTERN.test(
+  danger.github.pr.body,
 );
-if (releaseNotesSection && ISSUE_LINK_PATTERN.test(releaseNotesSection[0])) {
+if (hasIncorrectIssueLinks) {
   warn(
-    "Please format links to GitHub issues as plain Markdown links: `([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>))`",
+    [
+      "This PR has incorrectly formatted GitHub issue links in the release notes.",
+      "",
+      "GitHub issue links must be formatted as plain Markdown links:",
+      "",
+      "```",
+      "- Improved something ([#ISSUE](https://github.com/zed-industries/zed/issues/ISSUE))",
+      "```",
+    ].join("\n"),
   );
 }

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -33,3 +33,13 @@ if (!hasReleaseNotes) {
     ].join("\n"),
   );
 }
+
+const ISSUE_LINK_PATTERN = /\(#(\d+)\)/g;
+const releaseNotesSection = danger.github.pr.body.match(
+  /Release Notes:\r?\n([\s\S]*?)(?:\r?\n){2}/,
+);
+if (releaseNotesSection && ISSUE_LINK_PATTERN.test(releaseNotesSection[0])) {
+  warn(
+    "Please format links to GitHub issues as plain Markdown links: `([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>))`",
+  );
+}

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -34,7 +34,7 @@ if (!hasReleaseNotes) {
   );
 }
 
-const INCORRECT_ISSUE_LINK_PATTERN = new RegExp("-.*(#d+)", "g");
+const INCORRECT_ISSUE_LINK_PATTERN = new RegExp("-.*\\(#\\d+\\)", "g");
 
 const hasIncorrectIssueLinks = INCORRECT_ISSUE_LINK_PATTERN.test(
   danger.github.pr.body,

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -47,7 +47,7 @@ if (hasIncorrectIssueLinks) {
       "GitHub issue links must be formatted as plain Markdown links:",
       "",
       "```",
-      "- Improved something ([#ISSUE](https://github.com/zed-industries/zed/issues/ISSUE))",
+      "- Improved something ([#ISSUE](https://github.com/zed-industries/zed/issues/ISSUE)).",
       "```",
     ].join("\n"),
   );


### PR DESCRIPTION
This PR updates the Danger rules to check for GitHub issue links that aren't in the desired format:

<img width="916" alt="Screenshot 2024-07-17 at 5 11 48 PM" src="https://github.com/user-attachments/assets/c77d3c28-3b09-44aa-a97f-03c2400df2e6">

We don't yet check that the links are exactly formatted as expected, just that they aren't incorrectly formatted in the way that people typically get it wrong.

Release Notes:

- N/A
