### PR TITLE
editor: Implement `From` instead of `Into` for converting `BlockId`s  to `ElementId`s

### DIFF
--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -136,12 +136,12 @@ impl From<BlockId> for EntityId {
     }
 }
 
-impl Into<ElementId> for BlockId {
-    fn into(self) -> ElementId {
-        match self {
-            Self::Custom(CustomBlockId(id)) => ("Block", id).into(),
-            Self::ExcerptHeader(id) => ("ExcerptHeader", EntityId::from(id)).into(),
-            Self::ExcerptFooter(id) => ("ExcerptFooter", EntityId::from(id)).into(),
+impl From<BlockId> for ElementId {
+    fn from(value: BlockId) -> Self {
+        match value {
+            BlockId::Custom(CustomBlockId(id)) => ("Block", id).into(),
+            BlockId::ExcerptHeader(id) => ("ExcerptHeader", EntityId::from(id)).into(),
+            BlockId::ExcerptFooter(id) => ("ExcerptFooter", EntityId::from(id)).into(),
         }
     }
 }


### PR DESCRIPTION
This PR replaces the `Into<ElementId> for BlockId` implementation with `From<BlockId> for ElementId`.

This keeps in line with Rust's guidance for preferring implementing `From`, and gives us more flexibility when converting.

Release Notes:

- N/A
