### PR TITLE
Fix Windows build in CI

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "windows", allow(unused, dead_code))]
+
 pub mod assistant_panel;
 pub mod assistant_settings;
 mod context;

--- a/crates/assistant/src/model_selector.rs
+++ b/crates/assistant/src/model_selector.rs
@@ -18,7 +18,6 @@ use ui::{prelude::*, ListItem, PopoverMenu, PopoverMenuHandle, PopoverTrigger};
 
 const TRY_ZED_PRO_URL: &str = "https://zed.dev/pro";
 
-// Test.
 #[derive(IntoElement)]
 pub struct ModelSelector<T: PopoverTrigger> {
     handle: Option<PopoverMenuHandle<Picker<ModelPickerDelegate>>>,

--- a/crates/assistant/src/model_selector.rs
+++ b/crates/assistant/src/model_selector.rs
@@ -18,6 +18,7 @@ use ui::{prelude::*, ListItem, PopoverMenu, PopoverMenuHandle, PopoverTrigger};
 
 const TRY_ZED_PRO_URL: &str = "https://zed.dev/pro";
 
+// Test.
 #[derive(IntoElement)]
 pub struct ModelSelector<T: PopoverTrigger> {
     handle: Option<PopoverMenuHandle<Picker<ModelPickerDelegate>>>,


### PR DESCRIPTION
This PR fixes the Windows build in CI, which was failing due to Clippy warnings.

Release Notes:

- N/A
