### PR TITLE
repl: Rely on block decorations to size according to content

### DIFF
--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -2,7 +2,7 @@ use crate::components::KernelListItem;
 use crate::KernelStatus;
 use crate::{
     kernels::{Kernel, KernelSpecification, RunningKernel},
-    outputs::{ExecutionStatus, ExecutionView, LineHeight as _},
+    outputs::{ExecutionStatus, ExecutionView},
 };
 use client::telemetry::Telemetry;
 use collections::{HashMap, HashSet};
@@ -82,7 +82,8 @@ impl EditorBlock {
             let invalidation_anchor = buffer.read(cx).read(cx).anchor_before(next_row_start);
             let block = BlockProperties {
                 position: code_range.end,
-                height: (execution_view.num_lines(cx) + 1) as u32,
+                // Take up at least one height for status, allow the editor to determine the real height based on the content from render
+                height: 1,
                 style: BlockStyle::Sticky,
                 render: Self::create_output_area_renderer(execution_view.clone(), on_close.clone()),
                 disposition: BlockDisposition::Below,

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -1,4 +1,4 @@
-use crate::outputs::{ExecutionView, LineHeight};
+use crate::outputs::ExecutionView;
 use alacritty_terminal::vte::{
     ansi::{Attr, Color, NamedColor, Rgb},
     Params, ParamsIter, Parser, Perform,
@@ -7,7 +7,7 @@ use core::iter;
 use gpui::{font, prelude::*, AnyElement, StyledText, TextRun};
 use settings::Settings as _;
 use theme::ThemeSettings;
-use ui::{div, prelude::*, IntoElement, ViewContext, WindowContext};
+use ui::{div, prelude::*, IntoElement, ViewContext};
 
 /// Implements the most basic of terminal output for use by Jupyter outputs
 /// whether:
@@ -92,12 +92,6 @@ impl TerminalOutput {
             .font_family(buffer_font)
             .child(text)
             .into_any_element()
-    }
-}
-
-impl LineHeight for TerminalOutput {
-    fn num_lines(&self, _cx: &mut WindowContext) -> usize {
-        self.handler.buffer.lines().count().max(1)
     }
 }
 


### PR DESCRIPTION
We no longer have to use line height calculations now that https://github.com/zed-industries/zed/pull/15536 is in. Blocks resize according to their content. This fixes up some of the rendering issues on plaintext outputs as well.

Release Notes:

- Fix repl plain text output wrapping around and covering editor text (https://github.com/zed-industries/zed/issues/15491, https://github.com/zed-industries/zed/issues/14855)
