### PR TITLE
Fix `vertical_scroll_margin` not being capped for large `vertical_scroll_margin` values

### DIFF
--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -189,8 +189,8 @@ impl Editor {
                 self.set_scroll_position_internal(scroll_position, local, true, cx);
             }
             AutoscrollStrategy::Focused => {
-                scroll_position.y =
-                    (target_top - self.scroll_manager.vertical_scroll_margin).max(0.0);
+                let margin = margin.min(self.scroll_manager.vertical_scroll_margin);
+                scroll_position.y = (target_top - margin).max(0.0);
                 self.set_scroll_position_internal(scroll_position, local, true, cx);
             }
             AutoscrollStrategy::Top => {


### PR DESCRIPTION
When switching to function definitions in a new buffer the `AutoscrollStrategy::Focused` being emitted to scroll to the found location.
If a large value `vertical_scroll_margin` (e.g.: 99) is set, this leads to an incorrectly calculated position and the new buffer opens in the wrong place.

In `autoscroll_vertically()` there is a margin calculated to cap the value of `vertical_scroll_margin` for certain AutoscrollStrategies. This margin is being used in `AutoscrollStrategy::Fit` and `AutoscrollStrategy::Newest` but was probably forgotten for `AutoscrollStrategy::Focused`.

- Might fix [#15101](https://github.com/zed-industries/zed/issues/15101)

Release Notes:

- N/A