### PR TITLE
renovate: Fix selector for `wasmtime` group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   "packageRules": [
     {
       "description": "Group wasmtime crates together.",
-      "matchPackagePatterns": ["wasmtime**"],
+      "matchPackagePrefixes": ["wasmtime**"],
       "groupName": "wasmtime"
     }
   ]


### PR DESCRIPTION
This PR fixes the package name selector for the `wasmtime` group.

Release Notes:

- N/A
