### PR TITLE
ruby: Bump to v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13891,7 +13891,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruby"
-version = "0.0.6"
+version = "0.0.8"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/ruby/Cargo.toml
+++ b/extensions/ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.0.6"
+version = "0.0.8"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.0.7"
+version = "0.0.8"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Bump version of the Ruby extension to 0.0.8.

Changes:

- https://github.com/zed-industries/zed/pull/12642
- https://github.com/zed-industries/zed/pull/13216
- https://github.com/zed-industries/zed/pull/14661
- https://github.com/zed-industries/zed/pull/14693

Release Notes:

- N/A
