### PR TITLE
Treat `tsconfig.json` as JSONC

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -705,7 +705,7 @@
   //
   "file_types": {
     "JSON": ["flake.lock"],
-    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json"]
+    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "tsconfig.json"]
   },
   // The extensions that Zed should automatically install on startup.
   //


### PR DESCRIPTION
This PR updates the default settings to treat `tsconfig.json` files as JSONC.

Resolves https://github.com/zed-industries/zed/issues/14906.

Release Notes:

- TypeScript's `tsconfig.json` files are now treated as JSONC.
