### PR TITLE
typescript: Highlight `using` keyword

### DIFF
--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -193,6 +193,7 @@
   "throw"
   "try"
   "typeof"
+  "using"
   "var"
   "void"
   "while"

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -193,6 +193,7 @@
   "throw"
   "try"
   "typeof"
+  "using"
   "var"
   "void"
   "while"


### PR DESCRIPTION
Release Notes:

- Added syntax highlighting for the `using` keyword in TypeScript ([#14762](https://github.com/zed-industries/zed/issues/14762)).

