### PR TITLE
renovate: Separate major versions into multiple PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":semanticCommitsDisabled", "group:serdeMonorepo"],
+  "extends": [
+    "config:recommended",
+    ":semanticCommitsDisabled",
+    ":separateMultipleMajorReleases",
+    "group:serdeMonorepo"
+  ],
   "dependencyDashboard": true,
   "timezone": "America/New_York",
   "schedule": ["after 3pm on Wednesday"],


### PR DESCRIPTION
This PR updates the Renovate config to split major versions changes into multiple PRs.

This way we only have to deal with one set of breaking changes at a time instead of jumping across multiple major versions.

Release Notes:

- N/A
