### PR TITLE
gleam: Bump to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13990,7 +13990,7 @@ dependencies = [
 
 [[package]]
 name = "zed_gleam"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "html_to_markdown 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/extensions/gleam/Cargo.toml
+++ b/extensions/gleam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_gleam"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/gleam/extension.toml
+++ b/extensions/gleam/extension.toml
@@ -1,7 +1,7 @@
 id = "gleam"
 name = "Gleam"
 description = "Gleam support."
-version = "0.1.3"
+version = "0.2.0"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Gleam extension to v0.2.0.

Changes:

- Added `/gleam-project` slash command
- Added `gleam-hexdocs` provider for the `/docs` slash command
- https://github.com/zed-industries/zed/pull/12221
- https://github.com/zed-industries/zed/pull/15659

Release Notes:

- N/A
