### PR TITLE
Remove primary/secondary distinction for `CachedLspAdapter`

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -5084,34 +5084,28 @@ async fn test_lsp_hover(
 
     client_a.language_registry().add(rust_lang());
     let language_server_names = ["rust-analyzer", "CrabLang-ls"];
-    let mut fake_language_servers = client_a
-        .language_registry()
-        .register_specific_fake_lsp_adapter(
-            "Rust",
-            true,
-            FakeLspAdapter {
-                name: "rust-analyzer",
-                capabilities: lsp::ServerCapabilities {
-                    hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
-                    ..lsp::ServerCapabilities::default()
-                },
-                ..FakeLspAdapter::default()
+    let mut fake_language_servers = client_a.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            name: "rust-analyzer",
+            capabilities: lsp::ServerCapabilities {
+                hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                ..lsp::ServerCapabilities::default()
             },
-        );
-    let _other_server = client_a
-        .language_registry()
-        .register_specific_fake_lsp_adapter(
-            "Rust",
-            false,
-            FakeLspAdapter {
-                name: "CrabLang-ls",
-                capabilities: lsp::ServerCapabilities {
-                    hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
-                    ..lsp::ServerCapabilities::default()
-                },
-                ..FakeLspAdapter::default()
+            ..FakeLspAdapter::default()
+        },
+    );
+    let _other_server = client_a.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            name: "CrabLang-ls",
+            capabilities: lsp::ServerCapabilities {
+                hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+                ..lsp::ServerCapabilities::default()
             },
-        );
+            ..FakeLspAdapter::default()
+        },
+    );
 
     let (project_a, worktree_id) = client_a.build_local_project("/root-1", cx_a).await;
     let project_id = active_call_a

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -156,15 +156,11 @@ pub struct CachedLspAdapter {
     language_ids: HashMap<String, String>,
     pub adapter: Arc<dyn LspAdapter>,
     pub reinstall_attempt_count: AtomicU64,
-    /// Indicates whether this language server is the primary language server
-    /// for a given language. Currently, most LSP-backed features only work
-    /// with one language server, so one server needs to be primary.
-    pub is_primary: bool,
     cached_binary: futures::lock::Mutex<Option<LanguageServerBinary>>,
 }
 
 impl CachedLspAdapter {
-    pub fn new(adapter: Arc<dyn LspAdapter>, is_primary: bool) -> Arc<Self> {
+    pub fn new(adapter: Arc<dyn LspAdapter>) -> Arc<Self> {
         let name = adapter.name();
         let disk_based_diagnostic_sources = adapter.disk_based_diagnostic_sources();
         let disk_based_diagnostics_progress_token = adapter.disk_based_diagnostics_progress_token();
@@ -176,7 +172,6 @@ impl CachedLspAdapter {
             disk_based_diagnostics_progress_token,
             language_ids,
             adapter,
-            is_primary,
             cached_binary: Default::default(),
             reinstall_attempt_count: AtomicU64::new(0),
         })

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -282,15 +282,6 @@ impl LanguageRegistry {
         language_name: &str,
         adapter: crate::FakeLspAdapter,
     ) -> futures::channel::mpsc::UnboundedReceiver<lsp::FakeLanguageServer> {
-        self.register_specific_fake_lsp_adapter(language_name, adapter)
-    }
-
-    #[cfg(any(feature = "test-support", test))]
-    pub fn register_specific_fake_lsp_adapter(
-        &self,
-        language_name: &str,
-        adapter: crate::FakeLspAdapter,
-    ) -> futures::channel::mpsc::UnboundedReceiver<lsp::FakeLanguageServer> {
         self.state
             .write()
             .lsp_adapters

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -251,7 +251,7 @@ impl LanguageRegistry {
             name,
             Arc::new(move || {
                 let lsp_adapter = load();
-                CachedLspAdapter::new(lsp_adapter, true)
+                CachedLspAdapter::new(lsp_adapter)
             }),
         );
     }
@@ -273,20 +273,7 @@ impl LanguageRegistry {
             .lsp_adapters
             .entry(language_name)
             .or_default()
-            .push(CachedLspAdapter::new(adapter, true));
-    }
-
-    pub fn register_secondary_lsp_adapter(
-        &self,
-        language_name: Arc<str>,
-        adapter: Arc<dyn LspAdapter>,
-    ) {
-        self.state
-            .write()
-            .lsp_adapters
-            .entry(language_name)
-            .or_default()
-            .push(CachedLspAdapter::new(adapter, false));
+            .push(CachedLspAdapter::new(adapter));
     }
 
     #[cfg(any(feature = "test-support", test))]
@@ -295,14 +282,13 @@ impl LanguageRegistry {
         language_name: &str,
         adapter: crate::FakeLspAdapter,
     ) -> futures::channel::mpsc::UnboundedReceiver<lsp::FakeLanguageServer> {
-        self.register_specific_fake_lsp_adapter(language_name, true, adapter)
+        self.register_specific_fake_lsp_adapter(language_name, adapter)
     }
 
     #[cfg(any(feature = "test-support", test))]
     pub fn register_specific_fake_lsp_adapter(
         &self,
         language_name: &str,
-        primary: bool,
         adapter: crate::FakeLspAdapter,
     ) -> futures::channel::mpsc::UnboundedReceiver<lsp::FakeLanguageServer> {
         self.state
@@ -310,7 +296,7 @@ impl LanguageRegistry {
             .lsp_adapters
             .entry(language_name.into())
             .or_default()
-            .push(CachedLspAdapter::new(Arc::new(adapter), primary));
+            .push(CachedLspAdapter::new(Arc::new(adapter)));
         self.fake_language_servers(language_name)
     }
 

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -232,7 +232,7 @@ pub fn init(
     ];
 
     for language in tailwind_languages {
-        languages.register_secondary_lsp_adapter(
+        languages.register_lsp_adapter(
             language.into(),
             Arc::new(tailwind::TailwindLspAdapter::new(node_runtime.clone())),
         );
@@ -240,7 +240,7 @@ pub fn init(
 
     let eslint_languages = ["TSX", "TypeScript", "JavaScript", "Vue.js", "Svelte"];
     for language in eslint_languages {
-        languages.register_secondary_lsp_adapter(
+        languages.register_lsp_adapter(
             language.into(),
             Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone())),
         );

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -4623,9 +4623,8 @@ async fn test_multiple_language_server_hovers(cx: &mut gpui::TestAppContext) {
         "ESLintServer",
         "NoHoverCapabilitiesServer",
     ];
-    let mut fake_tsx_language_servers = language_registry.register_specific_fake_lsp_adapter(
+    let mut fake_tsx_language_servers = language_registry.register_fake_lsp_adapter(
         "tsx",
-        true,
         FakeLspAdapter {
             name: &language_server_names[0],
             capabilities: lsp::ServerCapabilities {
@@ -4635,9 +4634,8 @@ async fn test_multiple_language_server_hovers(cx: &mut gpui::TestAppContext) {
             ..FakeLspAdapter::default()
         },
     );
-    let _a = language_registry.register_specific_fake_lsp_adapter(
+    let _a = language_registry.register_fake_lsp_adapter(
         "tsx",
-        false,
         FakeLspAdapter {
             name: &language_server_names[1],
             capabilities: lsp::ServerCapabilities {
@@ -4647,9 +4645,8 @@ async fn test_multiple_language_server_hovers(cx: &mut gpui::TestAppContext) {
             ..FakeLspAdapter::default()
         },
     );
-    let _b = language_registry.register_specific_fake_lsp_adapter(
+    let _b = language_registry.register_fake_lsp_adapter(
         "tsx",
-        false,
         FakeLspAdapter {
             name: &language_server_names[2],
             capabilities: lsp::ServerCapabilities {
@@ -4659,9 +4656,8 @@ async fn test_multiple_language_server_hovers(cx: &mut gpui::TestAppContext) {
             ..FakeLspAdapter::default()
         },
     );
-    let _c = language_registry.register_specific_fake_lsp_adapter(
+    let _c = language_registry.register_fake_lsp_adapter(
         "tsx",
-        false,
         FakeLspAdapter {
             name: &language_server_names[3],
             capabilities: lsp::ServerCapabilities {
@@ -4847,9 +4843,8 @@ async fn test_multiple_language_server_actions(cx: &mut gpui::TestAppContext) {
         "ESLintServer",
         "NoActionsCapabilitiesServer",
     ];
-    let mut fake_tsx_language_servers = language_registry.register_specific_fake_lsp_adapter(
+    let mut fake_tsx_language_servers = language_registry.register_fake_lsp_adapter(
         "tsx",
-        true,
         FakeLspAdapter {
             name: &language_server_names[0],
             capabilities: lsp::ServerCapabilities {
@@ -4859,9 +4854,8 @@ async fn test_multiple_language_server_actions(cx: &mut gpui::TestAppContext) {
             ..FakeLspAdapter::default()
         },
     );
-    let _a = language_registry.register_specific_fake_lsp_adapter(
+    let _a = language_registry.register_fake_lsp_adapter(
         "tsx",
-        false,
         FakeLspAdapter {
             name: &language_server_names[1],
             capabilities: lsp::ServerCapabilities {
@@ -4871,9 +4865,8 @@ async fn test_multiple_language_server_actions(cx: &mut gpui::TestAppContext) {
             ..FakeLspAdapter::default()
         },
     );
-    let _b = language_registry.register_specific_fake_lsp_adapter(
+    let _b = language_registry.register_fake_lsp_adapter(
         "tsx",
-        false,
         FakeLspAdapter {
             name: &language_server_names[2],
             capabilities: lsp::ServerCapabilities {
@@ -4883,9 +4876,8 @@ async fn test_multiple_language_server_actions(cx: &mut gpui::TestAppContext) {
             ..FakeLspAdapter::default()
         },
     );
-    let _c = language_registry.register_specific_fake_lsp_adapter(
+    let _c = language_registry.register_fake_lsp_adapter(
         "tsx",
-        false,
         FakeLspAdapter {
             name: &language_server_names[3],
             capabilities: lsp::ServerCapabilities {


### PR DESCRIPTION
This PR removes the primary/secondary distinction for `CachedLspAdapter`s.

After #15624 we weren't relying on the `is_primary` field anywhere, so we can remove it.

Release Notes:

- N/A
