### PR TITLE
Allow to regenerate a summary of the assistant context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,6 @@ dependencies = [
  "assets",
  "assistant_slash_command",
  "async-watch",
- "breadcrumbs",
  "cargo_toml",
  "chrono",
  "client",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -26,7 +26,6 @@ anyhow.workspace = true
 assets.workspace = true
 assistant_slash_command.workspace = true
 async-watch.workspace = true
-breadcrumbs.workspace = true
 cargo_toml.workspace = true
 chrono.workspace = true
 client.workspace = true


### PR DESCRIPTION
Both manual and LLM-through ways are supported:

https://github.com/user-attachments/assets/afb0d2b3-9a9b-4f78-a909-1e663e686323


Release Notes:

- Improved assistant panel summarization usability