### PR TITLE
Fix corner radius when doing `rounded_full`

### DIFF
--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -1902,20 +1902,20 @@ where
 
 impl Corners<AbsoluteLength> {
     /// Converts the `AbsoluteLength` to `Pixels` based on the provided size and rem size, ensuring the resulting
-    /// `Pixels` do not exceed half of the maximum of the provided size's width and height.
+    /// `Pixels` do not exceed half of the minimum of the provided size's width and height.
     ///
     /// This method is particularly useful when dealing with corner radii, where the radius in pixels should not
     /// exceed half the size of the box it applies to, to avoid the corners overlapping.
     ///
     /// # Arguments
     ///
-    /// * `size` - The `Size<Pixels>` against which the maximum allowable radius is determined.
+    /// * `size` - The `Size<Pixels>` against which the minimum allowable radius is determined.
     /// * `rem_size` - The size of one REM unit in pixels, used for conversion if the `AbsoluteLength` is in REMs.
     ///
     /// # Returns
     ///
     /// Returns a `Corners<Pixels>` instance with each corner's length converted to pixels and clamped to the
-    /// maximum allowable radius based on the provided size.
+    /// minimum allowable radius based on the provided size.
     ///
     /// # Examples
     ///
@@ -1924,7 +1924,7 @@ impl Corners<AbsoluteLength> {
     /// let corners = Corners {
     ///     top_left: AbsoluteLength::Pixels(Pixels(15.0)),
     ///     top_right: AbsoluteLength::Rems(Rems(1.0)),
-    ///     bottom_right: AbsoluteLength::Pixels(Pixels(20.0)),
+    ///     bottom_right: AbsoluteLength::Pixels(Pixels(30.0)),
     ///     bottom_left: AbsoluteLength::Rems(Rems(2.0)),
     /// };
     /// let size = Size { width: Pixels(100.0), height: Pixels(50.0) };
@@ -1934,11 +1934,11 @@ impl Corners<AbsoluteLength> {
     /// // The resulting corners should not exceed half the size of the smallest dimension (50.0 / 2.0 = 25.0).
     /// assert_eq!(corners_in_pixels.top_left, Pixels(15.0));
     /// assert_eq!(corners_in_pixels.top_right, Pixels(16.0)); // 1 rem converted to pixels
-    /// assert_eq!(corners_in_pixels.bottom_right, Pixels(20.0).min(Pixels(25.0))); // Clamped to 25.0
-    /// assert_eq!(corners_in_pixels.bottom_left, Pixels(32.0).min(Pixels(25.0))); // 2 rems converted to pixels and clamped
+    /// assert_eq!(corners_in_pixels.bottom_right, Pixels(30.0).min(Pixels(25.0))); // Clamped to 25.0
+    /// assert_eq!(corners_in_pixels.bottom_left, Pixels(32.0).min(Pixels(25.0))); // 2 rems converted to pixels and clamped to 25.0
     /// ```
     pub fn to_pixels(&self, size: Size<Pixels>, rem_size: Pixels) -> Corners<Pixels> {
-        let max = size.width.max(size.height) / 2.;
+        let max = size.width.min(size.height) / 2.;
         Corners {
             top_left: self.top_left.to_pixels(rem_size).min(max),
             top_right: self.top_right.to_pixels(rem_size).min(max),


### PR DESCRIPTION
Release Notes:

- Fixed issue when doing `rounded_full`, it should render a pill-shape rect instead of current eye-shape.

For example with this code `div().h_4().w_16().bg(rgb(0xffffff)).rounded_full()`

Current:

<img width="144" alt="image" src="https://github.com/user-attachments/assets/f8b20c7c-d91f-4c20-9f38-d435f59e72b7">

Fixed:

<img width="172" alt="image" src="https://github.com/user-attachments/assets/ff8bbe26-2b31-4ef1-a2fb-25b458386ffb">
