### PR TITLE
Add `text_color` helper for tab contents

### DIFF
--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -417,11 +417,7 @@ impl Item for ChannelView {
             .gap_2()
             .child(
                 Label::new(channel_name)
-                    .color(if params.selected {
-                        Color::Default
-                    } else {
-                        Color::Muted
-                    })
+                    .color(params.text_color())
                     .italic(params.preview),
             )
             .when_some(status, |element, status| {

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -16,12 +16,14 @@ use gpui::{
     WindowContext,
 };
 use project::Project;
+use rpc::proto::ChannelVisibility;
 use std::{
     any::{Any, TypeId},
     sync::Arc,
 };
 use ui::prelude::*;
 use util::ResultExt;
+use workspace::item::TabContentParams;
 use workspace::{item::Dedup, notifications::NotificationId};
 use workspace::{
     item::{FollowableItem, Item, ItemEvent, ItemHandle},
@@ -385,20 +387,51 @@ impl Item for ChannelView {
         }
     }
 
-    fn tab_content_text(&self, cx: &WindowContext) -> Option<SharedString> {
-        let label = if let Some(channel) = self.channel(cx) {
-            match (
+    fn tab_icon(&self, cx: &WindowContext) -> Option<Icon> {
+        let channel = self.channel(cx)?;
+        let icon = match channel.visibility {
+            ChannelVisibility::Public => IconName::Public,
+            ChannelVisibility::Members => IconName::Hash,
+        };
+
+        Some(Icon::new(icon))
+    }
+
+    fn tab_content(&self, params: TabContentParams, cx: &WindowContext) -> gpui::AnyElement {
+        let (channel_name, status) = if let Some(channel) = self.channel(cx) {
+            let status = match (
                 self.channel_buffer.read(cx).buffer().read(cx).read_only(),
                 self.channel_buffer.read(cx).is_connected(),
             ) {
-                (false, true) => format!("#{}", channel.name),
-                (true, true) => format!("#{} (read-only)", channel.name),
-                (_, false) => format!("#{} (disconnected)", channel.name),
-            }
+                (false, true) => None,
+                (true, true) => Some("read-only"),
+                (_, false) => Some("disconnected"),
+            };
+
+            (channel.name.clone(), status)
         } else {
-            "channel notes (disconnected)".to_string()
+            ("<unknown>".into(), Some("disconnected"))
         };
-        Some(label.into())
+
+        h_flex()
+            .gap_2()
+            .child(
+                Label::new(channel_name)
+                    .color(if params.selected {
+                        Color::Default
+                    } else {
+                        Color::Muted
+                    })
+                    .italic(params.preview),
+            )
+            .when_some(status, |element, status| {
+                element.child(
+                    Label::new(status)
+                        .size(LabelSize::XSmall)
+                        .color(Color::Muted),
+                )
+            })
+            .into_any_element()
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -649,11 +649,7 @@ impl Item for ProjectDiagnosticsEditor {
     fn tab_content(&self, params: TabContentParams, _: &WindowContext) -> AnyElement {
         if self.summary.error_count == 0 && self.summary.warning_count == 0 {
             Label::new("No problems")
-                .color(if params.selected {
-                    Color::Default
-                } else {
-                    Color::Muted
-                })
+                .color(params.text_color())
                 .into_any_element()
         } else {
             h_flex()
@@ -663,13 +659,10 @@ impl Item for ProjectDiagnosticsEditor {
                         h_flex()
                             .gap_1()
                             .child(Icon::new(IconName::XCircle).color(Color::Error))
-                            .child(Label::new(self.summary.error_count.to_string()).color(
-                                if params.selected {
-                                    Color::Default
-                                } else {
-                                    Color::Muted
-                                },
-                            )),
+                            .child(
+                                Label::new(self.summary.error_count.to_string())
+                                    .color(params.text_color()),
+                            ),
                     )
                 })
                 .when(self.summary.warning_count > 0, |then| {
@@ -677,13 +670,10 @@ impl Item for ProjectDiagnosticsEditor {
                         h_flex()
                             .gap_1()
                             .child(Icon::new(IconName::ExclamationTriangle).color(Color::Warning))
-                            .child(Label::new(self.summary.warning_count.to_string()).color(
-                                if params.selected {
-                                    Color::Default
-                                } else {
-                                    Color::Muted
-                                },
-                            )),
+                            .child(
+                                Label::new(self.summary.warning_count.to_string())
+                                    .color(params.text_color()),
+                            ),
                     )
                 })
                 .into_any_element()

--- a/crates/diagnostics/src/grouped_diagnostics.rs
+++ b/crates/diagnostics/src/grouped_diagnostics.rs
@@ -466,11 +466,7 @@ impl Item for GroupedDiagnosticsEditor {
     fn tab_content(&self, params: TabContentParams, _: &WindowContext) -> AnyElement {
         if self.summary.error_count == 0 && self.summary.warning_count == 0 {
             Label::new("No problems")
-                .color(if params.selected {
-                    Color::Default
-                } else {
-                    Color::Muted
-                })
+                .color(params.text_color())
                 .into_any_element()
         } else {
             h_flex()
@@ -480,13 +476,10 @@ impl Item for GroupedDiagnosticsEditor {
                         h_flex()
                             .gap_1()
                             .child(Icon::new(IconName::XCircle).color(Color::Error))
-                            .child(Label::new(self.summary.error_count.to_string()).color(
-                                if params.selected {
-                                    Color::Default
-                                } else {
-                                    Color::Muted
-                                },
-                            )),
+                            .child(
+                                Label::new(self.summary.error_count.to_string())
+                                    .color(params.text_color()),
+                            ),
                     )
                 })
                 .when(self.summary.warning_count > 0, |then| {
@@ -494,13 +487,10 @@ impl Item for GroupedDiagnosticsEditor {
                         h_flex()
                             .gap_1()
                             .child(Icon::new(IconName::ExclamationTriangle).color(Color::Warning))
-                            .child(Label::new(self.summary.warning_count.to_string()).color(
-                                if params.selected {
-                                    Color::Default
-                                } else {
-                                    Color::Muted
-                                },
-                            )),
+                            .child(
+                                Label::new(self.summary.warning_count.to_string())
+                                    .color(params.text_color()),
+                            ),
                     )
                 })
                 .into_any_element()

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -80,11 +80,7 @@ impl Item for ImageView {
             .to_string();
         Label::new(title)
             .single_line()
-            .color(if params.selected {
-                Color::Default
-            } else {
-                Color::Muted
-            })
+            .color(params.text_color())
             .italic(params.preview)
             .into_any_element()
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -994,11 +994,7 @@ impl Item for TerminalView {
                         )
                     }),
             )
-            .child(Label::new(title).color(if params.selected {
-                Color::Default
-            } else {
-                Color::Muted
-            }))
+            .child(Label::new(title).color(params.text_color()))
             .into_any()
     }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -142,6 +142,17 @@ pub struct TabContentParams {
     pub preview: bool,
 }
 
+impl TabContentParams {
+    /// Returns the text color to be used for the tab content.
+    pub fn text_color(&self) -> Color {
+        if self.selected {
+            Color::Default
+        } else {
+            Color::Muted
+        }
+    }
+}
+
 pub trait Item: FocusableView + EventEmitter<Self::Event> {
     type Event;
 
@@ -154,13 +165,9 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
             return gpui::Empty.into_any();
         };
 
-        let color = if params.selected {
-            Color::Default
-        } else {
-            Color::Muted
-        };
-
-        Label::new(text).color(color).into_any_element()
+        Label::new(text)
+            .color(params.text_color())
+            .into_any_element()
     }
 
     /// Returns the textual contents of the tab.


### PR DESCRIPTION
This PR adds a `text_color` method to `TabContentParams` to more easily compute the text color to be used for tab contents.

This consolidates a number of conditionals that were scattered all over the place to give us a singular source of truth for these colors.

Release Notes:

- N/A
