### PR TITLE
assistant: Report all worktree entries in /file completions

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -10917,10 +10917,30 @@ impl<'a> fuzzy::PathMatchCandidateSet<'a> for PathMatchCandidateSet {
     }
 
     fn len(&self) -> usize {
-        if self.include_ignored {
-            self.snapshot.file_count()
-        } else {
-            self.snapshot.visible_file_count()
+        match self.candidates {
+            Candidates::Files => {
+                if self.include_ignored {
+                    self.snapshot.file_count()
+                } else {
+                    self.snapshot.visible_file_count()
+                }
+            }
+
+            Candidates::Directories => {
+                if self.include_ignored {
+                    self.snapshot.dir_count()
+                } else {
+                    self.snapshot.visible_dir_count()
+                }
+            }
+
+            Candidates::Entries => {
+                if self.include_ignored {
+                    self.snapshot.entry_count()
+                } else {
+                    self.snapshot.visible_entry_count()
+                }
+            }
         }
     }
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2118,6 +2118,24 @@ impl Snapshot {
         Ok(())
     }
 
+    pub fn entry_count(&self) -> usize {
+        self.entries_by_path.summary().count
+    }
+
+    pub fn visible_entry_count(&self) -> usize {
+        self.entries_by_path.summary().non_ignored_count
+    }
+
+    pub fn dir_count(&self) -> usize {
+        let summary = self.entries_by_path.summary();
+        summary.count - summary.file_count
+    }
+
+    pub fn visible_dir_count(&self) -> usize {
+        let summary = self.entries_by_path.summary();
+        summary.non_ignored_count - summary.non_ignored_file_count
+    }
+
     pub fn file_count(&self) -> usize {
         self.entries_by_path.summary().file_count
     }


### PR DESCRIPTION
We were reporting file count as worktree entry count, which led to us missing some of the entries in /file command completion.

/cc @bennetbo

The other components that used `PathMatchCandidateSet` are `/diagnostics` and file finder. File finder is unaffected, as it used `Candidates::Files` - thus previously reported count was correct for it; `/diagnostics` were using `::Entries` as well, so it could miss entries just like `/files`.

Release Notes:

- Fixed /file and /diagnostics slash commands omitting entries in it's completions menu. 
