### PR TITLE
zed: Persist window stack order across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9605,6 +9605,8 @@ name = "session"
 version = "0.1.0"
 dependencies = [
  "db",
+ "gpui",
+ "serde_json",
  "util",
  "uuid",
 ]
@@ -13357,6 +13359,7 @@ dependencies = [
  "smallvec",
  "sqlez",
  "task",
+ "tempfile",
  "theme",
  "ui",
  "util",

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -32,7 +32,7 @@ use rpc::{
 };
 use semantic_version::SemanticVersion;
 use serde_json::json;
-use session::Session;
+use session::{AppSession, Session};
 use settings::SettingsStore;
 use std::{
     cell::{Ref, RefCell, RefMut},
@@ -270,6 +270,7 @@ impl TestServer {
         let user_store = cx.new_model(|cx| UserStore::new(client.clone(), cx));
         let workspace_store = cx.new_model(|cx| WorkspaceStore::new(client.clone(), cx));
         let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
+        let session = cx.new_model(|cx| AppSession::new(Session::test(), cx));
         let app_state = Arc::new(workspace::AppState {
             client: client.clone(),
             user_store: user_store.clone(),
@@ -278,7 +279,7 @@ impl TestServer {
             fs: fs.clone(),
             build_window_options: |_, _| Default::default(),
             node_runtime: FakeNodeRuntime::new(),
-            session: Session::test(),
+            session,
         });
 
         let os_keymap = "keymaps/default-macos.json";
@@ -399,6 +400,7 @@ impl TestServer {
         let user_store = cx.new_model(|cx| UserStore::new(client.clone(), cx));
         let workspace_store = cx.new_model(|cx| WorkspaceStore::new(client.clone(), cx));
         let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
+        let session = cx.new_model(|cx| AppSession::new(Session::test(), cx));
         let app_state = Arc::new(workspace::AppState {
             client: client.clone(),
             user_store: user_store.clone(),
@@ -407,7 +409,7 @@ impl TestServer {
             fs: fs.clone(),
             build_window_options: |_, _| Default::default(),
             node_runtime: FakeNodeRuntime::new(),
-            session: Session::test(),
+            session,
         });
 
         cx.update(|cx| {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -469,12 +469,13 @@ impl AppContext {
             .collect()
     }
 
-    /// Returns the window handles ordered by their appearance on screen,
-    /// if the platform supports that.
-    /// Order should be front-to-back, with the first window in the returned vec being
-    /// the active/topmost window of the application.
-    pub fn windows_with_platform_ordering(&self) -> Option<Vec<AnyWindowHandle>> {
-        self.platform.windows_ordered()
+    /// Returns the window handles ordered by their appearance on screen, front to back.
+    ///
+    /// The first window in the returned list is the active/topmost window of the application.
+    ///
+    /// This method returns None if the platform doesn't implement the method yet.
+    pub fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
+        self.platform.window_stack()
     }
 
     /// Returns a handle to the window that is currently focused at the platform level, if one exists.

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -469,6 +469,14 @@ impl AppContext {
             .collect()
     }
 
+    /// Returns the window handles ordered by their appearance on screen,
+    /// if the platform supports that.
+    /// Order should be front-to-back, with the first window in the returned vec being
+    /// the active/topmost window of the application.
+    pub fn windows_with_platform_ordering(&self) -> Option<Vec<AnyWindowHandle>> {
+        self.platform.windows_ordered()
+    }
+
     /// Returns a handle to the window that is currently focused at the platform level, if one exists.
     pub fn active_window(&self) -> Option<AnyWindowHandle> {
         self.platform.active_window()

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -121,7 +121,7 @@ pub(crate) trait Platform: 'static {
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>>;
     fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>>;
     fn active_window(&self) -> Option<AnyWindowHandle>;
-    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
         None
     }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -121,6 +121,9 @@ pub(crate) trait Platform: 'static {
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>>;
     fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>>;
     fn active_window(&self) -> Option<AnyWindowHandle>;
+    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+        None
+    }
 
     fn open_window(
         &self,

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -63,7 +63,7 @@ impl LinuxClient for HeadlessClient {
         None
     }
 
-    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
         None
     }
 

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -63,6 +63,10 @@ impl LinuxClient for HeadlessClient {
         None
     }
 
+    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+        None
+    }
+
     fn open_window(
         &self,
         _handle: AnyWindowHandle,

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -77,7 +77,7 @@ pub trait LinuxClient {
     fn read_from_primary(&self) -> Option<ClipboardItem>;
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
     fn active_window(&self) -> Option<AnyWindowHandle>;
-    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>>;
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>>;
     fn run(&self);
 }
 
@@ -240,8 +240,8 @@ impl<P: LinuxClient + 'static> Platform for P {
         self.active_window()
     }
 
-    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
-        self.windows_ordered()
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
+        self.window_stack()
     }
 
     fn open_window(

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -77,6 +77,7 @@ pub trait LinuxClient {
     fn read_from_primary(&self) -> Option<ClipboardItem>;
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
     fn active_window(&self) -> Option<AnyWindowHandle>;
+    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>>;
     fn run(&self);
 }
 
@@ -144,11 +145,10 @@ impl<P: LinuxClient + 'static> Platform for P {
 
         LinuxClient::run(self);
 
-        self.with_common(|common| {
-            if let Some(mut fun) = common.callbacks.quit.take() {
-                fun();
-            }
-        });
+        let quit = self.with_common(|common| common.callbacks.quit.take());
+        if let Some(mut fun) = quit {
+            fun();
+        }
     }
 
     fn quit(&self) {
@@ -238,6 +238,10 @@ impl<P: LinuxClient + 'static> Platform for P {
 
     fn active_window(&self) -> Option<AnyWindowHandle> {
         self.active_window()
+    }
+
+    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+        self.windows_ordered()
     }
 
     fn open_window(

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -750,7 +750,7 @@ impl LinuxClient for WaylandClient {
             .map(|window| window.handle())
     }
 
-    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
         None
     }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -750,6 +750,10 @@ impl LinuxClient for WaylandClient {
             .map(|window| window.handle())
     }
 
+    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+        None
+    }
+
     fn compositor_name(&self) -> &'static str {
         "Wayland"
     }

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1346,7 +1346,7 @@ impl LinuxClient for X11Client {
         })
     }
 
-    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
         let state = self.0.borrow();
         let root = state.xcb_connection.setup().roots[state.x_root_index].root;
 

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1345,6 +1345,48 @@ impl LinuxClient for X11Client {
                 .map(|window| window.handle())
         })
     }
