### PR TITLE
Use US English spelling of "behavior" and "customize"

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -561,7 +561,7 @@ impl DisplaySnapshot {
         }
     }
 
-    // used by line_mode selections and tries to match vim behaviour
+    // used by line_mode selections and tries to match vim behavior
     pub fn expand_to_line(&self, range: Range<Point>) -> Range<Point> {
         let new_start = if range.start.row == 0 {
             MultiBufferPoint::new(0, 0)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11,7 +11,7 @@
 //!
 //! All other submodules and structs are mostly concerned with holding editor data about the way it displays current buffer region(s).
 //!
-//! If you're looking to improve Vim mode, you should check out Vim crate that wraps Editor and overrides its behaviour.
+//! If you're looking to improve Vim mode, you should check out Vim crate that wraps Editor and overrides its behavior.
 pub mod actions;
 mod blame_entry_tooltip;
 mod blink_manager;

--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -96,7 +96,7 @@ pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {
 /// In addition to passing a TestAppContext, you can also ask for a `StdRnd` instance.
 /// this will be seeded with the `SEED` environment variable and is used internally by
 /// the ForegroundExecutor and BackgroundExecutor to run tasks deterministically in tests.
-/// Using the same `StdRng` for behaviour in your test will allow you to exercise a wide
+/// Using the same `StdRng` for behavior in your test will allow you to exercise a wide
 /// variety of scenarios and interleavings just by changing the seed.
 ///
 /// #[gpui::test] also takes three different arguments:

--- a/crates/outline_panel/src/outline_panel_settings.rs
+++ b/crates/outline_panel/src/outline_panel_settings.rs
@@ -30,7 +30,7 @@ pub struct OutlinePanelSettingsContent {
     ///
     /// Default: true
     pub button: Option<bool>,
-    /// Customise default width (in pixels) taken by outline panel
+    /// Customize default width (in pixels) taken by outline panel
     ///
     /// Default: 240
     pub default_width: Option<f32>,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -38,7 +38,7 @@ pub enum DirenvSettings {
     ShellHook,
     /// Load direnv configuration directly using `direnv export json`
     ///
-    /// Warning: This option is experimental and might cause some inconsistent behaviour compared to using the shell hook.
+    /// Warning: This option is experimental and might cause some inconsistent behavior compared to using the shell hook.
     /// If it does, please report it to GitHub
     Direct,
 }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -654,7 +654,7 @@ impl ProjectPanel {
 
     pub fn collapse_all_entries(&mut self, _: &CollapseAllEntries, cx: &mut ViewContext<Self>) {
         // By keeping entries for fully collapsed worktrees, we avoid expanding them within update_visible_entries
-        // (which is it's default behaviour when there's no entry for a worktree in expanded_dir_ids).
+        // (which is it's default behavior when there's no entry for a worktree in expanded_dir_ids).
         self.expanded_dir_ids
             .retain(|_, expanded_entries| expanded_entries.is_empty());
         self.update_visible_entries(None, cx);

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -60,7 +60,7 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub button: Option<bool>,
-    /// Customise default width (in pixels) taken by project panel
+    /// Customize default width (in pixels) taken by project panel
     ///
     /// Default: 240
     pub default_width: Option<f32>,

--- a/crates/vim/README.md
+++ b/crates/vim/README.md
@@ -6,9 +6,9 @@ The backlog is maintained in the `#vim` channel notes.
 
 ## Testing against Neovim
 
-If you are making a change to make Zed's behaviour more closely match vim/nvim, you can create a test using the `NeovimBackedTestContext`.
+If you are making a change to make Zed's behavior more closely match vim/nvim, you can create a test using the `NeovimBackedTestContext`.
 
-For example, the following test checks that Zed and Neovim have the same behaviour when running `*` in visual mode:
+For example, the following test checks that Zed and Neovim have the same behaviur when running `*` in visual mode:
 
 ```rust
 #[gpui::test]
@@ -31,6 +31,6 @@ cargo test -p vim --features neovim test_visual_star_hash
 This will run your keystrokes against a headless neovim and cache the results in the test_data directory.
 
 
-## Testing zed-only behaviour
+## Testing zed-only behavior
 
 Zed does more than vim/neovim in their default modes. The `VimTestContext` can be used instead. This lets you test integration with the language server and other parts of zed's UI that don't have a NeoVim equivalent.

--- a/crates/vim/README.md
+++ b/crates/vim/README.md
@@ -8,7 +8,7 @@ The backlog is maintained in the `#vim` channel notes.
 
 If you are making a change to make Zed's behavior more closely match vim/nvim, you can create a test using the `NeovimBackedTestContext`.
 
-For example, the following test checks that Zed and Neovim have the same behaviur when running `*` in visual mode:
+For example, the following test checks that Zed and Neovim have the same behavior when running `*` in visual mode:
 
 ```rust
 #[gpui::test]

--- a/crates/vim/src/test/neovim_backed_test_context.rs
+++ b/crates/vim/src/test/neovim_backed_test_context.rs
@@ -35,7 +35,7 @@ impl SharedState {
     pub fn assert_matches(&self) {
         if self.neovim != self.editor || self.neovim_mode != self.editor_mode {
             panic!(
-                indoc! {"Test failed (zed does not match nvim behaviour)
+                indoc! {"Test failed (zed does not match nvim behavior)
                     # initial state:
                     {}
                     # keystrokes:
@@ -67,7 +67,7 @@ impl SharedState {
         let message = if self.neovim != marked_text {
             "Test is incorrect (currently expected != neovim_state)"
         } else {
-            "Editor does not match nvim behaviour"
+            "Editor does not match nvim behavior"
         };
         panic!(
             indoc! {"{}
@@ -110,7 +110,7 @@ impl SharedClipboard {
         let message = if expected == self.neovim {
             "Test is incorrect (currently expected != neovim_state)"
         } else {
-            "Editor does not match nvim behaviour"
+            "Editor does not match nvim behavior"
         };
 
         panic!(

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -392,7 +392,7 @@ impl Vim {
     }
 
     // When handling an action, you must create visual marks if you will switch to normal
-    // mode without the default selection behaviour.
+    // mode without the default selection behavior.
     fn store_visual_marks(&mut self, cx: &mut WindowContext) {
         let mode = self.state().mode;
         if mode.is_visual() {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -92,7 +92,7 @@ use ui::{
 use util::{maybe, ResultExt, TryFutureExt};
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, RestoreOnStartupBehaviour, TabBarSettings, WorkspaceSettings,
+    AutosaveSetting, RestoreOnStartupBehavior, TabBarSettings, WorkspaceSettings,
 };
 
 use crate::notifications::NotificationId;

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -12,7 +12,7 @@ pub struct WorkspaceSettings {
     pub confirm_quit: bool,
     pub show_call_status_icon: bool,
     pub autosave: AutosaveSetting,
-    pub restore_on_startup: RestoreOnStartupBehaviour,
+    pub restore_on_startup: RestoreOnStartupBehavior,
     pub drop_target_size: f32,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub use_system_path_prompts: bool,
@@ -43,7 +43,7 @@ impl CloseWindowWhenNoItems {
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum RestoreOnStartupBehaviour {
+pub enum RestoreOnStartupBehavior {
     /// Always start with an empty editor
     None,
     /// Restore the workspace that was closed last.
@@ -78,7 +78,7 @@ pub struct WorkspaceSettingsContent {
     /// Controls previous session restoration in freshly launched Zed instance.
     /// Values: none, last_workspace, last_session
     /// Default: last_session
-    pub restore_on_startup: Option<RestoreOnStartupBehaviour>,
+    pub restore_on_startup: Option<RestoreOnStartupBehavior>,
     /// The size of the workspace split drop targets on the outer edges.
     /// Given as a fraction that will be multiplied by the smaller dimension of the workspace.
     ///

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -697,27 +697,27 @@ pub(crate) async fn restorable_workspace_locations(
     cx: &mut AsyncAppContext,
     app_state: &Arc<AppState>,
 ) -> Option<Vec<workspace::LocalPaths>> {
-    let mut restore_behaviour = cx
+    let mut restore_behavior = cx
         .update(|cx| WorkspaceSettings::get(None, cx).restore_on_startup)
         .ok()?;
 
     let last_session_id = app_state.session.last_session_id();
     if last_session_id.is_none()
         && matches!(
-            restore_behaviour,
-            workspace::RestoreOnStartupBehaviour::LastSession
+            restore_behavior,
+            workspace::RestoreOnStartupBehavior::LastSession
         )
     {
-        restore_behaviour = workspace::RestoreOnStartupBehaviour::LastWorkspace;
+        restore_behavior = workspace::RestoreOnStartupBehavior::LastWorkspace;
     }
 
-    match restore_behaviour {
-        workspace::RestoreOnStartupBehaviour::LastWorkspace => {
+    match restore_behavior {
+        workspace::RestoreOnStartupBehavior::LastWorkspace => {
             workspace::last_opened_workspace_paths()
                 .await
                 .map(|location| vec![location])
         }
-        workspace::RestoreOnStartupBehaviour::LastSession => {
+        workspace::RestoreOnStartupBehavior::LastSession => {
             if let Some(last_session_id) = last_session_id {
                 workspace::last_session_workspace_locations(last_session_id)
                     .filter(|locations| !locations.is_empty())

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -10,7 +10,7 @@ Your settings file can be opened with `cmd-,` (on macOS) or `ctrl-,` (on Linux).
 
 This configuration is merged with any local configuration inside your projects. You can open the project settings by running `zed: Open Local Settings` from the command palette. This will create a `.zed` directory containing`.zed/settings.json`.
 
-Although most projects will only need one settings file at the root, you can add more local settings files for subdirectories as needed. Not all settings can be set in local files, just those that impact the behaviour of the editor and language tooling. For example you can set `tab_size`, `formatter` etc. but not `theme`, `vim_mode` and similar.
+Although most projects will only need one settings file at the root, you can add more local settings files for subdirectories as needed. Not all settings can be set in local files, just those that impact the behavior of the editor and language tooling. For example you can set `tab_size`, `formatter` etc. but not `theme`, `vim_mode` and similar.
 
 The syntax for configuration files is a super-set of JSON that allows `//` comments.
 
@@ -1562,7 +1562,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 
 ## Project Panel
 
-- Description: Customise project panel
+- Description: Customize project panel
 - Setting: `project_panel`
 - Default:
 
@@ -1633,7 +1633,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 
 ### Default Width
 
-- Description: Customise default width taken by project panel
+- Description: Customize default width taken by project panel
 - Setting: `default_width`
 - Default: N/A width in pixels (eg: 420)
 
@@ -1650,7 +1650,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 **Options**
 
 1. Enable auto reveal entries
-   
+
 ```json
 {
     "auto_reveal_entries": true,
@@ -1658,7 +1658,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 ```
 
 2. Disable auto reveal entries
-   
+
 ```json
 {
     "auto_reveal_entries": false,
@@ -1674,7 +1674,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 **Options**
 
 1. Enable auto fold dirs
-   
+
 ```json
 {
     "auto_fold_dirs": true,
@@ -1682,7 +1682,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 ```
 
 2. Disable auto fold dirs
-   
+
 ```json
 {
     "auto_fold_dirs": false,
@@ -1707,7 +1707,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 **Options**
 
 1. Show scrollbar in project panel
-   
+
 ```json
 {
     "scrollbar": {
@@ -1717,7 +1717,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 ```
 
 2. Hide scrollbar in project panel
-   
+
 ```json
 {
     "scrollbar": {
@@ -1728,7 +1728,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 
 ## Calls
 
-- Description: Customise behaviour when participating in a call
+- Description: Customize behavior when participating in a call
 - Setting: `calls`
 - Default:
 


### PR DESCRIPTION
This PR fixes some instances that weren't using US English spellings of "behavior" and "customize".

Release Notes:

- N/A
