### PR TITLE
theme: Use a non-transparent color for the fallback `title_bar.inactive_background`

### DIFF
--- a/crates/theme/src/one_themes.rs
+++ b/crates/theme/src/one_themes.rs
@@ -76,7 +76,7 @@ pub(crate) fn one_dark() -> Theme {
                 icon_accent: blue,
                 status_bar_background: bg,
                 title_bar_background: bg,
-                title_bar_inactive_background: SystemColors::default().transparent,
+                title_bar_inactive_background: bg,
                 toolbar_background: editor,
                 tab_bar_background: bg,
                 tab_inactive_background: bg,


### PR DESCRIPTION
This PR changes the fallback color for the `title_bar.inactive_background` theme property so that the title bar doesn't just disappear when a theme doesn't have a value set.

You're welcome, @naomieow.

Release Notes:

- linux: Changed the fallback color of `title_bar.inactive_background` to a non-transparent value.
