### PR TITLE
Sublime swap lines

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -12,8 +12,8 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-up": "editor::AddSelectionAbove",
-      "ctrl-shift-down": "editor::AddSelectionBelow",
+      "ctrl-shift-up": "editor::MoveLineUp",
+      "ctrl-shift-down": "editor::MoveLineDown",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-l": "editor::SplitSelectionIntoLines",
       "ctrl-shift-a": "editor::SelectLargerSyntaxNode",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -12,8 +12,10 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-up": "editor::MoveLineUp",
-      "ctrl-shift-down": "editor::MoveLineDown",
+      "ctrl-shift-up": "editor::AddSelectionAbove",
+      "ctrl-shift-down": "editor::AddSelectionBelow",
+      "cmd-ctrl-up": "editor::MoveLineUp",
+      "cmd-ctrl-down": "editor::MoveLineDown",
       "cmd-shift-space": "editor::SelectAll",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -12,8 +12,8 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-up": "editor::AddSelectionAbove",
-      "ctrl-shift-down": "editor::AddSelectionBelow",
+      "ctrl-shift-up": "editor::MoveLineUp",
+      "ctrl-shift-down": "editor::MoveLineDown",
       "cmd-shift-space": "editor::SelectAll",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",


### PR DESCRIPTION
Supersedes #14925.

![image](https://github.com/user-attachments/assets/4f5e7f09-58ed-4507-94a2-f7e4e9d217ea)

<img width="689" alt="image" src="https://github.com/user-attachments/assets/1883e4f2-0f76-42e3-9534-a998ab50588a">



Release Notes:

- Improved SublimeText keymap (Mac & Linux). Add bind for MoveLineUp/Down (`ctrl-shift-up` on linux and `cmd-ctrl-up` on MacOS). ([#15089](https://github.com/zed-industries/zed/issues/15089), thanks @unixtensor).