### PR TITLE
Display blocks over the git hunks

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1951,16 +1951,20 @@ impl EditorElement {
                             .x_for_index(align_to.column() as usize)
                     };
 
-                block.render(&mut BlockContext {
-                    context: cx,
-                    anchor_x,
-                    gutter_dimensions,
-                    line_height,
-                    em_width,
-                    block_id,
-                    max_width: text_hitbox.size.width.max(*scroll_width),
-                    editor_style: &self.style,
-                })
+                div()
+                    .size_full()
+                    .child(block.render(&mut BlockContext {
+                        context: cx,
+                        anchor_x,
+                        gutter_dimensions,
+                        line_height,
+                        em_width,
+                        block_id,
+                        max_width: text_hitbox.size.width.max(*scroll_width),
+                        editor_style: &self.style,
+                    }))
+                    .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
+                    .into_any_element()
             }
 
             Block::ExcerptHeader {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5568,15 +5568,15 @@ impl Element for EditorElement {
 
                     self.paint_text(layout, cx);
 
+                    if layout.gutter_hitbox.size.width > Pixels::ZERO {
+                        self.paint_gutter_highlights(layout, cx);
+                        self.paint_gutter_indicators(layout, cx);
+                    }
+
                     if !layout.blocks.is_empty() {
                         cx.with_element_namespace("blocks", |cx| {
                             self.paint_blocks(layout, cx);
                         });
-                    }
-
-                    if layout.gutter_hitbox.size.width > Pixels::ZERO {
-                        self.paint_gutter_highlights(layout, cx);
-                        self.paint_gutter_indicators(layout, cx);
                     }
 
                     self.paint_scrollbar(layout, cx);


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/614bbafd-f344-4c86-bd62-fff5f1ab143a)

After:
![after](https://github.com/user-attachments/assets/40a72a46-9fc4-4f94-9090-fb389f824a8d)


Release Notes:

- N/A
