### PR TITLE
Don't clobber other schema fields when attaching references

### DIFF
--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -649,30 +649,27 @@ impl settings::Settings for ThemeSettings {
             ("FontFallbacks".into(), font_fallback_schema.into()),
         ]);
 
-        root_schema
-            .schema
-            .object
-            .as_mut()
-            .unwrap()
-            .properties
-            .extend([
-                (
-                    "buffer_font_family".to_owned(),
-                    Schema::new_ref("#/definitions/FontFamilies".into()),
-                ),
-                (
-                    "buffer_font_fallbacks".to_owned(),
-                    Schema::new_ref("#/definitions/FontFallbacks".into()),
-                ),
-                (
-                    "ui_font_family".to_owned(),
-                    Schema::new_ref("#/definitions/FontFamilies".into()),
-                ),
-                (
-                    "ui_font_fallbacks".to_owned(),
-                    Schema::new_ref("#/definitions/FontFallbacks".into()),
-                ),
-            ]);
+        // The list of properties that should reference another definition in
+        // the schema.
+        let properties_with_references = vec![
+            ("buffer_font_family", "#/definitions/FontFamilies"),
+            ("buffer_font_fallbacks", "#/definitions/FontFallbacks"),
+            ("ui_font_family", "#/definitions/FontFamilies"),
+            ("ui_font_fallbacks", "#/definitions/FontFallbacks"),
+        ];
+
+        for (property, definition) in properties_with_references {
+            let Some(property) = root_schema.schema.object().properties.get_mut(property) else {
+                continue;
+            };
+
+            match property {
+                Schema::Object(schema) => {
+                    schema.reference = Some(definition.into());
+                }
+                Schema::Bool(_) => {}
+            }
+        }
 
         root_schema
     }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -659,15 +659,18 @@ impl settings::Settings for ThemeSettings {
         ];
 
         for (property, definition) in properties_with_references {
-            let Some(property) = root_schema.schema.object().properties.get_mut(property) else {
+            let Some(schema) = root_schema.schema.object().properties.get_mut(property) else {
+                log::warn!("property '{property}' not found in JSON schema");
                 continue;
             };
 
-            match property {
+            match schema {
                 Schema::Object(schema) => {
                     schema.reference = Some(definition.into());
                 }
-                Schema::Bool(_) => {}
+                Schema::Bool(_) => {
+                    // Boolean schemas can't have references.
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue where we would clobber the other JSON Schema fields for any field that we attached a reference to.

This resulted in these fields (e.g., `buffer_font_family`, `ui_font_family`) losing things like their descriptions.

The approach has been adjusted that references are now added in an additive fashion, rather than overriding the entire schema object.

Release Notes:

- Fixed an issue where font-related settings in `settings.json` were missing their descriptions.
