### PR TITLE
assistant panel: Tab-less configuration view

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3014,7 +3014,6 @@ impl ConfigurationView {
         let focus_handle = cx.focus_handle();
         let providers = LanguageModelRegistry::read_global(cx).providers();
 
-        println!("ConfigurationView::new");
         let configuration_views = providers
             .iter()
             .map(|provider| (provider.id(), provider.configuration_view(cx)))

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -9,9 +9,7 @@ pub mod settings;
 use anyhow::Result;
 use client::{Client, UserStore};
 use futures::{future::BoxFuture, stream::BoxStream};
-use gpui::{
-    AnyView, AppContext, AsyncAppContext, FocusHandle, Model, SharedString, Task, WindowContext,
-};
+use gpui::{AnyView, AppContext, AsyncAppContext, Model, SharedString, Task, WindowContext};
 pub use model::*;
 use project::Fs;
 use proto::Plan;
@@ -110,7 +108,7 @@ pub trait LanguageModelProvider: 'static {
     fn load_model(&self, _model: Arc<dyn LanguageModel>, _cx: &AppContext) {}
     fn is_authenticated(&self, cx: &AppContext) -> bool;
     fn authenticate(&self, cx: &mut AppContext) -> Task<Result<()>>;
-    fn configuration_view(&self, cx: &mut WindowContext) -> (AnyView, Option<FocusHandle>);
+    fn configuration_view(&self, cx: &mut WindowContext) -> AnyView;
     fn reset_credentials(&self, cx: &mut AppContext) -> Task<Result<()>>;
 }
 

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -19,6 +19,7 @@ use std::{sync::Arc, time::Duration};
 use strum::IntoEnumIterator;
 use theme::ThemeSettings;
 use ui::{prelude::*, Indicator};
+use util::ResultExt;
 
 const PROVIDER_ID: &str = "anthropic";
 const PROVIDER_NAME: &str = "Anthropic";
@@ -192,7 +193,8 @@ impl LanguageModelProvider for AnthropicLanguageModelProvider {
     }
 
     fn configuration_view(&self, cx: &mut WindowContext) -> AnyView {
-        cx.new_view(|cx| ConfigurationView::new(self.state.clone(), cx))
+        let authenticate = self.authenticate(cx);
+        cx.new_view(|cx| ConfigurationView::new(authenticate, self.state.clone(), cx))
             .into()
     }
 
