### PR TITLE
Show -v verbose flag in go test task label

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -537,7 +537,7 @@ impl ContextProvider for GoContextProvider {
             },
             TaskTemplate {
                 label: format!(
-                    "go test {} -run {}/{}",
+                    "go test {} -v -run {}/{}",
                     GO_PACKAGE_TASK_VARIABLE.template_value(),
                     VariableName::Symbol.template_value(),
                     GO_SUBTEST_NAME_TASK_VARIABLE.template_value(),


### PR DESCRIPTION
Before
<img width="545" alt="Screenshot 2024-07-28 at 11 20 24" src="https://github.com/user-attachments/assets/76607422-6dd7-4405-8557-96b1fad917e5">

After:
<img width="328" alt="Screenshot 2024-07-28 at 11 22 05" src="https://github.com/user-attachments/assets/753dffca-c31a-48ba-bbc7-54c5f0364d61">

Release Notes:

- N/A
