### PR TITLE
Prefer `.map` for conditionals with `else` conditions

### DIFF
--- a/crates/diagnostics/src/grouped_diagnostics.rs
+++ b/crates/diagnostics/src/grouped_diagnostics.rs
@@ -1320,9 +1320,8 @@ fn render_same_line_diagnostics(
         let editor_handle = editor_handle.clone();
         let parent = h_flex()
             .items_start()
-            .child(v_flex().size_full().when_some_else(
-                toggle_expand_label,
-                |parent, label| {
+            .child(v_flex().size_full().map(|parent| {
+                if let Some(label) = toggle_expand_label {
                     parent.child(Button::new(cx.block_id, label).on_click({
                         let diagnostics = Arc::clone(&diagnostics);
                         move |_, cx| {
@@ -1353,16 +1352,15 @@ fn render_same_line_diagnostics(
                             });
                         }
                     }))
-                },
-                |parent| {
+                } else {
                     parent.child(
                         h_flex()
                             .size(IconSize::default().rems())
                             .invisible()
                             .flex_none(),
                     )
-                },
-            ));
+                }
+            }));
         let max_message_rows = if expanded {
             None
         } else {

--- a/crates/gpui/src/util.rs
+++ b/crates/gpui/src/util.rs
@@ -40,44 +40,6 @@ pub trait FluentBuilder {
             }
         })
     }
-
-    /// Conditionally unwrap and modify self with one closure if the given option is Some, or another if it is None.
-    fn when_some_else<T>(
-        self,
-        option: Option<T>,
-        then: impl FnOnce(Self, T) -> Self,
-        otherwise: impl FnOnce(Self) -> Self,
-    ) -> Self
-    where
-        Self: Sized,
-    {
-        self.map(|this| {
-            if let Some(value) = option {
-                then(this, value)
-            } else {
-                otherwise(this)
-            }
-        })
-    }
-
-    /// Conditionally modify self with one closure or another
-    fn when_else(
-        self,
-        condition: bool,
-        then: impl FnOnce(Self) -> Self,
-        otherwise: impl FnOnce(Self) -> Self,
-    ) -> Self
-    where
-        Self: Sized,
-    {
-        self.map(|this| {
-            if condition {
-                then(this)
-            } else {
-                otherwise(this)
-            }
-        })
-    }
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -464,15 +464,12 @@ impl ProjectPanel {
             let is_remote = project.is_remote() && project.dev_server_project_id().is_none();
 
             let context_menu = ContextMenu::build(cx, |menu, cx| {
-                menu.context(self.focus_handle.clone()).when_else(
-                    is_read_only,
-                    |menu| {
-                        menu.action("Copy Relative Path", Box::new(CopyRelativePath))
-                            .when(is_dir, |menu| {
-                                menu.action("Search Inside", Box::new(NewSearchInDirectory))
-                            })
-                    },
-                    |menu| {
+                menu.context(self.focus_handle.clone()).map(|menu| {
+                    if is_read_only {
+                        menu.when(is_dir, |menu| {
+                            menu.action("Search Inside", Box::new(NewSearchInDirectory))
+                        })
+                    } else {
                         menu.action("New File", Box::new(NewFile))
                             .action("New Folder", Box::new(NewDirectory))
                             .separator()
@@ -545,8 +542,8 @@ impl ProjectPanel {
                                 menu.separator()
                                     .action("Collapse All", Box::new(CollapseAllEntries))
                             })
-                    },
-                )
+                    }
+                })
             });
 
             cx.focus_view(&context_menu);

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -83,37 +83,34 @@ impl QuickActionBar {
                     let status = menu_state.status;
                     let editor = editor.clone();
 
-                    menu.when_else(
-                        status.is_connected(),
-                        |running| {
+                    menu.map(|menu| {
+                        if status.is_connected() {
                             let status = status.clone();
-                            running
-                                .custom_row(move |_cx| {
-                                    h_flex()
-                                        .child(
-                                            Label::new(format!(
-                                                "kernel: {} ({})",
-                                                menu_state.kernel_name.clone(),
-                                                menu_state.kernel_language.clone()
-                                            ))
+                            menu.custom_row(move |_cx| {
+                                h_flex()
+                                    .child(
+                                        Label::new(format!(
+                                            "kernel: {} ({})",
+                                            menu_state.kernel_name.clone(),
+                                            menu_state.kernel_language.clone()
+                                        ))
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                    )
+                                    .into_any_element()
+                            })
+                            .custom_row(move |_cx| {
+                                h_flex()
+                                    .child(
+                                        Label::new(status.clone().to_string())
                                             .size(LabelSize::Small)
                                             .color(Color::Muted),
-                                        )
-                                        .into_any_element()
-                                })
-                                .custom_row(move |_cx| {
-                                    h_flex()
-                                        .child(
-                                            Label::new(status.clone().to_string())
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted),
-                                        )
-                                        .into_any_element()
-                                })
-                        },
-                        |not_running| {
+                                    )
+                                    .into_any_element()
+                            })
+                        } else {
                             let status = status.clone();
-                            not_running.custom_row(move |_cx| {
+                            menu.custom_row(move |_cx| {
                                 h_flex()
                                     .child(
                                         Label::new(format!("{}...", status.clone().to_string()))
@@ -122,8 +119,8 @@ impl QuickActionBar {
                                     )
                                     .into_any_element()
                             })
-                        },
-                    )
+                        }
+                    })
                     .separator()
                     .custom_entry(
                         move |_cx| {

--- a/crates/ui/src/components/setting.rs
+++ b/crates/ui/src/components/setting.rs
@@ -342,11 +342,13 @@ impl Render for LegacySettingsMenu {
             .max_w_96()
             .max_h_2_3()
             .px_2()
-            .when_else(
-                is_empty,
-                |empty| empty.py_1(),
-                |not_empty| not_empty.pt_0().pb_1(),
-            )
+            .map(|el| {
+                if is_empty {
+                    el.py_1()
+                } else {
+                    el.pt_0().pb_1()
+                }
+            })
             .gap_1()
             .when(is_empty, |this| {
                 this.child(Label::new("No settings found").color(Color::Muted))

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -119,9 +119,15 @@ impl Render for Toolbar {
                     .when(has_right_items, |this| {
                         this.child(
                             h_flex()
-                                // We're using `flex_none` here to prevent some flickering that can occur when the
-                                // size of the left items container changes.
-                                .when_else(has_left_items, Div::flex_none, Div::flex_auto)
+                                .map(|el| {
+                                    if has_left_items {
+                                        // We're using `flex_none` here to prevent some flickering that can occur when the
+                                        // size of the left items container changes.
+                                        el.flex_none()
+                                    } else {
+                                        el.flex_auto()
+                                    }
+                                })
                                 .justify_end()
                                 .children(self.right_items().map(|item| item.to_any())),
                         )


### PR DESCRIPTION
This PR updates instances where we were using `.when_else` and `.when_else_some` to use `.map` with a conditional inside.

This allows us to avoid reinventing Rust's syntax for conditionals and (IMO) makes the code easier to read.

Release Notes:

- N/A
