### PR TITLE
Fix rendering issue with vtsls

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -153,14 +153,16 @@ impl LspAdapter for VtslsLspAdapter {
             _ => None,
         }?;
 
+        let one_line = |s: &str| s.replace("    ", "").replace('\n', " ");
+
         let text = if let Some(description) = item
             .label_details
             .as_ref()
             .and_then(|label_details| label_details.description.as_ref())
         {
-            format!("{} {}", item.label, description)
+            format!("{} {}", item.label, one_line(description))
         } else if let Some(detail) = &item.detail {
-            format!("{} {}", item.label, detail)
+            format!("{} {}", item.label, one_line(detail))
         } else {
             item.label.clone()
         };


### PR DESCRIPTION

Release Notes:

- Fixed multiline details provided by vtsls breaking rendering in autocompletions

Before:
<img width="697" alt="Screenshot_2024-07-20_at_20 47 41" src="https://github.com/user-attachments/assets/bc6db18e-77b9-400b-a917-2545269b7d1b">
After:
<img width="707" alt="Screenshot_2024-07-23_at_22 09 27" src="https://github.com/user-attachments/assets/a0f6ebe5-fba0-4cc1-8d8b-b1982e2adf95">
