### PR TITLE
zed_extension_api: Release v0.0.7

### DIFF
--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -49,12 +49,10 @@ pub fn is_supported_wasm_api_version(
 /// Returns the Wasm API version range that is supported by the Wasm host.
 #[inline(always)]
 pub fn wasm_api_version_range(release_channel: ReleaseChannel) -> RangeInclusive<SemanticVersion> {
-    let max_version = match release_channel {
-        ReleaseChannel::Dev | ReleaseChannel::Nightly => latest::MAX_VERSION,
-        ReleaseChannel::Stable | ReleaseChannel::Preview => since_v0_0_6::MAX_VERSION,
-    };
+    // Note: The release channel can be used to stage a new version of the extension API.
+    let _ = release_channel;
 
-    since_v0_0_1::MIN_VERSION..=max_version
+    since_v0_0_1::MIN_VERSION..=latest::MAX_VERSION
 }
 
 pub enum Extension {
@@ -71,7 +69,10 @@ impl Extension {
         version: SemanticVersion,
         component: &Component,
     ) -> Result<(Self, Instance)> {
-        if release_channel == ReleaseChannel::Dev && version >= latest::MIN_VERSION {
+        // Note: The release channel can be used to stage a new version of the extension API.
+        let _ = release_channel;
+
+        if version >= latest::MIN_VERSION {
             let (extension, instance) =
                 latest::Extension::instantiate_async(store, &component, latest::linker())
                     .await

--- a/crates/extension/src/wasm_host/wit/since_v0_0_6.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_0_6.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, OnceLock};
 use wasmtime::component::{Linker, Resource};
 
 pub const MIN_VERSION: SemanticVersion = SemanticVersion::new(0, 0, 6);
-pub const MAX_VERSION: SemanticVersion = SemanticVersion::new(0, 0, 6);
 
 wasmtime::component::bindgen!({
     async: true,

--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -8,10 +8,6 @@ keywords = ["zed", "extension"]
 edition = "2021"
 license = "Apache-2.0"
 
-# Don't publish v0.0.7 until we're ready to commit to the breaking API changes
-# Marshall is DRI on this.
-publish = false
-
 [lints]
 workspace = true
 

--- a/crates/extension_api/README.md
+++ b/crates/extension_api/README.md
@@ -23,7 +23,7 @@ need to set your `crate-type` accordingly:
 
 ```toml
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.0.7"
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/extension_api/README.md
+++ b/crates/extension_api/README.md
@@ -63,6 +63,7 @@ Here is the compatibility of the `zed_extension_api` with versions of Zed:
 
 | Zed version | `zed_extension_api` version |
 | ----------- | --------------------------- |
+| `0.149.x`   | `0.0.1` - `0.0.7`           |
 | `0.131.x`   | `0.0.1` - `0.0.6`           |
 | `0.130.x`   | `0.0.1` - `0.0.5`           |
 | `0.129.x`   | `0.0.1` - `0.0.4`           |


### PR DESCRIPTION
This PR releases v0.0.7 of the Zed extension API.

Support for this version of the extension API will land in Zed v0.149.0.

Release Notes:

- N/A
