### PR TITLE
Recognize Cuda files as C++

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl"]
+path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "cu", "cuh"]
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
Closes #16070 

Release Notes:

- Added support for recognizing Cude files as C++.
