### PR TITLE
repl: Filter commands out of command palette when REPL is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8809,6 +8809,7 @@ dependencies = [
  "async-dispatcher",
  "base64 0.13.1",
  "collections",
+ "command_palette_hooks",
  "editor",
  "env_logger",
  "futures 0.3.28",

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -13,14 +13,15 @@ path = "src/repl.rs"
 doctest = false
 
 [dependencies]
-anyhow.workspace = true
 alacritty_terminal.workspace = true
+anyhow.workspace = true
 async-dispatcher.workspace = true
 base64.workspace = true
 collections.workspace = true
+command_palette_hooks.workspace = true
 editor.workspace = true
-gpui.workspace = true
 futures.workspace = true
+gpui.workspace = true
 image.workspace = true
 language.workspace = true
 log.workspace = true
@@ -32,20 +33,20 @@ serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smol.workspace = true
-theme.workspace = true
 terminal_view.workspace = true
+theme.workspace = true
 ui.workspace = true
-uuid.workspace = true
 util.workspace = true
+uuid.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
+http = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 theme = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
-http = { workspace = true, features = ["test-support"] }

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -25,6 +25,14 @@ pub use crate::repl_sessions_ui::{
 use crate::repl_store::ReplStore;
 pub use crate::session::Session;
 
+pub fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
+    set_dispatcher(zed_dispatcher(cx));
+    JupyterSettings::register(cx);
+    ::editor::init_settings(cx);
+    repl_sessions_ui::init(cx);
+    ReplStore::init(fs, cx);
+}
+
 fn zed_dispatcher(cx: &mut AppContext) -> impl Dispatcher {
     struct ZedDispatcher {
         dispatcher: Arc<dyn PlatformDispatcher>,
@@ -47,12 +55,4 @@ fn zed_dispatcher(cx: &mut AppContext) -> impl Dispatcher {
     ZedDispatcher {
         dispatcher: cx.background_executor().dispatcher.clone(),
     }
-}
-
-pub fn init(fs: Arc<dyn Fs>, cx: &mut AppContext) {
-    set_dispatcher(zed_dispatcher(cx));
-    JupyterSettings::register(cx);
-    ::editor::init_settings(cx);
-    repl_sessions_ui::init(cx);
-    ReplStore::init(fs, cx);
 }


### PR DESCRIPTION
This PR makes it so the `repl: ` commands don't appear in the command palette when the REPL feature is disabled.

Release Notes:

- N/A
