### PR TITLE
vim: Prevent overflowing integer when pushing count digit

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -491,11 +491,25 @@ impl Vim {
     fn push_count_digit(&mut self, number: usize, cx: &mut WindowContext) {
         if self.active_operator().is_some() {
             self.update_state(|state| {
-                state.post_count = Some(state.post_count.unwrap_or(0) * 10 + number)
+                let post_count = state.post_count.unwrap_or(0);
+
+                state.post_count = Some(
+                    post_count
+                        .checked_mul(10)
+                        .and_then(|post_count| post_count.checked_add(number))
+                        .unwrap_or(post_count),
+                )
             })
         } else {
             self.update_state(|state| {
-                state.pre_count = Some(state.pre_count.unwrap_or(0) * 10 + number)
+                let pre_count = state.pre_count.unwrap_or(0);
+
+                state.pre_count = Some(
+                    pre_count
+                        .checked_mul(10)
+                        .and_then(|pre_count| pre_count.checked_add(number))
+                        .unwrap_or(pre_count),
+                )
             })
         }
         // update the keymap so that 0 works


### PR DESCRIPTION
Minor bug where the command count overflows when enough digits are entered. This swaps out simple multiplication/addition for their checked counter parts, falling back to the previous value in case of overflow.

Release Notes:

- N/A
