### PR TITLE
Fix cmd-alt-g b for git blame

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -298,7 +298,6 @@
       "alt-cmd-c": "search::ToggleCaseSensitive",
       "alt-cmd-w": "search::ToggleWholeWord",
       "alt-cmd-f": "project_search::ToggleFilters",
-      "alt-cmd-g": "search::ToggleRegex",
       "alt-cmd-x": "search::ToggleRegex"
     }
   },


### PR DESCRIPTION
Broken by #14942 as the matching Pane binding for toggle regex now takes
precedence. cmd-alt-x still works for that.

Release Notes:

- N/A
