### PR TITLE
Tool bar: Remove tool grouping for clarity

### DIFF
--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -303,25 +303,17 @@ impl Render for QuickActionBar {
 
         h_flex()
             .id("quick action bar")
-            .gap(Spacing::XXLarge.rems(cx))
-            .child(
-                h_flex()
-                    .gap(Spacing::Medium.rems(cx))
-                    .children(self.render_repl_menu(cx))
-                    .children(self.render_toggle_markdown_preview(self.workspace.clone(), cx))
-                    .children(search_button)
-                    .when(
-                        AssistantSettings::get_global(cx).enabled
-                            && AssistantSettings::get_global(cx).button,
-                        |bar| bar.child(assistant_button),
-                    ),
+            .gap(Spacing::Medium.rems(cx))
+            .children(self.render_repl_menu(cx))
+            .children(self.render_toggle_markdown_preview(self.workspace.clone(), cx))
+            .children(search_button)
+            .when(
+                AssistantSettings::get_global(cx).enabled
+                    && AssistantSettings::get_global(cx).button,
+                |bar| bar.child(assistant_button),
             )
-            .child(
-                h_flex()
-                    .gap(Spacing::Medium.rems(cx))
-                    .children(editor_selections_dropdown)
-                    .child(editor_settings_dropdown),
-            )
+            .children(editor_selections_dropdown)
+            .child(editor_settings_dropdown)
             .when_some(self.repl_menu.as_ref(), |el, repl_menu| {
                 el.child(Self::render_menu_overlay(repl_menu))
             })


### PR DESCRIPTION
This PR makes the spacing between items in the tool bar (quick action bar) consistent vs grouped by type. The idea was to add clarity to the types of tools, but we haven't built this  system out enough for these groupings to be recognizable. So for now, let's make the spacing consistent.

Before:
![CleanShot 2024-07-26 at 11 58 22@2x](https://github.com/user-attachments/assets/9135fcce-fcf8-4bdf-a71b-6d6c7e5b3f63)


After:

![CleanShot 2024-07-26 at 11 57 02@2x](https://github.com/user-attachments/assets/0aceb981-01b6-466f-8d7e-97b564d014f9)

Release Notes:

- N/A
