### PR TITLE
gleam: Switch to published version of `zed_extension_api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13978,11 +13978,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed_extension_api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "594fd10dd0f2f853eb243e2425e7c95938cef49adb81d9602921d002c5e6d9d9"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "zed_gleam"
 version = "0.1.3"
 dependencies = [
  "html_to_markdown 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zed_extension_api 0.1.0",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 html_to_markdown = "0.1.0"
-zed_extension_api = { path = "../../crates/extension_api" }
+zed_extension_api = "0.1.0"


### PR DESCRIPTION
This PR updates the Gleam extension to use the published version of the `zed_extension_api`.

Release Notes:

- N/A
