### PR TITLE
Properly report the current dir

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -4,7 +4,9 @@
 pub mod settings;
 
 use core::fmt;
+use std::path::PathBuf;
 
+use serde::de::IntoDeserializer;
 use wit::*;
 
 pub use serde_json;
@@ -56,6 +58,17 @@ pub fn set_language_server_installation_status(
     status: &LanguageServerInstallationStatus,
 ) {
     wit::set_language_server_installation_status(&language_server_id.0, status)
+}
+
+pub fn current_dir() -> std::io::Result<PathBuf> {
+    let dir_string = std::env::current_dir()?.to_string_lossy().to_string();
+    println!("--> {}", dir_string);
+    if let Some(x) = dir_string.strip_prefix('/') {
+        println!("--> x: {}", x);
+        Ok(x.into())
+    } else {
+        Ok(dir_string.into())
+    }
 }
 
 /// A Zed extension.

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -60,14 +60,20 @@ pub fn set_language_server_installation_status(
     wit::set_language_server_installation_status(&language_server_id.0, status)
 }
 
+/// Properly retrieve the current dir
 pub fn current_dir() -> std::io::Result<PathBuf> {
-    let dir_string = std::env::current_dir()?.to_string_lossy().to_string();
-    println!("--> {}", dir_string);
-    if let Some(x) = dir_string.strip_prefix('/') {
-        println!("--> x: {}", x);
-        Ok(x.into())
-    } else {
-        Ok(dir_string.into())
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::env::current_dir()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let dir_string = std::env::current_dir()?.to_string_lossy().to_string();
+        if let Some(result) = dir_string.strip_prefix('/') {
+            Ok(result.into())
+        } else {
+            Ok(dir_string.into())
+        }
     }
 }
 

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -6,7 +6,6 @@ pub mod settings;
 use core::fmt;
 use std::path::PathBuf;
 
-use serde::de::IntoDeserializer;
 use wit::*;
 
 pub use serde_json;


### PR DESCRIPTION
Extensions should use `zed::current_dir` instead of `std::env::current_dir`. We may need to update all extensions to use this new funcion.

Release Notes:

- N/A
