### PR TITLE
Fix regression: Restore creation of multiple assist editors on `ctrl-enter` when selections span across multiple excerpts

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -45,7 +45,6 @@ use std::{
     task::{self, Poll},
     time::{Duration, Instant},
 };
-use text::ToOffset as _;
 use theme::ThemeSettings;
 use ui::{prelude::*, CheckboxWithLabel, IconButtonShape, Popover, Tooltip};
 use util::{RangeExt, ResultExt};

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -152,12 +152,6 @@ impl InlineAssistant {
             .map(|range| range.to_point(&snapshot))
             .collect::<Vec<Range<Point>>>();
 
-        println!("Selection ranges:");
-        for selection_range in &selection_ranges {
-            println!("{:?}", selection_range);
-        }
-        println!("Max point of snapshot: {:?}", snapshot.max_point());
-
         for selection_range in selection_ranges {
             let selection_is_newest = newest_selection_range.contains_inclusive(&selection_range);
             let mut transform_range = selection_range.start..selection_range.end;
@@ -207,13 +201,6 @@ impl InlineAssistant {
             focus_assist,
         } in codegen_ranges
         {
-            println!("Transform range:");
-            println!("{:?}", transform_range);
-            println!("Selection ranges:");
-            for selection_range in &selection_ranges {
-                println!("{:?}", selection_range);
-            }
-
             let transform_range = snapshot.anchor_before(transform_range.start)
                 ..snapshot.anchor_after(transform_range.end);
             let selection_ranges = selection_ranges

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -139,15 +139,17 @@ impl InlineAssistant {
         cx: &mut WindowContext,
     ) {
         let snapshot = editor.read(cx).buffer().read(cx).snapshot(cx);
-
         struct CodegenRange {
             transform_range: Range<Point>,
             selection_ranges: Vec<Range<Point>>,
             focus_assist: bool,
         }
 
+        snapshot.excerpts_in_ranges(editor.read(cx).selections.disjoint_anchor_ranges());
+
         let newest_selection = editor.read(cx).selections.newest::<Point>(cx);
         let mut codegen_ranges: Vec<CodegenRange> = Vec::new();
+
         for selection in editor.read(cx).selections.all::<Point>(cx) {
             let selection_is_newest = selection.id == newest_selection.id;
             let mut transform_range = selection.start..selection.end;

--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -208,6 +208,9 @@ impl PromptBuilder {
             rewrite_section.push_str(chunk);
         }
 
+        println!("Transform range: {:?}", transform_range);
+        println!("Selected ranges: {:?}", selected_ranges);
+
         let rewrite_section_with_selections = {
             let mut section_with_selections = String::new();
             let mut last_end = 0;

--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -208,9 +208,6 @@ impl PromptBuilder {
             rewrite_section.push_str(chunk);
         }
 
-        println!("Transform range: {:?}", transform_range);
-        println!("Selected ranges: {:?}", selected_ranges);
-
         let rewrite_section_with_selections = {
             let mut section_with_selections = String::new();
             let mut last_end = 0;

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6765,9 +6765,6 @@ mod tests {
     fn test_split_ranges(cx: &mut AppContext) {
         let buffer_1 = cx.new_model(|cx| Buffer::local(sample_text(6, 6, 'a'), cx));
         let buffer_2 = cx.new_model(|cx| Buffer::local(sample_text(6, 6, 'g'), cx));
-        let buffer_1_len = buffer_1.read(cx).len();
-        let buffer_2_len = buffer_2.read(cx).len();
-
         let multibuffer = cx.new_model(|_| MultiBuffer::new(0, Capability::ReadWrite));
         multibuffer.update(cx, |multibuffer, cx| {
             multibuffer.push_excerpts(
@@ -6790,29 +6787,90 @@ mod tests {
 
         let snapshot = multibuffer.read(cx).snapshot(cx);
 
+        let buffer_1_len = buffer_1.read(cx).len();
+        let buffer_2_len = buffer_2.read(cx).len();
         let buffer_1_midpoint = buffer_1_len / 2;
-        let buffer_2_midpoint = buffer_1_len + buffer_2_len / 2;
-        let total_len = buffer_1_len + buffer_2_len;
+        let buffer_2_start = buffer_1_len + '\n'.len_utf8();
+        let buffer_2_midpoint = buffer_2_start + buffer_2_len / 2;
+        let total_len = buffer_2_start + buffer_2_len;
 
-        let ranges = [
+        let input_ranges = [
             0..buffer_1_midpoint,
             buffer_1_midpoint..buffer_2_midpoint,
             buffer_2_midpoint..total_len,
-        ];
+        ]
+        .map(|range| snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end));
 
-        let actual_ranges =
-            snapshot
-                .split_ranges(ranges.into_iter().map(|range| {
-                    snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end)
-                }))
-                .map(|range| range.to_offset(&snapshot))
-                .collect::<Vec<_>>();
+        let actual_ranges = snapshot
+            .split_ranges(input_ranges.into_iter())
+            .map(|range| range.to_offset(&snapshot))
+            .collect::<Vec<_>>();
 
         let expected_ranges = vec![
             0..buffer_1_midpoint,
             buffer_1_midpoint..buffer_1_len,
-            buffer_1_len..buffer_2_midpoint,
+            buffer_2_start..buffer_2_midpoint,
             buffer_2_midpoint..total_len,
+        ];
+
+        assert_eq!(actual_ranges, expected_ranges);
+    }
+
+    #[gpui::test]
+    fn test_split_ranges_single_range_spanning_three_excerpts(cx: &mut AppContext) {
+        let buffer_1 = cx.new_model(|cx| Buffer::local(sample_text(6, 6, 'a'), cx));
+        let buffer_2 = cx.new_model(|cx| Buffer::local(sample_text(6, 6, 'g'), cx));
+        let buffer_3 = cx.new_model(|cx| Buffer::local(sample_text(6, 6, 'm'), cx));
+        let multibuffer = cx.new_model(|_| MultiBuffer::new(0, Capability::ReadWrite));
+        multibuffer.update(cx, |multibuffer, cx| {
+            multibuffer.push_excerpts(
+                buffer_1.clone(),
+                [ExcerptRange {
+                    context: 0..buffer_1.read(cx).len(),
+                    primary: None,
+                }],
+                cx,
+            )[0];
+            multibuffer.push_excerpts(
+                buffer_2.clone(),
+                [ExcerptRange {
+                    context: 0..buffer_2.read(cx).len(),
+                    primary: None,
+                }],
+                cx,
+            )[0];
+            multibuffer.push_excerpts(
+                buffer_3.clone(),
+                [ExcerptRange {
+                    context: 0..buffer_3.read(cx).len(),
+                    primary: None,
+                }],
+                cx,
+            )[0];
+        });
+
+        let snapshot = multibuffer.read(cx).snapshot(cx);
+
+        let buffer_1_len = buffer_1.read(cx).len();
+        let buffer_2_len = buffer_2.read(cx).len();
+        let buffer_3_len = buffer_3.read(cx).len();
+        let buffer_2_start = buffer_1_len + '\n'.len_utf8();
+        let buffer_3_start = buffer_2_start + buffer_2_len + '\n'.len_utf8();
+        let buffer_1_midpoint = buffer_1_len / 2;
+        let buffer_3_midpoint = buffer_3_start + buffer_3_len / 2;
+
+        let input_range =
+            snapshot.anchor_before(buffer_1_midpoint)..snapshot.anchor_after(buffer_3_midpoint);
+
+        let actual_ranges = snapshot
+            .split_ranges(std::iter::once(input_range))
+            .map(|range| range.to_offset(&snapshot))
+            .collect::<Vec<_>>();
+
+        let expected_ranges = vec![
+            buffer_1_midpoint..buffer_1_len,
+            buffer_2_start..buffer_2_start + buffer_2_len,
+            buffer_3_start..buffer_3_midpoint,
         ];
 
         assert_eq!(actual_ranges, expected_ranges);

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6774,7 +6774,7 @@ mod tests {
                     primary: None,
                 }],
                 cx,
-            )[0];
+            );
             multibuffer.push_excerpts(
                 buffer_2.clone(),
                 [ExcerptRange {
@@ -6782,7 +6782,7 @@ mod tests {
                     primary: None,
                 }],
                 cx,
-            )[0];
+            );
         });
 
         let snapshot = multibuffer.read(cx).snapshot(cx);
@@ -6830,7 +6830,7 @@ mod tests {
                     primary: None,
                 }],
                 cx,
-            )[0];
+            );
             multibuffer.push_excerpts(
                 buffer_2.clone(),
                 [ExcerptRange {
@@ -6838,7 +6838,7 @@ mod tests {
                     primary: None,
                 }],
                 cx,
-            )[0];
+            );
             multibuffer.push_excerpts(
                 buffer_3.clone(),
                 [ExcerptRange {
@@ -6846,7 +6846,7 @@ mod tests {
                     primary: None,
                 }],
                 cx,
-            )[0];
+            );
         });
 
         let snapshot = multibuffer.read(cx).snapshot(cx);

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3873,7 +3873,60 @@ impl MultiBufferSnapshot {
         }
     }
 
