### PR TITLE
vim: Add sneak motion

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -234,6 +234,8 @@
       "ctrl-r": "vim::Redo",
       "r": ["vim::PushOperator", "Replace"],
       "s": "vim::Substitute",
+      "z": ["vim::PushOperator", { "Sneak": {} }],
+      "Z": ["vim::PushOperator", { "SneakBackward": {} }],
       "shift-s": "vim::SubstituteLine",
       ">": ["vim::PushOperator", "Indent"],
       "<": ["vim::PushOperator", "Outdent"],

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -58,6 +58,8 @@ pub enum Operator {
     Object { around: bool },
     FindForward { before: bool },
     FindBackward { after: bool },
+    Sneak { first_char: Option<char> },
+    SneakBackward { first_char: Option<char> },
     AddSurrounds { target: Option<SurroundsType> },
     ChangeSurrounds { target: Option<Object> },
     DeleteSurrounds,
@@ -313,6 +315,8 @@ impl Operator {
             Operator::Digraph { .. } => "^K",
             Operator::FindForward { before: false } => "f",
             Operator::FindForward { before: true } => "t",
+            Operator::Sneak { .. } => "z",
+            Operator::SneakBackward { .. } => "Z",
             Operator::FindBackward { after: false } => "F",
             Operator::FindBackward { after: true } => "T",
             Operator::AddSurrounds { .. } => "ys",
@@ -340,6 +344,8 @@ impl Operator {
             | Operator::Mark
             | Operator::Jump { .. }
             | Operator::FindBackward { .. }
+            | Operator::Sneak { .. }
+            | Operator::SneakBackward { .. }
             | Operator::Register
             | Operator::RecordRegister
             | Operator::ReplayRegister

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -84,6 +84,8 @@ actions!(
         InnerObject,
         FindForward,
         FindBackward,
+        Sneak,
+        SneakBackward,
         OpenDefaultKeymap
     ]
 );
@@ -860,6 +862,48 @@ impl Vim {
                     vim.workspace_state.last_find = Some(find.clone())
                 });
                 motion::motion(find, cx)
+            }
+            Some(Operator::Sneak { first_char }) => {
+                if let Some(first_char) = first_char {
+                    if let Some(second_char) = text.chars().next() {
+                        let sneak = Motion::Sneak {
+                            first_char,
+                            second_char,
+                            smartcase: VimSettings::get_global(cx).use_smartcase_find,
+                        };
+                        Vim::update(cx, |vim, _| {
+                            vim.workspace_state.last_find = Some(sneak.clone())
+                        });
+                        motion::motion(sneak, cx)
+                    }
+                } else {
+                    let first_char = text.chars().next();
+                    Vim::update(cx, |vim, cx| {
+                        vim.pop_operator(cx);
+                        vim.push_operator(Operator::Sneak { first_char }, cx);
+                    });
+                }
+            }
+            Some(Operator::SneakBackward { first_char }) => {
+                if let Some(first_char) = first_char {
+                    if let Some(second_char) = text.chars().next() {
+                        let sneak = Motion::SneakBackward {
+                            first_char,
+                            second_char,
+                            smartcase: VimSettings::get_global(cx).use_smartcase_find,
+                        };
+                        Vim::update(cx, |vim, _| {
+                            vim.workspace_state.last_find = Some(sneak.clone())
+                        });
+                        motion::motion(sneak, cx)
+                    }
+                } else {
+                    let first_char = text.chars().next();
+                    Vim::update(cx, |vim, cx| {
+                        vim.pop_operator(cx);
+                        vim.push_operator(Operator::SneakBackward { first_char }, cx);
+                    });
+                }
             }
             Some(Operator::Replace) => match Vim::read(cx).state().mode {
                 Mode::Normal => normal_replace(text, cx),


### PR DESCRIPTION
Implement support for the vim sneak motion from the vim-sneak plugin. The motion jumps forward or backward to any location specified by two characters.

The Sneak & SneakBackward operators are bound to 'z' and 'Z' by default to avoid overwriting the 's' and 'S' default keybindings, similar to the way the original plugin uses 'z' with operators to avoid conflicts.

Reference:
https://github.com/justinmk/vim-sneak

Release Notes:

- Added support for the vim-sneak motion ([#13858](https://github.com/zed-industries/zed/issues/13858)).
