### PR TITLE
vim: Fix 'Y' to yank to end of line

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -215,7 +215,7 @@
       "shift-d": "vim::DeleteToEndOfLine",
       "shift-j": "vim::JoinLines",
       "y": ["vim::PushOperator", "Yank"],
-      "shift-y": "vim::YankLine",
+      "shift-y": "vim::YankToEndOfLine",
       "i": "vim::InsertBefore",
       "shift-i": "vim::InsertFirstNonWhitespace",
       "a": "vim::InsertAfter",

--- a/crates/vim/test_data/test_shift_y.json
+++ b/crates/vim/test_data/test_shift_y.json
@@ -1,0 +1,4 @@
+{"Put":{"state":"helˇlo\n"}}
+{"Key":"shift-y"}
+{"Get":{"state":"helˇlo\n","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"lo"}}


### PR DESCRIPTION
Instead of yanking the entire line.

Release Notes:

- vim: Updated `Y` to yank to end of line (like neovim) https://github.com/zed-industries/zed/issues/14771
