### PR TITLE
ruby: Support "binary" settings for Rubocop and Solargraph

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -66,6 +66,20 @@ Solargraph has formatting and diagnostics disabled by default. We can tell Zed t
 }
 ```
 
+To use Solargraph in the context of the bundle, you can use [folder-specific settings](../configuring-zed#settings-files) and specify the absolute path to the [`binstub`](https://bundler.io/v2.5/man/bundle-binstubs.1.html) of Solargraph:
+
+```json
+{
+  "lsp": {
+    "solargraph": {
+      "binary": {
+        "path": "<path_to_your_project>/bin/solargraph"
+      }
+    }
+  }
+}
+```
+
 ### Configuration
 
 Solargraph reads its configuration from a file called `.solargraph.yml` in the root of your project. For more information about this file, see the [Solargraph configuration documentation](https://solargraph.org/guides/configuration).
@@ -114,6 +128,20 @@ Rubocop has unsafe autocorrection disabled by default. We can tell Zed to enable
     "rubocop": {
       "initialization_options": {
         "safeAutocorrect": false
+      }
+    }
+  }
+}
+```
+
+To use Rubocop in the context of the bundle, you can use [folder-specific settings](../configuring-zed#settings-files) and specify the absolute path to the [`binstub`](https://bundler.io/v2.5/man/bundle-binstubs.1.html) of Rubocop:
+
+```json
+{
+  "lsp": {
+    "rubocop": {
+      "binary": {
+        "path": "<path_to_your_project>/bin/rubocop"
       }
     }
   }

--- a/extensions/ruby/src/language_servers/rubocop.rs
+++ b/extensions/ruby/src/language_servers/rubocop.rs
@@ -1,6 +1,9 @@
-use zed_extension_api::{self as zed, settings::LspSettings, Result};
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
 
-use crate::RubyLanguageServerCommand;
+pub struct RubocopBinary {
+    pub path: String,
+    pub args: Option<Vec<String>>,
+}
 
 pub struct Rubocop {}
 
@@ -12,33 +15,45 @@ impl Rubocop {
     }
 
     pub fn language_server_command(
-        &self,
+        &mut self,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
-    ) -> Result<RubyLanguageServerCommand> {
-        let mut binary = None;
-        let mut args = None;
+    ) -> Result<zed::Command> {
+        let binary = self.language_server_binary(language_server_id, worktree)?;
 
-        if let Some(binary_settings) =
-            LspSettings::for_worktree(Rubocop::LANGUAGE_SERVER_ID, worktree)
-                .ok()
-                .and_then(|lsp_settings| lsp_settings.binary)
-        {
-            if let Some(bin_path) = binary_settings.path {
-                binary = Some(bin_path);
-            }
-            if let Some(bin_args) = binary_settings.arguments {
-                args = Some(bin_args);
-            }
+        Ok(zed::Command {
+            command: binary.path,
+            args: binary.args.unwrap_or_else(|| vec!["--lsp".to_string()]),
+            env: worktree.shell_env(),
+        })
+    }
+
+    fn language_server_binary(
+        &self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<RubocopBinary> {
+        let binary_settings = LspSettings::for_worktree("rubocop", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+        let binary_args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone());
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            return Ok(RubocopBinary {
+                path,
+                args: binary_args,
+            });
         }
-        let command = if let Some(binary) = binary {
-            binary
-        } else {
-            worktree.which("rubocop").ok_or_else(|| {
-                "rubocop must be installed manually. Install it with `gem install rubocop` or specify the 'binary' path to it via local settings.".to_string()
-            })?
-        };
-        let args = args.unwrap_or_else(|| vec!["--lsp".into()]);
 
-        Ok(RubyLanguageServerCommand { command, args })
+        if let Some(path) = worktree.which("rubocop") {
+            return Ok(RubocopBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        Err("rubocop must be installed manually. Install it with `gem install rubocop` or specify the 'binary' path to it via local settings.".to_string())
     }
 }

--- a/extensions/ruby/src/language_servers/rubocop.rs
+++ b/extensions/ruby/src/language_servers/rubocop.rs
@@ -1,4 +1,6 @@
-use zed_extension_api::{self as zed, Result};
+use zed_extension_api::{self as zed, settings::LspSettings, Result};
+
+use crate::RubyLanguageServerCommand;
 
 pub struct Rubocop {}
 
@@ -9,11 +11,34 @@ impl Rubocop {
         Self {}
     }
 
-    pub fn server_script_path(&mut self, worktree: &zed::Worktree) -> Result<String> {
-        let path = worktree.which("rubocop").ok_or_else(|| {
-            "rubocop must be installed manually. Install it with `gem install rubocop` or specify the 'binary' path to it via local settings.".to_string()
-        })?;
+    pub fn language_server_command(
+        &self,
+        worktree: &zed::Worktree,
+    ) -> Result<RubyLanguageServerCommand> {
+        let mut binary = None;
+        let mut args = None;
 
-        Ok(path)
+        if let Some(binary_settings) =
+            LspSettings::for_worktree(Rubocop::LANGUAGE_SERVER_ID, worktree)
+                .ok()
+                .and_then(|lsp_settings| lsp_settings.binary)
+        {
+            if let Some(bin_path) = binary_settings.path {
+                binary = Some(bin_path);
+            }
+            if let Some(bin_args) = binary_settings.arguments {
+                args = Some(bin_args);
+            }
+        }
+        let command = if let Some(binary) = binary {
+            binary
+        } else {
+            worktree.which("rubocop").ok_or_else(|| {
+                "rubocop must be installed manually. Install it with `gem install rubocop` or specify the 'binary' path to it via local settings.".to_string()
+            })?
+        };
+        let args = args.unwrap_or_else(|| vec!["--lsp".into()]);
+
+        Ok(RubyLanguageServerCommand { command, args })
     }
 }

--- a/extensions/ruby/src/language_servers/ruby_lsp.rs
+++ b/extensions/ruby/src/language_servers/ruby_lsp.rs
@@ -59,7 +59,10 @@ impl RubyLsp {
             });
         }
 
-        Err("ruby-lsp must be installed manually".to_string())
+        Err(
+            "ruby-lsp must be installed manually. Install it with `gem install ruby-lsp`."
+                .to_string(),
+        )
     }
 
     pub fn label_for_completion(&self, completion: Completion) -> Option<CodeLabel> {

--- a/extensions/ruby/src/language_servers/solargraph.rs
+++ b/extensions/ruby/src/language_servers/solargraph.rs
@@ -1,9 +1,12 @@
 use zed::lsp::{Completion, CompletionKind, Symbol, SymbolKind};
 use zed::{CodeLabel, CodeLabelSpan};
 use zed_extension_api::settings::LspSettings;
-use zed_extension_api::{self as zed, Result};
+use zed_extension_api::{self as zed, LanguageServerId, Result};
 
-use crate::RubyLanguageServerCommand;
+pub struct SolargraphBinary {
+    pub path: String,
+    pub args: Option<Vec<String>>,
+}
 
 pub struct Solargraph {}
 
@@ -15,34 +18,46 @@ impl Solargraph {
     }
 
     pub fn language_server_command(
-        &self,
+        &mut self,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
-    ) -> Result<RubyLanguageServerCommand> {
-        let mut binary = None;
-        let mut args = None;
+    ) -> Result<zed::Command> {
+        let binary = self.language_server_binary(language_server_id, worktree)?;
 
-        if let Some(binary_settings) =
-            LspSettings::for_worktree(Solargraph::LANGUAGE_SERVER_ID, worktree)
-                .ok()
-                .and_then(|lsp_settings| lsp_settings.binary)
-        {
-            if let Some(bin_path) = binary_settings.path {
-                binary = Some(bin_path);
-            }
-            if let Some(bin_args) = binary_settings.arguments {
-                args = Some(bin_args);
-            }
+        Ok(zed::Command {
+            command: binary.path,
+            args: binary.args.unwrap_or_else(|| vec!["stdio".to_string()]),
+            env: worktree.shell_env(),
+        })
+    }
+
+    fn language_server_binary(
+        &self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<SolargraphBinary> {
+        let binary_settings = LspSettings::for_worktree("solargraph", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+        let binary_args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone());
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            return Ok(SolargraphBinary {
+                path,
+                args: binary_args,
+            });
         }
-        let command = if let Some(binary) = binary {
-            binary
-        } else {
-            worktree
-                .which("solargraph")
-                .ok_or_else(|| "solargraph must be installed manually".to_string())?
-        };
-        let args = args.unwrap_or_else(|| vec!["stdio".into()]);
 
-        Ok(RubyLanguageServerCommand { command, args })
+        if let Some(path) = worktree.which("solargraph") {
+            return Ok(SolargraphBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        Err("solargraph must be installed manually".to_string())
     }
 
     pub fn label_for_completion(&self, completion: Completion) -> Option<CodeLabel> {

--- a/extensions/ruby/src/language_servers/solargraph.rs
+++ b/extensions/ruby/src/language_servers/solargraph.rs
@@ -1,6 +1,9 @@
 use zed::lsp::{Completion, CompletionKind, Symbol, SymbolKind};
 use zed::{CodeLabel, CodeLabelSpan};
+use zed_extension_api::settings::LspSettings;
 use zed_extension_api::{self as zed, Result};
+
+use crate::RubyLanguageServerCommand;
 
 pub struct Solargraph {}
 
@@ -11,12 +14,35 @@ impl Solargraph {
         Self {}
     }
 
-    pub fn server_script_path(&mut self, worktree: &zed::Worktree) -> Result<String> {
-        let path = worktree
-            .which("solargraph")
-            .ok_or_else(|| "solargraph must be installed manually".to_string())?;
+    pub fn language_server_command(
+        &self,
+        worktree: &zed::Worktree,
+    ) -> Result<RubyLanguageServerCommand> {
+        let mut binary = None;
+        let mut args = None;
 
-        Ok(path)
+        if let Some(binary_settings) =
+            LspSettings::for_worktree(Solargraph::LANGUAGE_SERVER_ID, worktree)
+                .ok()
+                .and_then(|lsp_settings| lsp_settings.binary)
+        {
+            if let Some(bin_path) = binary_settings.path {
+                binary = Some(bin_path);
+            }
+            if let Some(bin_args) = binary_settings.arguments {
+                args = Some(bin_args);
+            }
+        }
+        let command = if let Some(binary) = binary {
+            binary
+        } else {
+            worktree
+                .which("solargraph")
+                .ok_or_else(|| "solargraph must be installed manually".to_string())?
+        };
+        let args = args.unwrap_or_else(|| vec!["stdio".into()]);
+
+        Ok(RubyLanguageServerCommand { command, args })
     }
 
     pub fn label_for_completion(&self, completion: Completion) -> Option<CodeLabel> {

--- a/extensions/ruby/src/ruby.rs
+++ b/extensions/ruby/src/ruby.rs
@@ -13,11 +13,6 @@ struct RubyExtension {
     rubocop: Option<Rubocop>,
 }
 
-struct RubyLanguageServerCommand {
-    command: String,
-    args: Vec<String>,
-}
-
 impl zed::Extension for RubyExtension {
     fn new() -> Self {
         Self {
@@ -32,27 +27,21 @@ impl zed::Extension for RubyExtension {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let language_server_command = match language_server_id.as_ref() {
-            Solargraph::LANGUAGE_SERVER_ID => self
-                .solargraph
-                .get_or_insert_with(|| Solargraph::new())
-                .language_server_command(worktree)?,
-            RubyLsp::LANGUAGE_SERVER_ID => self
-                .ruby_lsp
-                .get_or_insert_with(|| RubyLsp::new())
-                .language_server_command(worktree)?,
-            Rubocop::LANGUAGE_SERVER_ID => self
-                .rubocop
-                .get_or_insert_with(|| Rubocop::new())
-                .language_server_command(worktree)?,
-            _ => return Err(format!("Unknown language server: {language_server_id}")),
-        };
-
-        Ok(zed::Command {
-            command: language_server_command.command,
-            args: language_server_command.args,
-            env: worktree.shell_env(),
-        })
+        match language_server_id.as_ref() {
+            Solargraph::LANGUAGE_SERVER_ID => {
+                let solargraph = self.solargraph.get_or_insert_with(|| Solargraph::new());
+                solargraph.language_server_command(language_server_id, worktree)
+            }
+            RubyLsp::LANGUAGE_SERVER_ID => {
+                let ruby_lsp = self.ruby_lsp.get_or_insert_with(|| RubyLsp::new());
+                ruby_lsp.language_server_command(language_server_id, worktree)
+            }
+            Rubocop::LANGUAGE_SERVER_ID => {
+                let rubocop = self.rubocop.get_or_insert_with(|| Rubocop::new());
+                rubocop.language_server_command(language_server_id, worktree)
+            }
+            language_server_id => Err(format!("unknown language server: {language_server_id}")),
+        }
     }
 
     fn label_for_symbol(

--- a/extensions/ruby/src/ruby.rs
+++ b/extensions/ruby/src/ruby.rs
@@ -13,6 +13,11 @@ struct RubyExtension {
     rubocop: Option<Rubocop>,
 }
 
+struct RubyLanguageServerCommand {
+    command: String,
+    args: Vec<String>,
+}
+
 impl zed::Extension for RubyExtension {
     fn new() -> Self {
         Self {
@@ -27,36 +32,27 @@ impl zed::Extension for RubyExtension {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        match language_server_id.as_ref() {
-            Solargraph::LANGUAGE_SERVER_ID => {
-                let solargraph = self.solargraph.get_or_insert_with(|| Solargraph::new());
+        let language_server_command = match language_server_id.as_ref() {
+            Solargraph::LANGUAGE_SERVER_ID => self
+                .solargraph
+                .get_or_insert_with(|| Solargraph::new())
+                .language_server_command(worktree)?,
+            RubyLsp::LANGUAGE_SERVER_ID => self
+                .ruby_lsp
+                .get_or_insert_with(|| RubyLsp::new())
+                .language_server_command(worktree)?,
+            Rubocop::LANGUAGE_SERVER_ID => self
+                .rubocop
+                .get_or_insert_with(|| Rubocop::new())
+                .language_server_command(worktree)?,
+            _ => return Err(format!("Unknown language server: {language_server_id}")),
+        };
 
-                Ok(zed::Command {
-                    command: solargraph.server_script_path(worktree)?,
-                    args: vec!["stdio".into()],
-                    env: worktree.shell_env(),
-                })
-            }
-            RubyLsp::LANGUAGE_SERVER_ID => {
-                let ruby_lsp = self.ruby_lsp.get_or_insert_with(|| RubyLsp::new());
-
-                Ok(zed::Command {
-                    command: ruby_lsp.server_script_path(worktree)?,
-                    args: vec![],
-                    env: worktree.shell_env(),
-                })
-            }
-            Rubocop::LANGUAGE_SERVER_ID => {
-                let rubocop = self.rubocop.get_or_insert_with(|| Rubocop::new());
-
-                Ok(zed::Command {
-                    command: rubocop.server_script_path(worktree)?,
-                    args: vec!["--lsp".into()],
-                    env: worktree.shell_env(),
-                })
-            }
-            language_server_id => Err(format!("unknown language server: {language_server_id}")),
-        }
+        Ok(zed::Command {
+            command: language_server_command.command,
+            args: language_server_command.args,
+            env: worktree.shell_env(),
+        })
     }
 
     fn label_for_symbol(


### PR DESCRIPTION
Hello, this pull request adds support for specifying and using the "binary" settings for Rubocop and Solargraph LSPs. AFAIK, Ruby LSP does not require the bundler context but that could be added later easily.

In Ruby world, like in Node.js world, almost all
projects rely on project specific packages (gems) and their versions. Solargraph and Rubocop gems are usually installed as project dependencies. Attempting to use global installation of them fail in most cases due to incompatible or missing dependencies (gems).

To avoid that, Ruby engineers have the `bundler`
gem that provides the `exec` command. This command executes the given command in the context of the bundle.

This pull request adds support for pulling the `binary` settings to use them in starting both LSPs. For instance, to start the Solargraph gem in the context of the bundler, the end user must configure the binary settings in the folder-specific settings file like so:

```json
{
  "lsp": {
    "solargraph": {
      "binary": {
        "path": "/Users/vslobodin/Development/festivatica/bin/rubocop"
      }
    }
  }
}
```

The `path` key must be an absolute path to the `binstub` of the `solargraph` gem. The same applies to the "rubocop" gem. Side note but it would be awesome to use Zed specific environment variables to make this a bit easier. For instance, we could use the `ZED_WORKTREE_ROOT` environment variable:

```json
{
  "lsp": {
    "solargraph": {
      "binary": {
        "path": "${ZED_WORKTREE_ROOT}/bin/rubocop"
      }
    }
  }
}
```

But this is out of the scope of this pull request. The code is a bit messy and repeatable in some places, I am happy to improve it here or later.

References:
- https://bundler.io/v2.4/man/bundle-exec.1.html
- https://solargraph.org/guides/troubleshooting
- https://bundler.io/v2.5/man/bundle-binstubs.1.html

This pull request is based on these two pull requests:

- https://github.com/zed-industries/zed/pull/14655
- https://github.com/zed-industries/zed/issues/15001

Closes https://github.com/zed-industries/zed/issues/5109.

Release Notes:

- N/A