### PR TITLE
Fix off-by-one errors in syntax highlighting

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -376,7 +376,7 @@ impl WindowTextSystem {
         runs: &[TextRun],
         wrap_width: Option<Pixels>,
     ) -> Result<SmallVec<[WrappedLine; 1]>> {
-        let mut runs = runs.iter().cloned().peekable();
+        let mut runs = runs.iter().filter(|run| run.len > 0).cloned().peekable();
         let mut font_runs = self.font_runs_pool.lock().pop().unwrap_or_default();
 
         let mut lines = SmallVec::new();
@@ -444,7 +444,7 @@ impl WindowTextSystem {
             // Skip `\n` character.
             line_start = line_end + 1;
             if let Some(run) = runs.peek_mut() {
-                run.len = run.len.saturating_sub(1);
+                run.len -= 1;
                 if run.len == 0 {
                     runs.next();
                 }

--- a/crates/markdown/examples/markdown.rs
+++ b/crates/markdown/examples/markdown.rs
@@ -15,6 +15,15 @@ const MARKDOWN_EXAMPLE: &'static str = r#"
 ## Headings
 Headings are created by adding one or more `#` symbols before your heading text. The number of `#` you use will determine the size of the heading.
 
+```rust
+gpui::window::ViewContext
+impl<'a, V> ViewContext<'a, V>
+pub fn on_blur(&mut self, handle: &FocusHandle, listener: impl FnMut(&mut V, &mut iewContext<V>) + 'static) -> Subscription
+where
+    // Bounds from impl:
+    V: 'static,
+```
+
 ## Emphasis
 Emphasis can be added with italics or bold. *This text will be italic*. _This will also be italic_
 
@@ -94,12 +103,13 @@ pub fn main() {
         cx.bind_keys([KeyBinding::new("cmd-c", markdown::Copy, None)]);
 
         let node_runtime = FakeNodeRuntime::new();
-        let language_registry = Arc::new(LanguageRegistry::new(
-            Task::ready(()),
-            cx.background_executor().clone(),
-        ));
-        languages::init(language_registry.clone(), node_runtime, cx);
         theme::init(LoadThemes::JustBase, cx);
+
+        let language_registry =
+            LanguageRegistry::new(Task::ready(()), cx.background_executor().clone());
+        language_registry.set_theme(cx.theme().clone());
+        let language_registry = Arc::new(language_registry);
+        languages::init(language_registry.clone(), node_runtime, cx);
         Assets.load_fonts(cx).unwrap();
 
         cx.activate(true);


### PR DESCRIPTION
In the case that a line ended with a 0-length run, we would get our
highlights offset by one position.

Release Notes:

- Fixed syntax highlights being offset from syntax in diagnostics popovers.
