### PR TITLE
Upgrade `anyhow` to v1.0.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ checksum = "e78f17bacc1bc7b91fef7b1885c10772eb2b9e4e989356f6f0f6a972240f97cd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "approx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,7 @@ zed_actions = { path = "crates/zed_actions" }
 
 alacritty_terminal = "0.23"
 any_vec = "0.13"
-anyhow = "1.0.57"
+anyhow = "1.0.86"
 ashpd = "0.9.1"
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
 async-dispatcher = { version = "0.1" }


### PR DESCRIPTION
This PR upgrades `anyhow` to v1.0.86.

Release Notes:

- N/A
