### PR TITLE
csharp: Upgrade `zed_extension_api` to v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13732,7 +13732,7 @@ dependencies = [
 name = "zed_csharp"
 version = "0.0.2"
 dependencies = [
- "zed_extension_api 0.0.4",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/extensions/csharp/Cargo.toml
+++ b/extensions/csharp/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/csharp.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"

--- a/extensions/csharp/src/csharp.rs
+++ b/extensions/csharp/src/csharp.rs
@@ -8,7 +8,7 @@ struct CsharpExtension {
 impl CsharpExtension {
     fn language_server_binary_path(
         &mut self,
-        config: zed::LanguageServerConfig,
+        language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<String> {
         if let Some(path) = worktree.which("OmniSharp") {
@@ -22,7 +22,7 @@ impl CsharpExtension {
         }
 
         zed::set_language_server_installation_status(
-            &config.name,
+            language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
         let release = zed::latest_github_release(
@@ -63,7 +63,7 @@ impl CsharpExtension {
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             zed::set_language_server_installation_status(
-                &config.name,
+                language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
 
@@ -101,11 +101,11 @@ impl zed::Extension for CsharpExtension {
 
     fn language_server_command(
         &mut self,
-        config: zed::LanguageServerConfig,
+        language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         Ok(zed::Command {
-            command: self.language_server_binary_path(config, worktree)?,
+            command: self.language_server_binary_path(language_server_id, worktree)?,
             args: vec!["-lsp".to_string()],
             env: Default::default(),
         })


### PR DESCRIPTION
This PR upgrades the C# extension to use v0.0.6 of the `zed_extension_api`.

Release Notes:

- N/A
