### PR TITLE
ui: Make `Label` respect the `ui_font_weight` setting

### DIFF
--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -1,5 +1,7 @@
 use gpui::{relative, AnyElement, FontWeight, StyleRefinement, Styled};
+use settings::Settings;
 use smallvec::SmallVec;
+use theme::ThemeSettings;
 
 use crate::prelude::*;
 
@@ -45,7 +47,7 @@ pub trait LabelCommon {
 pub struct LabelLike {
     pub(super) base: Div,
     size: LabelSize,
-    weight: FontWeight,
+    weight: Option<FontWeight>,
     line_height_style: LineHeightStyle,
     pub(crate) color: Color,
     strikethrough: bool,
@@ -58,7 +60,7 @@ impl LabelLike {
         Self {
             base: div(),
             size: LabelSize::Default,
-            weight: FontWeight::default(),
+            weight: None,
             line_height_style: LineHeightStyle::default(),
             color: Color::Default,
             strikethrough: false,
@@ -86,7 +88,7 @@ impl LabelCommon for LabelLike {
     }
 
     fn weight(mut self, weight: FontWeight) -> Self {
-        self.weight = weight;
+        self.weight = Some(weight);
         self
     }
 
@@ -119,6 +121,8 @@ impl ParentElement for LabelLike {
 
 impl RenderOnce for LabelLike {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+        let settings = ThemeSettings::get_global(cx);
+
         self.base
             .when(self.strikethrough, |this| {
                 this.relative().child(
@@ -141,7 +145,7 @@ impl RenderOnce for LabelLike {
             })
             .when(self.italic, |this| this.italic())
             .text_color(self.color.color(cx))
-            .font_weight(self.weight)
+            .font_weight(self.weight.unwrap_or(settings.ui_font.weight))
             .children(self.children)
     }
 }

--- a/crates/ui/src/styles/typography.rs
+++ b/crates/ui/src/styles/typography.rs
@@ -102,7 +102,7 @@ pub enum TextSize {
     XSmall,
 
     /// The `ui_font_size` set by the user.
-    UI,
+    Ui,
     /// The `buffer_font_size` set by the user.
     Editor,
     // TODO: The terminal settings will need to be passed to
@@ -120,7 +120,7 @@ impl TextSize {
             Self::Default => rems_from_px(14.),
             Self::Small => rems_from_px(12.),
             Self::XSmall => rems_from_px(10.),
-            Self::UI => rems_from_px(theme_settings.ui_font_size.into()),
+            Self::Ui => rems_from_px(theme_settings.ui_font_size.into()),
             Self::Editor => rems_from_px(theme_settings.buffer_font_size.into()),
         }
     }


### PR DESCRIPTION
This PR makes the `Label` component respect the `ui_font_weight` setting, by default.

An explicit font weight can still be set via the `weight` method, which will override the `ui_font_weight` for that `Label`.

<img width="1566" alt="Screenshot 2024-07-25 at 8 55 16 PM" src="https://github.com/user-attachments/assets/2751e29c-c76e-4685-8564-604b3b77f603">

Release Notes:

- Updated UI labels to respect the `ui_font_weight` setting ([#15234](https://github.com/zed-industries/zed/issues/15234)).
