### PR TITLE
gpui: Align SVG sprites to whole pixels

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2601,7 +2601,9 @@ impl<'a> WindowContext<'a> {
             .insert_primitive(MonochromeSprite {
                 order: 0,
                 pad: 0,
-                bounds,
+                bounds: bounds
+                    .map_origin(|origin| origin.floor())
+                    .map_size(|size| size.ceil()),
                 content_mask,
                 color,
                 tile,


### PR DESCRIPTION
Related to https://github.com/zed-industries/zed/issues/12352 (and old issue https://github.com/zed-industries/zed/issues/643)

This fixes visual glitches that could happen when rendering icons on Linux and Windows (and in the Blade backend)

![image](https://github.com/user-attachments/assets/02646d1d-d35b-48be-89c9-189416510cf2)
![image](https://github.com/user-attachments/assets/ccf99867-25d2-40fb-8735-c540f8cf793a)
![image](https://github.com/user-attachments/assets/8d1124a3-669e-4be5-8b46-5dc2df14a28a)


Release Notes:

- Linux: Fixed visual glitches when rendering icons.

