### PR TITLE
vue: Install a global version of TypeScript if not present in the project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13946,6 +13946,7 @@ dependencies = [
 name = "zed_vue"
 version = "0.0.3"
 dependencies = [
+ "serde",
  "zed_extension_api 0.0.6",
 ]
 

--- a/extensions/vue/Cargo.toml
+++ b/extensions/vue/Cargo.toml
@@ -13,4 +13,5 @@ path = "src/vue.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
 zed_extension_api = "0.0.6"


### PR DESCRIPTION
This PR updates the Vue extension with support for installing and using its own copy of TypeScript if it can't find one in the project.

The way we resolve `typescript` is as follows:

- We check the project's `package.json` for `typescript` in either the `devDependencies` or `dependencies`
  - If found, we set the `typescript.tsdk` to `node_modules/typescript/lib` to use the project's copy of TypeScript
  - If not found, we install the latest version of `typescript` (if not already downloaded) to the extension's `package.json` and use that version for `typescript.tsdk` 

This should resolve instances where Vue projects that do not have an explicit `typescript` dependency—such as those using Vue with plain JavaScript—fail to load the language server due to TypeScript not being found.

Release Notes:

- N/A
