### PR TITLE
Add button to copy SHA from Git blame

### DIFF
--- a/crates/editor/src/blame_entry_tooltip.rs
+++ b/crates/editor/src/blame_entry_tooltip.rs
@@ -7,14 +7,9 @@ use gpui::{
 };
 use settings::Settings;
 use std::hash::Hash;
-use theme::{ActiveTheme, ThemeSettings};
+use theme::ThemeSettings;
 use time::UtcOffset;
-use ui::{
-    div, h_flex, tooltip_container, v_flex, Avatar, Button, ButtonStyle, Clickable as _, Color,
-    FluentBuilder, Icon, IconButton, IconName, IconPosition, InteractiveElement as _, IntoElement,
-    Selectable, SelectableButton, SharedString, Styled as _, ViewContext,
-};
-use ui::{ButtonCommon, Disableable as _};
+use ui::{prelude::*, tooltip_container, Avatar};
 use workspace::Workspace;
 
 use crate::git::blame::{CommitDetails, GitRemote};
@@ -131,9 +126,6 @@ impl Render for BlameEntryTooltip {
 
         let short_commit_id = self.blame_entry.sha.display_short();
         let full_sha = self.blame_entry.sha.to_string().clone();
-        let sha_copied = cx
-            .read_from_clipboard()
-            .map_or(false, |clipboard| clipboard.text() == &full_sha);
         let absolute_timestamp = blame_entry_absolute_timestamp(&self.blame_entry);
 
         let message = self
@@ -253,12 +245,7 @@ impl Render for BlameEntryTooltip {
                                                     cx.write_to_clipboard(ClipboardItem::new(
                                                         full_sha.clone(),
                                                     ))
-                                                })
-                                                .selected_icon(IconName::Check)
-                                                .selected_style(ButtonStyle::Tinted(
-                                                    ui::TintColor::Accent,
-                                                ))
-                                                .selected(sha_copied),
+                                                }),
                                         ),
                                 ),
                         ),


### PR DESCRIPTION
The git blame dialog doesn't give the user a way to quickly copy the SHA of the associated commit for a line. Adding an option for users to quickly access this SHA is helpful for user's to do any more git-fu they might need, such as viewing the full changes themselves within git, checking the commit out, bisecting off the commit, etc.

This is also very handy for user's of self-hosted git providers. Determining what provider a self-hosted repository is using could be quite difficult and this presents an easy option to allow users to look up more about a commit without having to memorize the short SHA.

Release Notes:

- Added a button to copy the SHA from a Git blame entry.

<img width="1552" alt="A screenshot showing the new copy SHA button within the Zed editor's inline blame " src="https://github.com/user-attachments/assets/9365950d-3a3f-4c11-b119-ab02654f5669">