### PR TITLE
Add Sign Out link for Supermaven

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -298,7 +298,9 @@ impl InlineCompletionButton {
 
     fn build_supermaven_context_menu(&self, cx: &mut ViewContext<Self>) -> View<ContextMenu> {
         ContextMenu::build(cx, |menu, cx| {
-            self.build_language_settings_menu(menu, cx).separator()
+            self.build_language_settings_menu(menu, cx)
+                .separator()
+                .action("Sign Out", supermaven::SignOut.boxed_clone())
         })
     }
 

--- a/crates/supermaven/src/messages.rs
+++ b/crates/supermaven/src/messages.rs
@@ -14,6 +14,7 @@ pub enum OutboundMessage {
     StateUpdate(StateUpdateMessage),
     #[allow(dead_code)]
     UseFreeVersion,
+    Logout,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -9,7 +9,9 @@ use client::{proto, Client};
 use collections::BTreeMap;
 
 use futures::{channel::mpsc, io::BufReader, AsyncBufReadExt, StreamExt};
-use gpui::{AppContext, AsyncAppContext, EntityId, Global, Model, ModelContext, Task, WeakModel};
+use gpui::{
+    actions, AppContext, AsyncAppContext, EntityId, Global, Model, ModelContext, Task, WeakModel,
+};
 use language::{
     language_settings::all_language_settings, Anchor, Buffer, BufferSnapshot, ToOffset,
 };
@@ -24,6 +26,8 @@ use smol::{
 use std::{path::PathBuf, process::Stdio, sync::Arc};
 use ui::prelude::*;
 use util::ResultExt;
+
+actions!(supermaven, [SignOut]);
 
 pub fn init(client: Arc<Client>, cx: &mut AppContext) {
     let supermaven = cx.new_model(|_| Supermaven::Starting);
@@ -46,6 +50,12 @@ pub fn init(client: Arc<Client>, cx: &mut AppContext) {
         }
     })
     .detach();
+
+    cx.on_action(|_: &SignOut, cx| {
+        if let Some(supermaven) = Supermaven::global(cx) {
+            supermaven.update(cx, |supermaven, _cx| supermaven.sign_out());
+        }
+    });
 }
 
 pub enum Supermaven {
@@ -173,6 +183,19 @@ impl Supermaven {
             )
         } else {
             None
+        }
+    }
+
+    pub fn sign_out(&mut self) {
+        if let Self::Spawned(agent) = self {
+            agent
+                .outgoing_tx
+                .unbounded_send(OutboundMessage::Logout)
+                .ok();
+            // The account status will get set to RequiresActivation or Ready when the next
+            // message from the agent comes in. Until that happens, set the status to Unknown
+            // to disable the button.
+            agent.account_status = AccountStatus::Unknown;
         }
     }
 }


### PR DESCRIPTION
Adds a menu item to sign out from a linked Supermaven account.

![image](https://github.com/user-attachments/assets/6af3c39f-9ca4-4ac2-a5c0-c7cb3c3aaac2)


Release Notes:

- Adds the ability to sign out of a Supermaven account #12715 