### PR TITLE
node_runtime: Bump downloaded Node.js version to Current (Jod)

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -22,7 +22,7 @@ use util::ResultExt;
 #[cfg(windows)]
 use smol::process::windows::CommandExt;
 
-const VERSION: &str = "v18.15.0";
+const VERSION: &str = "v22.5.1";
 
 #[cfg(not(windows))]
 const NODE_PATH: &str = "bin/node";


### PR DESCRIPTION
This PR bumps the hard-coded Node.js version from v18.x (Hydrogen), which was LTS until October 2023, to v20.x (Iron), which is the current LTS release.

Release Notes:

- N/A
