### PR TITLE
Add injections for tagged template literals

### DIFF
--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -35,7 +35,6 @@
                               (#set! "language" "sql"))
 )
 
-
 (call_expression
   function: (identifier) @_name (#eq? @_name "ts")
   arguments: (template_string (string_fragment) @content

--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -4,3 +4,47 @@
 
 ((regex) @content
   (#set! "language" "regex"))
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "css")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "css"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "html")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "html"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "js")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "javascript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "json")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "json"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "sql")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "sql"))
+)
+
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "ts")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "typescript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^ya?ml$")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "yaml"))
+)
+

--- a/crates/languages/src/tsx/injections.scm
+++ b/crates/languages/src/tsx/injections.scm
@@ -35,7 +35,6 @@
                               (#set! "language" "sql"))
 )
 
-
 (call_expression
   function: (identifier) @_name (#eq? @_name "ts")
   arguments: (template_string (string_fragment) @content

--- a/crates/languages/src/tsx/injections.scm
+++ b/crates/languages/src/tsx/injections.scm
@@ -4,3 +4,47 @@
 
 ((regex) @content
   (#set! "language" "regex"))
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "css")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "css"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "html")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "html"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "js")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "javascript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "json")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "json"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "sql")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "sql"))
+)
+
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "ts")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "typescript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^ya?ml$")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "yaml"))
+)
+

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -8,3 +8,47 @@
 
 ((regex) @content
   (#set! "language" "regex"))
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "css")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "css"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "html")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "html"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "js")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "javascript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "json")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "json"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "sql")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "sql"))
+)
+
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "ts")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "typescript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^ya?ml$")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "yaml"))
+)
+

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -39,7 +39,6 @@
                               (#set! "language" "sql"))
 )
 
-
 (call_expression
   function: (identifier) @_name (#eq? @_name "ts")
   arguments: (template_string (string_fragment) @content


### PR DESCRIPTION
This PR adds syntax highlighting support for `css`, `html`, `js`, `json`, `sql`, `ts`, `yaml` and `yml` in `javascript`, `typescript` and `tsx` languages where the contents of tagged template literals are now highlighted.

This does not actually enable language features (like LSP support), it only does syntax highlighting.

Before this change:
<img width="561" alt="image" src="https://github.com/user-attachments/assets/74bace1b-5ce1-4b17-8a97-035bba152d9c">


After this change:
<img width="607" alt="image" src="https://github.com/user-attachments/assets/f227145b-3f4a-4c27-b14f-7143bb19b4cf">

/cc @mrnugget 

Release Notes:

- Added syntax highlighting for tagged template literals in `javascript`, `typescript` and `tsx` languages for `css`, `html`, `js`, `json`, `sql`, `ts`, `yaml` and `yml`. ([#15984](https://github.com/zed-industries/zed/issues/15984))

