### PR TITLE
deno: Bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13744,7 +13744,7 @@ dependencies = [
 
 [[package]]
 name = "zed_deno"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/deno/Cargo.toml
+++ b/extensions/deno/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_deno"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/deno/extension.toml
+++ b/extensions/deno/extension.toml
@@ -1,7 +1,7 @@
 id = "deno"
 name = "Deno"
 description = "Deno support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Lino Le Van <11367844+lino-levan@users.noreply.github.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Deno extension to v0.0.2.

Changes:

- #14410

Release Notes:

- N/A
