### PR TITLE
linux: Ignore benign error when cancelling file picker

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -21,7 +21,6 @@ use std::{
 use anyhow::anyhow;
 use ashpd::desktop::file_chooser::{OpenFileRequest, SaveFileRequest};
 use ashpd::desktop::open_uri::{OpenDirectoryRequest, OpenFileRequest as OpenUriRequest};
-use ashpd::desktop::ResponseError;
 use ashpd::{url, ActivationToken};
 use async_task::Runnable;
 use calloop::channel::Channel;
@@ -300,7 +299,7 @@ impl<P: LinuxClient + 'static> Platform for P {
                             .filter_map(|uri| uri.to_file_path().ok())
                             .collect::<Vec<_>>(),
                     )),
-                    Err(ashpd::Error::Response(ResponseError::Cancelled)) => Ok(None),
+                    Err(ashpd::Error::Response(_)) => Ok(None),
                     Err(e) => Err(e.into()),
                 };
                 done_tx.send(result);
@@ -338,7 +337,7 @@ impl<P: LinuxClient + 'static> Platform for P {
                         .uris()
                         .first()
                         .and_then(|uri| uri.to_file_path().ok())),
-                    Err(ashpd::Error::Response(ResponseError::Cancelled)) => Ok(None),
+                    Err(ashpd::Error::Response(_)) => Ok(None),
                     Err(e) => Err(e.into()),
                 };
                 done_tx.send(result);


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/15485

This should be clearer on the `ashpd` side, but `ResponseError` comes from the portal [Response](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html#org-freedesktop-portal-request-response), which means the request itself didn't fail. Ignoring the `Other` variant here should be safe.

Release Notes:

- Linux: Fixed benign error being shown when cancelling file picker ([#15485](https://github.com/zed-industries/zed/issues/15485))
