### PR TITLE
assistant panel: Fix panic when opening panel with zed.dev provider

### DIFF
--- a/crates/language_model/src/provider/cloud.rs
+++ b/crates/language_model/src/provider/cloud.rs
@@ -84,8 +84,10 @@ impl CloudLanguageModelProvider {
             while let Some(status) = status_rx.next().await {
                 if let Some(this) = state_ref.upgrade() {
                     _ = this.update(&mut cx, |this, cx| {
-                        this.status = status;
-                        cx.notify();
+                        if this.status != status {
+                            this.status = status;
+                            cx.notify();
+                        }
                     });
                 } else {
                     break;


### PR DESCRIPTION
There was/is some race condition that gets triggered only with the zed.dev provider when opening the provider that would cause a double-borrow on workspace.

This PR fixes the issue by cloning the workspace weakly. Turns out we can go very far with just the weak reference.

We're still a bit unsure why exactly the race condition happened, since it's hard to reproduce, but we're working on configuration view/management in #15490 anyway.

Release Notes:

- N/A
