### PR TITLE
Add Spanish and Mandarin translations for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<h4 align="center">
+    <p>
+        <b>English</b> |
+        <a href="./docs/README_ES.md">Español</a> |
+        <a href="./docs/README_CH.md">普通话</a>
+    </p>
+</h4>
+
 # Zed
 
 [![CI](https://github.com/zed-industries/zed/actions/workflows/ci.yml/badge.svg)](https://github.com/zed-industries/zed/actions/workflows/ci.yml)

--- a/docs/README_CH.md
+++ b/docs/README_CH.md
@@ -1,0 +1,52 @@
+<h4 align="center">
+    <p>
+        <a href="../README.md">English</b> |
+        <a gref="./README_ES.md">Español</a> |
+        <b>普通话</b>
+    </p>
+</h4>
+
+# Zed
+
+[![CI](https://github.com/zed-industries/zed/actions/workflows/ci.yml/badge.svg)](https://github.com/zed-industries/zed/actions/workflows/ci.yml)
+
+欢迎使用 Zed，这是一款来自[Atom](https://github.com/atom/atom) 和 [Tree-sitter](https://github.com/tree-sitter/tree-sitter) 创建者的高性能多人代码编辑器
+
+--------
+
+### 设施
+
+
+<a href="https://repology.org/project/zed-editor/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/zed-editor.svg?minversion=0.143.5" alt="Packaging status" align="right">
+</a>
+
+在 macOS 和 Linux 上，您可以[直接下载 Zed](https://zed.dev/download) 或[通过本地包管理器安装 Zed](https://zed.dev/docs/linux#installing-via -a -包管理器）。
+
+Otras plataformas aún no están disponibles:
+
+- Windows ([tracking issue](https://github.com/zed-industries/zed/issues/5394))
+- Web ([tracking issue](https://github.com/zed-industries/zed/issues/5396))
+
+### 开发 Zed
+
+- [为 macOS 构建 Zed](./docs/src/development/macos.md)
+- [为 Linux 构建 Zed](./docs/src/development/linux.md)
+- [Zed Windows 版本] (./docs/src/development/windows.md)
+- [运行本地协作] (./docs/src/development/local-collaboration.md)
+
+### 贡献
+
+请参阅 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解为 Zed 做出贡献的方式。
+
+另外...我们正在招聘！检查我们的[职位](https://zed.dev/jobs) 页面以获取空缺职位。
+
+### 许可证
+
+必须正确提供第三方依赖项的许可证信息才能通过 CI。
+
+我们使用 [`cargo-about`](https://github.com/EmbarkStudios/cargo-about) 自动遵守开源许可证。如果 CI 失败，请检查以下内容：
+
+- 您创建的盒子是否收到错误“未指定许可证”？如果是这样，请在结帐的 Cargo.toml 中的“[package]”下添加“publish = false”。
+- 您是否收到依赖项的错误“无法满足许可要求”？如果是，首先确定该项目拥有什么许可证，以及该系统是否足以满足该许可证的要求。如果您不确定，请咨询律师。验证该系统可接受后，将许可证的 SPDX 标识符添加到“script/licenses/zed-licenses.toml”中的“accepted”数组中。
+- `cargo-about` 找不到依赖项的许可证？如果是这样，请在 `script/licenses/zed-licenses.toml` 的末尾添加一个说明字段，如 [cargo 书籍](https://embarkstudios.github.io/cargo-about/cli /generate /config.html#crate-configuration）。

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -1,0 +1,52 @@
+<h4 align="center">
+    <p>
+        <a href="../README.md">English</b> |
+        <b>Español</b> |
+        <a href="./README_CH.md">普通话</a>
+    </p>
+</h4>
+
+# Zed
+
+[![CI](https://github.com/zed-industries/zed/actions/workflows/ci.yml/badge.svg)](https://github.com/zed-industries/zed/actions/workflows/ci.yml)
+
+Bienvenido a Zed, un editor de código multijugador de alto rendimiento de los creadores de [Atom](https://github.com/atom/atom) y [Tree-sitter](https://github.com/tree-sitter/tree-sitter).
+
+--------
+
+### Instalación
+
+
+<a href="https://repology.org/project/zed-editor/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/zed-editor.svg?minversion=0.143.5" alt="Packaging status" align="right">
+</a>
+
+En macOS y Linux puedes [descargar Zed directamente](https://zed.dev/download) o [instale Zed a través de su administrador de paquetes local](https://zed.dev/docs/linux#installing-via-a-package-manager).
+
+Otras plataformas aún no están disponibles:
+
+- Windows ([tracking issue](https://github.com/zed-industries/zed/issues/5394))
+- Web ([tracking issue](https://github.com/zed-industries/zed/issues/5396))
+
+### Desarrollando Zed
+
+- [Construyendo Zed para macOS](./docs/src/development/macos.md)
+- [Construyendo Zed para Linux](./docs/src/development/linux.md)
+- [Construcción de Zed para Windows] (./docs/src/development/windows.md)
+- [Ejecución de colaboración local] (./docs/src/development/local-collaboration.md)
+
+### Contribuyendo
+
+Consulte [CONTRIBUTING.md](../CONTRIBUTING.md) para conocer las formas en que puede contribuir a Zed.
+
+Además... ¡estamos contratando! Consulte nuestra página de [trabajos](https://zed.dev/jobs) para conocer los puestos vacantes.
+
+### Licencias
+
+La información de licencia para dependencias de terceros se debe proporcionar correctamente para que CI pase.
+
+Usamos [`cargo-about`](https://github.com/EmbarkStudios/cargo-about) para cumplir automáticamente con las licencias de código abierto. Si CI falla, verifique lo siguiente:
+
+- ¿Aparece el error "no se ha especificado ninguna licencia" para una caja que has creado? Si es así, agregue `publish = false` bajo `[paquete]` en el Cargo.toml de su caja.
+- ¿Aparece el error "no se pudieron satisfacer los requisitos de licencia" para una dependencia? Si es así, primero determine qué licencia tiene el proyecto y si este sistema es suficiente para cumplir con los requisitos de esta licencia. Si no está seguro, consulte a un abogado. Una vez que haya verificado que este sistema es aceptable, agregue el identificador SPDX de la licencia a la matriz "aceptado" en "script/licenses/zed-licenses.toml".
+- ¿`cargo-about` no puede encontrar la licencia para una dependencia? Si es así, agregue un campo de aclaración al final de `script/licenses/zed-licenses.toml`, como se especifica en el [libro sobre carga](https://embarkstudios.github.io/cargo-about/cli/ generar/config.html#crate-configuration).


### PR DESCRIPTION
Edit Notes:

- Added navigable READMEs in Spanish and Mandarim

### Considerations

- Make the project more accessible to more people.
- Increase clarity of documentation for non-English speakers.
- Attract more contributors from other parts of the world.

Pros:
- More people can participate and understand the project.
- More diverse and engaged community.

Cons:
- It requires effort to translate and keep translations up to date.


