### PR TITLE
Add Nix package

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,40 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+name: "Publish to Cachix"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "*.nix"
+      - "Cargo.lock"
+      - "flake.lock"
+
+jobs:
+  build-and-cache:
+    runs-on: ubuntu-latest
+    if: secrets.CACHIX_TOKEN != null
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: "${{ vars.CACHIX_OWNER || github.repository_owner }}"
+          authToken: "${{ secrets.CACHIX_TOKEN }}"
+      - run: nix build --no-update-lock-file --no-link -L .#zed-editor
+      - run: nix shell .#zed-editor --command echo Ok
+      - run: |
+          ./tooling/nix/update-pins.sh
+          echo "```json" >> $GITHUB_STEP_SUMMARY
+          cat ./tooling/nix/pins.json >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
+        if: failure()
+      - uses: parkerbxyz/suggest-changes@v1
+        if: failure()
+        with:
+          comment: "The Nix pins are out of date, please update them."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on:
       - self-hosted
       - test
+    if: github.repository_owner == 'zed-industries'
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -88,6 +89,7 @@ jobs:
     runs-on:
       - self-hosted
       - test
+    if: github.repository_owner == 'zed-industries'
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -109,6 +111,7 @@ jobs:
   linux_tests:
     timeout-minutes: 60
     name: (Linux) Run Clippy and tests
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
       - deploy
@@ -135,6 +138,7 @@ jobs:
     timeout-minutes: 60
     name: (Windows) Run Clippy and tests
     runs-on: hosted-windows-1
