### PR TITLE
astro: Align version numbers in `extension.toml` and `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13853,7 +13853,7 @@ dependencies = [
 
 [[package]]
 name = "zed_astro"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/astro/Cargo.toml
+++ b/extensions/astro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_astro"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"


### PR DESCRIPTION
This PR aligns the version numbers in `extension.toml` and `Cargo.toml` for the Astro extension, as they had gotten out-of-sync.

Release Notes:

- N/A
