### PR TITLE
gpui: Prefer removable over integrated Metal devices

### DIFF
--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -113,7 +113,7 @@ impl MetalRenderer {
         // Silicon, there is only ever one GPU, so this is equivalent to
         // `metal::Device::system_default()`.
         let mut devices = metal::Device::all();
-        devices.sort_by_key(|device| (!device.is_removable(), device.is_low_power()));
+        devices.sort_by_key(|device| (device.is_removable(), device.is_low_power()));
         let Some(device) = devices.pop() else {
             log::error!("unable to access a compatible graphics device");
             std::process::exit(1);


### PR DESCRIPTION
For context, see:

- https://github.com/zed-industries/zed/issues/5124#issuecomment-2227743811
- https://github.com/zed-industries/zed/pull/14738#issuecomment-2236613976

Short version: on Intel MacBooks it's better to prefer integrated (`is_low_poer()`) GPUs, except when a user has an eGPU plugged-in, in which case they very likely want to prefer that.

Before this change, we'd always prefer the integrated GPU, even if an eGPU was available.

Now, with this change, if a user has

- eGPU
- integrated GPU
- discrete GPU

We'd first prefer eGPU, then integrated, then discrete.



Release Notes:

- Changed preference for GPUs on macOS so that eGPUs are now preferred over integrated ones (and both of which are preferred over discrete GPUs) on Intel Macs.