### PR TITLE
title_bar: Show a badge next to the user's avatar when on the Pro plan

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -542,7 +542,17 @@ impl TitleBar {
                         .child(
                             h_flex()
                                 .gap_0p5()
-                                .child(Avatar::new(user.avatar_uri.clone()))
+                                .child(
+                                    h_flex()
+                                        .gap_1()
+                                        .children(match plan {
+                                            None | Some(proto::Plan::Free) => None,
+                                            Some(proto::Plan::ZedPro) => {
+                                                Some(Label::new("Pro").size(LabelSize::Small))
+                                            }
+                                        })
+                                        .child(Avatar::new(user.avatar_uri.clone())),
+                                )
                                 .child(
                                     Icon::new(IconName::ChevronDown)
                                         .size(IconSize::Small)


### PR DESCRIPTION
This PR adds a badge next to the user's avatar in the title bar when they're on the Pro plan:

<img width="84" alt="Screenshot 2024-08-05 at 10 05 09 AM" src="https://github.com/user-attachments/assets/355ad497-99c9-4f10-b3cc-c026860f8e0c">

Release Notes:

- N/A
