### PR TITLE
Add global `Fs` instance

### DIFF
--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -19,7 +19,7 @@ collections.workspace = true
 futures.workspace = true
 git.workspace = true
 git2.workspace = true
-gpui = { workspace = true, optional = true }
+gpui.workspace = true
 lazy_static.workspace = true
 libc.workspace = true
 parking_lot.workspace = true

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -12,6 +12,7 @@ use std::os::unix::fs::MetadataExt;
 use async_tar::Archive;
 use futures::{future::BoxFuture, AsyncRead, Stream, StreamExt};
 use git::repository::{GitRepository, RealGitRepository};
+use gpui::{AppContext, Global, ReadGlobal};
 use rope::Rope;
 use smol::io::AsyncWriteExt;
 use std::{
@@ -99,6 +100,22 @@ pub trait Fs: Send + Sync {
     #[cfg(any(test, feature = "test-support"))]
     fn as_fake(&self) -> &FakeFs {
         panic!("called as_fake on a real fs");
+    }
+}
+
+struct GlobalFs(Arc<dyn Fs>);
+
+impl Global for GlobalFs {}
+
+impl dyn Fs {
+    /// Returns the global [`Fs`].
+    pub fn global(cx: &AppContext) -> Arc<Self> {
+        GlobalFs::global(cx).0.clone()
+    }
+
+    /// Sets the global [`Fs`].
+    pub fn set_global(fs: Arc<Self>, cx: &mut AppContext) {
+        cx.set_global(GlobalFs(fs));
     }
 }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -14,7 +14,7 @@ use collab_ui::channel_view::ChannelView;
 use db::kvp::KEY_VALUE_STORE;
 use editor::Editor;
 use env_logger::Builder;
-use fs::RealFs;
+use fs::{Fs, RealFs};
 use futures::{future, StreamExt};
 use git::GitHostingProviderRegistry;
 use gpui::{
@@ -398,6 +398,8 @@ fn main() {
         if let Some(build_sha) = option_env!("ZED_COMMIT_SHA") {
             AppCommitSha::set_global(AppCommitSha(build_sha.into()), cx);
         }
+
+        <dyn Fs>::set_global(fs.clone(), cx);
 
         GitHostingProviderRegistry::set_global(git_hosting_provider_registry, cx);
         git_hosting_providers::init(cx);


### PR DESCRIPTION
This PR adds a global `Fs` instance to the app context.

This will make it easier to access the filesystem in some cases instead of having to thread it around.

Release Notes:

- N/A
