### PR TITLE
feature_flags: Add support for flags that aren't auto-enabled for staff

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -7,8 +7,12 @@ struct FeatureFlags {
 }
 
 impl FeatureFlags {
-    fn has_flag(&self, flag: &str) -> bool {
-        self.staff || self.flags.iter().any(|f| f.as_str() == flag)
+    fn has_flag<T: FeatureFlag>(&self) -> bool {
+        if self.staff && T::enabled_for_staff() {
+            return true;
+        }
+
+        self.flags.iter().any(|f| f.as_str() == T::NAME)
     }
 }
 
@@ -17,11 +21,16 @@ impl Global for FeatureFlags {}
 /// To create a feature flag, implement this trait on a trivial type and use it as
 /// a generic parameter when called [`FeatureFlagAppExt::has_flag`].
 ///
-/// Feature flags are always enabled for members of Zed staff. To disable this behavior
+/// Feature flags are enabled for members of Zed staff by default. To disable this behavior
 /// so you can test flags being disabled, set ZED_DISABLE_STAFF=1 in your environment,
 /// which will force Zed to treat the current user as non-staff.
 pub trait FeatureFlag {
     const NAME: &'static str;
+
+    /// Returns whether this feature flag is enabled for Zed staff.
+    fn enabled_for_staff() -> bool {
+        true
+    }
 }
 
 pub struct Remoting {}
@@ -60,7 +69,7 @@ where
     {
         self.observe_global::<FeatureFlags>(move |v, cx| {
             let feature_flags = cx.global::<FeatureFlags>();
-            callback(feature_flags.has_flag(<T as FeatureFlag>::NAME), v, cx);
+            callback(feature_flags.has_flag::<T>(), v, cx);
         })
     }
 }
@@ -90,7 +99,7 @@ impl FeatureFlagAppExt for AppContext {
 
     fn has_flag<T: FeatureFlag>(&self) -> bool {
         self.try_global::<FeatureFlags>()
-            .map(|flags| flags.has_flag(T::NAME))
+            .map(|flags| flags.has_flag::<T>())
             .unwrap_or(false)
     }
 
@@ -106,7 +115,7 @@ impl FeatureFlagAppExt for AppContext {
     {
         self.observe_global::<FeatureFlags>(move |cx| {
             let feature_flags = cx.global::<FeatureFlags>();
-            callback(feature_flags.has_flag(<T as FeatureFlag>::NAME), cx);
+            callback(feature_flags.has_flag::<T>(), cx);
         })
     }
 }


### PR DESCRIPTION
This PR adds support for defining feature flags that aren't auto-enabled for Zed staff.

This will be useful in situations where we want to land a feature behind a feature flag, but only want to ship it to certain staff members (e.g., the members currently working on it) initially.

Release Notes:

- N/A
