### PR TITLE
Point PROTOC to nixpkgs.protobuf pkg in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -52,5 +52,6 @@ else
           "assets/fonts/zed-sans"
         ];
       };
+      PROTOC = "${pkgs.protobuf}/bin/protoc";
     };
   }


### PR DESCRIPTION
This fixes an issue on NixOS where Zed's proto crate fails to build. Cargo expects to find protoc in the Cargo registry, but due to the distro's non-standard filesystem this expectation is invalid.

Release Notes:

- N/A
