### PR TITLE
repl: Incorporate moving down to next cell in jupytext mode

### DIFF
--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -381,6 +381,7 @@ impl Session {
         &mut self,
         code: String,
         anchor_range: Range<Anchor>,
+        next_cell: Option<Anchor>,
         cx: &mut ViewContext<Self>,
     ) {
         let Some(editor) = self.editor.upgrade() else {
@@ -453,7 +454,11 @@ impl Session {
             return;
         };
 
-        let new_cursor_pos = editor_block.invalidation_anchor;
+        let new_cursor_pos = if let Some(next_cursor) = next_cell {
+            next_cursor
+        } else {
+            editor_block.invalidation_anchor
+        };
 
         self.blocks
             .insert(message.header.msg_id.clone(), editor_block);


### PR DESCRIPTION
`jupytext_snippets` now returns back both the jupytext snippets and the `Point` of the next jupytext snippet. 

Release Notes:

- N/A
