### PR TITLE
Fix typo in remote projects sign-in prompt

### DIFF
--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -1422,7 +1422,7 @@ impl DevServerProjects {
             .when(is_signed_out, |modal| {
                 modal
                     .section(Section::new().child(v_flex().mb_4().child(Label::new(
-                        "You are not currently signed in to Zed. Currently the remote development featuers are only available to signed in users. Please sign in to continue.",
+                        "You are not currently signed in to Zed. Currently the remote development features are only available to signed in users. Please sign in to continue.",
                     ))))
                     .footer(
                         ModalFooter::new().end_slot(


### PR DESCRIPTION
Visible at File → Open Recent → Open Remote Folder…

| Before | After |
| - | - |
| ![Screenshot showing "featuers"](https://github.com/user-attachments/assets/6e1822c7-74da-4166-a097-ab2315fddd1a) | ![Corrected "features"](https://github.com/user-attachments/assets/038380a6-15c1-4c71-ad47-ddd477094d85) |

Release Notes:

- Fixed typo in remote projects sign-in prompt.
