### PR TITLE
vim: Fix panic due to overflow when scrolling

### DIFF
--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -111,7 +111,10 @@ fn scroll_editor(
                 DisplayRow(top.row().0 + vertical_scroll_margin as u32)
             };
             let max_row = DisplayRow(
-                top.row().0 + visible_line_count as u32 - vertical_scroll_margin as u32 - 1,
+                top.row().0
+                    + (visible_line_count as u32)
+                        .saturating_sub(vertical_scroll_margin as u32)
+                        .saturating_sub(1),
             );
 
             let new_head = if head.row() < min_row {


### PR DESCRIPTION
When setting `"vertical_scroll_margin": 99` or other high values this can lead to a panic that crashes Zed.

Release Notes:

- vim: Fixed a possible panic that could happen when using a very high value for `vertical_scroll_margin` that exceeded the number of visible lines on the screen.