### PR TITLE
feature_flags: Allow overriding enabled feature flags via env variable

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -194,8 +194,16 @@ impl UserStore {
                                     if let Some(info) = info {
                                         let disable_staff = std::env::var("ZED_DISABLE_STAFF")
                                             .map_or(false, |v| v != "" && v != "0");
+                                        let flags = std::env::var("ZED_FEATURE_FLAGS_OVERRIDE")
+                                            .map(|override_flags| {
+                                                override_flags
+                                                    .split(",")
+                                                    .map(str::to_string)
+                                                    .collect()
+                                            })
+                                            .unwrap_or(info.flags);
                                         let staff = info.staff && !disable_staff;
-                                        cx.update_flags(staff, info.flags);
+                                        cx.update_flags(staff, flags);
                                         client.telemetry.set_authenticated_user_info(
                                             Some(info.metrics_id.clone()),
                                             staff,

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -20,6 +20,8 @@ impl Global for FeatureFlags {}
 /// Feature flags are always enabled for members of Zed staff. To disable this behavior
 /// so you can test flags being disabled, set ZED_DISABLE_STAFF=1 in your environment,
 /// which will force Zed to treat the current user as non-staff.
+/// Feature flags can be overwritten by providing a comma-separated list
+/// via the environment variable ZED_FEATURE_FLAGS_OVERRIDE,
 pub trait FeatureFlag {
     const NAME: &'static str;
 }


### PR DESCRIPTION
Adds environment variable `ZED_FEATURE_FLAGS_OVERRIDE` to override feature flags, mainly useful for development of features hidden behind feature flags, but could potentially be useful for users as well.

I wanted to check out the work @SomeoneToIgnore has been doing with #14515, and didn't figure out how an external user would be able to enable these flags. Hence this PR.

Release Notes:

- Added functionality to override enabled feature flags via environment variable.