### PR TITLE
http: Refactor construction of HTTP clients with a proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5315,6 +5315,7 @@ name = "http"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "derive_more",
  "futures 0.3.28",
  "futures-lite 1.13.0",
  "isahc",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -17,6 +17,7 @@ doctest = true
 
 [dependencies]
 anyhow.workspace = true
+derive_more.workspace = true
 futures.workspace = true
 isahc.workspace = true
 log.workspace = true

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -269,7 +269,16 @@ impl NodeRuntime for RealNodeRuntime {
             }
 
             if let Some(proxy) = self.http.proxy() {
-                command.args(["--proxy", proxy]);
+                // Map proxy settings from `http://localhost:10809` to `http://127.0.0.1:10809`
+                // NodeRuntime without environment information can not parse `localhost`
+                // correctly.
+                // TODO: map to `[::1]` if we are using ipv6
+                let proxy = proxy
+                    .to_string()
+                    .to_ascii_lowercase()
+                    .replace("localhost", "127.0.0.1");
+
+                command.args(["--proxy", &proxy]);
             }
 
             #[cfg(windows)]


### PR DESCRIPTION
This PR refactors the `http` crate to expose a better way of constructing an `HttpClient` that contains a proxy.

Release Notes:

- N/A
