### PR TITLE
assistant: Wrap edit workflow prompt in `<prompt>` tags, caveat language code fence block

### DIFF
--- a/assets/prompts/edit_workflow.hbs
+++ b/assets/prompts/edit_workflow.hbs
@@ -1,3 +1,5 @@
+<prompt>
+
 Guide the user through code changes in numbered steps that focus on individual functions, type definitions, etc.
 Surround each distinct step in a <step></step> XML tag.
 
@@ -85,3 +87,7 @@ The changes include:
 2. Updating the `new` method to accept an email parameter
 3. Modifying the `print_info` method to include the email
 4. Updating the main function to provide an email when creating a User instance
+
+ALWAYS use the language of the file for the code fence blocks.
+
+</prompt>

--- a/assets/prompts/edit_workflow.hbs
+++ b/assets/prompts/edit_workflow.hbs
@@ -1,10 +1,14 @@
-<prompt>
+<workflow>
+<description>
+Guide the user through edits in numbered steps.
+</description>
 
 Guide the user through code changes in numbered steps that focus on individual functions, type definitions, etc.
-Surround each distinct step in a <step></step> XML tag.
+Surround each distinct step in a <step></step> XML tag. ALWAYS use the language of the file for the code fence blocks.
 
-Here's an example of a user-assistant dialog with step numbers and a follow-up question in Rust:
+Here's an example of a user-assistant dialog with step numbers and a follow-up question:
 
+<example>
 1. User: I want to create a User struct with name and age fields, and a method to print the user's information. Can you help me with that?
 A: Certainly! Let's create a User struct with the specified fields and a method to print the information:
 <step>Define the User struct
@@ -88,6 +92,6 @@ The changes include:
 3. Modifying the `print_info` method to include the email
 4. Updating the main function to provide an email when creating a User instance
 
-ALWAYS use the language of the file for the code fence blocks.
+</example>
 
-</prompt>
+</workflow>


### PR DESCRIPTION
At least with Llama 3.1 models I was commonly seeing the model make code blocks with Rust instead of Python with the edit workflow:

![image](https://github.com/user-attachments/assets/5d0080b2-a439-45fd-aeaa-93c421145041)

I wrapped the overall prompt in `<prompt>` and also included a declaration to ALWAYS set the right language in the code fence block.


Release Notes:

- N/A
