### PR TITLE
Do not show signature help when editor is not focused

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2805,6 +2805,9 @@ impl EditorElement {
         em_width: Pixels,
         cx: &mut WindowContext,
     ) {
+        if !self.editor.focus_handle(cx).is_focused(cx) {
+            return;
+        }
         let Some(newest_selection_head) = newest_selection_head else {
             return;
         };


### PR DESCRIPTION
Show the help again, if it was not dismissed and the editor regains focus.

Release Notes:

- N/A
