### PR TITLE
Properly extract errors from the Anthropic API

### DIFF
--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -273,7 +273,7 @@ impl ContextOperation {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum ContextEvent {
     MessagesEdited,
     SummaryChanged,
@@ -2188,7 +2188,7 @@ impl ContextVersion {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PendingSlashCommand {
     pub name: String,
     pub argument: Option<String>,
@@ -2196,7 +2196,7 @@ pub struct PendingSlashCommand {
     pub source_range: Range<language::Anchor>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum PendingSlashCommandStatus {
     Idle,
     Running { _task: Shared<Task<()>> },


### PR DESCRIPTION
Before, we missed "successful" responses with the API errors, now they are properly shown in the assistant panel.

![image](https://github.com/user-attachments/assets/0c0936af-86c2-4def-9a58-25d5e0912b97)


Release Notes:

- N/A