+    if: github.repository_owner == 'zed-industries'
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -159,7 +163,9 @@ jobs:
     runs-on:
       - self-hosted
       - bundle
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling') }}
+    if: >
+      github.repository_owner == 'zed-industries' &&
+      (startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     needs: [macos_tests]
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -272,7 +278,9 @@ jobs:
     runs-on:
       - self-hosted
       - deploy
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling') }}
+    if: >
+      github.repository_owner == 'zed-industries' &&
+      (startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     needs: [linux_tests]
     env:
       ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
@@ -342,7 +350,9 @@ jobs:
     name: Create arm64 Linux bundle
     runs-on:
       - hosted-linux-arm-1
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling') }}
+    if: >
+      github.repository_owner == 'zed-industries' &&
+      (startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     needs: [linux_tests]
     env:
       ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}

--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy-docs:
     name: Deploy Docs
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   style:
     name: Check formatting and Clippy lints
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
       - test
@@ -31,6 +32,7 @@ jobs:
 
   tests:
     name: Run tests
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
       - test
@@ -57,6 +59,7 @@ jobs:
 
   publish:
     name: Publish collab server image
+    if: github.repository_owner == 'zed-industries'
     needs:
       - style
       - tests
@@ -89,6 +92,7 @@ jobs:
 
   deploy:
     name: Deploy new server image
+    if: github.repository_owner == 'zed-industries'
     needs:
       - publish
     runs-on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   check_formatting:
     name: "Check formatting"
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish_extension_cli.yml
+++ b/.github/workflows/publish_extension_cli.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   publish:
     name: Publish zed-extension CLI
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - ubuntu-latest
     steps:

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   tests:
     name: Run randomized tests
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
       - randomized-tests

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   discord_release:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'zed-industries'
     steps:
       - name: Get release URL
         id: get-release-url

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,33 @@
 {
   "nodes": {
+    "nixfenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1722666539,
+        "narHash": "sha256-3v7m4hrV5kJjlV+0cCNnwOMDipnL5u9WDtDm38ySfl8=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "69c2c0c3c2f56314966dae21d79274515b228482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719690277,
-        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
+        "lastModified": 1722421184,
+        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
         "type": "github"
       },
       "original": {
@@ -18,7 +39,25 @@
     },
     "root": {
       "inputs": {
+        "nixfenix": "nixfenix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1722589793,
+        "narHash": "sha256-OYDIo1Iqb6ldcC6JdqzKAKSRiXjDOwOAJKKMH8OZutk=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "aa00ddcf654a35ba0eafe17247cf189958d33182",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,29 +3,70 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    nixfenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs =
-    { self, nixpkgs }:
-    let
-      inherit (self) outputs;
-      systems = [
-        "aarch64-linux"
-        "x86_64-linux"
-        "aarch64-darwin"
-        "x86_64-darwin"
-      ];
-      forAllSystems = nixpkgs.lib.genAttrs systems;
-    in
-    {
-      devShells = forAllSystems (
-        system:
-        let
-          pkgs = import nixpkgs { inherit system; };
-        in
-        {
-          default = import ./shell.nix { inherit pkgs; };
-        }
-      );
-    };
+  outputs = {
+    self,
+    nixpkgs,
+    nixfenix,
+  }: let
+    inherit (self) outputs;
+    systems = [
+      "aarch64-linux"
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    forAllSystems = nixpkgs.lib.genAttrs systems;
+  in {
+    formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
+
+    packages = forAllSystems (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+        fenix = nixfenix.packages.${system};
+      in rec
+      {
+        zed-editor = import ./tooling/nix/package.nix {inherit pkgs fenix;};
+        default = zed-editor;
+      }
+    );
+
+    devShells = forAllSystems (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+        fenix = nixfenix.packages.${system};
+        rust-toolchain = (pkgs.lib.importTOML ./rust-toolchain.toml).toolchain;
+        complete-toolchain = fenix.fromToolchainName {
+          name = rust-toolchain.channel;
+          sha256 = "sha256-6eN/GKzjVSjEhGO9FhWObkRFaE1Jf+uqMSdQnb8lcB4=";
+        };
+        toolchain = complete-toolchain.withComponents (rust-toolchain.components
+          ++ [
+            "cargo"
+            "rust-src"
+            "rust-analyzer"
+            "clippy"
+          ]);
+      in rec
+      {
+        default = import ./shell.nix {inherit pkgs;};
+
+        # Usage, either:
+        #   a: `nix develop .#with-toolchain`
+        #   b: `echo "use flake .#with-toolchain" > .envrc`
+        with-toolchain = default.overrideAttrs (old: {
+          nativeBuildInputs =
+            old.nativeBuildInputs
+            ++ [
+              toolchain
+            ];
+        });
+      }
+    );
+  };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,56 +1,53 @@
-{
-  pkgs ? import <nixpkgs> { },
-}:
-
-let
+{pkgs ? import <nixpkgs> {}}: let
   stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.llvmPackages_18.stdenv;
 in
-if pkgs.stdenv.isDarwin then
-  # See https://github.com/NixOS/nixpkgs/issues/320084
-  throw "zed: nix dev-shell isn't supported on darwin yet."
-else
-  (pkgs.mkShell.override { inherit stdenv; }) rec {
-    nativeBuildInputs = with pkgs; [
-      copyDesktopItems
-      curl
-      perl
-      pkg-config
-      protobuf
-      rustPlatform.bindgenHook
-    ];
+  if pkgs.stdenv.isDarwin
+  then
+    # See https://github.com/NixOS/nixpkgs/issues/320084
+    throw "zed: nix dev-shell isn't supported on darwin yet."
+  else
+    (pkgs.mkShell.override {inherit stdenv;}) rec {
+      nativeBuildInputs = with pkgs; [
+        copyDesktopItems
+        curl
+        perl
+        pkg-config
+        protobuf
+        rustPlatform.bindgenHook
+      ];
 
-    buildInputs = with pkgs; [
-      curl
-      fontconfig
-      freetype
-      libgit2
-      openssl
-      sqlite
-      zlib
-      zstd
+      buildInputs = with pkgs; [
+        curl
+        fontconfig
+        freetype
+        libgit2
+        openssl
+        sqlite
+        zlib
+        zstd
 
-      alsa-lib
-      libxkbcommon
-      wayland
-      xorg.libxcb
-    ];
+        alsa-lib
+        libxkbcommon
+        wayland
+        xorg.libxcb
+      ];
 
-    env = {
-      LD_LIBRARY_PATH =
-        with pkgs;
-        lib.makeLibraryPath (
-          buildInputs
-          ++ [
-            stdenv.cc.cc.lib
-            vulkan-loader
-          ]
-        );
-      ZSTD_SYS_USE_PKG_CONFIG = true;
-      FONTCONFIG_FILE = pkgs.makeFontsConf {
-        fontDirectories = [
-          "assets/fonts/zed-mono"
-          "assets/fonts/zed-sans"
-        ];
+      env = {
+        LD_LIBRARY_PATH = with pkgs;
+          lib.makeLibraryPath (
+            buildInputs
+            ++ [
+              stdenv.cc.cc.lib
+              vulkan-loader
+            ]
+          );
+        PROTOC = "${pkgs.protobuf}/bin/protoc";
+        ZSTD_SYS_USE_PKG_CONFIG = true;
+        FONTCONFIG_FILE = pkgs.makeFontsConf {
+          fontDirectories = [
+            "assets/fonts/zed-mono"
+            "assets/fonts/zed-sans"
+          ];
+        };
       };
-    };
-  }
+    }

--- a/tooling/nix/README.md
+++ b/tooling/nix/README.md
@@ -1,0 +1,7 @@
+# Nix Package
+
+## How it works
+
+1. There is a patch that completely removes the download code from the node runtime.
+2. The path to NodeJS is hardcoded via the `NODE_PATH` environment variable (at build time), which is set inside
+   `./package.nix`.

--- a/tooling/nix/hardcode_nodejs.patch
+++ b/tooling/nix/hardcode_nodejs.patch
@@ -1,0 +1,115 @@
+diff --git a/crates/node_runtime/src/node_runtime.rs b/crates/node_runtime/src/node_runtime.rs
+index 5e199e65b..2f97eb7b2 100644
+--- a/crates/node_runtime/src/node_runtime.rs
++++ b/crates/node_runtime/src/node_runtime.rs
+@@ -2,18 +2,14 @@ mod archive;
+ 
+ use anyhow::{anyhow, bail, Context, Result};
+ pub use archive::extract_zip;
+-use async_compression::futures::bufread::GzipDecoder;
+-use async_tar::Archive;
+ use futures::AsyncReadExt;
+ use http_client::HttpClient;
+ use semver::Version;
+ use serde::Deserialize;
+-use smol::io::BufReader;
+ use smol::{fs, lock::Mutex, process::Command};
+ use std::io;
+ use std::process::{Output, Stdio};
+ use std::{
+-    env::consts,
+     path::{Path, PathBuf},
+     sync::Arc,
+ };
+@@ -22,8 +18,6 @@ use util::ResultExt;
+ #[cfg(windows)]
+ use smol::process::windows::CommandExt;
+ 
+-const VERSION: &str = "v22.5.1";
+-
+ #[cfg(not(windows))]
+ const NODE_PATH: &str = "bin/node";
+ #[cfg(windows)]
+@@ -34,11 +28,6 @@ const NPM_PATH: &str = "bin/npm";
+ #[cfg(windows)]
+ const NPM_PATH: &str = "node_modules/npm/bin/npm-cli.js";
+ 
+-enum ArchiveType {
+-    TarGz,
+-    Zip,
+-}
+-
+ #[derive(Debug, Deserialize)]
+ #[serde(rename_all = "kebab-case")]
+ pub struct NpmInfo {
+@@ -125,26 +114,11 @@ impl RealNodeRuntime {
+         let _lock = self.installation_lock.lock().await;
+         log::info!("Node runtime install_if_needed");
+ 
+-        let os = match consts::OS {
+-            "macos" => "darwin",
+-            "linux" => "linux",
+-            "windows" => "win",
+-            other => bail!("Running on unsupported os: {other}"),
+-        };
+-
+-        let arch = match consts::ARCH {
+-            "x86_64" => "x64",
+-            "aarch64" => "arm64",
+-            other => bail!("Running on unsupported architecture: {other}"),
+-        };
+-
+-        let folder_name = format!("node-{VERSION}-{os}-{arch}");
+-        let node_containing_dir = paths::support_dir().join("node");
+-        let node_dir = node_containing_dir.join(folder_name);
++        let node_dir = PathBuf::from(env!("NODE_PATH", "NODE_PATH is required for a Nix build"));
+         let paths = NodePaths {
+             node: node_dir.join(NODE_PATH),
+             npm: node_dir.join(NPM_PATH),
+-            cache: node_dir.join("cache"),
++            cache: paths::temp_dir().join("node"),
+         };
+ 
+         let mut command = paths.create_npm_command();
+@@ -162,40 +136,7 @@ impl RealNodeRuntime {
+         let valid = matches!(result, Ok(status) if status.success());
+ 
+         if !valid {
+-            _ = fs::remove_dir_all(&node_containing_dir).await;
+-            fs::create_dir(&node_containing_dir)
+-                .await
+-                .context("error creating node containing dir")?;
+-
+-            let archive_type = match consts::OS {
+-                "macos" | "linux" => ArchiveType::TarGz,
+-                "windows" => ArchiveType::Zip,
+-                other => bail!("Running on unsupported os: {other}"),
+-            };
+-
+-            let file_name = format!(
+-                "node-{VERSION}-{os}-{arch}.{extension}",
+-                extension = match archive_type {
+-                    ArchiveType::TarGz => "tar.gz",
+-                    ArchiveType::Zip => "zip",
+-                }
+-            );
+-            let url = format!("https://nodejs.org/dist/{VERSION}/{file_name}");
+-            let mut response = self
+-                .http
+-                .get(&url, Default::default(), true)
+-                .await
+-                .context("error downloading Node binary tarball")?;
+-
+-            let body = response.body_mut();
+-            match archive_type {
+-                ArchiveType::TarGz => {
+-                    let decompressed_bytes = GzipDecoder::new(BufReader::new(response.body_mut()));
+-                    let archive = Archive::new(decompressed_bytes);
+-                    archive.unpack(&node_containing_dir).await?;
+-                }
+-                ArchiveType::Zip => archive::extract_zip(&node_containing_dir, body).await?,
+-            }
++            bail!("failed to invoke npm at {:?} {:?}", paths.node, paths.npm);
+         }
+ 
+         // Note: Not in the `if !valid {}` so we can populate these for existing installations

--- a/tooling/nix/package.nix
+++ b/tooling/nix/package.nix
@@ -1,0 +1,164 @@
+{
+  pkgs ? import <nixpkgs> {},
+  fenix ? import (fetchTarball "https://github.com/nix-community/fenix/archive/main.tar.gz") {},
+}: let
+  inherit (pkgs) lib;
+  stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.llvmPackages_18.stdenv;
+  toolchain = fenix.fromToolchainName {
+    name = (lib.importTOML ./../../rust-toolchain.toml).toolchain.channel;
+    sha256 = "sha256-6eN/GKzjVSjEhGO9FhWObkRFaE1Jf+uqMSdQnb8lcB4=";
+  };
+  rustPlatform = pkgs.makeRustPlatform {
+    inherit (toolchain) cargo rustc;
+    inherit stdenv;
+  };
+  dynlibs = with pkgs; lib.optionals stdenv.isLinux [vulkan-loader];
+  version = (lib.importTOML ./../../crates/zed/Cargo.toml).package.version;
+in
+  rustPlatform.buildRustPackage rec {
+    pname = "zed-editor";
+    inherit version;
+
+    src = ./../..;
+
+    patches = [
+      ./hardcode_nodejs.patch
+    ];
+
+    # Nix needs to configure cargo in order to correctly link in dependencies and vendored crates. It currently uses
+    # the legacy `./.cargo/config` to do this. config.toml will take precedence, so remove it.
+    prePatch = ''
+      rm ./.cargo/config.toml
+    '';
+
+    nativeBuildInputs = with pkgs;
+      [
+        copyDesktopItems
+        curl
+        perl
+        pkg-config
+        protobuf
+        rustPlatform.bindgenHook
+      ]
+      ++ lib.optionals stdenv.isDarwin [xcbuild.xcrun];
+
+    buildInputs = with pkgs;
+      [
+        curl
+        fontconfig
+        freetype
+        libgit2
+        openssl
+        sqlite
+        zlib
+        zstd
+      ]
+      ++ lib.optionals stdenv.isLinux [
+        alsa-lib
+        libxkbcommon
+        wayland
+        xorg.libxcb
+      ]
+      ++ lib.optionals stdenv.isDarwin (
+        with darwin.apple_sdk.frameworks; [
+          AppKit
+          CoreAudio
+          CoreFoundation
+          CoreGraphics
+          CoreMedia
+          CoreServices
+          CoreText
+          Foundation
+          IOKit
+          Metal
+          Security
+          SystemConfiguration
+          VideoToolbox
+        ]
+      );
+
+    cargoLock = {
+      lockFile = ./../../Cargo.lock;
+
+      outputHashes = lib.importJSON ./pins.json;
+    };
+
+    cargoBuildFlags = [
+      "--package=zed"
+      "--package=cli"
+    ];
+
+    RUSTFLAGS = "-C symbol-mangling-version=v0 --cfg tokio_unstable";
+    buildFeatures = ["gpui/runtime_shaders" "mimalloc"];
+
+    env = {
+      ZSTD_SYS_USE_PKG_CONFIG = true;
+      OPENSSL_NO_VENDOR = 1;
+      FONTCONFIG_FILE = pkgs.makeFontsConf {
+        fontDirectories = [
+          "${src}/assets/fonts/zed-mono"
+          "${src}/assets/fonts/zed-sans"
+        ];
+      };
+      NODE_PATH = "${pkgs.nodejs_22}";
+    };
+
+    postFixup = pkgs.lib.concatStringsSep "; " (builtins.map
+      (b: "patchelf --add-rpath ${b.out}/lib $out/libexec/*")
+      dynlibs);
+
+    preCheck = ''
+      # the check phase seems to be ignoring the linking parameters
+      export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath (buildInputs ++ dynlibs)}:''${LD_LIBRARY_PATH:-}
+
+      # Nix creates an inaccessible homedir because it doesn't make sense for a build to interact with one. It does
+      # make sense for tests, though.
+      export HOME=$(mktemp -d)
+    '';
+
+    checkFlags = lib.optionals stdenv.hostPlatform.isLinux [
+      # Fails with "On 2823 Failed to find test1:A"
+      "--skip=test_base_keymap"
+      # Fails with "called `Result::unwrap()` on an `Err` value: Invalid keystroke `cmd-k`"
+      # https://github.com/zed-industries/zed/issues/10427
+      "--skip=test_disabled_keymap_binding"
+      # Fails with "FOREIGN KEY constraint failed" in the logs
+      "--skip=test_window_edit_state_restoring_enabled"
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/libexec
+      cp target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/zed $out/libexec/zed-editor
+      cp target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cli $out/bin/zed
+
+      install -D ${src}/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
+      install -D ${src}/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
+
+      # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
+      # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
+      (
+        export DO_STARTUP_NOTIFY="true"
+        export APP_CLI="zed"
+        export APP_ICON="zed"
+        export APP_NAME="Zed"
+        export APP_ARGS="%U"
+        mkdir -p "$out/share/applications"
+        ${lib.getExe pkgs.envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
+      )
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
+      homepage = "https://zed.dev";
+      changelog = "https://github.com/zed-industries/zed/releases/tag/v${version}";
+      license = licenses.gpl3Only;
+      mainProgram = "zed";
+      platforms = platforms.all;
+      # Currently broken on darwin: https://github.com/NixOS/nixpkgs/pull/303233#issuecomment-2048650618
+      broken = stdenv.isDarwin;
+    };
+  }

--- a/tooling/nix/pins.json
+++ b/tooling/nix/pins.json
@@ -1,0 +1,16 @@
+{
+  "alacritty_terminal-0.24.1-dev": "sha256-aVB1CNOLjNh6AtvdbomODNrk00Md8yz8QzldzvDo1LI=",
+  "async-pipe-0.1.3": "sha256-g120X88HGT8P6GNCrzpS5SutALx5H+45Sf4iSSxzctE=",
+  "blade-graphics-0.4.0": "sha256-o3iYBrHcLXSrdvd0J/LXJb7VkTcFyB/S2Nk9WrmZupI=",
+  "cosmic-text-0.11.2": "sha256-TLPDnqixuW+aPAhiBhSvuZIa69vgV3xLcw32OlkdCcM=",
+  "font-kit-0.14.1": "sha256-qUKvmi+RDoyhMrZ7T6SoVAyMc/aasQ9Y/okzre4SzXo=",
+  "lsp-types-0.95.1": "sha256-N4MKoU9j1p/Xeowki/+XiNQPwIcTm9DgmfM/Eieq4js=",
+  "nvim-rs-0.6.0-pre": "sha256-bdWWuCsBv01mnPA5e5zRpq48BgOqaqIcAu+b7y1NnM8=",
+  "tree-sitter-0.22.6": "sha256-P9pQcofDCIhOYWA1OC8TzB5UgWpD5GlDzX2DOS8SsH0=",
+  "tree-sitter-gomod-1.0.2": "sha256-/sjC117YAFniFws4F/8+Q5Wrd4l4v4nBUaO9IdkixSE=",
+  "tree-sitter-gowork-0.0.1": "sha256-803ujH5qwejQ2vQDDpma4JDC9a+vFX8ZQmr+77VyL2M=",
+  "tree-sitter-heex-0.0.1": "sha256-VakMZtWQ/h7dNy5ehk2Bh14a5s878AUgwY3Ipq8tPec=",
+  "tree-sitter-md-0.2.3": "sha256-Fa73P1h5GvKV3SxXr0KzHuNp4xa5wxUzI8ecXbGdrYE=",
+  "xim-0.4.0": "sha256-vxu3tjkzGeoRUj7vyP0vDGI7fweX8Drgy9hwOUOEQIA=",
+  "xkbcommon-0.7.0": "sha256-2RjZWiAaz8apYTrZ82qqH4Gv20WyCtPT+ldOzm0GWMo="
+}

--- a/tooling/nix/update-pins.sh
+++ b/tooling/nix/update-pins.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env nix
+#!nix shell nixpkgs#toml-cli nixpkgs#jq nixpkgs#url-parser --command bash
+
+set -euo pipefail
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+lockfile=$(toml get "$script_dir/../../Cargo.lock" .)
+
+result='{}'
+
+locks=$(jq -c '.package[] | select(.source != null) | select(.source | startswith("git+")) | { name: .name, version: .version, source: .source }' <<< "$lockfile")
+
+declare -A seen
+while IFS= read -r lock; do
+
+  name=$(jq -r '.name' <<< "$lock")
+  version=$(jq -r '.version' <<< "$lock")
+  source=$(jq -r '.source' <<< "$lock")
+
+  case "$source" in
+    git+* )
+      source="${source#'git+'}"
+      scheme=$(url-parser --url "$source" scheme)
+      host=$(url-parser --url "$source" host)
+      port=$(url-parser --url "$source" port)
+      path=$(url-parser --url "$source" path)
+      rev=$(url-parser --url "$source" fragment)
+
+      [ -n "${port:-}" ] && port=":${port}"
+
+      url="${scheme}://${host}${port}${path}"
+
+      key="${url}#${rev}"
+      [ -n "${seen["$key"]:-}" ] && continue
+      seen["$key"]=1
+
+      echo "Fetching hash for $key..." 1>&2
+      hash=$(nix-prefetch-git --url "${url}" --rev "${rev}" --quiet | jq '.hash')
+      echo "Got $hash" 1>&2
+      result=$(jq --arg key "${name}-${version}" --argjson value "${hash}" '.[$key] = $value' <<< "$result")
+      echo ""
+    ;;
+    *)
+      echo "unsupported source: $source" >&2
+      exit 1
+    ;;
+  esac
+
+done <<< "$locks"
+
+jq <<< "$result" > "$script_dir/pins.json"


### PR DESCRIPTION
Adds a flake-compatible Nix package, with workarounds for NodeJS.

An "idiomatic" Nix system probably doesn't have any build dependencies installed whatsoever - including `rustup` (these are usually brought in through `nix develop` or direnv). The `with-toolchain` devshell includes a comprehensive set of tools for nix developers.

Improvements to workflows. Some workflows will always fail in a fork, so owner repo conditions have been added to these. A workflow to push the build to Cachix has been added (so that end users don't have to do the build themselves). This workflow will also suggest updates to the `pins.json` file, if required.

This is an alternative approach to #15739 (though, it could also be applied on top of that PR if desired).

### Required from Zed team:

1. Create a cache on: https://www.cachix.org. Given that this is an open source project, a free/open cache can be used.
2. Create an access token and add it to the `CACHIX_TOKEN` repo secret. Optional: the `CACHIX_OWNER` variable can be set if the Cachix owner does not match the GitHub owner.

The Cachix info is usually placed in the readme (or other install instructions), I can do this once the cache is set up.

After merging I recommend adding the Cachix workflow to the branch protection rule.

Release Notes:

- Added Nix package