### PR TITLE
settings: Show error notification when settings are invalid

### DIFF
--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -1,4 +1,5 @@
 use crate::{settings_store::SettingsStore, Settings};
+use anyhow::Result;
 use fs::Fs;
 use futures::{channel::mpsc, StreamExt};
 use gpui::{AppContext, BackgroundExecutor, ReadGlobal, UpdateGlobal};
@@ -66,7 +67,7 @@ pub fn watch_config_file(
 pub fn handle_settings_file_changes(
     mut user_settings_file_rx: mpsc::UnboundedReceiver<String>,
     cx: &mut AppContext,
-    on_error: impl Fn(anyhow::Error, &mut AppContext) + 'static,
+    settings_changed: impl Fn(Result<()>, &mut AppContext) + 'static,
 ) {
     let user_settings_content = cx
         .background_executor()
@@ -80,10 +81,11 @@ pub fn handle_settings_file_changes(
     cx.spawn(move |mut cx| async move {
         while let Some(user_settings_content) = user_settings_file_rx.next().await {
             let result = cx.update_global(|store: &mut SettingsStore, cx| {
-                if let Err(err) = store.set_user_settings(&user_settings_content, cx) {
+                let result = store.set_user_settings(&user_settings_content, cx);
+                if let Err(err) = &result {
                     log::error!("Failed to load user settings: {err}");
-                    on_error(err, cx);
                 }
+                settings_changed(result, cx);
                 cx.refresh();
             });
             if result.is_err() {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5193,7 +5193,7 @@ fn activate_any_workspace_window(cx: &mut AsyncAppContext) -> Option<WindowHandl
     .flatten()
 }
 
-fn local_workspace_windows(cx: &AppContext) -> Vec<WindowHandle<Workspace>> {
+pub fn local_workspace_windows(cx: &AppContext) -> Vec<WindowHandle<Workspace>> {
     cx.windows()
         .into_iter()
         .filter_map(|window| window.downcast::<Workspace>())

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3096,7 +3096,7 @@ mod tests {
                 app_state.fs.clone(),
                 PathBuf::from("/keymap.json"),
             );
-            handle_settings_file_changes(settings_rx, cx);
+            handle_settings_file_changes(settings_rx, cx, |_, _| {});
             handle_keymap_file_changes(keymap_rx, cx);
         });
         workspace
@@ -3236,7 +3236,7 @@ mod tests {
                 PathBuf::from("/keymap.json"),
             );
 
-            handle_settings_file_changes(settings_rx, cx);
+            handle_settings_file_changes(settings_rx, cx, |_, _| {});
             handle_keymap_file_changes(keymap_rx, cx);
         });
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/07627142-e730-4446-a50b-7ef46f8e661c

We want to improve the design in the future, but it fixes a long standing paper cut for now.

In the future we want to extend this to the following files:
- Local/Global Tasks
- Keymap
- Local settings

Release Notes:

- Added a popup that is displayed when the settings are invalid
