### PR TITLE
repl: Pass session id to kernel connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8971,9 +8971,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a4a788465cf51b7ac8f36e4e4ca3dd26013dcddd5ba8376f98752278244294"
+checksum = "0c3d817764e3971867351e6103955b17d808f5330e9ef63aaaaab55bf8c664c1"
 dependencies = [
  "anyhow",
  "async-dispatcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ rand = "0.8.5"
 regex = "1.5"
 repair_json = "0.1.0"
 rsa = "0.9.6"
-runtimelib = { version = "0.12", default-features = false, features = [
+runtimelib = { version = "0.14", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }
 rusqlite = { version = "0.29.0", features = ["blob", "array", "modern_sqlite"] }

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -19,6 +19,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct KernelSpecification {
@@ -228,9 +229,17 @@ impl RunningKernel {
                 .spawn()
                 .context("failed to start the kernel process")?;
 
-            let mut iopub_socket = connection_info.create_client_iopub_connection("").await?;
-            let mut shell_socket = connection_info.create_client_shell_connection().await?;
-            let mut control_socket = connection_info.create_client_control_connection().await?;
+            let session_id = Uuid::new_v4().to_string();
+
+            let mut iopub_socket = connection_info
+                .create_client_iopub_connection("", &session_id)
+                .await?;
+            let mut shell_socket = connection_info
+                .create_client_shell_connection(&session_id)
+                .await?;
+            let mut control_socket = connection_info
+                .create_client_control_connection(&session_id)
+                .await?;
 
             let (mut iopub, iosub) = futures::channel::mpsc::channel(100);
 

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -305,6 +305,18 @@ impl Session {
                                         .ok();
                                 }
                             });
+
+                            // todo!(kyle): send kernelinforequest once our shell channel read/writes are split
+                            // cx.spawn(|this, mut cx| async move {
+                            //     cx.background_executor()
+                            //         .timer(Duration::from_millis(120))
+                            //         .await;
+                            //     this.update(&mut cx, |this, cx| {
+                            //         this.send(KernelInfoRequest {}.into(), cx).ok();
+                            //     })
+                            //     .ok();
+                            // })
+                            // .detach();
                         })
                         .ok();
                     }


### PR DESCRIPTION
Updated runtimelib to 0.14 and passed a kernel session ID through to identify our client.

Release Notes:

- N/A
