### PR TITLE
assistant panel: Show provider name in model selector

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2787,7 +2787,13 @@ impl Render for ContextEditorToolbarItem {
                                             Label::new(
                                                 LanguageModelRegistry::read_global(cx)
                                                     .active_model()
-                                                    .map(|model| model.name().0)
+                                                    .map(|model| {
+                                                        format!(
+                                                            "{}: {}",
+                                                            model.provider_name().0,
+                                                            model.name().0
+                                                        )
+                                                    })
                                                     .unwrap_or_else(|| "No model selected".into()),
                                             )
                                             .size(LabelSize::Small)


### PR DESCRIPTION
With zed.dev provider becoming more popular, it helps alleviate confusion when showing not only the model name but also the provider name.

Release Notes:

- N/A
