### PR TITLE
ruby: Adjust language servers languages

### DIFF
--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -8,15 +8,15 @@ repository = "https://github.com/zed-industries/zed"
 
 [language_servers.solargraph]
 name = "Solargraph"
-language = "Ruby"
+languages = ["Ruby"]
 
 [language_servers.ruby-lsp]
 name = "Ruby LSP"
-language = "Ruby"
+languages = ["Ruby", "ERB"]
 
 [language_servers.rubocop]
 name = "Rubocop"
-language = "Ruby"
+languages = ["Ruby"]
 
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"


### PR DESCRIPTION
Hi. This is a small pull request that changes the "language" field to the "languages" field
because the `language` field is deprecated.
Additionally, allow the Ruby LSP to run in `*.erb` files.

Release Notes:

- N/A
