### PR TITLE
Set the default Starlark LSP for zaucy/zed-starlark

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -815,6 +815,9 @@
         "plugins": ["prettier-plugin-sql"]
       }
     },
+    "Starlark": {
+      "language_servers": ["starpls", "!buck2-lsp", "..."]
+    },
     "Svelte": {
       "prettier": {
         "allowed": true,


### PR DESCRIPTION
given zaucy/zed-starlark#4 was merged, zed-starlark now has multiple LSPs and requires additional configuration which isn't available directly for extensions.

cc @zaucy 

Release Notes:

- N/A
