### PR TITLE
Make context and dropdown menus scrollable

### DIFF
--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -311,7 +311,10 @@ impl Render for ContextMenu {
         div().occlude().elevation_2(cx).flex().flex_row().child(
             WithRemSize::new(ui_font_size).flex().child(
                 v_flex()
+                    .id("context-menu")
                     .min_w(px(200.))
+                    .max_h(vh(0.75, cx))
+                    .overflow_y_scroll()
                     .track_focus(&self.focus_handle)
                     .on_mouse_down_out(cx.listener(|this, _, cx| this.cancel(&menu::Cancel, cx)))
                     .key_context("menu")

--- a/crates/ui/src/components/dropdown_menu.rs
+++ b/crates/ui/src/components/dropdown_menu.rs
@@ -1,4 +1,4 @@
-use gpui::{ClickEvent, CursorStyle, MouseButton, View};
+use gpui::{AnchorCorner, ClickEvent, CursorStyle, MouseButton, View};
 
 use crate::{prelude::*, ContextMenu, PopoverMenu};
 
@@ -45,6 +45,7 @@ impl RenderOnce for DropdownMenu {
             .full_width(self.full_width)
             .menu(move |_cx| Some(self.menu.clone()))
             .trigger(DropdownMenuTrigger::new(self.label).full_width(self.full_width))
+            .attach(AnchorCorner::BottomLeft)
     }
 }
 


### PR DESCRIPTION
This PR makes context and dropdown menus scrollable, so that they don't become totally unusable when they overflow the window.

Release Notes:

- N/A
