### PR TITLE
purescript: Upgrade `zed_extension_api` to v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13867,7 +13867,7 @@ dependencies = [
 name = "zed_purescript"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.4",
+ "zed_extension_api 0.0.6",
 ]
 
 [[package]]

--- a/extensions/purescript/Cargo.toml
+++ b/extensions/purescript/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/purescript.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"


### PR DESCRIPTION
This PR upgrades the PureScript extension to use v0.0.6 of the `zed_extension_api`.

Release Notes:

- N/A
