### PR TITLE
ruby: Add support for *.rbs files

### DIFF
--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -25,3 +25,7 @@ commit = "dc2d7d6b50f9975bc3c35bbec0ba11b2617b736b"
 [grammars.embedded_template]
 repository = "https://github.com/tree-sitter/tree-sitter-embedded-template"
 commit = "91fc5ae1140d5c9d922312431f7d251a48d7b8ce"
+
+[grammars.rbs]
+repository = "https://github.com/joker1007/tree-sitter-rbs"
+commit = "8d8e65ac3f77fbc9e15b1cdb9f980a3e0ac3ab99"

--- a/extensions/ruby/languages/rbs/config.toml
+++ b/extensions/ruby/languages/rbs/config.toml
@@ -1,0 +1,10 @@
+name = "rbs"
+grammar = "rbs"
+path_suffixes = ["rbs"]
+autoclose_before = "]})"
+brackets = [
+    { start = "(", end = ")", close = true, newline = false },
+    { start = "{", end = "}", close = true, newline = false },
+    { start = "[", end = "]", close = true, newline = false },
+]
+line_comments = ["#"]

--- a/extensions/ruby/languages/rbs/highlights.scm
+++ b/extensions/ruby/languages/rbs/highlights.scm
@@ -1,0 +1,144 @@
+; Taken from https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/rbs/highlights.scm
+; Use directive
+(use_clause
+  [
+    (type_name)
+    (simple_type_name)
+  ] @type)
+
+; Builtin constants and Keywords
+[
+  "true"
+  "false"
+] @boolean
+
+"nil" @constant.builtin
+
+[
+  "use"
+  "as"
+  "module"
+  "def"
+  "attr_reader"
+  "attr_writer"
+  "attr_accessor"
+  "end"
+  "alias"
+] @keyword
+
+[
+  "interface"
+  "type"
+  "class"
+] @keyword.type
+
+(class_decl
+  "end" @keyword.type)
+
+(interface_decl
+  "end" @keyword.type)
+
+"def" @keyword.function
+
+; Members of declaration
+[
+  "include"
+  "extend"
+  "prepend"
+] @function.method
+
+(visibility) @keyword.modifier
+
+(comment) @comment
+
+(method_member
+  (method_name
+    [
+      (identifier)
+      (constant)
+      (operator)
+      (setter)
+    ] @function.method))
+
+[
+  (ivar_name)
+  (cvar_name)
+] @variable.member
+
+(alias_member
+  (method_name) @function)
+
+(class_name
+  (constant) @type)
+
+(module_name
+  (constant) @type)
+
+(interface_name
+  (interface) @type)
+
+(alias_name
+  (identifier) @type)
+
+(type_variable) @constant
+
+(namespace
+  (constant) @module)
+
+(builtin_type) @type.builtin
+
+(const_name
+  (constant) @constant)
+
+(global_name) @variable
+
+; Standard Arguments
+(parameter
+  (var_name) @variable.parameter)
+
+; Keyword Arguments
+(keyword) @variable.parameter
+
+; Self
+(self) @variable.builtin
+
+; Literal
+(type
+  (symbol_literal) @string.special.symbol)
+
+(type
+  (string_literal
+    (escape_sequence) @string.escape))
+
+(type
+  (string_literal) @string)
+
+(type
+  (integer_literal) @number)
+
+; Operators
+[
+  "="
+  "->"
+  "<"
+  "**"
+  "*"
+  "&"
+  "|"
+  "^"
+] @operator
+
+; Punctuation
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ","
+  "."
+] @punctuation.delimiter

--- a/extensions/ruby/languages/rbs/indents.scm
+++ b/extensions/ruby/languages/rbs/indents.scm
@@ -1,0 +1,14 @@
+[
+  (class_decl)
+  (module_decl)
+  (interface_decl)
+  (parameters)
+  (tuple_type)
+  (record_type)
+] @indent.begin
+
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent
+
+(comment) @indent.ignore

--- a/extensions/ruby/languages/rbs/injections.scm
+++ b/extensions/ruby/languages/rbs/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Hi, this pull request adds support for RBS files for the Ruby language. [RBS](https://github.com/ruby/rbs) is a language to describe the structure of Ruby programs.

This pull request:

- adds a new grammar to the Ruby extension for RBS https://github.com/joker1007/tree-sitter-rbs
- configures the Ruby extension to use the added grammar.

Release Notes:

- N/A
