### PR TITLE
zig: Bump to v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13939,7 +13939,7 @@ dependencies = [
 
 [[package]]
 name = "zed_zig"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_zig"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -1,7 +1,7 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.1.4"
+version = "0.1.5"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Zig extension to v0.1.5.

Changes:

- #15197

Release Notes:

- N/A
