### PR TITLE
linux: Allow skipping "Unsupported GPU" warning

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -171,9 +171,9 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
                 For troubleshooting see: https://zed.dev/docs/linux
                 "#}, specs.device_name);
             let prompt = cx.prompt(PromptLevel::Critical, "Unsupported GPU", Some(&message),
-                &["Troubleshoot and Quit"]);
+                &["Skip", "Troubleshoot and Quit"]);
             cx.spawn(|_, mut cx| async move {
-                if prompt.await == Ok(0) {
+                if prompt.await == Ok(1) {
                     cx.update(|cx| {
                         cx.open_url("https://zed.dev/docs/linux#zed-fails-to-open-windows");
                         cx.quit();


### PR DESCRIPTION
I just want using Zed in virtual machine, current implement must read code and set env `ZED_ALLOW_EMULATED_GPU` then can work.

Release Notes:

- N/A
