### PR TITLE
assistant: Cleanup model selector

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2942,6 +2942,10 @@ impl Render for ContextEditorToolbarItem {
                     )
                     .child(self.model_summary_editor.clone())
             });
+
+        let active_provider = LanguageModelRegistry::read_global(cx).active_provider();
+        let active_model = LanguageModelRegistry::read_global(cx).active_model();
+
         let right_side = h_flex()
             .gap_2()
             .child(ModelSelector::new(
@@ -2957,22 +2961,25 @@ impl Render for ContextEditorToolbarItem {
                                     .overflow_x_hidden()
                                     .flex_grow()
                                     .whitespace_nowrap()
-                                    .child(
-                                        Label::new(
-                                            LanguageModelRegistry::read_global(cx)
-                                                .active_model()
-                                                .map(|model| {
-                                                    format!(
-                                                        "{}: {}",
-                                                        model.provider_name().0,
-                                                        model.name().0
-                                                    )
-                                                })
-                                                .unwrap_or_else(|| "No model selected".into()),
-                                        )
-                                        .size(LabelSize::Small)
-                                        .color(Color::Muted),
-                                    ),
+                                    .child(match (active_provider, active_model) {
+                                        (Some(provider), Some(model)) => h_flex()
+                                            .gap_1()
+                                            .child(
+                                                Icon::new(provider.icon())
+                                                    .color(Color::Muted)
+                                                    .size(IconSize::XSmall),
+                                            )
+                                            .child(
+                                                Label::new(model.name().0)
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                            )
+                                            .into_any_element(),
+                                        _ => Label::new("No model selected")
+                                            .size(LabelSize::Small)
+                                            .color(Color::Muted)
+                                            .into_any_element(),
+                                    }),
                             )
                             .child(
                                 Icon::new(IconName::ChevronDown)

--- a/crates/assistant/src/model_selector.rs
+++ b/crates/assistant/src/model_selector.rs
@@ -1,3 +1,4 @@
+use feature_flags::LanguageModels;
 use language_model::{LanguageModel, LanguageModelAvailability, LanguageModelRegistry};
 use proto::Plan;
 
@@ -188,6 +189,11 @@ impl PickerDelegate for ModelPickerDelegate {
     }
 
     fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<gpui::AnyElement> {
+        use feature_flags::FeatureFlagAppExt;
+        if !cx.has_flag::<LanguageModels>() {
+            return None;
+        }
+
         let plan = proto::Plan::ZedPro;
         let is_trial = false;
 

--- a/crates/assistant/src/model_selector.rs
+++ b/crates/assistant/src/model_selector.rs
@@ -34,7 +34,6 @@ pub struct ModelPickerDelegate {
 #[derive(Clone)]
 struct ModelInfo {
     model: Arc<dyn LanguageModel>,
-    _provider_name: SharedString,
     provider_icon: IconName,
     availability: LanguageModelAvailability,
     is_selected: bool,
@@ -123,11 +122,14 @@ impl PickerDelegate for ModelPickerDelegate {
 
             // Update the selection status
             let selected_model_id = model_info.model.id();
+            let selected_provider_id = model_info.model.provider_id();
             for model in &mut self.all_models {
-                model.is_selected = model.model.id() == selected_model_id;
+                model.is_selected = model.model.id() == selected_model_id
+                    && model.model.provider_id() == selected_provider_id;
             }
             for model in &mut self.filtered_models {
-                model.is_selected = model.model.id() == selected_model_id;
+                model.is_selected = model.model.id() == selected_model_id
+                    && model.model.provider_id() == selected_provider_id;
             }
         }
     }
@@ -247,9 +249,8 @@ impl<T: PopoverTrigger> RenderOnce for ModelSelector<T> {
             .providers()
             .iter()
             .flat_map(|provider| {
-                let provider_name = provider.name().0.clone();
-                let provider_icon = provider.icon();
                 let provider_id = provider.id();
+                let provider_icon = provider.icon();
                 let selected_model = selected_model.clone();
                 let selected_provider = selected_provider.clone();
 
@@ -258,7 +259,6 @@ impl<T: PopoverTrigger> RenderOnce for ModelSelector<T> {
 
                     ModelInfo {
                         model: model.clone(),
-                        _provider_name: provider_name.clone(),
                         provider_icon,
                         availability: model.availability(),
                         is_selected: selected_model.as_ref() == Some(&model.id())


### PR DESCRIPTION
We changed the following for the model selector:
- Fixed displaying checkmarks for selected models when using models with the same name from different providers
- We now show the icon for the active model instead of displaying the provider name in the trigger of the model selector
- Only display the footer when the language models feature flag is zed, so that we don't release the hint for Zed Pro to preview tomorrow

<img width="253" alt="image" src="https://github.com/user-attachments/assets/f95ccfb6-c0cf-43d4-9637-e2823100a427">


Release Notes:

- N/A
