### PR TITLE
terminal: Fix ctrl-a keybind on Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -246,13 +246,6 @@
       "ctrl-alt-shift-x": "search::ToggleRegex"
     }
   },
-  {
-    "context": "Terminal",
-    "bindings": {
-      "ctrl-w": ["terminal::SendKeystroke", "ctrl-w"],
-      "ctrl-e": ["terminal::SendKeystroke", "ctrl-e"]
-    }
-  },
   // Bindings from VS Code
   {
     "context": "Editor",
@@ -462,10 +455,14 @@
   {
     "bindings": {
       "ctrl-alt-shift-f": "workspace::FollowNextCollaborator",
-      // TODO: Move this to a dock open action
-      "ctrl-shift-c": "collab_panel::ToggleFocus",
       "ctrl-alt-i": "zed::DebugElements",
       "ctrl-:": "editor::ToggleInlayHints"
+    }
+  },
+  {
+    "context": "!Terminal",
+    "bindings": {
+      "ctrl-shift-c": "collab_panel::ToggleFocus"
     }
   },
   {
@@ -601,12 +598,14 @@
     "context": "Terminal",
     "bindings": {
       "ctrl-alt-space": "terminal::ShowCharacterPalette",
-      "shift-ctrl-c": "terminal::Copy",
+      "ctrl-shift-c": "terminal::Copy",
       "ctrl-insert": "terminal::Copy",
-      "ctrl-a": "editor::SelectAll",
-      "shift-ctrl-v": "terminal::Paste",
+      // "ctrl-a": "editor::SelectAll", // conflicts with readline
+      "ctrl-shift-v": "terminal::Paste",
       "shift-insert": "terminal::Paste",
       "ctrl-enter": "assistant::InlineAssist",
+      "ctrl-w": ["terminal::SendKeystroke", "ctrl-w"],
+      "ctrl-e": ["terminal::SendKeystroke", "ctrl-e"],
       "up": ["terminal::SendKeystroke", "up"],
       "pageup": ["terminal::SendKeystroke", "pageup"],
       "down": ["terminal::SendKeystroke", "down"],


### PR DESCRIPTION
- Disable Terminal ctrl-a (conflicts with readline). Introduced in #14828
- Standardize modifier order to use ctrl-shift instead of shift-ctrl to match existing keys.
- Move ctrl-shift-c (collab) to \!Terminal context (fix flickering in terminal right click menu).
- Consolidate two Terminal blocks in linux keybind

Release Notes:

- Fixed ctrl-a broken in Terminal (Linux-only, preview-only) ([#15512](https://github.com/zed-industries/zed/issues/15512)).
