### PR TITLE
go: Fix quoting of targeting expression for non-fish shells

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -518,7 +518,7 @@ impl ContextProvider for GoContextProvider {
                     "test".into(),
                     GO_PACKAGE_TASK_VARIABLE.template_value(),
                     "-run".into(),
-                    format!("'^{}$'", VariableName::Symbol.template_value(),),
+                    format!("^{}\\$", VariableName::Symbol.template_value(),),
                 ],
                 tags: vec!["go-test".to_owned()],
                 ..TaskTemplate::default()
@@ -549,7 +549,7 @@ impl ContextProvider for GoContextProvider {
                     "-v".into(),
                     "-run".into(),
                     format!(
-                        "'^{}$/^{}$'",
+                        "^{}\\$/^{}\\$",
                         VariableName::Symbol.template_value(),
                         GO_SUBTEST_NAME_TASK_VARIABLE.template_value(),
                     ),
@@ -570,7 +570,7 @@ impl ContextProvider for GoContextProvider {
                     "-benchmem".into(),
                     "-run=^$".into(),
                     "-bench".into(),
-                    format!("'^{}$'", VariableName::Symbol.template_value()),
+                    format!("^{}\\$", VariableName::Symbol.template_value()),
                 ],
                 tags: vec!["go-benchmark".to_owned()],
                 ..TaskTemplate::default()


### PR DESCRIPTION
This fixes #14818.

The change in #14055 broke the tasks in `zsh` (and I suspect in `bash`, `sh` too), because what was executed was NOT

    $ go test . -run '^TestThis$'

but instead this:

    $ go test . -run \'^TestThis$\'

And in `zsh` this means that `'` is part of the argument passed to `go`, which means the targeting string is wrong.

Since the problem in `fish` doesn't seem to be the `^` but the `$`, we can only escape that, which makes the escaped string work in `zsh` and `fish` and `bash` (in which I've tested this change here)

Release Notes:

- go: Fix running single tests by changing the quoted expression in the `go test` command to work again in `bash`, `zsh`, etc. ([#14818](https://github.com/zed-industries/zed/issues/14818))

