### PR TITLE
repl: Replace REPL panel with sessions view

### DIFF
--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View};
 use repl::{
-    ExecutionState, JupyterSettings, Kernel, KernelSpecification, KernelStatus, RuntimePanel,
-    Session, SessionSupport,
+    editor::SessionSupport, ExecutionState, JupyterSettings, Kernel, KernelSpecification,
+    KernelStatus, RuntimePanel, Session,
 };
 use ui::{
     prelude::*, ButtonLike, ContextMenu, IconWithIndicator, Indicator, IntoElement, PopoverMenu,
@@ -55,7 +55,7 @@ impl QuickActionBar {
             })
         };
 
-        let session = RuntimePanel::session(editor.downgrade(), cx);
+        let session = repl::editor::session(editor.downgrade(), cx);
         let session = match session {
             SessionSupport::ActiveSession(session) => session,
             SessionSupport::Inactive(spec) => {
@@ -140,7 +140,7 @@ impl QuickActionBar {
                             let editor = editor.clone();
                             move |cx| {
                                 editor.update(cx, |this, cx| {
-                                    RuntimePanel::run(editor.clone(), cx).log_err();
+                                    repl::editor::run(editor.clone(), cx).log_err();
                                 });
                             }
                         },
@@ -157,7 +157,7 @@ impl QuickActionBar {
                             let editor = editor.clone();
                             move |cx| {
                                 editor.update(cx, |this, cx| {
-                                    RuntimePanel::interrupt(editor.clone(), cx);
+                                    repl::editor::interrupt(editor.clone(), cx);
                                 });
                             }
                         },
@@ -174,7 +174,7 @@ impl QuickActionBar {
                             let editor = editor.clone();
                             move |cx| {
                                 editor.update(cx, |this, cx| {
-                                    RuntimePanel::clear_outputs(editor.clone(), cx);
+                                    repl::editor::clear_outputs(editor.clone(), cx);
                                 });
                             }
                         },
@@ -200,7 +200,7 @@ impl QuickActionBar {
                             let editor = editor.clone();
                             move |cx| {
                                 editor.update(cx, |this, cx| {
-                                    RuntimePanel::shutdown(editor.clone(), cx);
+                                    repl::editor::shutdown(editor.clone(), cx);
                                 });
                             }
                         },

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View};
 use repl::{
-    editor::SessionSupport, ExecutionState, JupyterSettings, Kernel, KernelSpecification,
-    KernelStatus, Session,
+    ExecutionState, JupyterSettings, Kernel, KernelSpecification, KernelStatus, Session,
+    SessionSupport,
 };
 use ui::{
     prelude::*, ButtonLike, ContextMenu, IconWithIndicator, Indicator, IntoElement, PopoverMenu,
@@ -54,7 +54,7 @@ impl QuickActionBar {
             })
         };
 
-        let session = repl::editor::session(editor.downgrade(), cx);
+        let session = repl::session(editor.downgrade(), cx);
         let session = match session {
             SessionSupport::ActiveSession(session) => session,
             SessionSupport::Inactive(spec) => {
@@ -137,7 +137,7 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                repl::editor::run(editor.clone(), cx).log_err();
+                                repl::run(editor.clone(), cx).log_err();
                             }
                         },
                     )
@@ -151,7 +151,7 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                repl::editor::interrupt(editor.clone(), cx);
+                                repl::interrupt(editor.clone(), cx);
                             }
                         },
                     )
@@ -165,7 +165,7 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                repl::editor::clear_outputs(editor.clone(), cx);
+                                repl::clear_outputs(editor.clone(), cx);
                             }
                         },
                     )
