### PR TITLE
assistant: Show a better error when `/docs` is used without a package name

### DIFF
--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -276,6 +276,15 @@ impl SlashCommand for DocsSlashCommand {
                     } => (provider, item_path),
                 };
 
+                if key.trim().is_empty() {
+                    let package_term = match provider.as_ref() {
+                        "docs-rs" | "rustdoc" => "crate",
+                        _ => "package",
+                    };
+
+                    bail!("no {package_term} name provided");
+                }
+
                 let store = store?;
 
                 if let Some(package) = args.package() {


### PR DESCRIPTION
This PR makes it so that running `/docs` without providing a package name gives a better error message:

<img width="248" alt="Screenshot 2024-08-13 at 9 24 58 AM" src="https://github.com/user-attachments/assets/c1cc794e-0fa0-490a-871a-a56702b03d42">

<img width="228" alt="Screenshot 2024-08-13 at 9 25 05 AM" src="https://github.com/user-attachments/assets/45dca2d7-171f-48f0-a03c-254b552cb50d">

Release Notes:

- N/A
