### PR TITLE
Bring back `ctrl-d` and `cmd-d` for Sublime Text keybinds

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -14,6 +14,7 @@
     "bindings": {
       "ctrl-shift-up": "editor::MoveLineUp",
       "ctrl-shift-down": "editor::MoveLineDown",
+      "ctrl-d": ["editor::SelectNext", { "replace_newest": false }],
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-l": "editor::SplitSelectionIntoLines",
       "ctrl-shift-a": "editor::SelectLargerSyntaxNode",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -12,10 +12,8 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-up": "editor::AddSelectionAbove",
-      "ctrl-shift-down": "editor::AddSelectionBelow",
-      "cmd-ctrl-up": "editor::MoveLineUp",
-      "cmd-ctrl-down": "editor::MoveLineDown",
+      "ctrl-shift-up": "editor::MoveLineUp",
+      "ctrl-shift-down": "editor::MoveLineDown",
       "cmd-shift-space": "editor::SelectAll",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -12,8 +12,10 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-up": "editor::MoveLineUp",
-      "ctrl-shift-down": "editor::MoveLineDown",
+      "ctrl-shift-up": "editor::AddSelectionAbove",
+      "ctrl-shift-down": "editor::AddSelectionBelow",
+      "cmd-ctrl-up": "editor::MoveLineUp",
+      "cmd-ctrl-down": "editor::MoveLineDown",
       "cmd-shift-space": "editor::SelectAll",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "cmd-shift-l": "editor::SplitSelectionIntoLines",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -14,6 +14,7 @@
     "bindings": {
       "ctrl-shift-up": "editor::AddSelectionAbove",
       "ctrl-shift-down": "editor::AddSelectionBelow",
+      "cmd-d": ["editor::SelectNext", { "replace_newest": false }],
       "cmd-ctrl-up": "editor::MoveLineUp",
       "cmd-ctrl-down": "editor::MoveLineDown",
       "cmd-shift-space": "editor::SelectAll",


### PR DESCRIPTION
# Release Notes:

- Bring back the functionality for `ctrl-d` (Linux) and `cmd-d` (Mac) with `["editor::SelectNext", { "replace_newest": false }]` for sublime_text.json.

This is a common key bind I use in Sublime Text, for an unknown reason the key bind was taken away in the recent Zed update
