### PR TITLE
vim: Fix count in visual indent

### DIFF
--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -157,10 +157,13 @@ pub(crate) fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace
     workspace.register_action(|_: &mut Workspace, _: &Indent, cx| {
         Vim::update(cx, |vim, cx| {
             vim.record_current_action(cx);
+            let count = vim.take_count(cx).unwrap_or(1);
             vim.update_active_editor(cx, |_, editor, cx| {
                 editor.transact(cx, |editor, cx| {
                     let mut original_positions = save_selection_starts(editor, cx);
-                    editor.indent(&Default::default(), cx);
+                    for _ in 0..count {
+                        editor.indent(&Default::default(), cx);
+                    }
                     restore_selection_cursors(editor, cx, &mut original_positions);
                 });
             });
@@ -173,10 +176,13 @@ pub(crate) fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace
     workspace.register_action(|_: &mut Workspace, _: &Outdent, cx| {
         Vim::update(cx, |vim, cx| {
             vim.record_current_action(cx);
+            let count = vim.take_count(cx).unwrap_or(1);
             vim.update_active_editor(cx, |_, editor, cx| {
                 editor.transact(cx, |editor, cx| {
                     let mut original_positions = save_selection_starts(editor, cx);
-                    editor.outdent(&Default::default(), cx);
+                    for _ in 0..count {
+                        editor.outdent(&Default::default(), cx);
+                    }
                     restore_selection_cursors(editor, cx, &mut original_positions);
                 });
             });

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1438,3 +1438,13 @@ async fn test_ctrl_w_override(cx: &mut gpui::TestAppContext) {
     cx.simulate_shared_keystrokes("ctrl-w").await;
     cx.shared_state().await.assert_eq("ˇ");
 }
+
+#[gpui::test]
+async fn test_visual_indent_count(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+    cx.set_state("ˇhi", Mode::Normal);
+    cx.simulate_keystrokes("shift-v 3 >");
+    cx.assert_state("            ˇhi", Mode::Normal);
+    cx.simulate_keystrokes("shift-v 2 <");
+    cx.assert_state("    ˇhi", Mode::Normal);
+}


### PR DESCRIPTION
Co-Authored-By: tobbe@tlundberg.com

Release Notes:

- vim: Added {count} for `>`/`<` in visual mode
