### PR TITLE
docs: Fix ordering of language servers in Ruby docs

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -29,7 +29,7 @@ The Ruby extension also provides support for `rubocop` language server for offen
 {
   "languages": {
     "Ruby": {
-      "language_servers": ["rubocop", "ruby-lsp", "!solargraph", "..."]
+      "language_servers": ["ruby-lsp", "rubocop", "!solargraph", "..."]
     }
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/15624.

Since #15624 introduced a fix for the language server ordering, this fixes the ordering in the Ruby docs.

Release Notes:

- N/A
