### PR TITLE
extensions: Allow defining language servers as secondary

### DIFF
--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -114,6 +114,8 @@ pub struct LanguageServerManifestEntry {
     pub language_ids: HashMap<String, String>,
     #[serde(default)]
     pub code_action_kinds: Option<Vec<lsp::CodeActionKind>>,
+    #[serde(default)]
+    pub secondary: bool,
 }
 
 impl LanguageServerManifestEntry {

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -1195,18 +1195,23 @@ impl ExtensionStore {
                 for (manifest, wasm_extension) in &wasm_extensions {
                     for (language_server_id, language_server_config) in &manifest.language_servers {
                         for language in language_server_config.languages() {
-                            this.language_registry.register_lsp_adapter(
-                                language.clone(),
-                                Arc::new(ExtensionLspAdapter {
-                                    extension: wasm_extension.clone(),
-                                    host: this.wasm_host.clone(),
-                                    language_server_id: language_server_id.clone(),
-                                    config: wit::LanguageServerConfig {
-                                        name: language_server_id.0.to_string(),
-                                        language_name: language.to_string(),
-                                    },
-                                }),
-                            );
+                            let adapter = Arc::new(ExtensionLspAdapter {
+                                extension: wasm_extension.clone(),
+                                host: this.wasm_host.clone(),
+                                language_server_id: language_server_id.clone(),
+                                config: wit::LanguageServerConfig {
+                                    name: language_server_id.0.to_string(),
+                                    language_name: language.to_string(),
+                                },
+                            });
+
+                            if language_server_config.secondary {
+                                this.language_registry
+                                    .register_secondary_lsp_adapter(language.clone(), adapter);
+                            } else {
+                                this.language_registry
+                                    .register_lsp_adapter(language.clone(), adapter);
+                            }
                         }
                     }
 

--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -17,6 +17,7 @@ languages = ["Ruby", "ERB"]
 [language_servers.rubocop]
 name = "Rubocop"
 languages = ["Ruby"]
+secondary = true
 
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"


### PR DESCRIPTION
This fixes the problem described in #15023 by allowing extensions to designate language servers as secondary language servers.

Secondary language servers can be used for formatting/linting/diagnostics, but they won't be used for go-to-definition and find-references.

The problem before this change was that extension authors and users didn't have any influence on which language server is used as the primary or secondary language server.

Since they were all designated as "primary", Zed would pick the first one in the list of running language servers. And the order of entries in that' list is dependent on the order in which the language servers were started.

We could somehow steer this behaviour through the order and, when trying to find a primary language server, traverse the list in the order of the language servers as they are defined in the settings, but that seems brittle.

We'd have to ensure that users have their language server entries ordered correctly and "teach" them  about primary vs. secondary language servers.

Instead, we can leave it up to the extension authors to decide which server can act as a primary language server and which as a secondary.

In the case of rubocop, too, I think it's pretty clear-cut that it's a secondary language server, like tailwind or ESLint.

cc @maxdeviant @maxbrunsfeld is it okay to update the manifest like this?


Release Notes:

- Fixed go-to-definition being broken in Ruby files when using `rubocop` alongside another language server such as `ruby-lsp`. This is done by allowing extension authors to define language servers as secondary-language-servers, which means they won't be used for go-to-definition requests. ([#15023](https://github.com/zed-industries/zed/issues/15023)).
