### PR TITLE
assistant: Display hamburger menu even when the panel is not focused

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -378,6 +378,7 @@ impl AssistantPanel {
                         el.child(Pane::render_menu_overlay(new_item_menu))
                     })
                     .into_any_element()
+                    .into()
             });
             pane.toolbar().update(cx, |toolbar, cx| {
                 toolbar.add_item(context_editor_toolbar.clone(), cx);

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -173,6 +173,9 @@ impl TerminalPanel {
         let additional_buttons = self.additional_tab_bar_buttons.clone();
         self.pane.update(cx, |pane, cx| {
             pane.set_render_tab_bar_buttons(cx, move |pane, cx| {
+                if !pane.has_focus(cx) {
+                    return None;
+                }
                 h_flex()
                     .gap_2()
                     .children(additional_buttons.clone())
@@ -229,6 +232,7 @@ impl TerminalPanel {
                             })
                     })
                     .into_any_element()
+                    .into()
             });
         });
     }


### PR DESCRIPTION
This commit gives tab button renderers control over the condition in which they should be displayed. Previously we displayed tab buttons only when the pane was focused. Now tab renderers can return an Option of AnyElement, which in turn makes it possible for them to control when and how they're rendered. Pane and Terminal handlers still check for self focus condition and Assistant Panel does not.



Release Notes:

- N/A
