### PR TITLE
terraform: Bump to v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13901,7 +13901,7 @@ dependencies = [
 
 [[package]]
 name = "zed_terraform"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/terraform/Cargo.toml
+++ b/extensions/terraform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_terraform"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/terraform/extension.toml
+++ b/extensions/terraform/extension.toml
@@ -1,7 +1,7 @@
 id = "terraform"
 name = "Terraform"
 description = "Terraform support."
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Caius Durling <dev@caius.name>", "Daniel Banck <dbanck@users.noreply.github.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Terraform extension to v0.0.4.

Changes:

- #10937
- #15171

Release Notes:

- N/A
