### PR TITLE
assistant: Fix prompts not being editable

### DIFF
--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -487,7 +487,7 @@ impl PromptLibrary {
                             let mut editor = Editor::auto_width(cx);
                             editor.set_placeholder_text("Untitled", cx);
                             editor.set_text(prompt_metadata.title.unwrap_or_default(), cx);
-                            editor.set_read_only(true);
+                            editor.set_read_only(prompt_id.is_built_in());
                             editor
                         });
                         let body_editor = cx.new_view(|cx| {
@@ -499,7 +499,7 @@ impl PromptLibrary {
                             });
 
                             let mut editor = Editor::for_buffer(buffer, None, cx);
-                            editor.set_read_only(true);
+                            editor.set_read_only(prompt_id.is_built_in());
                             editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
                             editor.set_show_gutter(false, cx);
                             editor.set_show_wrap_guides(false, cx);


### PR DESCRIPTION
Fixes a bug introduced in #15615, where prompts could not be edited in the prompt library.
This PR fixes the behavior by only preventing users to edit built-in prompts.

Release Notes:

- N/A
