### PR TITLE
vim: Add repeat support for add_surround

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -680,6 +680,9 @@ impl Vim {
                 | Operator::DeleteSurrounds
         ) {
             self.update_state(|state| state.operator_stack.clear());
+            if let Operator::AddSurrounds { target: None } = operator {
+                self.start_recording(cx);
+            }
         };
         self.update_state(|state| state.operator_stack.push(operator));
         self.sync_vim_settings(cx);


### PR DESCRIPTION

Fix: #14242

At present, we don't trigger the method `start_recording(cx)` to start recording when typing add_surround, so it can't be repeated well, delete and change actually don't increase, but when entering `d` and `c`, it happens that these two operations are recorded, I think maybe we also need to call `start_recording(cx)` when calling delete_surround and change_surround, otherwise when the user modifies their shortcuts, these two functions may not be supported by repeat

Release Notes:

- N/A
