### PR TITLE
Don't try to connect to X11/Wayland when headless

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -87,6 +87,9 @@ pub(crate) fn current_platform(headless: bool) -> Rc<dyn Platform> {
 #[cfg(target_os = "linux")]
 #[inline]
 pub fn guess_compositor() -> &'static str {
+    if std::env::var_os("ZED_HEADLESS").is_some() {
+        return "Headless";
+    }
     let wayland_display = std::env::var_os("WAYLAND_DISPLAY");
     let x11_display = std::env::var_os("DISPLAY");
 

--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -1170,7 +1170,7 @@ pub async fn spawn_ssh_task(
         "-x".to_string(),
         "-c".to_string(),
         format!(
-            r#"~/.local/bin/zed -v >/dev/stderr || (curl -f https://zed.dev/install.sh || wget -qO- https://zed.dev/install.sh) | sh && ~/.local/bin/zed --dev-server-token {}"#,
+            r#"~/.local/bin/zed -v >/dev/stderr || (curl -f https://zed.dev/install.sh || wget -qO- https://zed.dev/install.sh) | sh && ZED_HEADLESS=1 ~/.local/bin/zed --dev-server-token {}"#,
             access_token
         ),
     ];


### PR DESCRIPTION
Release Notes:

- remote development: Stopped logging every 16ms when connected to a remote server with a badly configured X server.
