### PR TITLE
Remove `completion` dependency from `collab`

### DIFF
--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -30,7 +30,6 @@ chrono.workspace = true
 clock.workspace = true
 clickhouse.workspace = true
 collections.workspace = true
-completion.workspace = true
 dashmap = "5.4"
 envy = "0.4.2"
 futures.workspace = true


### PR DESCRIPTION
This was causing CI to fail when trying to deploy collab.

Release Notes:

- N/A
