### PR TITLE
Add cursor_style settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -674,7 +674,20 @@
     "toolbar": {
       // Whether to display the terminal title in its toolbar.
       "title": true
-    }
+    },
+    // Set the cursor style in the terminal.
+    // May take 5 values:
+    //  1. Cursor is a block like `█`.
+    //         "cursor_style": "block",
+    //  2. Cursor is an underscore like `_`.
+    //         "cursor_style": "underline",
+    //  3. Cursor is a vertical bar `⎸`.
+    //         "cursor_style": "beam",
+    //  4. Cursor is a box like `▯`.
+    //         "cursor_style": "hollow_block",
+    //  5. Invisible cursor.
+    //         "cursor_style": "hidden",
+    "cursor_style": "block"
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.
     // "font_size": 15,

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -210,6 +210,7 @@ impl Project {
             Some(settings.blinking),
             settings.alternate_scroll,
             settings.max_scroll_history_lines,
+            settings.cursor_style,
             window,
             completion_tx,
             cx,

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -1,3 +1,6 @@
+use alacritty_terminal::vte::ansi::{
+    CursorShape as AlacCursorShape, CursorStyle as AlacCursorStyle,
+};
 use collections::HashMap;
 use gpui::{
     px, AbsoluteLength, AppContext, FontFallbacks, FontFeatures, FontWeight, Pixels, SharedString,
@@ -43,6 +46,7 @@ pub struct TerminalSettings {
     pub detect_venv: VenvSettings,
     pub max_scroll_history_lines: Option<usize>,
     pub toolbar: Toolbar,
+    pub cursor_style: CursorStyle,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -177,6 +181,10 @@ pub struct TerminalSettingsContent {
     pub max_scroll_history_lines: Option<usize>,
     /// Toolbar related settings
     pub toolbar: Option<ToolbarContent>,
+    /// Sets the cursor style in the terminal.
+    ///
+    /// Default: block
+    pub cursor_style: Option<CursorStyle>,
 }
 
 impl settings::Settings for TerminalSettings {
@@ -280,4 +288,41 @@ pub struct ToolbarContent {
     ///
     /// Default: true
     pub title: Option<bool>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorStyle {
+    /// Cursor is a block like `█`.
+    #[default]
+    Block,
+    /// Cursor is an underscore like `_`.
+    Underline,
+    /// Cursor is a vertical bar like `⎸`.
+    Beam,
+    /// Cursor is a box like `▯`.
+    HollowBlock,
+    /// Invisible cursor.
+    Hidden,
+}
+
+impl From<CursorStyle> for AlacCursorShape {
+    fn from(value: CursorStyle) -> Self {
+        match value {
+            CursorStyle::Block => AlacCursorShape::Block,
+            CursorStyle::Underline => AlacCursorShape::Underline,
+            CursorStyle::Beam => AlacCursorShape::Beam,
+            CursorStyle::HollowBlock => AlacCursorShape::HollowBlock,
+            CursorStyle::Hidden => AlacCursorShape::Hidden,
+        }
+    }
+}
+
+impl From<CursorStyle> for AlacCursorStyle {
+    fn from(value: CursorStyle) -> Self {
+        AlacCursorStyle {
+            shape: value.into(),
+            blinking: false,
+        }
+    }
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1316,6 +1316,54 @@ List of `integer` column numbers
 "blinking": "on",
 ```
 
+### Cursor Style
+
+- Description: Set the cursor style in the terminal.
+- Setting: `cursor_style`
+- Default: `block`
+
+**Options**
+
+1. Cursor is a block like `█`.
+
+```json
+{
+  "cursor_style": "block"
+}
+```
+
+2. Cursor is an underscore like `_`.
+
+```json
+{
+  "cursor_style": "underline"
+}
+```
+
+3. Cursor is a vertical bar like `⎸`.
+
+```json
+{
+  "cursor_style": "beam"
+}
+```
+
+4. Cursor is a box like `▯`.
+
+```json
+{
+  "cursor_style": "hollow_block"
+}
+```
+
+5. Invisible cursor.
+
+```json
+{
+  "cursor_style": "hidden"
+}
+```
+
 ### Copy On Select
 
 - Description: Whether or not selecting text in the terminal will automatically copy to the system clipboard.


### PR DESCRIPTION
Adjust from https://github.com/zed-industries/zed/pull/12398

The terminal cursor can be configured as a block, beam, underline, hollow block, or it can be completely hidden.

Release Notes:

- Added config option for terminal cursor style.
