### PR TITLE
astro: Upgrade `zed_extension_api` to v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13855,7 +13855,7 @@ dependencies = [
 name = "zed_astro"
 version = "0.0.2"
 dependencies = [
- "zed_extension_api 0.0.4",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/extensions/astro/Cargo.toml
+++ b/extensions/astro/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/astro.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"

--- a/extensions/astro/src/astro.rs
+++ b/extensions/astro/src/astro.rs
@@ -1,5 +1,5 @@
 use std::{env, fs};
-use zed_extension_api::{self as zed, Result};
+use zed_extension_api::{self as zed, serde_json, Result};
 
 const SERVER_PATH: &str = "node_modules/@astrojs/language-server/bin/nodeServer.js";
 const PACKAGE_NAME: &str = "@astrojs/language-server";
@@ -13,14 +13,14 @@ impl AstroExtension {
         fs::metadata(SERVER_PATH).map_or(false, |stat| stat.is_file())
     }
 
-    fn server_script_path(&mut self, config: zed::LanguageServerConfig) -> Result<String> {
+    fn server_script_path(&mut self, language_server_id: &zed::LanguageServerId) -> Result<String> {
         let server_exists = self.server_exists();
         if self.did_find_server && server_exists {
             return Ok(SERVER_PATH.to_string());
         }
 
         zed::set_language_server_installation_status(
-            &config.name,
+            language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
         let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
@@ -29,7 +29,7 @@ impl AstroExtension {
             || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)
         {
             zed::set_language_server_installation_status(
-                &config.name,
+                language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
             let result = zed::npm_install_package(PACKAGE_NAME, &version);
@@ -63,10 +63,10 @@ impl zed::Extension for AstroExtension {
 
     fn language_server_command(
         &mut self,
-        config: zed::LanguageServerConfig,
+        language_server_id: &zed::LanguageServerId,
         _worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let server_path = self.server_script_path(config)?;
+        let server_path = self.server_script_path(language_server_id)?;
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
@@ -83,17 +83,15 @@ impl zed::Extension for AstroExtension {
 
     fn language_server_initialization_options(
         &mut self,
-        _config: zed::LanguageServerConfig,
+        _language_server_id: &zed::LanguageServerId,
         _worktree: &zed::Worktree,
-    ) -> Result<Option<String>> {
-        let initialization_options = r#"{
+    ) -> Result<Option<serde_json::Value>> {
+        Ok(Some(serde_json::json!({
             "provideFormatter": true,
             "typescript": {
                 "tsdk": "node_modules/typescript/lib"
             }
-        }"#;
-
-        Ok(Some(initialization_options.to_string()))
+        })))
     }
 }
 


### PR DESCRIPTION
This PR upgrades the Astro extension to use v0.0.6 of the `zed_extension_api`.

Release Notes:

- N/A
