### PR TITLE
Use `ui::prelude::*` in a few more spots

### DIFF
--- a/crates/collab_ui/src/collab_panel/contact_finder.rs
+++ b/crates/collab_ui/src/collab_panel/contact_finder.rs
@@ -5,7 +5,6 @@ use gpui::{
 };
 use picker::{Picker, PickerDelegate};
 use std::sync::Arc;
-use theme::ActiveTheme as _;
 use ui::{prelude::*, Avatar, ListItem, ListItemSpacing};
 use util::{ResultExt as _, TryFutureExt};
 use workspace::ModalView;

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -1,9 +1,5 @@
-use gpui::{
-    div, prelude::*, px, AnyView, DismissEvent, FocusHandle, ManagedView, Render, Subscription,
-    View, ViewContext, WindowContext,
-};
-use theme::ActiveTheme as _;
-use ui::{h_flex, v_flex};
+use gpui::{AnyView, DismissEvent, FocusHandle, ManagedView, Subscription, View};
+use ui::prelude::*;
 
 pub enum DismissDecision {
     Dismiss(bool),


### PR DESCRIPTION
This PR updates a couple files to make use of the `ui::prelude::*` import.

Release Notes:

- N/A
