### PR TITLE
renovate: Group `wasmtime` updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   "prFooter": "Release Notes:\n\n- N/A",
   "packageRules": [
     {
-      "description": "Group wasmtime crates",
+      "description": "Group wasmtime crates together.",
       "matchPackagePatterns": ["wasmtime**"],
       "groupName": "wasmtime"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,12 @@
   "major": {
     "dependencyDashboardApproval": true
   },
-  "prFooter": "Release Notes:\n\n- N/A"
+  "prFooter": "Release Notes:\n\n- N/A",
+  "packageRules": [
+    {
+      "description": "Group wasmtime crates",
+      "matchPackagePatterns": ["wasmtime**"],
+      "groupName": "wasmtime"
+    }
+  ]
 }


### PR DESCRIPTION
This PR updates the Renovate config to group `wasmtime` crates together (e.g., `wasmtime` and `wasmtime-wasi`).

Release Notes:

- N/A