@@ -188,7 +188,7 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                repl::editor::shutdown(editor.clone(), cx);
+                                repl::shutdown(editor.clone(), cx);
                             }
                         },
                     )

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View};
 use repl::{
     editor::SessionSupport, ExecutionState, JupyterSettings, Kernel, KernelSpecification,
-    KernelStatus, RuntimePanel, Session,
+    KernelStatus, Session,
 };
 use ui::{
     prelude::*, ButtonLike, ContextMenu, IconWithIndicator, Indicator, IntoElement, PopoverMenu,
@@ -39,7 +39,6 @@ impl QuickActionBar {
             return None;
         }
 
-        let workspace = self.workspace.upgrade()?.read(cx);
         let editor = self.active_editor()?;
 
         let has_nonempty_selection = {
@@ -126,7 +125,6 @@ impl QuickActionBar {
                         },
                     )
                     .separator()
-                    // Run
                     .custom_entry(
                         move |_cx| {
                             Label::new(if has_nonempty_selection {
@@ -139,13 +137,10 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                editor.update(cx, |this, cx| {
-                                    repl::editor::run(editor.clone(), cx).log_err();
-                                });
+                                repl::editor::run(editor.clone(), cx).log_err();
                             }
                         },
                     )
-                    // Interrupt
                     .custom_entry(
                         move |_cx| {
                             Label::new("Interrupt")
@@ -156,13 +151,10 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                editor.update(cx, |this, cx| {
-                                    repl::editor::interrupt(editor.clone(), cx);
-                                });
+                                repl::editor::interrupt(editor.clone(), cx);
                             }
                         },
                     )
-                    // Clear Outputs
                     .custom_entry(
                         move |_cx| {
                             Label::new("Clear Outputs")
@@ -173,9 +165,7 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                editor.update(cx, |this, cx| {
-                                    repl::editor::clear_outputs(editor.clone(), cx);
-                                });
+                                repl::editor::clear_outputs(editor.clone(), cx);
                             }
                         },
                     )
@@ -188,7 +178,6 @@ impl QuickActionBar {
                     )
                     // TODO: Add Restart action
                     // .action("Restart", Box::new(gpui::NoAction))
