### PR TITLE
haskell: Pass environment to `hls`

### DIFF
--- a/extensions/haskell/src/haskell.rs
+++ b/extensions/haskell/src/haskell.rs
@@ -21,7 +21,7 @@ impl zed::Extension for HaskellExtension {
         Ok(zed::Command {
             command: path,
             args: vec!["lsp".to_string()],
-            env: Default::default(),
+            env: worktree.shell_env(),
         })
     }
 


### PR DESCRIPTION
Fixed environment not being passed to hls, breaking local nix-based installations

Release Notes:

- N/A