### PR TITLE
Change Sublime Text `ctrl+shift+up` & `ctrl+shift+down`  keybinds to move lines

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -12,8 +12,8 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-up": "editor::AddSelectionAbove",
-      "ctrl-shift-down": "editor::AddSelectionBelow",
+      "ctrl-shift-up": "editor::MoveLineUp",
+      "ctrl-shift-down": "editor::MoveLineDown",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-l": "editor::SplitSelectionIntoLines",
       "ctrl-shift-a": "editor::SelectLargerSyntaxNode",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -12,8 +12,8 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-up": "editor::AddSelectionAbove",
-      "ctrl-shift-down": "editor::AddSelectionBelow",
+      "ctrl-shift-up": "editor::MoveLineUp",
+      "ctrl-shift-down": "editor::MoveLineDown",
       "cmd-shift-space": "editor::SelectAll",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",


### PR DESCRIPTION
# Release Notes:

- Improved sublime_text.json (Linux & Mac) for `"base_keymap": "SublimeText"`, CTRL+SHIFT+UP now moves line selection upwards. CTRL+SHIFT+DOWN now moves line selection downwards.

After ~8 years of being a regular Sublime Text user this is a wildly useful keybind to get around a "cut & paste" operation while also saving a clipboard slot. Zed is now looking to be my replacement text editor.

![Screenshot_20240721_124805](https://github.com/user-attachments/assets/f909ee39-1b2a-4fbb-b171-11689369f9e0)
