### PR TITLE
linux: Fix crash in Wayland when dragging and dropping a tab not belonging to Zed

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1803,7 +1803,6 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
 
                             // Prevent dropping text from other programs.
                             if paths.is_empty() {
-                                data_offer.finish();
                                 data_offer.destroy();
                                 return;
                             }


### PR DESCRIPTION
close #14189 

Release Notes:

- N/A
