### PR TITLE
Open workflow step editors as preview tabs

### DIFF
--- a/assets/prompts/step_resolution.hbs
+++ b/assets/prompts/step_resolution.hbs
@@ -1,4 +1,4 @@
-Your task is to map a step from the conversation above to operations on symbols inside the provided source files.
+Your task is to map a step from the conversation above to suggestions on symbols inside the provided source files.
 
 Guidelines:
 - There's no need to describe *what* to do, just *where* to do it.
@@ -6,13 +6,13 @@ Guidelines:
 - Don't create and then update a file.
 - We'll create it in one shot.
 - Prefer updating symbols lower in the syntax tree if possible.
-- Never include operations on a parent symbol and one of its children in the same operations block.
-- Never nest an operation with another operation or include CDATA or other content. All operations are leaf nodes.
+- Never include suggestions on a parent symbol and one of its children in the same suggestions block.
+- Never nest an operation with another operation or include CDATA or other content. All suggestions are leaf nodes.
 - Include a description attribute for each operation with a brief, one-line description of the change to perform.
-- Descriptions are required for all operations except delete.
-- When generating multiple operations, ensure the descriptions are specific to each individual operation.
+- Descriptions are required for all suggestions except delete.
+- When generating multiple suggestions, ensure the descriptions are specific to each individual operation.
 - Avoid referring to the location in the description. Focus on the change to be made, not the location where it's made. That's implicit with the symbol you provide.
-- Don't generate multiple operations at the same location. Instead, combine them together in a single operation with a succinct combined description.
+- Don't generate multiple suggestions at the same location. Instead, combine them together in a single operation with a succinct combined description.
 
 Example 1:
 