-                    // Shut down kernel
                     .custom_entry(
                         move |_cx| {
                             Label::new("Shut Down Kernel")
@@ -199,9 +188,7 @@ impl QuickActionBar {
                         {
                             let editor = editor.clone();
                             move |cx| {
-                                editor.update(cx, |this, cx| {
-                                    repl::editor::shutdown(editor.clone(), cx);
-                                });
+                                repl::editor::shutdown(editor.clone(), cx);
                             }
                         },
                     )

--- a/crates/repl/src/editor.rs
+++ b/crates/repl/src/editor.rs
@@ -1,0 +1,181 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use editor::{Anchor, Editor, RangeToAnchorExt};
+use gpui::{prelude::*, AppContext, View, ViewContext, WeakView};
+use language::{Language, Point};
+use multi_buffer::MultiBufferRow;
+
+use crate::repl_store::ReplStore;
+use crate::session::SessionEvent;
+use crate::{KernelSpecification, Session};
+
+pub fn run(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) -> Result<()> {
+    let store = ReplStore::global(cx);
+    if !store.read(cx).is_enabled() {
+        return Ok(());
+    }
+
+    let (selected_text, language, anchor_range) = match snippet(editor.clone(), cx) {
+        Some(snippet) => snippet,
+        None => return Ok(()),
+    };
+
+    let entity_id = editor.entity_id();
+
+    let kernel_specification = store.update(cx, |store, cx| {
+        store
+            .kernelspec(&language, cx)
+            .with_context(|| format!("No kernel found for language: {}", language.name()))
+    })?;
+
+    let fs = store.read(cx).fs().clone();
+    let session = if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+        session
+    } else {
+        let session = cx.new_view(|cx| Session::new(editor, fs, kernel_specification, cx));
+        cx.notify();
+
+        let subscription = cx.subscribe(&session, {
+            let store = store.clone();
+            move |_this, _session, event, cx| match event {
+                SessionEvent::Shutdown(shutdown_event) => {
+                    store.update(cx, |store, _cx| {
+                        store.remove_session(shutdown_event.entity_id());
+                    });
+                }
+            }
+        });
+
+        subscription.detach();
+
+        store.update(cx, |store, _cx| {
+            store.insert_session(entity_id, session.clone());
+        });
+
+        session
+    };
+
+    session.update(cx, |session, cx| {
+        session.execute(&selected_text, anchor_range, cx);
+    });
+
+    anyhow::Ok(())
+}
+
+pub enum SessionSupport {
+    ActiveSession(View<Session>),
+    Inactive(Box<KernelSpecification>),
+    RequiresSetup(Arc<str>),
+    Unsupported,
+}
+
+pub fn session(editor: WeakView<Editor>, cx: &mut AppContext) -> SessionSupport {
+    let store = ReplStore::global(cx);
+    let entity_id = editor.entity_id();
+
+    if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+        return SessionSupport::ActiveSession(session);
+    };
+
+    let language = get_language(editor, cx);
+    let language = match language {
+        Some(language) => language,
+        None => return SessionSupport::Unsupported,
+    };
+    let kernelspec = store.update(cx, |store, cx| store.kernelspec(&language, cx));
+
+    match kernelspec {
+        Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),
+        None => match language.name().as_ref() {
+            "TypeScript" | "Python" => SessionSupport::RequiresSetup(language.name()),
+            _ => SessionSupport::Unsupported,
+        },
+    }
+}
+
+pub fn clear_outputs(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) {
+    let store = ReplStore::global(cx);
+    let entity_id = editor.entity_id();
+    if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+        session.update(cx, |session, cx| {
+            session.clear_outputs(cx);
+        });
+        cx.notify();
+    }
+}
+
+pub fn interrupt(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) {
+    let store = ReplStore::global(cx);
+    let entity_id = editor.entity_id();
+    if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+        session.update(cx, |session, cx| {
+            session.interrupt(cx);
+        });
+        cx.notify();
+    }
+}
+
+pub fn shutdown(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) {
+    let store = ReplStore::global(cx);
+    let entity_id = editor.entity_id();
+    if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
+        session.update(cx, |session, cx| {
+            session.shutdown(cx);
+        });
+        cx.notify();
+    }
+}
+
+fn snippet(
+    editor: WeakView<Editor>,
+    cx: &mut ViewContext<Editor>,
+) -> Option<(String, Arc<Language>, Range<Anchor>)> {
+    let editor = editor.upgrade()?;
+    let editor = editor.read(cx);
+
+    let buffer = editor.buffer().read(cx).snapshot(cx);
+
+    let selection = editor.selections.newest::<usize>(cx);
+    let multi_buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
+
+    let range = if selection.is_empty() {
+        let cursor = selection.head();
+
+        let cursor_row = multi_buffer_snapshot.offset_to_point(cursor).row;
+        let start_offset = multi_buffer_snapshot.point_to_offset(Point::new(cursor_row, 0));
+
+        let end_point = Point::new(
+            cursor_row,
+            multi_buffer_snapshot.line_len(MultiBufferRow(cursor_row)),
+        );
+        let end_offset = start_offset.saturating_add(end_point.column as usize);
+
+        // Create a range from the start to the end of the line
+        start_offset..end_offset
+    } else {
+        selection.range()
+    };
+
+    let anchor_range = range.to_anchors(&multi_buffer_snapshot);
+
+    let selected_text = buffer
+        .text_for_range(anchor_range.clone())
+        .collect::<String>();
+
+    let start_language = buffer.language_at(anchor_range.start)?;
+    let end_language = buffer.language_at(anchor_range.end)?;
+    if start_language != end_language {
+        return None;
+    }
+
+    Some((selected_text, start_language.clone(), anchor_range))
+}
+
+fn get_language(editor: WeakView<Editor>, cx: &mut AppContext) -> Option<Arc<Language>> {
+    let editor = editor.upgrade()?;
+    let selection = editor.read(cx).selections.newest::<usize>(cx);
+    let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
+    buffer.language_at(selection.head()).cloned()
+}

