### PR TITLE
ruff: Pass `--preview` by default and make it configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13875,7 +13875,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruff"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/ruff/Cargo.toml
+++ b/extensions/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruff"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"


### PR DESCRIPTION
Release Notes:

- N/A

Although #15001 has merged to avoid passing `--preview`, executing without this flag is only supported on [ruff binary versions higher than 0.5.3.](https://github.com/astral-sh/ruff/pull/12208) Currently it does not work in environments where can't use latest ruff binary.

Therefore, we need to set `--preview` as the default option to support older versions, while also making it configurable through settings.