### PR TITLE
SSH remoting: Fix Terminal failing to launch on Windows

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -350,7 +350,15 @@ pub fn wrap_for_ssh(
     if command.is_none() {
         args.push("-t".to_string())
     }
-    args.push(shell_invocation);
+
+    if cfg!(target_os = "windows") {
+        // On Windows, alacritty joins arguments into a single string instead of using std::process::Command
+        // Probably because of CVE-2024-24576.
+        args.push(shlex::try_quote(&shell_invocation).unwrap().into_owned());
+    } else {
+        args.push(shell_invocation);
+    }
+
     (program, args)
 }
 


### PR DESCRIPTION
When using remote development over SSH, the terminal fails to launch due to a bug in the SSH command executed internally. The arguments for the `sh` command are quoted, but the `sh -c` command itself is an argument to the `ssh` command and thus, it requires additional quoting.

Fixes #15991

Release Notes:

- N/A
