### PR TITLE
assistant: Fix inline assistant not working for non-terminal panel views

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -813,6 +813,11 @@ impl AssistantPanel {
             .and_then(|item| item.act_as::<Editor>(cx))
         {
             Some(InlineAssistTarget::Editor(workspace_editor, true))
+        } else if let Some(terminal_view) = workspace
+            .active_item(cx)
+            .and_then(|item| item.act_as::<TerminalView>(cx))
+        {
+            Some(InlineAssistTarget::Terminal(terminal_view))
         } else {
             None
         }


### PR DESCRIPTION
Fixes #15729

Release Notes:

- Fixed an issue where the terminal inline assistant would not appear when opening a terminal in the center pane ([#15729](https://github.com/zed-industries/zed/issues/15729)).