### PR TITLE
assistant: Respect `ui_font_weight` setting for inline assist in the terminal

### DIFF
--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -13,8 +13,8 @@ use editor::{
 use fs::Fs;
 use futures::{channel::mpsc, SinkExt, StreamExt};
 use gpui::{
-    AppContext, Context, EventEmitter, FocusHandle, FocusableView, FontWeight, Global, Model,
-    ModelContext, Subscription, Task, TextStyle, UpdateGlobal, View, WeakView,
+    AppContext, Context, EventEmitter, FocusHandle, FocusableView, Global, Model, ModelContext,
+    Subscription, Task, TextStyle, UpdateGlobal, View, WeakView,
 };
 use language::Buffer;
 use language_model::{LanguageModelRequest, LanguageModelRequestMessage, Role};
@@ -945,7 +945,7 @@ impl PromptEditor {
             font_family: settings.ui_font.family.clone(),
             font_features: settings.ui_font.features.clone(),
             font_size: rems(0.875).into(),
-            font_weight: FontWeight::NORMAL,
+            font_weight: settings.ui_font.weight.clone(),
             line_height: relative(1.3),
             ..Default::default()
         };

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -945,7 +945,7 @@ impl PromptEditor {
             font_family: settings.ui_font.family.clone(),
             font_features: settings.ui_font.features.clone(),
             font_size: rems(0.875).into(),
-            font_weight: settings.ui_font.weight.clone(),
+            font_weight: settings.ui_font.weight,
             line_height: relative(1.3),
             ..Default::default()
         };


### PR DESCRIPTION
This PR updates the terminal inline assist to respect the `ui_font_weight` setting.

Release Notes:

- N/A
