### PR TITLE
repl: Change keybinding to ctrl-shift-enter for repl::Run

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -485,7 +485,7 @@
   {
     "context": "Editor && jupyter && !ContextEditor",
     "bindings": {
-      "ctrl-enter": "repl::Run"
+      "ctrl-shift-enter": "repl::Run"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -183,7 +183,7 @@
   {
     "context": "Editor && jupyter && !ContextEditor",
     "bindings": {
-      "cmd-enter": "repl::Run"
+      "ctrl-shift-enter": "repl::Run"
     }
   },
   {


### PR DESCRIPTION
... on all platforms.

`ctrl-shift-enter` for the repl, `cmd-enter` for the assistant. People can override this behavior as they desire in their own keymaps.

Release Notes:

- N/A
