### PR TITLE
Handle supermaven account status messages

### DIFF
--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -354,7 +354,11 @@ impl SupermavenAgent {
                     None => AccountStatus::Ready,
                 };
             }
+            SupermavenMessage::ActivationSuccess => {
+                self.account_status = AccountStatus::Ready;
+            }
             SupermavenMessage::ServiceTier { service_tier } => {
+                self.account_status = AccountStatus::Ready;
                 self.service_tier = Some(service_tier);
             }
             SupermavenMessage::Response(response) => {


### PR DESCRIPTION
Sets the account status state to allow the Supermaven button to move out of the "Supermaven is initializing..." state. We also need to add the ability to sign out and change tiers but I will do that in a separate PR.

Release Notes:

- Improved Supermaven status messages ([#12715](https://github.com/zed-industries/zed/issues/12715)).
