### PR TITLE
recent_project: Fix overflow sub

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -669,7 +669,7 @@ impl RecentProjectsDelegate {
                     .unwrap_or_default();
                 this.update(&mut cx, move |picker, cx| {
                     picker.delegate.set_workspaces(workspaces);
-                    picker.delegate.set_selected_index(ix - 1, cx);
+                    picker.delegate.set_selected_index(ix.saturating_sub(1), cx);
                     picker.delegate.reset_selected_match_index = false;
                     picker.update_matches(picker.query(cx), cx)
                 })


### PR DESCRIPTION
close: #15783 

Release Notes:

- Fixed a potential panic that can occur when deleting entries from the recent-projects menu ([#15783](https://github.com/zed-industries/zed/issues/15783))
