### PR TITLE
windows: Remove `Send` and `Sync` implementation of `DirectWrite`

### DIFF
--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -47,15 +47,14 @@ pub(crate) struct TestPrompts {
 impl TestPlatform {
     pub fn new(executor: BackgroundExecutor, foreground_executor: ForegroundExecutor) -> Rc<Self> {
         #[cfg(target_os = "windows")]
-        unsafe {
+        let bitmap_factory = unsafe {
             windows::Win32::System::Ole::OleInitialize(None)
                 .expect("unable to initialize Windows OLE");
-        }
-        #[cfg(target_os = "windows")]
-        let bitmap_factory = std::mem::ManuallyDrop::new(unsafe {
-            CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)
-                .expect("Error creating bitmap factory.")
-        });
+            std::mem::ManuallyDrop::new(
+                CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)
+                    .expect("Error creating bitmap factory."),
+            )
+        };
 
         #[cfg(target_os = "macos")]
         let text_system = Arc::new(crate::platform::mac::MacTextSystem::new());

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -165,11 +165,6 @@ impl DirectWriteTextSystem {
             font_id_by_identifier: HashMap::default(),
         })))
     }
-
-    // pub(crate) fn destroy(&self) {
-    //     let mut lock = self.0.write();
-    //     unsafe { ManuallyDrop::drop(&mut lock.components.bitmap_factory) };
-    // }
 }
 
 impl PlatformTextSystem for DirectWriteTextSystem {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -21,7 +21,10 @@ use windows::{
     Win32::{
         Foundation::*,
         Globalization::u_memcpy,
-        Graphics::Gdi::*,
+        Graphics::{
+            Gdi::*,
+            Imaging::{CLSID_WICImagingFactory2, D2D::IWICImagingFactory2},
+        },
         Security::Credentials::*,
         System::{
             Com::*,
@@ -53,6 +56,7 @@ pub(crate) struct WindowsPlatform {
     clipboard_hash_format: u32,
     clipboard_metadata_format: u32,
     windows_version: WindowsVersion,
+    // bitmap_factory: IWICImagingFactory2,
 }
 
 pub(crate) struct WindowsPlatformState {
@@ -91,6 +95,10 @@ impl WindowsPlatform {
         let dispatcher = Arc::new(WindowsDispatcher::new());
         let background_executor = BackgroundExecutor::new(dispatcher.clone());
         let foreground_executor = ForegroundExecutor::new(dispatcher);
+        // let bitmap_factory: IWICImagingFactory2 = unsafe {
+        //     CoCreateInstance(&CLSID_WICImagingFactory2, None, CLSCTX_INPROC_SERVER)
+        //         .expect("Error creating bitmap factory.")
+        // };
         let text_system =
             Arc::new(DirectWriteTextSystem::new().expect("Error creating DirectWriteTextSystem"));
         let icon = load_icon().unwrap_or_default();
@@ -111,6 +119,7 @@ impl WindowsPlatform {
             clipboard_hash_format,
             clipboard_metadata_format,
             windows_version,
+            // bitmap_factory,
         }
     }
 
@@ -584,7 +593,7 @@ impl Platform for WindowsPlatform {
 
 impl Drop for WindowsPlatform {
     fn drop(&mut self) {
-        self.text_system.destroy();
+        // self.text_system.destroy();
         unsafe { OleUninitialize() };
     }
 }


### PR DESCRIPTION
This PR uses the `AgileReference` provided by the `windows-rs` crate to correctly implement `Send` and `Sync` for `DirectWrite`.

Release Notes:

- N/A
