### PR TITLE
Fix a bug where directories were not matching in the fuzzy matcher, when query contains the worktree root name

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -32,7 +32,7 @@ use futures::{
     stream::FuturesUnordered,
     AsyncWriteExt, Future, FutureExt, StreamExt,
 };
-use fuzzy::CharBag;
+
 use git::{blame::Blame, repository::GitRepository};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use gpui::{
@@ -11030,19 +11030,13 @@ impl<'a> Iterator for PathMatchCandidateSetIter<'a> {
     type Item = fuzzy::PathMatchCandidate<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.traversal.next().map(|entry| match entry.kind {
-            EntryKind::Dir => fuzzy::PathMatchCandidate {
-                is_dir: true,
+        self.traversal
+            .next()
+            .map(|entry| fuzzy::PathMatchCandidate {
+                is_dir: entry.kind.is_dir(),
                 path: &entry.path,
-                char_bag: CharBag::from_iter(entry.path.to_string_lossy().to_lowercase().chars()),
-            },
-            EntryKind::File(char_bag) => fuzzy::PathMatchCandidate {
-                is_dir: false,
-                path: &entry.path,
-                char_bag,
-            },
-            EntryKind::UnloadedDir | EntryKind::PendingDir => unreachable!(),
-        })
+                char_bag: entry.char_bag,
+            })
     }
 }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1612,7 +1612,7 @@ impl ProjectPanel {
                     new_entry_kind = if edit_state.is_dir {
                         EntryKind::Dir
                     } else {
-                        EntryKind::File(Default::default())
+                        EntryKind::File
                     };
                 }
             }
@@ -1652,6 +1652,7 @@ impl ProjectPanel {
                         git_status: entry.git_status,
                         canonical_path: entry.canonical_path.clone(),
                         is_symlink: entry.is_symlink,
+                        char_bag: entry.char_bag,
                     });
                 }
                 if expanded_dir_ids.binary_search(&entry.id).is_err()
@@ -1875,7 +1876,7 @@ impl ProjectPanel {
                     let status = git_status_setting.then(|| entry.git_status).flatten();
                     let is_expanded = expanded_entry_ids.binary_search(&entry.id).is_ok();
                     let icon = match entry.kind {
-                        EntryKind::File(_) => {
+                        EntryKind::File => {
                             if show_file_icons {
                                 FileIcons::get_icon(&entry.path, cx)
                             } else {


### PR DESCRIPTION
Release Notes:

- Fixed a bug where directories were often omitted from the completions for the `/file` slash command
