### PR TITLE
windows: Fix `eslint` installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10947,18 +10947,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10947,18 +10947,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/http_client/src/github.rs
+++ b/crates/http_client/src/github.rs
@@ -118,36 +118,50 @@ pub async fn get_release_by_tag_name(
     Ok(release)
 }
 
-pub fn build_tarball_url(repo_name_with_owner: &str, tag: &str) -> Result<String> {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum AssetKind {
+    TarGz,
+    Zip,
+}
+
+pub fn build_asset_url(repo_name_with_owner: &str, tag: &str, kind: AssetKind) -> Result<String> {
     let mut url = Url::parse(&format!(
         "https://github.com/{repo_name_with_owner}/archive/refs/tags",
     ))?;
     // We're pushing this here, because tags may contain `/` and other characters
     // that need to be escaped.
-    #[cfg(not(target_os = "windows"))]
-    let tarball_filename = format!("{}.tar.gz", tag);
-    #[cfg(target_os = "windows")]
-    let tarball_filename = format!("{}.zip", tag);
+    let asset_filename = format!(
+        "{tag}.{extension}",
+        extension = match kind {
+            AssetKind::TarGz => "tar.gz",
+            AssetKind::Zip => "zip",
+        }
+    );
     url.path_segments_mut()
         .map_err(|_| anyhow!("cannot modify url path segments"))?
-        .push(&tarball_filename);
+        .push(&asset_filename);
     Ok(url.to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::github::build_tarball_url;
+    use crate::github::{build_asset_url, AssetKind};
 
     #[test]
-    fn test_build_tarball_url() {
+    fn test_build_asset_url() {
         let tag = "release/2.3.5";
         let repo_name_with_owner = "microsoft/vscode-eslint";
 
-        let have = build_tarball_url(repo_name_with_owner, tag).unwrap();
-
+        let tarball = build_asset_url(repo_name_with_owner, tag, AssetKind::TarGz).unwrap();
         assert_eq!(
-            have,
+            tarball,
             "https://github.com/microsoft/vscode-eslint/archive/refs/tags/release%2F2.3.5.tar.gz"
+        );
+
+        let zip = build_asset_url(repo_name_with_owner, tag, AssetKind::Zip).unwrap();
+        assert_eq!(
+            zip,
+            "https://github.com/microsoft/vscode-eslint/archive/refs/tags/release%2F2.3.5.zip"
         );
     }
 }

--- a/crates/http_client/src/github.rs
+++ b/crates/http_client/src/github.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use url::Url;
 
+#[derive(Debug)]
 pub struct GitHubLspBinaryVersion {
     pub name: String,
     pub url: String,
@@ -123,7 +124,10 @@ pub fn build_tarball_url(repo_name_with_owner: &str, tag: &str) -> Result<String
     ))?;
     // We're pushing this here, because tags may contain `/` and other characters
     // that need to be escaped.
+    #[cfg(not(target_os = "windows"))]
     let tarball_filename = format!("{}.tar.gz", tag);
+    #[cfg(target_os = "windows")]
+    let tarball_filename = format!("{}.zip", tag);
     url.path_segments_mut()
         .map_err(|_| anyhow!("cannot modify url path segments"))?
         .push(&tarball_filename);

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -460,7 +460,7 @@ impl LspAdapter for EsLintLspAdapter {
 
             let ret = self
                 .node
-                .run_npm_subcommand(Some(&repo_root), "run-script", &["compile"])
+                .run_npm_subcommand(Some(&repo_root), "run-script", &["compile:server"])
                 .await;
             println!("ret2 ==>{:?}", ret);
             ret?;

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -58,7 +58,8 @@ fn typescript_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
 }
 
 fn eslint_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
-    vec![server_path.into(), "--stdio".into()]
+    // vec![server_path.into(), "--stdio".into()]
+    vec![server_path.into(), "--stdin".into()]
 }
 
 pub struct TypeScriptLspAdapter {
@@ -297,7 +298,8 @@ pub struct EsLintLspAdapter {
 impl EsLintLspAdapter {
     const CURRENT_VERSION: &'static str = "release/2.4.4";
 
-    const SERVER_PATH: &'static str = "vscode-eslint/server/out/eslintServer.js";
+    // const SERVER_PATH: &'static str = "vscode-eslint/server/out/eslintServer.js";
+    const SERVER_PATH: &'static str = "vscode-eslint/node_modules/.bin/eslint.ps1";
     const SERVER_NAME: &'static str = "eslint";
 
     const FLAT_CONFIG_FILE_NAMES: &'static [&'static str] =
@@ -446,35 +448,79 @@ impl LspAdapter for EsLintLspAdapter {
                 archive.unpack(&destination_path).await?;
             }
 
-            let mut dir = fs::read_dir(&destination_path).await?;
+            let mut dir = fs::read_dir(&destination_path).await.unwrap();
             let first = dir.next().await.ok_or(anyhow!("missing first file"))??;
             let repo_root = destination_path.join("vscode-eslint");
-            fs::rename(first.path(), &repo_root).await?;
+            fs::rename(first.path(), &repo_root).await.unwrap();
 
+            // panic!();
             let ret = self
                 .node
-                .run_npm_subcommand(Some(&repo_root), "install", &[])
-                .await?;
+                .run_npm_subcommand(Some(&repo_root), "ci", &[])
+                .await;
             println!("ret1 ==>{:?}", ret);
             {
-                println!("err: {}", String::from_utf8_lossy(&ret.stderr));
+                let ret = ret.log_err();
+                if let Some(ret) = ret {
+                    println!("err: {}", String::from_utf8_lossy(&ret.stderr));
+                }
             }
-
+            // panic!();
+            let ret = self
+                .node
+                .run_npm_subcommand(Some(&repo_root), "run-script", &["lint"])
+                .await;
+            println!("ret2 ==>{:?}", ret);
+            {
+                let ret = ret.log_err();
+                if let Some(ret) = ret {
+                    println!("err: {}", String::from_utf8_lossy(&ret.stderr));
+                }
+            }
+            // panic!();
             let ret = self
                 .node
                 .run_npm_subcommand(Some(&repo_root), "run-script", &["compile"])
-                .await?;
-            println!("ret2 ==>{:?}", ret);
+                .await;
+            println!("ret3 ==>{:?}", ret);
             {
-                println!("err: {}", String::from_utf8_lossy(&ret.stderr));
+                let ret = ret.log_err();
+                if let Some(ret) = ret {
+                    println!("err: {}", String::from_utf8_lossy(&ret.stderr));
+                }
             }
+            // panic!();
         }
 
-        Ok(LanguageServerBinary {
-            path: self.node.binary_path().await?,
-            env: None,
-            arguments: eslint_server_binary_arguments(&server_path),
-        })
+        // Ok(LanguageServerBinary {
+        //     path: self.node.binary_path().await?,
+        //     env: None,
+        //     arguments: eslint_server_binary_arguments(&server_path),
+        // })
+        {
+            let mut env_path = vec![self
+                .node
+                .binary_path()
+                .await?
+                .parent()
+                .expect("invalid node binary path")
+                .to_path_buf()];
+
+            if let Some(existing_path) = std::env::var_os("PATH") {
+                let mut paths = std::env::split_paths(&existing_path).collect::<Vec<_>>();
+                env_path.append(&mut paths);
+            }
+
+            let env_path = std::env::join_paths(env_path)?;
+            let mut env = HashMap::default();
+            env.insert("PATH".to_string(), env_path.to_string_lossy().to_string());
+
+            Ok(LanguageServerBinary {
+                path: "powershell.exe".into(),
+                env: Some(env),
+                arguments: eslint_server_binary_arguments(&server_path),
+            })
+        }
     }
 
     async fn cached_server_binary(

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -454,16 +454,20 @@ impl LspAdapter for EsLintLspAdapter {
             let ret = self
                 .node
                 .run_npm_subcommand(Some(&repo_root), "install", &[])
-                .await;
+                .await?;
             println!("ret1 ==>{:?}", ret);
-            ret.log_err();
+            {
+                println!("err: {}", String::from_utf8_lossy(&ret.stderr));
+            }
 
             let ret = self
                 .node
-                .run_npm_subcommand(Some(&repo_root), "run-script", &["compile:server"])
-                .await;
+                .run_npm_subcommand(Some(&repo_root), "run-script", &["compile"])
+                .await?;
             println!("ret2 ==>{:?}", ret);
-            ret?;
+            {
+                println!("err: {}", String::from_utf8_lossy(&ret.stderr));
+            }
         }
 
         Ok(LanguageServerBinary {

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -116,7 +116,7 @@ impl LspAdapter for TypeScriptLspAdapter {
         container_dir: PathBuf,
         _: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
-        let latest_version = latest_version.downcast::<TypeScriptVersions>()?;
+        let latest_version = latest_version.downcast::<TypeScriptVersions>().unwrap();
         let server_path = container_dir.join(Self::NEW_SERVER_PATH);
         let package_name = "typescript";
 
@@ -420,7 +420,7 @@ impl LspAdapter for EsLintLspAdapter {
         container_dir: PathBuf,
         delegate: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
-        let version = version.downcast::<GitHubLspBinaryVersion>()?;
+        let version = version.downcast::<GitHubLspBinaryVersion>().unwrap();
         let destination_path = container_dir.join(format!("vscode-eslint-{}", version.name));
         let server_path = destination_path.join(Self::SERVER_PATH);
 
@@ -561,7 +561,7 @@ mod tests {
 
         let buffer =
             cx.new_model(|cx| language::Buffer::local(text, cx).with_language(language, cx));
-        let outline = buffer.update(cx, |buffer, _| buffer.snapshot().outline(None)?);
+        let outline = buffer.update(cx, |buffer, _| buffer.snapshot().outline(None).unwrap());
         assert_eq!(
             outline
                 .items

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -467,31 +467,10 @@ impl LspAdapter for EsLintLspAdapter {
                 .await
                 .unwrap();
 
-            // self.node
-            //     .run_npm_subcommand(Some(&repo_root), "run-script", &["compile:server"])
-            //     .await
-            //     .log_err();
-
-            // let output = std::process::Command::new("powershell.exe")
-            //     .arg("npm install --proxy \"http://127.0.0.1:10809\"")
-            //     .current_dir(&repo_root)
-            //     .output()
-            //     .unwrap();
-            // if !output.status.success() {
-            //     println!("==> {}", String::from_utf8_lossy(output.stderr.as_slice()));
-            // }
-            // println!("1-->{}", String::from_utf8_lossy(output.stdout.as_slice()));
-            let output = std::process::Command::new("powershell.exe")
-                .arg("npm run compile:server")
-                .current_dir(&repo_root)
-                .output()
+            self.node
+                .run_npm_subcommand(Some(&repo_root), "run-script", &["compile"])
+                .await
                 .unwrap();
-            if !output.status.success() {
-                println!("==> {}", String::from_utf8_lossy(output.stderr.as_slice()));
-            }
-            println!("2-->{}", String::from_utf8_lossy(output.stdout.as_slice()));
-
-            panic!();
         }
 
         Ok(LanguageServerBinary {

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -4,7 +4,7 @@ use async_tar::Archive;
 use async_trait::async_trait;
 use collections::HashMap;
 use gpui::AsyncAppContext;
-use http_client::github::{build_tarball_url, GitHubLspBinaryVersion};
+use http_client::github::{build_asset_url, GitHubLspBinaryVersion};
 use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::{CodeActionKind, LanguageServerBinary};
 use node_runtime::NodeRuntime;
@@ -406,7 +406,11 @@ impl LspAdapter for EsLintLspAdapter {
         &self,
         _delegate: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
-        let url = build_tarball_url("microsoft/vscode-eslint", Self::CURRENT_VERSION)?;
+        let url = build_asset_url(
+            "microsoft/vscode-eslint",
+            Self::CURRENT_VERSION,
+            http_client::github::AssetKind::TarGz,
+        )?;
 
         Ok(Box::new(GitHubLspBinaryVersion {
             name: Self::CURRENT_VERSION.into(),

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -20,7 +20,7 @@ use std::{
     sync::Arc,
 };
 use task::{TaskTemplate, TaskTemplates, VariableName};
-use util::{fs::remove_matching, maybe, ResultExt, TryFutureExt};
+use util::{fs::remove_matching, maybe, ResultExt};
 
 pub(super) fn typescript_task_context() -> ContextProviderWithTasks {
     ContextProviderWithTasks::new(TaskTemplates(vec![

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -249,8 +249,6 @@ impl NodeRuntime for RealNodeRuntime {
             }
 
             let mut command = Command::new(node_binary);
-            // let mut command = Command::new("powershell.exe");
-            // command.arg(node_binary);
             command.env_clear();
             command.env("PATH", env_path);
             command.arg(npm_file).arg(subcommand);

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -250,7 +250,7 @@ impl NodeRuntime for RealNodeRuntime {
 
             let mut command = Command::new("powershell.exe");
             command.arg(node_binary);
-            command.env_clear();
+            // command.env_clear();
             command.env("PATH", env_path);
             command.arg(npm_file).arg(subcommand);
             command.args(["--cache".into(), installation_path.join("cache")]);

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -248,7 +248,8 @@ impl NodeRuntime for RealNodeRuntime {
                 return Err(anyhow!("missing npm file"));
             }
 
-            let mut command = Command::new(node_binary);
+            let mut command = Command::new("powershell.exe");
+            command.arg(node_binary);
             command.env_clear();
             command.env("PATH", env_path);
             command.arg(npm_file).arg(subcommand);

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -248,9 +248,10 @@ impl NodeRuntime for RealNodeRuntime {
                 return Err(anyhow!("missing npm file"));
             }
 
-            let mut command = Command::new("powershell.exe");
-            command.arg(node_binary);
-            // command.env_clear();
+            let mut command = Command::new(node_binary);
+            // let mut command = Command::new("powershell.exe");
+            // command.arg(node_binary);
+            command.env_clear();
             command.env("PATH", env_path);
             command.arg(npm_file).arg(subcommand);
             command.args(["--cache".into(), installation_path.join("cache")]);

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -292,6 +292,13 @@ impl NodeRuntime for RealNodeRuntime {
                 {
                     command.env("SYSTEMROOT", val);
                 }
+                // Without ComSpec, the post-install will always fail.
+                if let Some(val) = std::env::var("ComSpec")
+                    .context("Missing environment variable: ComSpec!")
+                    .log_err()
+                {
+                    command.env("ComSpec", val);
+                }
                 command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
             }
 


### PR DESCRIPTION
Close #13786. To make `eslint` running on Windows, I made the following changes:

1. Ensure that `zed` downloads the `.zip` file.
2. Handle the `$shared` symbolic link by copying files to the link location.
3. In #13891, I mentioned that the `npm` `post-install` script was always failing. After debugging, I found it was due to missing environment variables. This has been fixed, and I will submit a new PR to address the changes in #13891.

With this PR, `eslint` can now successfully run on Windows. Video:


https://github.com/user-attachments/assets/e85451b8-0388-490a-8a75-01c12d744f7c



Release Notes:

- Fixed `eslint` not running on Windows ([#13786](https://github.com/zed-industries/zed/issues/13786)).
