### PR TITLE
Improve settings file autocompletion behavior

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -16,7 +16,7 @@ use serde::{
     Deserialize, Deserializer, Serialize,
 };
 use serde_json::Value;
-use settings::{add_references_to_properties, Settings, SettingsLocation, SettingsSources};
+use settings::{adjust_schema_properties, Settings, SettingsLocation, SettingsSources};
 use std::{num::NonZeroU32, path::Path, sync::Arc};
 use util::serde::default_true;
 
@@ -1009,9 +1009,12 @@ impl settings::Settings for AllLanguageSettings {
             .definitions
             .extend([("Languages".into(), languages_object_schema.into())]);
 
-        add_references_to_properties(
+        adjust_schema_properties(
             &mut root_schema,
             &[("languages", "#/definitions/Languages")],
+            |schema, definition| {
+                schema.reference = Some(definition.to_string());
+            },
         );
 
         root_schema

--- a/crates/settings/src/json_schema.rs
+++ b/crates/settings/src/json_schema.rs
@@ -64,8 +64,6 @@ pub fn adjust_schema_properties<F>(
 
         match schema {
             Schema::Object(schema) => {
-                // schema.metadata().default = None;
-                // schema.reference = Some(definition.to_string());
                 f(schema, definition);
             }
             Schema::Bool(_) => {

--- a/crates/settings/src/json_schema.rs
+++ b/crates/settings/src/json_schema.rs
@@ -49,10 +49,13 @@ type ReferencePath<'a> = &'a str;
 ///     ("property_b", "#/definitions/DefinitionB"),
 /// ])
 /// ```
-pub fn add_references_to_properties(
+pub fn adjust_schema_properties<F>(
     root_schema: &mut RootSchema,
     properties_with_references: &[(PropertyName, ReferencePath)],
-) {
+    f: F,
+) where
+    F: Fn(&mut SchemaObject, &str),
+{
     for (property, definition) in properties_with_references {
         let Some(schema) = root_schema.schema.object().properties.get_mut(*property) else {
             log::warn!("property '{property}' not found in JSON schema");
@@ -61,8 +64,9 @@ pub fn add_references_to_properties(
 
         match schema {
             Schema::Object(schema) => {
-                schema.metadata().default = None;
-                schema.reference = Some(definition.to_string());
+                // schema.metadata().default = None;
+                // schema.reference = Some(definition.to_string());
+                f(schema, definition);
             }
             Schema::Bool(_) => {
                 // Boolean schemas can't have references.

--- a/crates/settings/src/json_schema.rs
+++ b/crates/settings/src/json_schema.rs
@@ -61,6 +61,7 @@ pub fn add_references_to_properties(
 
         match schema {
             Schema::Object(schema) => {
+                schema.metadata().default = None;
                 schema.reference = Some(definition.to_string());
             }
             Schema::Bool(_) => {

--- a/crates/settings/src/json_schema.rs
+++ b/crates/settings/src/json_schema.rs
@@ -44,10 +44,16 @@ type ReferencePath<'a> = &'a str;
 ///
 /// ```
 /// # let root_schema = RootSchema::default();
-/// add_references_to_properties(&mut root_schema, &[
-///     ("property_a", "#/definitions/DefinitionA"),
-///     ("property_b", "#/definitions/DefinitionB"),
-/// ])
+/// adjust_schema_properties(
+///     &mut root_schema,
+///     &[
+///         ("property_a", "#/definitions/DefinitionA"),
+///         ("property_b", "#/definitions/DefinitionB"),
+///     ],
+///     |schema, definition| {
+///         schema.reference = Some(definition.to_string());
+///     },
+/// );
 /// ```
 pub fn adjust_schema_properties<F>(
     root_schema: &mut RootSchema,

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -4,7 +4,7 @@ use gpui::{
 };
 use schemars::{gen::SchemaGenerator, schema::RootSchema, JsonSchema};
 use serde_derive::{Deserialize, Serialize};
-use settings::{add_references_to_properties, SettingsJsonSchemaParams, SettingsSources};
+use settings::{adjust_schema_properties, SettingsJsonSchemaParams, SettingsSources};
 use std::path::PathBuf;
 use task::Shell;
 
@@ -202,12 +202,16 @@ impl settings::Settings for TerminalSettings {
             ("FontFallbacks".into(), params.font_fallback_schema()),
         ]);
 
-        add_references_to_properties(
+        adjust_schema_properties(
             &mut root_schema,
             &[
                 ("font_family", "#/definitions/FontFamilies"),
                 ("font_fallbacks", "#/definitions/FontFallbacks"),
             ],
+            |schema, definition| {
+                schema.metadata().default = None;
+                schema.reference = Some(definition.to_string());
+            },
         );
 
         root_schema

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -629,17 +629,8 @@ impl settings::Settings for ThemeSettings {
             &mut root_schema,
             &[
                 ("buffer_font_family", "#/definitions/FontFamilies"),
-                ("ui_font_family", "#/definitions/FontFamilies"),
-            ],
-            |schema, definition| {
-                schema.metadata().default = None;
-                schema.reference = Some(definition.to_string());
-            },
-        );
-        adjust_schema_properties(
-            &mut root_schema,
-            &[
                 ("buffer_font_fallbacks", "#/definitions/FontFallbacks"),
+                ("ui_font_family", "#/definitions/FontFamilies"),
                 ("ui_font_fallbacks", "#/definitions/FontFallbacks"),
             ],
             |schema, definition| {

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -14,7 +14,7 @@ use schemars::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use settings::{add_references_to_properties, Settings, SettingsJsonSchemaParams, SettingsSources};
+use settings::{adjust_schema_properties, Settings, SettingsJsonSchemaParams, SettingsSources};
 use std::sync::Arc;
 use util::ResultExt as _;
 
@@ -625,14 +625,35 @@ impl settings::Settings for ThemeSettings {
             ("FontFallbacks".into(), params.font_fallback_schema()),
         ]);
 
-        add_references_to_properties(
+        adjust_schema_properties(
             &mut root_schema,
             &[
                 ("buffer_font_family", "#/definitions/FontFamilies"),
-                ("buffer_font_fallbacks", "#/definitions/FontFallbacks"),
                 ("ui_font_family", "#/definitions/FontFamilies"),
+            ],
+            |schema, definition| {
+                schema.metadata().default = None;
+                schema.reference = Some(definition.to_string());
+            },
+        );
+        adjust_schema_properties(
+            &mut root_schema,
+            &[
+                ("buffer_font_fallbacks", "#/definitions/FontFallbacks"),
                 ("ui_font_fallbacks", "#/definitions/FontFallbacks"),
             ],
+            |schema, definition| {
+                schema.metadata().default = None;
+                schema.reference = Some(definition.to_string());
+            },
+        );
+        adjust_schema_properties(
+            &mut root_schema,
+            &[("buffer_font_features", ""), ("ui_font_features", "")],
+            |schema, _| {
+                schema.metadata().default = None;
+                schema.instance_type = Some(InstanceType::Object.into());
+            },
         );
         println!("{:#?}", root_schema.schema.object().properties);
 

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -634,6 +634,7 @@ impl settings::Settings for ThemeSettings {
                 ("ui_font_fallbacks", "#/definitions/FontFallbacks"),
             ],
         );
+        println!("{:#?}", root_schema.schema.object().properties);
 
         root_schema
     }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -655,7 +655,6 @@ impl settings::Settings for ThemeSettings {
                 schema.instance_type = Some(InstanceType::Object.into());
             },
         );
-        println!("{:#?}", root_schema.schema.object().properties);
 
         root_schema
     }


### PR DESCRIPTION
In #15336, a modification from #15326 was not included. Currently, in the `settings.json` file on the main branch, the autocompletion behavior is:
```json
"buffer_font_family": null,
"buffer_font_features": null,
```


https://github.com/user-attachments/assets/0390e19c-0bb6-4703-b73e-71c61e003d7d

After this PR:


https://github.com/user-attachments/assets/f1835cd4-8579-4dec-8c6b-3edd212302c8



Release Notes:

- N/A
