### PR TITLE
Document git permalinks (GitHub, Gitlab, Bitbucket, SourceHut, Codeberg, etc)

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -134,6 +134,7 @@ impl ExtensionFilter {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 enum Feature {
     Git,
+    OpenIn,
     Vim,
     LanguageBash,
     LanguageC,
@@ -150,6 +151,19 @@ fn keywords_by_feature() -> &'static BTreeMap<Feature, Vec<&'static str>> {
     KEYWORDS_BY_FEATURE.get_or_init(|| {
         BTreeMap::from_iter([
             (Feature::Git, vec!["git"]),
+            (
+                Feature::OpenIn,
+                vec![
+                    "github",
+                    "gitlab",
+                    "bitbucket",
+                    "codeberg",
+                    "sourcehut",
+                    "permalink",
+                    "link",
+                    "open in",
+                ],
+            ),
             (Feature::Vim, vec!["vim"]),
             (Feature::LanguageBash, vec!["sh", "bash"]),
             (Feature::LanguageC, vec!["c", "clang"]),
@@ -957,6 +971,11 @@ impl ExtensionsPage {
                     "Zed comes with basic Git support. More Git features are coming in the future.",
                 )
                 .docs_url("https://zed.dev/docs/git"),
+                Feature::OpenIn => FeatureUpsell::new(
+                    telemetry,
+                    "Zed supports linking to a source line on GitHub and others.",
+                )
+                .docs_url("https://zed.dev/docs/git#git-integrations"),
                 Feature::Vim => FeatureUpsell::new(telemetry, "Vim support is built-in to Zed!")
                     .docs_url("https://zed.dev/docs/vim")
                     .child(CheckboxWithLabel::new(

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -8,3 +8,21 @@ Zed currently supports the following Git features:
 - Git blame viewing
 
 More advanced Git features—like staging and committing changes or viewing history within Zed—will be coming in the future.
+
+## Git Integrations
+
+Zed integrates with popular Git hosting services to ensure that git commit hashes
+and references to Issues / Pull Requests / Merge Requests become clickable links.
+Zed currently support links to
+[GitHub.com](https://github.com),
+[GitLab.com](https://gitlab.com),
+[Bitbucket.org](https://bitbucket.org),
+[SourceHut.org](https://sr.ht) and
+[Codeberg.org](https://codeberg.org).
+
+Zed also has a Copy Permalink feature to create a permanent link to a code snippet on your Git hosting service.
+These links are useful for sharing a specific line or range of lines in a file at a specific commit.
+Trigger this action via the [Command Palette](/docs/#command-palette) (search for `permalink`),
+by creating a [custom key bindings](/docs/key-bindings#custom-key-bindings) to the
+`editor::CopyPermalinkToLine` or `editor::OpenPermalinkToLine` actions
+or by simply right clicking and selecting `Copy Permalink` with line(s) selected in your editor.


### PR DESCRIPTION
Popular VScode extensions implementing Copy Permalink (number of installs):
- [Open in GitHub, Bitbucket, Gitlab, VisualStudio.com (ziyasal)](https://marketplace.visualstudio.com/items?itemName=ziyasal.vscode-open-in-github) (2.562M)
- [Open in GitHub (fabiospampinato)](https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-open-in-github) (104K)
- [Open In GitHub (sysoev)](https://marketplace.visualstudio.com/items?itemName=sysoev.vscode-open-in-github) (61K)

But in Zed you get this for free!

Release Notes:

- Docs: Added "Copy Permalink to Line" and "Open Permalink to Line"
