### PR TITLE
Link to pull requests in changelog notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,14 @@
-
+fixes: <issue_link>
 
 Release Notes:
 
-- Added/Fixed/Improved ... ([#NNNNN](https://github.com/zed-industries/zed/issues/NNNNN)).
+- Added/Fixed/Improved ...
 
 Optionally, include screenshots / media showcasing your addition that can be included in the release notes.
 
 ### Or...
+
+fixes: <issue_link>
 
 Release Notes:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-fixes: <issue_link>
+Closes #ISSUE
 
 Release Notes:
 
@@ -8,7 +8,7 @@ Optionally, include screenshots / media showcasing your addition that can be inc
 
 ### Or...
 
-fixes: <issue_link>
+Closes #ISSUE
 
 Release Notes:
 

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -21,7 +21,7 @@ if (!hasReleaseNotes) {
       "```",
       "Release Notes:",
       "",
-      "- (Added|Fixed|Improved) ... ([#<public_issue_number_if_exists>](https://github.com/zed-industries/zed/issues/<public_issue_number_if_exists>)).",
+      "- Added/Fixed/Improved ...",
       "```",
       "",
       'If your change is not user-facing, you can use "N/A" for the entry:',
@@ -29,25 +29,6 @@ if (!hasReleaseNotes) {
       "Release Notes:",
       "",
       "- N/A",
-      "```",
-    ].join("\n"),
-  );
-}
-
-const INCORRECT_ISSUE_LINK_PATTERN = new RegExp("-.*\\(#\\d+\\)", "g");
-
-const hasIncorrectIssueLinks = INCORRECT_ISSUE_LINK_PATTERN.test(
-  danger.github.pr.body,
-);
-if (hasIncorrectIssueLinks) {
-  warn(
-    [
-      "This PR has incorrectly formatted GitHub issue links in the release notes.",
-      "",
-      "GitHub issue links must be formatted as plain Markdown links:",
-      "",
-      "```",
-      "- Improved something ([#ISSUE](https://github.com/zed-industries/zed/issues/ISSUE)).",
       "```",
     ].join("\n"),
   );

--- a/script/get-preview-channel-changes
+++ b/script/get-preview-channel-changes
@@ -2,7 +2,8 @@
 
 const { execFileSync } = require("child_process");
 let { GITHUB_ACCESS_TOKEN } = process.env;
-const FIXES_REGEX = /(fixes|closes|completes) (.+[/#]\d+.*)$/im;
+const GITHUB_URL = "https://github.com";
+const SKIPPABLE_NOTE_REGEX = /^\s*-?\s*n\/?a\s*/ims;
 
 main();
 
@@ -45,10 +46,10 @@ async function main() {
   // Fetch the pull requests from the GitHub API.
   console.log("Merged Pull requests:");
   for (const pullRequestNumber of newPullRequestNumbers) {
-    const webURL = `https://github.com/zed-industries/zed/pull/${pullRequestNumber}`;
-    const apiURL = `https://api.github.com/repos/zed-industries/zed/pulls/${pullRequestNumber}`;
+    const pullRequestWebURL = `https://github.com/zed-industries/zed/pull/${pullRequestNumber}`;
+    const pullRequestApiURL = `https://api.github.com/repos/zed-industries/zed/pulls/${pullRequestNumber}`;
 
-    const response = await fetch(apiURL, {
+    const response = await fetch(pullRequestApiURL, {
       headers: {
         Authorization: `token ${GITHUB_ACCESS_TOKEN}`,
       },
@@ -59,26 +60,23 @@ async function main() {
     const releaseNotesHeader = /^\s*Release Notes:(.+)/ims;
 
     let releaseNotes = pullRequest.body || "";
-    let contributor = pullRequest.user?.login ?? "Unable to identify";
+    let contributor =
+      pullRequest.user?.login ?? "Unable to identify contributor";
     const captures = releaseNotesHeader.exec(releaseNotes);
     const notes = captures ? captures[1] : "MISSING";
-    const skippableNoteRegex = /^\s*-?\s*n\/?a\s*/ims;
 
-    if (skippableNoteRegex.exec(notes) != null) {
+    if (SKIPPABLE_NOTE_REGEX.exec(notes) != null) {
       continue;
     }
-    console.log("*", pullRequest.title);
-    console.log("  PR URL:    ", webURL);
-    console.log("  Author:    ", contributor);
 
-    // If the pull request contains a 'closes' line, print the closed issue.
-    const fixesMatch = (pullRequest.body || "").match(FIXES_REGEX);
-    if (fixesMatch) {
-      const fixedIssueURL = fixesMatch[2];
-      console.log("  Issue URL:    ", fixedIssueURL);
-    }
+    let credits = getCreditsString(pullRequestWebURL, contributor);
+
+    console.log("*", pullRequest.title);
+    console.log("  PR URL:    ", pullRequestWebURL);
+    console.log("  Credits:   ", credits);
 
     releaseNotes = notes.trim().split("\n");
+
     console.log("  Release Notes:");
 
     for (const line of releaseNotes) {
@@ -87,6 +85,21 @@ async function main() {
 
     console.log();
   }
+}
+
+function getCreditsString(pullRequestURL, contributor) {
+  let creditsString = pullRequestURL;
+
+  if (contributor) {
+    const contributorUrl = `[${contributor}](${GITHUB_URL}/${contributor})`;
+    creditsString += `; thanks ${contributorUrl}`;
+  }
+
+  if (creditsString) {
+    creditsString = `(${creditsString})`;
+  }
+
+  return creditsString;
 }
 
 function getPullRequestNumbers(oldTag, newTag) {

--- a/script/get-preview-channel-changes
+++ b/script/get-preview-channel-changes
@@ -7,6 +7,7 @@ const SKIPPABLE_NOTE_REGEX = /^\s*-?\s*n\/?a\s*/ims;
 const PULL_REQUEST_WEB_URL = "https://github.com/zed-industries/zed/pull";
 const PULL_REQUEST_API_URL =
   "https://api.github.com/repos/zed-industries/zed/pulls";
+const DIVIDER = "-".repeat(80);
 
 main();
 
@@ -48,6 +49,7 @@ async function main() {
 
   // Fetch the pull requests from the GitHub API.
   console.log("Merged Pull requests:");
+  console.log(DIVIDER);
   for (const pullRequestNumber of newPullRequestNumbers) {
     const pullRequestApiURL = `${PULL_REQUEST_API_URL}/${pullRequestNumber}`;
 
@@ -64,7 +66,8 @@ async function main() {
     let contributor =
       pullRequest.user?.login ?? "Unable to identify contributor";
     const captures = releaseNotesHeader.exec(releaseNotes);
-    const notes = captures ? captures[1] : "MISSING";
+    let notes = captures ? captures[1] : "MISSING";
+    notes = notes.trim();
 
     if (SKIPPABLE_NOTE_REGEX.exec(notes) != null) {
       continue;
@@ -72,18 +75,14 @@ async function main() {
 
     let credit = getCreditString(pullRequestNumber, contributor);
 
-    console.log("*", pullRequest.title);
-    console.log(`  Credit:     (${credit})`);
+    console.log(`PR Title: ${pullRequest.title}`);
+    console.log(`Credit: (${credit})`);
 
-    releaseNotes = notes.trim().split("\n");
-
-    console.log("  Release Notes:");
-
-    for (const line of releaseNotes) {
-      console.log(`    ${line}`);
-    }
-
+    console.log("Release Notes:");
     console.log();
+    console.log(notes);
+
+    console.log(DIVIDER);
   }
 }
 

--- a/script/get-preview-channel-changes
+++ b/script/get-preview-channel-changes
@@ -69,11 +69,11 @@ async function main() {
       continue;
     }
 
-    let credits = getCreditsString(pullRequestWebURL, contributor);
+    let paperTrail = getPaperTrailString(pullRequestWebURL, contributor);
 
     console.log("*", pullRequest.title);
     console.log("  PR URL:    ", pullRequestWebURL);
-    console.log("  Credits:   ", credits);
+    console.log("  Trail:     ", paperTrail);
 
     releaseNotes = notes.trim().split("\n");
 
@@ -87,16 +87,12 @@ async function main() {
   }
 }
 
-function getCreditsString(pullRequestURL, contributor) {
+function getPaperTrailString(pullRequestURL, contributor) {
   let creditsString = pullRequestURL;
 
   if (contributor) {
     const contributorUrl = `[${contributor}](${GITHUB_URL}/${contributor})`;
     creditsString += `; thanks ${contributorUrl}`;
-  }
-
-  if (creditsString) {
-    creditsString = `(${creditsString})`;
   }
 
   return creditsString;

--- a/script/get-preview-channel-changes
+++ b/script/get-preview-channel-changes
@@ -4,6 +4,9 @@ const { execFileSync } = require("child_process");
 let { GITHUB_ACCESS_TOKEN } = process.env;
 const GITHUB_URL = "https://github.com";
 const SKIPPABLE_NOTE_REGEX = /^\s*-?\s*n\/?a\s*/ims;
+const PULL_REQUEST_WEB_URL = "https://github.com/zed-industries/zed/pull";
+const PULL_REQUEST_API_URL =
+  "https://api.github.com/repos/zed-industries/zed/pulls";
 
 main();
 
@@ -46,8 +49,7 @@ async function main() {
   // Fetch the pull requests from the GitHub API.
   console.log("Merged Pull requests:");
   for (const pullRequestNumber of newPullRequestNumbers) {
-    const pullRequestWebURL = `https://github.com/zed-industries/zed/pull/${pullRequestNumber}`;
-    const pullRequestApiURL = `https://api.github.com/repos/zed-industries/zed/pulls/${pullRequestNumber}`;
+    const pullRequestApiURL = `${PULL_REQUEST_API_URL}/${pullRequestNumber}`;
 
     const response = await fetch(pullRequestApiURL, {
       headers: {
@@ -55,7 +57,6 @@ async function main() {
       },
     });
 
-    // Print the pull request title and URL.
     const pullRequest = await response.json();
     const releaseNotesHeader = /^\s*Release Notes:(.+)/ims;
 
@@ -69,11 +70,10 @@ async function main() {
       continue;
     }
 
-    let paperTrail = getPaperTrailString(pullRequestWebURL, contributor);
+    let credit = getCreditString(pullRequestNumber, contributor);
 
     console.log("*", pullRequest.title);
-    console.log("  PR URL:    ", pullRequestWebURL);
-    console.log("  Trail:     ", paperTrail);
+    console.log(`  Credit:     (${credit})`);
 
     releaseNotes = notes.trim().split("\n");
 
@@ -87,15 +87,20 @@ async function main() {
   }
 }
 
-function getPaperTrailString(pullRequestURL, contributor) {
-  let creditsString = pullRequestURL;
+function getCreditString(pullRequestNumber, contributor) {
+  let credit = "";
 
-  if (contributor) {
-    const contributorUrl = `[${contributor}](${GITHUB_URL}/${contributor})`;
-    creditsString += `; thanks ${contributorUrl}`;
+  if (pullRequestNumber) {
+    let pullRequestMarkdownLink = `[#${pullRequestNumber}](${PULL_REQUEST_WEB_URL}/${pullRequestNumber})`;
+    credit += pullRequestMarkdownLink;
   }
 
-  return creditsString;
+  if (contributor) {
+    const contributorMarkdownLink = `[${contributor}](${GITHUB_URL}/${contributor})`;
+    credit += `; thanks ${contributorMarkdownLink}`;
+  }
+
+  return credit;
 }
 
 function getPullRequestNumbers(oldTag, newTag) {


### PR DESCRIPTION
This PR changes how we ask users to draft up PRs and how release note generation happens. 

We no longer force the user to create the markdown URL link, but we do ask them to use the `closes` [GitHub magic word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link the PR to an issue, so that the issue is closed automatically when closing the PR.

As for the changelog release notes, we are no longer linking to the issues, but the PR itself, which should contain the issue if a reader wants to dive further back. This makes our output more consistent, as every line will have a link, even if there is no issue associated, and it removes the need for us to try to parse the issue url in the body to try to correct mistakes in how they were forming Markdown urls - the PR url is always returned in the request, which makes it easy. **Lastly, it's just a lot less annoying to make the release notes.**

The new PR format will be:

```
Closes #ISSUE

Release Notes:

- Added/Fixed/Improved ...
```

The new script output format will be:

```
PR Title: theme: Use a non-transparent color for the fallback `title_bar.inactive_background`
Credit: ([#15709](https://github.com/zed-industries/zed/pull/15709); thanks [maxdeviant](https://github.com/maxdeviant))
Release Notes:

- linux: Changed the fallback color of `title_bar.inactive_background` to a non-transparent value.
--------------------------------------------------------------------------------
PR Title: Skip over folded regions when iterating over multibuffer chunks
Credit: ([#15646](https://github.com/zed-industries/zed/pull/15646); thanks [osiewicz](https://github.com/osiewicz))
Release Notes:

- Fixed poor performance when editing in the assistant panel after inserting large files using slash commands
--------------------------------------------------------------------------------
```

This still requires us to manually apply the credit line, but the line is already fully formed, so this should still be faster than having to manually create that line / fix any line where someone messed it up (which was all the time). I would just automatically apply it to the release notes, but sometimes we have multiple bullet points in a single PR and no real structure is enforced, so I foresee doing anything automatic breaking and needing manual adjustment.

Release Notes:

- N/A
