### PR TITLE
Introduce prompt override script and adjust names

### DIFF
--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -54,7 +54,7 @@ impl PromptBuilder {
         cx: &gpui::AppContext,
         handlebars: Arc<Mutex<Handlebars<'static>>>,
     ) {
-        let templates_dir = paths::prompt_templates_dir();
+        let templates_dir = paths::prompt_overrides_dir();
 
         cx.background_executor()
             .spawn(async move {

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -187,13 +187,13 @@ pub fn prompts_dir() -> &'static PathBuf {
 /// Returns the path to the prompt templates directory.
 ///
 /// This is where the prompt templates for core features can be overridden with templates.
-pub fn prompt_templates_dir() -> &'static PathBuf {
+pub fn prompt_overrides_dir() -> &'static PathBuf {
     static PROMPT_TEMPLATES_DIR: OnceLock<PathBuf> = OnceLock::new();
     PROMPT_TEMPLATES_DIR.get_or_init(|| {
         if cfg!(target_os = "macos") {
-            config_dir().join("prompts").join("templates")
+            config_dir().join("prompt_overrides")
         } else {
-            support_dir().join("prompts").join("templates")
+            support_dir().join("prompt_overrides")
         }
     })
 }

--- a/script/prompts
+++ b/script/prompts
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check if 'prompts' branch exists, create if not
+if ! git show-ref --quiet refs/heads/prompts; then
+    git branch prompts
+fi
+
+if [ "$1" = "link" ]; then
+    # Remove existing link
+    rm -f ~/.config/zed/prompt_overrides
+    if [ "$2" = "--worktree" ]; then
+    # Check if 'prompts' worktree exists
+    if git worktree list | grep -q "../zed_prompts"; then
+        echo "Worktree already exists."
+    else
+        # Create worktree if it doesn't exist
+        git worktree add ../zed_prompts prompts || git worktree add ../zed_prompts -b prompts
+    fi
+    ln -sf "$(pwd)/../zed_prompts/assets/prompts" ~/.config/zed/prompt_overrides
+    else
+        ln -sf "$(pwd)/../prompts/assets/prompts" ~/.config/zed/prompt_overrides
+    fi
+elif [ "$1" = "unlink" ]; then
+    # Remove symbolic link
+    rm ~/.config/zed/prompt_overrides
+else
+    echo "This script helps you manage prompt overrides for Zed."
+    echo "You can link this directory to have Zed use the contents of your current repo templates as your active prompts,"
+    echo "or store your modifications in a separate Git worktree."
+    echo
+    echo "Usage: $0 [link [--worktree]|unlink]"
+    echo
+    echo "Options:"
+    echo "  link               Create a symbolic link from ./assets/prompts to ~/.config/zed/prompt_overrides"
+    echo "  link --worktree    Create a 'prompts' Git worktree in ../prompts, then link ../prompts/assets/prompts"
+    echo "                     to ~/.config/zed/prompt_overrides"
+    echo "  unlink             Remove the symbolic link at ~/.config/zed/prompt_overrides"
+    exit 1
+fi

--- a/script/prompts
+++ b/script/prompts
@@ -18,7 +18,7 @@ if [ "$1" = "link" ]; then
     fi
     ln -sf "$(pwd)/../zed_prompts/assets/prompts" ~/.config/zed/prompt_overrides
     else
-        ln -sf "$(pwd)/../prompts/assets/prompts" ~/.config/zed/prompt_overrides
+        ln -sf "$(pwd)/assets/prompts" ~/.config/zed/prompt_overrides
     fi
 elif [ "$1" = "unlink" ]; then
     # Remove symbolic link

--- a/script/prompts
+++ b/script/prompts
@@ -1,28 +1,46 @@
 #!/bin/bash
 
-# Check if 'prompts' branch exists, create if not
-if ! git show-ref --quiet refs/heads/prompts; then
-    git branch prompts
-fi
+# This script manages prompt overrides for the Zed editor.
+#
+# It provides functionality to:
+# 1. Link the current repository's prompt templates to Zed's configuration.
+# 2. Create and link a separate Git worktree for prompt management.
+# 3. Unlink previously linked prompt overrides.
+#
+# Usage:
+#   ./script_name.sh link             # Link current repo's prompts
+#   ./script_name.sh link --worktree  # Create and link a separate worktree
+#   ./script_name.sh unlink           # Remove existing prompt override link
+#
+# The script ensures proper Git branch and worktree setup when using the
+# --worktree option. It also provides informative output and error handling.
 
 if [ "$1" = "link" ]; then
     # Remove existing link
     rm -f ~/.config/zed/prompt_overrides
     if [ "$2" = "--worktree" ]; then
-    # Check if 'prompts' worktree exists
-    if git worktree list | grep -q "../zed_prompts"; then
-        echo "Worktree already exists."
-    else
-        # Create worktree if it doesn't exist
-        git worktree add ../zed_prompts prompts || git worktree add ../zed_prompts -b prompts
-    fi
-    ln -sf "$(pwd)/../zed_prompts/assets/prompts" ~/.config/zed/prompt_overrides
+        # Check if 'prompts' branch exists, create if not
+        if ! git show-ref --quiet refs/heads/prompts; then
+            git branch prompts
+        fi
+        # Check if 'prompts' worktree exists
+        if git worktree list | grep -q "../zed_prompts"; then
+            echo "Worktree already exists at ../zed_prompts."
+        else
+            # Create worktree if it doesn't exist
+            git worktree add ../zed_prompts prompts || git worktree add ../zed_prompts -b prompts
+        fi
+        ln -sf "$(pwd)/../zed_prompts/assets/prompts" ~/.config/zed/prompt_overrides
+        echo "Linked $(realpath "$(pwd)/../zed_prompts/assets/prompts") to ~/.config/zed/prompt_overrides"
+        echo -e "\033[0;31mDon't forget you have it linked, or your prompts will go stale\033[0m"
     else
         ln -sf "$(pwd)/assets/prompts" ~/.config/zed/prompt_overrides
+        echo "Linked $(pwd)/assets/prompts to ~/.config/zed/prompt_overrides"
     fi
 elif [ "$1" = "unlink" ]; then
     # Remove symbolic link
     rm ~/.config/zed/prompt_overrides
+    echo "Unlinked ~/.config/zed/prompt_overrides"
 else
     echo "This script helps you manage prompt overrides for Zed."
     echo "You can link this directory to have Zed use the contents of your current repo templates as your active prompts,"


### PR DESCRIPTION
This PR introduces a new script for iterative development of prompt overrides in Zed.

Just `script/prompts link` and your running Zed should start using prompts from `zed/assets/prompts`. Use `script/prompts unlink` to undo. You can also link with `script/prompts link --worktree` to store the prompts to a `../zed_prompts` worktree that's a sibling of your repo, in case you don't want to mess with your working copy. Just don't forget about it!

Key changes:
- Add new `script/prompts` for managing prompt overrides
- Rename `prompt_templates_dir` to `prompt_overrides_dir` for clarity
- Update paths to use `~/.config/zed/prompt_overrides` instead of `~/.config/zed/prompts/templates`
- Adjust `PromptBuilder` to use the new `prompt_overrides_dir` function

These changes simplify the process of customizing prompts and provide a more intuitive naming convention for override-related functionality.

Release Notes:

- N/A
