### PR TITLE
repl: Remove unused `repl_panel::ToggleFocus` action

### DIFF
--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -22,7 +22,6 @@ actions!(
         RefreshKernelspecs
     ]
 );
-actions!(repl_panel, [ToggleFocus]);
 
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(


### PR DESCRIPTION
This PR removes the `repl_panel::ToggleFocus` action, as we don't need it anymore.

Release Notes:

- N/A
