### PR TITLE
Support reading image files from context asset_source

### DIFF
--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -366,9 +366,16 @@ impl Asset for Image {
         let client = cx.http_client();
         let scale_factor = cx.scale_factor();
         let svg_renderer = cx.svg_renderer();
+        let asset_source = cx.asset_source().clone();
         async move {
             let bytes = match source.clone() {
-                UriOrPath::Path(uri) => fs::read(uri.as_ref())?,
+                UriOrPath::Path(uri) => {
+                    let asset_source_uri = uri.as_ref().to_str().unwrap();
+                    match asset_source.load(asset_source_uri) {
+                        Ok(Some(data)) => data.into(),
+                        _ => fs::read(uri.as_ref())?,
+                    }
+                },
                 UriOrPath::Uri(uri) => {
                     let mut response = client.get(uri.as_ref(), ().into(), true).await?;
                     let mut body = Vec::new();

--- a/crates/ui/src/components/stories/avatar.rs
+++ b/crates/ui/src/components/stories/avatar.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+use std::str::FromStr;
 use gpui::Render;
 use story::{StoryContainer, StoryItem, StorySection};
 
@@ -9,6 +11,12 @@ pub struct AvatarStory;
 impl Render for AvatarStory {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         StoryContainer::new("Avatar", "crates/ui/src/components/stories/avatar.rs")
+            .child(
+                StorySection::new().child(StoryItem::new(
+                    "Avatar asset from local file",
+                    Avatar::new(PathBuf::from_str("icons/copilot.svg").unwrap()),
+                )),
+            )
             .child(
                 StorySection::new()
                     .child(StoryItem::new(


### PR DESCRIPTION

Release Notes:

- Imporved img ui element load data from context asset_source

Before:
![image](https://github.com/user-attachments/assets/3fa91d31-caa1-4399-8aeb-fb80b185b287)

After:
![image](https://github.com/user-attachments/assets/f71205cd-2f5b-4798-afa3-36d0acbdc6cb)


Why are there two different windows in the screenshots?

The optimization example is based on a context asset source mechanism. The “Before” screenshot is taken from gpui crate, specifically from crates/gpui/examples/image/image.rs. This crate does demo not rely on asset mechanism, making it difficult to reference the code. Therefore, the “After” screenshot uses the avatar storybook to illustrate the point. Overall, the goal is to clearly demonstrate the purpose.

