### PR TITLE
php: Respect LSP settings for Intelephense

### DIFF
--- a/extensions/php/src/language_servers/intelephense.rs
+++ b/extensions/php/src/language_servers/intelephense.rs
@@ -1,6 +1,7 @@
 use std::{env, fs};
 
-use zed_extension_api::{self as zed, LanguageServerId, Result};
+use zed_extension_api::settings::LspSettings;
+use zed_extension_api::{self as zed, serde_json, LanguageServerId, Result};
 
 const SERVER_PATH: &str = "node_modules/intelephense/lib/intelephense.js";
 const PACKAGE_NAME: &str = "intelephense";
@@ -88,5 +89,19 @@ impl Intelephense {
 
         self.did_find_server = true;
         Ok(SERVER_PATH.to_string())
+    }
+
+    pub fn language_server_workspace_configuration(
+        &mut self,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree("intelephense", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+
+        Ok(Some(serde_json::json!({
+            "intelephense": settings
+        })))
     }
 }

--- a/extensions/php/src/php.rs
+++ b/extensions/php/src/php.rs
@@ -1,6 +1,6 @@
 mod language_servers;
 
-use zed_extension_api::{self as zed, LanguageServerId, Result};
+use zed_extension_api::{self as zed, serde_json, LanguageServerId, Result};
 
 use crate::language_servers::{Intelephense, Phpactor};
 
@@ -38,6 +38,23 @@ impl zed::Extension for PhpExtension {
             }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        match language_server_id.as_ref() {
+            Intelephense::LANGUAGE_SERVER_ID => {
+                if let Some(intelephense) = self.intelephense.as_mut() {
+                    return intelephense.language_server_workspace_configuration(worktree);
+                }
+            }
+            _ => (),
+        }
+
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
This PR updates the PHP extension with support for reading LSP settings when using Intelephense as the language server.

Addresses #4258.

Release Notes:

- N/A
