### PR TITLE
Add default terminal binding for buffer search on Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -474,7 +474,8 @@
   {
     "context": "!Terminal",
     "bindings": {
-      "ctrl-shift-c": "collab_panel::ToggleFocus"
+      "ctrl-shift-c": "collab_panel::ToggleFocus",
+      "ctrl-f": "buffer_search::Deploy"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -475,7 +475,7 @@
     "context": "!Terminal",
     "bindings": {
       "ctrl-shift-c": "collab_panel::ToggleFocus",
-      "ctrl-f": "buffer_search::Deploy"
+      "ctrl-shift-f": "buffer_search::Deploy"
     }
   },
   {


### PR DESCRIPTION
Release Notes:

- Fixed find in Terminal: `ctrl-shift-f` (Linux)
