### PR TITLE
Allow to cycle through center/top/bot scroll positions

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -270,6 +270,7 @@ gpui::actions!(
         ScrollCursorBottom,
         ScrollCursorCenter,
         ScrollCursorTop,
+        ScrollCursorCenterTopBottom,
         SelectAll,
         SelectAllMatches,
         SelectDown,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -561,6 +561,27 @@ pub struct Editor {
     file_header_size: u32,
     breadcrumb_header: Option<String>,
     focused_block: Option<FocusedBlock>,
+    // TODO kb recheck names
+    next_scroll_direction: NextScollCursorCenterTopBottom, 
+    _scroll_cursor_center_top_bottom_task: Task<()>,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+enum NextScollCursorCenterTopBottom {
+    #[default]
+    Center,
+    Top,
+    Bottom,
+}
+
+impl NextScollCursorCenterTopBottom {
+    fn next(&self) -> Self {
+        match self {
+            Self::Center => Self::Top,
+            Self::Top => Self::Bottom,
+            Self::Bottom => Self::Center,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1895,6 +1916,8 @@ impl Editor {
             previous_search_ranges: None,
             breadcrumb_header: None,
             focused_block: None,
+            next_scroll_direction: Default::default(),
+            _scroll_cursor_center_top_bottom_task: Task::ready(()),
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));
         this._subscriptions.extend(project_subscriptions);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -566,7 +566,7 @@ pub struct Editor {
     _scroll_cursor_center_top_bottom_task: Task<()>,
 }
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug,  PartialEq, Eq, Default)]
 enum NextScollCursorCenterTopBottom {
     #[default]
     Center,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -562,20 +562,19 @@ pub struct Editor {
     file_header_size: u32,
     breadcrumb_header: Option<String>,
     focused_block: Option<FocusedBlock>,
-    // TODO kb recheck names
-    next_scroll_direction: NextScollCursorCenterTopBottom,
+    next_scroll_position: NextScrollCursorCenterTopBottom,
     _scroll_cursor_center_top_bottom_task: Task<()>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-enum NextScollCursorCenterTopBottom {
+enum NextScrollCursorCenterTopBottom {
     #[default]
     Center,
     Top,
     Bottom,
 }
 
-impl NextScollCursorCenterTopBottom {
+impl NextScrollCursorCenterTopBottom {
     fn next(&self) -> Self {
         match self {
             Self::Center => Self::Top,
@@ -1917,7 +1916,7 @@ impl Editor {
             previous_search_ranges: None,
             breadcrumb_header: None,
             focused_block: None,
-            next_scroll_direction: NextScollCursorCenterTopBottom::default(),
+            next_scroll_position: NextScrollCursorCenterTopBottom::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -175,6 +175,7 @@ pub const CODE_ACTIONS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(250);
 pub const DOCUMENT_HIGHLIGHTS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
 
 pub(crate) const FORMAT_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub fn render_parsed_markdown(
     element_id: impl Into<ElementId>,
@@ -562,11 +563,11 @@ pub struct Editor {
     breadcrumb_header: Option<String>,
     focused_block: Option<FocusedBlock>,
     // TODO kb recheck names
-    next_scroll_direction: NextScollCursorCenterTopBottom, 
+    next_scroll_direction: NextScollCursorCenterTopBottom,
     _scroll_cursor_center_top_bottom_task: Task<()>,
 }
 
-#[derive(Copy, Clone, Debug,  PartialEq, Eq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 enum NextScollCursorCenterTopBottom {
     #[default]
     Center,
@@ -1916,7 +1917,7 @@ impl Editor {
             previous_search_ranges: None,
             breadcrumb_header: None,
             focused_block: None,
-            next_scroll_direction: Default::default(),
+            next_scroll_direction: NextScollCursorCenterTopBottom::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13149,6 +13149,75 @@ async fn test_input_text(cx: &mut gpui::TestAppContext) {
     );
 }
 
+#[gpui::test]
+async fn test_scroll_cursor_center_top_bottom(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state(
+        r#"let foo = 1;
+let foo = 2;
+let foo = 3;
+let fooˇ = 4;
+let foo = 5;
+let foo = 6;
+let foo = 7;
+let foo = 8;
+let foo = 9;
+let foo = 10;
+let foo = 11;
+let foo = 12;
+let foo = 13;
+let foo = 14;
+let foo = 15;"#,
+    );
+
+    cx.update_editor(|e, cx| {
+        assert_eq!(
+            e.next_scroll_direction,
+            NextScollCursorCenterTopBottom::Center
+        );
+    });
+    cx.update_editor(|e, cx| {
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+    });
+    cx.update_editor(|e, cx| {
+        assert_eq!(
+            e.next_scroll_direction,
+            NextScollCursorCenterTopBottom::Top
+        );
+    });
+
+    // TODO kb add asynchrosity and test that the position gets reset
+
+    cx.update_editor(|e, cx| {
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+    });
+    cx.update_editor(|e, cx| {
+        assert_eq!(e.next_scroll_direction, NextScollCursorCenterTopBottom::Bottom);
+    });
+
+    cx.update_editor(|e, cx| {
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+    });
+    cx.update_editor(|e, cx| {
+        assert_eq!(
+            e.next_scroll_direction,
+            NextScollCursorCenterTopBottom::Bottom
+        );
+    });
+
+    cx.update_editor(|e, cx| {
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+    });
+    cx.update_editor(|e, cx| {
+        assert_eq!(
+            e.next_scroll_direction,
+            NextScollCursorCenterTopBottom::Center
+        );
+    });
+}
+
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {
     let point = DisplayPoint::new(DisplayRow(row as u32), column as u32);
     point..point

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13175,45 +13175,47 @@ let foo = 15;"#,
     cx.update_editor(|e, cx| {
         assert_eq!(
             e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Center
+            NextScollCursorCenterTopBottom::Center,
+            "Default next scroll direction is center",
         );
-    });
-    cx.update_editor(|e, cx| {
+
         e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
-    });
-    cx.update_editor(|e, cx| {
         assert_eq!(
             e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Top
+            NextScollCursorCenterTopBottom::Top,
+            "After center, next scroll direction should be top",
+        );
+
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+        assert_eq!(
+            e.next_scroll_direction,
+            NextScollCursorCenterTopBottom::Bottom,
+            "After top, next scroll direction should be bottom",
+        );
+
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+        assert_eq!(
+            e.next_scroll_direction,
+            NextScollCursorCenterTopBottom::Center,
+            "After bottom, scrolling should start over",
+        );
+
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+        assert_eq!(
+            e.next_scroll_direction,
+            NextScollCursorCenterTopBottom::Top,
+            "Scrolling continues if retriggered fast enough"
         );
     });
 
-    // TODO kb add asynchrosity and test that the position gets reset
-
-    cx.update_editor(|e, cx| {
-        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
-    });
-    cx.update_editor(|e, cx| {
-        assert_eq!(e.next_scroll_direction, NextScollCursorCenterTopBottom::Bottom);
-    });
-
-    cx.update_editor(|e, cx| {
-        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
-    });
-    cx.update_editor(|e, cx| {
+    cx.executor()
+        .advance_clock(SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT + Duration::from_millis(200));
+    cx.executor().run_until_parked();
+    cx.update_editor(|e, _| {
         assert_eq!(
             e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Bottom
-        );
-    });
-
-    cx.update_editor(|e, cx| {
-        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
-    });
-    cx.update_editor(|e, cx| {
-        assert_eq!(
-            e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Center
+            NextScollCursorCenterTopBottom::Center,
+            "If scrolling is not triggered fast enough, it should reset"
         );
     });
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13174,36 +13174,36 @@ let foo = 15;"#,
 
     cx.update_editor(|e, cx| {
         assert_eq!(
-            e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Center,
+            e.next_scroll_position,
+            NextScrollCursorCenterTopBottom::Center,
             "Default next scroll direction is center",
         );
 
-        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom, cx);
         assert_eq!(
-            e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Top,
+            e.next_scroll_position,
+            NextScrollCursorCenterTopBottom::Top,
             "After center, next scroll direction should be top",
         );
 
-        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom, cx);
         assert_eq!(
-            e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Bottom,
+            e.next_scroll_position,
+            NextScrollCursorCenterTopBottom::Bottom,
             "After top, next scroll direction should be bottom",
         );
 
-        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom, cx);
         assert_eq!(
-            e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Center,
+            e.next_scroll_position,
+            NextScrollCursorCenterTopBottom::Center,
             "After bottom, scrolling should start over",
         );
 
-        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom::default(), cx);
+        e.scroll_cursor_center_top_bottom(&ScrollCursorCenterTopBottom, cx);
         assert_eq!(
-            e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Top,
+            e.next_scroll_position,
+            NextScrollCursorCenterTopBottom::Top,
             "Scrolling continues if retriggered fast enough"
         );
     });
@@ -13213,8 +13213,8 @@ let foo = 15;"#,
     cx.executor().run_until_parked();
     cx.update_editor(|e, _| {
         assert_eq!(
-            e.next_scroll_direction,
-            NextScollCursorCenterTopBottom::Center,
+            e.next_scroll_position,
+            NextScrollCursorCenterTopBottom::Center,
             "If scrolling is not triggered fast enough, it should reset"
         );
     });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -222,6 +222,7 @@ impl EditorElement {
         register_action(view, cx, Editor::scroll_cursor_top);
         register_action(view, cx, Editor::scroll_cursor_center);
         register_action(view, cx, Editor::scroll_cursor_bottom);
+        register_action(view, cx, Editor::scroll_cursor_center_top_bottom);
         register_action(view, cx, |editor, _: &LineDown, cx| {
             editor.scroll_screen(&ScrollAmount::Line(1.), cx)
         });

--- a/crates/editor/src/scroll/actions.rs
+++ b/crates/editor/src/scroll/actions.rs
@@ -1,7 +1,9 @@
+use std::time::Duration;
+
 use super::Axis;
 use crate::{
-    Autoscroll, Bias, Editor, EditorMode, NextScreen, ScrollAnchor, ScrollCursorBottom,
-    ScrollCursorCenter, ScrollCursorTop,
+    Autoscroll, Bias, Editor, EditorMode, NextScollCursorCenterTopBottom, NextScreen, ScrollAnchor,
+    ScrollCursorBottom, ScrollCursorCenter, ScrollCursorCenterTopBottom, ScrollCursorTop,
 };
 use gpui::{Point, ViewContext};
 
@@ -30,6 +32,68 @@ impl Editor {
     ) {
         self.scroll_manager.update_ongoing_scroll(axis);
         self.set_scroll_position(scroll_position, cx);
+    }
+
+    pub fn scroll_cursor_center_top_bottom(
+        &mut self,
+        _: &ScrollCursorCenterTopBottom,
+        cx: &mut ViewContext<Self>,
+    ) {
+        // TODO kb tidy up
+        let snapshot = self.snapshot(cx).display_snapshot;
+        let visible_rows = if let Some(visible_rows) = self.visible_line_count() {
+            visible_rows as u32
+        } else {
+            return;
+        };
+        let scroll_margin_rows = self.vertical_scroll_margin() as u32;
+
+        let new_anchor = match self.next_scroll_direction {
+            NextScollCursorCenterTopBottom::Center => {
+                let mut new_screen_top = self.selections.newest_display(cx).head();
+                *new_screen_top.row_mut() = new_screen_top.row().0.saturating_sub(visible_rows / 2);
+                *new_screen_top.column_mut() = 0;
+                let new_screen_top = new_screen_top.to_offset(&snapshot, Bias::Left);
+                snapshot.buffer_snapshot.anchor_before(new_screen_top)
+            }
+            NextScollCursorCenterTopBottom::Top => {
+                let mut new_screen_top = self.selections.newest_display(cx).head();
+                *new_screen_top.row_mut() =
+                    new_screen_top.row().0.saturating_sub(scroll_margin_rows);
+                *new_screen_top.column_mut() = 0;
+                let new_screen_top = new_screen_top.to_offset(&snapshot, Bias::Left);
+                snapshot.buffer_snapshot.anchor_before(new_screen_top)
+            }
+            NextScollCursorCenterTopBottom::Bottom => {
+                let mut new_screen_top = self.selections.newest_display(cx).head();
+                *new_screen_top.row_mut() = new_screen_top
+                    .row()
+                    .0
+                    .saturating_sub(visible_rows.saturating_sub(scroll_margin_rows));
+                *new_screen_top.column_mut() = 0;
+                let new_screen_top = new_screen_top.to_offset(&snapshot, Bias::Left);
+                snapshot.buffer_snapshot.anchor_before(new_screen_top)
+            }
+        };
+
+        self.set_scroll_anchor(
+            ScrollAnchor {
+                anchor: new_anchor,
+                offset: Default::default(),
+            },
+            cx,
+        );
+
+        self.next_scroll_direction = self.next_scroll_direction.next();
+        self._scroll_cursor_center_top_bottom_task =
+            cx.spawn(|editor, mut cx: gpui::AsyncWindowContext| async move {
+                cx.background_executor().timer(Duration::from_secs(1)).await;
+                editor
+                    .update(&mut cx, |editor, cx| {
+                        editor.next_scroll_direction = NextScollCursorCenterTopBottom::default();
+                    })
+                    .ok();
+            });
     }
 
     pub fn scroll_cursor_top(&mut self, _: &ScrollCursorTop, cx: &mut ViewContext<Editor>) {

--- a/crates/editor/src/scroll/actions.rs
+++ b/crates/editor/src/scroll/actions.rs
@@ -1,9 +1,8 @@
-use std::time::Duration;
-
 use super::Axis;
 use crate::{
     Autoscroll, Bias, Editor, EditorMode, NextScollCursorCenterTopBottom, NextScreen, ScrollAnchor,
     ScrollCursorBottom, ScrollCursorCenter, ScrollCursorCenterTopBottom, ScrollCursorTop,
+    SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT,
 };
 use gpui::{Point, ViewContext};
 
@@ -87,9 +86,11 @@ impl Editor {
         self.next_scroll_direction = self.next_scroll_direction.next();
         self._scroll_cursor_center_top_bottom_task =
             cx.spawn(|editor, mut cx: gpui::AsyncWindowContext| async move {
-                cx.background_executor().timer(Duration::from_secs(1)).await;
+                cx.background_executor()
+                    .timer(SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT)
+                    .await;
                 editor
-                    .update(&mut cx, |editor, cx| {
+                    .update(&mut cx, |editor, _| {
                         editor.next_scroll_direction = NextScollCursorCenterTopBottom::default();
                     })
                     .ok();


### PR DESCRIPTION
On top of `editor::ScrollCursorCenter`, `editor::ScrollCursorTop`, `editor::ScrollCursorBottom` actions, adds an `editor::ScrollCursorCenterTopBottom` one, that allows using a single keybinding to scroll between positions on the screen.

The implementation matches a corresponding Emacs feature: there's a timeout (1s) that is kept after every switch, to allow continuously changing the positions, center (initial) -> top -> bottom
Scrolling behavior is the same as the existing actions (e.g. editor will ignore scroll to bottom, if there's not enough space above).

After 1s, next position is reset to the initial, center, one.


Release Notes:

- Added an `editor::ScrollCursorCenterTopBottom` action for toggling scroll position with a single keybinding