### PR TITLE
Respect the `language_servers` setting's order when determining the primary language server

### DIFF
--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -1,3 +1,4 @@
+use crate::language_settings::LanguageSettings;
 use crate::{
     language_settings::{
         all_language_settings, AllLanguageSettingsContent, LanguageSettingsContent,
@@ -7,7 +8,7 @@ use crate::{
     LanguageServerName, LspAdapter, LspAdapterDelegate, PLAIN_TEXT,
 };
 use anyhow::{anyhow, Context as _, Result};
-use collections::{hash_map, HashMap};
+use collections::{hash_map, HashMap, HashSet};
 use futures::TryFutureExt;
 use futures::{
     channel::{mpsc, oneshot},
@@ -186,6 +187,22 @@ impl LanguageRegistry {
     /// Clears out all of the loaded languages and reload them from scratch.
     pub fn reload(&self) {
         self.state.write().reload();
+    }
+
+    /// Reorders the list of language servers for the given language.
+    ///
+    /// Uses the provided list of ordered [`CachedLspAdapters`] as the desired order.
+    ///
+    /// Any existing language servers not present in `ordered_lsp_adapters` will be
+    /// appended to the end.
+    pub fn reorder_language_servers(
+        &self,
+        language: &Arc<Language>,
+        ordered_lsp_adapters: Vec<Arc<CachedLspAdapter>>,
+    ) {
+        self.state
+            .write()
+            .reorder_language_servers(language, ordered_lsp_adapters);
     }
 
     /// Removes the specified languages and grammars from the registry.
@@ -918,6 +935,36 @@ impl LanguageRegistryState {
             language.loaded = false;
         }
         *self.subscription.0.borrow_mut() = ();
+    }
+
+    /// Reorders the list of language servers for the given language.
+    ///
+    /// Uses the provided list of ordered [`CachedLspAdapters`] as the desired order.
+    ///
+    /// Any existing language servers not present in `ordered_lsp_adapters` will be
+    /// appended to the end.
+    fn reorder_language_servers(
+        &mut self,
+        language: &Arc<Language>,
+        ordered_lsp_adapters: Vec<Arc<CachedLspAdapter>>,
+    ) {
+        let Some(lsp_adapters) = self.lsp_adapters.get_mut(&language.config.name) else {
+            return;
+        };
+
+        let ordered_lsp_adapter_ids = ordered_lsp_adapters
+            .iter()
+            .map(|lsp_adapter| lsp_adapter.name.clone())
+            .collect::<HashSet<_>>();
+
+        let mut new_lsp_adapters = ordered_lsp_adapters;
+        for adapter in lsp_adapters.iter() {
+            if !ordered_lsp_adapter_ids.contains(&adapter.name) {
+                new_lsp_adapters.push(adapter.clone());
+            }
+        }
+
+        *lsp_adapters = new_lsp_adapters;
     }
 
     fn remove_languages(

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -1,4 +1,3 @@
-use crate::language_settings::LanguageSettings;
 use crate::{
     language_settings::{
         all_language_settings, AllLanguageSettingsContent, LanguageSettingsContent,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2999,9 +2999,12 @@ impl Project {
                 .join(", ")
         );
 
-        for adapter in enabled_lsp_adapters {
-            self.start_language_server(worktree, adapter, language.clone(), cx);
+        for adapter in &enabled_lsp_adapters {
+            self.start_language_server(worktree, adapter.clone(), language.clone(), cx);
         }
+
+        self.languages()
+            .reorder_language_servers(&language, enabled_lsp_adapters);
     }
 
     fn start_language_server(


### PR DESCRIPTION
This PR updates how we determine the "primary" language server for a buffer to make it respect the order specified by the `language_servers` setting.

Previously we were relying on the language servers to be registered in the right order in order to select the primary one effectively.

However, in my testing I observed some cases where a native language server (e.g., `tailwindcss-language-server`) could end up first in the list of language servers despite not being first in the `language_servers` setting.

While this wasn't a problem for the Tailwind or ESLint language servers on account of them being defined natively with the designation of "secondary" language servers, this could cause problems with extension-based language servers.

To remedy this, every time we start up language servers we reorder the list of language servers for a given language to reflect the order in the `language_servers` setting. This ordering then allows us to treat the first language server in the list as the "primary" one.

Related issues:

- https://github.com/zed-industries/zed/issues/15023
- https://github.com/zed-industries/zed/issues/15279

Release Notes:

- The ordering of language servers will now respect the order in the `language_servers` setting.
  - The first language server in this list will be used as the primary language server.
