### PR TITLE
tasks: Use environment variables from project

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1204,6 +1204,15 @@ impl Project {
                 })
                 .await
                 .unwrap();
+
+            project.update(cx, |project, cx| {
+                let tree_id = tree.read(cx).id();
+                // In tests we always populate the environment to be empty so we don't run the shell
+                project
+                    .cached_shell_environments
+                    .insert(tree_id, HashMap::default());
+            });
+
             tree.update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
                 .await;
         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -9286,6 +9286,7 @@ impl Project {
         })?;
         let task_context = context_task.await.unwrap_or_default();
         Ok(proto::TaskContext {
+            project_env: task_context.project_env.into_iter().collect(),
             cwd: task_context
                 .cwd
                 .map(|cwd| cwd.to_string_lossy().to_string()),
@@ -10315,8 +10316,7 @@ impl Project {
             cx.background_executor().spawn(async move {
                 let task_context = task_context.await.log_err()?;
                 Some(TaskContext {
-                    // TODO: Implement this via protobuf
-                    project_env: HashMap::default(),
+                    project_env: task_context.project_env.into_iter().collect(),
                     cwd: task_context.cwd.map(PathBuf::from),
                     task_variables: task_context
                         .task_variables

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2257,6 +2257,7 @@ message TaskContextForLocation {
 message TaskContext {
     optional string cwd = 1;
     map<string, string> task_variables = 2;
+    map<string, string> project_env = 3;
 }
 
 message TaskTemplates {

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -271,6 +271,10 @@ pub struct TaskContext {
     pub cwd: Option<PathBuf>,
     /// Additional environment variables associated with a given task.
     pub task_variables: TaskVariables,
+    /// Environment variables obtained when loading the project into Zed.
+    /// This is the environment one would get when `cd`ing in a terminal
+    /// into the project's root directory.
+    pub project_env: HashMap<String, String>,
 }
 
 /// This is a new type representing a 'tag' on a 'runnable symbol', typically a test of main() function, found via treesitter.

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -190,7 +190,7 @@ impl TaskTemplate {
             let mut env = cx.project_env.clone();
 
             // Extend that environment with what's defined in the TaskTemplate
-            env.extend(self.env.clone().into_iter());
+            env.extend(self.env.clone());
 
             // Then we replace all task variables that could be set in environment varialbes
             let mut env = substitute_all_template_variables_in_map(

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -190,7 +190,7 @@ impl TaskTemplate {
             let mut env = cx.project_env.clone();
 
             // Extend that environment with what's defined in the TaskTemplate
-            env.extend(self.env.iter().map(|(k, v)| (k.to_owned(), v.to_owned())));
+            env.extend(self.env.clone().into_iter());
 
             // Then we replace all task variables that could be set in environment varialbes
             let mut env = substitute_all_template_variables_in_map(

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -192,7 +192,7 @@ impl TaskTemplate {
             // Extend that environment with what's defined in the TaskTemplate
             env.extend(self.env.clone());
 
-            // Then we replace all task variables that could be set in environment varialbes
+            // Then we replace all task variables that could be set in environment variables
             let mut env = substitute_all_template_variables_in_map(
                 &env,
                 &task_variables,

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -184,8 +184,12 @@ impl TaskTemplate {
             .context("hashing task variables")
             .log_err()?;
         let id = TaskId(format!("{id_base}_{task_hash}_{variables_hash}"));
+
+        let mut env = cx.project_env.clone();
+        env.extend(self.env.iter().map(|(k, v)| (k.to_owned(), v.to_owned())));
+
         let mut env = substitute_all_template_variables_in_map(
-            &self.env,
+            &env,
             &task_variables,
             &variable_names,
             &mut substituted_variables,
@@ -392,6 +396,7 @@ mod tests {
         let cx = TaskContext {
             cwd: None,
             task_variables: TaskVariables::default(),
+            project_env: HashMap::default(),
         };
         assert_eq!(
             resolved_task(&task_without_cwd, &cx).cwd,
@@ -403,6 +408,7 @@ mod tests {
         let cx = TaskContext {
             cwd: Some(context_cwd.clone()),
             task_variables: TaskVariables::default(),
+            project_env: HashMap::default(),
         };
         assert_eq!(
             resolved_task(&task_without_cwd, &cx)
@@ -421,6 +427,7 @@ mod tests {
         let cx = TaskContext {
             cwd: None,
             task_variables: TaskVariables::default(),
+            project_env: HashMap::default(),
         };
         assert_eq!(
             resolved_task(&task_with_cwd, &cx)
@@ -434,6 +441,7 @@ mod tests {
         let cx = TaskContext {
             cwd: Some(context_cwd.clone()),
             task_variables: TaskVariables::default(),
+            project_env: HashMap::default(),
         };
         assert_eq!(
             resolved_task(&task_with_cwd, &cx)
@@ -512,6 +520,7 @@ mod tests {
                 &TaskContext {
                     cwd: None,
                     task_variables: TaskVariables::from_iter(all_variables.clone()),
+                    project_env: HashMap::default(),
                 },
             ).unwrap_or_else(|| panic!("Should successfully resolve task {task_with_all_variables:?} with variables {all_variables:?}"));
 
@@ -599,6 +608,7 @@ mod tests {
                 &TaskContext {
                     cwd: None,
                     task_variables: TaskVariables::from_iter(not_all_variables),
+                    project_env: HashMap::default(),
                 },
             );
             assert_eq!(resolved_task_attempt, None, "If any of the Zed task variables is not substituted, the task should not be resolved, but got some resolution without the variable {removed_variable:?} (index {i})");
@@ -651,6 +661,7 @@ mod tests {
                 VariableName::Symbol,
                 "test_symbol".to_string(),
             ))),
+            project_env: HashMap::default(),
         };
 
         for (i, symbol_dependent_task) in [

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -180,7 +180,7 @@ fn active_item_selection_properties(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
     use editor::Editor;
     use gpui::{Entity, TestAppContext};
@@ -306,7 +306,8 @@ mod tests {
                     (VariableName::WorktreeRoot, "/dir".into()),
                     (VariableName::Row, "1".into()),
                     (VariableName::Column, "1".into()),
-                ])
+                ]),
+                project_env: HashMap::default(),
             }
         );
 
@@ -332,7 +333,8 @@ mod tests {
                     (VariableName::Column, "15".into()),
                     (VariableName::SelectedText, "is_i".into()),
                     (VariableName::Symbol, "this_is_a_rust_file".into()),
-                ])
+                ]),
+                project_env: HashMap::default(),
             }
         );
 
@@ -356,7 +358,8 @@ mod tests {
                     (VariableName::Row, "1".into()),
                     (VariableName::Column, "1".into()),
                     (VariableName::Symbol, "this_is_a_test".into()),
-                ])
+                ]),
+                project_env: HashMap::default(),
             }
         );
     }


### PR DESCRIPTION
This fixes #12125 and addresses what's described in here:

- https://github.com/zed-industries/zed/issues/4977#issuecomment-2162094388

Before the changes in this PR, when running tasks, they inherited the Zed process environment, but that might not be the process environment that you'd get if you `cd` into a project directory.

We already ran into that problem with language servers and we fixed it by loading the shell environment in the context of a projects root directory and then passing that to the language servers when starting them (or when looking for their binaries).

What the change here does is to add the behavior for tasks too: we use the project-environment as the base environment with which to spawn tasks. Everything else still works the same, except that the base env is different.

TODOs:

- [x] Add tests
- [x] Get it working over collab
- [x] See if the environment loading can be consolidated and/or cached on the project, so that we don't have to pay that cost every time we launch a task.

Release Notes:

- Improved the environment-variable detection when running tasks so that tasks can now access environment variables as if the task had been spawned in a terminal that `cd`ed into a project directory. That means environment variables set by `direnv`/`asdf`/`mise` and other tools are now picked up. ([#12125](https://github.com/zed-industries/zed/issues/12125)).

Demo:

https://github.com/user-attachments/assets/8bfcc98f-0f9b-4439-b0d9-298aef1a3efe


