### PR TITLE
Further improve /tabs command and slash arguments completion

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 use settings::{update_settings_file, Settings, SettingsStore};
 use slash_command::{
     default_command, diagnostics_command, docs_command, fetch_command, file_command, now_command,
-    project_command, prompt_command, search_command, symbols_command, tabs_command,
+    project_command, prompt_command, search_command, symbols_command, tab_command,
     terminal_command, workflow_command,
 };
 use std::sync::Arc;
@@ -287,7 +287,7 @@ fn register_slash_commands(prompt_builder: Option<Arc<PromptBuilder>>, cx: &mut 
     let slash_command_registry = SlashCommandRegistry::global(cx);
     slash_command_registry.register_command(file_command::FileSlashCommand, true);
     slash_command_registry.register_command(symbols_command::OutlineSlashCommand, true);
-    slash_command_registry.register_command(tabs_command::TabsSlashCommand, true);
+    slash_command_registry.register_command(tab_command::TabSlashCommand, true);
     slash_command_registry.register_command(project_command::ProjectSlashCommand, true);
     slash_command_registry.register_command(prompt_command::PromptSlashCommand, true);
     slash_command_registry.register_command(default_command::DefaultSlashCommand, false);

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1814,7 +1814,7 @@ impl ContextEditor {
         self.run_command(
             command.source_range,
             &command.name,
-            command.argument.as_deref(),
+            &command.arguments,
             false,
             self.workspace.clone(),
             cx,
@@ -2120,7 +2120,7 @@ impl ContextEditor {
                 self.run_command(
                     command.source_range,
                     &command.name,
-                    command.argument.as_deref(),
+                    &command.arguments,
                     true,
                     workspace.clone(),
                     cx,
@@ -2134,19 +2134,13 @@ impl ContextEditor {
         &mut self,
         command_range: Range<language::Anchor>,
         name: &str,
-        argument: Option<&str>,
+        arguments: &[String],
         insert_trailing_newline: bool,
         workspace: WeakView<Workspace>,
         cx: &mut ViewContext<Self>,
     ) {
         if let Some(command) = SlashCommandRegistry::global(cx).command(name) {
-            let argument = argument.map(ToString::to_string);
-            let output = command.run(
-                argument.as_deref(),
-                workspace,
-                self.lsp_adapter_delegate.clone(),
-                cx,
-            );
+            let output = command.run(arguments, workspace, self.lsp_adapter_delegate.clone(), cx);
             self.context.update(cx, |context, cx| {
                 context.insert_command_output(command_range, output, insert_trailing_newline, cx)
             });
@@ -2232,7 +2226,7 @@ impl ContextEditor {
                                             context_editor.run_command(
                                                 command.source_range.clone(),
                                                 &command.name,
-                                                command.argument.as_deref(),
+                                                &command.arguments,
                                                 false,
                                                 workspace.clone(),
                                                 cx,
@@ -2345,7 +2339,7 @@ impl ContextEditor {
                         self.run_command(
                             command.source_range,
                             &command.name,
-                            command.argument.as_deref(),
+                            &command.arguments,
                             false,
                             self.workspace.clone(),
                             cx,
@@ -4534,7 +4528,7 @@ fn render_docs_slash_command_trailer(
     command: PendingSlashCommand,
     cx: &mut WindowContext,
 ) -> AnyElement {
-    let Some(argument) = command.argument else {
+    let Some(argument) = command.arguments.first() else {
         return Empty.into_any();
     };
 

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -4528,11 +4528,10 @@ fn render_docs_slash_command_trailer(
     command: PendingSlashCommand,
     cx: &mut WindowContext,
 ) -> AnyElement {
-    let Some(argument) = command.arguments.first() else {
+    if command.arguments.is_empty() {
         return Empty.into_any();
-    };
-
-    let args = DocsSlashCommandArgs::parse(&argument);
+    }
+    let args = DocsSlashCommandArgs::parse(&command.arguments);
 
     let Some(store) = args
         .provider()

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1219,7 +1219,6 @@ impl Context {
                         .collect::<SmallVec<_>>();
                     if let Some(command) = SlashCommandRegistry::global(cx).command(name) {
                         if !command.requires_argument() || !arguments.is_empty() {
-                            // TODO kb should it be a last argument's start instead?
                             let start_ix = offset + command_line.name.start - 1;
                             let end_ix = offset
                                 + command_line
@@ -3759,7 +3758,7 @@ mod tests {
 
         fn complete_argument(
             self: Arc<Self>,
-            _query: String,
+            _arguments: &[String],
             _cancel: Arc<AtomicBool>,
             _workspace: Option<WeakView<Workspace>>,
             _cx: &mut WindowContext,

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1205,21 +1205,32 @@ impl Context {
             while let Some(line) = lines.next() {
                 if let Some(command_line) = SlashCommandLine::parse(line) {
                     let name = &line[command_line.name.clone()];
-                    let argument = command_line.argument.as_ref().and_then(|argument| {
-                        (!argument.is_empty()).then_some(&line[argument.clone()])
-                    });
+                    let arguments = command_line
+                        .arguments
+                        .iter()
+                        .filter_map(|argument_range| {
+                            if argument_range.is_empty() {
+                                None
+                            } else {
+                                line.get(argument_range.clone())
+                            }
+                        })
+                        .map(ToOwned::to_owned)
+                        .collect::<SmallVec<_>>();
                     if let Some(command) = SlashCommandRegistry::global(cx).command(name) {
-                        if !command.requires_argument() || argument.is_some() {
+                        if !command.requires_argument() || !arguments.is_empty() {
+                            // TODO kb should it be a last argument's start instead?
                             let start_ix = offset + command_line.name.start - 1;
                             let end_ix = offset
                                 + command_line
-                                    .argument
+                                    .arguments
+                                    .last()
                                     .map_or(command_line.name.end, |argument| argument.end);
                             let source_range =
                                 buffer.anchor_after(start_ix)..buffer.anchor_after(end_ix);
                             let pending_command = PendingSlashCommand {
                                 name: name.to_string(),
-                                argument: argument.map(ToString::to_string),
+                                arguments,
                                 source_range,
                                 status: PendingSlashCommandStatus::Idle,
                             };
@@ -2447,7 +2458,7 @@ impl ContextVersion {
 #[derive(Debug, Clone)]
 pub struct PendingSlashCommand {
     pub name: String,
-    pub argument: Option<String>,
+    pub arguments: SmallVec<[String; 3]>,
     pub status: PendingSlashCommandStatus,
     pub source_range: Range<language::Anchor>,
 }
@@ -3762,7 +3773,7 @@ mod tests {
 
         fn run(
             self: Arc<Self>,
-            _argument: Option<&str>,
+            _arguments: &[String],
             _workspace: WeakView<Workspace>,
             _delegate: Option<Arc<dyn LspAdapterDelegate>>,
             _cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -28,7 +28,7 @@ pub mod project_command;
 pub mod prompt_command;
 pub mod search_command;
 pub mod symbols_command;
-pub mod tabs_command;
+pub mod tab_command;
 pub mod terminal_command;
 pub mod workflow_command;
 

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -181,22 +181,20 @@ impl SlashCommandCompletionProvider {
                                         let command_range = command_range.clone();
                                         let command_name = command_name.clone();
                                         let command_argument = command_argument.new_text.clone();
-                                        move |intent: CompletionIntent, cx: &mut WindowContext| {
-                                            if intent.is_complete() {
-                                                let command_argument = command_argument.clone();
-                                                editor
-                                                    .update(cx, |editor, cx| {
-                                                        editor.run_command(
-                                                            command_range.clone(),
-                                                            &command_name,
-                                                            &[command_argument],
-                                                            true,
-                                                            workspace.clone(),
-                                                            cx,
-                                                        );
-                                                    })
-                                                    .ok();
-                                            }
+                                        move |_: CompletionIntent, cx: &mut WindowContext| {
+                                            let command_argument = command_argument.clone();
+                                            editor
+                                                .update(cx, |editor, cx| {
+                                                    editor.run_command(
+                                                        command_range.clone(),
+                                                        &command_name,
+                                                        &[command_argument],
+                                                        true,
+                                                        workspace.clone(),
+                                                        cx,
+                                                    );
+                                                })
+                                                .ok();
                                         }
                                     }) as Arc<_>
                                 })

--- a/crates/assistant/src/slash_command/default_command.rs
+++ b/crates/assistant/src/slash_command/default_command.rs
@@ -32,7 +32,7 @@ impl SlashCommand for DefaultSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancellation_flag: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/default_command.rs
+++ b/crates/assistant/src/slash_command/default_command.rs
@@ -42,7 +42,7 @@ impl SlashCommand for DefaultSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        _argument: Option<&str>,
+        _arguments: &[String],
         _workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -105,7 +105,7 @@ impl SlashCommand for DiagnosticsSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        query: String,
+        arguments: &[String],
         cancellation_flag: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,
         cx: &mut WindowContext,
@@ -113,7 +113,7 @@ impl SlashCommand for DiagnosticsSlashCommand {
         let Some(workspace) = workspace.and_then(|workspace| workspace.upgrade()) else {
             return Task::ready(Err(anyhow!("workspace was dropped")));
         };
-        let query = query.split_whitespace().last().unwrap_or("").to_string();
+        let query = arguments.last().cloned().unwrap_or_default();
 
         let paths = self.search_paths(query.clone(), cancellation_flag.clone(), &workspace, cx);
         let executor = cx.background_executor().clone();
@@ -245,25 +245,19 @@ const INCLUDE_WARNINGS_ARGUMENT: &str = "--include-warnings";
 
 impl Options {
     fn parse(arguments: &[String]) -> Self {
-        arguments
-            .first()
-            .map(|arguments_line| {
-                let args = arguments_line.split_whitespace().collect::<Vec<_>>();
-                let mut include_warnings = false;
-                let mut path_matcher = None;
-                for arg in args {
-                    if arg == INCLUDE_WARNINGS_ARGUMENT {
-                        include_warnings = true;
-                    } else {
-                        path_matcher = PathMatcher::new(&[arg.to_owned()]).log_err();
-                    }
-                }
-                Self {
-                    include_warnings,
-                    path_matcher,
-                }
-            })
-            .unwrap_or_default()
+        let mut include_warnings = false;
+        let mut path_matcher = None;
+        for arg in arguments {
+            if arg == INCLUDE_WARNINGS_ARGUMENT {
+                include_warnings = true;
+            } else {
+                path_matcher = PathMatcher::new(&[arg.to_owned()]).log_err();
+            }
+        }
+        Self {
+            include_warnings,
+            path_matcher,
+        }
     }
 
     fn match_candidates_for_args() -> [StringMatchCandidate; 1] {

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -157,7 +157,7 @@ impl SlashCommand for DiagnosticsSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
@@ -166,7 +166,7 @@ impl SlashCommand for DiagnosticsSlashCommand {
             return Task::ready(Err(anyhow!("workspace was dropped")));
         };
 
-        let options = Options::parse(argument);
+        let options = Options::parse(arguments);
 
         let task = collect_diagnostics(workspace.read(cx).project().clone(), options, cx);
 
@@ -244,8 +244,9 @@ struct Options {
 const INCLUDE_WARNINGS_ARGUMENT: &str = "--include-warnings";
 
 impl Options {
-    fn parse(arguments_line: Option<&str>) -> Self {
-        arguments_line
+    fn parse(arguments: &[String]) -> Self {
+        arguments
+            .first()
             .map(|arguments_line| {
                 let args = arguments_line.split_whitespace().collect::<Vec<_>>();
                 let mut include_warnings = false;

--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -270,13 +270,13 @@ impl SlashCommand for DocsSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         _workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
     ) -> Task<Result<SlashCommandOutput>> {
-        let Some(argument) = argument else {
-            return Task::ready(Err(anyhow!("missing argument")));
+        let Some(argument) = arguments.first() else {
+            return Task::ready(Err(anyhow!("missing an argument")));
         };
 
         let args = DocsSlashCommandArgs::parse(argument);

--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -180,7 +180,7 @@ impl SlashCommand for DocsSlashCommand {
                     .into_iter()
                     .map(|item| ArgumentCompletion {
                         label: item.clone().into(),
-                        new_text: format!("{item}"),
+                        new_text: item.to_string(),
                         run_command: true,
                     })
                     .collect()

--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -159,7 +159,6 @@ impl SlashCommand for DocsSlashCommand {
         true
     }
 
-    // TODO kb fix
     fn complete_argument(
         self: Arc<Self>,
         arguments: &[String],

--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -117,7 +117,7 @@ impl SlashCommand for FetchSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -127,12 +127,12 @@ impl SlashCommand for FetchSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
     ) -> Task<Result<SlashCommandOutput>> {
-        let Some(argument) = argument else {
+        let Some(argument) = arguments.first() else {
             return Task::ready(Err(anyhow!("missing URL")));
         };
         let Some(workspace) = workspace.upgrade() else {

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -168,7 +168,7 @@ impl SlashCommand for FileSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
@@ -177,7 +177,7 @@ impl SlashCommand for FileSlashCommand {
             return Task::ready(Err(anyhow!("workspace was dropped")));
         };
 
-        let Some(argument) = argument else {
+        let Some(argument) = arguments.first() else {
             return Task::ready(Err(anyhow!("missing path")));
         };
 

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -122,7 +122,7 @@ impl SlashCommand for FileSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        query: String,
+        arguments: &[String],
         cancellation_flag: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,
         cx: &mut WindowContext,
@@ -131,7 +131,12 @@ impl SlashCommand for FileSlashCommand {
             return Task::ready(Err(anyhow!("workspace was dropped")));
         };
 
-        let paths = self.search_paths(query, cancellation_flag, &workspace, cx);
+        let paths = self.search_paths(
+            arguments.last().cloned().unwrap_or_default(),
+            cancellation_flag,
+            &workspace,
+            cx,
+        );
         let comment_id = cx.theme().syntax().highlight_id("comment").map(HighlightId);
         cx.background_executor().spawn(async move {
             Ok(paths

--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -42,7 +42,7 @@ impl SlashCommand for NowSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        _argument: Option<&str>,
+        _arguments: &[String],
         _workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         _cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -32,7 +32,7 @@ impl SlashCommand for NowSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -103,7 +103,7 @@ impl SlashCommand for ProjectSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -117,7 +117,7 @@ impl SlashCommand for ProjectSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        _argument: Option<&str>,
+        _arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -53,12 +53,12 @@ impl SlashCommand for PromptSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        title: Option<&str>,
+        arguments: &[String],
         _workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
     ) -> Task<Result<SlashCommandOutput>> {
-        let Some(title) = title else {
+        let Some(title) = arguments.first() else {
             return Task::ready(Err(anyhow!("missing prompt name")));
         };
 

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -29,12 +29,13 @@ impl SlashCommand for PromptSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        query: String,
+        arguments: &[String],
         _cancellation_flag: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         cx: &mut WindowContext,
     ) -> Task<Result<Vec<ArgumentCompletion>>> {
         let store = PromptStore::global(cx);
+        let query = arguments.last().cloned().unwrap_or_default();
         cx.background_executor().spawn(async move {
             let prompts = store.await?.search(query).await;
             Ok(prompts

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -49,7 +49,7 @@ impl SlashCommand for SearchSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,
@@ -67,13 +67,13 @@ impl SlashCommand for SearchSlashCommand {
         let Some(workspace) = workspace.upgrade() else {
             return Task::ready(Err(anyhow::anyhow!("workspace was dropped")));
         };
-        let Some(argument) = arguments.first() else {
+        if arguments.is_empty() {
             return Task::ready(Err(anyhow::anyhow!("missing search query")));
         };
 
         let mut limit = None;
         let mut query = String::new();
-        for part in argument.split(' ') {
+        for part in arguments {
             if let Some(parameter) = part.strip_prefix("--") {
                 if let Ok(count) = parameter.parse::<usize>() {
                     limit = Some(count);

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -59,7 +59,7 @@ impl SlashCommand for SearchSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
@@ -67,7 +67,7 @@ impl SlashCommand for SearchSlashCommand {
         let Some(workspace) = workspace.upgrade() else {
             return Task::ready(Err(anyhow::anyhow!("workspace was dropped")));
         };
-        let Some(argument) = argument else {
+        let Some(argument) = arguments.first() else {
             return Task::ready(Err(anyhow::anyhow!("missing search query")));
         };
 

--- a/crates/assistant/src/slash_command/symbols_command.rs
+++ b/crates/assistant/src/slash_command/symbols_command.rs
@@ -26,7 +26,7 @@ impl SlashCommand for OutlineSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/symbols_command.rs
+++ b/crates/assistant/src/slash_command/symbols_command.rs
@@ -40,7 +40,7 @@ impl SlashCommand for OutlineSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        _argument: Option<&str>,
+        _arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/tab_command.rs
+++ b/crates/assistant/src/slash_command/tab_command.rs
@@ -41,42 +41,53 @@ impl SlashCommand for TabSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        query: String,
+        arguments: &[String],
         cancel: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,
         cx: &mut WindowContext,
     ) -> Task<Result<Vec<ArgumentCompletion>>> {
-        let has_all_tabs_completion_item = query.to_lowercase().contains(ALL_TABS_COMPLETION_ITEM);
-        let current_query = match query.rsplit_once(' ') {
-            Some((_, current_query)) => current_query.to_owned(),
-            None => query,
-        };
-        let all_tabs_completion_item =
-            if !has_all_tabs_completion_item && ALL_TABS_COMPLETION_ITEM.contains(&current_query) {
-                Some(ArgumentCompletion {
-                    label: ALL_TABS_COMPLETION_ITEM.into(),
-                    new_text: ALL_TABS_COMPLETION_ITEM.to_owned(),
-                    run_command: true,
-                })
-            } else {
-                None
-            };
-        let tab_items_search = tab_items_for_query(workspace, current_query, cancel, false, cx);
+        let mut has_all_tabs_completion_item = false;
+        let argument_set = arguments
+            .iter()
+            .filter(|argument| {
+                if has_all_tabs_completion_item || ALL_TABS_COMPLETION_ITEM == argument.as_str() {
+                    has_all_tabs_completion_item = true;
+                    false
+                } else {
+                    true
+                }
+            })
+            .cloned()
+            .collect::<HashSet<_>>();
+        if has_all_tabs_completion_item {
+            return Task::ready(Ok(Vec::new()));
+        }
+        let current_query = arguments.last().cloned().unwrap_or_default();
+        let tab_items_search =
+            tab_items_for_queries(workspace, &[current_query], cancel, false, cx);
         cx.spawn(|_| async move {
             let tab_items = tab_items_search.await?;
             let run_command = tab_items.len() == 1;
             let tab_completion_items = tab_items.into_iter().filter_map(|(path, ..)| {
                 let path_string = path.as_deref()?.to_string_lossy().to_string();
+                if argument_set.contains(&path_string) {
+                    return None;
+                }
                 Some(ArgumentCompletion {
                     label: path_string.clone().into(),
                     new_text: path_string,
                     run_command,
                 })
             });
-            Ok(all_tabs_completion_item
-                .into_iter()
-                .chain(tab_completion_items)
-                .collect::<Vec<_>>())
+
+            Ok(Some(ArgumentCompletion {
+                label: ALL_TABS_COMPLETION_ITEM.into(),
+                new_text: ALL_TABS_COMPLETION_ITEM.to_owned(),
+                run_command: true,
+            })
+            .into_iter()
+            .chain(tab_completion_items)
+            .collect::<Vec<_>>())
         })
     }
 
@@ -87,9 +98,9 @@ impl SlashCommand for TabSlashCommand {
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
     ) -> Task<Result<SlashCommandOutput>> {
-        let tab_items_search = tab_items_for_query(
+        let tab_items_search = tab_items_for_queries(
             Some(workspace),
-            arguments.first().cloned().unwrap_or_default(),
+            arguments,
             Arc::new(AtomicBool::new(false)),
             true,
             cx,
@@ -134,19 +145,21 @@ impl SlashCommand for TabSlashCommand {
     }
 }
 
-fn tab_items_for_query(
+fn tab_items_for_queries(
     workspace: Option<WeakView<Workspace>>,
-    query: String,
+    queries: &[String],
     cancel: Arc<AtomicBool>,
-    use_active_tab_for_empty_query: bool,
+    strict_match: bool,
     cx: &mut WindowContext,
 ) -> Task<anyhow::Result<Vec<(Option<PathBuf>, BufferSnapshot, usize)>>> {
+    let empty_query = queries.is_empty() || queries.iter().all(|query| query.trim().is_empty());
+    let queries = queries.to_owned();
     cx.spawn(|mut cx| async move {
         let mut open_buffers =
             workspace
                 .context("no workspace")?
                 .update(&mut cx, |workspace, cx| {
-                    if use_active_tab_for_empty_query && query.trim().is_empty() {
+                    if strict_match && empty_query {
                         let active_editor = workspace
                             .active_item(cx)
                             .context("no active item")?
@@ -193,48 +206,72 @@ fn tab_items_for_query(
         cx.background_executor()
             .spawn(async move {
                 open_buffers.sort_by_key(|(_, _, timestamp)| *timestamp);
-                let query = query.trim();
-                if query.is_empty() || query.to_lowercase() == ALL_TABS_COMPLETION_ITEM {
+                if empty_query
+                    || queries
+                        .iter()
+                        .any(|query| query == ALL_TABS_COMPLETION_ITEM)
+                {
                     return Ok(open_buffers);
                 }
 
-                let match_candidates = open_buffers
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(id, (full_path, ..))| {
-                        let path_string = full_path.as_deref()?.to_string_lossy().to_string();
-                        Some(fuzzy::StringMatchCandidate {
-                            id,
-                            char_bag: path_string.as_str().into(),
-                            string: path_string,
+                let matched_items = if strict_match {
+                    let match_candidates = open_buffers
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(id, (full_path, ..))| {
+                            let path_string = full_path.as_deref()?.to_string_lossy().to_string();
+                            Some((id, path_string))
                         })
-                    })
-                    .collect::<Vec<_>>();
-                let mut processed_matches = HashSet::default();
+                        .fold(HashMap::default(), |mut candidates, (id, path_string)| {
+                            candidates
+                                .entry(path_string)
+                                .or_insert_with(|| Vec::new())
+                                .push(id);
+                            candidates
+                        });
 
-                let file_queries = query.split(' ').map(|query| {
-                    fuzzy::match_strings(
-                        &match_candidates,
-                        query,
-                        true,
-                        usize::MAX,
-                        &cancel,
-                        background_executor.clone(),
-                    )
-                });
+                    queries
+                        .iter()
+                        .filter_map(|query| match_candidates.get(query))
+                        .flatten()
+                        .copied()
+                        .filter_map(|id| open_buffers.get(id))
+                        .cloned()
+                        .collect()
+                } else {
+                    let match_candidates = open_buffers
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(id, (full_path, ..))| {
+                            let path_string = full_path.as_deref()?.to_string_lossy().to_string();
+                            Some(fuzzy::StringMatchCandidate {
+                                id,
+                                char_bag: path_string.as_str().into(),
+                                string: path_string,
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    let mut processed_matches = HashSet::default();
+                    let file_queries = queries.iter().map(|query| {
+                        fuzzy::match_strings(
+                            &match_candidates,
+                            query,
+                            true,
+                            usize::MAX,
+                            &cancel,
+                            background_executor.clone(),
+                        )
+                    });
 
-                let matched_items = join_all(file_queries)
-                    .await
-                    .into_iter()
-                    .flatten()
-                    .filter(|string_match| processed_matches.insert(string_match.candidate_id))
-                    .filter_map(|string_match| open_buffers.get(string_match.candidate_id))
-                    .map(|a| {
-                        dbg!(&a.0);
-                        a
-                    })
-                    .cloned()
-                    .collect();
+                    join_all(file_queries)
+                        .await
+                        .into_iter()
+                        .flatten()
+                        .filter(|string_match| processed_matches.insert(string_match.candidate_id))
+                        .filter_map(|string_match| open_buffers.get(string_match.candidate_id))
+                        .cloned()
+                        .collect()
+                };
                 Ok(matched_items)
             })
             .await

--- a/crates/assistant/src/slash_command/tab_command.rs
+++ b/crates/assistant/src/slash_command/tab_command.rs
@@ -18,13 +18,13 @@ use std::{
 use ui::WindowContext;
 use workspace::Workspace;
 
-pub(crate) struct TabsSlashCommand;
+pub(crate) struct TabSlashCommand;
 
 const ALL_TABS_COMPLETION_ITEM: &str = "all";
 
-impl SlashCommand for TabsSlashCommand {
+impl SlashCommand for TabSlashCommand {
     fn name(&self) -> String {
-        "tabs".into()
+        "tab".into()
     }
 
     fn description(&self) -> String {

--- a/crates/assistant/src/slash_command/tabs_command.rs
+++ b/crates/assistant/src/slash_command/tabs_command.rs
@@ -82,14 +82,14 @@ impl SlashCommand for TabsSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
     ) -> Task<Result<SlashCommandOutput>> {
         let tab_items_search = tab_items_for_query(
             Some(workspace),
-            argument.map(ToOwned::to_owned).unwrap_or_default(),
+            arguments.first().cloned().unwrap_or_default(),
             Arc::new(AtomicBool::new(false)),
             true,
             cx,

--- a/crates/assistant/src/slash_command/terminal_command.rs
+++ b/crates/assistant/src/slash_command/terminal_command.rs
@@ -56,7 +56,7 @@ impl SlashCommand for TerminalSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
@@ -75,8 +75,9 @@ impl SlashCommand for TerminalSlashCommand {
             return Task::ready(Err(anyhow::anyhow!("no active terminal")));
         };
 
-        let line_count = argument
-            .and_then(|a| parse_argument(a))
+        let line_count = arguments
+            .first()
+            .and_then(|argument| parse_argument(argument))
             .unwrap_or(DEFAULT_CONTEXT_LINES);
 
         let lines = active_terminal

--- a/crates/assistant/src/slash_command/terminal_command.rs
+++ b/crates/assistant/src/slash_command/terminal_command.rs
@@ -42,7 +42,7 @@ impl SlashCommand for TerminalSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,
@@ -75,10 +75,13 @@ impl SlashCommand for TerminalSlashCommand {
             return Task::ready(Err(anyhow::anyhow!("no active terminal")));
         };
 
-        let line_count = arguments
-            .first()
-            .and_then(|argument| parse_argument(argument))
-            .unwrap_or(DEFAULT_CONTEXT_LINES);
+        let mut line_count = DEFAULT_CONTEXT_LINES;
+        if arguments.get(0).map(|s| s.as_str()) == Some(LINE_COUNT_ARG) {
+            if let Some(parsed_line_count) = arguments.get(1).and_then(|s| s.parse::<usize>().ok())
+            {
+                line_count = parsed_line_count;
+            }
+        }
 
         let lines = active_terminal
             .read(cx)
@@ -101,14 +104,4 @@ impl SlashCommand for TerminalSlashCommand {
             run_commands_in_text: false,
         }))
     }
-}
-
-fn parse_argument(argument: &str) -> Option<usize> {
-    let mut args = argument.split(' ');
-    if args.next() == Some(LINE_COUNT_ARG) {
-        if let Some(line_count) = args.next().and_then(|s| s.parse::<usize>().ok()) {
-            return Some(line_count);
-        }
-    }
-    None
 }

--- a/crates/assistant/src/slash_command/terminal_command.rs
+++ b/crates/assistant/src/slash_command/terminal_command.rs
@@ -42,16 +42,21 @@ impl SlashCommand for TerminalSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _arguments: &[String],
+        arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,
     ) -> Task<Result<Vec<ArgumentCompletion>>> {
-        Task::ready(Ok(vec![ArgumentCompletion {
-            label: LINE_COUNT_ARG.into(),
-            new_text: LINE_COUNT_ARG.to_string(),
-            run_command: true,
-        }]))
+        let completions = if arguments.iter().any(|arg| arg == LINE_COUNT_ARG) {
+            Vec::new()
+        } else {
+            vec![ArgumentCompletion {
+                label: LINE_COUNT_ARG.into(),
+                new_text: LINE_COUNT_ARG.to_string(),
+                run_command: false,
+            }]
+        };
+        Task::ready(Ok(completions))
     }
 
     fn run(

--- a/crates/assistant/src/slash_command/workflow_command.rs
+++ b/crates/assistant/src/slash_command/workflow_command.rs
@@ -52,7 +52,7 @@ impl SlashCommand for WorkflowSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        _argument: Option<&str>,
+        _arguments: &[String],
         _workspace: WeakView<Workspace>,
         _delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,

--- a/crates/assistant/src/slash_command/workflow_command.rs
+++ b/crates/assistant/src/slash_command/workflow_command.rs
@@ -42,7 +42,7 @@ impl SlashCommand for WorkflowSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        _query: String,
+        _arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -42,7 +42,7 @@ pub trait SlashCommand: 'static + Send + Sync {
     fn requires_argument(&self) -> bool;
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         workspace: WeakView<Workspace>,
         // TODO: We're just using the `LspAdapterDelegate` here because that is
         // what the extension API is already expecting.

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -34,7 +34,7 @@ pub trait SlashCommand: 'static + Send + Sync {
     fn menu_text(&self) -> String;
     fn complete_argument(
         self: Arc<Self>,
-        query: String,
+        arguments: &[String],
         cancel: Arc<AtomicBool>,
         workspace: Option<WeakView<Workspace>>,
         cx: &mut WindowContext,

--- a/crates/extension/src/extension_slash_command.rs
+++ b/crates/extension/src/extension_slash_command.rs
@@ -39,11 +39,12 @@ impl SlashCommand for ExtensionSlashCommand {
 
     fn complete_argument(
         self: Arc<Self>,
-        query: String,
+        arguments: &[String],
         _cancel: Arc<AtomicBool>,
         _workspace: Option<WeakView<Workspace>>,
         cx: &mut WindowContext,
     ) -> Task<Result<Vec<ArgumentCompletion>>> {
+        let arguments = arguments.to_owned();
         cx.background_executor().spawn(async move {
             self.extension
                 .call({
@@ -54,7 +55,7 @@ impl SlashCommand for ExtensionSlashCommand {
                                 .call_complete_slash_command_argument(
                                     store,
                                     &this.command,
-                                    query.as_ref(),
+                                    &arguments,
                                 )
                                 .await?
                                 .map_err(|e| anyhow!("{}", e))?;

--- a/crates/extension/src/extension_slash_command.rs
+++ b/crates/extension/src/extension_slash_command.rs
@@ -79,12 +79,12 @@ impl SlashCommand for ExtensionSlashCommand {
 
     fn run(
         self: Arc<Self>,
-        argument: Option<&str>,
+        arguments: &[String],
         _workspace: WeakView<Workspace>,
         delegate: Option<Arc<dyn LspAdapterDelegate>>,
         cx: &mut WindowContext,
     ) -> Task<Result<SlashCommandOutput>> {
-        let argument = argument.map(|arg| arg.to_string());
+        let arguments = arguments.to_owned();
         let output = cx.background_executor().spawn(async move {
             self.extension
                 .call({
@@ -97,12 +97,7 @@ impl SlashCommand for ExtensionSlashCommand {
                                 None
                             };
                             let output = extension
-                                .call_run_slash_command(
-                                    store,
-                                    &this.command,
-                                    argument.as_deref(),
-                                    resource,
-                                )
+                                .call_run_slash_command(store, &this.command, &arguments, resource)
                                 .await?
                                 .map_err(|e| anyhow!("{}", e))?;
 

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -277,13 +277,19 @@ impl Extension {
         &self,
         store: &mut Store<WasmState>,
         command: &SlashCommand,
-        argument: Option<&str>,
+        arguments: &[String],
         resource: Option<Resource<Arc<dyn LspAdapterDelegate>>>,
     ) -> Result<Result<SlashCommandOutput, String>> {
         match self {
             Extension::V010(ext) => {
-                ext.call_run_slash_command(store, command, argument, resource)
-                    .await
+                ext.call_run_slash_command(
+                    store,
+                    command,
+                    // TODO kb new API version?
+                    arguments.first().map(|s| s.as_str()),
+                    resource,
+                )
+                .await
             }
             Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => {
                 Err(anyhow!("`run_slash_command` not available prior to v0.1.0"))

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -266,13 +266,8 @@ impl Extension {
     ) -> Result<Result<Vec<SlashCommandArgumentCompletion>, String>> {
         match self {
             Extension::V010(ext) => {
-                // TODO kb new API version?
-                ext.call_complete_slash_command_argument(
-                    store,
-                    command,
-                    arguments.first().map(|s| s.as_str()).unwrap_or_default(),
-                )
-                .await
+                ext.call_complete_slash_command_argument(store, command, arguments)
+                    .await
             }
             Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Ok(Ok(Vec::new())),
         }
@@ -287,14 +282,8 @@ impl Extension {
     ) -> Result<Result<SlashCommandOutput, String>> {
         match self {
             Extension::V010(ext) => {
-                ext.call_run_slash_command(
-                    store,
-                    command,
-                    // TODO kb new API version?
-                    arguments.first().map(|s| s.as_str()),
-                    resource,
-                )
-                .await
+                ext.call_run_slash_command(store, command, arguments, resource)
+                    .await
             }
             Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => {
                 Err(anyhow!("`run_slash_command` not available prior to v0.1.0"))

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -262,12 +262,17 @@ impl Extension {
         &self,
         store: &mut Store<WasmState>,
         command: &SlashCommand,
-        query: &str,
+        arguments: &[String],
     ) -> Result<Result<Vec<SlashCommandArgumentCompletion>, String>> {
         match self {
             Extension::V010(ext) => {
-                ext.call_complete_slash_command_argument(store, command, query)
-                    .await
+                // TODO kb new API version?
+                ext.call_complete_slash_command_argument(
+                    store,
+                    command,
+                    arguments.first().map(|s| s.as_str()).unwrap_or_default(),
+                )
+                .await
             }
             Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Ok(Ok(Vec::new())),
         }

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -114,7 +114,7 @@ pub trait Extension: Send + Sync {
     fn complete_slash_command_argument(
         &self,
         _command: SlashCommand,
-        _query: String,
+        _args: Vec<String>,
     ) -> Result<Vec<SlashCommandArgumentCompletion>, String> {
         Ok(Vec::new())
     }
@@ -123,7 +123,7 @@ pub trait Extension: Send + Sync {
     fn run_slash_command(
         &self,
         _command: SlashCommand,
-        _argument: Option<String>,
+        _args: Vec<String>,
         _worktree: Option<&Worktree>,
     ) -> Result<SlashCommandOutput, String> {
         Err("`run_slash_command` not implemented".to_string())
@@ -257,17 +257,17 @@ impl wit::Guest for Component {
 
     fn complete_slash_command_argument(
         command: SlashCommand,
-        query: String,
+        args: Vec<String>,
     ) -> Result<Vec<SlashCommandArgumentCompletion>, String> {
-        extension().complete_slash_command_argument(command, query)
+        extension().complete_slash_command_argument(command, args)
     }
 
     fn run_slash_command(
         command: SlashCommand,
-        argument: Option<String>,
+        args: Vec<String>,
         worktree: Option<&Worktree>,
     ) -> Result<SlashCommandOutput, String> {
-        extension().run_slash_command(command, argument, worktree)
+        extension().run_slash_command(command, args, worktree)
     }
 
     fn suggest_docs_packages(provider: String) -> Result<Vec<String>, String> {

--- a/crates/extension_api/wit/since_v0.1.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.1.0/extension.wit
@@ -130,10 +130,10 @@ world extension {
     export labels-for-symbols: func(language-server-id: string, symbols: list<symbol>) -> result<list<option<code-label>>, string>;
 
     /// Returns the completions that should be shown when completing the provided slash command with the given query.
-    export complete-slash-command-argument: func(command: slash-command, query: string) -> result<list<slash-command-argument-completion>, string>;
+    export complete-slash-command-argument: func(command: slash-command, args: list<string>) -> result<list<slash-command-argument-completion>, string>;
 
     /// Returns the output from running the provided slash command.
-    export run-slash-command: func(command: slash-command, argument: option<string>, worktree: option<borrow<worktree>>) -> result<slash-command-output, string>;
+    export run-slash-command: func(command: slash-command, args: list<string>, worktree: option<borrow<worktree>>) -> result<slash-command-output, string>;
 
     /// Returns a list of packages as suggestions to be included in the `/docs`
     /// search results.

--- a/extensions/gleam/src/gleam.rs
+++ b/extensions/gleam/src/gleam.rs
@@ -154,7 +154,7 @@ impl zed::Extension for GleamExtension {
     fn complete_slash_command_argument(
         &self,
         command: SlashCommand,
-        _query: String,
+        _arguments: Vec<String>,
     ) -> Result<Vec<SlashCommandArgumentCompletion>, String> {
         match command.name.as_str() {
             "gleam-project" => Ok(vec![
@@ -181,12 +181,12 @@ impl zed::Extension for GleamExtension {
     fn run_slash_command(
         &self,
         command: SlashCommand,
-        argument: Option<String>,
+        args: Vec<String>,
         worktree: Option<&zed::Worktree>,
     ) -> Result<SlashCommandOutput, String> {
         match command.name.as_str() {
             "gleam-docs" => {
-                let argument = argument.ok_or_else(|| "missing argument".to_string())?;
+                let argument = args.last().ok_or_else(|| "missing argument".to_string())?;
 
                 let mut components = argument.split('/');
                 let package_name = components


### PR DESCRIPTION
* renames `/tabs` to `/tab`
* allows to insert multiple tabs when fuzzy matching by the names
* improve slash command completion API, introduce a notion of multiple arguments
* properly fire off commands on arguments' completions with `run_command: true`

Release Notes:

- N/A
