### PR TITLE
rpc: Add regression tests for encoding/decoding public keys

### DIFF
--- a/crates/rpc/src/auth.rs
+++ b/crates/rpc/src/auth.rs
@@ -108,6 +108,20 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_and_decode_base64_public_key() {
+        // A base64-encoded public key.
+        //
+        // We're using a literal string to ensure that encoding and decoding works across differences in implementations.
+        let encoded_public_key = "MIGJAoGBAMPvufou8wOuUIF1Wlkbtn0ZMM9nC55QJ06nTZvgMfZv5esFVU9-cQO_JC1P9ZoEcMDJweFERnQuQLqzsrMDLFbkdgL128ZU43WOLiQraxaICFIZsPUeTtWMKp2D5bPWsNxs-lnCma7vCAry6fpXuj5AKQdk7cTZJNucgvZQ0uUfAgMBAAE=".to_string();
+
+        // Make sure we can parse the public key.
+        let public_key = PublicKey::try_from(encoded_public_key.clone()).unwrap();
+
+        // Make sure we re-encode to the same format.
+        assert_eq!(encoded_public_key, String::try_from(public_key).unwrap());
+    }
+
+    #[test]
     fn test_tokens_are_always_url_safe() {
         for _ in 0..5 {
             let token = random_token();

--- a/typos.toml
+++ b/typos.toml
@@ -15,6 +15,11 @@ extend-exclude = [
     "crates/editor/src/editor_tests.rs",
     # Clojure uses .edn filename extension, which is not a misspelling of "end"
     "extensions/clojure/languages/clojure/config.toml",
+    # There are some names in the test data that are incorrectly flagged as typos.
+    "crates/git/test_data/blame_incremental_complex",
+    "crates/git/test_data/golden/blame_incremental_complex.json",
+    # We have some base64-encoded data that is incorrectly being flagged.
+    "crates/rpc/src/auth.rs",
     # glsl isn't recognized by this tool
     "extensions/glsl/languages/glsl/",
     # Windows likes its abbreviations


### PR DESCRIPTION
This PR adds some tests to ensure we don't regress in our public key encoding/decoding capabilities when making changes in this area.

Release Notes:

- N/A
