### PR TITLE
Restore linux ctrl-d functionality

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -40,7 +40,6 @@
       "backspace": "editor::Backspace",
       "shift-backspace": "editor::Backspace",
       "delete": "editor::Delete",
-      "ctrl-d": "editor::Delete",
       "tab": "editor::Tab",
       "shift-tab": "editor::TabPrev",
       "ctrl-k": "editor::CutToEndOfLine",
@@ -269,6 +268,7 @@
       "alt-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
       "ctrl-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "ctrl-f2": "editor::SelectAllMatches", // Select all occurrences of current word
+      "ctrl-d": ["editor::SelectNext", { "replace_newest": false }],
       "ctrl-shift-down": ["editor::SelectNext", { "replace_newest": false }], // Add selection to Next Find Match
       "ctrl-shift-up": ["editor::SelectPrevious", { "replace_newest": false }],
       "ctrl-k ctrl-d": ["editor::SelectNext", { "replace_newest": true }],


### PR DESCRIPTION
- Restore `ctrl-d` functionality accidentially removed in #14600.
- Remove duplicate `ctrl-d` keymap in `Editor` context (dead)

Release Notes:

- Fixed `ctrl-d` on Linux ([#15238](https://github.com/zed-industries/zed/pull/15238), thanks [@unixtensor](https://github.com/unixtensor))

See also: 
- https://github.com/zed-industries/zed/issues/15213
- https://github.com/zed-industries/zed/issues/15160