### PR TITLE
Return an empty measurement instead of panicking

### DIFF
--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -325,7 +325,9 @@ impl UniformList {
 
         let item_ix = cmp::min(self.item_to_measure_index, self.item_count - 1);
         let mut items = (self.render_items)(item_ix..item_ix + 1, cx);
-        let mut item_to_measure = items.pop().unwrap();
+        let Some(mut item_to_measure) = items.pop() else {
+            return Size::default();
+        };
         let available_space = size(
             list_width.map_or(AvailableSpace::MinContent, |width| {
                 AvailableSpace::Definite(width)


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/15256

Returns zero size for no items to render.

Incorrect worktree state made the uniform list to have 0 items to render, so
```Rust
let mut items = (self.render_items)(item_ix..item_ix + 1, cx);
let mut item_to_measure = items.pop().unwrap();
```
panicked as the first line returned an empty array despite a single-element range provided.


Release Notes:

- N/A
