### PR TITLE
assistant: Only insert the host's default prompt when creating a new context

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -795,7 +795,7 @@ impl AssistantPanel {
                     let weak_assistant_panel = cx.view().downgrade();
 
                     let editor = cx.new_view(|cx| {
-                        let mut editor = ContextEditor::for_context(
+                        ContextEditor::for_context(
                             context,
                             fs,
                             workspace,
@@ -803,9 +803,7 @@ impl AssistantPanel {
                             lsp_adapter_delegate,
                             weak_assistant_panel,
                             cx,
-                        );
-                        editor.insert_default_prompt(cx);
-                        editor
+                        )
                     });
 
                     this.show_context(editor, cx);


### PR DESCRIPTION
This PR fixes an issue where creating a new context as a guest would insert multiple default prompts: one for the host and one for the guest.

When creating a new context as a guest while collaborating, we should only use the host's default prompt.

Release Notes:

- N/A
