### PR TITLE
collab: Remove unused parameter to `run_database_migrations`

### DIFF
--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -93,7 +93,7 @@ impl TestDb {
                 .await
                 .unwrap();
             let migrations_path = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations");
-            run_database_migrations(db.options(), migrations_path, false)
+            run_database_migrations(db.options(), migrations_path)
                 .await
                 .unwrap();
             db.initialize_notification_kinds().await.unwrap();

--- a/crates/collab/src/llm/db/tests.rs
+++ b/crates/collab/src/llm/db/tests.rs
@@ -81,7 +81,7 @@ impl TestLlmDb {
                 .await
                 .unwrap();
             let migrations_path = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations_llm");
-            run_database_migrations(db.options(), migrations_path, false)
+            run_database_migrations(db.options(), migrations_path)
                 .await
                 .unwrap();
             db

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -220,7 +220,7 @@ async fn setup_app_database(config: &Config) -> Result<()> {
         Path::new(default_migrations)
     });
 
-    let migrations = run_database_migrations(db.options(), migrations_path, false).await?;
+    let migrations = run_database_migrations(db.options(), migrations_path).await?;
     for (migration, duration) in migrations {
         log::info!(
             "Migrated {} {} {:?}",
@@ -265,7 +265,7 @@ async fn setup_llm_database(config: &Config) -> Result<()> {
             Path::new(default_migrations)
         });
 
-    let migrations = run_database_migrations(db.options(), migrations_path, false).await?;
+    let migrations = run_database_migrations(db.options(), migrations_path).await?;
     for (migration, duration) in migrations {
         log::info!(
             "Migrated {} {} {:?}",

--- a/crates/collab/src/migrations.rs
+++ b/crates/collab/src/migrations.rs
@@ -11,7 +11,6 @@ use sqlx::Connection;
 pub async fn run_database_migrations(
     database_options: &ConnectOptions,
     migrations_path: impl AsRef<Path>,
-    ignore_checksum_mismatch: bool,
 ) -> Result<Vec<(Migration, Duration)>> {
     let migrations = MigrationSource::resolve(migrations_path.as_ref())
         .await
@@ -31,7 +30,7 @@ pub async fn run_database_migrations(
     for migration in migrations {
         match applied_migrations.get(&migration.version) {
             Some(applied_migration) => {
-                if migration.checksum != applied_migration.checksum && !ignore_checksum_mismatch {
+                if migration.checksum != applied_migration.checksum {
                     Err(anyhow!(
                         "checksum mismatch for applied migration {}",
                         migration.description


### PR DESCRIPTION
This PR removes the unused `ignore_checksum_mismatch` parameter to `run_database_migrations`.

We were always passing `false`, which meant the behavior didn't need to be parameterized.

Release Notes:

- N/A
