### PR TITLE
Auto fold directories in the project panel by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -312,7 +312,7 @@
     "auto_reveal_entries": true,
     // Whether to fold directories automatically and show compact folders
     // (e.g. "a/b/c" ) when a directory has only one subdirectory inside.
-    "auto_fold_dirs": false,
+    "auto_fold_dirs": true,
     /// Scrollbar-related settings
     "scrollbar": {
       /// When to show the scrollbar in the project panel.

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5085,6 +5085,9 @@ mod tests {
             Project::init_settings(cx);
 
             cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings::<ProjectPanelSettings>(cx, |project_panel_settings| {
+                    project_panel_settings.auto_fold_dirs = Some(false);
+                });
                 store.update_user_settings::<WorktreeSettings>(cx, |worktree_settings| {
                     worktree_settings.file_scan_exclusions = Some(Vec::new());
                 });
@@ -5102,6 +5105,15 @@ mod tests {
             crate::init((), cx);
             workspace::init(app_state.clone(), cx);
             Project::init_settings(cx);
+
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings::<ProjectPanelSettings>(cx, |project_panel_settings| {
+                    project_panel_settings.auto_fold_dirs = Some(false);
+                });
+                store.update_user_settings::<WorktreeSettings>(cx, |worktree_settings| {
+                    worktree_settings.file_scan_exclusions = Some(Vec::new());
+                });
+            });
         });
     }
 


### PR DESCRIPTION
Aligns the project panel with outline panel defaults.
Handles relatively frequent feedback from people unaware that this feature exists and makes Java projects to look normal without extra tweaks.

Release Notes:

-  Changed the project panel to auto fold directories by default