### PR TITLE
assistant: Adjust slash command popover padding

### DIFF
--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -43,7 +43,7 @@ impl RenderOnce for Popover {
         div()
             .flex()
             .gap_1()
-            .child(v_flex().elevation_2(cx).px_1().children(self.children))
+            .child(v_flex().elevation_2(cx).py_1().children(self.children))
             .when_some(self.aside, |this, aside| {
                 this.child(
                     v_flex()


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="382" alt="Screenshot 2024-08-13 at 17 12 07" src="https://github.com/user-attachments/assets/c793b129-0113-4532-9551-d2778d4d4753"> | <img width="395" alt="Screenshot 2024-08-13 at 16 00 48" src="https://github.com/user-attachments/assets/9792c6c3-758b-4ae4-8cd5-20667edbcb90"> | 

I've looked for other instances of the popover component where this change could cause a spacing regression but couldn't find any yet. Let me know if you do! Intuitively, I wouldn't change this padding directly on the component container, but I didn't find any other way to tackle it.

Release Notes:

- N/A
