### PR TITLE
linux: Add shortcuts for left/right keys in prompts

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -2,13 +2,11 @@
   // Standard Linux bindings
   {
     "bindings": {
-      "up": "menu::SelectPrev",
       "shift-tab": "menu::SelectPrev",
       "home": "menu::SelectFirst",
       "pageup": "menu::SelectFirst",
       "shift-pageup": "menu::SelectFirst",
       "ctrl-p": "menu::SelectPrev",
-      "down": "menu::SelectNext",
       "tab": "menu::SelectNext",
       "end": "menu::SelectLast",
       "pagedown": "menu::SelectLast",
@@ -31,6 +29,20 @@
       "ctrl-,": "zed::OpenSettings",
       "ctrl-q": "zed::Quit",
       "f11": "zed::ToggleFullScreen"
+    }
+  },
+  {
+    "context": "menu",
+    "bindings": {
+      "up": "menu::SelectPrev",
+      "down": "menu::SelectNext"
+    }
+  },
+  {
+    "context": "Prompt",
+    "bindings": {
+      "left": "menu::SelectPrev",
+      "right": "menu::SelectNext"
     }
   },
   {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/15151

Release Notes:

- Fixed prompts on Linux not being navigable by arrow keys ([#15151](https://github.com/zed-industries/zed/issues/15151)).