### PR TITLE
Remove unnecessary extend of global_listeners

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1201,7 +1201,7 @@ impl AppContext {
     fn dispatch_global_action(&mut self, action: &dyn Action) {
         self.propagate_event = true;
 
-        if let Some(mut global_listeners) = self
+        if let Some(global_listeners) = self
             .global_action_listeners
             .remove(&action.as_any().type_id())
         {
@@ -1212,18 +1212,12 @@ impl AppContext {
                 }
             }
 
-            global_listeners.extend(
-                self.global_action_listeners
-                    .remove(&action.as_any().type_id())
-                    .unwrap_or_default(),
-            );
-
             self.global_action_listeners
                 .insert(action.as_any().type_id(), global_listeners);
         }
 
         if self.propagate_event {
-            if let Some(mut global_listeners) = self
+            if let Some(global_listeners) = self
                 .global_action_listeners
                 .remove(&action.as_any().type_id())
             {
@@ -1233,12 +1227,6 @@ impl AppContext {
                         break;
                     }
                 }
-
-                global_listeners.extend(
-                    self.global_action_listeners
-                        .remove(&action.as_any().type_id())
-                        .unwrap_or_default(),
-                );
 
                 self.global_action_listeners
                     .insert(action.as_any().type_id(), global_listeners);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3491,12 +3491,6 @@ impl<'a> WindowContext<'a> {
                 }
             }
 
-            global_listeners.extend(
-                self.global_action_listeners
-                    .remove(&action.as_any().type_id())
-                    .unwrap_or_default(),
-            );
-
             self.global_action_listeners
                 .insert(action.as_any().type_id(), global_listeners);
         }
@@ -3557,12 +3551,6 @@ impl<'a> WindowContext<'a> {
                     break;
                 }
             }
-
-            global_listeners.extend(
-                self.global_action_listeners
-                    .remove(&action.as_any().type_id())
-                    .unwrap_or_default(),
-            );
 
             self.global_action_listeners
                 .insert(action.as_any().type_id(), global_listeners);


### PR DESCRIPTION
Improved code comprehension, as we do not need to extend `global_listeners`

Because:

1. Remove the `Vec` corresponding to the `&action.as_any().type_id()` key [here](https://github.com/zed-industries/zed/commit/3ae2f327f818811cf8e371aa94d24cff23e3a247#diff-044302c0d57147af17e68a0009fee3e8dcdfb4f32c27a915e70cfa80e987f765L1206)
2. So when you remove by `&action.as_any().type_id()` again [here](https://github.com/zed-industries/zed/commit/3ae2f327f818811cf8e371aa94d24cff23e3a247#diff-044302c0d57147af17e68a0009fee3e8dcdfb4f32c27a915e70cfa80e987f765L1217), it should return `None`, hence, extending is un-necessary

We need to eye ball it a bit to make sure my reasoning is correct.

Release Notes:

- N/A