### PR TITLE
astro: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13715,7 +13715,7 @@ dependencies = [
 
 [[package]]
 name = "zed_astro"
-version = "0.0.3"
+version = "0.1.0"
 dependencies = [
  "serde",
  "zed_extension_api 0.0.6",

--- a/extensions/astro/Cargo.toml
+++ b/extensions/astro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_astro"
-version = "0.0.3"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/astro/extension.toml
+++ b/extensions/astro/extension.toml
@@ -1,7 +1,7 @@
 id = "astro"
 name = "Astro"
 description = "Astro support."
-version = "0.0.3"
+version = "0.1.0"
 schema_version = 1
 authors = ["Alvaro Gaona <alvgaona@gmail.com>", "0xk1f0 <dev@k1f0.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Astro extension to v0.1.0.

Changes:

- #14849
- #15010
- #15011

Release Notes:

- N/A
