### PR TITLE
collab: Always use newest anthropic model version

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -16,13 +16,13 @@ pub const ANTHROPIC_API_URL: &'static str = "https://api.anthropic.com";
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
     #[default]
-    #[serde(alias = "claude-3-5-sonnet", rename = "claude-3-5-sonnet-20240620")]
+    #[serde(rename = "claude-3-5-sonnet", alias = "claude-3-5-sonnet-20240620")]
     Claude3_5Sonnet,
-    #[serde(alias = "claude-3-opus", rename = "claude-3-opus-20240229")]
+    #[serde(rename = "claude-3-opus", alias = "claude-3-opus-20240229")]
     Claude3Opus,
-    #[serde(alias = "claude-3-sonnet", rename = "claude-3-sonnet-20240229")]
+    #[serde(rename = "claude-3-sonnet", alias = "claude-3-sonnet-20240229")]
     Claude3Sonnet,
-    #[serde(alias = "claude-3-haiku", rename = "claude-3-haiku-20240307")]
+    #[serde(rename = "claude-3-haiku", alias = "claude-3-haiku-20240307")]
     Claude3Haiku,
     #[serde(rename = "custom")]
     Custom {


### PR DESCRIPTION
When Anthropic releases a new version of their models, Zed AI users should always get access to the new version even when using an old version of zed.

Co-Authored-By: Thorsten <thorsten@zed.dev>

Release Notes:

- N/A
