### PR TITLE
zed: Mark restored buffers as conflicted if file changed on disk between store & restore

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -35,7 +35,6 @@ use std::{
     ops::Range,
     path::Path,
     sync::Arc,
-    time::{Duration, UNIX_EPOCH},
 };
 use text::{BufferId, Selection};
 use theme::{Theme, ThemeSettings};
@@ -931,9 +930,6 @@ impl SerializableItem for Editor {
                     .session
                     .restore_unsaved_buffers
                 {
-                    let mtime = mtime.map(|(seconds, nanos)| {
-                        UNIX_EPOCH + Duration::new(seconds as u64, nanos as u32)
-                    });
                     (path, contents, language, mtime)
                 } else {
                     (path, None, None, None)
@@ -1059,13 +1055,7 @@ impl SerializableItem for Editor {
         let is_dirty = buffer.read(cx).is_dirty();
         let local_file = buffer.read(cx).file().and_then(|file| file.as_local());
         let path = local_file.map(|file| file.abs_path(cx));
-        let mtime = local_file.and_then(|file| {
-            file.mtime().and_then(|time| {
-                time.duration_since(UNIX_EPOCH)
-                    .ok()
-                    .map(|duration| (duration.as_secs() as i64, duration.subsec_nanos() as i32))
-            })
-        });
+        let mtime = local_file.and_then(|file| file.mtime());
 
         let snapshot = buffer.read(cx).snapshot();
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1075,7 +1075,7 @@ impl SerializableItem for Editor {
         let is_dirty = buffer.read(cx).is_dirty();
         let local_file = buffer.read(cx).file().and_then(|file| file.as_local());
         let path = local_file.map(|file| file.abs_path(cx));
-        let mtime = local_file.and_then(|file| file.mtime());
+        let mtime = buffer.read(cx).saved_mtime();
 
         let snapshot = buffer.read(cx).snapshot();
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1,7 +1,9 @@
 use crate::{
-    editor_settings::SeedQuerySetting, persistence::DB, scroll::ScrollAnchor, Anchor, Autoscroll,
-    Editor, EditorEvent, EditorSettings, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot,
-    NavigationData, SearchWithinRange, ToPoint as _,
+    editor_settings::SeedQuerySetting,
+    persistence::{SerializedEditor, DB},
+    scroll::ScrollAnchor,
+    Anchor, Autoscroll, Editor, EditorEvent, EditorSettings, ExcerptId, ExcerptRange, MultiBuffer,
+    MultiBufferSnapshot, NavigationData, SearchWithinRange, ToPoint as _,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::HashSet;
@@ -915,15 +917,19 @@ impl SerializableItem for Editor {
         cx: &mut ViewContext<Pane>,
     ) -> Task<Result<View<Self>>> {
         let path_content_language = match DB
-            .get_path_and_contents(item_id, workspace_id)
+            .get_serialized_editor(item_id, workspace_id)
             .context("Failed to query editor state")
         {
-            Ok(Some((path, content, language))) => {
+            Ok(Some(SerializedEditor {
+                path,
+                contents,
+                language,
+            })) => {
                 if ProjectSettings::get_global(cx)
                     .session
                     .restore_unsaved_buffers
                 {
-                    (path, content, language)
+                    (path, contents, language)
                 } else {
                     (path, None, None)
                 }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -821,6 +821,11 @@ impl FakeFs {
         })
     }
 
+    pub fn set_next_mtime(&self, next_mtime: SystemTime) {
+        let mut state = self.state.lock();
+        state.next_mtime = next_mtime;
+    }
+
     pub async fn insert_file(&self, path: impl AsRef<Path>, content: Vec<u8>) {
         self.write_file_internal(path, content).unwrap()
     }


### PR DESCRIPTION
Previously, we've only marked restored buffers as dirty. This PR changes that behavior in case the buffer has been associated with a file and that file has changed on disk since the last time Zed stored its contents.

Example timeline:

1. User edits file in Zed, buffer is dirty
2. User quites Zed with `cmd-q`
3. User changes file on disk: `echo foobar >> file.txt` or `git checkout file.txt`
4. User starts Zed
5. File/buffer are now marked as having a conflict (yellow icon)

Release Notes:

- Unsaved files that are restored when Zed starts are now marked as having a conflict if they have been changed on disk since the last time they were stored.

Demo:


https://github.com/user-attachments/assets/6098b485-b325-49b7-b694-fd2fc60cce64

