### PR TITLE
linux: Fix arrow keys in command palette

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -32,7 +32,7 @@
     }
   },
   {
-    "context": "menu",
+    "context": "Picker || menu",
     "bindings": {
       "up": "menu::SelectPrev",
       "down": "menu::SelectNext"


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/15870 (a recent regression from https://github.com/zed-industries/zed/commit/1f977410671ae18be97f5229e8716323b2276491)

Release Notes:

- N/A
