### PR TITLE
linux: Detect shift better

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -729,7 +729,7 @@ impl Keystroke {
             // we only include the shift for upper-case letters by convention,
             // so don't include for numbers and symbols, but do include for
             // tab/enter, etc.
-            if key.chars().count() == 1 && key_utf8 == key {
+            if key.chars().count() == 1 && key_utf8.to_lowercase() == key_utf8 {
                 modifiers.shift = false;
             }
         }

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -729,7 +729,7 @@ impl Keystroke {
             // we only include the shift for upper-case letters by convention,
             // so don't include for numbers and symbols, but do include for
             // tab/enter, etc.
-            if key.chars().count() == 1 && key_utf8.to_lowercase() == key_utf8 {
+            if key.chars().count() == 1 && key.to_lowercase() == key.to_uppercase() {
                 modifiers.shift = false;
             }
         }


### PR DESCRIPTION
Release Notes:

- linux: Fixed typing shortcuts like ctrl-/ on some systems
