### PR TITLE
assistant: Show an error when `/fetch` returns no content

### DIFF
--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -150,6 +150,10 @@ impl SlashCommand for FetchSlashCommand {
         let url = SharedString::from(url);
         cx.foreground_executor().spawn(async move {
             let text = text.await?;
+            if text.trim().is_empty() {
+                bail!("no textual content found");
+            }
+
             let range = 0..text.len();
             Ok(SlashCommandOutput {
                 text,


### PR DESCRIPTION
This PR makes it so the `/fetch` slash command will display an error when the URL does not have any textual content:

<img width="308" alt="Screenshot 2024-08-08 at 4 51 55 PM" src="https://github.com/user-attachments/assets/bf4cbc18-c65b-48a2-aedd-26b50f47f018">

Release Notes:

- N/A
