### PR TITLE
erlang: Upgrade `zed_extension_api` to v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13910,7 +13910,7 @@ dependencies = [
 name = "zed_erlang"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.4",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/extensions/erlang/Cargo.toml
+++ b/extensions/erlang/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/erlang.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"

--- a/extensions/erlang/src/erlang.rs
+++ b/extensions/erlang/src/erlang.rs
@@ -9,7 +9,7 @@ impl zed::Extension for ErlangExtension {
 
     fn language_server_command(
         &mut self,
-        _config: zed::LanguageServerConfig,
+        _language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let path = worktree


### PR DESCRIPTION
This PR upgrades the Erlang extension to use v0.0.6 of the `zed_extension_api`.

Release Notes:

- N/A
