### PR TITLE
rust: Add highlight selector for doc comments

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -134,6 +134,11 @@
 ] @comment
 
 [
+  (line_comment (doc_comment))
+  (block_comment (doc_comment))
+] @comment.doc
+
+[
   "!"
   "!="
   "%"


### PR DESCRIPTION
## Release Notes:

- Added ability to style doc comments in Rust separately with `comment.doc` ([#15322](https://github.com/zed-industries/zed/issues/15322)).


Just required adding another query to the highlights.scm file. Took inspiration from the tree-sitter-rust repository [here](https://github.com/tree-sitter/tree-sitter-rust/blob/master/queries/highlights.scm)

#### Doc comments customized in the theme are working now:
![grafik](https://github.com/user-attachments/assets/549f20d6-534c-4c3b-a317-3be6bc44352e)

#### Snippet from the .json theme file
![grafik](https://github.com/user-attachments/assets/da1d7e3d-b6a5-4ba5-9fef-047d69f9ea03)



