### PR TITLE
collab: Use the right `zed.dev` URL for the environment

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -153,7 +153,8 @@ async fn create_billing_subscription(
             quantity: Some(1),
             ..Default::default()
         }]);
-        params.success_url = Some("https://zed.dev/billing/success");
+        let success_url = format!("{}/settings", app.config.zed_dot_dev_url());
+        params.success_url = Some(&success_url);
 
         CheckoutSession::create(&stripe_client, params).await?
     };
@@ -260,7 +261,7 @@ async fn manage_billing_subscription(
             after_completion: Some(CreateBillingPortalSessionFlowDataAfterCompletion {
                 type_: stripe::CreateBillingPortalSessionFlowDataAfterCompletionType::Redirect,
                 redirect: Some(CreateBillingPortalSessionFlowDataAfterCompletionRedirect {
-                    return_url: "https://zed.dev/settings".into(),
+                    return_url: format!("{}/settings", app.config.zed_dot_dev_url()),
                 }),
                 ..Default::default()
             }),
@@ -277,7 +278,8 @@ async fn manage_billing_subscription(
 
     let mut params = CreateBillingPortalSession::new(customer_id);
     params.flow_data = Some(flow);
-    params.return_url = Some("https://zed.dev/settings");
+    let return_url = format!("{}/settings", app.config.zed_dot_dev_url());
+    params.return_url = Some(&return_url);
 
     let session = BillingPortalSession::create(&stripe_client, params).await?;
 

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -163,6 +163,15 @@ impl Config {
     pub fn is_development(&self) -> bool {
         self.zed_environment == "development".into()
     }
+
+    /// Returns the base `zed.dev` URL.
+    pub fn zed_dot_dev_url(&self) -> &str {
+        match self.zed_environment.as_ref() {
+            "development" => "http://localhost:3000",
+            "staging" => "https://staging.zed.dev",
+            _ => "https://zed.dev",
+        }
+    }
 }
 
 pub struct AppState {


### PR DESCRIPTION
This PR updates collab to pick the `zed.dev` URL based on the current environment rather than always using `https://zed.dev`.

This means that when developing locally we'll use `http://localhost:3000` to be taken to the locally-running version of `zed.dev`.

Release Notes:

- N/A
