### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,7 @@
   "schedule": ["after 3pm on Wednesday"],
   "major": {
     "dependencyDashboardApproval": true
-  }
+  },
+  "labels": ["cla-signed"],
+  "commitBody": "Release Notes:\n\n- N/A"
 }


### PR DESCRIPTION
This PR applies some further updates to the Renovate config.

We add the https://github.com/zed-industries/zed/labels/cla-signed label to the PRs so that check passes.

Also seeing if we can add a "Release Notes" sections to Renovate PRs.

Release Notes:

- N/A
