### PR TITLE
terraform: Make downloaded language server binary executable

### DIFF
--- a/extensions/terraform/src/terraform.rs
+++ b/extensions/terraform/src/terraform.rs
@@ -62,6 +62,8 @@ impl TerraformExtension {
             zed::download_file(&download_url, &version_dir, zed::DownloadedFileType::Zip)
                 .map_err(|e| format!("failed to download file: {e}"))?;
 
+            zed::make_file_executable(&binary_path)?;
+
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
             for entry in entries {


### PR DESCRIPTION
This PR updates the Terraform extension to make the downloaded language server binary executable.

Resolves #14502.

Release Notes:

- N/A
