### PR TITLE
lsp: Add server-side tracing support

### DIFF
--- a/crates/language_tools/src/lsp_log_tests.rs
+++ b/crates/language_tools/src/lsp_log_tests.rs
@@ -8,6 +8,7 @@ use gpui::{Context, SemanticVersion, TestAppContext, VisualTestContext};
 use language::{
     tree_sitter_rust, FakeLspAdapter, Language, LanguageConfig, LanguageMatcher, LanguageServerName,
 };
+use lsp_log::LogKind;
 use project::{FakeFs, Project};
 use serde_json::json;
 use settings::SettingsStore;

--- a/crates/language_tools/src/lsp_log_tests.rs
+++ b/crates/language_tools/src/lsp_log_tests.rs
@@ -92,8 +92,8 @@ async fn test_lsp_logs(cx: &mut TestAppContext) {
                     .root_name()
                     .to_string(),
                 rpc_trace_enabled: false,
-                rpc_trace_selected: false,
-                logs_selected: true,
+                selected_entry: LogKind::Logs,
+                trace_level: lsp::TraceValue::Off,
             }]
         );
         assert_eq!(view.editor.read(cx).text(cx), "hello from the server\n");

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -52,7 +52,7 @@ impl FluentBuilder for ContextMenu {}
 impl ContextMenu {
     pub fn build(
         cx: &mut WindowContext,
-        f: impl FnOnce(Self, &mut WindowContext) -> Self,
+        f: impl FnOnce(Self, &mut ViewContext<Self>) -> Self,
     ) -> View<Self> {
         cx.new_view(|cx| {
             let focus_handle = cx.focus_handle();


### PR DESCRIPTION
This PR adds another row to the LSP log view: Server traces
![image](https://github.com/user-attachments/assets/e3f77944-45e0-4d04-92fd-aea212859e86)

[Traces](https://docs.rs/lsp-types/latest/lsp_types/notification/enum.LogTrace.html) are intended for logging execution diagnostics, which is different from `LogMessage` that we currently support. 
When `Server trace` is selected, user can select the level of tracing (`off`/`messages`/`verbose`) to their liking. 

Release Notes:

- Added support for language server tracing to the LSP log view.