### PR TITLE
Create a basic API for user task windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -502,14 +502,18 @@ features = [
     "Win32_System_Ole",
     "Win32_System_SystemInformation",
     "Win32_System_SystemServices",
+    "Win32_Storage_FileSystem",
     "Win32_System_Threading",
     "Win32_System_WinRT",
+    "Win32_Storage_EnhancedStorage",
     "Win32_UI_Controls",
     "Win32_UI_HiDpi",
     "Win32_UI_Input_Ime",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell_PropertiesSystem",
 ]
 
 [patch.crates-io]


### PR DESCRIPTION
Added user tasks for set_dock_menu as per this issue implementation which doesn't implement use Action for now https://github.com/zed-industries/zed/issues/12068 I would really like someone to help me with this implementation and guide me. Zed for windows doesn't open a new window when an new instance of the app is launched it clones the same window again https://github.com/zed-industries/zed/pull/15371 this might the fix for it. Please do let me know the changed need to be done 
Thank you


https://github.com/user-attachments/assets/dc4fba80-2501-4e83-9196-a2a8259d1762

Release Notes:
-Added Tasks in windows jumplist
