### PR TITLE
Hide mouse cursor when typing starts

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -959,7 +959,7 @@ pub enum CursorStyle {
     /// corresponds to the CSS cursor value `context-menu`
     ContextualMenu,
 
-    /// A cursor indicating that you cannot point it.
+    /// Hides the cursor until the mouse pointer is moved or clicked
     /// corresponds to the CSS cursor value `none`
     None,
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -958,6 +958,10 @@ pub enum CursorStyle {
     /// A cursor indicating that the operation will result in a context menu
     /// corresponds to the CSS cursor value `context-menu`
     ContextualMenu,
+
+    /// A cursor indicating that you cannot point it.
+    /// corresponds to the CSS cursor value `none`
+    None,
 }
 
 impl Default for CursorStyle {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -628,6 +628,7 @@ impl CursorStyle {
             CursorStyle::DragLink => Shape::Alias,
             CursorStyle::DragCopy => Shape::Copy,
             CursorStyle::ContextualMenu => Shape::ContextMenu,
+            CursorStyle::None => unreachable!(),
         }
     }
 
@@ -657,6 +658,7 @@ impl CursorStyle {
             CursorStyle::DragLink => "alias",
             CursorStyle::DragCopy => "copy",
             CursorStyle::ContextualMenu => "context-menu",
+            CursorStyle::None => unreachable!(),
         }
         .to_string()
     }

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -831,6 +831,7 @@ impl Platform for MacPlatform {
                 CursorStyle::DragLink => msg_send![class!(NSCursor), dragLinkCursor],
                 CursorStyle::DragCopy => msg_send![class!(NSCursor), dragCopyCursor],
                 CursorStyle::ContextualMenu => msg_send![class!(NSCursor), contextualMenuCursor],
+                CursorStyle::None => msg_send![class!(NSCursor), setHiddenUntilMouseMoves:YES],
             };
 
             let old_cursor: id = msg_send![class!(NSCursor), currentCursor];

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3280,6 +3280,10 @@ impl<'a> WindowContext<'a> {
             keystroke,
             &dispatch_path,
         );
+
+        // Hide cursor when start typing
+        self.platform.set_cursor_style(CursorStyle::None);
+
         if !match_result.to_replay.is_empty() {
             self.replay_pending_input(match_result.to_replay)
         }

--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -312,6 +312,13 @@ pub fn cursor_style_methods(input: TokenStream) -> TokenStream {
             self.style().mouse_cursor = Some(gpui::CursorStyle::ResizeLeft);
             self
         }
+
+        /// Sets cursor style when hovering over an element to `none`.
+        /// [Docs](https://tailwindcss.com/docs/cursor)
+        #visibility fn cursor_none(mut self, cursor: CursorStyle) -> Self {
+            self.style().mouse_cursor = Some(gpui::CursorStyle::None);
+            self
+        }
     };
 
     output.into()


### PR DESCRIPTION
Closes  #4461
Release Notes:

- Added feature to hide mouse cursor when start typing (only in macOS)


This PR is related to https://github.com/zed-industries/zed/issues/4461.

But this PR is not perfect.
I have only macOS device and this `setHiddenUntilMouseMoves` feature works only in macOS.
For Windows and Linux environment, I want someone to implement this.

https://github.com/user-attachments/assets/fd35f7a2-ed1f-435c-b1ec-46578166171b

