### PR TITLE
Supporting img component to load data from context asset_source resources

### DIFF
--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -366,9 +366,16 @@ impl Asset for Image {
         let client = cx.http_client();
         let scale_factor = cx.scale_factor();
         let svg_renderer = cx.svg_renderer();
+        let asset_source = cx.asset_source().clone();
         async move {
             let bytes = match source.clone() {
-                UriOrPath::Path(uri) => fs::read(uri.as_ref())?,
+                UriOrPath::Path(uri) => {
+                    let asset_source_uri = uri.as_ref().to_str().unwrap();
+                    match asset_source.load(asset_source_uri) {
+                        Ok(Some(data)) => data.into(),
+                        _ => fs::read(uri.as_ref())?,
+                    }
+                },
                 UriOrPath::Uri(uri) => {
                     let mut response = client.get(uri.as_ref(), ().into(), true).await?;
                     let mut body = Vec::new();

--- a/crates/ui/src/components/stories/avatar.rs
+++ b/crates/ui/src/components/stories/avatar.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+use std::str::FromStr;
 use gpui::Render;
 use story::{StoryContainer, StoryItem, StorySection};
 
@@ -9,6 +11,12 @@ pub struct AvatarStory;
 impl Render for AvatarStory {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         StoryContainer::new("Avatar", "crates/ui/src/components/stories/avatar.rs")
+            .child(
+                StorySection::new().child(StoryItem::new(
+                    "Avatar asset from local file",
+                    Avatar::new(PathBuf::from_str("icons/copilot.svg").unwrap()),
+                )),
+            )
             .child(
                 StorySection::new()
                     .child(StoryItem::new(


### PR DESCRIPTION

Release Notes:

- Fixed gpui img component does not support relative paths

I discovered a bug in the gpui img component where it only supports absolute paths, not relative paths. For example, in the screenshots below, running the images.rs file in the gpui examples folder shows that the app-icon.png on the left failed to load, while the image on the right loaded successfully via URL.

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/5d5644ec-d493-4290-9987-61c8f5efaf0a">


This issue because the gpui img component uses the fs::read method to load images with PathBuf type parameters, which fails to resolve relative paths:

 ```rust
fs::read((PathBuf::from_str("examples/image/app-icon.png").unwrap()))?
 ```
 
 The code above results in an error as the file is not found:
 
```shell
 [2024-07-27T01:20:03Z ERROR gpui] Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

However, when using an absolute path the image loads successfully:

```rust
fs::read((PathBuf::from_str("/Users/xxx/xxx/xxx/gpui/examples/image/app-icon.png").unwrap()))?
```

Here is a screenshot of the code execution:

![image](https://github.com/user-attachments/assets/c56632da-f4fa-46b0-a87d-99d4ad95925d)

To fix this issue, the img component could either convert relative paths to absolute paths before loading, or directly support relative paths. I am considering submitting a PR to address this.

Another potential solution is to use the context’s global access_source method to load images. This allows for loading images with relative paths, similar to how icon resources are loaded. Below is the modified code and the result when running in the avatar storybook. The img component supports PathBuf parameters by first checking the zed assets directory for the resource before falling back to the existing logic:

![image](https://github.com/user-attachments/assets/c8be88d2-59b7-4f76-b276-f12a30a5873e)

In summary, the gpui img component currently does not support relative paths with PathBuf parameters and requires absolute paths. I have added functionality to load images using relative paths by checking the context‘s access_source first, integrating it with the project’s assets loading mechanism.


