### PR TITLE
Change default 'open project' keybinding because vim mode will override it

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -23,7 +23,7 @@
       "ctrl-alt-enter": ["picker::ConfirmInput", { "secondary": true }],
       "ctrl-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
-      "ctrl-o": "workspace::Open",
+      "shift-ctrl-o": "workspace::Open",
       "ctrl-=": "zed::IncreaseBufferFontSize",
       "ctrl-+": "zed::IncreaseBufferFontSize",
       "ctrl--": "zed::DecreaseBufferFontSize",

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -142,7 +142,6 @@ that you can't live without. You can restore them to their defaults by copying t
     "ctrl-v": "editor::Paste",         // vim default: visual block mode
     "ctrl-y": "editor::Undo",          // vim default: line up
     "ctrl-f": "buffer_search::Deploy", // vim default: page down
-    "ctrl-o": "workspace::Open",       // vim default: go back
     "ctrl-a": "editor::SelectAll",     // vim default: increment
   }
 },


### PR DESCRIPTION
Release Notes:

- Fixed/Improved Open Project key binding([#14947](https://github.com/zed-industries/zed/issues/14947)).
- Change default Open project key binding from ctrl + O to shift + ctrl + o because when vim mode is active the vim mode will override ctrl + O.