### PR TITLE
script/bootstrap: Fix sqlx command by using newer version

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -11,9 +11,9 @@ else
 fi
 
 # Install sqlx-cli if needed
-if [[ "$(sqlx --version)" != "sqlx-cli 0.5.7" ]]; then
-    echo "sqlx-cli not found or not the required version, installing version 0.5.7..."
-    cargo install sqlx-cli --version 0.5.7
+if [[ "$(sqlx --version)" != "sqlx-cli 0.7.2" ]]; then
+    echo "sqlx-cli not found or not the required version, installing version 0.7.2..."
+    cargo install sqlx-cli --version 0.7.2
 fi
 
 cd crates/collab


### PR DESCRIPTION
Version 0.5.7 doesn't have the `--database-url` command line flag, so `script/bootstrap` didn't work.

Since we use `0.7` in collab (see [here](https://github.com/zed-industries/zed/blob/73fb8277fc699600793e39e8320aa812cce48694/crates/collab/Cargo.toml#L60)) and sqlx 0.7.2 has the `--database-url` flag, we use that instead.


Release Notes:

- N/A
