### PR TITLE
repl: Log Jupyter kernel process stderr and stdout

### DIFF
--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -223,8 +223,8 @@ impl RunningKernel {
 
             let process = cmd
                 .current_dir(&working_directory)
-                // .stdout(Stdio::null())
-                // .stderr(Stdio::null())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
                 .kill_on_drop(true)
                 .spawn()
                 .context("failed to start the kernel process")?;


### PR DESCRIPTION
Super simple piping of logs from the Jupyter kernels to the Zed logs.

Release Notes:

- Added logging of stderr from Jupyter kernels to the Zed logs
