### PR TITLE
vim: Fix gv after actions

### DIFF
--- a/crates/vim/src/normal/case.rs
+++ b/crates/vim/src/normal/case.rs
@@ -125,7 +125,9 @@ where
 {
     Vim::update(cx, |vim, cx| {
         vim.record_current_action(cx);
+        vim.store_visual_marks(cx);
         let count = vim.take_count(cx).unwrap_or(1) as u32;
+
         vim.update_active_editor(cx, |vim, editor, cx| {
             let mut ranges = Vec::new();
             let mut cursor_positions = Vec::new();

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -47,6 +47,7 @@ fn increment(vim: &mut Vim, mut delta: i32, step: i32, cx: &mut WindowContext) {
     vim.update_active_editor(cx, |vim, editor, cx| {
         let mut edits = Vec::new();
         let mut new_anchors = Vec::new();
+        vim.store_visual_marks(cx);
 
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         for selection in editor.selections.all_adjusted(cx) {

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -44,10 +44,10 @@ pub fn register(workspace: &mut Workspace, _: &mut ViewContext<Workspace>) {
 }
 
 fn increment(vim: &mut Vim, mut delta: i32, step: i32, cx: &mut WindowContext) {
+    vim.store_visual_marks(cx);
     vim.update_active_editor(cx, |vim, editor, cx| {
         let mut edits = Vec::new();
         let mut new_anchors = Vec::new();
-        vim.store_visual_marks(cx);
 
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         for selection in editor.selections.all_adjusted(cx) {

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -30,7 +30,9 @@ pub(crate) fn register(workspace: &mut Workspace, _: &mut ViewContext<Workspace>
 fn paste(_: &mut Workspace, action: &Paste, cx: &mut ViewContext<Workspace>) {
     Vim::update(cx, |vim, cx| {
         vim.record_current_action(cx);
+        vim.store_visual_marks(cx);
         let count = vim.take_count(cx).unwrap_or(1);
+
         vim.update_active_editor(cx, |vim, editor, cx| {
             let text_layout_details = editor.text_layout_details(cx);
             editor.transact(cx, |editor, cx| {

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -155,6 +155,7 @@ fn search_deploy(_: &mut Workspace, _: &buffer_search::Deploy, cx: &mut ViewCont
 fn search_submit(workspace: &mut Workspace, _: &SearchSubmit, cx: &mut ViewContext<Workspace>) {
     let mut motion = None;
     Vim::update(cx, |vim, cx| {
+        vim.store_visual_marks(cx);
         let pane = workspace.active_pane().clone();
         pane.update(cx, |pane, cx| {
             if let Some(search_bar) = pane.toolbar().read(cx).item_of_type::<BufferSearchBar>() {

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -29,6 +29,7 @@ pub(crate) fn register(workspace: &mut Workspace, _: &mut ViewContext<Workspace>
 }
 
 pub fn substitute(vim: &mut Vim, count: Option<usize>, line_mode: bool, cx: &mut WindowContext) {
+    vim.store_visual_marks(cx);
     vim.update_active_editor(cx, |vim, editor, cx| {
         editor.set_clip_at_line_ends(false, cx);
         editor.transact(cx, |editor, cx| {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -391,6 +391,15 @@ impl Vim {
         self.stop_recording();
     }
 
+    // When handling an action, you must create visual marks if you will switch to normal
+    // mode without the default selection behaviour.
+    fn store_visual_marks(&mut self, cx: &mut WindowContext) {
+        let mode = self.state().mode;
+        if mode.is_visual() {
+            create_visual_marks(self, mode, cx);
+        }
+    }
+
     fn switch_mode(&mut self, mode: Mode, leave_selections: bool, cx: &mut WindowContext) {
         let state = self.state();
         let last_mode = state.mode;
@@ -412,12 +421,12 @@ impl Vim {
         // Sync editor settings like clip mode
         self.sync_vim_settings(cx);
 
-        if !mode.is_visual() && last_mode.is_visual() {
-            create_visual_marks(self, last_mode, cx);
-        }
-
         if leave_selections {
             return;
+        }
+
+        if !mode.is_visual() && last_mode.is_visual() {
+            create_visual_marks(self, last_mode, cx);
         }
 
         // Adjust selections

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -5,7 +5,7 @@ use editor::{
     display_map::{DisplaySnapshot, ToDisplayPoint},
     movement,
     scroll::Autoscroll,
-    Bias, DisplayPoint, Editor, ToOffset, ToPoint,
+    Bias, DisplayPoint, Editor, ToOffset,
 };
 use gpui::{actions, ViewContext, WindowContext};
 use language::{Point, Selection, SelectionGoal};
@@ -113,9 +113,6 @@ pub fn register(workspace: &mut Workspace, _: &mut ViewContext<Workspace>) {
                     let ranges = ranges
                         .into_iter()
                         .map(|(start, end, reversed)| {
-                            dbg!(&start.to_point(&map.buffer_snapshot));
-                            dbg!(&end.to_point(&map.buffer_snapshot));
-
                             let new_end =
                                 movement::saturating_right(&map, end.to_display_point(&map));
                             Selection {


### PR DESCRIPTION
Fixes: #13720

Co-Authored-By: <tobbe@tlundberg.com>



Release Notes:

- vim: Fixed `gv` after `y`, `d`, etc. ([#13760](https://github.com/zed-industries/zed/issues/13760)).
