### PR TITLE
Attempt better terminal rendering for box characters

### DIFF
--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -223,6 +223,8 @@ pub enum TerminalLineHeight {
     /// Use a standard line height, 1.3. This option is useful for TUIs,
     /// particularly if they use box characters
     Standard,
+    /// Use a line height of exactly 1.0 to be even tighter than standard for box characters.
+    Compact,
     /// Use a custom line height.
     Custom(f32),
 }
@@ -232,6 +234,7 @@ impl TerminalLineHeight {
         let value = match self {
             TerminalLineHeight::Comfortable => 1.618,
             TerminalLineHeight::Standard => 1.3,
+            TerminalLineHeight::Compact => 1.0,
             TerminalLineHeight::Custom(line_height) => f32::max(*line_height, 1.),
         };
         px(value).into()

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -95,7 +95,7 @@ impl LayoutCell {
 
             Point::new(
                 (origin.x + point.column as f32 * dimensions.cell_width).floor(),
-                origin.y + point.line as f32 * dimensions.line_height,
+                (origin.y + point.line as f32 * dimensions.line_height).floor(),
             )
         };
 
@@ -132,12 +132,12 @@ impl LayoutRect {
             let alac_point = self.point;
             point(
                 (origin.x + alac_point.column as f32 * dimensions.cell_width).floor(),
-                origin.y + alac_point.line as f32 * dimensions.line_height,
+                (origin.y + alac_point.line as f32 * dimensions.line_height).floor(),
             )
         };
         let size = point(
             (dimensions.cell_width * self.num_of_cells as f32).ceil(),
-            dimensions.line_height,
+            dimensions.line_height.ceil(),
         )
         .into();
 
@@ -296,6 +296,16 @@ impl TerminalElement {
                             layout_cell,
                         ))
                     };
+
+                    if let Some(rect) = cur_rect.as_mut() {
+                        rect.num_of_cells += 1;
+                    } else {
+                        cur_rect = Some(LayoutRect::new(
+                            AlacPoint::new(line_index as i32, cell.point.column.0 as i32),
+                            1,
+                            convert_color(&bg, &theme),
+                        ));
+                    }
                 }
             }
 


### PR DESCRIPTION
In pursuit of https://github.com/zed-industries/zed/issues/15927, this makes box characters for TUIs like seen in `python -m textual borders` _slightly_ better.

<img width="947" alt="image" src="https://github.com/user-attachments/assets/7211cef9-0265-4e69-9d99-14f72aad6522">

Total WIP, just want to put this out there to tinker with.

Release Notes:

- N/A
