### PR TITLE
Fix description of -l flag in bundle-mac

### DIFF
--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -24,7 +24,7 @@ Build the application bundle for macOS.
 
 Options:
   -d    Compile in debug mode
-  -l    Compile for local architecture and copy bundle to /Applications.
+  -l    Compile for local architecture only.
   -o    Open dir with the resulting DMG or launch the app itself in local mode.
   -i    Install the resulting DMG into /Applications in local mode. Noop without -l.
   -h    Display this help and exit.


### PR DESCRIPTION
This removes mention of "copy bundle to `/Applications`" from the help text for `bundle-mac` because, as far as I can tell, the `-l` flag only controls the build, not the copy/install. (The copy/install is controlled by using the `-i` flag in conjunction with `-l`.)


Release Notes:

- N/A
