### PR TITLE
Add missing workspace lints

### DIFF
--- a/crates/google_ai/Cargo.toml
+++ b/crates/google_ai/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/google_ai.rs"
 

--- a/crates/open_ai/Cargo.toml
+++ b/crates/open_ai/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/open_ai.rs"
 

--- a/crates/tab_switcher/Cargo.toml
+++ b/crates/tab_switcher/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/tab_switcher.rs"
 doctest = false


### PR DESCRIPTION
This PR adds the missing workspace lint configuration for the following crates that were missing it:

- `google_ai`
- `open_ai`
- `tab_switcher`

Release Notes:

- N/A
