### PR TITLE
repl: Render markdown output from kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8749,6 +8749,7 @@ dependencies = [
  "language",
  "languages",
  "log",
+ "markdown_preview",
  "multi_buffer",
  "project",
  "runtimelib",

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -26,6 +26,7 @@ gpui.workspace = true
 image.workspace = true
 language.workspace = true
 log.workspace = true
+markdown_preview.workspace = true
 multi_buffer.workspace = true
 project.workspace = true
 runtimelib.workspace = true


### PR DESCRIPTION
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/73e03a28-f5e3-4395-a58c-cabd07f57889">

Release Notes:

- Added markdown rendering for Jupyter/REPL outputs. Push Markdown from Deno/Typescript with `Deno.jupyter.md` and in IPython use `IPython.display.Markdown`.