### PR TITLE
repl: Increase accuracy of error output line height

### DIFF
--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -281,7 +281,7 @@ impl ErrorView {
             v_flex()
                 .w_full()
                 .bg(colors.background)
-                .p_4()
+                .py(cx.line_height() / 2.)
                 .border_l_1()
                 .border_color(theme.status().error_border)
                 .child(
@@ -297,7 +297,7 @@ impl ErrorView {
 
 impl LineHeight for ErrorView {
     fn num_lines(&self, cx: &mut WindowContext) -> u8 {
-        let mut height: u8 = 0;
+        let mut height: u8 = 1; // Start at 1 to account for the y padding
         height = height.saturating_add(self.ename.lines().count() as u8);
         height = height.saturating_add(self.evalue.lines().count() as u8);
         height = height.saturating_add(self.traceback.num_lines(cx));

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -219,7 +219,7 @@ impl Perform for TerminalHandler {
             }
             _ => {
                 // Format as hex
-                println!("[execute] byte={:02x}", byte);
+                // println!("[execute] byte={:02x}", byte);
             }
         }
     }

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -78,7 +78,14 @@ impl TerminalOutput {
             })
             .collect::<Vec<TextRun>>();
 
-        let text = StyledText::new(self.handler.buffer.trim_end().to_string()).with_runs(runs);
+        // Trim the last trailing newline for visual appeal
+        let trimmed = self
+            .handler
+            .buffer
+            .strip_suffix('\n')
+            .unwrap_or(&self.handler.buffer);
+
+        let text = StyledText::new(trimmed.to_string()).with_runs(runs);
         div()
             .font_family(buffer_font)
             .child(text)


### PR DESCRIPTION
More accurate line count for errors by making the vertical padding correspond to `line_height / 2`.

Release Notes:

- N/A
