### PR TITLE
Upgrade `rsa` to v0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6894,23 +6894,6 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bc3e36fd683e004fd59c64a425e0e991616f5a8b617c3b9a933a93c168facc"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
-name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
@@ -7154,7 +7137,7 @@ dependencies = [
  "hkdf",
  "hmac 0.12.1",
  "num",
- "num-bigint-dig 0.8.4",
+ "num-bigint-dig",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
  "serde",
@@ -7536,17 +7519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "pem"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
-dependencies = [
- "base64 0.13.1",
- "once_cell",
- "regex",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7715,7 +7687,7 @@ checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.8",
  "pkcs8 0.10.2",
- "spki 0.7.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -7735,7 +7707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.8",
- "spki 0.7.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -8911,7 +8883,7 @@ dependencies = [
  "parking_lot",
  "proto",
  "rand 0.8.5",
- "rsa 0.4.0",
+ "rsa",
  "serde",
  "serde_json",
  "strum",
@@ -8922,42 +8894,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.4.0"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ef841a26fc5d040ced0417c6c6a64ee851f42489df11cdf0218e545b6f8d28"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "lazy_static",
- "num-bigint-dig 0.7.1",
- "num-integer",
- "num-iter",
- "num-traits",
- "pem",
- "rand 0.8.5",
- "simple_asn1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
-dependencies = [
- "byteorder",
  "const-oid",
  "digest 0.10.7",
- "num-bigint-dig 0.8.4",
+ "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature 2.1.0",
- "spki 0.7.2",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -9799,18 +9749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
-name = "simple_asn1"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
-dependencies = [
- "chrono",
- "num-bigint",
- "num-traits",
- "thiserror",
-]
-
-[[package]]
 name = "simplecss"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9999,9 +9937,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.8",
@@ -10183,7 +10121,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rand 0.8.5",
- "rsa 0.9.2",
+ "rsa",
  "rust_decimal",
  "serde",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,6 +360,7 @@ rand = "0.8.5"
 refineable = { path = "./crates/refineable" }
 regex = "1.5"
 repair_json = "0.1.0"
+rsa = "0.9.6"
 runtimelib = { version = "0.12", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -27,7 +27,7 @@ gpui = { workspace = true, optional = true }
 parking_lot.workspace = true
 proto.workspace = true
 rand.workspace = true
-rsa = "0.4"
+rsa.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true

--- a/crates/rpc/src/auth.rs
+++ b/crates/rpc/src/auth.rs
@@ -108,6 +108,20 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_and_decode_base64_public_key() {
+        // A base64-encoded public key.
+        //
+        // We're using a literal string to ensure that encoding and decoding works across differences in implementations.
+        let encoded_public_key = "MIGJAoGBAMPvufou8wOuUIF1Wlkbtn0ZMM9nC55QJ06nTZvgMfZv5esFVU9-cQO_JC1P9ZoEcMDJweFERnQuQLqzsrMDLFbkdgL128ZU43WOLiQraxaICFIZsPUeTtWMKp2D5bPWsNxs-lnCma7vCAry6fpXuj5AKQdk7cTZJNucgvZQ0uUfAgMBAAE=".to_string();
+
+        // Make sure we can parse the public key.
+        let public_key = PublicKey::try_from(encoded_public_key.clone()).unwrap();
+
+        // Make sure we re-encode to the same format.
+        assert_eq!(encoded_public_key, String::try_from(public_key).unwrap());
+    }
+
+    #[test]
     fn test_tokens_are_always_url_safe() {
         for _ in 0..5 {
             let token = random_token();

--- a/crates/rpc/src/auth.rs
+++ b/crates/rpc/src/auth.rs
@@ -61,7 +61,7 @@ impl TryFrom<PublicKey> for String {
     fn try_from(key: PublicKey) -> Result<Self> {
         let bytes = key
             .0
-            .to_pkcs1_pem(rsa::pkcs8::LineEnding::LF)
+            .to_pkcs1_der()
             .context("failed to serialize public key")?;
         let string = base64::encode_config(&bytes, base64::URL_SAFE);
         Ok(string)
@@ -73,9 +73,7 @@ impl TryFrom<String> for PublicKey {
     fn try_from(value: String) -> Result<Self> {
         let bytes = base64::decode_config(&value, base64::URL_SAFE)
             .context("failed to base64-decode public key string")?;
-        let pem_key = String::from_utf8(bytes).context("failed to parse public key as UTF-8")?;
-        let key =
-            Self(RsaPublicKey::from_pkcs1_pem(&pem_key).context("failed to parse public key")?);
+        let key = Self(RsaPublicKey::from_pkcs1_der(&bytes).context("failed to parse public key")?);
         Ok(key)
     }
 }

--- a/crates/rpc/src/auth.rs
+++ b/crates/rpc/src/auth.rs
@@ -1,18 +1,19 @@
 use anyhow::{Context, Result};
 use rand::{thread_rng, Rng as _};
-use rsa::{PublicKey as _, PublicKeyEncoding, RSAPrivateKey, RSAPublicKey};
+use rsa::pkcs1::{DecodeRsaPublicKey, EncodeRsaPublicKey};
+use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use std::convert::TryFrom;
 
-pub struct PublicKey(RSAPublicKey);
+pub struct PublicKey(RsaPublicKey);
 
-pub struct PrivateKey(RSAPrivateKey);
+pub struct PrivateKey(RsaPrivateKey);
 
 /// Generate a public and private key for asymmetric encryption.
 pub fn keypair() -> Result<(PublicKey, PrivateKey)> {
     let mut rng = thread_rng();
     let bits = 1024;
-    let private_key = RSAPrivateKey::new(&mut rng, bits)?;
-    let public_key = RSAPublicKey::from(&private_key);
+    let private_key = RsaPrivateKey::new(&mut rng, bits)?;
+    let public_key = RsaPublicKey::from(&private_key);
     Ok((PublicKey(public_key), PrivateKey(private_key)))
 }
 
@@ -58,7 +59,10 @@ impl PrivateKey {
 impl TryFrom<PublicKey> for String {
     type Error = anyhow::Error;
     fn try_from(key: PublicKey) -> Result<Self> {
-        let bytes = key.0.to_pkcs1().context("failed to serialize public key")?;
+        let bytes = key
+            .0
+            .to_pkcs1_pem(rsa::pkcs8::LineEnding::LF)
+            .context("failed to serialize public key")?;
         let string = base64::encode_config(&bytes, base64::URL_SAFE);
         Ok(string)
     }
@@ -69,12 +73,14 @@ impl TryFrom<String> for PublicKey {
     fn try_from(value: String) -> Result<Self> {
         let bytes = base64::decode_config(&value, base64::URL_SAFE)
             .context("failed to base64-decode public key string")?;
-        let key = Self(RSAPublicKey::from_pkcs1(&bytes).context("failed to parse public key")?);
+        let pem_key = String::from_utf8(bytes).context("failed to parse public key as UTF-8")?;
+        let key =
+            Self(RsaPublicKey::from_pkcs1_pem(&pem_key).context("failed to parse public key")?);
         Ok(key)
     }
 }
 
-const PADDING_SCHEME: rsa::PaddingScheme = rsa::PaddingScheme::PKCS1v15Encrypt;
+const PADDING_SCHEME: Pkcs1v15Encrypt = Pkcs1v15Encrypt;
 
 #[cfg(test)]
 mod tests {

--- a/typos.toml
+++ b/typos.toml
@@ -15,6 +15,11 @@ extend-exclude = [
     "crates/editor/src/editor_tests.rs",
     # Clojure uses .edn filename extension, which is not a misspelling of "end"
     "extensions/clojure/languages/clojure/config.toml",
+    # There are some names in the test data that are incorrectly flagged as typos.
+    "crates/git/test_data/blame_incremental_complex",
+    "crates/git/test_data/golden/blame_incremental_complex.json",
+    # We have some base64-encoded data that is incorrectly being flagged.
+    "crates/rpc/src/auth.rs",
     # glsl isn't recognized by this tool
     "extensions/glsl/languages/glsl/",
     # Windows likes its abbreviations


### PR DESCRIPTION
This PR upgrades the `rsa` crate to v0.9.6.

The version we were using was rather old, and for something security-sensitive we should be using a recent version.

No behavioral changes have been made, just updates to account for changes in the crate's API.

Release Notes:

- N/A
