### PR TITLE
Suppress unused parameter warning on `remote/ssh_session.rs`

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -466,7 +466,7 @@ impl ProtoClient for SshSession {
 impl SshClientState {
     #[cfg(not(unix))]
     async fn new(
-        connection_options: SshConnectionOptions,
+        _connection_options: SshConnectionOptions,
         _delegate: Arc<dyn SshClientDelegate>,
         _cx: &mut AsyncAppContext,
     ) -> Result<Self> {


### PR DESCRIPTION
This was probably an oversight from https://github.com/zed-industries/zed/pull/15129.

![image](https://github.com/user-attachments/assets/5867e307-f581-4b40-8492-2fb80e87c18c)

Release Notes:

- N/A
