### PR TITLE
Fix missing description for some settings

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -89,6 +89,7 @@ impl TextSystem {
                 .iter()
                 .map(|font| font.family.to_string()),
         );
+        names.insert(".SystemUIFont".into());
         names.into_iter().collect()
     }
 

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -669,35 +669,6 @@ impl settings::Settings for ThemeSettings {
                     obj.reference = Some("#/definitions/FontFallbacks".into());
                 });
             });
-        {
-            let prop = &root_schema.schema.object().properties;
-            println!("{:#?}", prop);
-        }
-
-        // root_schema
-        //     .schema
-        //     .object
-        //     .as_mut()
-        //     .unwrap()
-        //     .properties
-        //     .extend([
-        //         (
-        //             "buffer_font_family".to_owned(),
-        //             Schema::new_ref("#/definitions/FontFamilies".into()),
-        //         ),
-        //         (
-        //             "buffer_font_fallbacks".to_owned(),
-        //             Schema::new_ref("#/definitions/FontFallbacks".into()),
-        //         ),
-        //         (
-        //             "ui_font_family".to_owned(),
-        //             Schema::new_ref("#/definitions/FontFamilies".into()),
-        //         ),
-        //         (
-        //             "ui_font_fallbacks".to_owned(),
-        //             Schema::new_ref("#/definitions/FontFallbacks".into()),
-        //         ),
-        //     ]);
 
         root_schema
     }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -649,35 +649,59 @@ impl settings::Settings for ThemeSettings {
             ("FontFallbacks".into(), font_fallback_schema.into()),
         ]);
 
-        root_schema
-            .schema
-            .object
-            .as_mut()
-            .unwrap()
-            .properties
-            .extend([
-                (
-                    "buffer_font_family".to_owned(),
-                    Schema::new_ref("#/definitions/FontFamilies".into()),
-                ),
-                (
-                    "buffer_font_fallbacks".to_owned(),
-                    Schema::new_ref("#/definitions/FontFallbacks".into()),
-                ),
-                (
-                    "ui_font_family".to_owned(),
-                    Schema::new_ref("#/definitions/FontFamilies".into()),
-                ),
-                (
-                    "ui_font_fallbacks".to_owned(),
-                    Schema::new_ref("#/definitions/FontFallbacks".into()),
-                ),
-            ]);
-
+        ["buffer_font_family", "ui_font_family"]
+            .into_iter()
+            .for_each(|key| {
+                let schema = root_schema.schema.object().properties.get_mut(key).unwrap();
+                match schema {
+                    Schema::Bool(_) => unreachable!(),
+                    Schema::Object(obj) => {
+                        obj.subschemas().all_of =
+                            Some(vec![Schema::new_ref("#/definitions/FontFamilies".into())]);
+                    }
+                }
+            });
+        ["buffer_font_fallbacks", "ui_font_fallbacks"]
+            .into_iter()
+            .for_each(|key| {
+                let schema = root_schema.schema.object().properties.get_mut(key).unwrap();
+                match schema {
+                    Schema::Bool(_) => unreachable!(),
+                    Schema::Object(obj) => {
+                        obj.subschemas().all_of =
+                            Some(vec![Schema::new_ref("#/definitions/FontFallbacks".into())]);
+                    }
+                }
+            });
         {
             let prop = &root_schema.schema.object().properties;
             println!("{:#?}", prop);
         }
+
+        // root_schema
+        //     .schema
+        //     .object
+        //     .as_mut()
+        //     .unwrap()
+        //     .properties
+        //     .extend([
+        //         (
+        //             "buffer_font_family".to_owned(),
+        //             Schema::new_ref("#/definitions/FontFamilies".into()),
+        //         ),
+        //         (
+        //             "buffer_font_fallbacks".to_owned(),
+        //             Schema::new_ref("#/definitions/FontFallbacks".into()),
+        //         ),
+        //         (
+        //             "ui_font_family".to_owned(),
+        //             Schema::new_ref("#/definitions/FontFamilies".into()),
+        //         ),
+        //         (
+        //             "ui_font_fallbacks".to_owned(),
+        //             Schema::new_ref("#/definitions/FontFallbacks".into()),
+        //         ),
+        //     ]);
 
         root_schema
     }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -7,7 +7,7 @@ use gpui::{
     Subscription, ViewContext, WindowContext,
 };
 use refineable::Refineable;
-use schemars::schema::{ArrayValidation, Metadata, RootSchema};
+use schemars::schema::{ArrayValidation, RootSchema};
 use schemars::{
     gen::SchemaGenerator,
     schema::{InstanceType, Schema, SchemaObject},
@@ -684,9 +684,14 @@ fn with_schema_object<F>(root_schema: &mut RootSchema, key: &str, f: F)
 where
     F: FnOnce(&mut SchemaObject),
 {
-    let schema = root_schema.schema.object().properties.get_mut(key).unwrap();
+    let Some(schema) = root_schema.schema.object().properties.get_mut(key) else {
+        log::error!("No schema found for key: {key}");
+        return;
+    };
     match schema {
-        Schema::Bool(_) => unreachable!(),
+        Schema::Bool(_) => {
+            log::error!("Expect schema object, but schema bool was found for key: {key}");
+        }
         Schema::Object(obj) => {
             f(obj);
         }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -7,7 +7,7 @@ use gpui::{
     Subscription, ViewContext, WindowContext,
 };
 use refineable::Refineable;
-use schemars::schema::ArrayValidation;
+use schemars::schema::{ArrayValidation, Metadata, RootSchema};
 use schemars::{
     gen::SchemaGenerator,
     schema::{InstanceType, Schema, SchemaObject},
@@ -674,6 +674,11 @@ impl settings::Settings for ThemeSettings {
                 ),
             ]);
 
+        {
+            let prop = &root_schema.schema.object().properties;
+            println!("{:#?}", prop);
+        }
+
         root_schema
     }
 }
@@ -681,5 +686,13 @@ impl settings::Settings for ThemeSettings {
 fn merge<T: Copy>(target: &mut T, value: Option<T>) {
     if let Some(value) = value {
         *target = value;
+    }
+}
+
+fn retrieve_schema_metadata(root_schema: &mut RootSchema, key: &str) -> Option<Box<Metadata>> {
+    let schema = root_schema.schema.object().properties.get(key)?;
+    match schema {
+        Schema::Bool(_) => None,
+        Schema::Object(obj) => obj.metadata.clone(),
     }
 }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -668,6 +668,8 @@ impl settings::Settings for ThemeSettings {
                 match schema {
                     Schema::Bool(_) => unreachable!(),
                     Schema::Object(obj) => {
+                        obj.instance_type = None;
+                        obj.array = None;
                         obj.subschemas().all_of =
                             Some(vec![Schema::new_ref("#/definitions/FontFallbacks".into())]);
                     }


### PR DESCRIPTION
Previously, some settings, specifically `*_font_family` and `*_font_fallbacks`, did not have descriptions provided. With this PR, the descriptions have been added back.


https://github.com/user-attachments/assets/09711cc1-b39e-4459-a1fe-7b95f7635fec



Release Notes:

- N/A
