### PR TITLE
Fix diagnostic popups not having a max width

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -725,6 +725,8 @@ impl DiagnosticPopover {
             .id("diagnostic")
             .block()
             .max_h(max_size.height)
+            .overflow_y_scroll()
+            .max_w(max_size.width)
             .elevation_2_borderless(cx)
             // Don't draw the background color if the theme
             // allows transparent surfaces.


### PR DESCRIPTION
They were probably broken by #14518 

Release Notes:

- N/A
