### PR TITLE
lsp: Pass back diagnostic .data when querying code actions for it

### DIFF
--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -954,6 +954,7 @@ fn random_diagnostic(
             is_primary,
             is_disk_based: false,
             is_unnecessary: false,
+            data: None,
         },
     }
 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -27,6 +27,7 @@ use gpui::{
 use lazy_static::lazy_static;
 use lsp::LanguageServerId;
 use parking_lot::Mutex;
+use serde_json::Value;
 use similar::{ChangeTag, TextDiff};
 use smallvec::SmallVec;
 use smol::future::yield_now;
@@ -213,6 +214,8 @@ pub struct Diagnostic {
     pub is_disk_based: bool,
     /// Whether this diagnostic marks unnecessary code.
     pub is_unnecessary: bool,
+    /// Data from language server that produced this diagnostic. Passed back to the LS when we request code actions for this diagnostic.
+    pub data: Option<Value>,
 }
 
 /// TODO - move this into the `project` crate and make it private.
@@ -3844,6 +3847,7 @@ impl Default for Diagnostic {
             is_primary: false,
             is_disk_based: false,
             is_unnecessary: false,
+            data: None,
         }
     }
 }

--- a/crates/language/src/diagnostic_set.rs
+++ b/crates/language/src/diagnostic_set.rs
@@ -69,6 +69,7 @@ impl DiagnosticEntry<PointUtf16> {
             severity: Some(self.diagnostic.severity),
             source: self.diagnostic.source.clone(),
             message: self.diagnostic.message.clone(),
+            data: self.diagnostic.data.clone(),
             ..Default::default()
         }
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4595,6 +4595,7 @@ impl Project {
                         is_primary: true,
                         is_disk_based,
                         is_unnecessary,
+                        data: diagnostic.data.clone(),
                     },
                 });
                 if let Some(infos) = &diagnostic.related_information {
@@ -4612,6 +4613,7 @@ impl Project {
                                     is_primary: false,
                                     is_disk_based,
                                     is_unnecessary: false,
+                                    data: diagnostic.data.clone(),
                                 },
                             });
                         }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -1890,6 +1890,7 @@ message Diagnostic {
         Information = 3;
         Hint = 4;
     }
+    optional string data = 12;
 }
 
 message Operation {


### PR DESCRIPTION
Per the LSP spec, we should pass .data field of diagnostics into code action request:
```
	/**
	 * A data entry field that is preserved between a
	 * `textDocument/publishDiagnostics` notification and
	 * `textDocument/codeAction` request. *
	 * @since 3.16.0 */ data?: LSPAny;
```


Release Notes:

- Fixed rare cases where a code action triggered by diagnostic may not be available for use.
