### PR TITLE
collab: Ignore Stripe events that are older than an hour

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -8,7 +8,7 @@ use axum::{
     routing::{get, post},
     Extension, Json, Router,
 };
-use chrono::{DateTime, SecondsFormat};
+use chrono::{DateTime, SecondsFormat, Utc};
 use reqwest::StatusCode;
 use sea_orm::ActiveValue;
 use serde::{Deserialize, Serialize};
@@ -426,6 +426,24 @@ async fn poll_stripe_events(
             stripe_event_type: event_type_to_string(event.type_),
             stripe_event_created_timestamp: event.created,
         };
+
+        // If the event has happened too far in the past, we don't want to
+        // process it and risk overwriting other more-recent updates.
+        //
+        // 1 hour was chosen arbitrarily. This could be made longer or shorter.
+        let one_hour = Duration::from_secs(60 * 60);
+        let an_hour_ago = Utc::now() - one_hour;
+        if an_hour_ago.timestamp() > event.created {
+            log::info!(
+                "Stripe event {} is more than {one_hour:?} old, marking as processed",
+                event_id
+            );
+            app.db
+                .create_processed_stripe_event(&processed_event_params)
+                .await?;
+
+            return Ok(());
+        }
 
         let process_result = match event.type_ {
             EventType::CustomerCreated | EventType::CustomerUpdated => {


### PR DESCRIPTION
This PR makes it so any Stripe events we receive that occurred over an hour ago are marked as processed.

We don't want to process an old event long after it occurred and potentially overwrite more recent updates.

This also makes running collab locally a bit nicer, as we won't be getting errors for a bunch of older events that will never get processed successfully.

The period after time after which we consider an event "stale" can be modified, as needed.

Release Notes:

- N/A
