### PR TITLE
theme_importer: Output logs to `stderr`

### DIFF
--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> Result<()> {
     TermLogger::init(
         LevelFilter::Trace,
         log_config,
-        TerminalMode::Mixed,
+        TerminalMode::Stderr,
         ColorChoice::Auto,
     )
     .expect("could not initialize logger");


### PR DESCRIPTION
Will allow writing directly to a file without logging via `cargo run -p theme_importer -- /path/to/file`

Release Notes:

- N/A
