### PR TITLE
windows: Fix extensions couldn't start if the path contained spaces

### DIFF
--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -119,14 +119,7 @@ impl LspAdapter for TailwindLspAdapter {
 
         #[cfg(target_os = "windows")]
         {
-            let mut env_path = vec![self.node.binary_path().await?.to_path_buf()];
-
-            if let Some(existing_path) = std::env::var_os("PATH") {
-                let mut paths = std::env::split_paths(&existing_path).collect::<Vec<_>>();
-                env_path.append(&mut paths);
-            }
-
-            let env_path = std::env::join_paths(env_path)?;
+            let env_path = self.node.node_environment_path().await?;
             let mut env = HashMap::default();
             env.insert("PATH".to_string(), env_path.to_string_lossy().to_string());
 

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -30,19 +30,7 @@ fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
 
 #[cfg(target_os = "windows")]
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
-    let x = vec![
-        "-File".into(),
-        // format!("{}", server_path.display())
-        //     .replace('/', "\\")
-        //     .into(),
-        server_path.into(),
-        "--stdio".into(),
-        // format!("& '{}' --stdio", server_path.display()).into(),
-    ];
-    // let x = "s".to_string()
-    println!("--> {:?}", x);
-    x
-    // vec![format!("\"& '{}' --stdio\"", server_path.display()).into()]
+    vec!["-File".into(), server_path.into(), "--stdio".into()]
 }
 
 pub struct TailwindLspAdapter {
@@ -142,7 +130,6 @@ impl LspAdapter for TailwindLspAdapter {
             let mut env = HashMap::default();
             env.insert("PATH".to_string(), env_path.to_string_lossy().to_string());
 
-            println!("--> {}", server_path.display());
             Ok(LanguageServerBinary {
                 path: "powershell.exe".into(),
                 env: Some(env),


### PR DESCRIPTION
Closes #15441 .

Fixed the issue where extensions couldn't start if the path contained spaces. Additionally, this PR introduces the `node_environment_path` function to obtain the PATH environment variable which includes the node path.

Release Notes:

- N/A
