### PR TITLE
Rework mouse handling of git hunks diff

### DIFF
--- a/crates/diagnostics/src/grouped_diagnostics.rs
+++ b/crates/diagnostics/src/grouped_diagnostics.rs
@@ -319,7 +319,7 @@ impl GroupedDiagnosticsEditor {
                 || server_to_update.map_or(false, |to_update| *server_id != to_update)
         });
 
-        // TODO kb change selections as in the old panel, to the next primary diagnostics
+        // TODO change selections as in the old panel, to the next primary diagnostics
         // TODO make [shift-]f8 to work, jump to the next block group
         let _was_empty = self.path_states.is_empty();
         let path_ix = match self.path_states.binary_search_by(|probe| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11760,8 +11760,11 @@ impl Editor {
         editor_snapshot: &EditorSnapshot,
         cx: &mut ViewContext<Self>,
     ) -> Option<gpui::Point<Pixels>> {
-        let line_height = self.style()?.text.line_height_in_pixels(cx.rem_size());
         let text_layout_details = self.text_layout_details(cx);
+        let line_height = text_layout_details
+            .editor_style
+            .text
+            .line_height_in_pixels(cx.rem_size());
         let source_point = source.to_display_point(editor_snapshot);
         let first_visible_line = text_layout_details
             .scroll_anchor
@@ -11771,7 +11774,9 @@ impl Editor {
             return None;
         }
         let source_x = editor_snapshot.x_for_display_point(source_point, &text_layout_details);
-        let source_y = line_height * (source_point.row() - first_visible_line.row()).0 as f32;
+        let source_y = line_height
+            * ((source_point.row() - first_visible_line.row()).0 as f32
+                - text_layout_details.scroll_anchor.offset.y);
         Some(gpui::Point::new(source_x, source_y))
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -536,7 +536,7 @@ pub struct Editor {
     show_inline_completions: bool,
     inlay_hint_cache: InlayHintCache,
     expanded_hunks: ExpandedHunks,
-    clicked_hunk: Option<HoveredHunk>,
+    clicked_hunk: Option<(gpui::Point<Pixels>, HoveredHunk)>,
     next_inlay_id: usize,
     _subscriptions: Vec<Subscription>,
     pixel_position_of_newest_cursor: Option<gpui::Point<Pixels>>,
@@ -2427,6 +2427,7 @@ impl Editor {
         let (changed, result) = self.selections.change_with(cx, change);
 
         if changed {
+            self.clicked_hunk = None;
             if let Some(autoscroll) = autoscroll {
                 self.request_autoscroll(autoscroll, cx);
             }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -77,8 +77,8 @@ use gpui::{
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HoverState};
-use hunk_diff::ExpandedHunks;
 pub(crate) use hunk_diff::HoveredHunk;
+use hunk_diff::{ExpandedHunk, ExpandedHunks};
 use indent_guides::ActiveIndentGuidesState;
 use inlay_hint_cache::{InlayHintCache, InlaySplice, InvalidationStrategy};
 pub use inline_completion_provider::*;
@@ -5119,6 +5119,30 @@ impl Editor {
                     cx,
                 );
             }))
+    }
+
+    fn render_close_hunk_diff_button(
+        &self,
+        hunk: ExpandedHunk,
+        _style: &EditorStyle,
+        is_active: bool,
+        row: DisplayRow,
+        cx: &mut ViewContext<Self>,
+    ) -> IconButton {
+        let hovered_hunk = HoveredHunk {
+            multi_buffer_range: hunk.hunk_range,
+            status: hunk.status,
+            diff_base_byte_range: hunk.diff_base_byte_range,
+        };
+        IconButton::new(
+            ("close_hunk_diff_indicator", row.0 as usize),
+            ui::IconName::Close,
+        )
+        .shape(ui::IconButtonShape::Square)
+        .icon_size(IconSize::XSmall)
+        .icon_color(Color::Muted)
+        .selected(is_active)
+        .on_click(cx.listener(move |editor, _e, cx| editor.toggle_hovered_hunk(&hovered_hunk, cx)))
     }
 
     pub fn context_menu_visible(&self) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -536,7 +536,7 @@ pub struct Editor {
     show_inline_completions: bool,
     inlay_hint_cache: InlayHintCache,
     expanded_hunks: ExpandedHunks,
-    clicked_hunk: Option<(gpui::Point<Pixels>, HoveredHunk)>,
+    clicked_hunk: Option<((Pixels, Pixels), HoveredHunk)>,
     next_inlay_id: usize,
     _subscriptions: Vec<Subscription>,
     pixel_position_of_newest_cursor: Option<gpui::Point<Pixels>>,
@@ -2380,6 +2380,7 @@ impl Editor {
             }
 
             hide_hover(self, cx);
+            self.clicked_hunk = None;
 
             if old_cursor_position.to_display_point(&display_map).row()
                 != new_cursor_position.to_display_point(&display_map).row()
@@ -2427,7 +2428,6 @@ impl Editor {
         let (changed, result) = self.selections.change_with(cx, change);
 
         if changed {
-            self.clicked_hunk = None;
             if let Some(autoscroll) = autoscroll {
                 self.request_autoscroll(autoscroll, cx);
             }
@@ -11677,6 +11677,7 @@ impl Editor {
             hide_hover(self, cx);
         }
 
+        self.clicked_hunk = None;
         self.hide_context_menu(cx);
         cx.emit(EditorEvent::Blurred);
         cx.notify();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11732,6 +11732,27 @@ impl Editor {
         });
         self.change_selections(None, cx, |selections| selections.refresh());
     }
+
+    pub fn to_pixel_point(
+        &mut self,
+        source: multi_buffer::Anchor,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<gpui::Point<Pixels>> {
+        let line_height = self.style()?.text.line_height_in_pixels(cx.rem_size());
+        let text_layout_details = self.text_layout_details(cx);
+        let editor_snapshot = self.snapshot(cx);
+        let source_point = source.to_display_point(&editor_snapshot);
+        let first_visible_line = text_layout_details
+            .scroll_anchor
+            .anchor
+            .to_display_point(&editor_snapshot);
+        if first_visible_line > source_point {
+            return None;
+        }
+        let source_x = editor_snapshot.x_for_display_point(source_point, &text_layout_details);
+        let source_y = line_height * (source_point.row() - first_visible_line.row()).0 as f32;
+        Some(gpui::Point::new(source_x, source_y))
+    }
 }
 
 fn hunks_for_selections(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -77,8 +77,8 @@ use gpui::{
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HoverState};
+use hunk_diff::ExpandedHunks;
 pub(crate) use hunk_diff::HoveredHunk;
-use hunk_diff::{ExpandedHunk, ExpandedHunks};
 use indent_guides::ActiveIndentGuidesState;
 use inlay_hint_cache::{InlayHintCache, InlaySplice, InvalidationStrategy};
 pub use inline_completion_provider::*;
@@ -5123,17 +5123,11 @@ impl Editor {
 
     fn render_close_hunk_diff_button(
         &self,
-        hunk: ExpandedHunk,
-        _style: &EditorStyle,
+        hunk: HoveredHunk,
         is_active: bool,
         row: DisplayRow,
         cx: &mut ViewContext<Self>,
     ) -> IconButton {
-        let hovered_hunk = HoveredHunk {
-            multi_buffer_range: hunk.hunk_range,
-            status: hunk.status,
-            diff_base_byte_range: hunk.diff_base_byte_range,
-        };
         IconButton::new(
             ("close_hunk_diff_indicator", row.0 as usize),
             ui::IconName::Close,
@@ -5142,7 +5136,7 @@ impl Editor {
         .icon_size(IconSize::XSmall)
         .icon_color(Color::Muted)
         .selected(is_active)
-        .on_click(cx.listener(move |editor, _e, cx| editor.toggle_hovered_hunk(&hovered_hunk, cx)))
+        .on_click(cx.listener(move |editor, _e, cx| editor.toggle_hovered_hunk(&hunk, cx)))
     }
 
     pub fn context_menu_visible(&self) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -536,7 +536,6 @@ pub struct Editor {
     show_inline_completions: bool,
     inlay_hint_cache: InlayHintCache,
     expanded_hunks: ExpandedHunks,
-    clicked_hunk: Option<((Pixels, Pixels), HoveredHunk)>,
     next_inlay_id: usize,
     _subscriptions: Vec<Subscription>,
     pixel_position_of_newest_cursor: Option<gpui::Point<Pixels>>,
@@ -1861,7 +1860,6 @@ impl Editor {
             active_inline_completion: None,
             inlay_hint_cache: InlayHintCache::new(inlay_hint_settings),
             expanded_hunks: ExpandedHunks::default(),
-            clicked_hunk: None,
             gutter_hovered: false,
             pixel_position_of_newest_cursor: None,
             last_bounds: None,
@@ -2380,7 +2378,6 @@ impl Editor {
             }
 
             hide_hover(self, cx);
-            self.clicked_hunk = None;
 
             if old_cursor_position.to_display_point(&display_map).row()
                 != new_cursor_position.to_display_point(&display_map).row()
@@ -11677,7 +11674,6 @@ impl Editor {
             hide_hover(self, cx);
         }
 
-        self.clicked_hunk = None;
         self.hide_context_menu(cx);
         cx.emit(EditorEvent::Blurred);
         cx.notify();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5124,7 +5124,6 @@ impl Editor {
     fn render_close_hunk_diff_button(
         &self,
         hunk: HoveredHunk,
-        is_active: bool,
         row: DisplayRow,
         cx: &mut ViewContext<Self>,
     ) -> IconButton {
@@ -5135,7 +5134,7 @@ impl Editor {
         .shape(ui::IconButtonShape::Square)
         .icon_size(IconSize::XSmall)
         .icon_color(Color::Muted)
-        .selected(is_active)
+        .tooltip(|cx| Tooltip::for_action("Close hunk diff", &ToggleHunkDiff, cx))
         .on_click(cx.listener(move |editor, _e, cx| editor.toggle_hovered_hunk(&hunk, cx)))
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -461,7 +461,7 @@ impl EditorElement {
             if modifiers.control || modifiers.platform {
                 editor.toggle_hovered_hunk(&hovered_hunk, cx);
             } else {
-                editor.clicked_hunk = Some(hovered_hunk);
+                editor.clicked_hunk = Some((event.position, hovered_hunk));
             }
             cx.notify();
             return;
@@ -1293,7 +1293,7 @@ impl EditorElement {
                                 gutter_hitbox.bounds,
                                 &hunk,
                             );
-                            if let Some(editor_clicked_hunk) =
+                            if let Some((clicked_point, editor_clicked_hunk)) =
                                 self.editor.read(cx).clicked_hunk.clone()
                             {
                                 let clicked_display_range = editor_clicked_hunk
@@ -1322,7 +1322,7 @@ impl EditorElement {
                                         AvailableSpace::MinContent,
                                     );
                                     rendered_popover.prepaint_as_root(
-                                        hunk_bounds.origin,
+                                        clicked_point,
                                         available_space,
                                         cx,
                                     );

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1310,10 +1310,13 @@ impl EditorElement {
                                             expanded_end_row == &display_row_range.end
                                         })
                                         .unwrap_or(false);
-                                    let mut rendered_popover =
-                                        HunkPopover::new(editor_clicked_hunk, expanded)
-                                            .render(cx)
-                                            .into_any_element();
+                                    let mut rendered_popover = HunkPopover::new(
+                                        self.editor.clone(),
+                                        editor_clicked_hunk,
+                                        expanded,
+                                    )
+                                    .render(cx)
+                                    .into_any_element();
                                     let available_space = size(
                                         AvailableSpace::MinContent,
                                         AvailableSpace::MinContent,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -458,7 +458,11 @@ impl EditorElement {
         let mut modifiers = event.modifiers;
 
         if let Some(hovered_hunk) = hovered_hunk {
-            editor.clicked_hunk = Some(hovered_hunk);
+            if modifiers.control || modifiers.platform {
+                editor.toggle_hovered_hunk(&hovered_hunk, cx);
+            } else {
+                editor.clicked_hunk = Some(hovered_hunk);
+            }
             cx.notify();
             return;
         } else if gutter_hitbox.is_hovered(cx) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3913,8 +3913,6 @@ impl EditorElement {
                             status: hunk.status,
                             diff_base_byte_range: hunk.diff_base_byte_range,
                         },
-                        // TODO kb
-                        false,
                         display_row,
                         cx,
                     );

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3901,7 +3901,6 @@ impl EditorElement {
         scroll_pixel_position: gpui::Point<Pixels>,
         gutter_dimensions: &GutterDimensions,
         gutter_hitbox: &Hitbox,
-        snapshot: &EditorSnapshot,
         cx: &mut WindowContext,
     ) -> Vec<AnyElement> {
         self.editor.update(cx, |editor, cx| {
@@ -3909,8 +3908,12 @@ impl EditorElement {
                 .into_iter()
                 .map(|(display_row, hunk)| {
                     let button = editor.render_close_hunk_diff_button(
-                        hunk,
-                        &self.style,
+                        HoveredHunk {
+                            multi_buffer_range: hunk.hunk_range,
+                            status: hunk.status,
+                            diff_base_byte_range: hunk.diff_base_byte_range,
+                        },
+                        // TODO kb
                         false,
                         display_row,
                         cx,
@@ -5231,7 +5234,6 @@ impl Element for EditorElement {
                         scroll_pixel_position,
                         &gutter_dimensions,
                         &gutter_hitbox,
-                        &snapshot,
                         cx,
                     );
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2506,19 +2506,19 @@ impl EditorElement {
 
     fn layout_mouse_context_menu(
         &self,
+        editor_snapshot: &EditorSnapshot,
         visible_range: Range<DisplayRow>,
         cx: &mut WindowContext,
     ) -> Option<AnyElement> {
         let position = self.editor.update(cx, |editor, cx| {
-            let editor_snapshot = editor.snapshot(cx);
             let visible_start_point = editor.display_to_pixel_point(
                 DisplayPoint::new(visible_range.start, 0),
-                &editor_snapshot,
+                editor_snapshot,
                 cx,
             )?;
             let visible_end_point = editor.display_to_pixel_point(
                 DisplayPoint::new(visible_range.end, 0),
-                &editor_snapshot,
+                editor_snapshot,
                 cx,
             )?;
 
@@ -2530,8 +2530,8 @@ impl EditorElement {
                     offset_x,
                     offset_y,
                 } => {
-                    let source_display_point = source.to_display_point(&editor_snapshot);
-                    let mut source_point = editor.to_pixel_point(source, &editor_snapshot, cx)?;
+                    let source_display_point = source.to_display_point(editor_snapshot);
+                    let mut source_point = editor.to_pixel_point(source, editor_snapshot, cx)?;
                     source_point.x += offset_x;
                     source_point.y += offset_y;
                     (Some(source_display_point), source_point)
@@ -5299,7 +5299,8 @@ impl Element for EditorElement {
                         );
                     }
 
-                    let mouse_context_menu = self.layout_mouse_context_menu(start_row..end_row, cx);
+                    let mouse_context_menu =
+                        self.layout_mouse_context_menu(&snapshot, start_row..end_row, cx);
 
                     cx.with_element_namespace("gutter_fold_toggles", |cx| {
                         self.prepaint_gutter_fold_toggles(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1337,17 +1337,12 @@ impl EditorElement {
                                     )
                                     .render(cx)
                                     .into_any_element();
-                                    let available_space = size(
-                                        AvailableSpace::MinContent,
-                                        AvailableSpace::MinContent,
-                                    );
-
                                     let mut clicked_point = hunk_bounds.origin;
                                     clicked_point.x += click_bounds_offset.0;
                                     clicked_point.y += click_bounds_offset.1;
                                     rendered_popover.prepaint_as_root(
                                         clicked_point,
-                                        available_space,
+                                        AvailableSpace::min_size(),
                                         cx,
                                     );
                                     clicked_hunk = Some(rendered_popover);
@@ -1430,9 +1425,7 @@ impl EditorElement {
         };
 
         let absolute_offset = point(start_x, start_y);
-        let available_space = size(AvailableSpace::MinContent, AvailableSpace::MinContent);
-
-        element.prepaint_as_root(absolute_offset, available_space, cx);
+        element.prepaint_as_root(absolute_offset, AvailableSpace::min_size(), cx);
 
         Some(element)
     }
@@ -2533,8 +2526,7 @@ impl EditorElement {
             return false;
         };
 
-        let available_space = size(AvailableSpace::MinContent, AvailableSpace::MinContent);
-        let context_menu_size = context_menu.layout_as_root(available_space, cx);
+        let context_menu_size = context_menu.layout_as_root(AvailableSpace::min_size(), cx);
 
         let (x, y) = match position {
             crate::ContextMenuOrigin::EditorPoint(point) => {
@@ -2630,8 +2622,6 @@ impl EditorElement {
             return;
         };
 
-        let available_space = size(AvailableSpace::MinContent, AvailableSpace::MinContent);
-
         // This is safe because we check on layout whether the required row is available
         let hovered_row_layout =
             &line_layouts[position.row().minus(visible_display_row_range.start) as usize];
@@ -2645,7 +2635,7 @@ impl EditorElement {
         let mut overall_height = Pixels::ZERO;
         let mut measured_hover_popovers = Vec::new();
         for mut hover_popover in hover_popovers {
-            let size = hover_popover.layout_as_root(available_space, cx);
+            let size = hover_popover.layout_as_root(AvailableSpace::min_size(), cx);
             let horizontal_offset =
                 (text_hitbox.upper_right().x - (hovered_point.x + size.width)).min(Pixels::ZERO);
 
@@ -5771,11 +5761,7 @@ impl CursorLayout {
                 .child(cursor_name.string.clone())
                 .into_any_element();
 
-            name_element.prepaint_as_root(
-                name_origin,
-                size(AvailableSpace::MinContent, AvailableSpace::MinContent),
-                cx,
-            );
+            name_element.prepaint_as_root(name_origin, AvailableSpace::min_size(), cx);
 
             self.cursor_name = Some(name_element);
         }

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -13,8 +13,8 @@ use multi_buffer::{
 use settings::SettingsStore;
 use text::{BufferId, Point};
 use ui::{
-    div, ActiveTheme, Context as _, IntoElement, Label, ParentElement, Pixels, RenderOnce, Styled,
-    ViewContext, VisualContext, WindowContext,
+    div, h_flex, ActiveTheme, ButtonLike, Context as _, ContextMenu, Icon, IconName, IntoElement,
+    Label, ParentElement, Pixels, RenderOnce, Styled, ViewContext, VisualContext, WindowContext,
 };
 use util::{debug_panic, RangeExt};
 
@@ -713,6 +713,21 @@ impl RenderOnce for HunkPopover {
             .min_h(Pixels(40.0))
             .min_w(Pixels(40.0))
             .bg(gpui::red())
-            .child(Label::new("test"))
+            .child(ContextMenu::build(cx, move |menu, cx| {
+                menu.context(cx.focus_handle())
+                    .custom_row(|_cx| Label::new("Hello World").into_any_element())
+                    .custom_row(|_cx| {
+                        {
+                            ButtonLike::new("hide-hunks")
+                                .child(
+                                    h_flex()
+                                        .gap_2()
+                                        .child(Icon::new(IconName::Visible))
+                                        .child(Label::new("Hide Git Hunks")),
+                                )
+                                .into_any_element()
+                        }
+                    })
+            }))
     }
 }

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -13,7 +13,7 @@ use multi_buffer::{
 use settings::SettingsStore;
 use text::{BufferId, Point};
 use ui::{
-    div, h_flex, ActiveTheme, Context as _, ContextMenu, InteractiveElement, IntoElement,
+    h_flex, v_flex, ActiveTheme, Context as _, ContextMenu, InteractiveElement, IntoElement,
     ParentElement, Pixels, Styled, ViewContext, VisualContext,
 };
 use util::{debug_panic, RangeExt};
@@ -439,7 +439,8 @@ impl Editor {
                         .bg(deleted_hunk_color)
                         .size_full()
                         .child(
-                            div()
+                            v_flex()
+                                .justify_center()
                                 .max_w(gutter_dimensions.full_width())
                                 .min_w(gutter_dimensions.full_width())
                                 .size_full()

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -85,7 +85,9 @@ impl Editor {
         let end_point = self
             .to_pixel_point(hovered_hunk.multi_buffer_range.start, &editor_snapshot, cx)
             .unwrap_or(clicked_point);
-        let closest_source = if start_point.y < end_point.y {
+        let norm =
+            |a: gpui::Point<Pixels>, b: gpui::Point<Pixels>| (a.x - b.x).abs() + (a.y - b.y).abs();
+        let closest_source = if norm(start_point, clicked_point) < norm(end_point, clicked_point) {
             hovered_hunk.multi_buffer_range.start
         } else {
             hovered_hunk.multi_buffer_range.end

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -428,6 +428,7 @@ impl Editor {
                     div()
                         .bg(deleted_hunk_color)
                         .size_full()
+                        // TODO kb add an X icon with toggle hunk action here
                         .pl(gutter_dimensions.full_width())
                         .when(
                             global_modifiers.control || global_modifiers.platform,

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -5,7 +5,10 @@ use std::{
 
 use collections::{hash_map, HashMap, HashSet};
 use git::diff::{DiffHunk, DiffHunkStatus};
-use gpui::{Action, AppContext, CursorStyle, Hsla, Model, MouseButton, Task, View};
+use gpui::{
+    anchored, deferred, Action, AnchorCorner, AppContext, CursorStyle, Hsla, Model, MouseButton,
+    Task, View,
+};
 use language::Buffer;
 use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptRange, MultiBuffer, MultiBufferRow, MultiBufferSnapshot, ToPoint,
@@ -831,6 +834,13 @@ impl RenderOnce for HunkPopover {
             })
         });
 
-        div().occlude().absolute().child(context_menu)
+        div().absolute().child(
+            deferred(
+                anchored()
+                    .anchor(AnchorCorner::TopRight)
+                    .child(context_menu),
+            )
+            .with_priority(1),
+        )
     }
 }

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -345,6 +345,7 @@ impl Editor {
                 position: hunk.multi_buffer_range.start,
                 height: editor_height.max(deleted_text_height),
                 style: BlockStyle::Flex,
+                disposition: BlockDisposition::Above,
                 render: Box::new(move |cx| {
                     let gutter_dimensions = editor_model.read(cx).gutter_dimensions;
                     let click_editor = editor.clone();
@@ -371,7 +372,6 @@ impl Editor {
                         .child(editor_with_deleted_text.clone())
                         .into_any_element()
                 }),
-                disposition: BlockDisposition::Above,
             }),
             None,
             cx,
@@ -865,8 +865,8 @@ impl RenderOnce for HunkPopover {
                         }),
                 )
                 // TODO kb + style improvements
-                // TODO kb deleted hunks push the opened menu below, instead, open THEM below
-                // * hide git hunks
+                // show keyboard shortcuts
+                // change the color of the hunk that got the click
                 .child(v_flex()),
         )
     }

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -79,7 +79,9 @@ impl Editor {
             .any(|expanded_hunk| expanded_hunk.hunk_range == hovered_hunk.multi_buffer_range);
         let editor_handle = cx.view().clone();
 
-        self.mouse_context_menu = Some(MouseContextMenu::new(
+        self.mouse_context_menu = MouseContextMenu::pinned_to_editor(
+            self,
+            hovered_hunk.multi_buffer_range.start,
             clicked_point,
             ContextMenu::build(cx, move |menu, _| {
                 menu.context(focus_handle)
@@ -151,7 +153,7 @@ impl Editor {
                     })
             }),
             cx,
-        ))
+        )
     }
 
     pub(super) fn toggle_hovered_hunk(

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -10,14 +10,61 @@ use gpui::prelude::FluentBuilder;
 use gpui::{DismissEvent, Pixels, Point, Subscription, View, ViewContext};
 use workspace::OpenInTerminal;
 
+pub enum MenuPosition {
+    /// When the editor is scrolled, the context menu stays on the exact
+    /// same position on the screen, never disappearing.
+    PinnedToScreen(Point<Pixels>),
+    /// When the editor is scrolled, the context menu follows the position it is associated with.
+    /// Disappears when the position is no longer visible.
+    PinnedToEditor {
+        source: multi_buffer::Anchor,
+        offset_x: Pixels,
+        offset_y: Pixels,
+    },
+}
+
 pub struct MouseContextMenu {
-    pub(crate) position: Point<Pixels>,
+    pub(crate) position: MenuPosition,
     pub(crate) context_menu: View<ui::ContextMenu>,
     _subscription: Subscription,
 }
 
 impl MouseContextMenu {
-    pub(crate) fn new(
+    pub(crate) fn pinned_to_editor(
+        editor: &mut Editor,
+        source: multi_buffer::Anchor,
+        position: Point<Pixels>,
+        context_menu: View<ui::ContextMenu>,
+        cx: &mut ViewContext<Editor>,
+    ) -> Option<Self> {
+        let context_menu_focus = context_menu.focus_handle(cx);
+        cx.focus(&context_menu_focus);
+
+        let _subscription = cx.subscribe(
+            &context_menu,
+            move |editor, _, _event: &DismissEvent, cx| {
+                editor.mouse_context_menu.take();
+                if context_menu_focus.contains_focused(cx) {
+                    editor.focus(cx);
+                }
+            },
+        );
+
+        let source_point = editor.to_pixel_point(source, cx)?;
+        let offset = position - source_point;
+
+        Some(Self {
+            position: MenuPosition::PinnedToEditor {
+                source,
+                offset_x: offset.x,
+                offset_y: offset.y,
+            },
+            context_menu,
+            _subscription,
+        })
+    }
+
+    pub(crate) fn pinned_to_screen(
         position: Point<Pixels>,
         context_menu: View<ui::ContextMenu>,
         cx: &mut ViewContext<Editor>,
@@ -25,16 +72,18 @@ impl MouseContextMenu {
         let context_menu_focus = context_menu.focus_handle(cx);
         cx.focus(&context_menu_focus);
 
-        let _subscription =
-            cx.subscribe(&context_menu, move |this, _, _event: &DismissEvent, cx| {
-                this.mouse_context_menu.take();
+        let _subscription = cx.subscribe(
+            &context_menu,
+            move |editor, _, _event: &DismissEvent, cx| {
+                editor.mouse_context_menu.take();
                 if context_menu_focus.contains_focused(cx) {
-                    this.focus(cx);
+                    editor.focus(cx);
                 }
-            });
+            },
+        );
 
         Self {
-            position,
+            position: MenuPosition::PinnedToScreen(position),
             context_menu,
             _subscription,
         }
@@ -71,6 +120,8 @@ pub fn deploy_context_menu(
         return;
     }
 
+    let display_map = editor.selections.display_map(cx);
+    let source_anchor = display_map.display_point_to_anchor(point, text::Bias::Right);
     let context_menu = if let Some(custom) = editor.custom_context_menu.take() {
         let menu = custom(editor, point, cx);
         editor.custom_context_menu = Some(custom);
@@ -128,8 +179,9 @@ pub fn deploy_context_menu(
             }
         })
     };
-    let mouse_context_menu = MouseContextMenu::new(position, context_menu, cx);
-    editor.mouse_context_menu = Some(mouse_context_menu);
+
+    editor.mouse_context_menu =
+        MouseContextMenu::pinned_to_editor(editor, source_anchor, position, context_menu, cx);
     cx.notify();
 }
 

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -50,7 +50,8 @@ impl MouseContextMenu {
             },
         );
 
-        let source_point = editor.to_pixel_point(source, cx)?;
+        let editor_snapshot = editor.snapshot(cx);
+        let source_point = editor.to_pixel_point(source, &editor_snapshot, cx)?;
         let offset = position - source_point;
 
         Some(Self {
@@ -149,6 +150,7 @@ pub fn deploy_context_menu(
         let focus = cx.focused();
         ui::ContextMenu::build(cx, |menu, _cx| {
             let builder = menu
+                .on_blur_subscription(Subscription::new(|| {}))
                 .action("Rename Symbol", Box::new(Rename))
                 .action("Go to Definition", Box::new(GoToDefinition))
                 .action("Go to Type Definition", Box::new(GoToTypeDefinition))

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -285,6 +285,11 @@ impl ContextMenu {
             cx.propagate()
         }
     }
+
+    pub fn on_blur_subscription(mut self, new_subscription: Subscription) -> Self {
+        self._on_blur_subscription = new_subscription;
+        self
+    }
 }
 
 impl ContextMenuItem {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/12404

![Screenshot 2024-07-18 at 14 02 31](https://github.com/user-attachments/assets/a8addd22-0ed9-4f4b-852a-f347314c27ce)

![Screenshot 2024-07-18 at 14 02 43](https://github.com/user-attachments/assets/0daaed10-b9f3-4d4b-b8d7-189aa7e013b9)

Video:

https://github.com/user-attachments/assets/58e62527-da75-4017-a43e-a37803bd7b49


* now shows a context menu on left click instead of expanding the hunk diff
* hunk diffs can be toggled with a single cmd-click still
* adds a X mark into gutter for every hunk expanded
* makes `editor::ToggleDiffHunk` to work inside the deleted hunk editors

Additionally, changes the way editor context menus behave when the editor is scrolled — right click and diff hunks context menu now will stick to the place it was invoked at, instead of staying onscreen at the same pixel positions.

Release Notes:

- Improved the way git hunks diff can be toggled with mouse ([#12404](https://github.com/zed-industries/zed/issues/12404))