### PR TITLE
wayland: Do not reset clipboard data offer on keyboard leave

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1128,8 +1128,6 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 state.enter_token.take();
                 // Prevent keyboard events from repeating after opening e.g. a file chooser and closing it quickly
                 state.repeat.current_id += 1;
-                state.clipboard.set_offer(None);
-                state.clipboard.set_primary_offer(None);
 
                 if let Some(window) = keyboard_focused_window {
                     if let Some(ref mut compose) = state.compose_state {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1110,10 +1110,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 state.keymap_state = Some(xkb::State::new(&keymap));
                 state.compose_state = get_xkb_compose_state(&xkb_context);
             }
-            wl_keyboard::Event::Enter {
-                serial, surface, ..
-            } => {
-                state.serial_tracker.update(SerialKind::KeyEnter, serial);
+            wl_keyboard::Event::Enter { surface, .. } => {
                 state.keyboard_focused_window = get_window(&mut state, &surface.id());
                 state.enter_token = Some(());
 

--- a/crates/gpui/src/platform/linux/wayland/serial.rs
+++ b/crates/gpui/src/platform/linux/wayland/serial.rs
@@ -6,7 +6,6 @@ pub(crate) enum SerialKind {
     InputMethod,
     MouseEnter,
     MousePress,
-    KeyEnter,
     KeyPress,
 }
 


### PR DESCRIPTION
Closes #14415 
(also removed an unused serial while I was at it)

Release Notes:

- Linux: Fixed cross-window copy/paste not working in some Wayland configurations.