### PR TITLE
Fix more gutter close button alignment issues

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4106,11 +4106,11 @@ fn prepaint_gutter_button(
     );
     let indicator_size = button.layout_as_root(available_space, cx);
 
-    let blame_offset = gutter_dimensions.git_blame_entries_width;
-    let gutter_offset = rows_with_hunk_bounds
+    let blame_width = gutter_dimensions.git_blame_entries_width;
+    let gutter_width = rows_with_hunk_bounds
         .get(&row)
-        .map(|bounds| bounds.origin.x + bounds.size.width);
-    let left_offset = blame_offset.max(gutter_offset).unwrap_or(Pixels::ZERO);
+        .map(|bounds| bounds.size.width);
+    let left_offset = blame_width.max(gutter_width).unwrap_or_default();
 
     let mut x = left_offset;
     let available_width = gutter_dimensions.margin + gutter_dimensions.left_padding

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1970,6 +1970,7 @@ impl EditorElement {
                         max_width: text_hitbox.size.width.max(*scroll_width),
                         editor_style: &self.style,
                     }))
+                    .cursor(CursorStyle::Arrow)
                     .on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
                     .into_any_element()
             }

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -484,7 +484,10 @@ impl Editor {
                                 .child(
                                     h_flex()
                                         .id("gutter hunk")
-                                        .pl(hunk_bounds.origin.x)
+                                        .pl(gutter_dimensions.margin
+                                            + gutter_dimensions
+                                                .git_blame_entries_width
+                                                .unwrap_or_default())
                                         .max_w(hunk_bounds.size.width)
                                         .min_w(hunk_bounds.size.width)
                                         .size_full()

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -13,8 +13,8 @@ use multi_buffer::{
 use settings::SettingsStore;
 use text::{BufferId, Point};
 use ui::{
-    div, h_flex, v_flex, ActiveTheme, Context as _, ContextMenu, InteractiveElement, IntoElement,
-    ParentElement, Pixels, Styled, ViewContext, VisualContext,
+    div, h_flex, rems, v_flex, ActiveTheme, Context as _, ContextMenu, InteractiveElement,
+    IntoElement, ParentElement, Pixels, Styled, ViewContext, VisualContext,
 };
 use util::{debug_panic, RangeExt};
 
@@ -512,7 +512,7 @@ impl Editor {
                                 .child(
                                     v_flex()
                                         .size_full()
-                                        .pt(ui::rems(0.25))
+                                        .pt(rems(0.25))
                                         .justify_start()
                                         .child(close_button),
                                 ),


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/15178

* shows proper cursor on hovering a block that's over a git hunk
* show gutter buttons better when git hunks are on the same line
* show deleted hunks' gutter buttons better when git blame info is shown in the gutter

Release Notes:

- N/A
