### PR TITLE
renovate: Add release notes to PR footer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,5 @@
   "major": {
     "dependencyDashboardApproval": true
   },
-  "labels": ["cla-signed"],
-  "commitBody": "Release Notes:\n\n- N/A"
+  "prFooter": "Release Notes:\n\n- N/A"
 }


### PR DESCRIPTION
This PR updates the Renovate config to place the "Release Notes" section in the PR body footer.

Also removed the `cla-signed` label, because the CLA bot just removes it.

Release Notes:

- N/A
