### PR TITLE
Set the working directory according to the editor file path

### DIFF
--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -13,6 +13,7 @@ use runtimelib::{
 };
 use smol::{net::TcpListener, process::Command};
 use std::{
+    env::temp_dir,
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
@@ -171,6 +172,7 @@ pub struct RunningKernel {
     _control_task: Task<anyhow::Result<()>>,
     _routing_task: Task<anyhow::Result<()>>,
     connection_path: PathBuf,
+    pub working_directory: PathBuf,
     pub request_tx: mpsc::Sender<JupyterMessage>,
     pub execution_state: ExecutionState,
     pub kernel_info: Option<KernelInfoReply>,
@@ -190,6 +192,7 @@ impl RunningKernel {
     pub fn new(
         kernel_specification: KernelSpecification,
         entity_id: EntityId,
+        working_directory: PathBuf,
         fs: Arc<dyn Fs>,
         cx: &mut AppContext,
     ) -> Task<anyhow::Result<(Self, JupyterMessageChannel)>> {
@@ -220,7 +223,9 @@ impl RunningKernel {
             fs.atomic_write(connection_path.clone(), content).await?;
 
             let mut cmd = kernel_specification.command(&connection_path)?;
+
             let process = cmd
+                .current_dir(&working_directory)
                 // .stdout(Stdio::null())
                 // .stderr(Stdio::null())
                 .kill_on_drop(true)
@@ -301,6 +306,7 @@ impl RunningKernel {
                 Self {
                     process,
                     request_tx,
+                    working_directory,
                     _shell_task,
                     _iopub_task,
                     _control_task,

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -13,7 +13,6 @@ use runtimelib::{
 };
 use smol::{net::TcpListener, process::Command};
 use std::{
-    env::temp_dir,
     fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,

--- a/crates/repl/src/runtime_panel.rs
+++ b/crates/repl/src/runtime_panel.rs
@@ -208,9 +208,16 @@ impl RuntimePanel {
         cx.notify();
     }
 
-    // Gets the active selection in the editor or the current line
-    fn selection(&self, editor: View<Editor>, cx: &mut ViewContext<Self>) -> Range<Anchor> {
+    pub fn snippet(
+        &self,
+        editor: WeakView<Editor>,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<(String, Arc<Language>, Range<Anchor>)> {
+        let editor = editor.upgrade()?;
         let editor = editor.read(cx);
+
+        let buffer = editor.buffer().read(cx).snapshot(cx);
+
         let selection = editor.selections.newest::<usize>(cx);
         let multi_buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
 
@@ -232,18 +239,7 @@ impl RuntimePanel {
             selection.range()
         };
 
-        range.to_anchors(&multi_buffer_snapshot)
-    }
-
-    pub fn snippet(
-        &self,
-        editor: WeakView<Editor>,
-        cx: &mut ViewContext<Self>,
-    ) -> Option<(String, Arc<Language>, Range<Anchor>)> {
-        let editor = editor.upgrade()?;
-
-        let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
-        let anchor_range = self.selection(editor, cx);
+        let anchor_range = range.to_anchors(&multi_buffer_snapshot);
 
         let selected_text = buffer
             .text_for_range(anchor_range.clone())


### PR DESCRIPTION
Kernels now launch in the same directory as the script invoking them, similar to notebook behavior.

![image](https://github.com/user-attachments/assets/def86308-bea4-4fa3-8211-132a282a5ecc)


Release Notes:

- N/A