+
+    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+        let state = self.0.borrow();
+        let root = state.xcb_connection.setup().roots[state.x_root_index].root;
+
+        let reply = state
+            .xcb_connection
+            .get_property(
+                false,
+                root,
+                state.atoms._NET_CLIENT_LIST_STACKING,
+                xproto::AtomEnum::WINDOW,
+                0,
+                u32::MAX,
+            )
+            .ok()?
+            .reply()
+            .ok()?;
+
+        let window_ids = reply
+            .value
+            .chunks_exact(4)
+            .map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap()))
+            .collect::<Vec<xproto::Window>>();
+
+        let mut handles = Vec::new();
+
+        // We need to reverse, since _NET_CLIENT_LIST_STACKING has
+        // a back-to-front order.
+        // See: https://specifications.freedesktop.org/wm-spec/1.3/ar01s03.html
+        for window_ref in window_ids
+            .iter()
+            .rev()
+            .filter_map(|&win| state.windows.get(&win))
+        {
+            if !window_ref.window.state.borrow().destroyed {
+                handles.push(window_ref.handle());
+            }
+        }
+
+        Some(handles)
+    }
 }
 
 // Adatpted from:

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -56,6 +56,7 @@ x11rb::atom_manager! {
         _GTK_SHOW_WINDOW_MENU,
         _GTK_FRAME_EXTENTS,
         _GTK_EDGE_CONSTRAINTS,
+        _NET_CLIENT_LIST_STACKING,
     }
 }
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -524,7 +524,7 @@ impl Platform for MacPlatform {
 
     // Returns the windows ordered front-to-back, meaning that the active
     // window is the first one in the returned vec.
-    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
         Some(MacWindow::ordered_windows())
     }
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -522,6 +522,12 @@ impl Platform for MacPlatform {
         MacWindow::active_window()
     }
 
