### PR TITLE
Put `/docs` behind a feature flag

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -280,7 +280,6 @@ fn register_slash_commands(prompt_builder: Option<Arc<PromptBuilder>>, cx: &mut 
     slash_command_registry.register_command(term_command::TermSlashCommand, true);
     slash_command_registry.register_command(now_command::NowSlashCommand, true);
     slash_command_registry.register_command(diagnostics_command::DiagnosticsSlashCommand, true);
-    slash_command_registry.register_command(docs_command::DocsSlashCommand, true);
     if let Some(prompt_builder) = prompt_builder {
         slash_command_registry.register_command(
             workflow_command::WorkflowSlashCommand::new(prompt_builder),
@@ -289,9 +288,21 @@ fn register_slash_commands(prompt_builder: Option<Arc<PromptBuilder>>, cx: &mut 
     }
     slash_command_registry.register_command(fetch_command::FetchSlashCommand, false);
 
-    cx.observe_flag::<search_command::SearchSlashCommandFeatureFlag, _>(move |is_enabled, _cx| {
-        if is_enabled {
-            slash_command_registry.register_command(search_command::SearchSlashCommand, true);
+    cx.observe_flag::<docs_command::DocsSlashCommandFeatureFlag, _>({
+        let slash_command_registry = slash_command_registry.clone();
+        move |is_enabled, _cx| {
+            if is_enabled {
+                slash_command_registry.register_command(docs_command::DocsSlashCommand, true);
+            }
+        }
+    })
+    .detach();
+    cx.observe_flag::<search_command::SearchSlashCommandFeatureFlag, _>({
+        let slash_command_registry = slash_command_registry.clone();
+        move |is_enabled, _cx| {
+            if is_enabled {
+                slash_command_registry.register_command(search_command::SearchSlashCommand, true);
+            }
         }
     })
     .detach();

--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, bail, Result};
 use assistant_slash_command::{
     ArgumentCompletion, SlashCommand, SlashCommandOutput, SlashCommandOutputSection,
 };
+use feature_flags::FeatureFlag;
 use gpui::{AppContext, BackgroundExecutor, Model, Task, WeakView};
 use indexed_docs::{
     DocsDotRsProvider, IndexedDocsRegistry, IndexedDocsStore, LocalRustdocProvider, PackageName,
@@ -17,6 +18,12 @@ use project::{Project, ProjectPath};
 use ui::prelude::*;
 use util::{maybe, ResultExt};
 use workspace::Workspace;
+
+pub(crate) struct DocsSlashCommandFeatureFlag;
+
+impl FeatureFlag for DocsSlashCommandFeatureFlag {
+    const NAME: &'static str = "docs-slash-command";
+}
 
 pub(crate) struct DocsSlashCommand;
 


### PR DESCRIPTION
This PR puts the `/docs` slash command behind a feature flag.

Release Notes:

- N/A
