### PR TITLE
Hide blinking cursor when window is deactivated

### DIFF
--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -98,6 +98,7 @@ impl BlinkManager {
     }
 
     pub fn disable(&mut self, _cx: &mut ModelContext<Self>) {
+        self.visible = false;
         self.enabled = false;
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1884,7 +1884,6 @@ impl Editor {
                         if active {
                             blink_manager.enable(cx);
                         } else {
-                            blink_manager.show_cursor(cx);
                             blink_manager.disable(cx);
                         }
                     });


### PR DESCRIPTION

Release Notes:

- Fixed to hide blinking cursor, when window is deactivated.

Close issue #4710 

## Before 

https://github.com/user-attachments/assets/affb8407-a20e-4258-a8f7-b271da5d7b77

## After


https://github.com/user-attachments/assets/654fe7b9-330a-40c8-8885-72e69fa85b0a



