### PR TITLE
Rename `zed.dev/settings` to `zed.dev/account`

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -153,7 +153,7 @@ async fn create_billing_subscription(
             quantity: Some(1),
             ..Default::default()
         }]);
-        let success_url = format!("{}/settings", app.config.zed_dot_dev_url());
+        let success_url = format!("{}/account", app.config.zed_dot_dev_url());
         params.success_url = Some(&success_url);
 
         CheckoutSession::create(&stripe_client, params).await?
@@ -261,7 +261,7 @@ async fn manage_billing_subscription(
             after_completion: Some(CreateBillingPortalSessionFlowDataAfterCompletion {
                 type_: stripe::CreateBillingPortalSessionFlowDataAfterCompletionType::Redirect,
                 redirect: Some(CreateBillingPortalSessionFlowDataAfterCompletionRedirect {
-                    return_url: format!("{}/settings", app.config.zed_dot_dev_url()),
+                    return_url: format!("{}/account", app.config.zed_dot_dev_url()),
                 }),
                 ..Default::default()
             }),
@@ -278,7 +278,7 @@ async fn manage_billing_subscription(
 
     let mut params = CreateBillingPortalSession::new(customer_id);
     params.flow_data = Some(flow);
-    let return_url = format!("{}/settings", app.config.zed_dot_dev_url());
+    let return_url = format!("{}/account", app.config.zed_dot_dev_url());
     params.return_url = Some(&return_url);
 
     let session = BillingPortalSession::create(&stripe_client, params).await?;

--- a/crates/language_model/src/provider/cloud.rs
+++ b/crates/language_model/src/provider/cloud.rs
@@ -402,7 +402,7 @@ impl ConfigurationView {
 impl Render for ConfigurationView {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         const ZED_AI_URL: &str = "https://zed.dev/ai";
-        const ACCOUNT_SETTINGS_URL: &str = "https://zed.dev/settings";
+        const ACCOUNT_SETTINGS_URL: &str = "https://zed.dev/account";
 
         let is_connected = self.state.read(cx).is_connected();
         let plan = self.state.read(cx).user_store.read(cx).current_plan();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -425,7 +425,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut AppContext) {
             .register_action(
                 |_: &mut Workspace, _: &OpenAccountSettings, cx: &mut ViewContext<Workspace>| {
                     let server_url = &client::ClientSettings::get_global(cx).server_url;
-                    cx.open_url(&format!("{server_url}/settings"));
+                    cx.open_url(&format!("{server_url}/account"));
                 },
             )
             .register_action(


### PR DESCRIPTION
This PR renames the links to the `zed.dev/settings` page to the `zed.dev/account`.

Some of these spots will likely link out to a marketing page later.

Release Notes:

- N/A
