### PR TITLE
Fix `.env.toml` paths

### DIFF
--- a/crates/collab/src/bin/dotenv.rs
+++ b/crates/collab/src/bin/dotenv.rs
@@ -1,7 +1,7 @@
 use collab::env::get_dotenv_vars;
 
 fn main() -> anyhow::Result<()> {
-    for (key, value) in get_dotenv_vars()? {
+    for (key, value) in get_dotenv_vars(".")? {
         println!("export {}=\"{}\"", key, value);
     }
     Ok(())

--- a/crates/collab/src/env.rs
+++ b/crates/collab/src/env.rs
@@ -1,14 +1,17 @@
 use anyhow::{anyhow, Result};
 use std::fs;
+use std::path::Path;
 
-pub fn get_dotenv_vars() -> Result<Vec<(String, String)>> {
+pub fn get_dotenv_vars(current_dir: impl AsRef<Path>) -> Result<Vec<(String, String)>> {
+    let current_dir = current_dir.as_ref();
+
     let mut vars = Vec::new();
-    let env_content = fs::read_to_string("./crates/collab/.env.toml")
+    let env_content = fs::read_to_string(current_dir.join(".env.toml"))
         .map_err(|_| anyhow!("no .env.toml file found"))?;
 
     add_vars(env_content, &mut vars)?;
 
-    if let Ok(secret_content) = fs::read_to_string("./crates/collab/.env.secret.toml") {
+    if let Ok(secret_content) = fs::read_to_string(current_dir.join(".env.secret.toml")) {
         add_vars(secret_content, &mut vars)?;
     }
 
@@ -16,7 +19,7 @@ pub fn get_dotenv_vars() -> Result<Vec<(String, String)>> {
 }
 
 pub fn load_dotenv() -> Result<()> {
-    for (key, value) in get_dotenv_vars()? {
+    for (key, value) in get_dotenv_vars("./crates/collab")? {
         std::env::set_var(key, value);
     }
     Ok(())


### PR DESCRIPTION
This PR fixes the `.env.toml` paths, since we inadvertently broke them in https://github.com/zed-industries/zed/pull/15557.

There's likely a better way we can do this, but I wanted to restore the previous behavior, for now.

Release Notes:

- N/A
