### PR TITLE
typescript: Highlight `infer` keyword

### DIFF
--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -219,6 +219,7 @@
   "enum"
   "export"
   "implements"
+  "infer"
   "interface"
   "keyof"
   "namespace"


### PR DESCRIPTION
This PR adds syntax highlighting to TypeScript's [`infer`](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#inferring-within-conditional-types) keyword.

Theme used: Sandcastle

**Before:**
![image](https://github.com/user-attachments/assets/e082cc8c-2e12-4cfa-a641-40324dd93f31)

**After:**
![image](https://github.com/user-attachments/assets/6263b5b2-19c8-4b64-87b6-ceead947bc03)



Release Notes:

- Added syntax highlighting to TypeScript's infer keyword (https://github.com/zed-industries/zed/pull/14696).
