### PR TITLE
rust: Add static items to the outline

### DIFF
--- a/crates/languages/src/rust/outline.scm
+++ b/crates/languages/src/rust/outline.scm
@@ -59,6 +59,11 @@
     "const" @context
     name: (_) @name) @item
 
+(static_item
+    (visibility_modifier)? @context
+    "static" @context
+    name: (_) @name) @item
+
 (field_declaration
     (visibility_modifier)? @context
     name: (_) @name) @item


### PR DESCRIPTION
Fixes #15208
Release Notes:

- Outline panel for Rust files now includes static items.
