### PR TITLE
repl: Improve kernelspec discoverability

### DIFF
--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -37,7 +37,7 @@ pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) ->
 
         let kernel_specification = store.update(cx, |store, cx| {
             store
-                .kernelspec(&language, cx)
+                .kernelspec(language.code_fence_block_name().as_ref(), cx)
                 .with_context(|| format!("No kernel found for language: {}", language.name()))
         })?;
 
@@ -114,7 +114,9 @@ pub fn session(editor: WeakView<Editor>, cx: &mut AppContext) -> SessionSupport 
     let Some(language) = get_language(editor, cx) else {
         return SessionSupport::Unsupported;
     };
-    let kernelspec = store.update(cx, |store, cx| store.kernelspec(&language, cx));
+    let kernelspec = store.update(cx, |store, cx| {
+        store.kernelspec(language.code_fence_block_name().as_ref(), cx)
+    });
 
     match kernelspec {
         Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -218,7 +218,7 @@ impl Render for ReplSessionsPage {
                             .child(Label::new("Install Kernels"))
                             .on_click(move |_, cx| {
                                 cx.open_url(
-                                    "https://docs.jupyter.org/en/latest/install/kernels.html",
+                                    "https://zed.dev/docs/repl#language-specific-instructions",
                                 )
                             }),
                     ),
@@ -236,6 +236,23 @@ impl Render for ReplSessionsPage {
         let kernels_available = v_flex()
             .child(Label::new("Kernels available").size(LabelSize::Large))
             .gap_2()
+            .child(
+                h_flex()
+                    .child(Label::new(
+                        "Defaults indicated with a checkmark. Learn how to change your default kernel in the ",
+                    ))
+                    .child(
+                        ButtonLike::new("configure-kernels")
+                            .style(ButtonStyle::Filled)
+                            // .size(ButtonSize::Compact)
+                            .layer(ElevationIndex::Surface)
+                            .child(Label::new("REPL documentation"))
+                            .child(Icon::new(IconName::Link))
+                            .on_click(move |_, cx| {
+                                cx.open_url("https://zed.dev/docs/repl#changing-kernels")
+                            }),
+                    ),
+            )
             .children(kernels_by_language.into_iter().map(|(language, specs)| {
                 let chosen_kernel = store.read(cx).kernelspec(&language, cx);
 
@@ -252,17 +269,25 @@ impl Render for ReplSessionsPage {
 
                         let path = SharedString::from(spec.path.to_string_lossy().to_string());
 
-                        // Ok I can make this div be a interactive instead
-                        let button = ButtonLike::new(ElementId::Name(path.clone()))
-                            .tooltip(move |cx| Tooltip::text(path.clone(), cx))
+                        ListItem::new(path.clone())
+                            .selectable(false)
+                            .tooltip({
+                                let path = path.clone();
+                                move |cx| Tooltip::text(path.clone(), cx)})
                             .child(
                                 h_flex()
                                     .gap_1()
-                                    .child(Label::new(spec.name.clone()))
-                                    .when(is_choice, |el| el.child(Icon::new(IconName::Check))),
-                            );
+                                    .child(div().id(path.clone()).child(Label::new(spec.name.clone())))
+                                    .when(is_choice, |el| {
 
-                        button
+                                        let language = language.clone();
+
+                                        el.child(
+
+                                        div().id("check").tooltip(move |cx| Tooltip::text(format!("Default Kernel for {language}"), cx))
+                                            .child(Icon::new(IconName::Check)))}),
+                            )
+
                     }))
             }));
 

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -4,8 +4,7 @@ use gpui::{
     actions, prelude::*, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView,
     FontWeight, Subscription, View,
 };
-use settings::Settings as _;
-use ui::{prelude::*, ButtonLike, ElevationIndex, Indicator, KeyBinding, ListItem, Tooltip};
+use ui::{prelude::*, ButtonLike, ElevationIndex, KeyBinding, ListItem, Tooltip};
 use util::ResultExt as _;
 use workspace::item::ItemEvent;
 use workspace::WorkspaceId;

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -7,7 +7,6 @@ use command_palette_hooks::CommandPaletteFilter;
 use gpui::{
     prelude::*, AppContext, EntityId, Global, Model, ModelContext, Subscription, Task, View,
 };
-use language::Language;
 use project::Fs;
 use settings::{Settings, SettingsStore};
 


### PR DESCRIPTION
<img width="862" alt="image" src="https://github.com/user-attachments/assets/ae8c479d-d9f9-4c46-bb1a-be411ab07876">

Release Notes:

- Added additional context about available to kernel sessions
- Fixed bug in kernelspec launch choosing first available kernel matching the language rather than selected name

