### PR TITLE
workspace: Improve error handling when dropping a file that cannot be opened into the workspace pane

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2017,7 +2017,7 @@ impl Pane {
                         .read(cx)
                         .path_for_entry(project_entry_id, cx)
                     {
-                        let load_path_task = workspace.load_path(path.into(), cx);
+                        let load_path_task = workspace.load_path(path, cx);
                         cx.spawn(|workspace, mut cx| async move {
                             match load_path_task.await {
                                 Ok((project_entry_id, build_item)) => {
@@ -2120,8 +2120,8 @@ impl Pane {
                     {
                         let opened_items: Vec<_> = open_task.await;
                         _ = workspace.update(&mut cx, |workspace, cx| {
-                            for item in opened_items {
-                                if let Some(Err(e)) = item {
+                            for item in opened_items.into_iter().flatten() {
+                                if let Err(e) = item {
                                     workspace.show_error(&e, cx);
                                 }
                             }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2023,21 +2023,23 @@ impl Pane {
                             if let Some((project_entry_id, build_item)) =
                                 load_path_task.await.notify_async_err(&mut cx)
                             {
-                                _ = workspace.update(&mut cx, |workspace, cx| {
-                                    if let Some(split_direction) = split_direction {
-                                        to_pane =
-                                            workspace.split_pane(to_pane, split_direction, cx);
-                                    }
-                                    to_pane.update(cx, |pane, cx| {
-                                        pane.open_item(
-                                            project_entry_id,
-                                            true,
-                                            false,
-                                            cx,
-                                            build_item,
-                                        )
+                                workspace
+                                    .update(&mut cx, |workspace, cx| {
+                                        if let Some(split_direction) = split_direction {
+                                            to_pane =
+                                                workspace.split_pane(to_pane, split_direction, cx);
+                                        }
+                                        to_pane.update(cx, |pane, cx| {
+                                            pane.open_item(
+                                                project_entry_id,
+                                                true,
+                                                false,
+                                                cx,
+                                                build_item,
+                                            )
+                                        })
                                     })
-                                });
+                                    .log_err();
                             }
                         })
                         .detach();


### PR DESCRIPTION
This PR can improve the UX when dropping a file that cannot be opened into the workspace pane. Previously, nothing happened without any messages when such error occurred, which could be awkward for users. Additionally the pane was being split even though the file failed to open.

Here's a screen recording demonstrating the previous/updated behavior:

https://github.com/user-attachments/assets/cfdf3488-9464-4568-b16a-9b87718bd729

Changes:

- It now displays an error message if a file cannot be opened.
- Updated the logic to first try to open the file. The pane splits only if the file opening process is successful.

Release Notes:

- Improved error handling when opening files in the workspace pane. An error message will now be displayed if the file cannot be opened.
- Fixed an issue where unnecessary pane splitting occurred when a file fails to open.