### PR TITLE
Change PathLikeWithPosition<P> into a non-generic type and replace ad-hoc Windows path parsing

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use cli::{ipc::IpcOneShotServer, CliRequest, CliResponse, IpcHandshake};
 use parking_lot::Mutex;
 use std::{
-    convert::Infallible,
     env, fs, io,
     path::{Path, PathBuf},
     process::ExitStatus,
@@ -54,10 +53,7 @@ struct Args {
 }
 
 fn parse_path_with_position(argument_str: &str) -> Result<String, std::io::Error> {
-    let path = PathWithPosition::parse_str::<Infallible>(argument_str, |path_str| {
-        Ok(Path::new(path_str).to_path_buf())
-    })
-    .unwrap();
+    let path = PathWithPosition::parse_str(argument_str);
     let curdir = env::current_dir()?;
 
     let canonicalized = path.map_path(|path| match fs::canonicalize(&path) {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,7 +12,7 @@ use std::{
     sync::Arc,
     thread::{self, JoinHandle},
 };
-use util::paths::PathLikeWithPosition;
+use util::paths::PathWithPosition;
 
 struct Detect;
 
@@ -54,13 +54,13 @@ struct Args {
 }
 
 fn parse_path_with_position(argument_str: &str) -> Result<String, std::io::Error> {
-    let path_like = PathLikeWithPosition::parse_str::<Infallible>(argument_str, |_, path_str| {
+    let path = PathWithPosition::parse_str::<Infallible>(argument_str, |path_str| {
         Ok(Path::new(path_str).to_path_buf())
     })
     .unwrap();
     let curdir = env::current_dir()?;
 
-    let canonicalized = path_like.map_path_like(|path| match fs::canonicalize(&path) {
+    let canonicalized = path.map_path(|path| match fs::canonicalize(&path) {
         Ok(path) => Ok(path),
         Err(e) => {
             if let Some(mut parent) = path.parent() {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -158,7 +158,7 @@ pub struct FileFinderDelegate {
     search_count: usize,
     latest_search_id: usize,
     latest_search_did_cancel: bool,
-    latest_search_query: Option<PathLikeWithPosition<FileSearchQuery>>,
+    latest_search_query: Option<FileSearchQuery>,
     currently_opened_path: Option<FoundPath>,
     matches: Matches,
     selected_index: usize,
@@ -226,7 +226,7 @@ impl Matches {
         &'a mut self,
         history_items: impl IntoIterator<Item = &'a FoundPath> + Clone,
         currently_opened: Option<&'a FoundPath>,
-        query: Option<&PathLikeWithPosition<FileSearchQuery>>,
+        query: Option<&FileSearchQuery>,
         new_search_matches: impl Iterator<Item = ProjectPanelOrdMatch>,
         extend_old_matches: bool,
     ) {
@@ -303,7 +303,7 @@ impl Matches {
 fn matching_history_item_paths<'a>(
     history_items: impl IntoIterator<Item = &'a FoundPath>,
     currently_opened: Option<&'a FoundPath>,
-    query: Option<&PathLikeWithPosition<FileSearchQuery>>,
+    query: Option<&FileSearchQuery>,
 ) -> HashMap<Arc<Path>, Option<ProjectPanelOrdMatch>> {
     let Some(query) = query else {
         return history_items
@@ -351,7 +351,7 @@ fn matching_history_item_paths<'a>(
             fuzzy::match_fixed_path_set(
                 candidates,
                 worktree.to_usize(),
-                query.path_like.path_query(),
+                query.path_query(),
                 false,
                 max_results,
             )
@@ -400,6 +400,7 @@ pub enum Event {
 struct FileSearchQuery {
     raw_query: String,
     file_query_end: Option<usize>,
+    path_position: PathLikeWithPosition<PathBuf>,
 }
 
 impl FileSearchQuery {
@@ -456,7 +457,7 @@ impl FileFinderDelegate {
 
     fn spawn_search(
         &mut self,
-        query: PathLikeWithPosition<FileSearchQuery>,
+        query: FileSearchQuery,
         cx: &mut ViewContext<Picker<Self>>,
     ) -> Task<()> {
         let relative_to = self
@@ -491,7 +492,7 @@ impl FileFinderDelegate {
         cx.spawn(|picker, mut cx| async move {
             let matches = fuzzy::match_path_sets(
                 candidate_sets.as_slice(),
-                query.path_like.path_query(),
+                query.path_query(),
                 relative_to,
                 false,
                 100,
@@ -516,18 +517,18 @@ impl FileFinderDelegate {
         &mut self,
         search_id: usize,
         did_cancel: bool,
-        query: PathLikeWithPosition<FileSearchQuery>,
+        query: FileSearchQuery,
         matches: impl IntoIterator<Item = ProjectPanelOrdMatch>,
         cx: &mut ViewContext<Picker<Self>>,
     ) {
         if search_id >= self.latest_search_id {
             self.latest_search_id = search_id;
             let extend_old_matches = self.latest_search_did_cancel
-                && Some(query.path_like.path_query())
+                && Some(query.path_query())
                     == self
                         .latest_search_query
                         .as_ref()
-                        .map(|query| query.path_like.path_query());
+                        .map(|query| query.path_query());
             self.matches.push_new_matches(
                 &self.history_items,
                 self.currently_opened_path.as_ref(),
@@ -658,7 +659,7 @@ impl FileFinderDelegate {
 
     fn lookup_absolute_path(
         &self,
-        query: PathLikeWithPosition<FileSearchQuery>,
+        query: FileSearchQuery,
         cx: &mut ViewContext<'_, Picker<Self>>,
     ) -> Task<()> {
         cx.spawn(|picker, mut cx| async move {
@@ -672,7 +673,7 @@ impl FileFinderDelegate {
                 return;
             };
 
-            let query_path = Path::new(query.path_like.path_query());
+            let query_path = Path::new(query.path_query());
             let mut path_matches = Vec::new();
             match fs.metadata(query_path).await.log_err() {
                 Some(Some(_metadata)) => {
@@ -796,20 +797,25 @@ impl PickerDelegate for FileFinderDelegate {
             cx.notify();
             Task::ready(())
         } else {
-            let query =
-                PathLikeWithPosition::parse_str(&raw_query, |normalized_query, path_like_str| {
-                    Ok::<_, std::convert::Infallible>(FileSearchQuery {
-                        raw_query: normalized_query.to_owned(),
-                        file_query_end: if path_like_str == raw_query {
-                            None
-                        } else {
-                            Some(path_like_str.len())
-                        },
-                    })
-                })
-                .expect("infallible");
+            let path_position = PathLikeWithPosition::parse_str(&raw_query, |_, path_str| {
+                Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
+            })
+            .expect("infallible");
 
-            if Path::new(query.path_like.path_query()).is_absolute() {
+            let query = FileSearchQuery {
+                raw_query: raw_query.trim().to_owned(),
+                file_query_end: if path_position.path_like.to_str().unwrap_or(raw_query)
+                    == raw_query
+                {
+                    None
+                } else {
+                    // Safe to unwrap as we won't get here when the unwrap in if fails
+                    Some(path_position.path_like.to_str().unwrap().len())
+                },
+                path_position,
+            };
+
+            if Path::new(query.path_query()).is_absolute() {
                 self.lookup_absolute_path(query, cx)
             } else {
                 self.spawn_search(query, cx)
@@ -898,12 +904,12 @@ impl PickerDelegate for FileFinderDelegate {
                 let row = self
                     .latest_search_query
                     .as_ref()
-                    .and_then(|query| query.row)
+                    .and_then(|query| query.path_position.row)
                     .map(|row| row.saturating_sub(1));
                 let col = self
                     .latest_search_query
                     .as_ref()
-                    .and_then(|query| query.column)
+                    .and_then(|query| query.path_position.column)
                     .unwrap_or(0)
                     .saturating_sub(1);
                 let finder = self.file_finder.clone();

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -797,10 +797,7 @@ impl PickerDelegate for FileFinderDelegate {
             cx.notify();
             Task::ready(())
         } else {
-            let path_position = PathWithPosition::parse_str(&raw_query, |path_str| {
-                Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
-            })
-            .expect("infallible");
+            let path_position = PathWithPosition::parse_str(&raw_query);
 
             let query = FileSearchQuery {
                 raw_query: raw_query.trim().to_owned(),

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -28,7 +28,7 @@ use std::{
 };
 use text::Point;
 use ui::{prelude::*, HighlightedLabel, ListItem, ListItemSpacing};
-use util::{paths::PathLikeWithPosition, post_inc, ResultExt};
+use util::{paths::PathWithPosition, post_inc, ResultExt};
 use workspace::{item::PreviewTabsSettings, ModalView, Workspace};
 
 actions!(file_finder, [SelectPrev]);
@@ -400,7 +400,7 @@ pub enum Event {
 struct FileSearchQuery {
     raw_query: String,
     file_query_end: Option<usize>,
-    path_position: PathLikeWithPosition<PathBuf>,
+    path_position: PathWithPosition,
 }
 
 impl FileSearchQuery {
@@ -797,20 +797,18 @@ impl PickerDelegate for FileFinderDelegate {
             cx.notify();
             Task::ready(())
         } else {
-            let path_position = PathLikeWithPosition::parse_str(&raw_query, |_, path_str| {
+            let path_position = PathWithPosition::parse_str(&raw_query, |path_str| {
                 Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
             })
             .expect("infallible");
 
             let query = FileSearchQuery {
                 raw_query: raw_query.trim().to_owned(),
-                file_query_end: if path_position.path_like.to_str().unwrap_or(raw_query)
-                    == raw_query
-                {
+                file_query_end: if path_position.path.to_str().unwrap_or(raw_query) == raw_query {
                     None
                 } else {
                     // Safe to unwrap as we won't get here when the unwrap in if fails
-                    Some(path_position.path_like.to_str().unwrap().len())
+                    Some(path_position.path.to_str().unwrap().len())
                 },
                 path_position,
             };

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -357,7 +357,7 @@ async fn test_matching_cancellation(cx: &mut TestAppContext) {
 
     let (picker, _, cx) = build_find_picker(project, cx);
 
-    let query = test_path_like("hi");
+    let query = test_path_position("hi");
     picker
         .update(cx, |picker, cx| {
             picker.delegate.spawn_search(query.clone(), cx)
@@ -450,7 +450,7 @@ async fn test_ignored_root(cx: &mut TestAppContext) {
 
     picker
         .update(cx, |picker, cx| {
-            picker.delegate.spawn_search(test_path_like("hi"), cx)
+            picker.delegate.spawn_search(test_path_position("hi"), cx)
         })
         .await;
     picker.update(cx, |picker, _| assert_eq!(picker.delegate.matches.len(), 7));
@@ -478,7 +478,7 @@ async fn test_single_file_worktrees(cx: &mut TestAppContext) {
     // is included in the matching, because the worktree is a single file.
     picker
         .update(cx, |picker, cx| {
-            picker.delegate.spawn_search(test_path_like("thf"), cx)
+            picker.delegate.spawn_search(test_path_position("thf"), cx)
         })
         .await;
     cx.read(|cx| {
@@ -499,7 +499,7 @@ async fn test_single_file_worktrees(cx: &mut TestAppContext) {
     // not match anything.
     picker
         .update(cx, |f, cx| {
-            f.delegate.spawn_search(test_path_like("thf/"), cx)
+            f.delegate.spawn_search(test_path_position("thf/"), cx)
         })
         .await;
     picker.update(cx, |f, _| assert_eq!(f.delegate.matches.len(), 0));
@@ -548,7 +548,7 @@ async fn test_path_distance_ordering(cx: &mut TestAppContext) {
     let finder = open_file_picker(&workspace, cx);
     finder
         .update(cx, |f, cx| {
-            f.delegate.spawn_search(test_path_like("a.txt"), cx)
+            f.delegate.spawn_search(test_path_position("a.txt"), cx)
         })
         .await;
 
@@ -581,7 +581,7 @@ async fn test_search_worktree_without_files(cx: &mut TestAppContext) {
 
     picker
         .update(cx, |f, cx| {
-            f.delegate.spawn_search(test_path_like("dir"), cx)
+            f.delegate.spawn_search(test_path_position("dir"), cx)
         })
         .await;
     cx.read(|cx| {
@@ -1854,18 +1854,18 @@ fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
     })
 }
 
-fn test_path_like(test_str: &str) -> FileSearchQuery {
-    let path_position = PathLikeWithPosition::parse_str(&test_str, |_, path_str| {
+fn test_path_position(test_str: &str) -> FileSearchQuery {
+    let path_position = PathWithPosition::parse_str(&test_str, |path_str| {
         Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
     })
     .unwrap();
 
     FileSearchQuery {
         raw_query: test_str.to_owned(),
-        file_query_end: if path_position.path_like.to_str().unwrap() == test_str {
+        file_query_end: if path_position.path.to_str().unwrap() == test_str {
             None
         } else {
-            Some(path_position.path_like.to_str().unwrap().len())
+            Some(path_position.path.to_str().unwrap().len())
         },
         path_position,
     }

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1855,10 +1855,7 @@ fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
 }
 
 fn test_path_position(test_str: &str) -> FileSearchQuery {
-    let path_position = PathWithPosition::parse_str(&test_str, |path_str| {
-        Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
-    })
-    .unwrap();
+    let path_position = PathWithPosition::parse_str(&test_str);
 
     FileSearchQuery {
         raw_query: test_str.to_owned(),

--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -39,7 +39,7 @@ use ui::{
     RadioWithLabel, Tooltip,
 };
 use ui_input::{FieldLabelLayout, TextField};
-use util::paths::PathLikeWithPosition;
+use util::paths::PathWithPosition;
 use util::ResultExt;
 use workspace::notifications::NotifyResultExt;
 use workspace::OpenOptions;
@@ -991,7 +991,7 @@ impl DevServerProjects {
                         project
                             .paths
                             .into_iter()
-                            .map(|path| PathLikeWithPosition::from_path(PathBuf::from(path)))
+                            .map(|path| PathWithPosition::from_path(PathBuf::from(path)))
                             .collect(),
                         app_state,
                         OpenOptions::default(),

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -19,7 +19,7 @@ use ui::{
     h_flex, v_flex, FluentBuilder as _, Icon, IconName, IconSize, InteractiveElement, IntoElement,
     Label, LabelCommon, Styled, StyledExt as _, ViewContext, VisualContext, WindowContext,
 };
-use util::paths::PathLikeWithPosition;
+use util::paths::PathWithPosition;
 use workspace::{AppState, ModalView, Workspace};
 
 #[derive(Deserialize)]
@@ -345,7 +345,7 @@ pub fn connect_over_ssh(
 
 pub async fn open_ssh_project(
     connection_options: SshConnectionOptions,
-    paths: Vec<PathLikeWithPosition<PathBuf>>,
+    paths: Vec<PathWithPosition>,
     app_state: Arc<AppState>,
     _open_options: workspace::OpenOptions,
     cx: &mut AsyncAppContext,
@@ -398,7 +398,7 @@ pub async fn open_ssh_project(
     for path in paths {
         project
             .update(cx, |project, cx| {
-                project.find_or_create_worktree(&path.path_like, true, cx)
+                project.find_or_create_worktree(&path.path, true, cx)
             })?
             .await?;
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -26,7 +26,7 @@ use terminal::{
 };
 use terminal_element::{is_blank, TerminalElement};
 use ui::{h_flex, prelude::*, ContextMenu, Icon, IconName, Label, Tooltip};
-use util::{paths::PathLikeWithPosition, ResultExt};
+use util::{paths::PathWithPosition, ResultExt};
 use workspace::{
     item::{BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams},
     notifications::NotifyResultExt,
@@ -672,7 +672,7 @@ fn subscribe_for_terminal_events(
                             .await;
                         let paths_to_open = valid_files_to_open
                             .iter()
-                            .map(|(p, _)| p.path_like.clone())
+                            .map(|(p, _)| p.path.clone())
                             .collect();
                         let opened_items = task_workspace
                             .update(&mut cx, |workspace, cx| {
@@ -746,7 +746,7 @@ fn possible_open_paths_metadata(
     column: Option<u32>,
     potential_paths: HashSet<PathBuf>,
     cx: &mut ViewContext<TerminalView>,
-) -> Task<Vec<(PathLikeWithPosition<PathBuf>, Metadata)>> {
+) -> Task<Vec<(PathWithPosition, Metadata)>> {
     cx.background_executor().spawn(async move {
         let mut paths_with_metadata = Vec::with_capacity(potential_paths.len());
 
@@ -755,8 +755,8 @@ fn possible_open_paths_metadata(
             .map(|potential_path| async {
                 let metadata = fs.metadata(&potential_path).await.ok().flatten();
                 (
-                    PathLikeWithPosition {
-                        path_like: potential_path,
+                    PathWithPosition {
+                        path: potential_path,
                         row,
                         column,
                     },
@@ -781,14 +781,14 @@ fn possible_open_targets(
     cwd: &Option<PathBuf>,
     maybe_path: &String,
     cx: &mut ViewContext<TerminalView>,
-) -> Task<Vec<(PathLikeWithPosition<PathBuf>, Metadata)>> {
-    let path_like = PathLikeWithPosition::parse_str(maybe_path.as_str(), |_, path_str| {
+) -> Task<Vec<(PathWithPosition, Metadata)>> {
+    let path_position = PathWithPosition::parse_str(maybe_path.as_str(), |path_str| {
         Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
     })
     .expect("infallible");
-    let row = path_like.row;
-    let column = path_like.column;
-    let maybe_path = path_like.path_like;
+    let row = path_position.row;
+    let column = path_position.column;
+    let maybe_path = path_position.path;
     let potential_abs_paths = if maybe_path.is_absolute() {
         HashSet::from_iter([maybe_path])
     } else if maybe_path.starts_with("~") {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -782,10 +782,7 @@ fn possible_open_targets(
     maybe_path: &String,
     cx: &mut ViewContext<TerminalView>,
 ) -> Task<Vec<(PathWithPosition, Metadata)>> {
-    let path_position = PathWithPosition::parse_str(maybe_path.as_str(), |path_str| {
-        Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
-    })
-    .expect("infallible");
+    let path_position = PathWithPosition::parse_str(maybe_path.as_str());
     let row = path_position.row;
     let column = path_position.column;
     let maybe_path = path_position.path;

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -14,8 +14,6 @@ use futures::{FutureExt, SinkExt, StreamExt};
 use gpui::{AppContext, AsyncAppContext, Global, WindowHandle};
 use language::{Bias, Point};
 use remote::SshConnectionOptions;
-use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{process, thread};
@@ -58,11 +56,8 @@ impl OpenRequest {
 
     fn parse_file_path(&mut self, file: &str) {
         if let Some(decoded) = urlencoding::decode(file).log_err() {
-            if let Some(path_buf) =
-                PathWithPosition::parse_str(&decoded, |s| PathBuf::try_from(s)).log_err()
-            {
-                self.open_paths.push(path_buf)
-            }
+            let path_buf = PathWithPosition::parse_str(&decoded);
+            self.open_paths.push(path_buf)
         }
     }
 
@@ -380,10 +375,7 @@ async fn open_workspaces(
         let paths_with_position = paths
             .into_iter()
             .map(|path_with_position_string| {
-                PathWithPosition::parse_str(&path_with_position_string, |path_str| {
-                    Ok::<_, std::convert::Infallible>(Path::new(path_str).to_path_buf())
-                })
-                .expect("Infallible")
+                PathWithPosition::parse_str(&path_with_position_string)
             })
             .collect();
         vec![paths_with_position]


### PR DESCRIPTION
This simplifies `PathWithPosition` by making the common use case concrete and removing the manual, incomplete Windows path parsing. Windows paths also don't get '/'s replaced by '\\'s anymore to limit the responsibility of the code to just parsing out the suffix and creating `PathBuf` from the rest. `Path::file_name()` is now used to extract the filename and potential suffix instead of manual parsing from the full input. This way e.g. Windows paths that begin with a drive letter are handled correctly without platform-specific hacks.

Release Notes:

- N/A
