### PR TITLE
Larger rate limit integers

### DIFF
--- a/crates/collab/migrations_llm/20240809130000_change_rate_limit_columns_to_bigint.sql
+++ b/crates/collab/migrations_llm/20240809130000_change_rate_limit_columns_to_bigint.sql
@@ -1,0 +1,4 @@
+ALTER TABLE models
+    ALTER COLUMN max_requests_per_minute TYPE bigint,
+    ALTER COLUMN max_tokens_per_minute TYPE bigint,
+    ALTER COLUMN max_tokens_per_day TYPE bigint;

--- a/crates/collab/src/llm/db/queries/providers.rs
+++ b/crates/collab/src/llm/db/queries/providers.rs
@@ -4,9 +4,9 @@ use std::str::FromStr;
 use strum::IntoEnumIterator as _;
 
 pub struct ModelRateLimits {
-    pub max_requests_per_minute: i32,
-    pub max_tokens_per_minute: i32,
-    pub max_tokens_per_day: i32,
+    pub max_requests_per_minute: i64,
+    pub max_tokens_per_minute: i64,
+    pub max_tokens_per_day: i64,
 }
 
 impl LlmDatabase {

--- a/crates/collab/src/llm/db/tables/model.rs
+++ b/crates/collab/src/llm/db/tables/model.rs
@@ -10,9 +10,9 @@ pub struct Model {
     pub id: ModelId,
     pub provider_id: ProviderId,
     pub name: String,
-    pub max_requests_per_minute: i32,
-    pub max_tokens_per_minute: i32,
-    pub max_tokens_per_day: i32,
+    pub max_requests_per_minute: i64,
+    pub max_tokens_per_minute: i64,
+    pub max_tokens_per_day: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]


### PR DESCRIPTION
Tokens per day may exceed the range of Postgres's 32-bit `integer` data type.

Release Notes:

- N/A
