### PR TITLE
assistant: Don't unwrap built-in step resolution prompt

### DIFF
--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1407,7 +1407,7 @@ impl Context {
             async move {
                 let prompt_store = cx.update(|cx| PromptStore::global(cx))?.await?;
 
-                let mut prompt = prompt_store.step_resolution_prompt();
+                let mut prompt = prompt_store.step_resolution_prompt()?;
                 prompt.push_str(&step_text);
 
                 request.messages.push(LanguageModelRequestMessage {

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -1505,15 +1505,15 @@ impl PromptStore {
         self.metadata_cache.read().metadata.first().cloned()
     }
 
-    pub fn step_resolution_prompt(&self) -> String {
-        String::from_utf8(
+    pub fn step_resolution_prompt(&self) -> Result<String> {
+        let path = "prompts/step_resolution.md";
+
+        Ok(String::from_utf8(
             Assets
-                .load("prompts/step_resolution.md")
-                .unwrap()
-                .unwrap()
+                .load(path)?
+                .ok_or_else(|| anyhow!("{path} not found"))?
                 .to_vec(),
-        )
-        .unwrap()
+        )?)
     }
 }
 


### PR DESCRIPTION
This PR removes some `unwrap`s while loading the built-in step resolution prompt.

While these `unwrap`s are safe today, they are relying on some implicit contracts that might change in the future. We're using this in a context where it's easy to propagate an error upwards, so we may as well avoid the `unwrap`s entirely and use a `Result`.

Release Notes:

- N/A
