### PR TITLE
repl: Scroll down after running code

### DIFF
--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -27,7 +27,7 @@ impl Autoscroll {
         Self::Strategy(AutoscrollStrategy::Center)
     }
 
-    /// scrolls so the neweset cursor is near the top
+    /// scrolls so the newest cursor is near the top
     /// (offset by vertical_scroll_margin)
     pub fn focused() -> Self {
         Self::Strategy(AutoscrollStrategy::Focused)

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -7,6 +7,7 @@ use editor::{
     display_map::{
         BlockContext, BlockDisposition, BlockId, BlockProperties, BlockStyle, RenderBlock,
     },
+    scroll::Autoscroll,
     Anchor, AnchorRangeExt as _, Editor, MultiBuffer, ToPoint,
 };
 use futures::{FutureExt as _, StreamExt as _};
@@ -329,6 +330,8 @@ impl Session {
             return;
         };
 
+        let new_cursor_pos = editor_block.invalidation_anchor;
+
         self.blocks
             .insert(message.header.msg_id.clone(), editor_block);
 
@@ -352,6 +355,13 @@ impl Session {
             }
             _ => {}
         }
+
+        // Now move the cursor to after the block
+        editor.update(cx, move |editor, cx| {
+            editor.change_selections(Some(Autoscroll::fit()), cx, |selections| {
+                selections.select_ranges([new_cursor_pos..new_cursor_pos]);
+            });
+        });
     }
 
     fn route(&mut self, message: &JupyterMessage, cx: &mut ViewContext<Self>) {

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -358,7 +358,7 @@ impl Session {
 
         // Now move the cursor to after the block
         editor.update(cx, move |editor, cx| {
-            editor.change_selections(Some(Autoscroll::fit()), cx, |selections| {
+            editor.change_selections(Some(Autoscroll::top_relative(8)), cx, |selections| {
                 selections.select_ranges([new_cursor_pos..new_cursor_pos]);
             });
         });


### PR DESCRIPTION
Go to the next line after running code. Allows for fluid coding and running.

https://github.com/user-attachments/assets/d11ac05d-7801-4191-b275-3b20302e54c5

Release Notes:

- N/A
