### PR TITLE
ruby: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13969,7 +13969,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruby"
-version = "0.0.8"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/ruby/Cargo.toml
+++ b/extensions/ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.0.8"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.0.8"
+version = "0.1.0"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
ruby: Bump extension version to v0.1.0 Why not v0.0.9? I think the Ruby extension is mature, and it's time to release the first minor version. But I am totally OK with changing it to 0.0.9.

Included changes:

- https://github.com/zed-industries/zed/pull/15778
- https://github.com/zed-industries/zed/pull/15762
- https://github.com/zed-industries/zed/pull/15110
- https://github.com/zed-industries/zed/pull/15297

Release Notes:

- N/A
