### PR TITLE
x11: Do not check hover state on properties change

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -791,15 +791,6 @@ impl X11WindowStatePtr {
                 state.hidden = true;
             }
         }
-
-        let hovered_window = self
-            .xcb_connection
-            .query_pointer(state.x_root_window)
-            .unwrap()
-            .reply()
-            .unwrap()
-            .child;
-        self.set_hovered(hovered_window == self.x_window);
     }
 
     pub fn close(&self) {


### PR DESCRIPTION
This fixes an issue where the window's hovered state would be incorrect, causing the cursor not to update because it would think the window wasn't hovered ([relevant check](https://github.com/zed-industries/zed/blob/a03beeeb5bcce3fbb464a5d2a06a6ae47e8dda92/crates/gpui/src/window.rs#L3016-L3017)).

The code here doesn't really seem to make sense, since there's already the `XinputEnter` and `XinputLeave` events that indicate mouse focus state on the window. The properties change event wouldn't necessarily indicate when mouse focus changes.

Thanks @Emc2356 for reporting this on the Discord and helping figure out the issue!
 
Release Notes:

- Linux: Fixed the cursor sometimes not changing on X11
