### PR TITLE
quick_action_bar: Add menu entry to view REPL sessions

### DIFF
--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -192,7 +192,8 @@ impl QuickActionBar {
                             }
                         },
                     )
-                    // .separator()
+                    .separator()
+                    .action("View Sessions", Box::new(repl::Sessions))
                     // TODO: Add shut down all kernels action
                     // .action("Shut Down all Kernels", Box::new(gpui::NoAction))
                 })

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -16,7 +16,7 @@ mod stdio;
 pub use jupyter_settings::JupyterSettings;
 pub use kernels::{Kernel, KernelSpecification, KernelStatus};
 pub use repl_editor::*;
-pub use repl_sessions_ui::{ClearOutputs, Interrupt, ReplSessionsPage, Run, Shutdown};
+pub use repl_sessions_ui::{ClearOutputs, Interrupt, ReplSessionsPage, Run, Sessions, Shutdown};
 pub use runtimelib::ExecutionState;
 pub use session::Session;
 


### PR DESCRIPTION
This PR adds a new menu entry in the REPL item in the quick action bar to open up the REPL sessions view:

<img width="232" alt="Screenshot 2024-07-22 at 4 54 36 PM" src="https://github.com/user-attachments/assets/acc60a25-7722-4331-9b80-fab9cca65842">

This makes this more discoverable than having to know that the command exists.

Release Notes:

- N/A