@@ -33,12 +33,12 @@ impl Rectangle {
 <step>Add new methods 'calculate_area' and 'calculate_perimeter' to the Rectangle struct</step>
 <step>Implement the 'Display' trait for the Rectangle struct</step>
 
-What are the operations for the step: <step>Add a new method 'calculate_area' to the Rectangle struct</step>
+What are the suggestions for the step: <step>Add a new method 'calculate_area' to the Rectangle struct</step>
 
 A (wrong):
 {
   "title": "Add Rectangle methods",
-  "operations": [
+  "suggestions": [
     {
       "kind": "AppendChild",
       "path": "src/shapes.rs",
@@ -59,7 +59,7 @@ This demonstrates what NOT to do. NEVER append multiple children at the same loc
 A (corrected):
 {
   "title": "Add Rectangle methods",
-  "operations": [
+  "suggestions": [
     {
       "kind": "AppendChild",
       "path": "src/shapes.rs",
@@ -70,12 +70,12 @@ A (corrected):
 }
 
 User:
-What are the operations for the step: <step>Implement the 'Display' trait for the Rectangle struct</step>
+What are the suggestions for the step: <step>Implement the 'Display' trait for the Rectangle struct</step>
 
 A:
 {
   "title": "Implement Display for Rectangle",
-  "operations": [
+  "suggestions": [
     {
       "kind": "InsertSiblingAfter",
       "path": "src/shapes.rs",
@@ -109,12 +109,12 @@ impl User {
 <step>Update the 'print_info' method to use formatted output</step>
 <step>Remove the 'email' field from the User struct</step>
 
-What are the operations for the step: <step>Update the 'print_info' method to use formatted output</step>
+What are the suggestions for the step: <step>Update the 'print_info' method to use formatted output</step>
 
 A:
 {
   "title": "Use formatted output",
-  "operations": [
+  "suggestions": [
     {
       "kind": "Update",
       "path": "src/user.rs",
@@ -125,12 +125,12 @@ A:
 }
 
 User:
-What are the operations for the step: <step>Remove the 'email' field from the User struct</step>
+What are the suggestions for the step: <step>Remove the 'email' field from the User struct</step>
 
 A:
 {
   "title": "Remove email field",
-  "operations": [
+  "suggestions": [
       {
         "kind": "Delete",
         "path": "src/user.rs",
@@ -163,12 +163,12 @@ impl Vehicle {
 <step>Add a 'use std::fmt;' statement at the beginning of the file</step>
 <step>Add a new method 'start_engine' in the Vehicle impl block</step>
 
-What are the operations for the step: <step>Add a 'use std::fmt;' statement at the beginning of the file</step>
+What are the suggestions for the step: <step>Add a 'use std::fmt;' statement at the beginning of the file</step>
 
 A:
 {
   "title": "Add use std::fmt statement",
-  "operations": [
+  "suggestions": [
     {
       "kind": "PrependChild",
       "path": "src/vehicle.rs",
@@ -178,12 +178,12 @@ A:
 }
 
 User:
-What are the operations for the step: <step>Add a new method 'start_engine' in the Vehicle impl block</step>
+What are the suggestions for the step: <step>Add a new method 'start_engine' in the Vehicle impl block</step>
 
 A:
 {
   "title": "Add start_engine method",
-  "operations": [
+  "suggestions": [
     {
       "kind": "InsertSiblingAfter",
       "path": "src/vehicle.rs",
@@ -222,12 +222,12 @@ impl Employee {
 
 <step>Make salary an f32</step>
 
-What are the operations for the step: <step>Make salary an f32</step>
+What are the suggestions for the step: <step>Make salary an f32</step>
 
 A (wrong):
 {
   "title": "Change salary to f32",
-  "operations": [
+  "suggestions": [
     {
       "kind": "Update",
       "path": "src/employee.rs",
@@ -248,7 +248,7 @@ This example demonstrates what not to do. `struct Employee salary` is a child of
 A (corrected):
 {
   "title": "Change salary to f32",
-  "operations": [
+  "suggestions": [
     {
       "kind": "Update",
       "path": "src/employee.rs",
@@ -259,12 +259,12 @@ A (corrected):
 }
 
 User:
-What are the correct operations for the step: <step>Remove the 'department' field and update the 'print_details' method</step>
+What are the correct suggestions for the step: <step>Remove the 'department' field and update the 'print_details' method</step>
 
 A:
 {
   "title": "Remove department",
-  "operations": [
+  "suggestions": [
     {
       "kind": "Delete",
       "path": "src/employee.rs",
@@ -311,7 +311,7 @@ impl Game {
 A:
 {
   "title": "Add level field to Player",
-  "operations": [
+  "suggestions": [
     {
       "kind": "InsertSiblingAfter",
       "path": "src/game.rs",
@@ -349,7 +349,7 @@ impl Config {
 A:
 {
   "title": "Add load_from_file method",
-  "operations": [
+  "suggestions": [
     {
       "kind": "PrependChild",
       "path": "src/config.rs",
@@ -389,7 +389,7 @@ impl Database {
 A:
 {
   "title": "Add error handling to query",
-  "operations": [
+  "suggestions": [
     {
       "kind": "PrependChild",
       "path": "src/database.rs",
@@ -410,4 +410,4 @@ A:
   ]
 }
 
-Now generate the operations for the following step:
+Now generate the suggestions for the following step:

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -10,14 +10,14 @@ use crate::{
     },
     terminal_inline_assistant::TerminalInlineAssistant,
     Assist, CodegenStatus, ConfirmCommand, Context, ContextEvent, ContextId, ContextStore,
-    CycleMessageRole, DebugEditSteps, DeployHistory, DeployPromptLibrary, EditSuggestionGroup,
-    InlineAssist, InlineAssistId, InlineAssistant, InsertIntoEditor, MessageStatus, ModelSelector,
+    CycleMessageRole, DebugEditSteps, DeployHistory, DeployPromptLibrary, InlineAssist,
+    InlineAssistId, InlineAssistant, InsertIntoEditor, MessageStatus, ModelSelector,
     PendingSlashCommand, PendingSlashCommandStatus, QuoteSelection, RemoteContextMetadata,
-    ResolvedWorkflowStepEditSuggestions, SavedContextMetadata, Split, ToggleFocus,
-    ToggleModelSelector, WorkflowStepEditSuggestions,
+    SavedContextMetadata, Split, ToggleFocus, ToggleModelSelector, WorkflowStepStatus,
+    WorkflowStepSuggestions,
 };
 use crate::{ContextStoreEvent, ShowConfiguration};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use assistant_slash_command::{SlashCommand, SlashCommandOutputSection};
 use client::{proto, Client, Status};
 use collections::{BTreeSet, HashMap, HashSet};
@@ -41,8 +41,7 @@ use gpui::{
 };
 use indexed_docs::IndexedDocsStore;
 use language::{
-    language_settings::SoftWrap, Buffer, Capability, LanguageRegistry, LspAdapterDelegate, Point,
-    ToOffset,
+    language_settings::SoftWrap, Capability, LanguageRegistry, LspAdapterDelegate, Point, ToOffset,
 };
 use language_model::{
     provider::cloud::PROVIDER_ID, LanguageModelProvider, LanguageModelProviderId,
@@ -1330,15 +1329,10 @@ struct ScrollPosition {
     cursor: Anchor,
 }
 
-struct StepAssists {
-    assist_ids: Vec<InlineAssistId>,
+struct StepAssist {
     editor: WeakView<Editor>,
-}
-
-#[derive(Debug, Eq, PartialEq)]
-struct ActiveWorkflowStep {
-    range: Range<language::Anchor>,
-    suggestions: Option<ResolvedWorkflowStepEditSuggestions>,
+    editor_was_open: bool,
+    assist_ids: Vec<InlineAssistId>,
 }
 
 pub struct ContextEditor {
@@ -1353,9 +1347,9 @@ pub struct ContextEditor {
     remote_id: Option<workspace::ViewId>,
     pending_slash_command_creases: HashMap<Range<language::Anchor>, CreaseId>,
     pending_slash_command_blocks: HashMap<Range<language::Anchor>, CustomBlockId>,
+    step_assists: HashMap<Range<language::Anchor>, StepAssist>,
+    active_workflow_step_range: Option<Range<language::Anchor>>,
     _subscriptions: Vec<Subscription>,
-    assists_by_step: HashMap<Range<language::Anchor>, StepAssists>,
-    active_workflow_step: Option<ActiveWorkflowStep>,
     assistant_panel: WeakView<AssistantPanel>,
     error_message: Option<SharedString>,
 }
@@ -1413,8 +1407,8 @@ impl ContextEditor {
             pending_slash_command_creases: HashMap::default(),
             pending_slash_command_blocks: HashMap::default(),
             _subscriptions,
-            assists_by_step: HashMap::default(),
-            active_workflow_step: None,
+            step_assists: HashMap::default(),
+            active_workflow_step_range: None,
             assistant_panel,
             error_message: None,
         };
@@ -1457,8 +1451,8 @@ impl ContextEditor {
     }
 
     fn apply_edit_step(&mut self, cx: &mut ViewContext<Self>) -> bool {
-        if let Some(step) = self.active_workflow_step.as_ref() {
-            if let Some(assists) = self.assists_by_step.get(&step.range) {
+        if let Some(step_range) = self.active_workflow_step_range.as_ref() {
+            if let Some(assists) = self.step_assists.get(&step_range) {
                 let assist_ids = assists.assist_ids.clone();
                 cx.window_context().defer(|cx| {
                     InlineAssistant::update_global(cx, |assistant, cx| {
@@ -1519,8 +1513,8 @@ impl ContextEditor {
                     .text_for_range(step.tagged_range.clone())
                     .collect::<String>()
             ));
-            match &step.edit_suggestions {
-                WorkflowStepEditSuggestions::Resolved(ResolvedWorkflowStepEditSuggestions {
+            match &step.status {
+                WorkflowStepStatus::Resolved(WorkflowStepSuggestions {
                     title,
                     edit_suggestions,
                 }) => {
@@ -1528,7 +1522,7 @@ impl ContextEditor {
                     output.push_str(&format!("  {:?}\n", title));
                     output.push_str(&format!("  {:?}\n", edit_suggestions));
                 }
-                WorkflowStepEditSuggestions::Pending(_) => {
+                WorkflowStepStatus::Pending(_) => {
                     output.push_str("Resolution: Pending\n");
                 }
             }
@@ -1957,14 +1951,11 @@ impl ContextEditor {
                     .context
                     .read(cx)
                     .workflow_step_for_range(step_range.clone())?;
-                Some(ActiveWorkflowStep {
-                    range: workflow_step.tagged_range.clone(),
-                    suggestions: workflow_step.edit_suggestions.as_resolved().cloned(),
-                })
+                Some(workflow_step.tagged_range.clone())
             });
-        if new_step.as_ref() != self.active_workflow_step.as_ref() {
-            if let Some(old_step) = self.active_workflow_step.take() {
-                self.cancel_workflow_step_if_idle(old_step.range, cx);
+        if new_step.as_ref() != self.active_workflow_step_range.as_ref() {
+            if let Some(old_step_range) = self.active_workflow_step_range.take() {
+                self.cancel_workflow_step_if_idle(old_step_range, cx);
             }
 
             if let Some(new_step) = new_step {
@@ -1978,16 +1969,16 @@ impl ContextEditor {
         step_range: Range<language::Anchor>,
         cx: &mut ViewContext<Self>,
     ) {
-        let Some(step_assists) = self.assists_by_step.get_mut(&step_range) else {
+        let Some(step_assist) = self.step_assists.get_mut(&step_range) else {
             return;
         };
-        let Some(editor) = step_assists.editor.upgrade() else {
-            self.assists_by_step.remove(&step_range);
+        let Some(editor) = step_assist.editor.upgrade() else {
+            self.step_assists.remove(&step_range);
             return;
         };
 
         InlineAssistant::update_global(cx, |assistant, cx| {
-            step_assists.assist_ids.retain(|assist_id| {
+            step_assist.assist_ids.retain(|assist_id| {
                 match assistant.status_for_assist(*assist_id, cx) {
                     Some(CodegenStatus::Idle) | None => {
                         assistant.finish_assist(*assist_id, true, cx);
@@ -1998,14 +1989,15 @@ impl ContextEditor {
             });
         });
 
-        if step_assists.assist_ids.is_empty() {
-            self.assists_by_step.remove(&step_range);
+        if step_assist.assist_ids.is_empty() {
+            let editor_was_open = step_assist.editor_was_open;
+            self.step_assists.remove(&step_range);
             self.workspace
                 .update(cx, |workspace, cx| {
                     if let Some(pane) = workspace.pane_for(&editor) {
                         pane.update(cx, |pane, cx| {
                             let item_id = editor.entity_id();
-                            if pane.is_active_preview_item(item_id) {
+                            if !editor_was_open && pane.is_active_preview_item(item_id) {
                                 pane.close_item_by_id(item_id, SaveIntent::Skip, cx)
                                     .detach_and_log_err(cx);
                             }
@@ -2016,162 +2008,200 @@ impl ContextEditor {
         }
     }
 
-    fn activate_workflow_step(&mut self, step: ActiveWorkflowStep, cx: &mut ViewContext<Self>) {
-        if let Some(step_assists) = self.assists_by_step.get(&step.range) {
-            if let Some(editor) = step_assists.editor.upgrade() {
-                for assist_id in &step_assists.assist_ids {
-                    match InlineAssistant::global(cx).status_for_assist(*assist_id, cx) {
-                        Some(CodegenStatus::Idle) | None => {}
-                        _ => {
-                            self.workspace
-                                .update(cx, |workspace, cx| {
-                                    workspace.activate_item(&editor, false, false, cx);
-                                })
-                                .ok();
-                            InlineAssistant::update_global(cx, |assistant, cx| {
-                                assistant.scroll_to_assist(*assist_id, cx)
-                            });
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-
-        if let Some(ResolvedWorkflowStepEditSuggestions {
-            title,
-            edit_suggestions,
-        }) = step.suggestions.as_ref()
-        {
-            if let Some((editor, assist_ids)) =
-                self.suggest_edits(title.clone(), edit_suggestions.clone(), cx)
-            {
-                self.assists_by_step.insert(
-                    step.range.clone(),
-                    StepAssists {
-                        assist_ids,
-                        editor: editor.downgrade(),
-                    },
-                );
-            }
-        }
-
-        self.active_workflow_step = Some(step);
-    }
-
-    fn suggest_edits(
+    fn activate_workflow_step(
         &mut self,
-        title: String,
-        edit_suggestions: HashMap<Model<Buffer>, Vec<EditSuggestionGroup>>,
+        step_range: Range<language::Anchor>,
         cx: &mut ViewContext<Self>,
-    ) -> Option<(View<Editor>, Vec<InlineAssistId>)> {
-        let assistant_panel = self.assistant_panel.upgrade()?;
-        if edit_suggestions.is_empty() {
+    ) -> Option<()> {
+        if self.scroll_to_existing_workflow_assist(&step_range, cx) {
             return None;
         }
 
-        let editor;
-        let mut suggestion_groups = Vec::new();
-        if edit_suggestions.len() == 1 && edit_suggestions.values().next().unwrap().len() == 1 {
-            // If there's only one buffer and one suggestion group, open it directly
-            let (buffer, groups) = edit_suggestions.into_iter().next().unwrap();
-            let group = groups.into_iter().next().unwrap();
-            editor = self
-                .workspace
-                .update(cx, |workspace, cx| {
-                    let active_pane = workspace.active_pane().clone();
-                    workspace.open_project_item::<Editor>(active_pane, buffer, false, false, cx)
-                })
-                .log_err()?;
+        let step = self
+            .workflow_step(&step_range, cx)
+            .with_context(|| format!("could not find workflow step for range {:?}", step_range))
+            .log_err()?;
+        let Some(resolved) = step.status.as_resolved() else {
+            return None;
+        };
 
-            let (&excerpt_id, _, _) = editor
-                .read(cx)
-                .buffer()
-                .read(cx)
-                .read(cx)
-                .as_singleton()
-                .unwrap();
+        let title = resolved.title.clone();
+        let edit_suggestions = resolved.edit_suggestions.clone();
 
-            // Scroll the editor to the suggested assist
-            editor.update(cx, |editor, cx| {
-                let multibuffer = editor.buffer().read(cx).snapshot(cx);
-                let (&excerpt_id, _, buffer) = multibuffer.as_singleton().unwrap();
-                let anchor = if group.context_range.start.to_offset(buffer) == 0 {
-                    Anchor::min()
-                } else {
-                    multibuffer
-                        .anchor_in_excerpt(excerpt_id, group.context_range.start)
-                        .unwrap()
-                };
+        if let Some((editor, assist_ids, editor_was_open)) = {
+            let assistant_panel = self.assistant_panel.upgrade()?;
+            if edit_suggestions.is_empty() {
+                return None;
+            }
 
-                editor.set_scroll_anchor(
-                    ScrollAnchor {
-                        offset: gpui::Point::default(),
-                        anchor,
-                    },
-                    cx,
-                );
-            });
+            let editor;
+            let mut editor_was_open = false;
+            let mut suggestion_groups = Vec::new();
+            if edit_suggestions.len() == 1 && edit_suggestions.values().next().unwrap().len() == 1 {
+                // If there's only one buffer and one suggestion group, open it directly
+                let (buffer, groups) = edit_suggestions.into_iter().next().unwrap();
+                let group = groups.into_iter().next().unwrap();
+                editor = self
+                    .workspace
+                    .update(cx, |workspace, cx| {
+                        let active_pane = workspace.active_pane().clone();
+                        editor_was_open =
+                            workspace.is_project_item_open::<Editor>(&active_pane, &buffer, cx);
+                        workspace.open_project_item::<Editor>(active_pane, buffer, false, false, cx)
+                    })
+                    .log_err()?;
 
-            suggestion_groups.push((excerpt_id, group));
-        } else {
-            // If there are multiple buffers or suggestion groups, create a multibuffer
-            let multibuffer = cx.new_model(|cx| {
-                let replica_id = self.project.read(cx).replica_id();
-                let mut multibuffer =
-                    MultiBuffer::new(replica_id, Capability::ReadWrite).with_title(title);
-                for (buffer, groups) in edit_suggestions {
-                    let excerpt_ids = multibuffer.push_excerpts(
-                        buffer,
-                        groups.iter().map(|suggestion_group| ExcerptRange {
-                            context: suggestion_group.context_range.clone(),
-                            primary: None,
-                        }),
+                let (&excerpt_id, _, _) = editor
+                    .read(cx)
+                    .buffer()
+                    .read(cx)
+                    .read(cx)
+                    .as_singleton()
+                    .unwrap();
+
+                // Scroll the editor to the suggested assist
+                editor.update(cx, |editor, cx| {
+                    let multibuffer = editor.buffer().read(cx).snapshot(cx);
+                    let (&excerpt_id, _, buffer) = multibuffer.as_singleton().unwrap();
+                    let anchor = if group.context_range.start.to_offset(buffer) == 0 {
+                        Anchor::min()
+                    } else {
+                        multibuffer
+                            .anchor_in_excerpt(excerpt_id, group.context_range.start)
+                            .unwrap()
+                    };
+
+                    editor.set_scroll_anchor(
+                        ScrollAnchor {
+                            offset: gpui::Point::default(),
+                            anchor,
+                        },
                         cx,
                     );
-                    suggestion_groups.extend(excerpt_ids.into_iter().zip(groups));
-                }
-                multibuffer
-            });
+                });
 
-            editor = cx.new_view(|cx| {
-                Editor::for_multibuffer(multibuffer, Some(self.project.clone()), true, cx)
-            });
-            self.workspace
-                .update(cx, |workspace, cx| {
-                    workspace.add_item_to_active_pane(Box::new(editor.clone()), None, false, cx)
-                })
-                .log_err()?;
-        }
+                suggestion_groups.push((excerpt_id, group));
+            } else {
+                // If there are multiple buffers or suggestion groups, create a multibuffer
+                let multibuffer = cx.new_model(|cx| {
+                    let replica_id = self.project.read(cx).replica_id();
+                    let mut multibuffer =
+                        MultiBuffer::new(replica_id, Capability::ReadWrite).with_title(title);
+                    for (buffer, groups) in edit_suggestions {
+                        let excerpt_ids = multibuffer.push_excerpts(
+                            buffer,
+                            groups.iter().map(|suggestion_group| ExcerptRange {
+                                context: suggestion_group.context_range.clone(),
+                                primary: None,
+                            }),
+                            cx,
+                        );
+                        suggestion_groups.extend(excerpt_ids.into_iter().zip(groups));
+                    }
+                    multibuffer
+                });
 
-        let mut assist_ids = Vec::new();
-        for (excerpt_id, suggestion_group) in suggestion_groups {
-            for suggestion in suggestion_group.suggestions {
-                assist_ids.extend(suggestion.show(
-                    &editor,
-                    excerpt_id,
-                    &self.workspace,
-                    &assistant_panel,
-                    cx,
-                ));
+                editor = cx.new_view(|cx| {
+                    Editor::for_multibuffer(multibuffer, Some(self.project.clone()), true, cx)
+                });
+                self.workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, false, cx)
+                    })
+                    .log_err()?;
             }
-        }
 
-        if let Some(range) = self
-            .active_workflow_step
-            .as_ref()
-            .map(|step| step.range.clone())
-        {
-            self.assists_by_step.insert(
-                range,
-                StepAssists {
-                    assist_ids: assist_ids.clone(),
+            let mut assist_ids = Vec::new();
+            for (excerpt_id, suggestion_group) in suggestion_groups {
+                for suggestion in suggestion_group.suggestions {
+                    assist_ids.extend(suggestion.show(
+                        &editor,
+                        excerpt_id,
+                        &self.workspace,
+                        &assistant_panel,
+                        cx,
+                    ));
+                }
+            }
+
+            if let Some(range) = self.active_workflow_step_range.clone() {
+                self.step_assists.insert(
+                    range,
+                    StepAssist {
+                        assist_ids: assist_ids.clone(),
+                        editor: editor.downgrade(),
+                        editor_was_open,
+                    },
+                );
+            }
+
+            Some((editor, assist_ids, editor_was_open))
+        } {
+            self.step_assists.insert(
+                step_range.clone(),
+                StepAssist {
+                    assist_ids,
+                    editor_was_open,
                     editor: editor.downgrade(),
                 },
             );
         }
 
-        Some((editor, assist_ids))
+        self.active_workflow_step_range = Some(step_range);
+
+        Some(())
+    }
+
+    fn active_workflow_step<'a>(&'a self, cx: &'a AppContext) -> Option<&'a crate::WorkflowStep> {
+        self.active_workflow_step_range
+            .as_ref()
+            .and_then(|step_range| {
+                self.context
+                    .read(cx)
+                    .workflow_step_for_range(step_range.clone())
+            })
+    }
+
+    fn workflow_step<'a>(
+        &'a mut self,
+        step_range: &Range<text::Anchor>,
+        cx: &'a mut ViewContext<ContextEditor>,
+    ) -> Option<&'a crate::WorkflowStep> {
+        self.context
+            .read(cx)
+            .workflow_step_for_range(step_range.clone())
+    }
+
+    fn scroll_to_existing_workflow_assist(
+        &self,
+        step_range: &Range<language::Anchor>,
+        cx: &mut ViewContext<Self>,
+    ) -> bool {
+        let step_assists = match self.step_assists.get(step_range) {
+            Some(assists) => assists,
+            None => return false,
+        };
+        let editor = match step_assists.editor.upgrade() {
+            Some(editor) => editor,
+            None => return false,
+        };
+        for assist_id in &step_assists.assist_ids {
+            match InlineAssistant::global(cx).status_for_assist(*assist_id, cx) {
+                Some(CodegenStatus::Idle) | None => {}
+                _ => {
+                    self.workspace
+                        .update(cx, |workspace, cx| {
+                            workspace.activate_item(&editor, false, false, cx);
+                        })
+                        .ok();
+                    InlineAssistant::update_global(cx, |assistant, cx| {
+                        assistant.scroll_to_assist(*assist_id, cx)
+                    });
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     fn handle_editor_search_event(
@@ -2555,12 +2585,12 @@ impl ContextEditor {
 
     fn render_send_button(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let focus_handle = self.focus_handle(cx).clone();
-        let button_text = match self.active_workflow_step.as_ref() {
+        let button_text = match self.active_workflow_step(cx) {
             Some(step) => {
-                if step.suggestions.is_none() {
-                    "Computing Changes..."
-                } else {
+                if step.status.is_resolved() {
                     "Apply Changes"
+                } else {
+                    "Computing Changes..."
                 }
             }
             None => "Send",

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1333,7 +1333,6 @@ struct ScrollPosition {
 struct StepAssists {
     assist_ids: Vec<InlineAssistId>,
     editor: WeakView<Editor>,
-    preview_edit_count: usize,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -2047,15 +2046,11 @@ impl ContextEditor {
             if let Some((editor, assist_ids)) =
                 self.suggest_edits(title.clone(), edit_suggestions.clone(), cx)
             {
-                let preview_edit_count = editor.update(cx, |editor, cx| {
-                    editor.buffer().read(cx).read(cx).edit_count()
-                });
                 self.assists_by_step.insert(
                     step.range.clone(),
                     StepAssists {
                         assist_ids,
                         editor: editor.downgrade(),
-                        preview_edit_count,
                     },
                 );
             }
@@ -2162,10 +2157,6 @@ impl ContextEditor {
             }
         }
 
-        let preview_edit_count = editor.update(cx, |editor, cx| {
-            editor.buffer().read(cx).read(cx).edit_count()
-        });
-
         if let Some(range) = self
             .active_workflow_step
             .as_ref()
@@ -2176,7 +2167,6 @@ impl ContextEditor {
                 StepAssists {
                     assist_ids: assist_ids.clone(),
                     editor: editor.downgrade(),
-                    preview_edit_count,
                 },
             );
         }

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -505,7 +505,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, true, true, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
-                    buffer.preserve_preview(cx);
+                    buffer.refresh_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start
@@ -521,7 +521,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, true, true, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
-                    buffer.preserve_preview(cx);
+                    buffer.refresh_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start
@@ -537,7 +537,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, false, true, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
-                    buffer.preserve_preview(cx);
+                    buffer.refresh_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start
@@ -553,7 +553,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, true, false, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
-                    buffer.preserve_preview(cx);
+                    buffer.refresh_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -505,6 +505,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, true, true, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
+                    buffer.preserve_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start
@@ -520,6 +521,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, true, true, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
+                    buffer.preserve_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start
@@ -535,6 +537,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, false, true, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
+                    buffer.preserve_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start
@@ -550,6 +553,7 @@ impl WorkflowSuggestion {
                     buffer.start_transaction(cx);
                     let line_start = buffer.insert_empty_line(position, true, false, cx);
                     initial_transaction_id = buffer.end_transaction(cx);
+                    buffer.preserve_preview(cx);
 
                     let line_start = buffer.read(cx).anchor_before(line_start);
                     line_start..line_start

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -2510,12 +2510,12 @@ impl Codegen {
         self.buffer.update(cx, |buffer, cx| {
             if let Some(transaction_id) = self.transformation_transaction_id.take() {
                 buffer.undo_transaction(transaction_id, cx);
-                buffer.preserve_preview(cx);
+                buffer.refresh_preview(cx);
             }
 
             if let Some(transaction_id) = self.initial_transaction_id.take() {
                 buffer.undo_transaction(transaction_id, cx);
-                buffer.preserve_preview(cx);
+                buffer.refresh_preview(cx);
             }
         });
     }

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -2156,7 +2156,7 @@ impl Codegen {
 
         if let Some(transformation_transaction_id) = self.transformation_transaction_id.take() {
             self.buffer.update(cx, |buffer, cx| {
-                buffer.undo_transaction(transformation_transaction_id, cx)
+                buffer.undo_transaction(transformation_transaction_id, cx);
             });
         }
 
@@ -2510,10 +2510,12 @@ impl Codegen {
         self.buffer.update(cx, |buffer, cx| {
             if let Some(transaction_id) = self.transformation_transaction_id.take() {
                 buffer.undo_transaction(transaction_id, cx);
+                buffer.preserve_preview(cx);
             }
 
             if let Some(transaction_id) = self.initial_transaction_id.take() {
                 buffer.undo_transaction(transaction_id, cx);
+                buffer.preserve_preview(cx);
             }
         });
     }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -894,6 +894,11 @@ impl Item for Editor {
             _ => {}
         }
     }
+
+    fn edited_since_preview(&self, _cx: &AppContext) -> bool {
+        // todo! actually implement this
+        false
+    }
 }
 
 impl SerializableItem for Editor {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -894,11 +894,6 @@ impl Item for Editor {
             _ => {}
         }
     }
-
-    fn edited_since_preview(&self, _cx: &AppContext) -> bool {
-        // todo! actually implement this
-        false
-    }
 }
 
 impl SerializableItem for Editor {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -895,8 +895,8 @@ impl Item for Editor {
         }
     }
 
-    fn should_dismiss_preview(&self, cx: &AppContext) -> bool {
-        self.buffer.read(cx).should_dismiss_preview(cx)
+    fn preserve_preview(&self, cx: &AppContext) -> bool {
+        self.buffer.read(cx).preserve_preview(cx)
     }
 }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -895,9 +895,8 @@ impl Item for Editor {
         }
     }
 
-    fn edited_since_preview(&self, _cx: &AppContext) -> bool {
-        // todo! actually implement this
-        false
+    fn should_dismiss_preview(&self, cx: &AppContext) -> bool {
+        self.buffer.read(cx).should_dismiss_preview(cx)
     }
 }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1353,7 +1353,7 @@ impl Buffer {
             })
             .collect();
 
-        let preserve_preview = !self.preserve_preview();
+        let preserve_preview = self.preserve_preview();
         self.edit(edits, None, cx);
         if preserve_preview {
             self.refresh_preview();
@@ -2211,7 +2211,7 @@ impl Buffer {
 
     /// Whether we should preserve the preview status of a tab containing this buffer.
     pub fn preserve_preview(&self) -> bool {
-        self.has_edits_since(&self.preview_version)
+        !self.has_edits_since(&self.preview_version)
     }
 }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -97,6 +97,8 @@ pub struct Buffer {
     /// The version vector when this buffer was last loaded from
     /// or saved to disk.
     saved_version: clock::Global,
+    preview_version: clock::Global,
+    preview_preserved: bool,
     transaction_depth: usize,
     was_dirty_before_starting_transaction: Option<bool>,
     reload_task: Option<Task<Result<()>>>,
@@ -703,6 +705,7 @@ impl Buffer {
         Self {
             saved_mtime,
             saved_version: buffer.version(),
+            preview_version: buffer.version(),
             reload_task: None,
             transaction_depth: 0,
             was_dirty_before_starting_transaction: None,
@@ -733,6 +736,7 @@ impl Buffer {
             completion_triggers_timestamp: Default::default(),
             deferred_ops: OperationQueue::new(),
             has_conflict: false,
+            preview_preserved: false,
         }
     }
 
@@ -2194,6 +2198,17 @@ impl Buffer {
     /// Usually this is driven by LSP server which returns a list of trigger characters for completions.
     pub fn completion_triggers(&self) -> &[String] {
         &self.completion_triggers
+    }
+
+    /// Call this directly after performing edits to prevent the preview tab
+    /// from being dismissed by those edits. It causes `should_dismiss_preview`
+    /// to return false until there are additional edits.
+    pub fn preserve_preview(&mut self) {
+        self.preview_version = self.version.clone();
+    }
+
+    pub fn should_dismiss_preview(&self) -> bool {
+        self.has_edits_since(&self.preview_version)
     }
 }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1353,10 +1353,10 @@ impl Buffer {
             })
             .collect();
 
-        let preserve_preview = !self.should_dismiss_preview();
+        let preserve_preview = !self.preserve_preview();
         self.edit(edits, None, cx);
         if preserve_preview {
-            self.refresh_preview_version();
+            self.refresh_preview();
         }
     }
 
@@ -2205,11 +2205,12 @@ impl Buffer {
     /// Call this directly after performing edits to prevent the preview tab
     /// from being dismissed by those edits. It causes `should_dismiss_preview`
     /// to return false until there are additional edits.
-    pub fn refresh_preview_version(&mut self) {
+    pub fn refresh_preview(&mut self) {
         self.preview_version = self.version.clone();
     }
 
-    pub fn should_dismiss_preview(&self) -> bool {
+    /// Whether we should preserve the preview status of a tab containing this buffer.
+    pub fn preserve_preview(&self) -> bool {
         self.has_edits_since(&self.preview_version)
     }
 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -98,7 +98,6 @@ pub struct Buffer {
     /// or saved to disk.
     saved_version: clock::Global,
     preview_version: clock::Global,
-    preview_preserved: bool,
     transaction_depth: usize,
     was_dirty_before_starting_transaction: Option<bool>,
     reload_task: Option<Task<Result<()>>>,
@@ -736,7 +735,6 @@ impl Buffer {
             completion_triggers_timestamp: Default::default(),
             deferred_ops: OperationQueue::new(),
             has_conflict: false,
-            preview_preserved: false,
         }
     }
 
@@ -1355,7 +1353,11 @@ impl Buffer {
             })
             .collect();
 
+        let preserve_preview = !self.should_dismiss_preview();
         self.edit(edits, None, cx);
+        if preserve_preview {
+            self.refresh_preview_version();
+        }
     }
 
     /// Create a minimal edit that will cause the given row to be indented
@@ -2203,7 +2205,7 @@ impl Buffer {
     /// Call this directly after performing edits to prevent the preview tab
     /// from being dismissed by those edits. It causes `should_dismiss_preview`
     /// to return false until there are additional edits.
-    pub fn preserve_preview(&mut self) {
+    pub fn refresh_preview_version(&mut self) {
         self.preview_version = self.version.clone();
     }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1836,11 +1836,11 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
         buffer.set_sync_parse_timeout(Duration::ZERO);
 
         buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::EachLine), cx);
-        buffer.refresh_preview_version();
+        buffer.refresh_preview();
 
         // Synchronously, we haven't auto-indented and we're still preserving the preview.
         assert_eq!(buffer.text(), "fn a() {\n\n}");
-        assert!(!buffer.should_dismiss_preview());
+        assert!(!buffer.preserve_preview());
         buffer
     });
 
@@ -1850,7 +1850,7 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
     // The auto-indent applied, but didn't dismiss our preview
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "fn a() {\n    \n}");
-        assert!(!buffer.should_dismiss_preview());
+        assert!(!buffer.preserve_preview());
 
         // Edit inserting another line. It will autoindent async.
         // Then refresh the preview version.
@@ -1859,14 +1859,14 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
             Some(AutoindentMode::EachLine),
             cx,
         );
-        buffer.refresh_preview_version();
+        buffer.refresh_preview();
         assert_eq!(buffer.text(), "fn a() {\n    \n\n}");
-        assert!(!buffer.should_dismiss_preview());
+        assert!(!buffer.preserve_preview());
 
         // Then perform another edit, this time without refreshing the preview version.
         buffer.edit([(Point::new(1, 4)..Point::new(1, 4), "x")], None, cx);
         // This causes the preview to not be preserved.
-        assert!(buffer.should_dismiss_preview());
+        assert!(buffer.preserve_preview());
     });
 
     // Let the async autoindent from the first edit finish.
@@ -1875,7 +1875,7 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
     // The autoindent applies, but it shouldn't restore the preview status because we had an edit in the meantime.
     buffer.update(cx, |buffer, _| {
         assert_eq!(buffer.text(), "fn a() {\n    \n    \n}");
-        assert!(buffer.should_dismiss_preview());
+        assert!(buffer.preserve_preview());
     });
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1840,7 +1840,7 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
 
         // Synchronously, we haven't auto-indented and we're still preserving the preview.
         assert_eq!(buffer.text(), "fn a() {\n\n}");
-        assert!(!buffer.preserve_preview());
+        assert!(buffer.preserve_preview());
         buffer
     });
 
@@ -1850,7 +1850,7 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
     // The auto-indent applied, but didn't dismiss our preview
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "fn a() {\n    \n}");
-        assert!(!buffer.preserve_preview());
+        assert!(buffer.preserve_preview());
 
         // Edit inserting another line. It will autoindent async.
         // Then refresh the preview version.
@@ -1861,12 +1861,12 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
         );
         buffer.refresh_preview();
         assert_eq!(buffer.text(), "fn a() {\n    \n\n}");
-        assert!(!buffer.preserve_preview());
+        assert!(buffer.preserve_preview());
 
         // Then perform another edit, this time without refreshing the preview version.
         buffer.edit([(Point::new(1, 4)..Point::new(1, 4), "x")], None, cx);
         // This causes the preview to not be preserved.
-        assert!(buffer.preserve_preview());
+        assert!(!buffer.preserve_preview());
     });
 
     // Let the async autoindent from the first edit finish.
@@ -1874,8 +1874,8 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
 
     // The autoindent applies, but it shouldn't restore the preview status because we had an edit in the meantime.
     buffer.update(cx, |buffer, _| {
-        assert_eq!(buffer.text(), "fn a() {\n    \n    \n}");
-        assert!(buffer.preserve_preview());
+        assert_eq!(buffer.text(), "fn a() {\n    x\n    \n}");
+        assert!(!buffer.preserve_preview());
     });
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1823,6 +1823,63 @@ fn test_autoindent_query_with_outdent_captures(cx: &mut AppContext) {
 }
 
 #[gpui::test]
+async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
+    cx.update(|cx| init_settings(cx, |_| {}));
+
+    // First we insert some newlines to request an auto-indent (asynchronously).
+    // Then we request that a preview tab be preserved for the new version, even though it's edited.
+    let buffer = cx.new_model(|cx| {
+        let text = "fn a() {}";
+        let mut buffer = Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx);
+
+        // This causes autoindent to be async.
+        buffer.set_sync_parse_timeout(Duration::ZERO);
+
+        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::EachLine), cx);
+        buffer.refresh_preview_version();
+
+        // Synchronously, we haven't auto-indented and we're still preserving the preview.
+        assert_eq!(buffer.text(), "fn a() {\n\n}");
+        assert!(!buffer.should_dismiss_preview());
+        buffer
+    });
+
+    // Now let the autoindent finish
+    cx.executor().run_until_parked();
+
+    // The auto-indent applied, but didn't dismiss our preview
+    buffer.update(cx, |buffer, cx| {
+        assert_eq!(buffer.text(), "fn a() {\n    \n}");
+        assert!(!buffer.should_dismiss_preview());
+
+        // Edit inserting another line. It will autoindent async.
+        // Then refresh the preview version.
+        buffer.edit(
+            [(Point::new(1, 4)..Point::new(1, 4), "\n")],
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
+        buffer.refresh_preview_version();
+        assert_eq!(buffer.text(), "fn a() {\n    \n\n}");
+        assert!(!buffer.should_dismiss_preview());
+
+        // Then perform another edit, this time without refreshing the preview version.
+        buffer.edit([(Point::new(1, 4)..Point::new(1, 4), "x")], None, cx);
+        // This causes the preview to not be preserved.
+        assert!(buffer.should_dismiss_preview());
+    });
+
+    // Let the async autoindent from the first edit finish.
+    cx.executor().run_until_parked();
+
+    // The autoindent applies, but it shouldn't restore the preview status because we had an edit in the meantime.
+    buffer.update(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "fn a() {\n    \n    \n}");
+        assert!(buffer.should_dismiss_preview());
+    });
+}
+
+#[gpui::test]
 fn test_insert_empty_line(cx: &mut AppContext) {
     init_settings(cx, |_| {});
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1762,6 +1762,21 @@ impl MultiBuffer {
         cx.notify();
     }
 
+    pub fn preserve_preview(&self, cx: &mut ModelContext<Self>) {
+        for buffer_state in self.buffers.borrow().values() {
+            buffer_state
+                .buffer
+                .update(cx, |buffer, _cx| buffer.preserve_preview());
+        }
+    }
+
+    pub fn should_dismiss_preview(&self, cx: &AppContext) -> bool {
+        self.buffers
+            .borrow()
+            .values()
+            .any(|state| state.buffer.read(cx).should_dismiss_preview())
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     pub fn is_parsing(&self, cx: &AppContext) -> bool {
         self.as_singleton().unwrap().read(cx).is_parsing()

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1766,7 +1766,7 @@ impl MultiBuffer {
         for buffer_state in self.buffers.borrow().values() {
             buffer_state
                 .buffer
-                .update(cx, |buffer, _cx| buffer.preserve_preview());
+                .update(cx, |buffer, _cx| buffer.refresh_preview_version());
         }
     }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1762,19 +1762,21 @@ impl MultiBuffer {
         cx.notify();
     }
 
-    pub fn preserve_preview(&self, cx: &mut ModelContext<Self>) {
+    /// Preserve preview tabs containing this multibuffer until additional edits occur.
+    pub fn refresh_preview(&self, cx: &mut ModelContext<Self>) {
         for buffer_state in self.buffers.borrow().values() {
             buffer_state
                 .buffer
-                .update(cx, |buffer, _cx| buffer.refresh_preview_version());
+                .update(cx, |buffer, _cx| buffer.refresh_preview());
         }
     }
 
-    pub fn should_dismiss_preview(&self, cx: &AppContext) -> bool {
+    /// Whether we should preserve the preview status of a tab containing this multi-buffer.
+    pub fn preserve_preview(&self, cx: &AppContext) -> bool {
         self.buffers
             .borrow()
             .values()
-            .any(|state| state.buffer.read(cx).should_dismiss_preview())
+            .all(|state| state.buffer.read(cx).preserve_preview())
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4990,7 +4990,6 @@ impl Project {
                 if ensure_final_newline {
                     buffer.ensure_final_newline(cx);
                 }
-                // dbg!();
                 buffer.end_transaction(cx)
             })?;
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4990,6 +4990,7 @@ impl Project {
                 if ensure_final_newline {
                     buffer.ensure_final_newline(cx);
                 }
+                // dbg!();
                 buffer.end_transaction(cx)
             })?;
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -288,7 +288,7 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
         None
     }
 
-    fn should_dismiss_preview(&self, _cx: &AppContext) -> bool {
+    fn preserve_preview(&self, _cx: &AppContext) -> bool {
         true
     }
 }
@@ -431,7 +431,7 @@ pub trait ItemHandle: 'static + Send {
     fn pixel_position_of_cursor(&self, cx: &AppContext) -> Option<Point<Pixels>>;
     fn downgrade_item(&self) -> Box<dyn WeakItemHandle>;
     fn workspace_settings<'a>(&self, cx: &'a AppContext) -> &'a WorkspaceSettings;
-    fn should_dismiss_preview(&self, cx: &AppContext) -> bool;
+    fn preserve_preview(&self, cx: &AppContext) -> bool;
 }
 
 pub trait WeakItemHandle: Send + Sync {
@@ -824,8 +824,8 @@ impl<T: Item> ItemHandle for View<T> {
         SerializableItemRegistry::view_to_serializable_item_handle(self.to_any(), cx)
     }
 
-    fn should_dismiss_preview(&self, cx: &AppContext) -> bool {
-        self.read(cx).should_dismiss_preview(cx)
+    fn preserve_preview(&self, cx: &AppContext) -> bool {
+        self.read(cx).preserve_preview(cx)
     }
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -287,10 +287,6 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
     fn pixel_position_of_cursor(&self, _: &AppContext) -> Option<Point<Pixels>> {
         None
     }
-
-    fn edited_since_preview(&self, _cx: &AppContext) -> bool {
-        false
-    }
 }
 
 pub trait SerializableItem: Item {
@@ -431,7 +427,6 @@ pub trait ItemHandle: 'static + Send {
     fn pixel_position_of_cursor(&self, cx: &AppContext) -> Option<Point<Pixels>>;
     fn downgrade_item(&self) -> Box<dyn WeakItemHandle>;
     fn workspace_settings<'a>(&self, cx: &'a AppContext) -> &'a WorkspaceSettings;
-    fn edited_since_preview(&self, cx: &AppContext) -> bool;
 }
 
 pub trait WeakItemHandle: Send + Sync {
@@ -822,10 +817,6 @@ impl<T: Item> ItemHandle for View<T> {
         cx: &AppContext,
     ) -> Option<Box<dyn SerializableItemHandle>> {
         SerializableItemRegistry::view_to_serializable_item_handle(self.to_any(), cx)
-    }
-
-    fn edited_since_preview(&self, cx: &AppContext) -> bool {
-        self.read(cx).edited_since_preview(cx)
     }
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -289,7 +289,7 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
     }
 
     fn preserve_preview(&self, _cx: &AppContext) -> bool {
-        true
+        false
     }
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -288,8 +288,8 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
         None
     }
 
-    fn edited_since_preview(&self, _cx: &AppContext) -> bool {
-        false
+    fn should_dismiss_preview(&self, _cx: &AppContext) -> bool {
+        true
     }
 }
 
@@ -431,7 +431,7 @@ pub trait ItemHandle: 'static + Send {
     fn pixel_position_of_cursor(&self, cx: &AppContext) -> Option<Point<Pixels>>;
     fn downgrade_item(&self) -> Box<dyn WeakItemHandle>;
     fn workspace_settings<'a>(&self, cx: &'a AppContext) -> &'a WorkspaceSettings;
-    fn edited_since_preview(&self, cx: &AppContext) -> bool;
+    fn should_dismiss_preview(&self, cx: &AppContext) -> bool;
 }
 
 pub trait WeakItemHandle: Send + Sync {
@@ -824,8 +824,8 @@ impl<T: Item> ItemHandle for View<T> {
         SerializableItemRegistry::view_to_serializable_item_handle(self.to_any(), cx)
     }
 
-    fn edited_since_preview(&self, cx: &AppContext) -> bool {
-        self.read(cx).edited_since_preview(cx)
+    fn should_dismiss_preview(&self, cx: &AppContext) -> bool {
+        self.read(cx).should_dismiss_preview(cx)
     }
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -287,6 +287,10 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
     fn pixel_position_of_cursor(&self, _: &AppContext) -> Option<Point<Pixels>> {
         None
     }
+
+    fn edited_since_preview(&self, _cx: &AppContext) -> bool {
+        false
+    }
 }
 
 pub trait SerializableItem: Item {
@@ -427,6 +431,7 @@ pub trait ItemHandle: 'static + Send {
     fn pixel_position_of_cursor(&self, cx: &AppContext) -> Option<Point<Pixels>>;
     fn downgrade_item(&self) -> Box<dyn WeakItemHandle>;
     fn workspace_settings<'a>(&self, cx: &'a AppContext) -> &'a WorkspaceSettings;
+    fn edited_since_preview(&self, cx: &AppContext) -> bool;
 }
 
 pub trait WeakItemHandle: Send + Sync {
@@ -817,6 +822,10 @@ impl<T: Item> ItemHandle for View<T> {
         cx: &AppContext,
     ) -> Option<Box<dyn SerializableItemHandle>> {
         SerializableItemRegistry::view_to_serializable_item_handle(self.to_any(), cx)
+    }
+
+    fn edited_since_preview(&self, cx: &AppContext) -> bool {
+        self.read(cx).edited_since_preview(cx)
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -665,6 +665,12 @@ impl Pane {
         self.preview_item_id
     }
 
+    pub fn preview_item(&self) -> Option<Box<dyn ItemHandle>> {
+        self.preview_item_id
+            .and_then(|id| self.items.iter().find(|item| item.item_id() == id))
+            .cloned()
+    }
+
     fn preview_item_idx(&self) -> Option<usize> {
         if let Some(preview_item_id) = self.preview_item_id {
             self.items
@@ -688,9 +694,9 @@ impl Pane {
     }
 
     pub fn handle_item_edit(&mut self, item_id: EntityId, cx: &AppContext) {
-        if let Some(preview_item_id) = self.preview_item_id {
-            if preview_item_id == item_id {
-                self.set_preview_item_id(None, cx)
+        if let Some(preview_item) = self.preview_item() {
+            if preview_item.item_id() == item_id && preview_item.edited_since_preview(cx) {
+                self.set_preview_item_id(None, cx);
             }
         }
     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -695,7 +695,7 @@ impl Pane {
 
     pub fn handle_item_edit(&mut self, item_id: EntityId, cx: &AppContext) {
         if let Some(preview_item) = self.preview_item() {
-            if preview_item.item_id() == item_id && preview_item.edited_since_preview(cx) {
+            if preview_item.item_id() == item_id && preview_item.should_dismiss_preview(cx) {
                 self.set_preview_item_id(None, cx);
             }
         }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -695,7 +695,7 @@ impl Pane {
 
     pub fn handle_item_edit(&mut self, item_id: EntityId, cx: &AppContext) {
         if let Some(preview_item) = self.preview_item() {
-            if preview_item.item_id() == item_id && preview_item.edited_since_preview(cx) {
+            if preview_item.item_id() == item_id {
                 self.set_preview_item_id(None, cx);
             }
         }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -695,7 +695,7 @@ impl Pane {
 
     pub fn handle_item_edit(&mut self, item_id: EntityId, cx: &AppContext) {
         if let Some(preview_item) = self.preview_item() {
-            if preview_item.item_id() == item_id {
+            if preview_item.item_id() == item_id && preview_item.edited_since_preview(cx) {
                 self.set_preview_item_id(None, cx);
             }
         }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -695,7 +695,7 @@ impl Pane {
 
     pub fn handle_item_edit(&mut self, item_id: EntityId, cx: &AppContext) {
         if let Some(preview_item) = self.preview_item() {
-            if preview_item.item_id() == item_id && preview_item.should_dismiss_preview(cx) {
+            if preview_item.item_id() == item_id && !preview_item.preserve_preview(cx) {
                 self.set_preview_item_id(None, cx);
             }
         }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2611,6 +2611,25 @@ impl Workspace {
         open_project_item
     }
 
+    pub fn is_project_item_open<T>(
+        &self,
+        pane: &View<Pane>,
+        project_item: &Model<T::Item>,
+        cx: &AppContext,
+    ) -> bool
+    where
+        T: ProjectItem,
+    {
+        use project::Item as _;
+
+        project_item
+            .read(cx)
+            .entry_id(cx)
+            .and_then(|entry_id| pane.read(cx).item_for_entry(entry_id, cx))
+            .and_then(|item| item.downcast::<T>())
+            .is_some()
+    }
+
     pub fn open_project_item<T>(
         &mut self,
         pane: View<Pane>,


### PR DESCRIPTION
This PR opens workflow step editors as preview tabs and closes them upon exiting the step if they are still in preview mode and they weren't already open before entering the step.

Making this work was tricky, because we often edit the buffer as part of displaying the workflow step suggestions to create empty lines where we can generate. We undo these edits if the transformation is not applied, but they were causing the preview to be dismissed.

After trying a few approaches, I decided to give workspace `Item`s a `preserve_preview` method that defaults to false. When the workspace sees an edit event for the item, it checks if the item wants to preserve its preview. For buffers, after editing, you can call `refresh_preview`, which sets a preview version to the current version of the buffer. Any edits after this version will cause preview to not be preserved.

One final issue is with async auto-indent. To ensure these async edits don't dismiss the preview, I automatically refresh the preview version if preview was preserved prior to performing the auto-indent. The assumption is that these are edits created by other edits, and if we didn't want to dismiss the preview with the originating edits, then the auto-indent edits shouldn't dismiss it either.

Release Notes:

- N/A
