### PR TITLE
windows: Implement theme changed events

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -12,7 +12,6 @@ use windows::Win32::{
         WindowsAndMessaging::*,
     },
 };
-use windows_core::{HSTRING, PCWSTR};
 
 use crate::*;
 
@@ -84,10 +83,8 @@ pub(crate) fn handle_msg(
         WM_IME_STARTCOMPOSITION => handle_ime_position(handle, state_ptr),
         WM_IME_COMPOSITION => handle_ime_composition(handle, lparam, state_ptr),
         WM_SETCURSOR => handle_set_cursor(lparam, state_ptr),
-        WM_SETTINGCHANGE => handle_system_settings_changed(handle, lparam, state_ptr),
-        WM_DWMCOLORIZATIONCOLORCHANGED | WM_THEMECHANGED => {
-            handle_system_theme_changed(msg, state_ptr)
-        }
+        WM_SETTINGCHANGE => handle_system_settings_changed(handle, state_ptr),
+        WM_DWMCOLORIZATIONCOLORCHANGED => handle_system_theme_changed(state_ptr),
         CURSOR_STYLE_CHANGED => handle_cursor_changed(lparam, state_ptr),
         _ => None,
     };
@@ -1083,13 +1080,8 @@ fn handle_set_cursor(lparam: LPARAM, state_ptr: Rc<WindowsWindowStatePtr>) -> Op
 
 fn handle_system_settings_changed(
     handle: HWND,
-    lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
-    unsafe {
-        let string = PCWSTR::from_raw(lparam.0 as _);
-        println!("==> {:?}", string.to_string());
-    }
     let mut lock = state_ptr.state.borrow_mut();
     // mouse wheel
     lock.system_settings.mouse_wheel_settings.update();
@@ -1111,8 +1103,7 @@ fn handle_system_command(wparam: WPARAM, state_ptr: Rc<WindowsWindowStatePtr>) -
     None
 }
 
-fn handle_system_theme_changed(msg: u32, state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
-    println!("WM_CORLR");
+fn handle_system_theme_changed(state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
     let mut callback = state_ptr
         .state
         .borrow_mut()


### PR DESCRIPTION
Closes [#16198](https://github.com/zed-industries/zed/issues/16198)

AFAIK, when the system's theme mode or accent color changes, there are typically two types of broadcast messages:

1. A `WM_SETTINGCHANGE` message, where `lParam` points to the string "ImmersiveColorSet".
2. A `WM_DWMCOLORIZATIONCOLORCHANGED` message.

I use `WM_DWMCOLORIZATIONCOLORCHANGED` here for simplicity.

https://github.com/user-attachments/assets/422f8e4e-c698-4e7c-8d2d-01f453b9a7b3


Release Notes:

- N/A
