### PR TITLE
Fix scrolling issue with overridden cards

### DIFF
--- a/crates/extensions_ui/src/components/extension_card.rs
+++ b/crates/extensions_ui/src/components/extension_card.rs
@@ -48,7 +48,6 @@ impl RenderOnce for ExtensionCard {
                             .absolute()
                             .top_0()
                             .left_0()
-                            .occlude()
                             .size_full()
                             .items_center()
                             .justify_center()

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -587,6 +587,7 @@ impl ExtensionsPage {
                                     SharedString::from(format!("repository-{}", extension.id)),
                                     IconName::Github,
                                 )
+                                .disabled(has_dev_extension)
                                 .icon_color(Color::Accent)
                                 .icon_size(IconSize::Small)
                                 .style(ButtonStyle::Filled)
@@ -608,6 +609,7 @@ impl ExtensionsPage {
                                         SharedString::from(format!("more-{}", extension.id)),
                                         IconName::Ellipsis,
                                     )
+                                    .disabled(has_dev_extension)
                                     .icon_color(Color::Accent)
                                     .icon_size(IconSize::Small)
                                     .style(ButtonStyle::Filled),
@@ -690,7 +692,7 @@ impl ExtensionsPage {
             // If we have a dev extension for the given extension, just treat it as uninstalled.
             // The button here is a placeholder, as it won't be interactable anyways.
             return (
-                Button::new(SharedString::from(extension.id.clone()), "Install"),
+                Button::new(SharedString::from(extension.id.clone()), "Install").disabled(true),
                 None,
             );
         }


### PR DESCRIPTION
Release Notes:

- Fixed a scrolling issue in the extensions panel when the pointer is above an overridden extension

When scrolling in the extensions panel, when the cursor passes over an overridden extension, the scrolling is interrupted since the card has an occluded overlay.

Before:

https://github.com/user-attachments/assets/54fa3196-e748-49b6-a051-5f112fcc1329

After:

https://github.com/user-attachments/assets/7afe13a2-741b-4209-8c57-15c8db67f63a

I'm still understanding GPUI but I was not able to understand how to enabling scrolling while keeping the overlay occluded. I was also unable to prevent hover events from going to children without `occlude` (otherwise scrolling over the buttons highlights them). I tried `on_hover()` with a `cx.stop_propagation()` but that didn't work. Had to disable the buttons in the end which results in the cursor changing:
![zed](https://github.com/user-attachments/assets/54d3321a-6842-47e0-be02-c40b67c014e9)

