### PR TITLE
linux: Fix backspace copying characters to primary clipboard

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2285,29 +2285,6 @@ impl Editor {
         show_completions: bool,
         cx: &mut ViewContext<Self>,
     ) {
-        // Copy selections to primary selection buffer
-        #[cfg(target_os = "linux")]
-        if local {
-            let selections = self.selections.all::<usize>(cx);
-            let buffer_handle = self.buffer.read(cx).read(cx);
-
-            let mut text = String::new();
-            for (index, selection) in selections.iter().enumerate() {
-                let text_for_selection = buffer_handle
-                    .text_for_range(selection.start..selection.end)
-                    .collect::<String>();
-
-                text.push_str(&text_for_selection);
-                if index != selections.len() - 1 {
-                    text.push('\n');
-                }
-            }
-
-            if !text.is_empty() {
-                cx.write_to_primary(ClipboardItem::new_string(text));
-            }
-        }
-
         if self.focus_handle.is_focused(cx) && self.leader_peer_id.is_none() {
             self.buffer.update(cx, |buffer, cx| {
                 buffer.set_active_selections(

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -259,6 +259,19 @@ impl TestAppContext {
         self.test_platform.read_from_clipboard()
     }
 
+    /// Simulates writing to the primary Linux clipboard
+    #[cfg(target_os = "linux")]
+    pub fn write_to_primary(&self, item: ClipboardItem) {
+        self.test_platform.write_to_primary(item)
+    }
+
+    /// Simulates reading from the primary Linux clipboard.
+    /// This will return the most recent value from `write_to_primary`.
+    #[cfg(target_os = "linux")]
+    pub fn read_from_primary(&self) -> Option<ClipboardItem> {
+        self.test_platform.read_from_primary()
+    }
+
     /// Simulates choosing a File in the platform's "Open" dialog.
     pub fn simulate_new_path_selection(
         &self,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/14362

This PR moves the primary clipboard writing logic of the editor crate to mouse up, instead of `selections_did_change`. This prevents actions like `Backspace` from copying to the primary clipboard.

Selecting with the keyboard also no longer copies to the primary clipboard, but this seems to vary from program to program.

Release Notes:

- Linux: Fixed backspace copying characters to primary clipboard.