### PR TITLE
Fix min and max versions for v0.1.0 of the extension API

### DIFF
--- a/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
@@ -22,8 +22,8 @@ use std::{
 use util::maybe;
 use wasmtime::component::{Linker, Resource};
 
-pub const MIN_VERSION: SemanticVersion = SemanticVersion::new(0, 0, 7);
-pub const MAX_VERSION: SemanticVersion = SemanticVersion::new(0, 0, 7);
+pub const MIN_VERSION: SemanticVersion = SemanticVersion::new(0, 1, 0);
+pub const MAX_VERSION: SemanticVersion = SemanticVersion::new(0, 1, 0);
 
 wasmtime::component::bindgen!({
     async: true,


### PR DESCRIPTION
Missed this in #16158.

Release Notes:

- N/A
