### PR TITLE
SSH remoting: terminal & tasks

### DIFF
--- a/crates/project/src/prettier_support.rs
+++ b/crates/project/src/prettier_support.rs
@@ -515,7 +515,8 @@ impl Project {
         buffer: &Model<Buffer>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Option<(Option<PathBuf>, PrettierTask)>> {
-        if !self.is_local() {
+        // todo(ssh remote): prettier support
+        if self.is_remote() || self.ssh_session.is_some() {
             return Task::ready(None);
         }
         let buffer = buffer.read(cx);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7687,11 +7687,7 @@ impl Project {
     ) -> Option<(Model<Worktree>, PathBuf)> {
         self.worktree_store.read_with(cx, |worktree_store, cx| {
             for tree in worktree_store.worktrees() {
-                if let Some(relative_path) = tree
-                    .read(cx)
-                    .as_local()
-                    .and_then(|t| abs_path.strip_prefix(t.abs_path()).ok())
-                {
+                if let Ok(relative_path) = abs_path.strip_prefix(tree.read(cx).abs_path()) {
                     return Some((tree.clone(), relative_path.into()));
                 }
             }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1914,6 +1914,13 @@ impl Project {
         }
     }
 
+    pub fn is_ssh(&self) -> bool {
+        match &self.client_state {
+            ProjectClientState::Local | ProjectClientState::Shared { .. } => true,
+            ProjectClientState::Remote { .. } => false,
+        }
+    }
+
     pub fn is_remote(&self) -> bool {
         !self.is_local()
     }

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -255,14 +255,13 @@ impl Project {
             .directories
             .into_iter()
             .map(|virtual_environment_name| abs_path.join(virtual_environment_name))
-            .filter(|venv_path| {
+            .find(|venv_path| {
                 self.find_worktree(&venv_path, cx)
                     .and_then(|(worktree, relative_path)| {
                         worktree.read(cx).entry_for_path(&relative_path)
                     })
                     .is_some()
             })
-            .next()
     }
 
     fn python_activate_command(
@@ -327,7 +326,7 @@ pub fn wrap_for_ssh(
         }
     }
     if let Some(venv_directory) = venv_directory {
-        if let Some(str) = shlex::try_quote(&venv_directory.to_string_lossy().to_string()).ok() {
+        if let Some(str) = shlex::try_quote(venv_directory.to_string_lossy().as_ref()).ok() {
             env_changes.push_str(&format!("PATH={}:$PATH ", str));
         }
     }

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use task::{Shell, SpawnInTerminal};
 use terminal::{
-    terminal_settings::{self, TerminalSettings, VenvSettingsContent},
+    terminal_settings::{self, TerminalSettings},
     TaskState, TaskStatus, Terminal, TerminalBuilder,
 };
 use util::ResultExt;
@@ -110,36 +110,46 @@ impl Project {
         }
         let settings = TerminalSettings::get(settings_location, cx);
 
-        let python_settings = settings.detect_venv.clone();
         let (completion_tx, completion_rx) = bounded(1);
 
         let mut env = settings.env.clone();
 
-        let is_terminal = matches!(kind, TerminalKind::Shell(_)) && ssh_command.is_none();
         let local_path = if ssh_command.is_none() {
             path.clone()
         } else {
             None
         };
-        let venv_base_directory = local_path.clone().unwrap_or_else(|| PathBuf::new());
+        let python_venv_directory = path
+            .as_ref()
+            .and_then(|path| self.python_venv_directory(path, settings, cx));
+        let mut python_venv_activate_command = None;
 
         let (spawn_task, shell) = match kind {
-            TerminalKind::Shell(_) => match &ssh_command {
-                Some(ssh_command) => {
-                    log::debug!("Connecting to a remote server: {ssh_command:?}");
-
-                    // Alacritty sets its terminfo to `alacritty`, this requiring hosts to have it installed
-                    // to properly display colors.
-                    // We do not have the luxury of assuming the host has it installed,
-                    // so we set it to a default that does not break the highlighting via ssh.
-                    env.entry("TERM".to_string())
-                        .or_insert_with(|| "xterm-256color".to_string());
-
-                    let (program, args) = wrap_for_ssh(ssh_command, None, path.as_deref());
-                    (None, Shell::WithArguments { program, args })
+            TerminalKind::Shell(_) => {
+                if let Some(python_venv_directory) = python_venv_directory {
+                    python_venv_activate_command =
+                        self.python_activate_command(&python_venv_directory, settings);
                 }
-                None => (None, settings.shell.clone()),
-            },
+
+                match &ssh_command {
+                    Some(ssh_command) => {
+                        log::debug!("Connecting to a remote server: {ssh_command:?}");
+
+                        // Alacritty sets its terminfo to `alacritty`, this requiring hosts to have it installed
+                        // to properly display colors.
+                        // We do not have the luxury of assuming the host has it installed,
+                        // so we set it to a default that does not break the highlighting via ssh.
+                        env.entry("TERM".to_string())
+                            .or_insert_with(|| "xterm-256color".to_string());
+
+                        let (program, args) =
+                            wrap_for_ssh(ssh_command, None, path.as_deref(), env, None);
+                        env = HashMap::default();
+                        (None, Shell::WithArguments { program, args })
+                    }
+                    None => (None, settings.shell.clone()),
+                }
+            }
             TerminalKind::Task(spawn_task) => {
                 let task_state = Some(TaskState {
                     id: spawn_task.id,
@@ -151,6 +161,15 @@ impl Project {
                     completion_rx,
                 });
 
+                env.extend(spawn_task.env);
+
+                if let Some(venv_path) = &python_venv_directory {
+                    env.insert(
+                        "VIRTUAL_ENV".to_string(),
+                        venv_path.to_string_lossy().to_string(),
+                    );
+                }
+
                 match &ssh_command {
                     Some(ssh_command) => {
                         log::debug!("Connecting to a remote server: {ssh_command:?}");
@@ -160,18 +179,15 @@ impl Project {
                             ssh_command,
                             Some((&spawn_task.command, &spawn_task.args)),
                             path.as_deref(),
+                            env,
+                            python_venv_directory,
                         );
+                        env = HashMap::default();
                         (task_state, Shell::WithArguments { program, args })
                     }
                     None => {
-                        // todo: this should happen on remotes if ssh command is set
-                        env.extend(spawn_task.env);
-                        if let Some(python_settings) = &python_settings.as_option() {
-                            self.set_python_venv_path_for_tasks(
-                                python_settings,
-                                &venv_base_directory,
-                                &mut env,
-                            )
+                        if let Some(venv_path) = &python_venv_directory {
+                            add_environment_path(&mut env, &venv_path.join("bin")).log_err();
                         }
 
                         (
@@ -219,20 +235,8 @@ impl Project {
             })
             .detach();
 
-            // if the terminal is not a task, activate full Python virtual environment
-            if is_terminal {
-                if let Some(python_settings) = &python_settings.as_option() {
-                    if let Some(activate_script_path) =
-                        self.find_activate_script_path(python_settings, &venv_base_directory)
-                    {
-                        self.activate_python_virtual_environment(
-                            Project::get_activate_command(python_settings),
-                            activate_script_path,
-                            &terminal_handle,
-                            cx,
-                        );
-                    }
-                }
+            if let Some(activate_command) = python_venv_activate_command {
+                self.activate_python_virtual_environment(activate_command, &terminal_handle, cx);
             }
             terminal_handle
         });
@@ -240,80 +244,59 @@ impl Project {
         terminal
     }
 
-    pub fn find_activate_script_path(
-        &mut self,
-        settings: &VenvSettingsContent,
-        venv_base_directory: &Path,
+    pub fn python_venv_directory(
+        &self,
+        abs_path: &Path,
+        settings: &TerminalSettings,
+        cx: &AppContext,
     ) -> Option<PathBuf> {
-        let activate_script_name = match settings.activate_script {
+        let venv_settings = settings.detect_venv.as_option()?;
+        venv_settings
+            .directories
+            .into_iter()
+            .map(|virtual_environment_name| abs_path.join(virtual_environment_name))
+            .filter(|venv_path| {
+                self.find_worktree(&venv_path, cx)
+                    .and_then(|(worktree, relative_path)| {
+                        worktree.read(cx).entry_for_path(&relative_path)
+                    })
+                    .is_some()
+            })
+            .next()
+    }
+
+    fn python_activate_command(
+        &self,
+        venv_base_directory: &Path,
+        settings: &TerminalSettings,
+    ) -> Option<String> {
+        let venv_settings = settings.detect_venv.as_option()?;
+        let activate_script_name = match venv_settings.activate_script {
             terminal_settings::ActivateScript::Default => "activate",
             terminal_settings::ActivateScript::Csh => "activate.csh",
             terminal_settings::ActivateScript::Fish => "activate.fish",
             terminal_settings::ActivateScript::Nushell => "activate.nu",
         };
+        let path = venv_base_directory
+            .join("bin")
+            .join(activate_script_name)
+            .to_string_lossy()
+            .to_string();
+        let quoted = shlex::try_quote(&path).ok()?;
 
-        settings
-            .directories
-            .into_iter()
-            .find_map(|virtual_environment_name| {
-                let path = venv_base_directory
-                    .join(virtual_environment_name)
-                    .join("bin")
-                    .join(activate_script_name);
-                path.exists().then_some(path)
-            })
-    }
-
-    pub fn set_python_venv_path_for_tasks(
-        &mut self,
-        settings: &VenvSettingsContent,
-        venv_base_directory: &Path,
-        env: &mut HashMap<String, String>,
-    ) {
-        let activate_path = settings
-            .directories
-            .into_iter()
-            .find_map(|virtual_environment_name| {
-                let path = venv_base_directory.join(virtual_environment_name);
-                path.exists().then_some(path)
-            });
-
-        if let Some(path) = activate_path {
-            // Some tools use VIRTUAL_ENV to detect the virtual environment
-            env.insert(
-                "VIRTUAL_ENV".to_string(),
-                path.to_string_lossy().to_string(),
-            );
-
-            // We need to set the PATH to include the virtual environment's bin directory
-            add_environment_path(env, &path.join("bin")).log_err();
-        }
-    }
-
-    fn get_activate_command(settings: &VenvSettingsContent) -> &'static str {
-        match settings.activate_script {
-            terminal_settings::ActivateScript::Nushell => "overlay use",
-            _ => "source",
-        }
+        Some(match venv_settings.activate_script {
+            terminal_settings::ActivateScript::Nushell => format!("overlay use {}\n", quoted),
+            _ => format!("source {}\n", quoted),
+        })
     }
 
     fn activate_python_virtual_environment(
-        &mut self,
-        activate_command: &'static str,
-        activate_script: PathBuf,
+        &self,
+        command: String,
         terminal_handle: &Model<Terminal>,
         cx: &mut ModelContext<Project>,
     ) {
-        // Paths are not strings so we need to jump through some hoops to format the command without `format!`
-        let mut command = Vec::from(activate_command.as_bytes());
-        command.push(b' ');
-        // Wrapping path in double quotes to catch spaces in folder name
-        command.extend_from_slice(b"\"");
-        command.extend_from_slice(activate_script.as_os_str().as_encoded_bytes());
-        command.extend_from_slice(b"\"");
-        command.push(b'\n');
-
-        terminal_handle.update(cx, |this, _| this.input_bytes(command));
+        terminal_handle.update(cx, |this, _| this.input_bytes(command.into_bytes()));
     }
 
     pub fn local_terminal_handles(&self) -> &Vec<WeakModel<terminal::Terminal>> {
@@ -325,6 +308,8 @@ pub fn wrap_for_ssh(
     ssh_command: &SshCommand,
     command: Option<(&String, &Vec<String>)>,
     path: Option<&Path>,
+    env: HashMap<String, String>,
+    venv_directory: Option<PathBuf>,
 ) -> (String, Vec<String>) {
     let to_run = if let Some((command, args)) = command {
         iter::once(command)
@@ -335,10 +320,22 @@ pub fn wrap_for_ssh(
         "exec ${SHELL:-sh} -l".to_string()
     };
 
+    let mut env_changes = String::new();
+    for (k, v) in env.iter() {
+        if let Some((k, v)) = shlex::try_quote(k).ok().zip(shlex::try_quote(v).ok()) {
+            env_changes.push_str(&format!("{}={} ", k, v));
+        }
+    }
+    if let Some(venv_directory) = venv_directory {
+        if let Some(str) = shlex::try_quote(&venv_directory.to_string_lossy().to_string()).ok() {
+            env_changes.push_str(&format!("PATH={}:$PATH ", str));
+        }
+    }
+
     let commands = if let Some(path) = path {
-        format!("cd {:?}; {}", path, to_run)
+        format!("cd {:?}; {} {}", path, env_changes, to_run)
     } else {
-        format!("cd; {to_run}")
+        format!("cd; {env_changes} {to_run}")
     };
     let shell_invocation = format!("sh -c {}", shlex::try_quote(&commands).unwrap());
 

--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -28,6 +28,7 @@ use settings::Settings;
 use task::HideStrategy;
 use task::RevealStrategy;
 use task::SpawnInTerminal;
+use task::SshCommand;
 use task::TerminalWorkDir;
 use terminal_view::terminal_panel::TerminalPanel;
 use ui::ElevationIndex;
@@ -1650,7 +1651,7 @@ pub async fn spawn_ssh_task(
                     args,
                     command_label: ssh_connection_string.clone(),
                     cwd: Some(TerminalWorkDir::Ssh {
-                        ssh_command: ssh_connection_string,
+                        ssh_command: SshCommand::DevServer(ssh_connection_string),
                         path: None,
                     }),
                     use_new_terminal: true,

--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -1642,6 +1643,8 @@ pub async fn spawn_ssh_task(
     let (command, args) = wrap_for_ssh(
         &SshCommand::DevServer(ssh_connection_string.clone()),
         Some((&command, &args)),
+        None,
+        HashMap::default(),
         None,
     );
 

--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -19,6 +19,7 @@ use gpui::{
 use markdown::Markdown;
 use markdown::MarkdownStyle;
 use project::terminals::wrap_for_ssh;
+use project::terminals::SshCommand;
 use rpc::proto::RegenerateDevServerTokenResponse;
 use rpc::{
     proto::{CreateDevServerResponse, DevServerStatus},
@@ -29,8 +30,6 @@ use settings::Settings;
 use task::HideStrategy;
 use task::RevealStrategy;
 use task::SpawnInTerminal;
-use task::SshCommand;
-use task::TerminalWorkDir;
 use terminal_view::terminal_panel::TerminalPanel;
 use ui::ElevationIndex;
 use ui::Section;
@@ -1661,9 +1660,7 @@ pub async fn spawn_ssh_task(
                     allow_concurrent_runs: false,
                     reveal: RevealStrategy::Always,
                     hide: HideStrategy::Never,
-                    env: [("TERM".to_string(), "xterm-256color".to_string())]
-                        .into_iter()
-                        .collect(),
+                    env: Default::default(),
                     shell: Default::default(),
                 },
                 cx,

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -21,6 +21,15 @@ pub use vscode_format::VsCodeTaskFile;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize)]
 pub struct TaskId(pub String);
 
+/// SshCommand describes how to connect to a remote server
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SshCommand {
+    /// DevServers give a string from the user
+    DevServer(String),
+    /// Direct ssh has a list of arguments to pass to ssh
+    Direct(Vec<String>),
+}
+
 /// TerminalWorkDir describes where a task should be run
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TerminalWorkDir {
@@ -29,7 +38,7 @@ pub enum TerminalWorkDir {
     /// SSH runs the terminal over ssh
     Ssh {
         /// The command to run to connect
-        ssh_command: String,
+        ssh_command: SshCommand,
         /// The path on the remote server
         path: Option<String>,
     },

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -9,9 +9,9 @@ use collections::{hash_map, HashMap, HashSet};
 use gpui::SharedString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::{borrow::Cow, path::Path};
 
 pub use task_template::{HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates};
 pub use vscode_format::VsCodeTaskFile;
@@ -20,47 +20,6 @@ pub use vscode_format::VsCodeTaskFile;
 /// Based on it, task reruns and terminal tabs are managed.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize)]
 pub struct TaskId(pub String);
-
-/// SshCommand describes how to connect to a remote server
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SshCommand {
-    /// DevServers give a string from the user
-    DevServer(String),
-    /// Direct ssh has a list of arguments to pass to ssh
-    Direct(Vec<String>),
-}
-
-/// TerminalWorkDir describes where a task should be run
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TerminalWorkDir {
-    /// Local is on this machine
-    Local(PathBuf),
-    /// SSH runs the terminal over ssh
-    Ssh {
-        /// The command to run to connect
-        ssh_command: SshCommand,
-        /// The path on the remote server
-        path: Option<String>,
-    },
-}
-
-impl TerminalWorkDir {
-    /// Returns whether the terminal task is supposed to be spawned on a local machine or not.
-    pub fn is_local(&self) -> bool {
-        match self {
-            Self::Local(_) => true,
-            Self::Ssh { .. } => false,
-        }
-    }
-
-    /// Returns a local CWD if the terminal is local, None otherwise.
-    pub fn local_path(&self) -> Option<&Path> {
-        match self {
-            Self::Local(path) => Some(path),
-            Self::Ssh { .. } => None,
-        }
-    }
-}
 
 /// Contains all information needed by Zed to spawn a new terminal tab for the given task.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,7 +38,7 @@ pub struct SpawnInTerminal {
     /// A human-readable label, containing command and all of its arguments, joined and substituted.
     pub command_label: String,
     /// Current working directory to spawn the command into.
-    pub cwd: Option<TerminalWorkDir>,
+    pub cwd: Option<PathBuf>,
     /// Env overrides for the command, will be appended to the terminal's environment from the settings.
     pub env: HashMap<String, String>,
     /// Whether to use a new terminal tab or reuse the existing one to spawn the process.

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -274,7 +274,7 @@ impl IntoIterator for TaskVariables {
 
 /// Keeps track of the file associated with a task and context of tasks execution (i.e. current file or current function).
 /// Keeps all Zed-related state inside, used to produce a resolved task out of its template.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TaskContext {
     /// A path to a directory in which the task should be executed.
     pub cwd: Option<PathBuf>,

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 use util::{truncate_and_remove_front, ResultExt};
 
 use crate::{
-    ResolvedTask, Shell, SpawnInTerminal, TaskContext, TaskId, TerminalWorkDir, VariableName,
+    ResolvedTask, Shell, SpawnInTerminal, TaskContext, TaskId, VariableName,
     ZED_VARIABLE_NAME_PREFIX,
 };
 
@@ -134,14 +134,11 @@ impl TaskTemplate {
                     &variable_names,
                     &mut substituted_variables,
                 )?;
-                Some(TerminalWorkDir::Local(PathBuf::from(substitured_cwd)))
+                Some(PathBuf::from(substitured_cwd))
             }
             None => None,
         }
-        .or(cx
-            .cwd
-            .as_ref()
-            .map(|cwd| TerminalWorkDir::Local(cwd.clone())));
+        .or(cx.cwd.clone());
         let human_readable_label = substitute_all_template_variables_in_str(
             &self.label,
             &truncated_variables,

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -418,11 +418,8 @@ mod tests {
             project_env: HashMap::default(),
         };
         assert_eq!(
-            resolved_task(&task_without_cwd, &cx)
-                .cwd
-                .as_ref()
-                .and_then(|cwd| cwd.local_path()),
-            Some(context_cwd.as_path()),
+            resolved_task(&task_without_cwd, &cx).cwd,
+            Some(context_cwd.clone()),
             "TaskContext's cwd should be taken on resolve if task's cwd is None"
         );
 
@@ -437,11 +434,8 @@ mod tests {
             project_env: HashMap::default(),
         };
         assert_eq!(
-            resolved_task(&task_with_cwd, &cx)
-                .cwd
-                .as_ref()
-                .and_then(|cwd| cwd.local_path()),
-            Some(task_cwd.as_path()),
+            resolved_task(&task_with_cwd, &cx).cwd,
+            Some(task_cwd.clone()),
             "TaskTemplate's cwd should be taken on resolve if TaskContext's cwd is None"
         );
 
@@ -451,11 +445,8 @@ mod tests {
             project_env: HashMap::default(),
         };
         assert_eq!(
-            resolved_task(&task_with_cwd, &cx)
-                .cwd
-                .as_ref()
-                .and_then(|cwd| cwd.local_path()),
-            Some(task_cwd.as_path()),
+            resolved_task(&task_with_cwd, &cx).cwd,
+            Some(task_cwd),
             "TaskTemplate's cwd should be taken on resolve if TaskContext's cwd is not None"
         );
     }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1,6 +1,6 @@
 use std::{ops::ControlFlow, path::PathBuf, sync::Arc};
 
-use crate::TerminalView;
+use crate::{default_working_directory, TerminalView};
 use collections::{HashMap, HashSet};
 use db::kvp::KEY_VALUE_STORE;
 use futures::future::join_all;
@@ -10,11 +10,11 @@ use gpui::{
     Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use itertools::Itertools;
-use project::{Fs, ProjectEntryId};
+use project::{terminals::TerminalKind, Fs, ProjectEntryId};
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
 use serde::{Deserialize, Serialize};
 use settings::Settings;
-use task::{RevealStrategy, Shell, SpawnInTerminal, TaskId, TerminalWorkDir};
+use task::{RevealStrategy, Shell, SpawnInTerminal, TaskId};
 use terminal::{
     terminal_settings::{TerminalDockPosition, TerminalSettings},
     Terminal,
@@ -348,14 +348,13 @@ impl TerminalPanel {
             return;
         };
 
-        let terminal_work_dir = workspace
-            .project()
-            .read(cx)
-            .terminal_work_dir_for(Some(action.working_directory.clone()), cx);
-
         terminal_panel
             .update(cx, |panel, cx| {
-                panel.add_terminal(terminal_work_dir, None, RevealStrategy::Always, cx)
+                panel.add_terminal(
+                    TerminalKind::Shell(Some(action.working_directory.clone())),
+                    RevealStrategy::Always,
+                    cx,
+                )
             })
             .detach_and_log_err(cx);
     }
@@ -484,7 +483,7 @@ impl TerminalPanel {
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<Model<Terminal>>> {
         let reveal = spawn_task.reveal;
-        self.add_terminal(spawn_task.cwd.clone(), Some(spawn_task), reveal, cx)
+        self.add_terminal(TerminalKind::Task(spawn_task), reveal, cx)
     }
 
     /// Create a new Terminal in the current working directory or the user's home directory
@@ -497,9 +496,11 @@ impl TerminalPanel {
             return;
         };
 
+        let kind = TerminalKind::Shell(default_working_directory(workspace, cx));
+
         terminal_panel
             .update(cx, |this, cx| {
-                this.add_terminal(None, None, RevealStrategy::Always, cx)
+                this.add_terminal(kind, RevealStrategy::Always, cx)
             })
             .detach_and_log_err(cx);
     }
@@ -533,22 +534,14 @@ impl TerminalPanel {
 
     fn add_terminal(
         &mut self,
-        working_directory: Option<TerminalWorkDir>,
-        spawn_task: Option<SpawnInTerminal>,
+        kind: TerminalKind,
         reveal_strategy: RevealStrategy,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<Model<Terminal>>> {
         if !self.enabled {
-            if spawn_task.is_none()
-                || !matches!(
-                    spawn_task.as_ref().unwrap().cwd,
-                    Some(TerminalWorkDir::Ssh { .. })
-                )
-            {
-                return Task::ready(Err(anyhow::anyhow!(
-                    "terminal not yet supported for remote projects"
-                )));
-            }
+            return Task::ready(Err(anyhow::anyhow!(
+                "terminal not yet supported for remote projects"
+            )));
         }
 
         let workspace = self.workspace.clone();
@@ -557,18 +550,10 @@ impl TerminalPanel {
         cx.spawn(|terminal_panel, mut cx| async move {
             let pane = terminal_panel.update(&mut cx, |this, _| this.pane.clone())?;
             let result = workspace.update(&mut cx, |workspace, cx| {
-                let working_directory = if let Some(working_directory) = working_directory {
-                    Some(working_directory)
-                } else {
-                    let working_directory_strategy =
-                        TerminalSettings::get_global(cx).working_directory.clone();
-                    crate::get_working_directory(workspace, cx, working_directory_strategy)
-                };
-
                 let window = cx.window_handle();
-                let terminal = workspace.project().update(cx, |project, cx| {
-                    project.create_terminal(working_directory, spawn_task, window, cx)
-                })?;
+                let terminal = workspace
+                    .project()
+                    .update(cx, |project, cx| project.create_terminal(kind, window, cx))?;
                 let terminal_view = Box::new(cx.new_view(|cx| {
                     TerminalView::new(
                         terminal.clone(),
@@ -655,7 +640,7 @@ impl TerminalPanel {
         let window = cx.window_handle();
         let new_terminal = project.update(cx, |project, cx| {
             project
-                .create_terminal(spawn_task.cwd.clone(), Some(spawn_task), window, cx)
+                .create_terminal(TerminalKind::Task(spawn_task), window, cx)
                 .log_err()
         })?;
         terminal_to_replace.update(cx, |terminal_to_replace, cx| {
@@ -802,10 +787,19 @@ impl Panel for TerminalPanel {
     }
 
     fn set_active(&mut self, active: bool, cx: &mut ViewContext<Self>) {
-        if active && self.has_no_terminals(cx) {
-            self.add_terminal(None, None, RevealStrategy::Never, cx)
-                .detach_and_log_err(cx)
+        if !active || !self.has_no_terminals(cx) {
+            return;
         }
+        cx.defer(|this, cx| {
+            let Ok(kind) = this.workspace.update(cx, |workspace, cx| {
+                TerminalKind::Shell(default_working_directory(workspace, cx))
+            }) else {
+                return;
+            };
+
+            this.add_terminal(kind, RevealStrategy::Never, cx)
+                .detach_and_log_err(cx)
+        })
     }
 
     fn icon_label(&self, cx: &WindowContext) -> Option<String> {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -351,7 +351,7 @@ impl TerminalPanel {
         let terminal_work_dir = workspace
             .project()
             .read(cx)
-            .terminal_work_dir_for(Some(&action.working_directory), cx);
+            .terminal_work_dir_for(Some(action.working_directory.clone()), cx);
 
         terminal_panel
             .update(cx, |panel, cx| {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -13,8 +13,7 @@ use gpui::{
 };
 use language::Bias;
 use persistence::TERMINAL_DB;
-use project::{search::SearchQuery, Fs, LocalWorktree, Metadata, Project};
-use task::TerminalWorkDir;
+use project::{search::SearchQuery, terminals::TerminalKind, Fs, Metadata, Project};
 use terminal::{
     alacritty_terminal::{
         index::Point,
@@ -38,7 +37,6 @@ use workspace::{
 };
 
 use anyhow::Context;
-use dirs::home_dir;
 use serde::Deserialize;
 use settings::{Settings, SettingsStore};
 use smol::Timer;
@@ -130,15 +128,13 @@ impl TerminalView {
         _: &NewCenterTerminal,
         cx: &mut ViewContext<Workspace>,
     ) {
-        let strategy = TerminalSettings::get_global(cx);
-        let working_directory =
-            get_working_directory(workspace, cx, strategy.working_directory.clone());
+        let working_directory = default_working_directory(workspace, cx);
 
         let window = cx.window_handle();
         let terminal = workspace
             .project()
             .update(cx, |project, cx| {
-                project.create_terminal(working_directory, None, window, cx)
+                project.create_terminal(TerminalKind::Shell(working_directory), window, cx)
             })
             .notify_err(workspace, cx);
 
@@ -1134,19 +1130,18 @@ impl SerializableItem for TerminalView {
                         .as_ref()
                         .is_some_and(|from_db| !from_db.as_os_str().is_empty())
                     {
-                        project.read(cx).terminal_work_dir_for(from_db, cx)
+                        from_db
                     } else {
-                        let strategy = TerminalSettings::get_global(cx).working_directory.clone();
-                        workspace.upgrade().and_then(|workspace| {
-                            get_working_directory(workspace.read(cx), cx, strategy)
-                        })
+                        workspace
+                            .upgrade()
+                            .and_then(|workspace| default_working_directory(workspace.read(cx), cx))
                     }
                 })
                 .ok()
                 .flatten();
 
             let terminal = project.update(&mut cx, |project, cx| {
-                project.create_terminal(cwd, None, window, cx)
+                project.create_terminal(TerminalKind::Shell(cwd), window, cx)
             })??;
             pane.update(&mut cx, |_, cx| {
                 cx.new_view(|cx| TerminalView::new(terminal, workspace, Some(workspace_id), cx))
@@ -1274,14 +1269,12 @@ impl SearchableItem for TerminalView {
 }
 
 ///Gets the working directory for the given workspace, respecting the user's settings.
-pub fn get_working_directory(
-    workspace: &Workspace,
-    cx: &AppContext,
-    strategy: WorkingDirectory,
-) -> Option<TerminalWorkDir> {
-    let res = match strategy {
-        WorkingDirectory::CurrentProjectDirectory => current_project_directory(workspace, cx)
-            .or_else(|| first_project_directory(workspace, cx)),
+/// None implies "~" on whichever machine we end up on.
+pub fn default_working_directory(workspace: &Workspace, cx: &AppContext) -> Option<PathBuf> {
+    match &TerminalSettings::get_global(cx).working_directory {
+        WorkingDirectory::CurrentProjectDirectory => {
+            workspace.project().read(cx).active_project_directory(cx)
+        }
         WorkingDirectory::FirstProjectDirectory => first_project_directory(workspace, cx),
         WorkingDirectory::AlwaysHome => None,
         WorkingDirectory::Always { directory } => {
@@ -1290,8 +1283,7 @@ pub fn get_working_directory(
                 .map(|dir| Path::new(&dir.to_string()).to_path_buf())
                 .filter(|dir| dir.is_dir())
         }
-    };
-    workspace.project().read(cx).terminal_work_dir_for(res, cx)
+    }
 }
 
 ///Gets the first project's home directory, or the home directory
@@ -1299,28 +1291,6 @@ fn first_project_directory(workspace: &Workspace, cx: &AppContext) -> Option<Pat
     let project = workspace.project().read(cx);
 
     for worktree in project.worktrees(cx) {
-        let worktree = worktree.read(cx);
-        if worktree.root_entry().is_some_and(|re| re.is_dir()) {
-            return Some(worktree.abs_path().to_path_buf());
-        }
-    }
-    None
-}
-
-///Gets the intuitively correct working directory from the given workspace
-///If there is an active entry for this project, returns that entry's worktree root.
-///If there's no active entry but there is a worktree, returns that worktrees root.
-///If either of these roots are files, or if there are any other query failures,
-///  returns the user's home directory
-fn current_project_directory(workspace: &Workspace, cx: &AppContext) -> Option<PathBuf> {
-    let project = workspace.project().read(cx);
-
-    for worktree in project
-        .active_entry()
-        .and_then(|entry_id| project.worktree_for_entry(entry_id, cx))
-        .into_iter()
-        .chain(project.worktrees(cx))
-    {
         let worktree = worktree.read(cx);
         if worktree.root_entry().is_some_and(|re| re.is_dir()) {
             return Some(worktree.abs_path().to_path_buf());

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -35,17 +35,9 @@ Once a connection is established, Zed will be downloaded and installed to `~/.lo
 If you don't see any output from the Zed command, it is likely that Zed is crashing
 on startup. You can troubleshoot this by switching to manual mode and passing the `--foreground` flag. Please [file a bug](https://github.com/zed-industries/zed) so we can debug it together.
 
-### SSH-like connections
+If you are trying to connect to a platform like GitHub Codespaces or Google Cloud, you may want to first make sure that your SSH configuration is set up correctly. Once you can `ssh X` to connect to the machine, then Zed will be able to connect.
 
-Zed intercepts `ssh` in a way that should make it possible to intercept connections made by most "ssh wrappers". For example you
-can specify:
-
-- `user@host` will assume you meant `ssh user@host`
-- `ssh -J jump target` to connect via a jump-host
-- `gh cs ssh -c example-codespace` to connect to a GitHub codespace
-- `doctl compute ssh example-droplet` to connect to a DigitalOcean Droplet
-- `gcloud compute ssh` for a Google Cloud instance
-- `ssh -i path_to_key_file user@host` to connect to a host using a key file or certificate
+> **Note:** In an earlier version of remoting, we supported typing in `gh cs ssh` or `gcloud compute ssh` directly. This is no longer supported. Instead you should make sure your SSH configuration is up to date with `gcloud compute ssh --config` or `gh cs ssh --config`, or use Manual setup mode if you cannot ssh directly to the machine.
 
 ### zed --dev-server-token isn't connecting
 


### PR DESCRIPTION
This also rolls back the `TerminalWorkDir` abstraction I added for the original remoting, and tidies up the terminal creation code to be clear about whether we're creating a task *or* a terminal. The previous logic was a little muddy because it assumed we could be doing both at the same time (which was not true).

Release Notes:

- remoting alpha: Removed the ability to specify `gh cs ssh` or `gcloud compute ssh` etc. See https://zed.dev/docs/remote-development for alternatives.
- remoting alpha: Added support for terminal and tasks to new experimental ssh remoting
