### PR TITLE
assistant: Remove feature flag for terminal inline assistant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,6 @@ dependencies = [
  "ctor",
  "editor",
  "env_logger",
- "feature_flags",
  "fs",
  "futures 0.3.28",
  "fuzzy",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -34,7 +34,6 @@ collections.workspace = true
 command_palette_hooks.workspace = true
 completion.workspace = true
 editor.workspace = true
-feature_flags.workspace = true
 fs.workspace = true
 futures.workspace = true
 fuzzy.workspace = true

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -619,11 +619,6 @@ impl AssistantPanel {
                 .focus_handle(cx)
                 .contains_focused(cx)
             {
-                use feature_flags::FeatureFlagAppExt;
-                if !cx.has_flag::<feature_flags::TerminalInlineAssist>() {
-                    return None;
-                }
-
                 if let Some(terminal_view) = terminal_panel
                     .read(cx)
                     .pane()

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -43,11 +43,6 @@ impl FeatureFlag for LanguageModels {
     const NAME: &'static str = "language-models";
 }
 
-pub struct TerminalInlineAssist {}
-impl FeatureFlag for TerminalInlineAssist {
-    const NAME: &'static str = "terminal-inline-assist";
-}
-
 pub struct GroupedDiagnostics {}
 impl FeatureFlag for GroupedDiagnostics {
     const NAME: &'static str = "grouped-diagnostics";


### PR DESCRIPTION
This PR removes the feature flag for the terminal inline assistant, making it available to everyone.

Release Notes:

- Use Ctrl+Enter to summon the inline assistant in the terminal, which let's you generate terminal commands based on your description ([demo](https://twitter.com/thorstenball/status/1814241447383605329))