### PR TITLE
keymap: Show error notification when keymap is invalid

### DIFF
--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -1,5 +1,4 @@
 use crate::{settings_store::SettingsStore, Settings};
-use anyhow::Result;
 use fs::Fs;
 use futures::{channel::mpsc, StreamExt};
 use gpui::{AppContext, BackgroundExecutor, ReadGlobal, UpdateGlobal};
@@ -67,7 +66,7 @@ pub fn watch_config_file(
 pub fn handle_settings_file_changes(
     mut user_settings_file_rx: mpsc::UnboundedReceiver<String>,
     cx: &mut AppContext,
-    settings_changed: impl Fn(Result<()>, &mut AppContext) + 'static,
+    settings_changed: impl Fn(Option<anyhow::Error>, &mut AppContext) + 'static,
 ) {
     let user_settings_content = cx
         .background_executor()
@@ -85,7 +84,7 @@ pub fn handle_settings_file_changes(
                 if let Err(err) = &result {
                     log::error!("Failed to load user settings: {err}");
                 }
-                settings_changed(result, cx);
+                settings_changed(result.err(), cx);
                 cx.refresh();
             });
             if result.is_err() {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -430,7 +430,7 @@ fn main() {
 
         settings::init(cx);
         handle_settings_file_changes(user_settings_file_rx, cx, handle_settings_changed);
-        handle_keymap_file_changes(user_keymap_file_rx, cx);
+        handle_keymap_file_changes(user_keymap_file_rx, cx, handle_keymap_changed);
 
         client::init_settings(cx);
         let client = Client::production(cx);
@@ -543,15 +543,39 @@ fn main() {
     });
 }
 
-fn handle_settings_changed(result: Result<()>, cx: &mut AppContext) {
+fn handle_keymap_changed(error: Option<anyhow::Error>, cx: &mut AppContext) {
+    struct KeymapParseErrorNotification;
+    let id = NotificationId::unique::<KeymapParseErrorNotification>();
+
+    for workspace in workspace::local_workspace_windows(cx) {
+        workspace
+            .update(cx, |workspace, cx| match &error {
+                Some(error) => {
+                    workspace.show_notification(id.clone(), cx, |cx| {
+                        cx.new_view(|_| {
+                            MessageNotification::new(format!("Invalid keymap file\n{error}"))
+                                .with_click_message("Open keymap file")
+                                .on_click(|cx| {
+                                    cx.dispatch_action(zed_actions::OpenKeymap.boxed_clone());
+                                    cx.emit(DismissEvent);
+                                })
+                        })
+                    });
+                }
+                None => workspace.dismiss_notification(&id, cx),
+            })
+            .log_err();
+    }
+}
+
+fn handle_settings_changed(error: Option<anyhow::Error>, cx: &mut AppContext) {
     struct SettingsParseErrorNotification;
     let id = NotificationId::unique::<SettingsParseErrorNotification>();
 
     for workspace in workspace::local_workspace_windows(cx) {
         workspace
-            .update(cx, |workspace, cx| match &result {
-                Ok(()) => workspace.dismiss_notification(&id, cx),
-                Err(error) => {
+            .update(cx, |workspace, cx| match &error {
+                Some(error) => {
                     workspace.show_notification(id.clone(), cx, |cx| {
                         cx.new_view(|_| {
                             MessageNotification::new(format!("Invalid settings file\n{error}"))
@@ -563,6 +587,7 @@ fn handle_settings_changed(result: Result<()>, cx: &mut AppContext) {
                         })
                     });
                 }
+                None => workspace.dismiss_notification(&id, cx),
             })
             .log_err();
     }


### PR DESCRIPTION
This adds an error notification that pops up when the user has an invalid keymap, similar to what we added for settings in #15905.

Release Notes:

- Added a popup that is displayed when the keymap is invalid
