### PR TITLE
gleam: Revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13971,7 +13971,7 @@ dependencies = [
 
 [[package]]
 name = "zed_gleam"
-version = "0.1.4"
+version = "0.1.3"
 dependencies = [
  "html_to_markdown 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zed_extension_api 0.0.7",

--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_gleam"
-version = "0.1.4"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/gleam/extension.toml
+++ b/extensions/gleam/extension.toml
@@ -1,7 +1,7 @@
 id = "gleam"
 name = "Gleam"
 description = "Gleam support."
-version = "0.1.4"
+version = "0.1.3"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR reverts a version bump to the Gleam extension that was included in #15866, as we're not ready to publish a new version.

Release Notes:

- N/A
