### PR TITLE
renovate: Pin GitHub Action versions with SHAs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     ":semanticCommitsDisabled",
     ":separateMultipleMajorReleases",
+    "helpers:pinGitHubActionDigests",
     "group:serdeMonorepo"
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
This PR updates the Renovate config to pin all GitHub Action versions to SHAs.

From the Renovate docs:

> The [GitHub Docs, using third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommend that you pin third-party GitHub Actions to a full-length commit SHA.
>
> We recommend pinning all Actions. That's why the helpers:pinGitHubActionDigests preset pins all GitHub Actions.
>
> For an in-depth explanation why you should pin your Github Actions, read the [Palo Alto Networks blog post about the GitHub Actions worm](https://www.paloaltonetworks.com/blog/prisma-cloud/github-actions-worm-dependencies/).

Release Notes:

- N/A
