### PR TITLE
Use lowercase command names in initial settings files

### DIFF
--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -3,7 +3,7 @@
 // For information on binding keys, see the Zed
 // documentation: https://zed.dev/docs/key-bindings
 //
-// To see the default key bindings run `zed: Open Default Keymap`
+// To see the default key bindings run `zed: open default keymap`
 // from the command palette.
 [
   {

--- a/assets/settings/initial_user_settings.json
+++ b/assets/settings/initial_user_settings.json
@@ -4,8 +4,8 @@
 // documentation: https://zed.dev/docs/configuring-zed
 //
 // To see all of Zed's default settings without changing your
-// custom settings, run the `zed: Open Default Settings` command
-// from the command palette
+// custom settings, run `zed: open default settings` from the
+// command palette
 {
   "ui_font_size": 16,
   "buffer_font_size": 16,


### PR DESCRIPTION
Release Notes:

- N/A

Making these two comments match what I see in the command palette:

<img width="629" alt="Xnapper-2024-08-03-08 09 26" src="https://github.com/user-attachments/assets/f3eab05b-1560-4b0a-8df2-0eaf5746e422">
