### PR TITLE
settings_ui: Add font ligature settings controls

### DIFF
--- a/crates/gpui/src/text_system/font_features.rs
+++ b/crates/gpui/src/text_system/font_features.rs
@@ -12,6 +12,16 @@ impl FontFeatures {
     pub fn tag_value_list(&self) -> &[(String, u32)] {
         &self.0.as_slice()
     }
+
+    /// Returns whether the `calt` feature is enabled.
+    ///
+    /// Returns `None` if the feature is not present.
+    pub fn is_calt_enabled(&self) -> Option<bool> {
+        self.0
+            .iter()
+            .find(|(feature, _)| feature == "calt")
+            .map(|(_, value)| *value == 1)
+    }
 }
 
 impl std::fmt::Debug for FontFeatures {


### PR DESCRIPTION
This PR adds settings controls for changing whether ligatures are enabled for the UI and buffer fonts.

Release Notes:

- N/A
