### PR TITLE
haskell: Bump to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13994,7 +13994,7 @@ dependencies = [
 
 [[package]]
 name = "zed_haskell"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_haskell"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/haskell/extension.toml
+++ b/extensions/haskell/extension.toml
@@ -1,7 +1,7 @@
 id = "haskell"
 name = "Haskell"
 description = "Haskell support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = [
     "Pocæus <github@pocaeus.com>",


### PR DESCRIPTION
This PR bumps the Haskell extension to v0.1.1.

Changes:

- https://github.com/zed-industries/zed/pull/13268
- https://github.com/zed-industries/zed/pull/15998

Release Notes:

- N/A
