### PR TITLE
Allow to input spaces in the outline panel filter input

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -457,7 +457,9 @@ impl OutlinePanel {
     }
 
     fn open(&mut self, _: &Open, cx: &mut ViewContext<Self>) {
-        if let Some(selected_entry) = self.selected_entry.clone() {
+        if self.filter_editor.focus_handle(cx).is_focused(cx) {
+            cx.propagate()
+        } else if let Some(selected_entry) = self.selected_entry.clone() {
             self.open_entry(&selected_entry, cx);
         }
     }


### PR DESCRIPTION

Release Notes:

- Fixed outline panel's filter not accepting spaces