### PR TITLE
Don't insert unnecessary space below the end of an inline transformation

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -334,7 +334,7 @@ impl InlineAssistant {
             BlockProperties {
                 style: BlockStyle::Sticky,
                 position: range.end,
-                height: 1,
+                height: 0,
                 render: Box::new(|cx| {
                     v_flex()
                         .h_full()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2379,9 +2379,12 @@ impl EditorElement {
         };
 
         if let BlockId::Custom(custom_block_id) = block_id {
-            let element_height_in_lines = ((final_size.height / line_height).ceil() as u32).max(1);
-            if element_height_in_lines != block.height() {
-                resized_blocks.insert(custom_block_id, element_height_in_lines);
+            if block.height() > 0 {
+                let element_height_in_lines =
+                    ((final_size.height / line_height).ceil() as u32).max(1);
+                if element_height_in_lines != block.height() {
+                    resized_blocks.insert(custom_block_id, element_height_in_lines);
+                }
             }
         }
 


### PR DESCRIPTION
We achieved this by allowing block decorations to have a height of `0` and superimposing the border on top of the line, as opposed to carving out space below it.

Release Notes:

- N/A
