### PR TITLE
Fix editor & assistant panel toolbar height mismatch

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -196,6 +196,7 @@ impl Render for BufferSearchBar {
         };
 
         let search_line = h_flex()
+            .mb_1p5()
             .child(
                 h_flex()
                     .id("editor-scroll")
@@ -295,7 +296,7 @@ impl Render for BufferSearchBar {
                         &SelectNextMatch,
                     ))
                     .when(!narrow_mode, |this| {
-                        this.child(h_flex().min_w(rems_from_px(40.)).child(
+                        this.child(h_flex().ml_2().min_w(rems_from_px(40.)).child(
                             Label::new(match_text).color(if self.active_match_index.is_some() {
                                 Color::Default
                             } else {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -196,7 +196,7 @@ impl Render for BufferSearchBar {
         };
 
         let search_line = h_flex()
-            .mb_1p5()
+            .mb_1()
             .child(
                 h_flex()
                     .id("editor-scroll")

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -105,12 +105,15 @@ impl Render for Toolbar {
             .bg(cx.theme().colors().toolbar_background)
             .child(
                 h_flex()
+                    .min_h(rems_from_px(24.))
+                    .items_center()
                     .justify_between()
                     .gap(Spacing::Large.rems(cx))
                     .when(has_left_items, |this| {
                         this.child(
                             h_flex()
                                 .flex_auto()
+                                .items_center()
                                 .justify_start()
                                 .overflow_x_hidden()
                                 .children(self.left_items().map(|item| item.to_any())),

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -113,7 +113,6 @@ impl Render for Toolbar {
                         this.child(
                             h_flex()
                                 .flex_auto()
-                                .items_center()
                                 .justify_start()
                                 .overflow_x_hidden()
                                 .children(self.left_items().map(|item| item.to_any())),

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -106,7 +106,6 @@ impl Render for Toolbar {
             .child(
                 h_flex()
                     .min_h(rems_from_px(24.))
-                    .items_center()
                     .justify_between()
                     .gap(Spacing::Large.rems(cx))
                     .when(has_left_items, |this| {


### PR DESCRIPTION
This PR ensures that the toolbar within the editor and the assistant panel have the same height. I also pushed in some other tiny design (spacing, really) tweaks. There's still a mismatch between the editor toolbar and the assistant panel's history tab, but I'll try to tackle this separately.

| Before | After |
|--------|--------|
| <img width="152" alt="Screenshot 2024-07-31 at 15 26 26" src="https://github.com/user-attachments/assets/d689ef65-420d-479e-8124-71e5d03aca45"> | <img width="152" alt="Screenshot 2024-07-31 at 15 26 49" src="https://github.com/user-attachments/assets/71040504-0530-4335-a645-0ec83588dead"> |
| <img width="961" alt="Screenshot 2024-07-31 at 15 33 09" src="https://github.com/user-attachments/assets/dfadb08f-c2b5-41c4-9260-64e3c4410d44"> | <img width="961" alt="Screenshot 2024-07-31 at 15 33 28" src="https://github.com/user-attachments/assets/a7be1ad9-6872-4262-9b12-2a234036a886"> | 

---

Release Notes:

- N/A
