### PR TITLE
emmet: Upgrade `zed_extension_api` to v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13767,7 +13767,7 @@ dependencies = [
 name = "zed_emmet"
 version = "0.0.3"
 dependencies = [
- "zed_extension_api 0.0.4",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/extensions/emmet/Cargo.toml
+++ b/extensions/emmet/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/emmet.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"


### PR DESCRIPTION
This PR upgrades the Emmet extension to use v0.0.6 of the `zed_extension_api`.

Release Notes:

- N/A
