### PR TITLE
fix: Typos

### DIFF
--- a/crates/assistant/README.zmd
+++ b/crates/assistant/README.zmd
@@ -38,7 +38,7 @@ Considering these aspects will ensure our conversation view design is optimized 
 
 @nate> 2 feels like it isn't important at the moment, we can explore that later. Let's start with 4, which I think will lead us to discussion 3 and 5.
 
-#zed share your thoughts on the points we need to consider to design a layout and visualization for a conversation view between you (#zed) and multuple peoople, or between multiple people and multiple bots (you and other bots).
+#zed share your thoughts on the points we need to consider to design a layout and visualization for a conversation view between you (#zed) and multiple people, or between multiple people and multiple bots (you and other bots).
 
 @nathan> Agreed. I'm interested in threading I think more than anything. Or 4 yeah. I think we need to scope the threading conversation. Also, asking #zed to propose the solution... not sure it will be that effective but it's worth a try...
 

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -983,7 +983,7 @@ impl TerminalTransaction {
     }
 
     pub fn push(&mut self, hunk: String, cx: &mut AppContext) {
-        // Ensure that the assistant cannot accidently execute commands that are streamed into the terminal
+        // Ensure that the assistant cannot accidentally execute commands that are streamed into the terminal
         let input = hunk.replace(CARRIAGE_RETURN, " ");
         self.terminal
             .update(cx, |terminal, _| terminal.input(input));

--- a/crates/assistant_tooling/README.md
+++ b/crates/assistant_tooling/README.md
@@ -80,6 +80,6 @@ while let Some(delta) = stream.next().await {
 }
 ```
 
-Once the stream of tokens is complete, you can exexute the tool call by calling `tool_registry.execute_tool_call(tool_call, cx)`, which returns a `Task<Result<()>>`.
+Once the stream of tokens is complete, you can execute the tool call by calling `tool_registry.execute_tool_call(tool_call, cx)`, which returns a `Task<Result<()>>`.
 
 As the tokens stream in and tool calls are executed, your `ToolView` will get updates. Render each tool call by passing that `tool_call` in to `tool_registry.render_tool_call(tool_call, cx)`. The final message for the model can be pulled by calling `self.tool_registry.content_for_tool_call( tool_call, &mut project_context, cx, )`.

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -153,7 +153,7 @@ async fn main() -> Result<()> {
             let signal = async move {
                 // todo(windows):
                 // `ctrl_close` does not work well, because tokio's signal handler always returns soon,
-                // but system termiates the application soon after returning CTRL+CLOSE handler.
+                // but system terminates the application soon after returning CTRL+CLOSE handler.
                 // So we should implement blocking handler to treat CTRL+CLOSE signal.
                 let mut ctrl_break = tokio::signal::windows::ctrl_break()
                     .expect("failed to listen for interrupt signal");

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9440,7 +9440,7 @@ struct Row8;
 struct Row9;
 struct Row10;"#};
 
-    // Deletion hunks trigger with carets on ajacent rows, so carets and selections have to stay farther to avoid the revert
+    // Deletion hunks trigger with carets on adjacent rows, so carets and selections have to stay farther to avoid the revert
     assert_hunk_revert(
         indoc! {r#"struct Row;
                    struct Row2;

--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -180,7 +180,7 @@ impl Transformation {
     }
 
     fn into_matrix(self, center: Point<Pixels>, scale_factor: f32) -> TransformationMatrix {
-        //Note: if you read this as a sequence of matrix mulitplications, start from the bottom
+        //Note: if you read this as a sequence of matrix multiplications, start from the bottom
         TransformationMatrix::unit()
             .translate(center.scale(scale_factor) + self.translate.scale(scale_factor))
             .rotate(self.rotate)

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -916,7 +916,7 @@ fn get_module_handle() -> HMODULE {
 fn register_drag_drop(state_ptr: Rc<WindowsWindowStatePtr>) {
     let window_handle = state_ptr.hwnd;
     let handler = WindowsDragDropHandler(state_ptr);
-    // The lifetime of `IDropTarget` is handled by Windows, it wont release untill
+    // The lifetime of `IDropTarget` is handled by Windows, it won't release until
     // we call `RevokeDragDrop`.
     // So, it's safe to drop it here.
     let drag_drop_handler: IDropTarget = handler.into();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2049,7 +2049,7 @@ impl<'a> WindowContext<'a> {
             })
     }
 
-    /// Provide elements in the called function with a new namespace in which their identiers must be unique.
+    /// Provide elements in the called function with a new namespace in which their identifiers must be unique.
     /// This can be used within a custom element to distinguish multiple sets of child elements.
     pub fn with_element_namespace<R>(
         &mut self,

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -98,7 +98,7 @@ pub enum Motion {
     WindowMiddle,
     WindowBottom,
 
-    // we don't have a good way to run a search syncronously, so
+    // we don't have a good way to run a search synchronously, so
     // we handle search motions by running the search async and then
     // calling back into motion with this
     ZedSearchResult {

--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -272,7 +272,7 @@ pub fn change_surrounds(text: Arc<str>, target: Object, cx: &mut WindowContext) 
                                     match chars_and_offset.peek() {
                                         Some((next_ch, _)) => {
                                             // If the next position is already a space or line break,
-                                            // we don't need to splice another space even under arround
+                                            // we don't need to splice another space even under around
                                             if surround && !next_ch.is_whitespace() {
                                                 open_str.push_str(" ");
                                             } else if !surround && next_ch.to_string() == " " {
@@ -556,7 +556,7 @@ mod test {
     async fn test_add_surrounds(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
 
-        // test add surrounds with arround
+        // test add surrounds with around
         cx.set_state(
             indoc! {"
             The quˇick brown
@@ -573,7 +573,7 @@ mod test {
             Mode::Normal,
         );
 
-        // test add surrounds not with arround
+        // test add surrounds not with around
         cx.set_state(
             indoc! {"
             The quˇick brown
@@ -712,7 +712,7 @@ mod test {
             )])
         });
 
-        // test add surrounds with arround
+        // test add surrounds with around
         cx.set_state(
             indoc! {"
             The quˇick brown
@@ -729,7 +729,7 @@ mod test {
             Mode::Normal,
         );
 
-        // test add surrounds not with arround
+        // test add surrounds not with around
         cx.set_state(
             indoc! {"
             The quˇick brown
@@ -907,7 +907,7 @@ mod test {
             Mode::Normal,
         );
 
-        // test multi cursor delete surrounds with arround
+        // test multi cursor delete surrounds with around
         cx.set_state(
             indoc! {"
             Tˇhe [ quick ] brown
@@ -1035,7 +1035,7 @@ mod test {
             Mode::Normal,
         );
 
-        // test multi cursor change surrount with not arround
+        // test multi cursor change surrount with not around
         cx.set_state(
             indoc! {"
             Thˇe { quick } brown


### PR DESCRIPTION
Fixed typos in the code base according with output from `codespell` tool.

Release Notes:

- N/A
