### PR TITLE
Revert "Remove extra empty space for files when file icons are turned off (#16142)

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2120,12 +2120,13 @@ impl ProjectPanel {
                                 .into_any_element(),
                         )
                     })
-                    .when_some(icon, |this, icon| {
-                        this.child(
-                            h_flex().child(
-                                Icon::from_path(icon.to_string()).color(filename_text_color),
-                            ),
-                        )
+                    .child(if let Some(icon) = &icon {
+                        h_flex().child(Icon::from_path(icon.to_string()).color(filename_text_color))
+                    } else {
+                        h_flex()
+                            .size(IconSize::default().rems())
+                            .invisible()
+                            .flex_none()
                     })
                     .child(
                         if let (Some(editor), true) = (Some(&self.filename_editor), show_editor) {


### PR DESCRIPTION
This PR reverts #16142, as it isn't what we want from a design standpoint.

Having the file names misaligned from the folder names is not the desired behavior:

<img width="243" alt="Screenshot 2024-08-13 at 11 16 53 AM" src="https://github.com/user-attachments/assets/12914e89-2641-4932-96c2-00e89e56d6d7">

We can revisit when we have design bandwidth.

This reverts commit ee6a40137f21998a1b82df480c81207ec569fc98.

Release Notes:

- Reverted #16142.
  - @JosephTLyons @notpeter for release notes curation
