### PR TITLE
repl: Iterate on design of REPL sessions view

### DIFF
--- a/crates/repl/src/components.rs
+++ b/crates/repl/src/components.rs
@@ -1,0 +1,3 @@
+mod session_entry;
+
+pub use session_entry::*;

--- a/crates/repl/src/components.rs
+++ b/crates/repl/src/components.rs
@@ -1,3 +1,3 @@
-mod session_entry;
+mod kernel_list_item;
 
-pub use session_entry::*;
+pub use kernel_list_item::*;

--- a/crates/repl/src/components/kernel_list_item.rs
+++ b/crates/repl/src/components/kernel_list_item.rs
@@ -4,14 +4,14 @@ use ui::{prelude::*, Indicator, ListItem};
 use crate::KernelSpecification;
 
 #[derive(IntoElement)]
-pub struct SessionEntry {
+pub struct KernelListItem {
     kernel_specification: KernelSpecification,
     status_color: Color,
     buttons: Vec<AnyElement>,
     children: Vec<AnyElement>,
 }
 
-impl SessionEntry {
+impl KernelListItem {
     pub fn new(kernel_specification: KernelSpecification) -> Self {
         Self {
             kernel_specification,
@@ -26,7 +26,6 @@ impl SessionEntry {
         self
     }
 
-    #[allow(unused)]
     pub fn button(mut self, button: impl IntoElement) -> Self {
         self.buttons.push(button.into_any_element());
         self
@@ -39,13 +38,13 @@ impl SessionEntry {
     }
 }
 
-impl ParentElement for SessionEntry {
+impl ParentElement for KernelListItem {
     fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
         self.children.extend(elements);
     }
 }
 
-impl RenderOnce for SessionEntry {
+impl RenderOnce for KernelListItem {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
         ListItem::new(SharedString::from(self.kernel_specification.name.clone()))
             .selectable(false)

--- a/crates/repl/src/components/session_entry.rs
+++ b/crates/repl/src/components/session_entry.rs
@@ -1,0 +1,61 @@
+use gpui::AnyElement;
+use ui::{prelude::*, Indicator, ListItem};
+
+use crate::KernelSpecification;
+
+#[derive(IntoElement)]
+pub struct SessionEntry {
+    kernel_specification: KernelSpecification,
+    status_color: Color,
+    buttons: Vec<AnyElement>,
+    children: Vec<AnyElement>,
+}
+
+impl SessionEntry {
+    pub fn new(kernel_specification: KernelSpecification) -> Self {
+        Self {
+            kernel_specification,
+            status_color: Color::Disabled,
+            buttons: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+
+    pub fn status_color(mut self, color: Color) -> Self {
+        self.status_color = color;
+        self
+    }
+
+    #[allow(unused)]
+    pub fn button(mut self, button: impl IntoElement) -> Self {
+        self.buttons.push(button.into_any_element());
+        self
+    }
+
+    pub fn buttons(mut self, buttons: impl IntoIterator<Item = impl IntoElement>) -> Self {
+        self.buttons
+            .extend(buttons.into_iter().map(|button| button.into_any_element()));
+        self
+    }
+}
+
+impl ParentElement for SessionEntry {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements);
+    }
+}
+
+impl RenderOnce for SessionEntry {
+    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
+        ListItem::new(SharedString::from(self.kernel_specification.name.clone()))
+            .selectable(false)
+            .start_slot(
+                h_flex()
+                    .size_3()
+                    .justify_center()
+                    .child(Indicator::dot().color(self.status_color)),
+            )
+            .children(self.children)
+            .end_slot(h_flex().gap_2().children(self.buttons))
+    }
+}

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -71,15 +71,6 @@ async fn peek_ports(ip: IpAddr) -> Result<[u16; 5]> {
     Ok(ports)
 }
 
-#[derive(Debug)]
-pub enum Kernel {
-    RunningKernel(RunningKernel),
-    StartingKernel(Shared<Task<()>>),
-    ErroredLaunch(String),
-    ShuttingDown,
-    Shutdown,
-}
-
 #[derive(Debug, Clone)]
 pub enum KernelStatus {
     Idle,
@@ -89,6 +80,7 @@ pub enum KernelStatus {
     ShuttingDown,
     Shutdown,
 }
+
 impl KernelStatus {
     pub fn is_connected(&self) -> bool {
         match self {
@@ -126,6 +118,15 @@ impl From<&Kernel> for KernelStatus {
     }
 }
 
+#[derive(Debug)]
+pub enum Kernel {
+    RunningKernel(RunningKernel),
+    StartingKernel(Shared<Task<()>>),
+    ErroredLaunch(String),
+    ShuttingDown,
+    Shutdown,
+}
+
 impl Kernel {
     pub fn status(&self) -> KernelStatus {
         self.into()
@@ -146,6 +147,16 @@ impl Kernel {
                 running_kernel.kernel_info = Some(kernel_info.clone());
             }
             _ => {}
+        }
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        match self {
+            Kernel::ShuttingDown => true,
+            Kernel::RunningKernel(_)
+            | Kernel::StartingKernel(_)
+            | Kernel::ErroredLaunch(_)
+            | Kernel::Shutdown => false,
         }
     }
 }

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -18,7 +18,6 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use ui::{Color, Indicator};
 
 #[derive(Debug, Clone)]
 pub struct KernelSpecification {
@@ -128,19 +127,6 @@ impl From<&Kernel> for KernelStatus {
 }
 
 impl Kernel {
-    pub fn dot(&self) -> Indicator {
-        match self {
-            Kernel::RunningKernel(kernel) => match kernel.execution_state {
-                ExecutionState::Idle => Indicator::dot().color(Color::Success),
-                ExecutionState::Busy => Indicator::dot().color(Color::Modified),
-            },
-            Kernel::StartingKernel(_) => Indicator::dot().color(Color::Modified),
-            Kernel::ErroredLaunch(_) => Indicator::dot().color(Color::Error),
-            Kernel::ShuttingDown => Indicator::dot().color(Color::Modified),
-            Kernel::Shutdown => Indicator::dot().color(Color::Disabled),
-        }
-    }
-
     pub fn status(&self) -> KernelStatus {
         self.into()
     }

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -1,9 +1,4 @@
-use async_dispatcher::{set_dispatcher, Dispatcher, Runnable};
-use gpui::{AppContext, PlatformDispatcher};
-use project::Fs;
-use settings::Settings as _;
-use std::{sync::Arc, time::Duration};
-
+mod components;
 mod jupyter_settings;
 mod kernels;
 mod outputs;
@@ -13,14 +8,22 @@ mod repl_store;
 mod session;
 mod stdio;
 
-pub use jupyter_settings::JupyterSettings;
-pub use kernels::{Kernel, KernelSpecification, KernelStatus};
-pub use repl_editor::*;
-pub use repl_sessions_ui::{ClearOutputs, Interrupt, ReplSessionsPage, Run, Sessions, Shutdown};
-pub use runtimelib::ExecutionState;
-pub use session::Session;
+use std::{sync::Arc, time::Duration};
 
+use async_dispatcher::{set_dispatcher, Dispatcher, Runnable};
+use gpui::{AppContext, PlatformDispatcher};
+use project::Fs;
+pub use runtimelib::ExecutionState;
+use settings::Settings as _;
+
+pub use crate::jupyter_settings::JupyterSettings;
+pub use crate::kernels::{Kernel, KernelSpecification, KernelStatus};
+pub use crate::repl_editor::*;
+pub use crate::repl_sessions_ui::{
+    ClearOutputs, Interrupt, ReplSessionsPage, Run, Sessions, Shutdown,
+};
 use crate::repl_store::ReplStore;
+pub use crate::session::Session;
 
 fn zed_dispatcher(cx: &mut AppContext) -> impl Dispatcher {
     struct ZedDispatcher {

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -9,7 +9,7 @@ use workspace::item::ItemEvent;
 use workspace::WorkspaceId;
 use workspace::{item::Item, Workspace};
 
-use crate::components::SessionEntry;
+use crate::components::KernelListItem;
 use crate::jupyter_settings::JupyterSettings;
 use crate::repl_store::ReplStore;
 
@@ -221,7 +221,7 @@ impl Render for ReplSessionsPage {
                 )
                 .child(Label::new("Kernels available").size(LabelSize::Large))
                 .children(kernel_specifications.into_iter().map(|spec| {
-                    SessionEntry::new(spec.clone()).child(
+                    KernelListItem::new(spec.clone()).child(
                         h_flex()
                             .gap_2()
                             .child(Label::new(spec.name))

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -1,8 +1,9 @@
 use editor::Editor;
 use gpui::{
-    actions, prelude::*, AppContext, EventEmitter, FocusHandle, FocusableView, Subscription, View,
+    actions, prelude::*, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView,
+    Subscription, View,
 };
-use ui::{prelude::*, ButtonLike, ElevationIndex, KeyBinding};
+use ui::{prelude::*, ButtonLike, ElevationIndex, KeyBinding, ListItem};
 use util::ResultExt as _;
 use workspace::item::ItemEvent;
 use workspace::WorkspaceId;
@@ -187,15 +188,11 @@ impl Render for ReplSessionsPage {
         // install kernels. It can be assumed they don't have a running kernel if we have no
         // specifications.
         if kernel_specifications.is_empty() {
-            return v_flex()
-                .p_4()
-                .size_full()
-                .gap_2()
+            let instructions = "To start interactively running code in your editor, you need to install and configure Jupyter kernels.";
+
+            return ReplSessionsContainer::new()
                 .child(Label::new("No Jupyter Kernels Available").size(LabelSize::Large))
-                .child(
-                    Label::new("To start interactively running code in your editor, you need to install and configure Jupyter kernels.")
-                        .size(LabelSize::Default),
-                )
+                .child(Label::new(instructions))
                 .child(
                     h_flex().w_full().p_4().justify_center().gap_2().child(
                         ButtonLike::new("install-kernels")
@@ -209,48 +206,60 @@ impl Render for ReplSessionsPage {
                                 )
                             }),
                     ),
-                )
-                .into_any_element();
+                );
         }
 
         // When there are no sessions, show the command to run code in an editor
         if sessions.is_empty() {
-            return v_flex()
-                .p_4()
-                .size_full()
-                .gap_2()
+            let instructions = "To run code in a Jupyter kernel, select some code and use the 'repl::Run' command.";
+
+            return ReplSessionsContainer::new()
                 .child(Label::new("No Jupyter Kernel Sessions").size(LabelSize::Large))
                 .child(
-                    v_flex().child(
-                        Label::new("To run code in a Jupyter kernel, select some code and use the 'repl::Run' command.")
-                            .size(LabelSize::Default)
-                    )
-                    .children(
-                            KeyBinding::for_action(&Run, cx)
-                            .map(|binding|
-                                binding.into_any_element()
-                            )
-                    )
+                    v_flex()
+                        .child(Label::new(instructions))
+                        .children(KeyBinding::for_action(&Run, cx)),
                 )
                 .child(Label::new("Kernels available").size(LabelSize::Large))
-                .children(
-                    kernel_specifications.into_iter().map(|spec| {
-                        h_flex().gap_2().child(Label::new(spec.name.clone()))
-                            .child(Label::new(spec.kernelspec.language.clone()).color(Color::Muted))
-                    })
-                )
-
-                .into_any_element();
+                .children(kernel_specifications.into_iter().map(|spec| {
+                    ListItem::new(SharedString::from(spec.name.clone()))
+                        .selectable(false)
+                        .child(
+                            h_flex()
+                                .gap_2()
+                                .child(Label::new(spec.name))
+                                .child(Label::new(spec.kernelspec.language).color(Color::Muted)),
+                        )
+                }));
         }
 
-        v_flex()
-            .p_4()
+        ReplSessionsContainer::new()
             .child(Label::new("Jupyter Kernel Sessions").size(LabelSize::Large))
-            .children(
-                sessions
-                    .into_iter()
-                    .map(|session| session.clone().into_any_element()),
-            )
-            .into_any_element()
+            .children(sessions)
+    }
+}
+
+#[derive(IntoElement)]
+struct ReplSessionsContainer {
+    children: Vec<AnyElement>,
+}
+
+impl ReplSessionsContainer {
+    pub fn new() -> Self {
+        Self {
+            children: Vec::new(),
+        }
+    }
+}
+
+impl ParentElement for ReplSessionsContainer {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements)
+    }
+}
+
+impl RenderOnce for ReplSessionsContainer {
+    fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
+        v_flex().p_4().gap_2().size_full().children(self.children)
     }
 }

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -24,7 +24,9 @@ use runtimelib::{
 use settings::Settings as _;
 use std::{env::temp_dir, ops::Range, sync::Arc, time::Duration};
 use theme::{ActiveTheme, ThemeSettings};
-use ui::{h_flex, prelude::*, v_flex, ButtonLike, ButtonStyle, IconButtonShape, Label, Tooltip};
+use ui::{
+    h_flex, prelude::*, v_flex, ButtonLike, ButtonStyle, IconButtonShape, Label, ListItem, Tooltip,
+};
 
 pub struct Session {
     editor: WeakView<Editor>,
@@ -599,14 +601,20 @@ impl Render for Session {
             Kernel::Shutdown => format!("{} (Shutdown)", self.kernel_specification.name),
         };
 
-        return v_flex()
-            .gap_1()
-            .child(
-                h_flex()
-                    .gap_2()
-                    .child(self.kernel.dot())
-                    .child(Label::new(status_text)),
-            )
-            .child(h_flex().gap_2().children(buttons));
+        ListItem::new(SharedString::from(self.kernel_specification.name.clone()))
+            .selectable(false)
+            .start_slot(self.kernel.dot())
+            .child(Label::new(status_text))
+            .end_slot(h_flex().gap_2().children(buttons))
+
+        // v_flex()
+        //     .gap_1()
+        //     .child(
+        //         h_flex()
+        //             .gap_2()
+        //             .child(self.kernel.dot())
+        //             .child(Label::new(status_text)),
+        //     )
+        //     .child(h_flex().gap_2().children(buttons))
     }
 }

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -1,4 +1,4 @@
-use crate::components::SessionEntry;
+use crate::components::KernelListItem;
 use crate::{
     kernels::{Kernel, KernelSpecification, RunningKernel},
     outputs::{ExecutionStatus, ExecutionView, LineHeight as _},
@@ -583,7 +583,7 @@ impl Render for Session {
             Kernel::Shutdown => (Some("Shutdown".into()), None),
         };
 
-        SessionEntry::new(self.kernel_specification.clone())
+        KernelListItem::new(self.kernel_specification.clone())
             .status_color(match &self.kernel {
                 Kernel::RunningKernel(kernel) => match kernel.execution_state {
                     ExecutionState::Idle => Color::Success,


### PR DESCRIPTION
This PR iterates on the design of the REPL sessions view.

We now use the same component for both available kernels and running ones to provide some consistency between the two modes:

<img width="1208" alt="Screenshot 2024-07-22 at 6 49 08 PM" src="https://github.com/user-attachments/assets/8b5c3600-e438-49fa-8484-cefabf4b44f1">

<img width="1208" alt="Screenshot 2024-07-22 at 6 49 14 PM" src="https://github.com/user-attachments/assets/5125e9b3-6465-4d1e-9036-e6ca270dedcb">

Release Notes:

- N/A
