### PR TITLE
collab: Keep track of last seen Stripe event for each record

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -422,7 +422,8 @@ CREATE TABLE IF NOT EXISTS billing_subscriptions (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     billing_customer_id INTEGER NOT NULL REFERENCES billing_customers(id),
     stripe_subscription_id TEXT NOT NULL,
-    stripe_subscription_status TEXT NOT NULL
+    stripe_subscription_status TEXT NOT NULL,
+    last_stripe_event_id TEXT
 );
 
 CREATE INDEX "ix_billing_subscriptions_on_billing_customer_id" ON billing_subscriptions (billing_customer_id);
@@ -432,7 +433,8 @@ CREATE TABLE IF NOT EXISTS billing_customers (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     user_id INTEGER NOT NULL REFERENCES users(id),
-    stripe_customer_id TEXT NOT NULL
+    stripe_customer_id TEXT NOT NULL,
+    last_stripe_event_id TEXT
 );
 
 CREATE UNIQUE INDEX "uix_billing_customers_on_user_id" ON billing_customers (user_id);

--- a/crates/collab/migrations/20240730122654_add_last_stripe_event_id.sql
+++ b/crates/collab/migrations/20240730122654_add_last_stripe_event_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE billing_customers ADD COLUMN last_stripe_event_id TEXT;
+ALTER TABLE billing_subscriptions ADD COLUMN last_stripe_event_id TEXT;

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -46,7 +46,9 @@ pub use tests::TestDb;
 
 pub use ids::*;
 pub use queries::billing_customers::CreateBillingCustomerParams;
-pub use queries::billing_subscriptions::CreateBillingSubscriptionParams;
+pub use queries::billing_subscriptions::{
+    CreateBillingSubscriptionParams, UpdateBillingSubscriptionParams,
+};
 pub use queries::contributors::ContributorSelector;
 pub use sea_orm::ConnectOptions;
 pub use tables::user::Model as User;

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -45,7 +45,7 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 pub use tests::TestDb;
 
 pub use ids::*;
-pub use queries::billing_customers::CreateBillingCustomerParams;
+pub use queries::billing_customers::{CreateBillingCustomerParams, UpdateBillingCustomerParams};
 pub use queries::billing_subscriptions::{
     CreateBillingSubscriptionParams, UpdateBillingSubscriptionParams,
 };

