### PR TITLE
Improve same line diagnostic rendering

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -4,7 +4,7 @@ mod toolbar_controls;
 
 #[cfg(test)]
 mod diagnostics_tests;
-mod grouped_diagnostics;
+pub(crate) mod grouped_diagnostics;
 
 use anyhow::Result;
 use collections::{BTreeSet, HashSet};

--- a/crates/diagnostics/src/grouped_diagnostics.rs
+++ b/crates/diagnostics/src/grouped_diagnostics.rs
@@ -51,18 +51,18 @@ pub fn init(cx: &mut AppContext) {
         .detach();
 }
 
-struct GroupedDiagnosticsEditor {
-    project: Model<Project>,
+pub struct GroupedDiagnosticsEditor {
+    pub project: Model<Project>,
     workspace: WeakView<Workspace>,
     focus_handle: FocusHandle,
     editor: View<Editor>,
     summary: DiagnosticSummary,
     excerpts: Model<MultiBuffer>,
     path_states: Vec<PathState>,
-    paths_to_update: BTreeSet<(ProjectPath, LanguageServerId)>,
-    include_warnings: bool,
+    pub paths_to_update: BTreeSet<(ProjectPath, LanguageServerId)>,
+    pub include_warnings: bool,
     context: u32,
-    update_paths_tx: UnboundedSender<(ProjectPath, Option<LanguageServerId>)>,
+    pub update_paths_tx: UnboundedSender<(ProjectPath, Option<LanguageServerId>)>,
     _update_excerpts_task: Task<Result<()>>,
     _subscription: Subscription,
 }
@@ -260,7 +260,7 @@ impl GroupedDiagnosticsEditor {
         }
     }
 
-    fn toggle_warnings(&mut self, _: &ToggleWarnings, cx: &mut ViewContext<Self>) {
+    pub fn toggle_warnings(&mut self, _: &ToggleWarnings, cx: &mut ViewContext<Self>) {
         self.include_warnings = !self.include_warnings;
         self.enqueue_update_all_excerpts(cx);
         cx.notify();
@@ -297,7 +297,7 @@ impl GroupedDiagnosticsEditor {
     /// to have changed. If a language server id is passed, then only the excerpts for
     /// that language server's diagnostics will be updated. Otherwise, all stale excerpts
     /// will be refreshed.
-    fn enqueue_update_stale_excerpts(&mut self, language_server_id: Option<LanguageServerId>) {
+    pub fn enqueue_update_stale_excerpts(&mut self, language_server_id: Option<LanguageServerId>) {
         for (path, server_id) in &self.paths_to_update {
             if language_server_id.map_or(true, |id| id == *server_id) {
                 self.update_paths_tx
@@ -340,7 +340,6 @@ impl GroupedDiagnosticsEditor {
             }
         };
 
-        // TODO kb when warnings are turned off, there's a lot of refresh for many paths happening, why?
         let max_severity = if self.include_warnings {
             DiagnosticSeverity::WARNING
         } else {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12824,23 +12824,31 @@ pub fn highlight_diagnostic_message(
 
     let mut prev_offset = 0;
     let mut in_code_block = false;
+    let has_row_limit = max_message_rows.is_some();
     let mut newline_indices = diagnostic
         .message
         .match_indices('\n')
+        .filter(|_| has_row_limit)
         .map(|(ix, _)| ix)
         .fuse()
         .peekable();
-    for (ix, _) in diagnostic
+
+    for (quote_ix, _) in diagnostic
         .message
         .match_indices('`')
         .chain([(diagnostic.message.len(), "")])
     {
-        let mut trimmed_ix = ix;
-        while let Some(newline_index) = newline_indices.peek() {
-            if *newline_index < ix {
+        let mut first_newline_ix = None;
+        let mut last_newline_ix = None;
+        while let Some(newline_ix) = newline_indices.peek() {
+            if *newline_ix < quote_ix {
+                if first_newline_ix.is_none() {
+                    first_newline_ix = Some(*newline_ix);
+                }
+                last_newline_ix = Some(*newline_ix);
+
                 if let Some(rows_left) = &mut max_message_rows {
                     if *rows_left == 0 {
-                        trimmed_ix = newline_index.saturating_sub(1);
                         break;
                     } else {
                         *rows_left -= 1;
@@ -12852,14 +12860,14 @@ pub fn highlight_diagnostic_message(
             }
         }
         let prev_len = text_without_backticks.len();
-        let new_text = &diagnostic.message[prev_offset..trimmed_ix];
+        let new_text = &diagnostic.message[prev_offset..first_newline_ix.unwrap_or(quote_ix)];
         text_without_backticks.push_str(new_text);
         if in_code_block {
             code_ranges.push(prev_len..text_without_backticks.len());
         }
-        prev_offset = trimmed_ix + 1;
+        prev_offset = last_newline_ix.unwrap_or(quote_ix) + 1;
         in_code_block = !in_code_block;
-        if trimmed_ix != ix {
+        if first_newline_ix.map_or(false, |newline_ix| newline_ix < quote_ix) {
             text_without_backticks.push_str("...");
             break;
         }


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/14515

Fixed certain visual artifacts, related to multi line diagnostics and block toggle rendering.
Also enabled diagnostics toolbar controls for the experimental view too.


Release Notes:

- N/A
