### PR TITLE
Fix inline assist deletion blocks

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1015,6 +1015,7 @@ impl InlineAssistant {
                         div()
                             .bg(cx.theme().status().deleted_background)
                             .size_full()
+                            .h(height as f32 * cx.line_height())
                             .pl(cx.gutter_dimensions.full_width())
                             .child(deleted_lines_editor.clone())
                             .into_any_element()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2373,7 +2373,7 @@ impl EditorElement {
         };
 
         if let BlockId::Custom(custom_block_id) = block_id {
-            let element_height_in_lines = (final_size.height / line_height).ceil() as u32;
+            let element_height_in_lines = ((final_size.height / line_height).ceil() as u32).max(1);
             if element_height_in_lines != block.height() {
                 resized_blocks.insert(custom_block_id, element_height_in_lines);
             }


### PR DESCRIPTION
After the changes in #15536, block decorations need to be given an explicit height if their content doesn't consume height on its own. We missed that inline transformation deletion decorations didn't do this, creating weird results. This fixes the issue and prevents block decorations from ever having a zero height. That helps avoid major weirdness, but this still a bit of a gotcha.

We need to back port this to Preview Channel (0.147.x)

Release Notes:

- N/A