+    // Takes an iterator over anchor ranges and returns a new iterator over anchor ranges that don't
+    // span across excerpt boundaries.
+    pub fn split_ranges<'a, I>(&'a self, ranges: I) -> impl Iterator<Item = Range<Anchor>> + 'a
+    where
+        I: IntoIterator<Item = Range<Anchor>> + 'a,
+    {
+        let mut ranges = ranges.into_iter().map(|range| range.to_offset(self));
+        let mut cursor = self.excerpts.cursor::<usize>();
+        cursor.next(&());
+        let mut current_range = ranges.next();
+        iter::from_fn(move || {
+            let range = current_range.clone()?;
+            if range.start >= cursor.end(&()) {
+                cursor.seek_forward(&range.start, Bias::Right, &());
+                if range.start == self.len() {
+                    cursor.prev(&());
+                }
+            }
+
+            let excerpt = cursor.item()?;
+            let range_start_in_excerpt = cmp::max(range.start, *cursor.start());
+            let range_end_in_excerpt = if excerpt.has_trailing_newline {
+                cmp::min(range.end, cursor.end(&()) - 1)
+            } else {
+                cmp::min(range.end, cursor.end(&()))
+            };
+            let buffer_range = MultiBufferExcerpt::new(excerpt, *cursor.start())
+                .map_range_to_buffer(range_start_in_excerpt..range_end_in_excerpt);
+
+            let subrange_start_anchor = Anchor {
+                buffer_id: Some(excerpt.buffer_id),
+                excerpt_id: excerpt.id,
+                text_anchor: excerpt.buffer.anchor_before(buffer_range.start),
+            };
+            let subrange_end_anchor = Anchor {
+                buffer_id: Some(excerpt.buffer_id),
+                excerpt_id: excerpt.id,
+                text_anchor: excerpt.buffer.anchor_after(buffer_range.end),
+            };
+
+            if range.end > cursor.end(&()) {
+                cursor.next(&());
+            } else {
+                current_range = ranges.next();
+            }
+
+            Some(subrange_start_anchor..subrange_end_anchor)
+        })
+    }
+
     /// Returns excerpts overlapping the given ranges. If range spans multiple excerpts returns one range for each excerpt
