### PR TITLE
docs: Remove wrongly documented secrets portals

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -119,9 +119,8 @@ All of these features are provided by XDG desktop portals, specifically:
 
 - `org.freedesktop.portal.FileChooser`
 - `org.freedesktop.portal.OpenURI`
-- `org.freedesktop.portal.Secret`, or `org.freedesktop.Secrets`
 
-Some window managers, such as `Hyprland`, don't provide a file picker by default. See [this list](https://wiki.archlinux.org/title/XDG_Desktop_Portal#List_of_backends_and_interfaces) as a starting point for alternatives. `KDE` doesn't implement the secret portal, installing `gnome-keyring` may solve this.
+Some window managers, such as `Hyprland`, don't provide a file picker by default. See [this list](https://wiki.archlinux.org/title/XDG_Desktop_Portal#List_of_backends_and_interfaces) as a starting point for alternatives.
 
 ### Could not start inotify
 


### PR DESCRIPTION
- The secrets portal is only used if the application is sandboxed without access to the org.freedesktop.secrets on the host but as zed is not really working correctly if sandboxed as is, it is better to completely omit that part
- The org.freedestkop.secrets is not a portal but a spec file that is implemented by both gnome in gnome-keyring, kde in kwallet but also by other password managers like keepassxc and it is a requirement for a "correctly" set up linux desktop so just remove that wrongly documented bit

Release Notes:

- N/A
