### PR TITLE
Fix GitHub Copilot chat authentication on Windows

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -217,7 +217,7 @@ pub fn copilot_chat_config_path() -> &'static PathBuf {
 
     COPILOT_CHAT_CONFIG_DIR.get_or_init(|| {
         if cfg!(target_os = "windows") {
-            home_dir().join("AppData")
+            home_dir().join("AppData").join("Local")
         } else {
             home_dir().join(".config")
         }


### PR DESCRIPTION
This PR fixes Copilot chat authentication on Windows. GitHub Copilot chat in assistant panel uses auth token file generated by [copilot language server](https://github.com/zed-industries/copilot). The path to authentication token file is platform dependent. On Windows, it happens to be `~\AppData\Local\github-copilot\hosts.json`.

Release Notes:

- Fixed Copilot chat sign in issue on Windows ... ([#4673](https://github.com/zed-industries/zed/issues/4673)).
