### PR TITLE
command_palette: Remove project as a dependency in Cargo.toml

### DIFF
--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -20,7 +20,6 @@ fuzzy.workspace = true
 gpui.workspace = true
 picker.workspace = true
 postage.workspace = true
-project.workspace = true
 serde.workspace = true
 settings.workspace = true
 theme.workspace = true


### PR DESCRIPTION
The *project crate* is only needed as a dev dependency in the command palette..
So I am doing some code / dependency cleanup...

Release Notes:

- N/A
