### PR TITLE
repl: Factor out `ReplStore`

### DIFF
--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -29,7 +29,7 @@ pub struct KernelSpecification {
 
 impl KernelSpecification {
     #[must_use]
-    fn command(&self, connection_path: &PathBuf) -> anyhow::Result<Command> {
+    fn command(&self, connection_path: &PathBuf) -> Result<Command> {
         let argv = &self.kernelspec.argv;
 
         anyhow::ensure!(!argv.is_empty(), "Empty argv in kernelspec {}", self.name);
@@ -60,7 +60,7 @@ impl KernelSpecification {
 
 // Find a set of open ports. This creates a listener with port set to 0. The listener will be closed at the end when it goes out of scope.
 // There's a race condition between closing the ports and usage by a kernel, but it's inherent to the Jupyter protocol.
-async fn peek_ports(ip: IpAddr) -> anyhow::Result<[u16; 5]> {
+async fn peek_ports(ip: IpAddr) -> Result<[u16; 5]> {
     let mut addr_zeroport: SocketAddr = SocketAddr::new(ip, 0);
     addr_zeroport.set_port(0);
     let mut ports: [u16; 5] = [0; 5];
@@ -166,10 +166,10 @@ impl Kernel {
 
 pub struct RunningKernel {
     pub process: smol::process::Child,
-    _shell_task: Task<anyhow::Result<()>>,
-    _iopub_task: Task<anyhow::Result<()>>,
-    _control_task: Task<anyhow::Result<()>>,
-    _routing_task: Task<anyhow::Result<()>>,
+    _shell_task: Task<Result<()>>,
+    _iopub_task: Task<Result<()>>,
+    _control_task: Task<Result<()>>,
+    _routing_task: Task<Result<()>>,
     connection_path: PathBuf,
     pub working_directory: PathBuf,
     pub request_tx: mpsc::Sender<JupyterMessage>,
@@ -194,7 +194,7 @@ impl RunningKernel {
         working_directory: PathBuf,
         fs: Arc<dyn Fs>,
         cx: &mut AppContext,
-    ) -> Task<anyhow::Result<(Self, JupyterMessageChannel)>> {
+    ) -> Task<Result<(Self, JupyterMessageChannel)>> {
         cx.spawn(|cx| async move {
             let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
             let ports = peek_ports(ip).await?;
@@ -332,7 +332,7 @@ async fn read_kernelspec_at(
     // /usr/local/share/jupyter/kernels/python3
     kernel_dir: PathBuf,
     fs: &dyn Fs,
-) -> anyhow::Result<KernelSpecification> {
+) -> Result<KernelSpecification> {
     let path = kernel_dir;
     let kernel_name = if let Some(kernel_name) = path.file_name() {
         kernel_name.to_string_lossy().to_string()
@@ -356,7 +356,7 @@ async fn read_kernelspec_at(
 }
 
 /// Read a directory of kernelspec directories
-async fn read_kernels_dir(path: PathBuf, fs: &dyn Fs) -> anyhow::Result<Vec<KernelSpecification>> {
+async fn read_kernels_dir(path: PathBuf, fs: &dyn Fs) -> Result<Vec<KernelSpecification>> {
     let mut kernelspec_dirs = fs.read_dir(&path).await?;
 
     let mut valid_kernelspecs = Vec::new();
@@ -376,7 +376,7 @@ async fn read_kernels_dir(path: PathBuf, fs: &dyn Fs) -> anyhow::Result<Vec<Kern
     Ok(valid_kernelspecs)
 }
 
-pub async fn kernel_specifications(fs: Arc<dyn Fs>) -> anyhow::Result<Vec<KernelSpecification>> {
+pub async fn kernel_specifications(fs: Arc<dyn Fs>) -> Result<Vec<KernelSpecification>> {
     let data_dirs = dirs::data_dirs();
     let kernel_dirs = data_dirs
         .iter()

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -48,6 +48,7 @@ fn zed_dispatcher(cx: &mut AppContext) -> impl Dispatcher {
 pub fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
     set_dispatcher(zed_dispatcher(cx));
     JupyterSettings::register(cx);
+    editor::init_settings(cx);
     runtime_panel::init(cx);
     ReplStore::init(fs, cx);
 }

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -1,11 +1,13 @@
 use async_dispatcher::{set_dispatcher, Dispatcher, Runnable};
 use gpui::{AppContext, PlatformDispatcher};
+use project::Fs;
 use settings::Settings as _;
 use std::{sync::Arc, time::Duration};
 
 mod jupyter_settings;
 mod kernels;
 mod outputs;
+mod repl_store;
 mod runtime_panel;
 mod session;
 mod stdio;
@@ -16,6 +18,8 @@ pub use runtime_panel::{ClearOutputs, Interrupt, Run, Shutdown};
 pub use runtime_panel::{RuntimePanel, SessionSupport};
 pub use runtimelib::ExecutionState;
 pub use session::Session;
+
+use crate::repl_store::ReplStore;
 
 fn zed_dispatcher(cx: &mut AppContext) -> impl Dispatcher {
     struct ZedDispatcher {
@@ -41,8 +45,9 @@ fn zed_dispatcher(cx: &mut AppContext) -> impl Dispatcher {
     }
 }
 
-pub fn init(cx: &mut AppContext) {
+pub fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
     set_dispatcher(zed_dispatcher(cx));
     JupyterSettings::register(cx);
-    runtime_panel::init(cx)
+    runtime_panel::init(cx);
+    ReplStore::init(fs, cx);
 }

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -1,0 +1,273 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use collections::HashMap;
+use editor::{Anchor, Editor, RangeToAnchorExt};
+use gpui::{
+    prelude::*, AppContext, EntityId, Global, Model, ModelContext, Subscription, Task, View,
+    ViewContext, WeakView,
+};
+use language::{Language, Point};
+use multi_buffer::MultiBufferRow;
+use project::Fs;
+use settings::{Settings, SettingsStore};
+
+use crate::kernels::kernel_specifications;
+use crate::session::SessionEvent;
+use crate::{JupyterSettings, KernelSpecification, Session};
+
+pub enum SessionSupport {
+    ActiveSession(View<Session>),
+    Inactive(Box<KernelSpecification>),
+    RequiresSetup(Arc<str>),
+    Unsupported,
+}
+
+struct GlobalReplStore(Model<ReplStore>);
+
+impl Global for GlobalReplStore {}
+
+pub struct ReplStore {
+    fs: Arc<dyn Fs>,
+    enabled: bool,
+    sessions: HashMap<EntityId, View<Session>>,
+    kernel_specifications: Vec<KernelSpecification>,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl ReplStore {
+    pub(crate) fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
+        let store = cx.new_model(move |cx| Self::new(fs, cx));
+
+        cx.set_global(GlobalReplStore(store))
+    }
+
+    pub fn global(cx: &AppContext) -> Model<Self> {
+        cx.global::<GlobalReplStore>().0.clone()
+    }
+
+    pub fn new(fs: Arc<dyn Fs>, cx: &mut ModelContext<Self>) -> Self {
+        let subscriptions = vec![cx.observe_global::<SettingsStore>(move |this, cx| {
+            this.set_enabled(JupyterSettings::enabled(cx), cx);
+        })];
+
+        Self {
+            fs,
+            enabled: JupyterSettings::enabled(cx),
+            sessions: HashMap::default(),
+            kernel_specifications: Vec::new(),
+            _subscriptions: subscriptions,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn kernel_specifications(&self) -> impl Iterator<Item = &KernelSpecification> {
+        self.kernel_specifications.iter()
+    }
+
+    pub fn sessions(&self) -> impl Iterator<Item = &View<Session>> {
+        self.sessions.values()
+    }
+
+    fn set_enabled(&mut self, enabled: bool, cx: &mut ModelContext<Self>) {
+        if self.enabled != enabled {
+            self.enabled = enabled;
+            cx.notify();
+        }
+    }
+
+    pub fn snippet(
+        &self,
+        editor: WeakView<Editor>,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<(String, Arc<Language>, Range<Anchor>)> {
+        let editor = editor.upgrade()?;
+        let editor = editor.read(cx);
+
+        let buffer = editor.buffer().read(cx).snapshot(cx);
+
+        let selection = editor.selections.newest::<usize>(cx);
+        let multi_buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
+
+        let range = if selection.is_empty() {
+            let cursor = selection.head();
+
+            let cursor_row = multi_buffer_snapshot.offset_to_point(cursor).row;
+            let start_offset = multi_buffer_snapshot.point_to_offset(Point::new(cursor_row, 0));
+
+            let end_point = Point::new(
+                cursor_row,
+                multi_buffer_snapshot.line_len(MultiBufferRow(cursor_row)),
+            );
+            let end_offset = start_offset.saturating_add(end_point.column as usize);
+
+            // Create a range from the start to the end of the line
+            start_offset..end_offset
+        } else {
+            selection.range()
+        };
+
+        let anchor_range = range.to_anchors(&multi_buffer_snapshot);
+
+        let selected_text = buffer
+            .text_for_range(anchor_range.clone())
+            .collect::<String>();
+
+        let start_language = buffer.language_at(anchor_range.start)?;
+        let end_language = buffer.language_at(anchor_range.end)?;
+        if start_language != end_language {
+            return None;
+        }
+
+        Some((selected_text, start_language.clone(), anchor_range))
+    }
+
+    pub fn language(
+        &self,
+        editor: WeakView<Editor>,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<Arc<Language>> {
+        let editor = editor.upgrade()?;
+        let selection = editor.read(cx).selections.newest::<usize>(cx);
+        let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
+        buffer.language_at(selection.head()).cloned()
+    }
+
+    pub fn refresh_kernelspecs(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        let kernel_specifications = kernel_specifications(self.fs.clone());
+        cx.spawn(|this, mut cx| async move {
+            let kernel_specifications = kernel_specifications.await?;
+
+            this.update(&mut cx, |this, cx| {
+                this.kernel_specifications = kernel_specifications;
+                cx.notify();
+            })
+        })
+    }
+
+    pub fn kernelspec(
+        &self,
+        language: &Language,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<KernelSpecification> {
+        let settings = JupyterSettings::get_global(cx);
+        let language_name = language.code_fence_block_name();
+        let selected_kernel = settings.kernel_selections.get(language_name.as_ref());
+
+        self.kernel_specifications
+            .iter()
+            .find(|runtime_specification| {
+                if let Some(selected) = selected_kernel {
+                    // Top priority is the selected kernel
+                    runtime_specification.name.to_lowercase() == selected.to_lowercase()
+                } else {
+                    // Otherwise, we'll try to find a kernel that matches the language
+                    runtime_specification.kernelspec.language.to_lowercase()
+                        == language_name.to_lowercase()
+                }
+            })
+            .cloned()
+    }
+
+    pub fn run(&mut self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) -> Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let (selected_text, language, anchor_range) = match self.snippet(editor.clone(), cx) {
+            Some(snippet) => snippet,
+            None => return Ok(()),
+        };
+
+        let entity_id = editor.entity_id();
+
+        let kernel_specification = self
+            .kernelspec(&language, cx)
+            .with_context(|| format!("No kernel found for language: {}", language.name()))?;
+
+        let session = self.sessions.entry(entity_id).or_insert_with(|| {
+            let view =
+                cx.new_view(|cx| Session::new(editor, self.fs.clone(), kernel_specification, cx));
+            cx.notify();
+
+            let subscription = cx.subscribe(&view, |this, _session, event, _cx| match event {
+                SessionEvent::Shutdown(shutdown_event) => {
+                    this.sessions.remove(&shutdown_event.entity_id());
+                }
+            });
+
+            subscription.detach();
+
+            view
+        });
+
+        session.update(cx, |session, cx| {
+            session.execute(&selected_text, anchor_range, cx);
+        });
+
+        anyhow::Ok(())
+    }
+
+    pub fn session(
+        &mut self,
+        editor: WeakView<Editor>,
+        cx: &mut ViewContext<Self>,
+    ) -> SessionSupport {
+        let entity_id = editor.entity_id();
+        let session = self.sessions.get(&entity_id).cloned();
+
+        match session {
+            Some(session) => SessionSupport::ActiveSession(session),
+            None => {
+                let language = self.language(editor, cx);
+                let language = match language {
+                    Some(language) => language,
+                    None => return SessionSupport::Unsupported,
+                };
+                let kernelspec = self.kernelspec(&language, cx);
+
+                match kernelspec {
+                    Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),
+                    None => match language.name().as_ref() {
+                        "TypeScript" | "Python" => SessionSupport::RequiresSetup(language.name()),
+                        _ => SessionSupport::Unsupported,
+                    },
+                }
+            }
+        }
+    }
+
+    pub fn clear_outputs(&mut self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) {
+        let entity_id = editor.entity_id();
+        if let Some(session) = self.sessions.get_mut(&entity_id) {
+            session.update(cx, |session, cx| {
+                session.clear_outputs(cx);
+            });
+            cx.notify();
+        }
+    }
+
+    pub fn interrupt(&mut self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) {
+        let entity_id = editor.entity_id();
+        if let Some(session) = self.sessions.get_mut(&entity_id) {
+            session.update(cx, |session, cx| {
+                session.interrupt(cx);
+            });
+            cx.notify();
+        }
+    }
+
+    pub fn shutdown(&self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) {
+        let entity_id = editor.entity_id();
+        if let Some(session) = self.sessions.get(&entity_id) {
+            session.update(cx, |session, cx| {
+                session.shutdown(cx);
+            });
+            cx.notify();
+        }
+    }
+}

--- a/crates/repl/src/runtime_panel.rs
+++ b/crates/repl/src/runtime_panel.rs
@@ -405,21 +405,14 @@ impl RuntimePanel {
                     Some(language) => language,
                     None => return SessionSupport::Unsupported,
                 };
-                // Check for kernelspec
                 let kernelspec = self.kernelspec(&language, cx);
 
                 match kernelspec {
                     Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),
-                    None => {
-                        // If no kernelspec but language is one of typescript or python
-                        // then we return RequiresSetup
-                        match language.name().as_ref() {
-                            "TypeScript" | "Python" => {
-                                SessionSupport::RequiresSetup(language.name())
-                            }
-                            _ => SessionSupport::Unsupported,
-                        }
-                    }
+                    None => match language.name().as_ref() {
+                        "TypeScript" | "Python" => SessionSupport::RequiresSetup(language.name()),
+                        _ => SessionSupport::Unsupported,
+                    },
                 }
             }
         }
@@ -503,25 +496,25 @@ impl Render for RuntimePanel {
                 .p_4()
                 .size_full()
                 .gap_2()
-                        .child(Label::new("No Jupyter Kernels Available").size(LabelSize::Large))
-                        .child(
-                            Label::new("To start interactively running code in your editor, you need to install and configure Jupyter kernels.")
-                                .size(LabelSize::Default),
-                        )
-                        .child(
-                            h_flex().w_full().p_4().justify_center().gap_2().child(
-                                ButtonLike::new("install-kernels")
-                                    .style(ButtonStyle::Filled)
-                                    .size(ButtonSize::Large)
-                                    .layer(ElevationIndex::ModalSurface)
-                                    .child(Label::new("Install Kernels"))
-                                    .on_click(move |_, cx| {
-                                        cx.open_url(
-                                        "https://docs.jupyter.org/en/latest/install/kernels.html",
-                                    )
-                                    }),
-                            ),
-                        )
+                .child(Label::new("No Jupyter Kernels Available").size(LabelSize::Large))
+                .child(
+                    Label::new("To start interactively running code in your editor, you need to install and configure Jupyter kernels.")
+                        .size(LabelSize::Default),
+                )
+                .child(
+                    h_flex().w_full().p_4().justify_center().gap_2().child(
+                        ButtonLike::new("install-kernels")
+                            .style(ButtonStyle::Filled)
+                            .size(ButtonSize::Large)
+                            .layer(ElevationIndex::ModalSurface)
+                            .child(Label::new("Install Kernels"))
+                            .on_click(move |_, cx| {
+                                cx.open_url(
+                                    "https://docs.jupyter.org/en/latest/install/kernels.html",
+                                )
+                            }),
+                    ),
+                )
                 .into_any_element();
         }
 

--- a/crates/repl/src/runtime_panel.rs
+++ b/crates/repl/src/runtime_panel.rs
@@ -1,20 +1,19 @@
 use crate::repl_store::ReplStore;
 use crate::{
     jupyter_settings::{JupyterDockPosition, JupyterSettings},
-    kernels::{kernel_specifications, KernelSpecification},
+    kernels::KernelSpecification,
     session::{Session, SessionEvent},
 };
 use anyhow::{Context as _, Result};
-use collections::HashMap;
 use editor::{Anchor, Editor, RangeToAnchorExt};
 use gpui::{
-    actions, prelude::*, AppContext, AsyncWindowContext, EntityId, EventEmitter, FocusHandle,
-    FocusOutEvent, FocusableView, Subscription, Task, View, WeakView, WindowContext,
+    actions, prelude::*, AppContext, AsyncWindowContext, EventEmitter, FocusHandle, FocusOutEvent,
+    FocusableView, Subscription, Task, View, WeakView,
 };
 use language::{Language, Point};
 use multi_buffer::MultiBufferRow;
 use project::Fs;
-use settings::{Settings as _, SettingsStore};
+use settings::Settings as _;
 use std::{ops::Range, sync::Arc};
 use ui::{prelude::*, ButtonLike, ElevationIndex, KeyBinding};
 use util::ResultExt as _;
@@ -29,6 +28,13 @@ actions!(
 );
 actions!(repl_panel, [ToggleFocus]);
 
+pub enum SessionSupport {
+    ActiveSession(View<Session>),
+    Inactive(Box<KernelSpecification>),
+    RequiresSetup(Arc<str>),
+    Unsupported,
+}
+
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(
         |workspace: &mut Workspace, _cx: &mut ViewContext<Workspace>| {
@@ -36,7 +42,7 @@ pub fn init(cx: &mut AppContext) {
                 workspace.toggle_panel_focus::<RuntimePanel>(cx);
             });
 
-            workspace.register_action(|workspace, _: &RefreshKernelspecs, cx| {
+            workspace.register_action(|_workspace, _: &RefreshKernelspecs, cx| {
                 let store = ReplStore::global(cx);
                 store.update(cx, |store, cx| {
                     store.refresh_kernelspecs(cx).detach();
@@ -67,10 +73,7 @@ pub fn init(cx: &mut AppContext) {
                     let weak_editor = cx.view().downgrade();
                     panel.update(cx, |_, cx| {
                         cx.defer(|panel, cx| {
-                            let store = ReplStore::global(cx);
-                            store.update(cx, |store, cx| {
-                                store.run(weak_editor, cx).log_err();
-                            });
+                            panel.run(weak_editor, cx).log_err();
                         });
                     })
                 },
@@ -181,8 +184,11 @@ impl RuntimePanel {
                 })
             })?;
 
-            view.update(&mut cx, |this, cx| this.refresh_kernelspecs(cx))?
-                .await?;
+            view.update(&mut cx, |_panel, cx| {
+                let store = ReplStore::global(cx);
+                store.update(cx, |store, cx| store.refresh_kernelspecs(cx))
+            })?
+            .await?;
 
             Ok(view)
         })
@@ -194,6 +200,173 @@ impl RuntimePanel {
 
     fn focus_out(&mut self, _event: FocusOutEvent, cx: &mut ViewContext<Self>) {
         cx.notify();
+    }
+
+    fn snippet(
+        editor: WeakView<Editor>,
+        cx: &mut ViewContext<Self>,
+    ) -> Option<(String, Arc<Language>, Range<Anchor>)> {
+        let editor = editor.upgrade()?;
+        let editor = editor.read(cx);
+
+        let buffer = editor.buffer().read(cx).snapshot(cx);
+
+        let selection = editor.selections.newest::<usize>(cx);
+        let multi_buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
+
+        let range = if selection.is_empty() {
+            let cursor = selection.head();
+
+            let cursor_row = multi_buffer_snapshot.offset_to_point(cursor).row;
+            let start_offset = multi_buffer_snapshot.point_to_offset(Point::new(cursor_row, 0));
+
+            let end_point = Point::new(
+                cursor_row,
+                multi_buffer_snapshot.line_len(MultiBufferRow(cursor_row)),
+            );
+            let end_offset = start_offset.saturating_add(end_point.column as usize);
+
+            // Create a range from the start to the end of the line
+            start_offset..end_offset
+        } else {
+            selection.range()
+        };
+
+        let anchor_range = range.to_anchors(&multi_buffer_snapshot);
+
+        let selected_text = buffer
+            .text_for_range(anchor_range.clone())
+            .collect::<String>();
+
+        let start_language = buffer.language_at(anchor_range.start)?;
+        let end_language = buffer.language_at(anchor_range.end)?;
+        if start_language != end_language {
+            return None;
+        }
+
+        Some((selected_text, start_language.clone(), anchor_range))
+    }
+
+    fn language(editor: WeakView<Editor>, cx: &mut ViewContext<Self>) -> Option<Arc<Language>> {
+        let editor = editor.upgrade()?;
+        let selection = editor.read(cx).selections.newest::<usize>(cx);
+        let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
+        buffer.language_at(selection.head()).cloned()
+    }
+
+    pub fn run(&mut self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) -> Result<()> {
+        let store = ReplStore::global(cx);
+
+        if !store.read(cx).is_enabled() {
+            return Ok(());
+        }
+
+        let (selected_text, language, anchor_range) = match Self::snippet(editor.clone(), cx) {
+            Some(snippet) => snippet,
+            None => return Ok(()),
+        };
+
+        let entity_id = editor.entity_id();
+
+        let kernel_specification = store.update(cx, |store, cx| {
+            store
+                .kernelspec(&language, cx)
+                .with_context(|| format!("No kernel found for language: {}", language.name()))
+        })?;
+
+        let session = if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+            session
+        } else {
+            let session =
+                cx.new_view(|cx| Session::new(editor, self.fs.clone(), kernel_specification, cx));
+            cx.notify();
+
+            let subscription = cx.subscribe(&session, {
+                let store = store.clone();
+                move |_this, _session, event, cx| match event {
+                    SessionEvent::Shutdown(shutdown_event) => {
+                        store.update(cx, |store, _cx| {
+                            store.remove_session(shutdown_event.entity_id());
+                        });
+                    }
+                }
+            });
+
+            subscription.detach();
+
+            store.update(cx, |store, _cx| {
+                store.insert_session(entity_id, session.clone());
+            });
+
+            session
+        };
+
+        session.update(cx, |session, cx| {
+            session.execute(&selected_text, anchor_range, cx);
+        });
+
+        anyhow::Ok(())
+    }
+
+    pub fn session(
+        &mut self,
+        editor: WeakView<Editor>,
+        cx: &mut ViewContext<Self>,
+    ) -> SessionSupport {
+        let store = ReplStore::global(cx);
+        let entity_id = editor.entity_id();
+
+        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+            return SessionSupport::ActiveSession(session);
+        };
+
+        let language = Self::language(editor, cx);
+        let language = match language {
+            Some(language) => language,
+            None => return SessionSupport::Unsupported,
+        };
+        let kernelspec = store.update(cx, |store, cx| store.kernelspec(&language, cx));
+
+        match kernelspec {
+            Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),
+            None => match language.name().as_ref() {
+                "TypeScript" | "Python" => SessionSupport::RequiresSetup(language.name()),
+                _ => SessionSupport::Unsupported,
+            },
+        }
+    }
+
+    pub fn clear_outputs(&mut self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) {
+        let store = ReplStore::global(cx);
+        let entity_id = editor.entity_id();
+        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+            session.update(cx, |session, cx| {
+                session.clear_outputs(cx);
+            });
+            cx.notify();
+        }
+    }
+
+    pub fn interrupt(&mut self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) {
+        let store = ReplStore::global(cx);
+        let entity_id = editor.entity_id();
+        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+            session.update(cx, |session, cx| {
+                session.interrupt(cx);
+            });
+            cx.notify();
+        }
+    }
+
+    pub fn shutdown(&self, editor: WeakView<Editor>, cx: &mut ViewContext<Self>) {
+        let store = ReplStore::global(cx);
+        let entity_id = editor.entity_id();
+        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+            session.update(cx, |session, cx| {
+                session.shutdown(cx);
+            });
+            cx.notify();
+        }
     }
 }
 
@@ -270,7 +443,7 @@ impl Render for RuntimePanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let store = ReplStore::global(cx);
 
-        let (kernel_specifications, sessions) = store.update(cx, |store, cx| {
+        let (kernel_specifications, sessions) = store.update(cx, |store, _cx| {
             (
                 store.kernel_specifications().cloned().collect::<Vec<_>>(),
                 store.sessions().cloned().collect::<Vec<_>>(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -167,7 +167,7 @@ fn init_common(app_state: Arc<AppState>, cx: &mut AppContext) {
     supermaven::init(app_state.client.clone(), cx);
     inline_completion_registry::init(app_state.client.telemetry().clone(), cx);
     assistant::init(app_state.fs.clone(), app_state.client.clone(), cx);
-    repl::init(cx);
+    repl::init(app_state.fs.clone(), cx);
     extension::init(
         app_state.fs.clone(),
         app_state.client.clone(),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3417,7 +3417,7 @@ mod tests {
             outline_panel::init((), cx);
             terminal_view::init(cx);
             assistant::init(app_state.fs.clone(), app_state.client.clone(), cx);
-            repl::init(cx);
+            repl::init(app_state.fs.clone(), cx);
             tasks_ui::init(cx);
             initialize_workspace(app_state.clone(), cx);
             app_state


### PR DESCRIPTION
This PR factors a `ReplStore` out of the `RuntimePanel`.

Since we're planning to remove the `RuntimePanel` and replace it with an ephemeral tab that can be opened, we need the kernel specifications and sessions to have somewhere long-lived that they can reside in.

Release Notes:

- N/A
