### PR TITLE
Fix panic when rendering long error messages as Markdown

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -10,7 +10,10 @@ use gpui::{
     TextStyle, TextStyleRefinement, View,
 };
 use language::{Language, LanguageRegistry, Rope};
-use parser::{parse_links_only, parse_markdown, MarkdownEvent, MarkdownTag, MarkdownTagEnd};
+use parser::{
+    parse_links_only, parse_markdown, safe_markdown_slice, MarkdownEvent, MarkdownTag,
+    MarkdownTagEnd,
+};
 
 use std::{iter, mem, ops::Range, rc::Rc, sync::Arc};
 use theme::SyntaxTheme;
@@ -695,7 +698,10 @@ impl Element for MarkdownElement {
                     _ => log::error!("unsupported markdown tag end: {:?}", tag),
                 },
                 MarkdownEvent::Text => {
-                    builder.push_text(&parsed_markdown.source[range.clone()], range.start);
+                    let (safe_text, start_index) =
+                        safe_markdown_slice(&parsed_markdown.source, range.clone());
+
+                    builder.push_text(safe_text, start_index);
                 }
                 MarkdownEvent::Code => {
                     builder.push_text_style(self.style.inline_code.clone());

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -698,10 +698,11 @@ impl Element for MarkdownElement {
                     _ => log::error!("unsupported markdown tag end: {:?}", tag),
                 },
                 MarkdownEvent::Text => {
-                    let (safe_text, start_index) =
-                        safe_markdown_slice(&parsed_markdown.source, range.clone());
-
-                    builder.push_text(safe_text, start_index);
+                    if let Some((safe_text, start_index)) =
+                        safe_markdown_slice(&parsed_markdown.source, range.clone())
+                    {
+                        builder.push_text(safe_text, start_index);
+                    }
                 }
                 MarkdownEvent::Code => {
                     builder.push_text_style(self.style.inline_code.clone());

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -123,10 +123,10 @@ pub fn parse_links_only(text: &str) -> Vec<(Range<usize>, MarkdownEvent)> {
     events
 }
 
-pub fn safe_markdown_slice(source: &str, range: std::ops::Range<usize>) -> (&str, usize) {
+pub fn safe_markdown_slice(source: &str, range: std::ops::Range<usize>) -> Option<(&str, usize)> {
     let source_len = source.len();
     if range.start >= source_len {
-        return ("", source_len);
+        return None;
     }
 
     let adjusted_end = if range.end > source_len {
@@ -139,10 +139,10 @@ pub fn safe_markdown_slice(source: &str, range: std::ops::Range<usize>) -> (&str
 
     if source.is_char_boundary(adjusted_range.start) && source.is_char_boundary(adjusted_range.end)
     {
-        (&source[adjusted_range.clone()], adjusted_range.start)
-    } else {
-        ("", adjusted_range.start)
+        return Some((&source[adjusted_range.clone()], adjusted_range.start));
     }
+
+    None
 }
 
 /// A static-lifetime equivalent of pulldown_cmark::Event so we can cache the

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -123,6 +123,28 @@ pub fn parse_links_only(text: &str) -> Vec<(Range<usize>, MarkdownEvent)> {
     events
 }
 
+pub fn safe_markdown_slice(source: &str, range: std::ops::Range<usize>) -> (&str, usize) {
+    let source_len = source.len();
+    if range.start >= source_len {
+        return ("", source_len);
+    }
+
+    let adjusted_end = if range.end > source_len {
+        source_len
+    } else {
+        range.end
+    };
+
+    let adjusted_range = range.start..adjusted_end;
+
+    if source.is_char_boundary(adjusted_range.start) && source.is_char_boundary(adjusted_range.end)
+    {
+        (&source[adjusted_range.clone()], adjusted_range.start)
+    } else {
+        ("", adjusted_range.start)
+    }
+}
+
 /// A static-lifetime equivalent of pulldown_cmark::Event so we can cache the
 /// parse result for rendering without resorting to unsafe lifetime coercion.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Closes #16058 

Release Notes:

- Fixed the size of the markdown slices for long error messages.



<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d5ca71e2-b46f-4af2-b889-e679cf0a434e">

Issue with max width should be resolved by another PR:
https://github.com/zed-industries/zed/pull/16092

