### PR TITLE
Multiple blade backends (Vulkan/Metal or GLES)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,11 +1652,12 @@ dependencies = [
 [[package]]
 name = "blade-graphics"
 version = "0.4.0"
-source = "git+https://github.com/zed-industries/blade?rev=a477c2008db27db0b9f745715e119b3ee7ab7818#a477c2008db27db0b9f745715e119b3ee7ab7818"
+source = "git+https://github.com/lukaslihotzki/blade?branch=multi-backend#01be6eff07d7c22441c84003fd06a4eea232c39b"
 dependencies = [
  "ash",
  "ash-window",
  "bitflags 2.6.0",
+ "blade-macros",
  "block",
  "bytemuck",
  "codespan-reporting",
@@ -1669,7 +1670,7 @@ dependencies = [
  "khronos-egl",
  "libloading 0.8.0",
  "log",
- "metal",
+ "metal 0.29.0",
  "mint",
  "naga",
  "objc",
@@ -1682,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "blade-macros"
 version = "0.2.1"
-source = "git+https://github.com/zed-industries/blade?rev=a477c2008db27db0b9f745715e119b3ee7ab7818#a477c2008db27db0b9f745715e119b3ee7ab7818"
+source = "git+https://github.com/lukaslihotzki/blade?branch=multi-backend#01be6eff07d7c22441c84003fd06a4eea232c39b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1692,7 +1693,7 @@ dependencies = [
 [[package]]
 name = "blade-util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/blade?rev=a477c2008db27db0b9f745715e119b3ee7ab7818#a477c2008db27db0b9f745715e119b3ee7ab7818"
+source = "git+https://github.com/lukaslihotzki/blade?branch=multi-backend#01be6eff07d7c22441c84003fd06a4eea232c39b"
 dependencies = [
  "blade-graphics",
  "bytemuck",
@@ -4915,7 +4916,6 @@ dependencies = [
  "backtrace",
  "bindgen 0.65.1",
  "blade-graphics",
- "blade-macros",
  "blade-util",
  "block",
  "bytemuck",
@@ -4946,7 +4946,7 @@ dependencies = [
  "linkme",
  "log",
  "media",
- "metal",
+ "metal 0.25.0",
  "num_cpus",
  "objc",
  "oo7",
@@ -6596,7 +6596,7 @@ dependencies = [
  "bindgen 0.65.1",
  "core-foundation",
  "foreign-types 0.5.0",
- "metal",
+ "metal 0.25.0",
  "objc",
 ]
 
@@ -6648,6 +6648,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "550b24b0cd4cf923f36bae78eca457b3a10d8a6a14a9c84cb2687b527e6a84af"
 dependencies = [
  "bitflags 1.3.2",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.6.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -6748,8 +6763,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "naga"
-version = "0.20.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=425526828f738c95ec50b016c6a761bc00d2fb25#425526828f738c95ec50b016c6a761bc00d2fb25"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09eeccb9b50f4f7839b214aa3e08be467159506a986c18e0702170ccf720a453"
 dependencies = [
  "arrayvec",
  "bit-set 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,9 +295,8 @@ async-watch = "0.3.1"
 async_zip = { version = "0.0.17", features = ["deflate", "deflate64"] }
 base64 = "0.13"
 bitflags = "2.6.0"
-blade-graphics = { git = "https://github.com/zed-industries/blade", rev = "a477c2008db27db0b9f745715e119b3ee7ab7818" }
-blade-macros = { git = "https://github.com/zed-industries/blade", rev = "a477c2008db27db0b9f745715e119b3ee7ab7818" }
-blade-util = { git = "https://github.com/zed-industries/blade", rev = "a477c2008db27db0b9f745715e119b3ee7ab7818" }
+blade-graphics = { git = "https://github.com/lukaslihotzki/blade", branch = "multi-backend" }
+blade-util = { git = "https://github.com/lukaslihotzki/blade", branch = "multi-backend" }
 cap-std = "3.0"
 cargo_toml = "0.20"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -19,7 +19,7 @@ test-support = [
     "http/test-support",
 ]
 runtime_shaders = []
-macos-blade = ["blade-graphics", "blade-macros", "blade-util", "bytemuck"]
+macos-blade = ["blade-graphics", "blade-util", "bytemuck"]
 
 [lib]
 path = "src/gpui.rs"
@@ -29,8 +29,7 @@ doctest = false
 anyhow.workspace = true
 async-task = "4.7"
 backtrace = { version = "0.3", optional = true }
-blade-graphics = { workspace = true, optional = true }
-blade-macros = { workspace = true, optional = true }
+blade-graphics = { workspace = true, features = ["derive", "gles"], optional = true }
 blade-util = { workspace = true, optional = true }
 bytemuck = { version = "1", optional = true }
 collections.workspace = true
@@ -104,7 +103,7 @@ objc = "0.2"
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 flume = "0.11"
 blade-graphics.workspace = true
-blade-macros.workspace = true
+blade-graphics.features = ["derive", "gles"]
 blade-util.workspace = true
 bytemuck = "1"
 cosmic-text = { git = "https://github.com/pop-os/cosmic-text", rev = "542b20c" }

--- a/crates/gpui/src/platform/blade.rs
+++ b/crates/gpui/src/platform/blade.rs
@@ -1,5 +1,79 @@
-mod blade_atlas;
-mod blade_renderer;
+mod blade_gles;
+mod blade_hal;
 
-pub(crate) use blade_atlas::*;
-pub(crate) use blade_renderer::*;
+use crate::{Bounds, DevicePixels, PlatformAtlas, Point, Size};
+use blade_graphics as gpu;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+
+use std::sync::Arc;
+
+pub trait BladeRenderer {
+    fn update_drawable_size(&mut self, size: Size<DevicePixels>);
+    fn update_transparency(&mut self, transparent: bool);
+    fn viewport_size(&self) -> gpu::Extent;
+    fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
+
+    #[cfg(target_os = "macos")]
+    fn layer(&self) -> metal::MetalLayer;
+
+    #[cfg(target_os = "macos")]
+    fn layer_ptr(&self) -> *mut metal::CAMetalLayer;
+
+    fn destroy(&mut self);
+    fn draw(&mut self, scene: &crate::Scene);
+}
+
+pub fn new_renderer<W: HasWindowHandle + HasDisplayHandle>(
+    raw: &W,
+    config: BladeSurfaceConfig,
+) -> anyhow::Result<Box<dyn BladeRenderer>> {
+    Ok(
+        if std::env::var("USE_GLES")
+            .ok()
+            .filter(|t| !t.is_empty())
+            .is_some()
+        {
+            Box::new(blade_gles::BladeRenderer::new_from_window(raw, config)?)
+        } else {
+            Box::new(blade_hal::BladeRenderer::new_from_window(raw, config)?)
+        },
+    )
+}
+
+pub struct BladeSurfaceConfig {
+    pub size: gpu::Extent,
+    pub transparent: bool,
+}
+
+impl From<Size<DevicePixels>> for etagere::Size {
+    fn from(size: Size<DevicePixels>) -> Self {
+        etagere::Size::new(size.width.into(), size.height.into())
+    }
+}
+
+impl From<etagere::Point> for Point<DevicePixels> {
+    fn from(value: etagere::Point) -> Self {
+        Point {
+            x: DevicePixels::from(value.x),
+            y: DevicePixels::from(value.y),
+        }
+    }
+}
+
+impl From<etagere::Size> for Size<DevicePixels> {
+    fn from(size: etagere::Size) -> Self {
+        Size {
+            width: DevicePixels::from(size.width),
+            height: DevicePixels::from(size.height),
+        }
+    }
+}
+
+impl From<etagere::Rectangle> for Bounds<DevicePixels> {
+    fn from(rectangle: etagere::Rectangle) -> Self {
+        Bounds {
+            origin: rectangle.min.into(),
+            size: rectangle.size().into(),
+        }
+    }
+}

--- a/crates/gpui/src/platform/blade/blade_gles.rs
+++ b/crates/gpui/src/platform/blade/blade_gles.rs
@@ -1,0 +1,12 @@
+pub(crate) use blade_graphics::gles as hal;
+
+#[path = "blade_atlas.rs"]
+mod blade_atlas;
+
+#[path = "blade_renderer.rs"]
+mod blade_renderer;
+
+unsafe impl Send for blade_atlas::BladeAtlasState {}
+
+pub(crate) use blade_atlas::*;
+pub(crate) use blade_renderer::*;

--- a/crates/gpui/src/platform/blade/blade_hal.rs
+++ b/crates/gpui/src/platform/blade/blade_hal.rs
@@ -1,0 +1,10 @@
+pub(crate) use blade_graphics::hal;
+
+#[path = "blade_atlas.rs"]
+mod blade_atlas;
+
+#[path = "blade_renderer.rs"]
+mod blade_renderer;
+
+pub(crate) use blade_atlas::*;
+pub(crate) use blade_renderer::*;


### PR DESCRIPTION
This adds multiple blade backends to zed. Vulkan or Metal is used by default. The environment variable `USE_GLES=1` can be set to switch to GLES. This depends on https://github.com/kvark/blade/pull/148.

The implementation uses a file-based polymorphism approach, where the same file is included twice in the default and gles module by using the same `path` attribute. This approach was chosen, because blade does not expose everything as traits. Both backends expose a `dyn BladeRenderer` trait object, so there is little performance overhead, basically just one indirection on every draw scene call.