### PR TITLE
Relax "test" runnable check

### DIFF
--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -13,7 +13,7 @@
             [((identifier) @_attribute)
                 (scoped_identifier (identifier) @_attribute)
                 ])
-            (#eq? @_attribute "test")
+            (#match? @_attribute "test")
         ) @start
         .
         (attribute_item) *


### PR DESCRIPTION
This commit updates the Tree-sitter query to match Rust attributes containing the word "test". The previous query only matched attributes with the exact string "test", which was too restrictive for custom test macros like https://docs.rs/test-log/0.2.10/test_log/#

Discussion - https://github.com/zed-industries/zed/discussions/15580

Release Notes:

- Rust test detection now works for attributes containing `test` substring.