### PR TITLE
project_panel: Double-click on blank space in project panel to create a new file

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2144,6 +2144,8 @@ impl ProjectPanel {
                             return;
                         }
                         if !show_editor {
+                            cx.stop_propagation();
+
                             if let Some(selection) =
                                 this.selection.filter(|_| event.down.modifiers.shift)
                             {
@@ -2437,6 +2439,32 @@ impl Render for ProjectPanel {
                         .on_action(cx.listener(Self::copy))
                         .on_action(cx.listener(Self::paste))
                         .on_action(cx.listener(Self::duplicate))
+                        .on_click(cx.listener(|this, event: &gpui::ClickEvent, cx| {
+                            // trigger new_file when double-clicked on the blank space
+                            //
+                            // NOTE: this multi-click event triggered only when the blank space is clicked
+                            // (the click event on entry will not be propagated to this event)
+                            if event.up.click_count > 1 {
+                                if let Some(entry_id) = this.last_worktree_root_id {
+                                    let project = this.project.read(cx);
+
+                                    let worktree_id = if let Some(worktree) =
+                                        project.worktree_for_entry(entry_id, cx)
+                                    {
+                                        worktree.read(cx).id()
+                                    } else {
+                                        return;
+                                    };
+
+                                    this.selection = Some(SelectedEntry {
+                                        worktree_id,
+                                        entry_id,
+                                    });
+
+                                    this.new_file(&NewFile, cx);
+                                }
+                            }
+                        }))
                 })
                 .when(project.is_local(), |el| {
                     el.on_action(cx.listener(Self::reveal_in_finder))

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2440,10 +2440,6 @@ impl Render for ProjectPanel {
                         .on_action(cx.listener(Self::paste))
                         .on_action(cx.listener(Self::duplicate))
                         .on_click(cx.listener(|this, event: &gpui::ClickEvent, cx| {
-                            // trigger new_file when double-clicked on the blank space
-                            //
-                            // NOTE: this multi-click event triggered only when the blank space is clicked
-                            // (the click event on entry will not be propagated to this event)
                             if event.up.click_count > 1 {
                                 if let Some(entry_id) = this.last_worktree_root_id {
                                     let project = this.project.read(cx);


### PR DESCRIPTION
Similar feature implemented in VSCode.

https://github.com/user-attachments/assets/ae250b5f-283c-4211-8947-d5d5703eb2d0


Release Notes:

- Added double-click to create a new file when clicking on blank space in the project panel.

