### PR TITLE
Upgrade `base64` to v0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,12 +1486,6 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -2454,7 +2448,7 @@ dependencies = [
  "aws-sdk-s3",
  "axum",
  "axum-extra",
- "base64 0.13.1",
+ "base64 0.22.0",
  "call",
  "channel",
  "chrono",
@@ -8708,7 +8702,7 @@ dependencies = [
  "alacritty_terminal 0.23.0",
  "anyhow",
  "async-dispatcher",
- "base64 0.13.1",
+ "base64 0.22.0",
  "client",
  "collections",
  "command_palette_hooks",
@@ -8932,7 +8926,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",
- "base64 0.13.1",
+ "base64 0.22.0",
  "chrono",
  "collections",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ async-trait = "0.1"
 async-tungstenite = "0.23"
 async-watch = "0.3.1"
 async_zip = { version = "0.0.17", features = ["deflate", "deflate64"] }
-base64 = "0.13"
+base64 = "0.22"
 bitflags = "2.6.0"
 blade-graphics = { git = "https://github.com/zed-industries/blade", rev = "7e497c534d5d4a30c18d9eb182cf39eaf0aaa25e" }
 blade-macros = { git = "https://github.com/zed-industries/blade", rev = "7e497c534d5d4a30c18d9eb182cf39eaf0aaa25e" }

--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -9,6 +9,7 @@ use axum::{
     middleware::Next,
     response::IntoResponse,
 };
+use base64::prelude::*;
 use prometheus::{exponential_buckets, register_histogram, Histogram};
 pub use rpc::auth::random_token;
 use scrypt::{
@@ -155,10 +156,7 @@ pub async fn create_access_token(
 /// protection.
 pub fn hash_access_token(token: &str) -> String {
     let digest = sha2::Sha256::digest(token);
-    format!(
-        "$sha256${}",
-        base64::encode_config(digest, base64::URL_SAFE)
-    )
+    format!("$sha256${}", BASE64_URL_SAFE.encode(digest))
 }
 
 /// Encrypts the given access token with the given public key to avoid leaking it on the way

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use crate::stdio::TerminalOutput;
 use anyhow::Result;
+use base64::prelude::*;
 use gpui::{
     img, percentage, Animation, AnimationExt, AnyElement, FontWeight, ImageData, Render, TextRun,
     Transformation, View,
@@ -63,7 +64,7 @@ impl ImageView {
     }
 
     fn from(base64_encoded_data: &str) -> Result<Self> {
-        let bytes = base64::decode(base64_encoded_data)?;
+        let bytes = BASE64_STANDARD.decode(base64_encoded_data)?;
 
         let format = image::guess_format(&bytes)?;
         let mut data = image::load_from_memory_with_format(&bytes, format)?.into_rgba8();


### PR DESCRIPTION
This PR upgrades the `base64` dependency to v0.22.

Supersedes #15300.

Release Notes:

- N/A
