### PR TITLE
Update zed.desktop.in to include the MimeType for empty files by default

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -10,7 +10,7 @@ Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
 Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
-MimeType=text/plain;inode/directory;x-scheme-handler/zed;
+MimeType=text/plain;application/x-zerosize;inode/directory;x-scheme-handler/zed;
 Actions=NewWorkspace;
 
 [Desktop Action NewWorkspace]


### PR DESCRIPTION
Update zed.desktop.in to include the MimeType for empty files.
Seems to be the default for all "text editors" .desktop files.

Release Notes:

- Improved MimeType list in XDG .desktop file. 