### PR TITLE
assistant: Put `/docs` and `/project` behind a setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -400,6 +400,19 @@
       "model": "gpt-4o"
     }
   },
+  // The settings for slash commands.
+  "slash_commands": {
+    // Settings for the `/docs` command.
+    "docs": {
+      // Whether `/docs` is enabled.
+      "enabled": false
+    },
+    // Settings for the `/project` command.
+    "project": {
+      // Whether `/project` is enabled.
+      "enabled": false
+    }
+  },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -402,12 +402,12 @@
   },
   // The settings for slash commands.
   "slash_commands": {
-    // Settings for the `/docs` command.
+    // Settings for the `/docs` slash command.
     "docs": {
       // Whether `/docs` is enabled.
       "enabled": false
     },
-    // Settings for the `/project` command.
+    // Settings for the `/project` slash command.
     "project": {
       // Whether `/project` is enabled.
       "enabled": false

--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -7,7 +7,6 @@ use anyhow::{anyhow, bail, Result};
 use assistant_slash_command::{
     ArgumentCompletion, SlashCommand, SlashCommandOutput, SlashCommandOutputSection,
 };
-use feature_flags::FeatureFlag;
 use gpui::{AppContext, BackgroundExecutor, Model, Task, WeakView};
 use indexed_docs::{
     DocsDotRsProvider, IndexedDocsRegistry, IndexedDocsStore, LocalRustdocProvider, PackageName,
@@ -18,12 +17,6 @@ use project::{Project, ProjectPath};
 use ui::prelude::*;
 use util::{maybe, ResultExt};
 use workspace::Workspace;
-
-pub(crate) struct DocsSlashCommandFeatureFlag;
-
-impl FeatureFlag for DocsSlashCommandFeatureFlag {
-    const NAME: &'static str = "docs-slash-command";
-}
 
 pub(crate) struct DocsSlashCommand;
 

--- a/crates/assistant/src/slash_command_settings.rs
+++ b/crates/assistant/src/slash_command_settings.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use gpui::AppContext;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use settings::{Settings, SettingsSources};
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone, JsonSchema)]
+pub struct SlashCommandSettings {
+    #[serde(default)]
+    pub docs: DocsCommandSettings,
+    #[serde(default)]
+    pub project: ProjectCommandSettings,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone, JsonSchema)]
+pub struct DocsCommandSettings {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone, JsonSchema)]
+pub struct ProjectCommandSettings {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Settings for SlashCommandSettings {
+    const KEY: Option<&'static str> = Some("slash_commands");
+
+    type FileContent = Self;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _cx: &mut AppContext) -> Result<Self> {
+        SettingsSources::<Self::FileContent>::json_merge_with(
+            [sources.default].into_iter().chain(sources.user),
+        )
+    }
+}

--- a/crates/assistant/src/slash_command_settings.rs
+++ b/crates/assistant/src/slash_command_settings.rs
@@ -4,22 +4,29 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
 
+/// Settings for slash commands.
 #[derive(Deserialize, Serialize, Debug, Default, Clone, JsonSchema)]
 pub struct SlashCommandSettings {
+    /// Settings for the `/docs` slash command.
     #[serde(default)]
     pub docs: DocsCommandSettings,
+    /// Settings for the `/project` slash command.
     #[serde(default)]
     pub project: ProjectCommandSettings,
 }
 
+/// Settings for the `/docs` slash command.
 #[derive(Deserialize, Serialize, Debug, Default, Clone, JsonSchema)]
 pub struct DocsCommandSettings {
+    /// Whether `/docs` is enabled.
     #[serde(default)]
     pub enabled: bool,
 }
 
+/// Settings for the `/project` slash command.
 #[derive(Deserialize, Serialize, Debug, Default, Clone, JsonSchema)]
 pub struct ProjectCommandSettings {
+    /// Whether `/project` is enabled.
     #[serde(default)]
     pub enabled: bool,
 }

--- a/crates/assistant_slash_command/src/slash_command_registry.rs
+++ b/crates/assistant_slash_command/src/slash_command_registry.rs
@@ -56,6 +56,14 @@ impl SlashCommandRegistry {
         state.commands.insert(command_name, Arc::new(command));
     }
 
+    /// Unregisters the provided [`SlashCommand`].
+    pub fn unregister_command(&self, command: impl SlashCommand) {
+        let mut state = self.state.write();
+        let command_name: Arc<str> = command.name().into();
+        state.featured_commands.remove(&command_name);
+        state.commands.remove(&command_name);
+    }
+
     /// Returns the names of registered [`SlashCommand`]s.
     pub fn command_names(&self) -> Vec<Arc<str>> {
         self.state.read().commands.keys().cloned().collect()


### PR DESCRIPTION
This PR puts the availability of the `/docs` and `/project` slash commands behind their respective settings.

Release Notes:

- N/A