--- a/crates/repl/src/jupyter_settings.rs
+++ b/crates/repl/src/jupyter_settings.rs
@@ -5,21 +5,9 @@ use gpui::AppContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
-use ui::Pixels;
-
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum JupyterDockPosition {
-    Left,
-    #[default]
-    Right,
-    Bottom,
-}
 
 #[derive(Debug, Default)]
 pub struct JupyterSettings {
-    pub dock: JupyterDockPosition,
-    pub default_width: Pixels,
     pub kernel_selections: HashMap<String, String>,
 }
 
@@ -34,31 +22,15 @@ impl JupyterSettings {
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct JupyterSettingsContent {
-    /// Where to dock the Jupyter panel.
-    ///
-    /// Default: `right`
-    dock: Option<JupyterDockPosition>,
-    /// Default width in pixels when the jupyter panel is docked to the left or right.
-    ///
-    /// Default: 640
-    pub default_width: Option<f32>,
     /// Default kernels to select for each language.
     ///
     /// Default: `{}`
     pub kernel_selections: Option<HashMap<String, String>>,
 }
 
-impl JupyterSettingsContent {
-    pub fn set_dock(&mut self, dock: JupyterDockPosition) {
-        self.dock = Some(dock);
-    }
-}
-
 impl Default for JupyterSettingsContent {
     fn default() -> Self {
         JupyterSettingsContent {
-            dock: Some(JupyterDockPosition::Right),
-            default_width: Some(640.0),
             kernel_selections: Some(HashMap::new()),
         }
     }
@@ -79,14 +51,6 @@ impl Settings for JupyterSettings {
         let mut settings = JupyterSettings::default();
 
         for value in sources.defaults_and_customizations() {
-            if let Some(dock) = value.dock {
-                settings.dock = dock;
-            }
-
-            if let Some(default_width) = value.default_width {
-                settings.default_width = Pixels::from(default_width);
-            }
-
             if let Some(source) = &value.kernel_selections {
                 for (k, v) in source {
                     settings.kernel_selections.insert(k.clone(), v.clone());
@@ -114,14 +78,6 @@ mod tests {
         JupyterSettings::register(cx);
 
         assert_eq!(JupyterSettings::enabled(cx), false);
-        assert_eq!(
-            JupyterSettings::get_global(cx).dock,
-            JupyterDockPosition::Right
-        );
-        assert_eq!(
-            JupyterSettings::get_global(cx).default_width,
-            Pixels::from(640.0)
-        );
 
         // Setting a custom setting through user settings
         SettingsStore::update_global(cx, |store, cx| {
@@ -140,13 +96,5 @@ mod tests {
         });
 
         assert_eq!(JupyterSettings::enabled(cx), true);
-        assert_eq!(
-            JupyterSettings::get_global(cx).dock,
-            JupyterDockPosition::Left
-        );
-        assert_eq!(
-            JupyterSettings::get_global(cx).default_width,
-            Pixels::from(800.0)
-        );
     }
 }

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -4,10 +4,10 @@ use project::Fs;
 use settings::Settings as _;
 use std::{sync::Arc, time::Duration};
 
-pub mod editor;
 mod jupyter_settings;
 mod kernels;
 mod outputs;
+mod repl_editor;
 mod repl_store;
 mod runtime_panel;
 mod session;
@@ -15,6 +15,7 @@ mod stdio;
 
 pub use jupyter_settings::JupyterSettings;
 pub use kernels::{Kernel, KernelSpecification, KernelStatus};
+pub use repl_editor::*;
 pub use runtime_panel::RuntimePanel;
 pub use runtime_panel::{ClearOutputs, Interrupt, Run, Shutdown};
 pub use runtimelib::ExecutionState;

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -4,6 +4,7 @@ use project::Fs;
 use settings::Settings as _;
 use std::{sync::Arc, time::Duration};
 
+pub mod editor;
 mod jupyter_settings;
 mod kernels;
 mod outputs;
@@ -14,8 +15,8 @@ mod stdio;
 
 pub use jupyter_settings::JupyterSettings;
 pub use kernels::{Kernel, KernelSpecification, KernelStatus};
+pub use runtime_panel::RuntimePanel;
 pub use runtime_panel::{ClearOutputs, Interrupt, Run, Shutdown};
-pub use runtime_panel::{RuntimePanel, SessionSupport};
 pub use runtimelib::ExecutionState;
 pub use session::Session;
 
@@ -48,7 +49,7 @@ fn zed_dispatcher(cx: &mut AppContext) -> impl Dispatcher {
 pub fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
     set_dispatcher(zed_dispatcher(cx));
     JupyterSettings::register(cx);
-    editor::init_settings(cx);
+    ::editor::init_settings(cx);
     runtime_panel::init(cx);
     ReplStore::init(fs, cx);
 }

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -8,16 +8,15 @@ mod jupyter_settings;
 mod kernels;
 mod outputs;
 mod repl_editor;
+mod repl_sessions_ui;
 mod repl_store;
-mod runtime_panel;
 mod session;
 mod stdio;
 
 pub use jupyter_settings::JupyterSettings;
 pub use kernels::{Kernel, KernelSpecification, KernelStatus};
 pub use repl_editor::*;
-pub use runtime_panel::RuntimePanel;
-pub use runtime_panel::{ClearOutputs, Interrupt, Run, Shutdown};
+pub use repl_sessions_ui::{ClearOutputs, Interrupt, ReplSessionsPage, Run, Shutdown};
 pub use runtimelib::ExecutionState;
 pub use session::Session;
 
@@ -51,6 +50,6 @@ pub fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
     set_dispatcher(zed_dispatcher(cx));
     JupyterSettings::register(cx);
     ::editor::init_settings(cx);
-    runtime_panel::init(cx);
+    repl_sessions_ui::init(cx);
     ReplStore::init(fs, cx);
 }

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -1,3 +1,5 @@
+//! REPL operations on an [`Editor`].
+
 use std::ops::Range;
 use std::sync::Arc;
 

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -32,12 +32,12 @@ pub fn init(cx: &mut AppContext) {
                     .active_pane()
                     .read(cx)
                     .items()
-                    .find_map(|item| item.downcast::<RuntimePanel>());
+                    .find_map(|item| item.downcast::<ReplSessionsPage>());
 
                 if let Some(existing) = existing {
                     workspace.activate_item(&existing, true, true, cx);
                 } else {
-                    let extensions_page = RuntimePanel::new(cx);
+                    let extensions_page = ReplSessionsPage::new(cx);
                     workspace.add_item_to_active_pane(Box::new(extensions_page), None, true, cx)
                 }
             });
@@ -114,12 +114,12 @@ pub fn init(cx: &mut AppContext) {
     .detach();
 }
 
-pub struct RuntimePanel {
+pub struct ReplSessionsPage {
     focus_handle: FocusHandle,
     _subscriptions: Vec<Subscription>,
 }
 
-impl RuntimePanel {
+impl ReplSessionsPage {
     pub fn new(cx: &mut ViewContext<Workspace>) -> View<Self> {
         cx.new_view(|cx: &mut ViewContext<Self>| {
             let focus_handle = cx.focus_handle();
@@ -137,15 +137,15 @@ impl RuntimePanel {
     }
 }
 
-impl EventEmitter<ItemEvent> for RuntimePanel {}
+impl EventEmitter<ItemEvent> for ReplSessionsPage {}
 
-impl FocusableView for RuntimePanel {
+impl FocusableView for ReplSessionsPage {
     fn focus_handle(&self, _cx: &AppContext) -> FocusHandle {
         self.focus_handle.clone()
     }
 }
 
-impl Item for RuntimePanel {
+impl Item for ReplSessionsPage {
     type Event = ItemEvent;
 
     fn tab_content_text(&self, _cx: &WindowContext) -> Option<SharedString> {
@@ -173,7 +173,7 @@ impl Item for RuntimePanel {
     }
 }
 
-impl Render for RuntimePanel {
+impl Render for ReplSessionsPage {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let store = ReplStore::global(cx);
 

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -49,6 +49,10 @@ impl ReplStore {
         }
     }
 
+    pub fn fs(&self) -> &Arc<dyn Fs> {
+        &self.fs
+    }
+
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -28,6 +28,10 @@ impl ReplStore {
     pub(crate) fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
         let store = cx.new_model(move |cx| Self::new(fs, cx));
 
+        store
+            .update(cx, |store, cx| store.refresh_kernelspecs(cx))
+            .detach_and_log_err(cx);
+
         cx.set_global(GlobalReplStore(store))
     }
 

--- a/crates/repl/src/runtime_panel.rs
+++ b/crates/repl/src/runtime_panel.rs
@@ -34,13 +34,6 @@ actions!(
 );
 actions!(repl_panel, [ToggleFocus]);
 
-pub enum SessionSupport {
-    ActiveSession(View<Session>),
-    Inactive(Box<KernelSpecification>),
-    RequiresSetup(Arc<str>),
-    Unsupported,
-}
-
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(
         |workspace: &mut Workspace, _cx: &mut ViewContext<Workspace>| {
@@ -84,7 +77,7 @@ pub fn init(cx: &mut AppContext) {
 
                     let weak_editor = cx.view().downgrade();
                     cx.defer(|panel, cx| {
-                        RuntimePanel::run(weak_editor, cx).log_err();
+                        crate::editor::run(weak_editor, cx).log_err();
                     });
                 },
             ))
@@ -99,7 +92,7 @@ pub fn init(cx: &mut AppContext) {
 
                     let weak_editor = cx.view().downgrade();
                     cx.defer(|panel, cx| {
-                        RuntimePanel::clear_outputs(weak_editor, cx);
+                        crate::editor::clear_outputs(weak_editor, cx);
                     });
                 },
             ))
@@ -114,7 +107,7 @@ pub fn init(cx: &mut AppContext) {
 
                     let weak_editor = cx.view().downgrade();
                     cx.defer(|panel, cx| {
-                        RuntimePanel::interrupt(weak_editor, cx);
+                        crate::editor::interrupt(weak_editor, cx);
                     });
                 },
             ))
@@ -129,7 +122,7 @@ pub fn init(cx: &mut AppContext) {
 
                     let weak_editor = cx.view().downgrade();
                     cx.defer(|panel, cx| {
-                        RuntimePanel::shutdown(weak_editor, cx);
+                        crate::editor::shutdown(weak_editor, cx);
                     });
                 },
             ))
@@ -203,168 +196,6 @@ impl RuntimePanel {
 
     fn focus_out(&mut self, _event: FocusOutEvent, cx: &mut ViewContext<Self>) {
         cx.notify();
-    }
-
-    fn snippet(
-        editor: WeakView<Editor>,
-        cx: &mut ViewContext<Editor>,
-    ) -> Option<(String, Arc<Language>, Range<Anchor>)> {
-        let editor = editor.upgrade()?;
-        let editor = editor.read(cx);
-
-        let buffer = editor.buffer().read(cx).snapshot(cx);
-
-        let selection = editor.selections.newest::<usize>(cx);
-        let multi_buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
-
-        let range = if selection.is_empty() {
-            let cursor = selection.head();
-
-            let cursor_row = multi_buffer_snapshot.offset_to_point(cursor).row;
-            let start_offset = multi_buffer_snapshot.point_to_offset(Point::new(cursor_row, 0));
-
-            let end_point = Point::new(
-                cursor_row,
-                multi_buffer_snapshot.line_len(MultiBufferRow(cursor_row)),
-            );
-            let end_offset = start_offset.saturating_add(end_point.column as usize);
-
-            // Create a range from the start to the end of the line
-            start_offset..end_offset
-        } else {
-            selection.range()
-        };
-
-        let anchor_range = range.to_anchors(&multi_buffer_snapshot);
-
-        let selected_text = buffer
-            .text_for_range(anchor_range.clone())
-            .collect::<String>();
-
-        let start_language = buffer.language_at(anchor_range.start)?;
-        let end_language = buffer.language_at(anchor_range.end)?;
-        if start_language != end_language {
-            return None;
-        }
-
-        Some((selected_text, start_language.clone(), anchor_range))
-    }
-
-    fn language(editor: WeakView<Editor>, cx: &mut AppContext) -> Option<Arc<Language>> {
-        let editor = editor.upgrade()?;
-        let selection = editor.read(cx).selections.newest::<usize>(cx);
-        let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
-        buffer.language_at(selection.head()).cloned()
-    }
-
-    pub fn run(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) -> Result<()> {
-        let store = ReplStore::global(cx);
-        if !store.read(cx).is_enabled() {
-            return Ok(());
-        }
-
-        let (selected_text, language, anchor_range) = match Self::snippet(editor.clone(), cx) {
-            Some(snippet) => snippet,
-            None => return Ok(()),
-        };
-
-        let entity_id = editor.entity_id();
-
-        let kernel_specification = store.update(cx, |store, cx| {
-            store
-                .kernelspec(&language, cx)
-                .with_context(|| format!("No kernel found for language: {}", language.name()))
-        })?;
-
-        let fs = store.read(cx).fs().clone();
-        let session = if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
-            session
-        } else {
-            let session = cx.new_view(|cx| Session::new(editor, fs, kernel_specification, cx));
-            cx.notify();
-
-            let subscription = cx.subscribe(&session, {
-                let store = store.clone();
-                move |_this, _session, event, cx| match event {
-                    SessionEvent::Shutdown(shutdown_event) => {
-                        store.update(cx, |store, _cx| {
-                            store.remove_session(shutdown_event.entity_id());
-                        });
-                    }
-                }
-            });
-
-            subscription.detach();
-
-            store.update(cx, |store, _cx| {
-                store.insert_session(entity_id, session.clone());
-            });
-
-            session
-        };
-
-        session.update(cx, |session, cx| {
-            session.execute(&selected_text, anchor_range, cx);
-        });
-
-        anyhow::Ok(())
-    }
-
-    pub fn session(editor: WeakView<Editor>, cx: &mut AppContext) -> SessionSupport {
-        let store = ReplStore::global(cx);
-        let entity_id = editor.entity_id();
-
-        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
-            return SessionSupport::ActiveSession(session);
-        };
-
-        let language = Self::language(editor, cx);
-        let language = match language {
-            Some(language) => language,
-            None => return SessionSupport::Unsupported,
-        };
-        let kernelspec = store.update(cx, |store, cx| store.kernelspec(&language, cx));
-
-        match kernelspec {
-            Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),
-            None => match language.name().as_ref() {
-                "TypeScript" | "Python" => SessionSupport::RequiresSetup(language.name()),
-                _ => SessionSupport::Unsupported,
-            },
-        }
-    }
-
-    pub fn clear_outputs(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) {
-        let store = ReplStore::global(cx);
-        let entity_id = editor.entity_id();
-        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
-            session.update(cx, |session, cx| {
-                session.clear_outputs(cx);
-            });
-            cx.notify();
-        }
-    }
-
-    pub fn interrupt(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) {
-        let store = ReplStore::global(cx);
-        let entity_id = editor.entity_id();
-        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
-            session.update(cx, |session, cx| {
-                session.interrupt(cx);
-            });
-            cx.notify();
-        }
-    }
-
-    pub fn shutdown(editor: WeakView<Editor>, cx: &mut ViewContext<Editor>) {
-        let store = ReplStore::global(cx);
-        let entity_id = editor.entity_id();
-        if let Some(session) = store.read(cx).get_session(entity_id).cloned() {
-            session.update(cx, |session, cx| {
-                session.shutdown(cx);
-            });
-            cx.notify();
-        }
     }
 }
 

--- a/crates/repl/src/runtime_panel.rs
+++ b/crates/repl/src/runtime_panel.rs
@@ -67,7 +67,7 @@ pub fn init(cx: &mut AppContext) {
                         return;
                     }
 
-                    crate::editor::run(editor_handle.clone(), cx).log_err();
+                    crate::run(editor_handle.clone(), cx).log_err();
                 }
             })
             .detach();
