### PR TITLE
windows: Fix extensions report wrong path

### DIFF
--- a/crates/extension/src/extension_lsp_adapter.rs
+++ b/crates/extension/src/extension_lsp_adapter.rs
@@ -92,7 +92,15 @@ impl LspAdapter for ExtensionLspAdapter {
                 }
             }
 
-            Ok(LanguageServerBinary {
+            #[cfg(not(target_os = "windows"))]
+            return Ok(LanguageServerBinary {
+                path,
+                arguments: command.args.into_iter().map(|arg| arg.into()).collect(),
+                env: Some(command.env.into_iter().collect()),
+            });
+
+            #[cfg(target_os = "windows")]
+            return Ok(LanguageServerBinary {
                 path,
                 arguments: command
                     .args
@@ -106,7 +114,7 @@ impl LspAdapter for ExtensionLspAdapter {
                     })
                     .collect(),
                 env: Some(command.env.into_iter().collect()),
-            })
+            });
         }
         .boxed_local()
     }

--- a/crates/extension/src/extension_lsp_adapter.rs
+++ b/crates/extension/src/extension_lsp_adapter.rs
@@ -94,7 +94,17 @@ impl LspAdapter for ExtensionLspAdapter {
 
             Ok(LanguageServerBinary {
                 path,
-                arguments: command.args.into_iter().map(|arg| arg.into()).collect(),
+                arguments: command
+                    .args
+                    .into_iter()
+                    .map(|arg| {
+                        if let Some(arg) = arg.strip_prefix('/') {
+                            arg.into()
+                        } else {
+                            arg.into()
+                        }
+                    })
+                    .collect(),
                 env: Some(command.env.into_iter().collect()),
             })
         }


### PR DESCRIPTION
Partially fix #12013 

The issue is that in a WASM environment, `std::env::current_dir()` will **ALWAYS** return a path prefixed with `/`.

For example, with the `purescript` extension:
```rust
env::current_dir()
    .unwrap()
    .join(&server_path)
    .to_string_lossy()
    .to_string()
```
it produces something like: "/C:\\Users\\...\\...". See:

![Screenshot 2024-07-21 154738](https://github.com/user-attachments/assets/eaa801d2-fbb0-4bf3-86cc-7b0f4cb22815)


With this fix, most extensions should work properly. For example, extension `Dockerfile` can work properly now:

![Screenshot 2024-07-21 155407](https://github.com/user-attachments/assets/968effe3-8797-4af2-b0c8-f4699df54ba4)


Release Notes:

- N/A
