### PR TITLE
Switch editor::AcceptPartialInlineCompletion keybind to match VSCode

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -121,7 +121,7 @@
     "bindings": {
       "alt-]": "editor::NextInlineCompletion",
       "alt-[": "editor::PreviousInlineCompletion",
-      "alt-right": "editor::AcceptPartialInlineCompletion"
+      "ctrl-right": "editor::AcceptPartialInlineCompletion"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -152,7 +152,7 @@
     "bindings": {
       "alt-]": "editor::NextInlineCompletion",
       "alt-[": "editor::PreviousInlineCompletion",
-      "alt-right": "editor::AcceptPartialInlineCompletion"
+      "cmd-right": "editor::AcceptPartialInlineCompletion"
     }
   },
   {


### PR DESCRIPTION
Release Notes:

- Fixed editor::AcceptPartialInlineCompletion keybind to match VSCode ([#15487](https://github.com/zed-industries/zed/issues/15487)).
