### PR TITLE
editor: Ctrl-a move to absolute line beginning

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7273,7 +7273,7 @@ impl Editor {
         self.change_selections(Some(Autoscroll::fit()), cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
-                    movement::indented_line_beginning(map, head, action.stop_at_soft_wraps),
+                    movement::line_beginning(map, head, action.stop_at_soft_wraps),
                     SelectionGoal::None,
                 )
             });


### PR DESCRIPTION
This PR changes the behavior of ctrl-a so that the cursor moves to the
absolute beginning of line.

Before this PR, Zed would move the cursor to the indentation start. By
changing this to absolute start, Zed behaves like most other code
editors.

Close #11129

Release Notes:

- Fix so that ctrl-a moves to line beginning ([#11129](https://github.com/zed-industries/zed/issues/11129)).