--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -12,7 +12,7 @@ pub struct CreateBillingSubscriptionParams {
     pub last_stripe_event_id: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct UpdateBillingSubscriptionParams {
     pub billing_customer_id: ActiveValue<BillingCustomerId>,
     pub stripe_subscription_id: ActiveValue<String>,

--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -1,3 +1,5 @@
+use sea_orm::IntoActiveValue;
+
 use crate::db::billing_subscription::StripeSubscriptionStatus;
 
 use super::*;
@@ -7,6 +9,15 @@ pub struct CreateBillingSubscriptionParams {
     pub billing_customer_id: BillingCustomerId,
     pub stripe_subscription_id: String,
     pub stripe_subscription_status: StripeSubscriptionStatus,
+    pub last_stripe_event_id: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct UpdateBillingSubscriptionParams {
+    pub billing_customer_id: ActiveValue<BillingCustomerId>,
+    pub stripe_subscription_id: ActiveValue<String>,
+    pub stripe_subscription_status: ActiveValue<StripeSubscriptionStatus>,
+    pub last_stripe_event_id: ActiveValue<Option<String>>,
 }
 
 impl Database {
@@ -20,6 +31,7 @@ impl Database {
                 billing_customer_id: ActiveValue::set(params.billing_customer_id),
                 stripe_subscription_id: ActiveValue::set(params.stripe_subscription_id.clone()),
                 stripe_subscription_status: ActiveValue::set(params.stripe_subscription_status),
+                last_stripe_event_id: params.last_stripe_event_id.clone().into_active_value(),
                 ..Default::default()
             })
             .exec_without_returning(&*tx)
@@ -30,24 +42,22 @@ impl Database {
         .await
     }
 
-    /// Upserts the billing subscription by its Stripe subscription ID.
-    pub async fn upsert_billing_subscription_by_stripe_subscription_id(
+    /// Updates the specified billing subscription.
+    pub async fn update_billing_subscription(
         &self,
-        params: &CreateBillingSubscriptionParams,
+        id: BillingSubscriptionId,
+        params: &UpdateBillingSubscriptionParams,
     ) -> Result<()> {
         self.transaction(|tx| async move {
-            billing_subscription::Entity::insert(billing_subscription::ActiveModel {
-                billing_customer_id: ActiveValue::set(params.billing_customer_id),
-                stripe_subscription_id: ActiveValue::set(params.stripe_subscription_id.clone()),
-                stripe_subscription_status: ActiveValue::set(params.stripe_subscription_status),
+            billing_subscription::Entity::update(billing_subscription::ActiveModel {
+                id: ActiveValue::set(id),
+                billing_customer_id: params.billing_customer_id.clone(),
+                stripe_subscription_id: params.stripe_subscription_id.clone(),
+                stripe_subscription_status: params.stripe_subscription_status.clone(),
+                last_stripe_event_id: params.last_stripe_event_id.clone(),
                 ..Default::default()
             })
-            .on_conflict(
-                OnConflict::columns([billing_subscription::Column::StripeSubscriptionId])
-                    .update_columns([billing_subscription::Column::StripeSubscriptionStatus])
-                    .to_owned(),
-            )
-            .exec_with_returning(&*tx)
+            .exec(&*tx)
             .await?;
 
             Ok(())
@@ -62,6 +72,22 @@ impl Database {
     ) -> Result<Option<billing_subscription::Model>> {
         self.transaction(|tx| async move {
             Ok(billing_subscription::Entity::find_by_id(id)
+                .one(&*tx)
+                .await?)
+        })
+        .await
+    }
+
+    /// Returns the billing subscription with the specified Stripe subscription ID.
+    pub async fn get_billing_subscription_by_stripe_subscription_id(
+        &self,
+        stripe_subscription_id: &str,
+    ) -> Result<Option<billing_subscription::Model>> {
+        self.transaction(|tx| async move {
+            Ok(billing_subscription::Entity::find()
+                .filter(
+                    billing_subscription::Column::StripeSubscriptionId.eq(stripe_subscription_id),
+                )
                 .one(&*tx)
                 .await?)
         })

--- a/crates/collab/src/db/tables/billing_customer.rs
+++ b/crates/collab/src/db/tables/billing_customer.rs
@@ -9,6 +9,7 @@ pub struct Model {
     pub id: BillingCustomerId,
     pub user_id: UserId,
     pub stripe_customer_id: String,
+    pub last_stripe_event_id: Option<String>,
     pub created_at: DateTime,
 }
 

--- a/crates/collab/src/db/tables/billing_subscription.rs
+++ b/crates/collab/src/db/tables/billing_subscription.rs
@@ -10,6 +10,7 @@ pub struct Model {
     pub billing_customer_id: BillingCustomerId,
     pub stripe_subscription_id: String,
     pub stripe_subscription_status: StripeSubscriptionStatus,
+    pub last_stripe_event_id: Option<String>,
     pub created_at: DateTime,
 }
 

--- a/crates/collab/src/db/tests/billing_subscription_tests.rs
+++ b/crates/collab/src/db/tests/billing_subscription_tests.rs
@@ -29,6 +29,7 @@ async fn test_get_active_billing_subscriptions(db: &Arc<Database>) {
             .create_billing_customer(&CreateBillingCustomerParams {
                 user_id,
                 stripe_customer_id: "cus_active_user".into(),
+                last_stripe_event_id: None,
             })
             .await
             .unwrap();
@@ -64,6 +65,7 @@ async fn test_get_active_billing_subscriptions(db: &Arc<Database>) {
             .create_billing_customer(&CreateBillingCustomerParams {
                 user_id,
                 stripe_customer_id: "cus_past_due_user".into(),
+                last_stripe_event_id: None,
             })
             .await
             .unwrap();

--- a/crates/collab/src/db/tests/billing_subscription_tests.rs
+++ b/crates/collab/src/db/tests/billing_subscription_tests.rs
@@ -38,6 +38,7 @@ async fn test_get_active_billing_subscriptions(db: &Arc<Database>) {
             billing_customer_id: customer.id,
             stripe_subscription_id: "sub_active_user".into(),
             stripe_subscription_status: StripeSubscriptionStatus::Active,
+            last_stripe_event_id: None,
         })
         .await
         .unwrap();
@@ -72,6 +73,7 @@ async fn test_get_active_billing_subscriptions(db: &Arc<Database>) {
             billing_customer_id: customer.id,
             stripe_subscription_id: "sub_past_due_user".into(),
             stripe_subscription_status: StripeSubscriptionStatus::PastDue,
+            last_stripe_event_id: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
This PR improves our Stripe event handling by keeping track of the last event we've seen for each record.

The `billing_customers` and `billing_subscriptions` tables both have a new `last_stripe_event_id` column. When we apply an event to one of these records, we store the event ID that was applied.

Then, when we are going through events we can ignore any event that has an ID that came before the `last_stripe_event_id` (based on the lexicographical ordering of the IDs).

Release Notes:

- N/A
