### PR TITLE
windows: Treat `settings.json` as JSONC

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -136,7 +136,14 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.cert",
+    "**/*.crt",
+    "**/secrets.yml"
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -705,7 +712,12 @@
   //
   "file_types": {
     "JSON": ["flake.lock"],
-    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "tsconfig.json"]
+    "JSONC": [
+      "**/.zed/**/*.json",
+      "**/zed/**/*.json",
+      "tsconfig.json",
+      "**/Zed/**/*.json"
+    ]
   },
   // The extensions that Zed should automatically install on startup.
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -136,14 +136,7 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": [
-    "**/.env*",
-    "**/*.pem",
-    "**/*.key",
-    "**/*.cert",
-    "**/*.crt",
-    "**/secrets.yml"
-  ],
+  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -712,12 +705,7 @@
   //
   "file_types": {
     "JSON": ["flake.lock"],
-    "JSONC": [
-      "**/.zed/**/*.json",
-      "**/zed/**/*.json",
-      "**/Zed/**/*.json",
-      "tsconfig.json"
-    ]
+    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json", "tsconfig.json"]
   },
   // The extensions that Zed should automatically install on startup.
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -715,8 +715,8 @@
     "JSONC": [
       "**/.zed/**/*.json",
       "**/zed/**/*.json",
-      "tsconfig.json",
-      "**/Zed/**/*.json"
+      "**/Zed/**/*.json",
+      "tsconfig.json"
     ]
   },
   // The extensions that Zed should automatically install on startup.


### PR DESCRIPTION
Before this PR, comments in `settings.json` are marked with red lines, indicating that `"comments are not allowed in JSON."`

![Screenshot 2024-07-22 153951](https://github.com/user-attachments/assets/fbb631e8-43cf-4473-97c0-50c83c4d6ab1)


After this PR, this issue is resolved.

![Screenshot 2024-07-22 153527](https://github.com/user-attachments/assets/ee0f7877-c623-4caa-94cd-97e82f9b8945)

Release Notes:

- N/A
