### PR TITLE
assistant: Fixed "quote selection" with Vim visual line mode

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1685,9 +1685,11 @@ impl ContextEditor {
             return;
         };
 
+        let selection = editor.update(cx, |editor, cx| editor.selections.newest_adjusted(cx));
         let editor = editor.read(cx);
-        let range = editor.selections.newest::<usize>(cx).range();
         let buffer = editor.buffer().read(cx).snapshot(cx);
+        let range = editor::ToOffset::to_offset(&selection.start, &buffer)
+            ..editor::ToOffset::to_offset(&selection.end, &buffer);
         let start_language = buffer.language_at(range.start);
         let end_language = buffer.language_at(range.end);
         let language_name = if start_language == end_language {

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -157,6 +157,18 @@ impl SelectionsCollection {
         selections
     }
 
+    /// Returns the newest selection, adjusted to take into account the selection line_mode
+    pub fn newest_adjusted(&self, cx: &mut AppContext) -> Selection<Point> {
+        let mut selection = self.newest::<Point>(cx);
+        if self.line_mode {
+            let map = self.display_map(cx);
+            let new_range = map.expand_to_line(selection.range());
+            selection.start = new_range.start;
+            selection.end = new_range.end;
+        }
+        selection
+    }
+
     pub fn all_adjusted_display(
         &self,
         cx: &mut AppContext,


### PR DESCRIPTION
Previously, when using Vim mode and doing a line-wise visual selection, the `assistant: quote selection` action would not work correctly, since it would ignore that these were line-wise selections.

With this change, one can now select lines using visual line mode and "quote selection works"

Release Notes:

- Fixes `assistant: quote selection` not working correctly when making visual-line-mode selections in Vim mode.