### PR TITLE
zig: Update zls mac/linux tar extension

### DIFF
--- a/extensions/zig/src/zig.rs
+++ b/extensions/zig/src/zig.rs
@@ -90,7 +90,7 @@ impl ZigExtension {
                 zed::Os::Windows => "windows",
             },
             extension = match platform {
-                zed::Os::Mac | zed::Os::Linux => "tar.gz",
+                zed::Os::Mac | zed::Os::Linux => "tar.xz",
                 zed::Os::Windows => "zip",
             }
         );


### PR DESCRIPTION
zls release tar extensions has changed. Update to allow zls working without additional LSP setting needed
https://github.com/zigtools/zls/releases

Release Notes:

- zig extension: Fixed ZLS not being downloaded due to wrong file extension in latest release. ([#14935](https://github.com/zed-industries/zed/issues/14935)).

