### PR TITLE
assistant: Run `/docs` when completing a suggested (unindexed) package

### DIFF
--- a/crates/assistant/src/slash_command/docs_command.rs
+++ b/crates/assistant/src/slash_command/docs_command.rs
@@ -233,7 +233,7 @@ impl SlashCommand for DocsSlashCommand {
                         .map(|package_name| ArgumentCompletion {
                             label: format!("{package_name} (unindexed)").into(),
                             new_text: format!("{package_name}"),
-                            run_command: false,
+                            run_command: true,
                         })
                         .collect::<Vec<_>>();
                     items.extend(workspace_crate_completions);


### PR DESCRIPTION
This PR is a follow-up to https://github.com/zed-industries/zed/pull/16216, as we want to run the `/docs` command when completing a suggested package that has yet to be indexed.

Release Notes:

- N/A