+    // Returns the windows ordered front-to-back, meaning that the active
+    // window is the first one in the returned vec.
+    fn windows_ordered(&self) -> Option<Vec<AnyWindowHandle>> {
+        Some(MacWindow::ordered_windows())
+    }
+
     fn open_window(
         &self,
         handle: AnyWindowHandle,

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -738,6 +738,25 @@ impl MacWindow {
             }
         }
     }
+
+    pub fn ordered_windows() -> Vec<AnyWindowHandle> {
+        unsafe {
+            let app = NSApplication::sharedApplication(nil);
+            let windows: id = msg_send![app, orderedWindows];
+            let count: NSUInteger = msg_send![windows, count];
+
+            let mut window_handles = Vec::new();
+            for i in 0..count {
+                let window: id = msg_send![windows, objectAtIndex:i];
+                if msg_send![window, isKindOfClass: WINDOW_CLASS] {
+                    let handle = get_window_state(&*window).lock().handle;
+                    window_handles.push(handle);
+                }
+            }
+
+            window_handles
+        }
+    }
 }
 
 impl Drop for MacWindow {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4576,6 +4576,12 @@ impl WindowId {
     }
 }
 
+impl From<u64> for WindowId {
+    fn from(value: u64) -> Self {
+        WindowId(slotmap::KeyData::from_ffi(value))
+    }
+}
+
 /// A handle to a window with a specific root view type.
 /// Note that this does not keep the window alive on its own.
 #[derive(Deref, DerefMut)]

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -19,5 +19,7 @@ test-support = [
 
 [dependencies]
 db.workspace = true
+gpui.workspace = true
 uuid.workspace = true
 util.workspace = true
+serde_json.workspace = true

--- a/crates/session/src/session.rs
+++ b/crates/session/src/session.rs
@@ -1,29 +1,48 @@
+use std::time::Duration;
+
 use db::kvp::KEY_VALUE_STORE;
+use gpui::{AppContext, Task, WindowId};
 use util::ResultExt;
 use uuid::Uuid;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Session {
     session_id: String,
     old_session_id: Option<String>,
+    old_window_ids: Option<Vec<WindowId>>,
+    serialization_task: Option<Task<()>>,
 }
+
+const SESSION_ID_KEY: &'static str = "session_id";
+const SESSION_ORDERED_WINDOWS_KEY: &'static str = "session_ordered_window_ids";
 
 impl Session {
     pub async fn new() -> Self {
-        let key_name = "session_id".to_string();
-
-        let old_session_id = KEY_VALUE_STORE.read_kvp(&key_name).ok().flatten();
+        let old_session_id = KEY_VALUE_STORE.read_kvp(&SESSION_ID_KEY).ok().flatten();
 
         let session_id = Uuid::new_v4().to_string();
 
         KEY_VALUE_STORE
-            .write_kvp(key_name, session_id.clone())
+            .write_kvp(SESSION_ID_KEY.to_string(), session_id.clone())
             .await
             .log_err();
+
+        let old_window_ids = KEY_VALUE_STORE
+            .read_kvp(&SESSION_ORDERED_WINDOWS_KEY)
+            .ok()
+            .flatten()
+            .and_then(|json| serde_json::from_str::<Vec<u64>>(&json).ok())
+            .map(|vec| {
+                vec.into_iter()
+                    .map(WindowId::from)
+                    .collect::<Vec<WindowId>>()
+            });
 
         Self {
             session_id,
             old_session_id,
+            old_window_ids,
+            serialization_task: None,
         }
     }
 
@@ -32,13 +51,50 @@ impl Session {
         Self {
             session_id: Uuid::new_v4().to_string(),
             old_session_id: None,
+            old_window_ids: None,
+            serialization_task: Some(Task::ready(())),
         }
     }
 
     pub fn id(&self) -> &str {
         &self.session_id
     }
+
     pub fn last_session_id(&self) -> Option<&str> {
         self.old_session_id.as_deref()
+    }
+
+    pub fn last_session_windows_order(&self) -> Option<Vec<WindowId>> {
+        self.old_window_ids.clone()
+    }
+
+    pub fn start_serialization(&mut self, cx: &mut AppContext) {
+        if self.serialization_task.is_none() {
+            self.serialization_task = Some(cx.spawn(|cx| async move {
+                loop {
+                    if let Some(windows) = cx
+                        .update(|cx| cx.windows_with_platform_ordering())
+                        .ok()
+                        .flatten()
+                    {
+                        let window_ids = windows
+                            .into_iter()
+                            .map(|window| window.window_id().as_u64())
+                            .collect::<Vec<_>>();
+
+                        if let Ok(window_ids_json) = serde_json::to_string(&window_ids) {
+                            KEY_VALUE_STORE
+                                .write_kvp(SESSION_ORDERED_WINDOWS_KEY.to_string(), window_ids_json)
+                                .await
+                                .log_err();
+                        }
+                    }
+
+                    cx.background_executor()
+                        .timer(Duration::from_millis(100))
+                        .await;
+                }
+            }))
+        }
     }
 }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -74,3 +74,4 @@ project = { workspace = true, features = ["test-support"] }
 session = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 http_client =  { workspace = true, features = ["test-support"] }
+tempfile.workspace = true

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -171,6 +171,7 @@ define_connection! {
     //   fullscreen: Option<bool>, // Is the window fullscreen?
     //   centered_layout: Option<bool>, // Is the Centered Layout mode activated?
     //   session_id: Option<String>, // Session id
+    //   window_id: Option<u64>, // Window Id
     // )
     //
     // pane_groups(

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -216,6 +216,7 @@ pub(crate) struct SerializedWorkspace {
     pub(crate) display: Option<Uuid>,
     pub(crate) docks: DockStructure,
     pub(crate) session_id: Option<String>,
+    pub(crate) window_id: Option<u64>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4906,9 +4906,9 @@ pub async fn last_opened_workspace_paths() -> Option<LocalPaths> {
 
 pub fn last_session_workspace_locations(
     last_session_id: &str,
-    last_session_window_order: Option<Vec<WindowId>>,
+    last_session_window_stack: Option<Vec<WindowId>>,
 ) -> Option<Vec<LocalPaths>> {
-    DB.last_session_workspace_locations(last_session_id, last_session_window_order)
+    DB.last_session_workspace_locations(last_session_id, last_session_window_stack)
         .log_err()
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -36,7 +36,7 @@ use gpui::{
     EventEmitter, Flatten, FocusHandle, FocusableView, Global, Hsla, KeyContext, Keystroke,
     ManagedView, Model, ModelContext, MouseButton, PathPromptOptions, Point, PromptLevel, Render,
     ResizeEdge, Size, Stateful, Subscription, Task, Tiling, View, WeakView, WindowBounds,
-    WindowHandle, WindowOptions,
+    WindowHandle, WindowId, WindowOptions,
 };
 use item::{
     FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, PreviewTabsSettings,
@@ -4032,6 +4032,7 @@ impl Workspace {
                 docks,
                 centered_layout: self.centered_layout,
                 session_id: self.session_id.clone(),
+                window_id: Some(cx.window_handle().window_id().as_u64()),
             };
             return cx.spawn(|_| persistence::DB.save_workspace(serialized_workspace));
         }
@@ -4902,8 +4903,11 @@ pub async fn last_opened_workspace_paths() -> Option<LocalPaths> {
     DB.last_workspace().await.log_err().flatten()
 }
 
-pub fn last_session_workspace_locations(last_session_id: &str) -> Option<Vec<LocalPaths>> {
-    DB.last_session_workspace_locations(last_session_id)
+pub fn last_session_workspace_locations(
+    last_session_id: &str,
+    last_session_window_order: Option<Vec<WindowId>>,
+) -> Option<Vec<LocalPaths>> {
+    DB.last_session_workspace_locations(last_session_id, last_session_window_order)
         .log_err()
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -58,7 +58,7 @@ pub use persistence::{
 use postage::stream::Stream;
 use project::{DirectoryLister, Project, ProjectEntryId, ProjectPath, Worktree, WorktreeId};
 use serde::Deserialize;
-use session::Session;
+use session::AppSession;
 use settings::Settings;
 use shared_screen::SharedScreen;
 use sqlez::{
@@ -539,7 +539,7 @@ pub struct AppState {
     pub fs: Arc<dyn fs::Fs>,
     pub build_window_options: fn(Option<Uuid>, &mut AppContext) -> WindowOptions,
     pub node_runtime: Arc<dyn NodeRuntime>,
-    pub session: Session,
+    pub session: Model<AppSession>,
 }
 
 struct GlobalAppState(Weak<AppState>);
@@ -587,7 +587,7 @@ impl AppState {
         let clock = Arc::new(clock::FakeSystemClock::default());
         let http_client = http_client::FakeHttpClient::with_404_response();
         let client = Client::new(clock, http_client.clone(), cx);
-        let session = Session::test();
+        let session = cx.new_model(|cx| AppSession::new(Session::test(), cx));
         let user_store = cx.new_model(|cx| UserStore::new(client.clone(), cx));
         let workspace_store = cx.new_model(|cx| WorkspaceStore::new(client.clone(), cx));
 
@@ -917,7 +917,7 @@ impl Workspace {
 
         let modal_layer = cx.new_view(|_| ModalLayer::new());
 
-        let session_id = app_state.session.id().to_owned();
+        let session_id = app_state.session.read(cx).id().to_owned();
 
         let mut active_call = None;
         if let Some(call) = ActiveCall::try_global(cx) {
@@ -4292,6 +4292,7 @@ impl Workspace {
         let user_store = project.read(cx).user_store();
 
         let workspace_store = cx.new_model(|cx| WorkspaceStore::new(client.clone(), cx));
+        let session = cx.new_model(|cx| AppSession::new(Session::test(), cx));
         cx.activate_window();
         let app_state = Arc::new(AppState {
             languages: project.read(cx).languages().clone(),
@@ -4301,7 +4302,7 @@ impl Workspace {
             fs: project.read(cx).fs().clone(),
             build_window_options: |_, _| Default::default(),
             node_runtime: FakeNodeRuntime::new(),
-            session: Session::test(),
+            session,
         });
         let workspace = Self::new(Default::default(), project, app_state, cx);
         workspace.active_pane.update(cx, |pane, cx| pane.focus(cx));

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -709,13 +709,13 @@ pub(crate) async fn restorable_workspace_locations(
         .ok()?;
 
     let session_handle = app_state.session.clone();
-    let (last_session_id, last_session_window_order) = cx
+    let (last_session_id, last_session_window_stack) = cx
         .update(|cx| {
             let session = session_handle.read(cx);
 
             (
                 session.last_session_id().map(|id| id.to_string()),
-                session.last_session_windows_order(),
+                session.last_session_window_stack(),
             )
         })
         .ok()?;
@@ -737,11 +737,11 @@ pub(crate) async fn restorable_workspace_locations(
         }
         workspace::RestoreOnStartupBehavior::LastSession => {
             if let Some(last_session_id) = last_session_id {
-                let ordered = last_session_window_order.is_some();
+                let ordered = last_session_window_stack.is_some();
 
                 let mut locations = workspace::last_session_workspace_locations(
                     &last_session_id,
-                    last_session_window_order,
+                    last_session_window_stack,
                 )
                 .filter(|locations| !locations.is_empty());
 


### PR DESCRIPTION
This changes the workspace/session serialization to also persist the order of windows across restarts.

Release Notes:

- Improved restoring of windows across restarts: the order of the windows is now also restored. That means windows that were in the foreground when Zed was quit will be in the foreground after restart. (Right now only supported on Linux/X11, not on Linux/Wayland.)

Demo:


https://github.com/user-attachments/assets/0b8162f8-f06d-43df-88d3-c45d8460fb68



