### PR TITLE
assistant: Fix debug inspector removing workflow step it's applied to

### DIFF
--- a/crates/assistant/src/context_inspector.rs
+++ b/crates/assistant/src/context_inspector.rs
@@ -6,7 +6,7 @@ use editor::{
     Editor,
 };
 use gpui::{AppContext, Model, View};
-use text::{ToOffset, ToPoint};
+use text::{Bias, ToOffset, ToPoint};
 use ui::{
     div, h_flex, Color, Element as _, ParentElement as _, Styled, ViewContext, WindowContext,
 };
@@ -87,13 +87,14 @@ impl ContextInspector {
             .unwrap_or_else(|| Arc::from("Error fetching debug info"));
         self.editor.update(cx, |editor, cx| {
             let buffer = editor.buffer().read(cx).as_singleton()?;
-
+            let snapshot = buffer.read(cx).text_snapshot();
+            let start_offset = range.end.to_offset(&snapshot) + 1;
+            let start_offset = snapshot.clip_offset(start_offset, Bias::Right);
             let text_len = text.len();
-            let snapshot = buffer.update(cx, |this, cx| {
-                this.edit([(range.end..range.end, text)], None, cx);
-                this.text_snapshot()
+            buffer.update(cx, |this, cx| {
+                this.edit([(start_offset..start_offset, text)], None, cx);
             });
-            let start_offset = range.end.to_offset(&snapshot);
+
             let end_offset = start_offset + text_len;
             let multibuffer_snapshot = editor.buffer().read(cx).snapshot(cx);
             let anchor_before = multibuffer_snapshot.anchor_after(start_offset);


### PR DESCRIPTION
Debug inspector broke immediately after merge as #16036 landed in parallel; one of the changes of that PR is removing any steps whose content was edited, which is what debug inspector happened to do. The fix is to make the edit right past the step block.


Release Notes:

- N/A
