### PR TITLE
linux: Fix wrong names reported by `all_font_names`

### DIFF
--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -4,7 +4,7 @@ use crate::{
     ShapedGlyph, SharedString, Size,
 };
 use anyhow::{anyhow, Context, Ok, Result};
-use collections::HashMap;
+use collections::{BTreeSet, HashMap};
 use cosmic_text::{
     Attrs, AttrsList, CacheKey, Family, Font as CosmicTextFont, FontSystem, ShapeBuffer, ShapeLine,
     SwashCache,
@@ -64,16 +64,15 @@ impl PlatformTextSystem for CosmicTextSystem {
     }
 
     fn all_font_names(&self) -> Vec<String> {
-        let ret = self
-            .0
+        self.0
             .read()
             .font_system
             .db()
             .faces()
             .filter_map(|face| face.families.first().map(|family| family.0.clone()))
-            .collect_vec();
-        println!("{:#?}", ret);
-        ret
+            .collect::<BTreeSet<String>>()
+            .into_iter()
+            .collect_vec()
     }
 
     fn all_font_families(&self) -> Vec<String> {

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -64,13 +64,16 @@ impl PlatformTextSystem for CosmicTextSystem {
     }
 
     fn all_font_names(&self) -> Vec<String> {
-        self.0
+        let ret = self
+            .0
             .read()
             .font_system
             .db()
             .faces()
-            .map(|face| face.post_script_name.clone())
-            .collect()
+            .filter_map(|face| face.families.first().map(|family| family.0.clone()))
+            .collect_vec();
+        println!("{:#?}", ret);
+        ret
     }
 
     fn all_font_families(&self) -> Vec<String> {

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -4,7 +4,7 @@ use crate::{
     ShapedGlyph, SharedString, Size,
 };
 use anyhow::{anyhow, Context, Ok, Result};
-use collections::{BTreeSet, HashMap};
+use collections::HashMap;
 use cosmic_text::{
     Attrs, AttrsList, CacheKey, Family, Font as CosmicTextFont, FontSystem, ShapeBuffer, ShapeLine,
     SwashCache,
@@ -64,15 +64,17 @@ impl PlatformTextSystem for CosmicTextSystem {
     }
 
     fn all_font_names(&self) -> Vec<String> {
-        self.0
+        let mut result = self
+            .0
             .read()
             .font_system
             .db()
             .faces()
             .filter_map(|face| face.families.first().map(|family| family.0.clone()))
-            .collect::<BTreeSet<String>>()
-            .into_iter()
-            .collect_vec()
+            .collect_vec();
+        result.sort();
+        result.dedup();
+        result
     }
 
     fn all_font_families(&self) -> Vec<String> {


### PR DESCRIPTION
The names suggested by `buffer_font_family` are reported by `all_font_names`. Therefore, `all_font_names` should report family names rather than postscript names.

close #14854 

Release Notes:

- N/A
