### PR TITLE
Show "full" paths in the /file command output

### DIFF
--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -273,20 +273,25 @@ fn collect_files(
                         continue;
                     };
                     if let Some(buffer) = open_buffer_task.await.log_err() {
-                        let snapshot = cx.read_model(&buffer, |buffer, _| buffer.snapshot())?;
+                        let buffer_snapshot =
+                            cx.read_model(&buffer, |buffer, _| buffer.snapshot())?;
                         let prev_len = text.len();
-                        collect_file_content(&mut text, &snapshot, filename.clone());
+                        collect_file_content(
+                            &mut text,
+                            &buffer_snapshot,
+                            path_including_worktree_name.to_string_lossy().to_string(),
+                        );
                         text.push('\n');
                         if !write_single_file_diagnostics(
                             &mut text,
                             Some(&path_including_worktree_name),
-                            &snapshot,
+                            &buffer_snapshot,
                         ) {
                             text.pop();
                         }
                         ranges.push((
                             prev_len..text.len(),
-                            PathBuf::from(filename),
+                            path_including_worktree_name,
                             EntryType::File,
                         ));
                         text.push('\n');


### PR DESCRIPTION
Same as /tabs command outputs them

Before:
![Screenshot 2024-07-30 at 16 52 11](https://github.com/user-attachments/assets/acf1c79e-4607-41fc-bd5e-b20dc668eff4)

![Screenshot 2024-07-30 at 16 52 03](https://github.com/user-attachments/assets/dd7fa42f-3ba8-4f1c-9420-2a0246df64b7)

After:
![Screenshot 2024-07-30 at 16 53 16](https://github.com/user-attachments/assets/ee866ecb-2142-4303-9385-c6b856310d43)

![Screenshot 2024-07-30 at 16 53 21](https://github.com/user-attachments/assets/d42b9c77-d5e9-4aaf-8de9-3b160078e622)


Release Notes:

- N/A
