### PR TITLE
lsp: Check if "Goto Definition" supported before request

### DIFF
--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -786,6 +786,7 @@ mod tests {
         let mut cx = EditorLspTestContext::new_rust(
             lsp::ServerCapabilities {
                 hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                definition_provider: Some(lsp::OneOf::Left(true)),
                 ..Default::default()
             },
             cx,

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -427,6 +427,13 @@ impl LspCommand for GetDefinition {
     type LspRequest = lsp::request::GotoDefinition;
     type ProtoRequest = proto::GetDefinition;
 
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .definition_provider
+            .is_some()
+    }
+
     fn to_lsp(
         &self,
         path: &Path,


### PR DESCRIPTION
This is related to #15023 where we have the running Rubocop LSP that provides diagnostics and formatting capabilities. Rubocop LSP sends its capabilities
back to Zed without support for "textDocument/definition" request, Zed actually does not check that and sends a request to Rubocop that results in the server error "Unsupported method: textDocument/definition".

The fix here is related to https://github.com/zed-industries/zed/pull/14666

Release Notes:

- N/A
