### PR TITLE
regression: Fix a panic when removing git-containing worktree from the project panel

### DIFF
--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -96,7 +96,15 @@ impl WorktreeStore {
     pub fn remove_worktree(&mut self, id_to_remove: WorktreeId, cx: &mut ModelContext<Self>) {
         self.worktrees.retain(|worktree| {
             if let Some(worktree) = worktree.upgrade() {
-                worktree.read(cx).id() != id_to_remove
+                if worktree.read(cx).id() == id_to_remove {
+                    cx.emit(WorktreeStoreEvent::WorktreeRemoved(
+                        worktree.entity_id(),
+                        id_to_remove,
+                    ));
+                    false
+                } else {
+                    true
+                }
             } else {
                 false
             }


### PR DESCRIPTION
Fix crash when remove worktree from project panel, which is introducing from #14989 

![image](https://github.com/user-attachments/assets/ba00dc55-d299-4edc-9a1f-01e92f0dd9ca)

when click `Remove from Project`, it will crash.


Release Notes:

- N/A
