### PR TITLE
repl: Don't show cmd window on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8768,6 +8768,7 @@ dependencies = [
  "ui",
  "util",
  "uuid",
+ "windows 0.58.0",
  "workspace",
 ]
 

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -43,6 +43,9 @@ util.workspace = true
 uuid.workspace = true
 workspace.workspace = true
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows.workspace = true
+
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -55,6 +55,12 @@ impl KernelSpecification {
             cmd.envs(env);
         }
 
+        #[cfg(windows)]
+        {
+            use smol::process::windows::CommandExt;
+            cmd.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
+        }
+
         Ok(cmd)
     }
 }
@@ -394,11 +400,17 @@ pub async fn kernel_specifications(fs: Arc<dyn Fs>) -> Result<Vec<KernelSpecific
     }
 
     // Search for kernels inside the base python environment
-    let command = Command::new("python")
-        .arg("-c")
-        .arg("import sys; print(sys.prefix)")
-        .output()
-        .await;
+    let mut command = Command::new("python");
+    command.arg("-c");
+    command.arg("import sys; print(sys.prefix)");
+
+    #[cfg(windows)]
+    {
+        use smol::process::windows::CommandExt;
+        command.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
+    }
+
+    let command = command.output().await;
 
     if let Ok(command) = command {
         if command.status.success() {


### PR DESCRIPTION
Closes #15955 .

Release Notes:

- Fixed `cmd` window showing when repl executing commands([#15955](https://github.com/zed-industries/zed/issues/15955) ).
