### PR TITLE
Enable mingw build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,7 @@ futures-batch = "0.6.1"
 futures-lite = "1.13"
 git2 = { version = "0.19", default-features = false }
 globset = "0.4"
-heed = { version = "0.20.1", features = ["read-txn-no-tls"] }
+heed = { version = "0.20.3", features = ["read-txn-no-tls"] }
 hex = "0.4.3"
 html5ever = "0.27.0"
 ignore = "0.4.22"


### PR DESCRIPTION
Now if you will try to build master on windows with mingw toolchain, you will get an error
<details>
  <summary>Failed to cast one pointer type to another in c lang</summary>
  
  ```
error: failed to run custom build command for `lmdb-master-sys v0.2.2`

Caused by:
  process didn't exit successfully: `D:\proj\zed\target\debug\build\lmdb-master-sys-8cfd3453e6af3066\build-script-build` (exit code: 1)
  --- stdout
  OUT_DIR = Some(D:\proj\zed\target\debug\build\lmdb-master-sys-e0220147f8fe3d5c\out)
  TARGET = Some(x86_64-pc-windows-gnu)
  OPT_LEVEL = Some(0)
  HOST = Some(x86_64-pc-windows-gnu)
  cargo:rerun-if-env-changed=CC_x86_64-pc-windows-gnu
  CC_x86_64-pc-windows-gnu = None
  cargo:rerun-if-env-changed=CC_x86_64_pc_windows_gnu
  CC_x86_64_pc_windows_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  CARGO_CFG_TARGET_FEATURE = Some(cmpxchg16b,fxsr,sse,sse2,sse3)
  cargo:rerun-if-env-changed=CFLAGS_x86_64-pc-windows-gnu
  CFLAGS_x86_64-pc-windows-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_pc_windows_gnu
  CFLAGS_x86_64_pc_windows_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  OUT_DIR = Some(D:\proj\zed\target\debug\build\lmdb-master-sys-e0220147f8fe3d5c\out)
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  CARGO_CFG_TARGET_FEATURE = Some(cmpxchg16b,fxsr,sse,sse2,sse3)
  cargo:rerun-if-env-changed=CFLAGS_x86_64-pc-windows-gnu
  CFLAGS_x86_64-pc-windows-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_pc_windows_gnu
  CFLAGS_x86_64_pc_windows_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  OUT_DIR = Some(D:\proj\zed\target\debug\build\lmdb-master-sys-e0220147f8fe3d5c\out)
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  CARGO_CFG_TARGET_FEATURE = Some(cmpxchg16b,fxsr,sse,sse2,sse3)
  cargo:rerun-if-env-changed=CFLAGS_x86_64-pc-windows-gnu
  CFLAGS_x86_64-pc-windows-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_pc_windows_gnu
  CFLAGS_x86_64_pc_windows_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  OUT_DIR = Some(D:\proj\zed\target\debug\build\lmdb-master-sys-e0220147f8fe3d5c\out)
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  CARGO_CFG_TARGET_FEATURE = Some(cmpxchg16b,fxsr,sse,sse2,sse3)
  cargo:rerun-if-env-changed=CFLAGS_x86_64-pc-windows-gnu
  CFLAGS_x86_64-pc-windows-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_pc_windows_gnu
  CFLAGS_x86_64_pc_windows_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c: In function 'mdb_page_flush':
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:3916:76: error: passing argument 3 of 'GetOverlappedResult' from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning= 3916 |                                 if (!GetOverlappedResult(fd, &ov[async_i], &wres, TRUE)) {
  cargo:warning=      |                                                                            ^~~~~
  cargo:warning=      |                                                                            |
  cargo:warning=      |                                                                            ssize_t * {aka long long int *}
  cargo:warning=In file included from D:/apps/mingw64/x86_64-w64-mingw32/include/winbase.h:21,
  cargo:warning=                 from D:/apps/mingw64/x86_64-w64-mingw32/include/windows.h:70,
  cargo:warning=                 from C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:43:
  cargo:warning=D:/apps/mingw64/x86_64-w64-mingw32/include/ioapiset.h:18:99: note: expected 'LPDWORD' {aka 'long unsigned int *'} but argument is of type 'ssize_t *' {aka 'long long int *'}
  cargo:warning=   18 |   WINBASEAPI WINBOOL WINAPI GetOverlappedResult (HANDLE hFile, LPOVERLAPPED lpOverlapped, LPDWORD lpNumberOfBytesTransferred, WINBOOL bWait);
  cargo:warning=      |                                                                                           ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:3826:1: warning: label 'retry_write' defined but not used [-Wunused-label]
  cargo:warning= 3826 | retry_write:
  cargo:warning=      | ^~~~~~~~~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c: In function 'mdb_env_write_meta':
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:4454:1: warning: label 'done' defined but not used [-Wunused-label]
  cargo:warning= 4454 | done:
  cargo:warning=      | ^~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:4448:1: warning: label 'fail' defined but not used [-Wunused-label]
  cargo:warning= 4448 | fail:
  cargo:warning=      | ^~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c: In function 'mdb_env_open2':
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:4938:27: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'NTSTATUS (*)(void *)' {aka 'long int (*)(void *)'} [-Wcast-function-type]
  cargo:warning= 4938 |                 NtClose = (NtCloseFunc *)GetProcAddress(h, "NtClose");
  cargo:warning=      |                           ^
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:4941:38: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'NTSTATUS (*)(void **, void *, void **, ULONG_PTR,  SIZE_T,  LARGE_INTEGER *, ULONG_PTR *, SECTION_INHERIT,  ULONG,  ULONG)' {aka 'long int (*)(void **, void *, void **, long long unsigned int,  long long unsigned int,  LARGE_INTEGER *, long long unsigned int *, enum _SECTION_INHERIT,  long unsigned int,  long unsigned int)'} [-Wcast-function-type]
  cargo:warning= 4941 |                 NtMapViewOfSection = (NtMapViewOfSectionFunc *)GetProcAddress(h, "NtMapViewOfSection");
  cargo:warning=      |                                      ^
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:4944:35: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'NTSTATUS (*)(void **, ACCESS_MASK,  void *, LARGE_INTEGER *, ULONG,  ULONG,  void *)' {aka 'long int (*)(void **, long unsigned int,  void *, LARGE_INTEGER *, long unsigned int,  long unsigned int,  void *)'} [-Wcast-function-type]
  cargo:warning= 4944 |                 NtCreateSection = (NtCreateSectionFunc *)GetProcAddress(h, "NtCreateSection");
  cargo:warning=      |                                   ^
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c: In function 'mdb_reader_list':
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:11256:33: warning: 'I' flag used with '%x' gnu_printf format [-Wformat=]
  cargo:warning=11256 |                                 "%10d %"Z"x -\n" : "%10d %"Z"x %"Yu"\n",
  cargo:warning=      |                                 ^~~~~~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:11256:43: note: format string is defined here
  cargo:warning=11256 |                                 "%10d %"Z"x -\n" : "%10d %"Z"x %"Yu"\n",
  cargo:warning=      |                                           ^
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:11256:33: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'long long unsigned int' [-Wformat=]
  cargo:warning=11256 |                                 "%10d %"Z"x -\n" : "%10d %"Z"x %"Yu"\n",
  cargo:warning=      |                                 ^~~~~~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:11256:43: note: format string is defined here
  cargo:warning=11256 |                                 "%10d %"Z"x -\n" : "%10d %"Z"x %"Yu"\n",
  cargo:warning=      |                                       ~~~~^
  cargo:warning=      |                                           |
  cargo:warning=      |                                           unsigned int
  cargo:warning=      |                                       %"Z"llx
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:11256:52: warning: 'I' flag used with '%x' gnu_printf format [-Wformat=]
  cargo:warning=11256 |                                 "%10d %"Z"x -\n" : "%10d %"Z"x %"Yu"\n",
  cargo:warning=      |                                                    ^~~~~~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:11256:52: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'long long unsigned int' [-Wformat=]
  cargo:warning=11256 |                                 "%10d %"Z"x -\n" : "%10d %"Z"x %"Yu"\n",
  cargo:warning=      |                                                    ^~~~~~~~
  cargo:warning=C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\lmdb-master-sys-0.2.2\lmdb\libraries\liblmdb\mdb.c:11256:52: warning: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'txnid_t' {aka 'long long unsigned int'} [-Wformat=]
  cargo:warning=11256 |                                 "%10d %"Z"x -\n" : "%10d %"Z"x %"Yu"\n",
  cargo:warning=      |                                                    ^~~~~~~~
  cargo:warning=11257 |                                 (int)mr[i].mr_pid, (size_t)mr[i].mr_tid, txnid);
  cargo:warning=      |                                                                          ~~~~~
  cargo:warning=      |                                                                          |
  cargo:warning=      |                                                                          txnid_t {aka long long unsigned int}
  exit code: 1
  cargo:warning=ToolExecError: Command "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-gdwarf-2" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "-Wno-unused-parameter" "-Wbad-function-cast" "-Wuninitialized" "-DMDB_IDL_LOGN=16" "-o" "D:\\proj\\zed\\target\\debug\\build\\lmdb-master-sys-e0220147f8fe3d5c\\out\\7695c1652dd54341-mdb.o" "-c" "C:\\Users\\user\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\lmdb-master-sys-0.2.2\\lmdb\\libraries\\liblmdb\\mdb.c" with args gcc.exe did not execute successfully (status code exit code: 1).
  exit code: 0

  --- stderr
```
  
</details>
The error is already fixed in cargo crate, but we are missing few updates to make it in our codebase