### PR TITLE
Add gpt-4o-mini as an available model

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -396,6 +396,7 @@
       // 2. "gpt-4"
       // 3. "gpt-4-turbo-preview"
       // 4. "gpt-4o"
+      // 5. "gpt-4o-mini"
       "default_model": "gpt-4o"
     }
   },

--- a/crates/assistant/src/assistant_settings.rs
+++ b/crates/assistant/src/assistant_settings.rs
@@ -23,6 +23,7 @@ pub enum CloudModel {
     Gpt4Turbo,
     #[default]
     Gpt4Omni,
+    Gpt4OmniMini,
     Claude3_5Sonnet,
     Claude3Opus,
     Claude3Sonnet,
@@ -107,6 +108,7 @@ impl CloudModel {
             Self::Gpt4 => "gpt-4",
             Self::Gpt4Turbo => "gpt-4-turbo-preview",
             Self::Gpt4Omni => "gpt-4o",
+            Self::Gpt4OmniMini => "gpt-4o-mini",
             Self::Claude3_5Sonnet => "claude-3-5-sonnet",
             Self::Claude3Opus => "claude-3-opus",
             Self::Claude3Sonnet => "claude-3-sonnet",
@@ -123,6 +125,7 @@ impl CloudModel {
             Self::Gpt4 => "GPT 4",
             Self::Gpt4Turbo => "GPT 4 Turbo",
             Self::Gpt4Omni => "GPT 4 Omni",
+            Self::Gpt4OmniMini => "GPT 4 Omni Mini",
             Self::Claude3_5Sonnet => "Claude 3.5 Sonnet",
             Self::Claude3Opus => "Claude 3 Opus",
             Self::Claude3Sonnet => "Claude 3 Sonnet",
@@ -138,6 +141,7 @@ impl CloudModel {
             Self::Gpt3Point5Turbo => 2048,
             Self::Gpt4 => 4096,
             Self::Gpt4Turbo | Self::Gpt4Omni => 128000,
+            Self::Gpt4OmniMini => 128000,
             Self::Claude3_5Sonnet
             | Self::Claude3Opus
             | Self::Claude3Sonnet

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -59,6 +59,8 @@ pub enum Model {
     #[serde(rename = "gpt-4o", alias = "gpt-4o-2024-05-13")]
     #[default]
     FourOmni,
+    #[serde(rename = "gpt-4o-mini", alias = "gpt-4o-mini-2024-07-18")]
+    FourOmniMini,
     #[serde(rename = "custom")]
     Custom { name: String, max_tokens: usize },
 }
@@ -70,6 +72,7 @@ impl Model {
             "gpt-4" => Ok(Self::Four),
             "gpt-4-turbo-preview" => Ok(Self::FourTurbo),
             "gpt-4o" => Ok(Self::FourOmni),
+            "gpt-4o-mini" => Ok(Self::FourOmniMini),
             _ => Err(anyhow!("invalid model id")),
         }
     }
@@ -80,6 +83,7 @@ impl Model {
             Self::Four => "gpt-4",
             Self::FourTurbo => "gpt-4-turbo-preview",
             Self::FourOmni => "gpt-4o",
+            Self::FourOmniMini => "gpt-4o-mini",
             Self::Custom { .. } => "custom",
         }
     }
@@ -90,6 +94,7 @@ impl Model {
             Self::Four => "gpt-4",
             Self::FourTurbo => "gpt-4-turbo",
             Self::FourOmni => "gpt-4o",
+            Self::FourOmniMini => "gpt-4o-mini",
             Self::Custom { name, .. } => name,
         }
     }
@@ -100,6 +105,7 @@ impl Model {
             Model::Four => 8192,
             Model::FourTurbo => 128000,
             Model::FourOmni => 128000,
+            Self::FourOmniMini => 128000,
             Model::Custom { max_tokens, .. } => *max_tokens,
         }
     }

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -101,12 +101,12 @@ impl Model {
 
     pub fn max_token_count(&self) -> usize {
         match self {
-            Model::ThreePointFiveTurbo => 4096,
-            Model::Four => 8192,
-            Model::FourTurbo => 128000,
-            Model::FourOmni => 128000,
+            Self::ThreePointFiveTurbo => 4096,
+            Self::Four => 8192,
+            Self::FourTurbo => 128000,
+            Self::FourOmni => 128000,
             Self::FourOmniMini => 128000,
-            Model::Custom { max_tokens, .. } => *max_tokens,
+            Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
 }


### PR DESCRIPTION
Release Notes:

- Added support for gpt-4o-mini ([#14769](https://github.com/zed-industries/zed/issues/14769), thanks [versecafe](https://github.com/versecafe)).