### PR TITLE
assistant: Add gap to the context toolbar

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -4141,6 +4141,7 @@ impl Render for ContextEditorToolbarItem {
 
         h_flex()
             .size_full()
+            .gap_2()
             .justify_between()
             .child(left_side)
             .child(right_side)


### PR DESCRIPTION
Not the ideal solution yet, but just a small treatment so these two blocks don't collide.

| Before | After |
|--------|--------|
| <img width="672" alt="Screenshot 2024-08-13 at 16 59 45" src="https://github.com/user-attachments/assets/81f57ae7-3b37-4a41-8611-3fd69a218320"> | <img width="646" alt="Screenshot 2024-08-13 at 17 04 37" src="https://github.com/user-attachments/assets/5cc73dc7-763a-44cf-8a87-2abe8bd51639"> | 

Release Notes:

- N/A
