### PR TITLE
Fix tooltips sometimes continuously displaying when the button is selected

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1869,6 +1869,11 @@ impl Interactivity {
                 });
             }
 
+            // Ensure to remove active tooltip if tooltip builder is none
+            if self.tooltip_builder.is_none() {
+                element_state.active_tooltip.take();
+            }
+
             if let Some(tooltip_builder) = self.tooltip_builder.take() {
                 let tooltip_is_hoverable = tooltip_builder.hoverable;
                 let active_tooltip = element_state


### PR DESCRIPTION

Release Notes:

- Fixed sometime tooltip will continuously display when the button is selected.

---

@mrnugget The #13857 This change has led into a bug, the selected item before tooltip will continuous display if there are no other tooltips.


https://github.com/user-attachments/assets/06b4a9a4-dede-4c18-b020-e20b6090341f


