### PR TITLE
Show current plan in user menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11186,6 +11186,7 @@ dependencies = [
  "dev_server_projects",
  "editor",
  "extensions_ui",
+ "feature_flags",
  "feedback",
  "gpui",
  "http_client",

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1137,6 +1137,8 @@ impl Server {
                         .await?;
                 }
 
+                update_user_plan(user.id, session).await?;
+
                 let (contacts, dev_server_projects) = future::try_join(
                     self.app_state.db.get_contacts(user.id),
                     self.app_state.db.dev_server_projects_update(user.id),
@@ -3533,6 +3535,30 @@ async fn remove_contact(
 
 fn should_auto_subscribe_to_channels(version: ZedVersion) -> bool {
     version.0.minor() < 139
+}
+
+async fn update_user_plan(user_id: UserId, session: &Session) -> Result<()> {
+    let active_subscriptions = session
+        .db()
+        .await
+        .get_active_billing_subscriptions(user_id)
+        .await?;
+
+    let plan = if active_subscriptions.is_empty() {
+        proto::Plan::Free
+    } else {
+        proto::Plan::ZedPro
+    };
+
+    session
+        .peer
+        .send(
+            session.connection_id,
+            proto::UpdateUserPlan { plan: plan.into() },
+        )
+        .trace_err();
+
+    Ok(())
 }
 
 async fn subscribe_to_channels(_: proto::SubscribeToChannels, session: Session) -> Result<()> {

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -3538,16 +3538,13 @@ fn should_auto_subscribe_to_channels(version: ZedVersion) -> bool {
 }
 
 async fn update_user_plan(user_id: UserId, session: &Session) -> Result<()> {
-    let active_subscriptions = session
-        .db()
-        .await
-        .get_active_billing_subscriptions(user_id)
-        .await?;
+    let db = session.db().await;
+    let active_subscriptions = db.get_active_billing_subscriptions(user_id).await?;
 
-    let plan = if active_subscriptions.is_empty() {
-        proto::Plan::Free
-    } else {
+    let plan = if session.is_staff() || !active_subscriptions.is_empty() {
         proto::Plan::ZedPro
+    } else {
+        proto::Plan::Free
     };
 
     session

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -48,6 +48,11 @@ impl FeatureFlag for GroupedDiagnostics {
     const NAME: &'static str = "grouped-diagnostics";
 }
 
+pub struct ZedPro {}
+impl FeatureFlag for ZedPro {
+    const NAME: &'static str = "zed-pro";
+}
+
 pub trait FeatureFlagViewExt<V: 'static> {
     fn observe_flag<T: FeatureFlag, F>(&mut self, callback: F) -> Subscription
     where

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -126,6 +126,7 @@ message Envelope {
         Unfollow unfollow = 101;
         GetPrivateUserInfo get_private_user_info = 102;
         GetPrivateUserInfoResponse get_private_user_info_response = 103;
+        UpdateUserPlan update_user_plan = 234; // current max
         UpdateDiffBase update_diff_base = 104;
 
         OnTypeFormatting on_type_formatting = 105;
@@ -256,7 +257,7 @@ message Envelope {
         OpenContext open_context = 212;
         OpenContextResponse open_context_response = 213;
         CreateContext create_context = 232;
-        CreateContextResponse create_context_response = 233; // current max
+        CreateContextResponse create_context_response = 233;
         UpdateContext update_context = 214;
         SynchronizeContexts synchronize_contexts = 215;
         SynchronizeContextsResponse synchronize_contexts_response = 216;
@@ -1678,6 +1679,15 @@ message GetPrivateUserInfoResponse {
     string metrics_id = 1;
     bool staff = 2;
     repeated string flags = 3;
+}
+
+enum Plan {
+    Free = 0;
+    ZedPro = 1;
+}
+
+message UpdateUserPlan {
+    Plan plan = 1;
 }
 
 // Entities

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -359,6 +359,7 @@ messages!(
     (UpdateParticipantLocation, Foreground),
     (UpdateProject, Foreground),
     (UpdateProjectCollaborator, Foreground),
+    (UpdateUserPlan, Foreground),
     (UpdateWorktree, Foreground),
     (UpdateWorktreeSettings, Foreground),
     (UsersResponse, Foreground),

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -36,6 +36,7 @@ command_palette.workspace = true
 dev_server_projects.workspace = true
 extensions_ui.workspace = true
 feedback.workspace = true
+feature_flags.workspace = true
 gpui.workspace = true
 notifications.workspace = true
 project.workspace = true

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -11,6 +11,7 @@ use crate::platforms::{platform_linux, platform_mac, platform_windows};
 use auto_update::AutoUpdateStatus;
 use call::ActiveCall;
 use client::{Client, UserStore};
+use feature_flags::{FeatureFlagAppExt, ZedPro};
 use gpui::{
     actions, div, px, Action, AnyElement, AppContext, Decorations, Element, InteractiveElement,
     Interactivity, IntoElement, Model, MouseButton, ParentElement, Render, Stateful,
@@ -512,19 +513,21 @@ impl TitleBar {
             let plan = user_store.current_plan();
             PopoverMenu::new("user-menu")
                 .menu(move |cx| {
-                    ContextMenu::build(cx, |menu, _| {
-                        menu.action(
-                            format!(
-                                "Current Plan: {}",
-                                match plan {
-                                    None => "",
-                                    Some(proto::Plan::Free) => "Free",
-                                    Some(proto::Plan::ZedPro) => "Pro",
-                                }
-                            ),
-                            zed_actions::OpenAccountSettings.boxed_clone(),
-                        )
-                        .separator()
+                    ContextMenu::build(cx, |menu, cx| {
+                        menu.when(cx.has_flag::<ZedPro>(), |menu| {
+                            menu.action(
+                                format!(
+                                    "Current Plan: {}",
+                                    match plan {
+                                        None => "",
+                                        Some(proto::Plan::Free) => "Free",
+                                        Some(proto::Plan::ZedPro) => "Pro",
+                                    }
+                                ),
+                                zed_actions::OpenAccountSettings.boxed_clone(),
+                            )
+                            .separator()
+                        })
                         .action("Settings", zed_actions::OpenSettings.boxed_clone())
                         .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
                         .action("Themes…", theme_selector::Toggle::default().boxed_clone())

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -47,7 +47,7 @@ use workspace::{
     open_new, AppState, NewFile, NewWindow, OpenLog, Toast, Workspace, WorkspaceSettings,
 };
 use workspace::{notifications::DetachAndPromptErr, Pane};
-use zed_actions::{OpenBrowser, OpenSettings, OpenZedUrl, Quit};
+use zed_actions::{OpenAccountSettings, OpenBrowser, OpenSettings, OpenZedUrl, Quit};
 
 actions!(
     zed,
@@ -420,6 +420,12 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
                         || settings::initial_user_settings_content().as_ref().into(),
                         cx,
                     );
+                },
+            )
+            .register_action(
+                |_: &mut Workspace, _: &OpenAccountSettings, cx: &mut ViewContext<Workspace>| {
+                    let server_url = &client::ClientSettings::get_global(cx).server_url;
+                    cx.open_url(&format!("{server_url}/settings"));
                 },
             )
             .register_action(

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -26,6 +26,7 @@ actions!(
     zed,
     [
         OpenSettings,
+        OpenAccountSettings,
         Quit,
         OpenKeymap,
         About,


### PR DESCRIPTION
This PR updates the user menu to show the user's current plan.

Also adds a new RPC message to send this information down to the client when Zed starts.

This is behind a feature flag.

Release Notes:

- N/A
