### PR TITLE
elixir: Make `start_lexical.sh` executable

### DIFF
--- a/extensions/elixir/src/language_servers/lexical.rs
+++ b/extensions/elixir/src/language_servers/lexical.rs
@@ -94,6 +94,8 @@ impl Lexical {
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
 
+            zed::make_file_executable(&binary_path)?;
+
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
             for entry in entries {


### PR DESCRIPTION
This PR fixes an issue in the Lexical language server installation where the `start_lexical.sh` script was not being made executable when installed from GitHub.

Release Notes:

- N/A
