### PR TITLE
terminal: Fix Python virtual environment detection

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -260,7 +260,7 @@ impl Project {
                     .and_then(|(worktree, relative_path)| {
                         worktree.read(cx).entry_for_path(&relative_path)
                     })
-                    .is_some()
+                    .is_some_and(|entry| entry.is_dir())
             })
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/15570

A Python virtual environment places a copy of the Python interpreter and related files into a special directory, such as `.env` or `env`. Currently, the built-in Zed terminal does not check if any entries specified in `terminal.detect_venv.directories` are directories. If a regular file with the same name exists, the terminal incorrectly attempts to activate it as a virtual environment. The fix is to ensure that an entry is a directory before attempting to activate the virtual environment.

Here are screenshots of 3 possible scenarios:

# With a regular file `.env` in the worktree

## Before

![before](https://github.com/user-attachments/assets/6237a048-432c-4530-892e-91db16ac71bb)

## After

![after](https://github.com/user-attachments/assets/8268dbf4-7f22-441c-a46d-5df9c38131f9)


# With a directory called `.env` in the worktree

![with_pyenv](https://github.com/user-attachments/assets/8d901874-758d-4473-b35a-9c3db32d3b38)


Release Notes:

- Fixed detection of Python virtual environments.
