### PR TITLE
collab: Lay groundwork for reconciling with Stripe using the events API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2f14b5943a52cf051bbbbb68538e93a69d1e291934174121e769f4b181113f5"
 dependencies = [
+ "chrono",
  "futures-util",
  "http-types",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,6 @@ async-dispatcher = "0.1"
 async-fs = "1.6"
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
 async-recursion = "1.0.0"
-async-stripe = { version = "0.37", default-features = false, features = ["runtime-tokio-hyper-rustls", "billing", "checkout"] }
 async-tar = "0.4.2"
 async-trait = "0.1"
 async-tungstenite = "0.23"
@@ -460,6 +459,19 @@ wasmtime = { version = "21.0.1", default-features = false, features = [
 wasmtime-wasi = "21.0.1"
 which = "6.0.0"
 wit-component = "0.201"
+
+[workspace.dependencies.async-stripe]
+version = "0.37"
+default-features = false
+features = [
+    "runtime-tokio-hyper-rustls",
+    "billing",
+    "checkout",
+    "events",
+    # The features below are only enabled to get the `events` feature to build.
+    "chrono",
+    "connect",
+]
 
 [workspace.dependencies.windows]
 version = "0.58"

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -204,6 +204,8 @@ async fn manage_billing_subscription(
 
 const POLL_EVENTS_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
+/// Polls the Stripe events API periodically to reconcile the records in our
+/// database with the data in Stripe.
 pub fn poll_stripe_events_periodically(app: Arc<AppState>) {
     let Some(stripe_client) = app.stripe_client.clone() else {
         log::warn!("failed to retrieve Stripe client");
@@ -249,7 +251,6 @@ async fn poll_stripe_events(
         let mut params = ListEvents::new();
         params.types = Some(event_types.clone());
         params.limit = Some(100);
-        // params.starting_after
 
         let events = stripe::Event::list(stripe_client, &params).await?;
         for event in events.data {

--- a/crates/collab/src/db/queries/billing_customers.rs
+++ b/crates/collab/src/db/queries/billing_customers.rs
@@ -39,4 +39,18 @@ impl Database {
         })
         .await
     }
+
+    /// Returns the billing customer for the user with the specified Stripe customer ID.
+    pub async fn get_billing_customer_by_stripe_customer_id(
+        &self,
+        stripe_customer_id: &str,
+    ) -> Result<Option<billing_customer::Model>> {
+        self.transaction(|tx| async move {
+            Ok(billing_customer::Entity::find()
+                .filter(billing_customer::Column::StripeCustomerId.eq(stripe_customer_id))
+                .one(&*tx)
+                .await?)
+        })
+        .await
+    }
 }

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -61,6 +61,17 @@ impl Database {
         .await
     }
 
+    /// Returns a user by email address. There are no access checks here, so this should only be used internally.
+    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<User>> {
+        self.transaction(|tx| async move {
+            Ok(user::Entity::find()
+                .filter(user::Column::EmailAddress.eq(email))
+                .one(&*tx)
+                .await?)
+        })
+        .await
+    }
+
     /// Returns a user by GitHub user ID. There are no access checks here, so this should only be used internally.
     pub async fn get_user_by_github_user_id(&self, github_user_id: i32) -> Result<Option<User>> {
         self.transaction(|tx| async move {

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::get,
     Extension, Router,
 };
+use collab::api::billing::poll_stripe_events_periodically;
 use collab::{
     api::fetch_extensions_from_blob_store_periodically, db, env, executor::Executor,
     rpc::ResultExt, AppState, Config, RateLimiter, Result,
@@ -95,6 +96,7 @@ async fn main() -> Result<()> {
             }
 
             if is_api {
+                poll_stripe_events_periodically(state.clone());
                 fetch_extensions_from_blob_store_periodically(state.clone());
             }
 


### PR DESCRIPTION
This PR lays the initial groundwork for using the Stripe events API to reconcile the data in our system with what's in Stripe.

We're using the events API over webhooks so that we don't need to stand up the associated infrastructure needed to handle webhooks effectively (namely an asynchronous job queue).

Since we haven't configured the Stripe API keys yet, we won't actually spawn the reconciliation background task yet, so this is currently a no-op.

Release Notes:

- N/A
