### PR TITLE
Accept finished inline transformations only if the user saves manually

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -436,6 +436,7 @@ pub trait ItemHandle: 'static + Send {
 
 pub trait WeakItemHandle: Send + Sync {
     fn id(&self) -> EntityId;
+    fn boxed_clone(&self) -> Box<dyn WeakItemHandle>;
     fn upgrade(&self) -> Option<Box<dyn ItemHandle>>;
 }
 
@@ -850,6 +851,10 @@ impl Clone for Box<dyn ItemHandle> {
 impl<T: Item> WeakItemHandle for WeakView<T> {
     fn id(&self) -> EntityId {
         self.entity_id()
+    }
+
+    fn boxed_clone(&self) -> Box<dyn WeakItemHandle> {
+        Box::new(self.clone())
     }
 
     fn upgrade(&self) -> Option<Box<dyn ItemHandle>> {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -184,7 +184,7 @@ pub enum Event {
     Focus,
     ZoomIn,
     ZoomOut,
-    UserSaved {
+    UserSavedItem {
         item: Box<dyn WeakItemHandle>,
         save_intent: SaveIntent,
     },
@@ -215,8 +215,8 @@ impl fmt::Debug for Event {
             Event::Focus => f.write_str("Focus"),
             Event::ZoomIn => f.write_str("ZoomIn"),
             Event::ZoomOut => f.write_str("ZoomOut"),
-            Event::UserSaved { item, save_intent } => f
-                .debug_struct("UserSaved")
+            Event::UserSavedItem { item, save_intent } => f
+                .debug_struct("UserSavedItem")
                 .field("item", &item.id())
                 .field("save_intent", save_intent)
                 .finish(),
@@ -1512,7 +1512,7 @@ impl Pane {
         }
 
         pane.update(cx, |_, cx| {
-            cx.emit(Event::UserSaved {
+            cx.emit(Event::UserSavedItem {
                 item: item.downgrade_item(),
                 save_intent,
             });

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -166,16 +166,28 @@ impl DeploySearch {
 const MAX_NAVIGATION_HISTORY_LEN: usize = 1024;
 
 pub enum Event {
-    AddItem { item: Box<dyn ItemHandle> },
-    ActivateItem { local: bool },
+    AddItem {
+        item: Box<dyn ItemHandle>,
+    },
+    ActivateItem {
+        local: bool,
+    },
     Remove,
-    RemoveItem { idx: usize },
-    RemovedItem { item_id: EntityId },
+    RemoveItem {
+        idx: usize,
+    },
+    RemovedItem {
+        item_id: EntityId,
+    },
     Split(SplitDirection),
     ChangeItemTitle,
     Focus,
     ZoomIn,
     ZoomOut,
+    UserSaved {
+        item: Box<dyn WeakItemHandle>,
+        save_intent: SaveIntent,
+    },
 }
 
 impl fmt::Debug for Event {
@@ -203,6 +215,11 @@ impl fmt::Debug for Event {
             Event::Focus => f.write_str("Focus"),
             Event::ZoomIn => f.write_str("ZoomIn"),
             Event::ZoomOut => f.write_str("ZoomOut"),
+            Event::UserSaved { item, save_intent } => f
+                .debug_struct("UserSaved")
+                .field("item", &item.id())
+                .field("save_intent", save_intent)
+                .finish(),
         }
     }
 }
@@ -1494,7 +1511,13 @@ impl Pane {
             }
         }
 
-        Ok(true)
+        pane.update(cx, |_, cx| {
+            cx.emit(Event::UserSaved {
+                item: item.downgrade_item(),
+                save_intent,
+            });
+            true
+        })
     }
 
     fn can_autosave_item(item: &dyn ItemHandle, cx: &AppContext) -> bool {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -40,7 +40,7 @@ use gpui::{
 };
 use item::{
     FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, PreviewTabsSettings,
-    ProjectItem, SerializableItem, SerializableItemHandle,
+    ProjectItem, SerializableItem, SerializableItemHandle, WeakItemHandle,
 };
 use itertools::Itertools;
 use language::{LanguageRegistry, Rope};
@@ -670,6 +670,11 @@ pub enum Event {
     ItemAdded,
     ItemRemoved,
     ActiveItemChanged,
+    UserSavedItem {
+        pane: WeakView<Pane>,
+        item: Box<dyn WeakItemHandle>,
+        save_intent: SaveIntent,
+    },
     ContactRequestedJoin(u64),
     WorkspaceCreated(WeakView<Workspace>),
     SpawnTask(Box<SpawnInTerminal>),
@@ -2934,6 +2939,11 @@ impl Workspace {
                     self.update_active_view_for_followers(cx);
                 }
             }
+            pane::Event::UserSaved { item, save_intent } => cx.emit(Event::UserSavedItem {
+                pane: pane.downgrade(),
+                item: item.boxed_clone(),
+                save_intent: *save_intent,
+            }),
             pane::Event::ChangeItemTitle => {
                 if pane == self.active_pane {
                     self.active_item_path_changed(cx);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2939,7 +2939,7 @@ impl Workspace {
                     self.update_active_view_for_followers(cx);
                 }
             }
-            pane::Event::UserSaved { item, save_intent } => cx.emit(Event::UserSavedItem {
+            pane::Event::UserSavedItem { item, save_intent } => cx.emit(Event::UserSavedItem {
                 pane: pane.downgrade(),
                 item: item.boxed_clone(),
                 save_intent: *save_intent,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/16042

This commit modifies the behavior of inline transformations to only accept finished transformations when the user manually saves the file. Previously, transformations were automatically accepted on any save event, including autosaves.

This was achieved by updating the `Pane` and `Workspace` structs to emit a new `UserSavedItem` event when a manual save occurs, and modifying the `InlineAssistant` to register and handle this new event (instead of `editor::Saved`).

Release Notes:

- N/A
