### PR TITLE
windows: Fix supermaven

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10509,6 +10509,7 @@ dependencies = [
  "theme",
  "ui",
  "util",
+ "windows 0.58.0",
 ]
 
 [[package]]

--- a/crates/supermaven/Cargo.toml
+++ b/crates/supermaven/Cargo.toml
@@ -31,6 +31,9 @@ text.workspace = true
 ui.workspace = true
 util.workspace = true
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows.workspace = true
+
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -92,6 +92,7 @@ impl Supermaven {
             cx.spawn(|this, mut cx| async move {
                 let binary_path =
                     supermaven_api::get_supermaven_agent_path(client.http_client()).await?;
+                println!("==> SM path: {}", binary_path.display());
 
                 this.update(&mut cx, |this, cx| {
                     if let Self::Starting = this {
@@ -260,6 +261,7 @@ impl SupermavenAgent {
         client: Arc<Client>,
         cx: &mut ModelContext<Supermaven>,
     ) -> Result<Self> {
+        // TODO:
         let mut process = Command::new(&binary_path)
             .arg("stdio")
             .stdin(Stdio::piped())

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -261,15 +261,21 @@ impl SupermavenAgent {
         client: Arc<Client>,
         cx: &mut ModelContext<Supermaven>,
     ) -> Result<Self> {
-        // TODO:
-        let mut process = Command::new(&binary_path)
+        let mut process = Command::new(&binary_path);
+        process
             .arg("stdio")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .context("failed to start the binary")?;
+            .kill_on_drop(true);
+
+        #[cfg(target_os = "windows")]
+        {
+            use smol::process::windows::CommandExt;
+            process.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
+        }
+
+        let mut process = process.spawn().context("failed to start the binary")?;
 
         let stdin = process
             .stdin

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -92,7 +92,6 @@ impl Supermaven {
             cx.spawn(|this, mut cx| async move {
                 let binary_path =
                     supermaven_api::get_supermaven_agent_path(client.http_client()).await?;
-                println!("==> SM path: {}", binary_path.display());
 
                 this.update(&mut cx, |this, cx| {
                     if let Self::Starting = this {

--- a/crates/supermaven_api/src/supermaven_api.rs
+++ b/crates/supermaven_api/src/supermaven_api.rs
@@ -260,7 +260,6 @@ pub fn get_supermaven_agent_path(
         }
 
         let request = HttpRequest::get(&download_info.download_url);
-        let proxy = client.proxy();
 
         let mut response = client
             .send(request.body(AsyncBody::default())?)

--- a/crates/supermaven_api/src/supermaven_api.rs
+++ b/crates/supermaven_api/src/supermaven_api.rs
@@ -212,7 +212,11 @@ pub async fn latest_release(
 }
 
 pub fn version_path(version: u64) -> PathBuf {
-    supermaven_dir().join(format!("sm-agent-{}", version))
+    supermaven_dir().join(format!(
+        "sm-agent-{}{}",
+        version,
+        std::env::consts::EXE_SUFFIX
+    ))
 }
 
 pub async fn has_version(version_path: &Path) -> bool {
@@ -256,6 +260,7 @@ pub fn get_supermaven_agent_path(
         }
 
         let request = HttpRequest::get(&download_info.download_url);
+        let proxy = client.proxy();
 
         let mut response = client
             .send(request.body(AsyncBody::default())?)


### PR DESCRIPTION
Closes #16194

This PR introduces the following changes:

1. Updated the download process to retrieve the `.exe` file, as the API response indicates that the `.exe` file should be downloaded on Windows.
> API response: "https://supermaven-public.s3.amazonaws.com/sm-agent/26/windows/amd64/sm-agent.exe"
2. Modified the startup behavior of supermaven to prevent the cmd window from appearing.

Release Notes:

- N/A