+    ///
+    /// The ranges are specified in the coordinate space of the multibuffer, not the individual excerpted buffers.
+    /// Each returned excerpt's range is in the coordinate space of its source buffer.
     pub fn excerpts_in_ranges(
         &self,
         ranges: impl IntoIterator<Item = Range<Anchor>>,
@@ -6706,5 +6759,62 @@ mod tests {
             .collect_vec();
 
         validate_excerpts(&excerpts, &expected_excerpts);
+    }
+
+    #[gpui::test]
+    fn test_split_ranges(cx: &mut AppContext) {
+        let buffer_1 = cx.new_model(|cx| Buffer::local(sample_text(6, 6, 'a'), cx));
+        let buffer_2 = cx.new_model(|cx| Buffer::local(sample_text(6, 6, 'g'), cx));
+        let buffer_1_len = buffer_1.read(cx).len();
+        let buffer_2_len = buffer_2.read(cx).len();
+
+        let multibuffer = cx.new_model(|_| MultiBuffer::new(0, Capability::ReadWrite));
+        multibuffer.update(cx, |multibuffer, cx| {
+            multibuffer.push_excerpts(
+                buffer_1.clone(),
+                [ExcerptRange {
+                    context: 0..buffer_1.read(cx).len(),
+                    primary: None,
+                }],
+                cx,
+            )[0];
+            multibuffer.push_excerpts(
+                buffer_2.clone(),
+                [ExcerptRange {
+                    context: 0..buffer_2.read(cx).len(),
+                    primary: None,
+                }],
+                cx,
+            )[0];
+        });
+
+        let snapshot = multibuffer.read(cx).snapshot(cx);
+
+        let buffer_1_midpoint = buffer_1_len / 2;
+        let buffer_2_midpoint = buffer_1_len + buffer_2_len / 2;
+        let total_len = buffer_1_len + buffer_2_len;
+
+        let ranges = [
+            0..buffer_1_midpoint,
+            buffer_1_midpoint..buffer_2_midpoint,
+            buffer_2_midpoint..total_len,
+        ];
+
+        let actual_ranges =
+            snapshot
+                .split_ranges(ranges.into_iter().map(|range| {
+                    snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end)
+                }))
+                .map(|range| range.to_offset(&snapshot))
+                .collect::<Vec<_>>();
+
+        let expected_ranges = vec![
+            0..buffer_1_midpoint,
+            buffer_1_midpoint..buffer_1_len,
+            buffer_1_len..buffer_2_midpoint,
+            buffer_2_midpoint..total_len,
+        ];
+
+        assert_eq!(actual_ranges, expected_ranges);
     }
 }


### PR DESCRIPTION
Release Notes:

- N/A