### PR TITLE
repl: Enable jupyter by default, allow disabling

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -890,6 +890,15 @@
     //     }
     // }
   },
+  // Jupyter settings
+  "jupyter": {
+    "enabled": true
+    // Specify the language name as the key and the kernel name as the value.
+    // "kernel_selections": {
+    //    "python": "conda-base"
+    //    "typescript": "deno"
+    // }
+  },
   // Vim settings
   "vim": {
     "use_system_clipboard": "always",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1953,7 +1953,7 @@ impl Editor {
             EditorMode::Full => "full",
         };
 
-        if EditorSettings::get_global(cx).jupyter.enabled {
+        if EditorSettings::jupyter_enabled(cx) {
             key_context.add("jupyter");
         }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -28,7 +28,6 @@ pub struct EditorSettings {
     pub search_wrap: bool,
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
-    #[serde(default)]
     pub jupyter: Jupyter,
 }
 
@@ -69,12 +68,20 @@ pub enum DoubleClickInMultibuffer {
     Open,
 }
 
-#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Jupyter {
     /// Whether the Jupyter feature is enabled.
     ///
-    /// Default: `true`
+    /// Default: true
+    pub enabled: bool,
+}
+
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct JupyterContent {
+    /// Whether the Jupyter feature is enabled.
+    ///
+    /// Default: true
     pub enabled: Option<bool>,
 }
 
@@ -247,7 +254,7 @@ pub struct EditorSettingsContent {
     pub show_signature_help_after_edits: Option<bool>,
 
     /// Jupyter REPL settings.
-    pub jupyter: Option<Jupyter>,
+    pub jupyter: Option<JupyterContent>,
 }
 
 // Toolbar related settings
@@ -320,10 +327,7 @@ pub struct GutterContent {
 
 impl EditorSettings {
     pub fn jupyter_enabled(cx: &AppContext) -> bool {
-        EditorSettings::get_global(cx)
-            .jupyter
-            .enabled
-            .unwrap_or(true)
+        EditorSettings::get_global(cx).jupyter.enabled
     }
 }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -74,8 +74,8 @@ pub enum DoubleClickInMultibuffer {
 pub struct Jupyter {
     /// Whether the Jupyter feature is enabled.
     ///
-    /// Default: `false`
-    pub enabled: bool,
+    /// Default: `true`
+    pub enabled: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -316,6 +316,15 @@ pub struct GutterContent {
     ///
     /// Default: true
     pub folds: Option<bool>,
+}
+
+impl EditorSettings {
+    pub fn jupyter_enabled(cx: &AppContext) -> bool {
+        EditorSettings::get_global(cx)
+            .jupyter
+            .enabled
+            .unwrap_or(true)
+    }
 }
 
 impl Settings for EditorSettings {

--- a/crates/repl/src/jupyter_settings.rs
+++ b/crates/repl/src/jupyter_settings.rs
@@ -16,7 +16,8 @@ impl JupyterSettings {
         // In order to avoid a circular dependency between `editor` and `repl` crates,
         // we put the `enable` flag on its settings.
         // This allows the editor to set up context for key bindings/actions.
-        EditorSettings::get_global(cx).jupyter.enabled
+
+        EditorSettings::jupyter_enabled(cx)
     }
 }
 

--- a/crates/repl/src/jupyter_settings.rs
+++ b/crates/repl/src/jupyter_settings.rs
@@ -16,7 +16,6 @@ impl JupyterSettings {
         // In order to avoid a circular dependency between `editor` and `repl` crates,
         // we put the `enable` flag on its settings.
         // This allows the editor to set up context for key bindings/actions.
-
         EditorSettings::jupyter_enabled(cx)
     }
 }
@@ -60,42 +59,5 @@ impl Settings for JupyterSettings {
         }
 
         Ok(settings)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use gpui::{AppContext, UpdateGlobal};
-    use settings::SettingsStore;
-
-    use super::*;
-
-    #[gpui::test]
-    fn test_deserialize_jupyter_settings(cx: &mut AppContext) {
-        let store = settings::SettingsStore::test(cx);
-        cx.set_global(store);
-
-        EditorSettings::register(cx);
-        JupyterSettings::register(cx);
-
-        assert_eq!(JupyterSettings::enabled(cx), false);
-
-        // Setting a custom setting through user settings
-        SettingsStore::update_global(cx, |store, cx| {
-            store
-                .set_user_settings(
-                    r#"{
-                        "jupyter": {
-                            "enabled": true,
-                            "dock": "left",
-                            "default_width": 800.0
-                        }
-                    }"#,
-                    cx,
-                )
-                .unwrap();
-        });
-
-        assert_eq!(JupyterSettings::enabled(cx), true);
     }
 }


### PR DESCRIPTION
Enables the jupyter feature by default, which is shown only when we have a kernelspec or know that we (can) support it well (Python, Deno/TypeScript).

Release Notes:

- N/A
