### PR TITLE
Remove `TODO` in `JsonLspAdapter`

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -166,11 +166,10 @@ impl LspAdapter for JsonLspAdapter {
             .await;
 
         if should_install_language_server {
-            // TODO: the postinstall fails on Windows
             self.node
                 .npm_install_packages(&container_dir, &[(package_name, latest_version.as_str())])
                 .await
-                .log_err();
+                .unwrap();
         }
 
         Ok(LanguageServerBinary {

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -168,8 +168,7 @@ impl LspAdapter for JsonLspAdapter {
         if should_install_language_server {
             self.node
                 .npm_install_packages(&container_dir, &[(package_name, latest_version.as_str())])
-                .await
-                .unwrap();
+                .await?;
         }
 
         Ok(LanguageServerBinary {


### PR DESCRIPTION
As the post-install issue is fixed via #15331 , we can remove this `TODO` now. I have tested on win11, it works fine.

Release Notes:

- N/A
