### PR TITLE
live_kit_server: Replace `jwt` with `jsonwebtoken`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5843,18 +5843,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwt"
-version = "0.16.0"
+name = "jsonwebtoken"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
- "base64 0.13.1",
- "crypto-common",
- "digest",
- "hmac",
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring",
  "serde",
  "serde_json",
- "sha2",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -6275,15 +6275,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "hmac",
- "jwt",
+ "jsonwebtoken",
  "log",
  "prost",
  "prost-build",
  "prost-types",
  "reqwest",
  "serde",
- "sha2",
 ]
 
 [[package]]
@@ -7539,6 +7537,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.0",
+ "serde",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -9776,6 +9784,18 @@ name = "similar"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "simplecss"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,8 +353,8 @@ indoc = "2"
 isahc = { version = "1.7.2", default-features = false, features = [
     "text-decoding",
 ] }
-jsonwebtoken = "9.3"
 itertools = "0.11.0"
+jsonwebtoken = "9.3"
 lazy_static = "1.4.0"
 libc = "0.2"
 linkify = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,6 +353,7 @@ indoc = "2"
 isahc = { version = "1.7.2", default-features = false, features = [
     "text-decoding",
 ] }
+jsonwebtoken = "9.3"
 itertools = "0.11.0"
 lazy_static = "1.4.0"
 libc = "0.2"

--- a/crates/live_kit_server/Cargo.toml
+++ b/crates/live_kit_server/Cargo.toml
@@ -16,14 +16,12 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-hmac = "0.12"
-jwt = "0.16"
+jsonwebtoken.workspace = true
 log.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 reqwest = "0.11"
 serde.workspace = true
-sha2.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true


### PR DESCRIPTION
This PR replaces `live_kit_server`'s usage of `jwt` with `jsonwebtoken`.

`jwt` hasn't been updated in 2 years and seems unmaintained.

`jsonwebtoken` has significantly more downloads and appears to be a healthier crate overall.

Release Notes:

- N/A
