### PR TITLE
Don't panic on GPU hang

### DIFF
--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -18,7 +18,7 @@ use blade_graphics as gpu;
 use blade_util::{BufferBelt, BufferBeltDescriptor};
 use std::{mem, sync::Arc};
 
-const MAX_FRAME_TIME_MS: u32 = 1000;
+const MAX_FRAME_TIME_MS: u32 = 10000;
 
 #[cfg(target_os = "macos")]
 pub type Context = ();
@@ -412,7 +412,8 @@ impl BladeRenderer {
     fn wait_for_gpu(&mut self) {
         if let Some(last_sp) = self.last_sync_point.take() {
             if !self.gpu.wait_for(&last_sp, MAX_FRAME_TIME_MS) {
-                panic!("GPU hung");
+                log::error!("GPU hung");
+                while !self.gpu.wait_for(&last_sp, MAX_FRAME_TIME_MS) {}
             }
         }
     }


### PR DESCRIPTION
Fixes: #12766
Fixes: #14022

Release Notes:

- linux: Fix panic when GPU is temporarily unavailable.
