### PR TITLE
Run clippy for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: cargo clippy
-        run: ./script/clippy
+        # Windows can't run shell scripts, so we need to use `cargo xtask`.
+        run: cargo xtask clippy
 
       - name: Build Zed
         run: cargo build -p zed

--- a/crates/remote_server/src/main.rs
+++ b/crates/remote_server/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "windows", allow(unused, dead_code))]
+
 use fs::RealFs;
 use futures::channel::mpsc;
 use gpui::Context as _;
@@ -15,6 +17,12 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(windows)]
+fn main() {
+    unimplemented!()
+}
+
+#[cfg(not(windows))]
 fn main() {
     env::set_var("RUST_BACKTRACE", "1");
     env_logger::builder()


### PR DESCRIPTION
This PR fixes running clippy on Windows, as it broke in #13223.

We can't run shell scripts on Windows, so we need to use something else.

Release Notes:

- N/A