@@ -384,16 +386,32 @@ impl LanguageModel for AnthropicModel {
 struct ConfigurationView {
     api_key_editor: View<Editor>,
     state: gpui::Model<State>,
+    load_credentials_task: Option<Task<()>>,
 }
 
 impl ConfigurationView {
     const PLACEHOLDER_TEXT: &'static str = "sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
-    fn new(state: gpui::Model<State>, cx: &mut ViewContext<Self>) -> Self {
+    fn new(
+        authenticate: Task<Result<()>>,
+        state: gpui::Model<State>,
+        cx: &mut ViewContext<Self>,
+    ) -> Self {
         cx.observe(&state, |_, _, cx| {
             cx.notify();
         })
         .detach();
+
+        let load_credentials_task = Some(cx.spawn({
+            |this, mut cx| async move {
+                authenticate.await.log_err();
+                this.update(&mut cx, |this, cx| {
+                    this.load_credentials_task = None;
+                    cx.notify();
+                })
+                .log_err();
+            }
+        }));
 
         Self {
             api_key_editor: cx.new_view(|cx| {
@@ -402,6 +420,7 @@ impl ConfigurationView {
                 editor
             }),
             state,
+            load_credentials_task,
         }
     }
 
@@ -478,7 +497,9 @@ impl Render for ConfigurationView {
             "Paste your Anthropic API key below and hit enter to use the assistant:",
         ];
 
-        if self.should_render_editor(cx) {
+        if self.load_credentials_task.is_some() {
+            div().child(Label::new("Loading credentials...")).into_any()
+        } else if self.should_render_editor(cx) {
             v_flex()
                 .size_full()
                 .on_action(cx.listener(Self::save_api_key))

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -510,7 +510,7 @@ impl Render for ConfigurationView {
                     h_flex()
                         .gap_2()
                         .child(Indicator::dot().color(Color::Success))
-                        .child(Label::new("API Key configured").size(LabelSize::Small)),
+                        .child(Label::new("API key configured").size(LabelSize::Small)),
                 )
                 .child(
                     Button::new("reset-key", "Reset key")

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -408,7 +408,8 @@ impl ConfigurationView {
                     .update(&mut cx, |state, cx| state.authenticate(cx))
                     .log_err()
                 {
-                    task.await.log_err();
+                    // We don't log an error, because "not signed in" is also an error.
+                    let _ = task.await;
                 }
                 this.update(&mut cx, |this, cx| {
                     this.load_credentials_task = None;

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -84,6 +84,34 @@ impl State {
     fn is_authenticated(&self) -> bool {
         self.api_key.is_some()
     }
+
+    fn authenticate(&self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        if self.is_authenticated() {
+            Task::ready(Ok(()))
+        } else {
+            let api_url = AllLanguageModelSettings::get_global(cx)
+                .anthropic
+                .api_url
+                .clone();
+
+            cx.spawn(|this, mut cx| async move {
+                let api_key = if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
+                    api_key
+                } else {
+                    let (_, api_key) = cx
+                        .update(|cx| cx.read_credentials(&api_url))?
+                        .await?
+                        .ok_or_else(|| anyhow!("credentials not found"))?;
+                    String::from_utf8(api_key)?
+                };
+
+                this.update(&mut cx, |this, cx| {
+                    this.api_key = Some(api_key);
+                    cx.notify();
+                })
+            })
+        }
+    }
 }
 
 impl AnthropicLanguageModelProvider {
@@ -165,36 +193,11 @@ impl LanguageModelProvider for AnthropicLanguageModelProvider {
     }
 
     fn authenticate(&self, cx: &mut AppContext) -> Task<Result<()>> {
-        if self.is_authenticated(cx) {
-            Task::ready(Ok(()))
-        } else {
-            let api_url = AllLanguageModelSettings::get_global(cx)
-                .anthropic
-                .api_url
-                .clone();
-            let state = self.state.clone();
-            cx.spawn(|mut cx| async move {
-                let api_key = if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
-                    api_key
-                } else {
-                    let (_, api_key) = cx
-                        .update(|cx| cx.read_credentials(&api_url))?
-                        .await?
-                        .ok_or_else(|| anyhow!("credentials not found"))?;
-                    String::from_utf8(api_key)?
-                };
-
-                state.update(&mut cx, |this, cx| {
-                    this.api_key = Some(api_key);
-                    cx.notify();
-                })
-            })
-        }
+        self.state.update(cx, |state, cx| state.authenticate(cx))
     }
 
     fn configuration_view(&self, cx: &mut WindowContext) -> AnyView {
-        let authenticate = self.authenticate(cx);
-        cx.new_view(|cx| ConfigurationView::new(authenticate, self.state.clone(), cx))
+        cx.new_view(|cx| ConfigurationView::new(self.state.clone(), cx))
             .into()
     }
 
@@ -392,19 +395,21 @@ struct ConfigurationView {
 impl ConfigurationView {
     const PLACEHOLDER_TEXT: &'static str = "sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
-    fn new(
-        authenticate: Task<Result<()>>,
-        state: gpui::Model<State>,
-        cx: &mut ViewContext<Self>,
-    ) -> Self {
+    fn new(state: gpui::Model<State>, cx: &mut ViewContext<Self>) -> Self {
         cx.observe(&state, |_, _, cx| {
             cx.notify();
         })
         .detach();
 
         let load_credentials_task = Some(cx.spawn({
+            let state = state.clone();
             |this, mut cx| async move {
-                authenticate.await.log_err();
+                if let Some(task) = state
+                    .update(&mut cx, |state, cx| state.authenticate(cx))
+                    .log_err()
+                {
+                    task.await.log_err();
+                }
                 this.update(&mut cx, |this, cx| {
                     this.load_credentials_task = None;
                     cx.notify();

--- a/crates/language_model/src/provider/cloud.rs
+++ b/crates/language_model/src/provider/cloud.rs
@@ -8,9 +8,7 @@ use anyhow::{anyhow, Context as _, Result};
 use client::{Client, UserStore};
 use collections::BTreeMap;
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
-use gpui::{
-    AnyView, AppContext, AsyncAppContext, FocusHandle, Model, ModelContext, Subscription, Task,
-};
+use gpui::{AnyView, AppContext, AsyncAppContext, Model, ModelContext, Subscription, Task};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
@@ -198,13 +196,11 @@ impl LanguageModelProvider for CloudLanguageModelProvider {
         Task::ready(Ok(()))
     }
 
-    fn configuration_view(&self, cx: &mut WindowContext) -> (AnyView, Option<FocusHandle>) {
-        let view = cx
-            .new_view(|_cx| ConfigurationView {
-                state: self.state.clone(),
-            })
-            .into();
-        (view, None)
+    fn configuration_view(&self, cx: &mut WindowContext) -> AnyView {
+        cx.new_view(|_cx| ConfigurationView {
+            state: self.state.clone(),
+        })
+        .into()
     }
 
     fn reset_credentials(&self, _cx: &mut AppContext) -> Task<Result<()>> {

--- a/crates/language_model/src/provider/cloud.rs
+++ b/crates/language_model/src/provider/cloud.rs
@@ -58,8 +58,8 @@ pub struct State {
 }
 
 impl State {
-    fn is_connected(&self) -> bool {
-        self.status.is_connected()
+    fn is_signed_out(&self) -> bool {
+        self.status.is_signed_out()
     }
 
     fn authenticate(&self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
@@ -189,7 +189,7 @@ impl LanguageModelProvider for CloudLanguageModelProvider {
     }
 
     fn is_authenticated(&self, cx: &AppContext) -> bool {
-        self.state.read(cx).status.is_connected()
+        !self.state.read(cx).is_signed_out()
     }
 
     fn authenticate(&self, _cx: &mut AppContext) -> Task<Result<()>> {
@@ -435,7 +435,7 @@ impl Render for ConfigurationView {
         const ZED_AI_URL: &str = "https://zed.dev/ai";
         const ACCOUNT_SETTINGS_URL: &str = "https://zed.dev/account";
 
-        let is_connected = self.state.read(cx).is_connected();
+        let is_connected = self.state.read(cx).is_signed_out();
         let plan = self.state.read(cx).user_store.read(cx).current_plan();
 
         let is_pro = plan == Some(proto::Plan::ZedPro);

--- a/crates/language_model/src/provider/copilot_chat.rs
+++ b/crates/language_model/src/provider/copilot_chat.rs
@@ -11,8 +11,8 @@ use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt};
 use gpui::{
-    percentage, svg, Animation, AnimationExt, AnyView, AppContext, AsyncAppContext, FocusHandle,
-    Model, Render, Subscription, Task, Transformation,
+    percentage, svg, Animation, AnimationExt, AnyView, AppContext, AsyncAppContext, Model, Render,
+    Subscription, Task, Transformation,
 };
 use settings::{Settings, SettingsStore};
 use std::time::Duration;
@@ -132,10 +132,9 @@ impl LanguageModelProvider for CopilotChatLanguageModelProvider {
         Task::ready(result)
     }
 
-    fn configuration_view(&self, cx: &mut WindowContext) -> (AnyView, Option<FocusHandle>) {
+    fn configuration_view(&self, cx: &mut WindowContext) -> AnyView {
         let state = self.state.clone();
-        let view = cx.new_view(|cx| ConfigurationView::new(state, cx)).into();
-        (view, None)
+        cx.new_view(|cx| ConfigurationView::new(state, cx)).into()
     }
 
     fn reset_credentials(&self, _cx: &mut AppContext) -> Task<Result<()>> {

--- a/crates/language_model/src/provider/fake.rs
+++ b/crates/language_model/src/provider/fake.rs
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::anyhow;
 use collections::HashMap;
 use futures::{channel::mpsc, future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
-use gpui::{AnyView, AppContext, AsyncAppContext, FocusHandle, Task};
+use gpui::{AnyView, AppContext, AsyncAppContext, Task};
 use http_client::Result;
 use std::{
     future,
@@ -66,7 +66,7 @@ impl LanguageModelProvider for FakeLanguageModelProvider {
         Task::ready(Ok(()))
     }
 
-    fn configuration_view(&self, _: &mut WindowContext) -> (AnyView, Option<FocusHandle>) {
+    fn configuration_view(&self, _: &mut WindowContext) -> AnyView {
         unimplemented!()
     }
 

--- a/crates/language_model/src/provider/google.rs
+++ b/crates/language_model/src/provider/google.rs
@@ -327,7 +327,8 @@ impl ConfigurationView {
                     .update(&mut cx, |state, cx| state.authenticate(cx))
                     .log_err()
                 {
-                    task.await.log_err();
+                    // We don't log an error, because "not signed in" is also an error.
+                    let _ = task.await;
                 }
                 this.update(&mut cx, |this, cx| {
                     this.load_credentials_task = None;

--- a/crates/language_model/src/provider/ollama.rs
+++ b/crates/language_model/src/provider/ollama.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
-use gpui::{AnyView, AppContext, AsyncAppContext, FocusHandle, ModelContext, Subscription, Task};
+use gpui::{AnyView, AppContext, AsyncAppContext, ModelContext, Subscription, Task};
 use http_client::HttpClient;
 use ollama::{
     get_models, preload_model, stream_chat_completion, ChatMessage, ChatOptions, ChatRequest,
@@ -149,12 +149,9 @@ impl LanguageModelProvider for OllamaLanguageModelProvider {
         }
     }
 
-    fn configuration_view(&self, cx: &mut WindowContext) -> (AnyView, Option<FocusHandle>) {
+    fn configuration_view(&self, cx: &mut WindowContext) -> AnyView {
         let state = self.state.clone();
-        (
-            cx.new_view(|cx| ConfigurationView::new(state, cx)).into(),
-            None,
-        )
+        cx.new_view(|cx| ConfigurationView::new(state, cx)).into()
     }
 
     fn reset_credentials(&self, cx: &mut AppContext) -> Task<Result<()>> {

--- a/crates/language_model/src/provider/ollama.rs
+++ b/crates/language_model/src/provider/ollama.rs
@@ -8,6 +8,7 @@ use ollama::{
 use settings::{Settings, SettingsStore};
 use std::{future, sync::Arc, time::Duration};
 use ui::{prelude::*, ButtonLike, Indicator};
+use util::ResultExt;
 
 use crate::{
     settings::AllLanguageModelSettings, LanguageModel, LanguageModelId, LanguageModelName,
@@ -69,6 +70,14 @@ impl State {
                 cx.notify();
             })
         })
+    }
+
+    fn authenticate(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        if self.is_authenticated() {
+            Task::ready(Ok(()))
+        } else {
+            self.fetch_models(cx)
+        }
     }
 }
 
@@ -142,11 +151,7 @@ impl LanguageModelProvider for OllamaLanguageModelProvider {
     }
 
     fn authenticate(&self, cx: &mut AppContext) -> Task<Result<()>> {
-        if self.is_authenticated(cx) {
-            Task::ready(Ok(()))
-        } else {
-            self.state.update(cx, |state, cx| state.fetch_models(cx))
-        }
+        self.state.update(cx, |state, cx| state.authenticate(cx))
     }
 
     fn configuration_view(&self, cx: &mut WindowContext) -> AnyView {
@@ -293,11 +298,32 @@ impl LanguageModel for OllamaLanguageModel {
 
 struct ConfigurationView {
     state: gpui::Model<State>,
+    loading_models_task: Option<Task<()>>,
 }
 
 impl ConfigurationView {
-    pub fn new(state: gpui::Model<State>, _cx: &mut ViewContext<Self>) -> Self {
-        Self { state }
+    pub fn new(state: gpui::Model<State>, cx: &mut ViewContext<Self>) -> Self {
+        let loading_models_task = Some(cx.spawn({
+            let state = state.clone();
+            |this, mut cx| async move {
+                if let Some(task) = state
+                    .update(&mut cx, |state, cx| state.authenticate(cx))
+                    .log_err()
+                {
+                    task.await.log_err();
+                }
+                this.update(&mut cx, |this, cx| {
+                    this.loading_models_task = None;
+                    cx.notify();
+                })
+                .log_err();
+            }
+        }));
+
+        Self {
+            state,
+            loading_models_task,
+        }
     }
 
     fn retry_connection(&self, cx: &mut WindowContext) {
@@ -318,94 +344,101 @@ impl Render for ConfigurationView {
         let mut inline_code_bg = cx.theme().colors().editor_background;
         inline_code_bg.fade_out(0.5);
 
-        v_flex()
-            .size_full()
-            .gap_3()
-            .child(
-                v_flex()
-                    .size_full()
-                    .gap_2()
-                    .p_1()
-                    .child(Label::new(ollama_intro))
-                    .child(Label::new(ollama_reqs))
-                    .child(
-                        h_flex()
-                            .gap_0p5()
-                            .child(Label::new("Once installed, try "))
-                            .child(
-                                div()
-                                    .bg(inline_code_bg)
-                                    .px_1p5()
-                                    .rounded_md()
-                                    .child(Label::new("ollama run llama3.1")),
-                            ),
-                    ),
-            )
-            .child(
-                h_flex()
-                    .w_full()
-                    .pt_2()
-                    .justify_between()
-                    .gap_2()
-                    .child(
-                        h_flex()
-                            .w_full()
-                            .gap_2()
-                            .map(|this| {
-                                if is_authenticated {
-                                    this.child(
-                                        Button::new("ollama-site", "Ollama")
-                                            .style(ButtonStyle::Subtle)
-                                            .icon(IconName::ExternalLink)
-                                            .icon_size(IconSize::XSmall)
-                                            .icon_color(Color::Muted)
-                                            .on_click(move |_, cx| cx.open_url(OLLAMA_SITE))
-                                            .into_any_element(),
-                                    )
-                                } else {
-                                    this.child(
-                                        Button::new("download_ollama_button", "Download Ollama")
+        if self.loading_models_task.is_some() {
+            div().child(Label::new("Loading models...")).into_any()
+        } else {
+            v_flex()
+                .size_full()
+                .gap_3()
+                .child(
+                    v_flex()
+                        .size_full()
+                        .gap_2()
+                        .p_1()
+                        .child(Label::new(ollama_intro))
+                        .child(Label::new(ollama_reqs))
+                        .child(
+                            h_flex()
+                                .gap_0p5()
+                                .child(Label::new("Once installed, try "))
+                                .child(
+                                    div()
+                                        .bg(inline_code_bg)
+                                        .px_1p5()
+                                        .rounded_md()
+                                        .child(Label::new("ollama run llama3.1")),
+                                ),
+                        ),
+                )
+                .child(
+                    h_flex()
+                        .w_full()
+                        .pt_2()
+                        .justify_between()
+                        .gap_2()
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .gap_2()
+                                .map(|this| {
+                                    if is_authenticated {
+                                        this.child(
+                                            Button::new("ollama-site", "Ollama")
+                                                .style(ButtonStyle::Subtle)
+                                                .icon(IconName::ExternalLink)
+                                                .icon_size(IconSize::XSmall)
+                                                .icon_color(Color::Muted)
+                                                .on_click(move |_, cx| cx.open_url(OLLAMA_SITE))
+                                                .into_any_element(),
+                                        )
+                                    } else {
+                                        this.child(
+                                            Button::new(
+                                                "download_ollama_button",
+                                                "Download Ollama",
+                                            )
                                             .style(ButtonStyle::Subtle)
                                             .icon(IconName::ExternalLink)
                                             .icon_size(IconSize::XSmall)
                                             .icon_color(Color::Muted)
                                             .on_click(move |_, cx| cx.open_url(OLLAMA_DOWNLOAD_URL))
                                             .into_any_element(),
-                                    )
-                                }
-                            })
-                            .child(
-                                Button::new("view-models", "All Models")
-                                    .style(ButtonStyle::Subtle)
-                                    .icon(IconName::ExternalLink)
-                                    .icon_size(IconSize::XSmall)
-                                    .icon_color(Color::Muted)
-                                    .on_click(move |_, cx| cx.open_url(OLLAMA_LIBRARY_URL)),
-                            ),
-                    )
-                    .child(if is_authenticated {
-                        // This is only a button to ensure the spacing is correct
-                        // it should stay disabled
-                        ButtonLike::new("connected")
-                            .disabled(true)
-                            // Since this won't ever be clickable, we can use the arrow cursor
-                            .cursor_style(gpui::CursorStyle::Arrow)
-                            .child(
-                                h_flex()
-                                    .gap_2()
-                                    .child(Indicator::dot().color(Color::Success))
-                                    .child(Label::new("Connected"))
-                                    .into_any_element(),
-                            )
-                            .into_any_element()
-                    } else {
-                        Button::new("retry_ollama_models", "Connect")
-                            .icon_position(IconPosition::Start)
-                            .icon(IconName::ArrowCircle)
-                            .on_click(cx.listener(move |this, _, cx| this.retry_connection(cx)))
-                            .into_any_element()
-                    }),
-            )
-            .into_any()
+                                        )
+                                    }
+                                })
+                                .child(
+                                    Button::new("view-models", "All Models")
+                                        .style(ButtonStyle::Subtle)
+                                        .icon(IconName::ExternalLink)
+                                        .icon_size(IconSize::XSmall)
+                                        .icon_color(Color::Muted)
+                                        .on_click(move |_, cx| cx.open_url(OLLAMA_LIBRARY_URL)),
+                                ),
+                        )
+                        .child(if is_authenticated {
+                            // This is only a button to ensure the spacing is correct
+                            // it should stay disabled
+                            ButtonLike::new("connected")
+                                .disabled(true)
+                                // Since this won't ever be clickable, we can use the arrow cursor
+                                .cursor_style(gpui::CursorStyle::Arrow)
+                                .child(
+                                    h_flex()
+                                        .gap_2()
+                                        .child(Indicator::dot().color(Color::Success))
+                                        .child(Label::new("Connected"))
+                                        .into_any_element(),
+                                )
+                                .into_any_element()
+                        } else {
+                            Button::new("retry_ollama_models", "Connect")
+                                .icon_position(IconPosition::Start)
+                                .icon(IconName::ArrowCircle)
+                                .on_click(cx.listener(move |this, _, cx| this.retry_connection(cx)))
+                                .into_any_element()
+                        }),
+                )
+                .into_any()
+        }
     }
 }

--- a/crates/language_model/src/provider/open_ai.rs
+++ b/crates/language_model/src/provider/open_ai.rs
@@ -80,6 +80,32 @@ impl State {
             })
         })
     }
+
+    fn authenticate(&self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+        if self.is_authenticated() {
+            Task::ready(Ok(()))
+        } else {
+            let api_url = AllLanguageModelSettings::get_global(cx)
+                .openai
+                .api_url
+                .clone();
+            cx.spawn(|this, mut cx| async move {
+                let api_key = if let Ok(api_key) = std::env::var("OPENAI_API_KEY") {
+                    api_key
+                } else {
+                    let (_, api_key) = cx
+                        .update(|cx| cx.read_credentials(&api_url))?
+                        .await?
+                        .ok_or_else(|| anyhow!("credentials not found"))?;
+                    String::from_utf8(api_key)?
+                };
+                this.update(&mut cx, |this, cx| {
+                    this.api_key = Some(api_key);
+                    cx.notify();
+                })
+            })
+        }
+    }
 }
 
 impl OpenAiLanguageModelProvider {
@@ -159,35 +185,11 @@ impl LanguageModelProvider for OpenAiLanguageModelProvider {
     }
 
     fn authenticate(&self, cx: &mut AppContext) -> Task<Result<()>> {
-        if self.is_authenticated(cx) {
-            Task::ready(Ok(()))
-        } else {
-            let api_url = AllLanguageModelSettings::get_global(cx)
-                .openai
-                .api_url
-                .clone();
-            let state = self.state.clone();
-            cx.spawn(|mut cx| async move {
-                let api_key = if let Ok(api_key) = std::env::var("OPENAI_API_KEY") {
-                    api_key
-                } else {
-                    let (_, api_key) = cx
-                        .update(|cx| cx.read_credentials(&api_url))?
-                        .await?
-                        .ok_or_else(|| anyhow!("credentials not found"))?;
-                    String::from_utf8(api_key)?
-                };
-                state.update(&mut cx, |this, cx| {
-                    this.api_key = Some(api_key);
-                    cx.notify();
-                })
-            })
-        }
+        self.state.update(cx, |state, cx| state.authenticate(cx))
     }
 
     fn configuration_view(&self, cx: &mut WindowContext) -> AnyView {
-        let authenticate = self.authenticate(cx);
-        cx.new_view(|cx| ConfigurationView::new(authenticate, self.state.clone(), cx))
+        cx.new_view(|cx| ConfigurationView::new(self.state.clone(), cx))
             .into()
     }
 
@@ -322,11 +324,7 @@ struct ConfigurationView {
 }
 
 impl ConfigurationView {
-    fn new(
-        authenticate: Task<Result<()>>,
-        state: gpui::Model<State>,
-        cx: &mut ViewContext<Self>,
-    ) -> Self {
+    fn new(state: gpui::Model<State>, cx: &mut ViewContext<Self>) -> Self {
         let api_key_editor = cx.new_view(|cx| {
             let mut editor = Editor::single_line(cx);
             editor.set_placeholder_text("sk-000000000000000000000000000000000000000000000000", cx);
@@ -339,8 +337,14 @@ impl ConfigurationView {
         .detach();
 
         let load_credentials_task = Some(cx.spawn({
+            let state = state.clone();
             |this, mut cx| async move {
-                authenticate.await.log_err();
+                if let Some(task) = state
+                    .update(&mut cx, |state, cx| state.authenticate(cx))
+                    .log_err()
+                {
+                    task.await.log_err();
+                }
                 this.update(&mut cx, |this, cx| {
                     this.load_credentials_task = None;
                     cx.notify();

--- a/crates/language_model/src/provider/open_ai.rs
+++ b/crates/language_model/src/provider/open_ai.rs
@@ -445,7 +445,7 @@ impl Render for ConfigurationView {
                     h_flex()
                         .gap_2()
                         .child(Indicator::dot().color(Color::Success))
-                        .child(Label::new("API Key configured").size(LabelSize::Small)),
+                        .child(Label::new("API key configured").size(LabelSize::Small)),
                 )
                 .child(
                     Button::new("reset-key", "Reset key")

--- a/crates/language_model/src/provider/open_ai.rs
+++ b/crates/language_model/src/provider/open_ai.rs
@@ -343,8 +343,10 @@ impl ConfigurationView {
                     .update(&mut cx, |state, cx| state.authenticate(cx))
                     .log_err()
                 {
-                    task.await.log_err();
+                    // We don't log an error, because "not signed in" is also an error.
+                    let _ = task.await;
                 }
+
                 this.update(&mut cx, |this, cx| {
                     this.load_credentials_task = None;
                     cx.notify();

--- a/crates/language_model/src/provider/open_ai.rs
+++ b/crates/language_model/src/provider/open_ai.rs
@@ -15,7 +15,7 @@ use std::{future, sync::Arc, time::Duration};
 use strum::IntoEnumIterator;
 use theme::ThemeSettings;
 use ui::{prelude::*, Indicator};
-use util::{ResultExt, TryFutureExt};
+use util::ResultExt;
 
 use crate::{
     settings::AllLanguageModelSettings, LanguageModel, LanguageModelId, LanguageModelName,

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -166,11 +166,8 @@ impl LanguageModelRegistry {
             .collect()
     }
 
-    pub fn provider(
-        &self,
-        name: &LanguageModelProviderId,
-    ) -> Option<Arc<dyn LanguageModelProvider>> {
-        self.providers.get(name).cloned()
+    pub fn provider(&self, id: &LanguageModelProviderId) -> Option<Arc<dyn LanguageModelProvider>> {
+        self.providers.get(id).cloned()
     }
 
     pub fn select_active_model(


### PR DESCRIPTION
TODOs for follow-up:
- [ ] When opening panel: nudge user to sign in if they're not signed-in and have no provider configured (or if they're not signed-in and have Zed AI configured)
- [ ] Configuration page is not scrollable
- [ ] Design tweaks

Current status:


https://github.com/user-attachments/assets/d26d65ea-43e8-481b-81a3-b3cba01704a8


Release Notes:

- N/A
