### PR TITLE
docs: Fix links to "Backend dependencies" setup

### DIFF
--- a/docs/src/development/local-collaboration.md
+++ b/docs/src/development/local-collaboration.md
@@ -1,6 +1,10 @@
 # Local Collaboration
 
-First, make sure you've installed Zed's [backend dependencies](../developing-zed.md#backend-dependencies).
+First, make sure you've installed Zed's backend dependencies for your platform:
+
+- [macOS](./macos.md#backend-dependencies)
+- [Linux](./linux.md#backend-dependencies)
+- [Windows](./windows.md#backend-dependencies)
 
 ## Database setup
 


### PR DESCRIPTION
This PR fixes the links to the "Backend dependencies" section from the local collaboration docs.

We now provide links to the section in the platform-specific development docs.

Release Notes:

- N/A
