### PR TITLE
repl: Ensure that the output's computed line height is at least 1

### DIFF
--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -553,9 +553,10 @@ impl LineHeight for ExecutionView {
         self.outputs
             .iter()
             .map(|output| output.num_lines(cx))
-            .fold(0, |acc, additional_height| {
+            .fold(0_u8, |acc, additional_height| {
                 acc.saturating_add(additional_height)
             })
+            .max(1)
     }
 }
 

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -88,7 +88,7 @@ impl TerminalOutput {
 
 impl LineHeight for TerminalOutput {
     fn num_lines(&self, _cx: &mut WindowContext) -> u8 {
-        self.handler.buffer.lines().count() as u8
+        self.handler.buffer.lines().count().max(1) as u8
     }
 }
 


### PR DESCRIPTION
In an edge case where a `text/plain` output is an empty string, the line length would be zero, causing a bad render. We have to ensure it's at least 1 line tall so the padding etc. doesn't overlap other lines.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/9a39b408-bd5e-4568-9cea-d9e4603f93d3" width="460px"></td>
    <td><img src="https://github.com/user-attachments/assets/0f17df1f-892e-4e42-ab92-623342ce306e" width="460px">
</td>
  </tr>
</table>

Release Notes:

- N/A
