### PR TITLE
Ensure quick action bar icon buttons are a square

### DIFF
--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -14,7 +14,7 @@ use gpui::{
 use search::{buffer_search, BufferSearchBar};
 use settings::{Settings, SettingsStore};
 use ui::{
-    prelude::*, ButtonSize, ButtonStyle, ContextMenu, IconButton, IconName, IconSize, Tooltip,
+    prelude::*, ButtonStyle, ContextMenu, IconButton, IconButtonShape, IconName, IconSize, Tooltip,
 };
 use workspace::{
     item::ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
@@ -158,7 +158,7 @@ impl Render for QuickActionBar {
 
         let editor_selections_dropdown = selection_menu_enabled.then(|| {
             IconButton::new("toggle_editor_selections_icon", IconName::TextCursor)
-                .size(ButtonSize::Compact)
+                .shape(IconButtonShape::Square)
                 .icon_size(IconSize::Small)
                 .style(ButtonStyle::Subtle)
                 .selected(self.toggle_selections_menu.is_some())
@@ -207,7 +207,7 @@ impl Render for QuickActionBar {
 
         let editor_settings_dropdown =
             IconButton::new("toggle_editor_settings_icon", IconName::Sliders)
-                .size(ButtonSize::Compact)
+                .shape(IconButtonShape::Square)
                 .icon_size(IconSize::Small)
                 .style(ButtonStyle::Subtle)
                 .selected(self.toggle_settings_menu.is_some())
@@ -300,7 +300,7 @@ impl Render for QuickActionBar {
 
         h_flex()
             .id("quick action bar")
-            .gap(Spacing::XLarge.rems(cx))
+            .gap(Spacing::Large.rems(cx))
             .child(
                 h_flex()
                     .gap(Spacing::Medium.rems(cx))
@@ -378,7 +378,7 @@ impl RenderOnce for QuickActionBarButton {
         let action = self.action.boxed_clone();
 
         IconButton::new(self.id.clone(), self.icon)
-            .size(ButtonSize::Compact)
+            .shape(IconButtonShape::Square)
             .icon_size(IconSize::Small)
             .style(ButtonStyle::Subtle)
             .selected(self.toggled)


### PR DESCRIPTION
As the title says! Also decreased a bit the gap between them so that's consistent with other similar icon button stacks. I wish they could be bigger buttons but the icons would need to be refined further for that, as each has been drawn with a different dimension/bounding-box. Maybe in the near future :)

### Before

https://github.com/user-attachments/assets/62a26faf-81b8-4fa9-8730-183d0be8bf8b

### After 

https://github.com/user-attachments/assets/68dc6e14-d067-426f-b7f1-d90090dc8e1e

---

Release Notes:

- N/A
