### PR TITLE
file finder: Fix `./` breaking new-path prompt

### DIFF
--- a/crates/file_finder/src/new_path_prompt.rs
+++ b/crates/file_finder/src/new_path_prompt.rs
@@ -248,7 +248,10 @@ impl PickerDelegate for NewPathDelegate {
         query: String,
         cx: &mut ViewContext<picker::Picker<Self>>,
     ) -> gpui::Task<()> {
-        let query = query.trim().trim_start_matches('/');
+        let query = query
+            .trim()
+            .trim_start_matches("./")
+            .trim_start_matches('/');
         let (dir, suffix) = if let Some(index) = query.rfind('/') {
             let suffix = if index + 1 < query.len() {
                 Some(query[index + 1..].to_string())


### PR DESCRIPTION
Fixes #15426.

The `./` was implicitly assumed to be there by the prompt, so we'd end up with `././foobar` when typing in an explicit `./`.

This fixes the issue by stripping `./` from the query, like we also strip `/`.

Release Notes:

- Fixed paths starting with `./` breaking the new-path file picker when the system prompts are disabled. ([#15426](https://github.com/zed-industries/zed/issues/15426)).