### PR TITLE
Allow extensions to suggest packages for `/docs` completions

### DIFF
--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -291,6 +291,19 @@ impl Extension {
         }
     }
 
+    pub async fn call_suggest_docs_packages(
+        &self,
+        store: &mut Store<WasmState>,
+        provider: &str,
+    ) -> Result<Result<Vec<String>, String>> {
+        match self {
+            Extension::V010(ext) => ext.call_suggest_docs_packages(store, provider).await,
+            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Err(anyhow!(
+                "`suggest_docs_packages` not available prior to v0.1.0"
+            )),
+        }
+    }
+
     pub async fn call_index_docs(
         &self,
         store: &mut Store<WasmState>,

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -129,6 +129,16 @@ pub trait Extension: Send + Sync {
         Err("`run_slash_command` not implemented".to_string())
     }
 
+    /// Returns a list of package names as suggestions to be included in the
+    /// search results of the `/docs` slash command.
+    ///
+    /// This can be used to provide completions for known packages (e.g., from the
+    /// local project or a registry) before a package has been indexed.
+    fn suggest_docs_packages(&self, _provider: String) -> Result<Vec<String>, String> {
+        Ok(Vec::new())
+    }
+
+    /// Indexes the docs for the specified package.
     fn index_docs(
         &self,
         _provider: String,
@@ -258,6 +268,10 @@ impl wit::Guest for Component {
         worktree: Option<&Worktree>,
     ) -> Result<SlashCommandOutput, String> {
         extension().run_slash_command(command, argument, worktree)
+    }
+
+    fn suggest_docs_packages(provider: String) -> Result<Vec<String>, String> {
+        extension().suggest_docs_packages(provider)
     }
 
     fn index_docs(

--- a/crates/extension_api/wit/since_v0.1.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.1.0/extension.wit
@@ -135,6 +135,13 @@ world extension {
     /// Returns the output from running the provided slash command.
     export run-slash-command: func(command: slash-command, argument: option<string>, worktree: option<borrow<worktree>>) -> result<slash-command-output, string>;
 
+    /// Returns a list of packages as suggestions to be included in the `/docs`
+    /// search results.
+    ///
+    /// This can be used to provide completions for known packages (e.g., from the
+    /// local project or a registry) before a package has been indexed.
+    export suggest-docs-packages: func(provider-name: string) -> result<list<string>, string>;
+
     /// Indexes the docs for the specified package.
     export index-docs: func(provider-name: string, package-name: string, database: borrow<key-value-store>) -> result<_, string>;
 }

--- a/extensions/gleam/src/gleam.rs
+++ b/extensions/gleam/src/gleam.rs
@@ -246,6 +246,17 @@ impl zed::Extension for GleamExtension {
         }
     }
 
+    fn suggest_docs_packages(&self, provider: String) -> Result<Vec<String>, String> {
+        match provider.as_str() {
+            "gleam-hexdocs" => Ok(vec![
+                "gleam_stdlib".to_string(),
+                "birdie".to_string(),
+                "startest".to_string(),
+            ]),
+            _ => Ok(Vec::new()),
+        }
+    }
+
     fn index_docs(
         &self,
         provider: String,


### PR DESCRIPTION
This PR gives extensions the ability to suggest packages to show up in `/docs` completions by default.

Release Notes:

- N/A
