### PR TITLE
extension: Always use a real HTTP client in the `ExtensionBuilder`

### DIFF
--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -243,7 +243,12 @@ impl ExtensionStore {
             extension_index: Default::default(),
             installed_dir,
             index_path,
-            builder: Arc::new(ExtensionBuilder::new(http_client.clone(), build_dir)),
+            builder: Arc::new(ExtensionBuilder::new(
+                // Construct a real HTTP client for the extension builder, as we
+                // don't want to use a fake one in the tests.
+                ::http_client::client(None, http_client.proxy().cloned()),
+                build_dir,
+            )),
             outstanding_operations: Default::default(),
             modified_extensions: Default::default(),
             reload_complete_senders: Vec::new(),


### PR DESCRIPTION
This PR makes it so we always construct a real HTTP client in the `ExtensionBuilder`.

This used to be the case, but was inadvertently changed in https://github.com/zed-industries/zed/pull/15470.

Release Notes:

- N/A
