### PR TITLE
Use user configs for jupyter settings

### DIFF
--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -54,7 +54,7 @@ impl QuickActionBar {
             })
         };
 
-        let session = repl::session(editor.downgrade(), cx);
+        let session = repl::session(editor.clone(), cx);
         let session = match session {
             SessionSupport::ActiveSession(session) => session,
             SessionSupport::Inactive(spec) => {

--- a/crates/repl/src/jupyter_settings.rs
+++ b/crates/repl/src/jupyter_settings.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
-use editor::EditorSettings;
-use gpui::AppContext;
+use editor::{Editor, EditorSettings};
+use gpui::{AppContext, View};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
+use workspace::item::ItemHandle;
 
 #[derive(Debug, Default)]
 pub struct JupyterSettings {
@@ -17,6 +18,14 @@ impl JupyterSettings {
         // we put the `enable` flag on its settings.
         // This allows the editor to set up context for key bindings/actions.
         EditorSettings::jupyter_enabled(cx)
+    }
+
+    pub fn settings<'a>(editor: View<Editor>, cx: &'a AppContext) -> &'a Self {
+        let project_path = editor.project_path(cx);
+        match project_path {
+            Some(project_path) => JupyterSettings::get(Some((&project_path).into()), cx),
+            None => JupyterSettings::get_global(cx),
+        }
     }
 }
 

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -36,7 +36,7 @@ pub fn run(editor: WeakView<Editor>, cx: &mut WindowContext) -> Result<()> {
 
         let kernel_specification = store.update(cx, |store, cx| {
             store
-                .kernelspec(&language, cx)
+                .kernelspec(editor.clone(), &language, cx)
                 .with_context(|| format!("No kernel found for language: {}", language.name()))
         })?;
 
@@ -96,7 +96,7 @@ pub enum SessionSupport {
     Unsupported,
 }
 
-pub fn session(editor: WeakView<Editor>, cx: &mut AppContext) -> SessionSupport {
+pub fn session(editor: View<Editor>, cx: &mut AppContext) -> SessionSupport {
     let store = ReplStore::global(cx);
     let entity_id = editor.entity_id();
 
@@ -104,10 +104,10 @@ pub fn session(editor: WeakView<Editor>, cx: &mut AppContext) -> SessionSupport 
         return SessionSupport::ActiveSession(session);
     };
 
-    let Some(language) = get_language(editor, cx) else {
+    let Some(language) = get_language(editor.downgrade(), cx) else {
         return SessionSupport::Unsupported;
     };
-    let kernelspec = store.update(cx, |store, cx| store.kernelspec(&language, cx));
+    let kernelspec = store.update(cx, |store, cx| store.kernelspec(editor, &language, cx));
 
     match kernelspec {
         Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -3,12 +3,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use collections::HashMap;
 use command_palette_hooks::CommandPaletteFilter;
+use editor::Editor;
 use gpui::{
     prelude::*, AppContext, EntityId, Global, Model, ModelContext, Subscription, Task, View,
 };
 use language::Language;
 use project::Fs;
-use settings::{Settings, SettingsStore};
+use settings::SettingsStore;
 
 use crate::kernels::kernel_specifications;
 use crate::{JupyterSettings, KernelSpecification, Session};
@@ -113,10 +114,11 @@ impl ReplStore {
 
     pub fn kernelspec(
         &self,
+        editor: View<Editor>,
         language: &Language,
         cx: &mut ModelContext<Self>,
     ) -> Option<KernelSpecification> {
-        let settings = JupyterSettings::get_global(cx);
+        let settings = JupyterSettings::settings(editor, cx);
         let language_name = language.code_fence_block_name();
         let selected_kernel = settings.kernel_selections.get(language_name.as_ref());
 


### PR DESCRIPTION
Release Notes:

-  Use user configs for jupyter settings. This basically makes it usable with remotes, so zed will use remote config instead of local machine one (chances are you have two different configs for local and remote)