@@ -80,7 +80,7 @@ pub fn init(cx: &mut AppContext) {
                         return;
                     }
 
-                    crate::editor::clear_outputs(editor_handle.clone(), cx);
+                    crate::clear_outputs(editor_handle.clone(), cx);
                 }
             })
             .detach();
@@ -93,7 +93,7 @@ pub fn init(cx: &mut AppContext) {
                         return;
                     }
 
-                    crate::editor::interrupt(editor_handle.clone(), cx);
+                    crate::interrupt(editor_handle.clone(), cx);
                 }
             })
             .detach();
@@ -106,7 +106,7 @@ pub fn init(cx: &mut AppContext) {
                         return;
                     }
 
-                    crate::editor::shutdown(editor_handle.clone(), cx);
+                    crate::shutdown(editor_handle.clone(), cx);
                 }
             })
             .detach();

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -80,7 +80,7 @@ impl EditorBlock {
                 position: code_range.end,
                 height: execution_view.num_lines(cx).saturating_add(1),
                 style: BlockStyle::Sticky,
-                render: Self::create_output_area_render(execution_view.clone(), on_close.clone()),
+                render: Self::create_output_area_renderer(execution_view.clone(), on_close.clone()),
                 disposition: BlockDisposition::Below,
             };
 
@@ -111,7 +111,7 @@ impl EditorBlock {
                     self.block_id,
                     (
                         Some(self.execution_view.num_lines(cx).saturating_add(1)),
-                        Self::create_output_area_render(
+                        Self::create_output_area_renderer(
                             self.execution_view.clone(),
                             self.on_close.clone(),
                         ),
@@ -122,7 +122,7 @@ impl EditorBlock {
             .ok();
     }
 
-    fn create_output_area_render(
+    fn create_output_area_renderer(
         execution_view: View<ExecutionView>,
         on_close: CloseBlockFn,
     ) -> RenderBlock {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -199,8 +199,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
             let assistant_panel =
                 assistant::AssistantPanel::load(workspace_handle.clone(), cx.clone());
 
-            let runtime_panel = repl::RuntimePanel::load(workspace_handle.clone(), cx.clone());
-
             let project_panel = ProjectPanel::load(workspace_handle.clone(), cx.clone());
             let outline_panel = OutlinePanel::load(workspace_handle.clone(), cx.clone());
             let terminal_panel = TerminalPanel::load(workspace_handle.clone(), cx.clone());
@@ -218,7 +216,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
                 outline_panel,
                 terminal_panel,
                 assistant_panel,
-                runtime_panel,
                 channels_panel,
                 chat_panel,
                 notification_panel,
@@ -227,7 +224,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
                 outline_panel,
                 terminal_panel,
                 assistant_panel,
-                runtime_panel,
                 channels_panel,
                 chat_panel,
                 notification_panel,
@@ -235,7 +231,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
 
             workspace_handle.update(&mut cx, |workspace, cx| {
                 workspace.add_panel(assistant_panel, cx);
-                workspace.add_panel(runtime_panel, cx);
                 workspace.add_panel(project_panel, cx);
                 workspace.add_panel(outline_panel, cx);
                 workspace.add_panel(terminal_panel, cx);


### PR DESCRIPTION
This PR removes the REPL panel and replaces it with a new sessions view that gets displayed in its own pane.

The sessions view can be opened with the `repl: sessions` command (we can adjust the name, as needed).

There was a rather in-depth refactoring needed to extricate the various REPL functionality on the editor from the `RuntimePanel`.

<img width="1136" alt="Screenshot 2024-07-22 at 4 12 12 PM" src="https://github.com/user-attachments/assets/ac0da351-778e-4200-b08c-39f9e77d78bf">

<img width="1136" alt="Screenshot 2024-07-22 at 4 12 17 PM" src="https://github.com/user-attachments/assets/6ca53476-6ac4-4f8b-afc8-f7863f7065c7">

Release Notes:

- N/A
