### PR TITLE
zig: Upgrade `zed_extension_api` to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14121,7 +14121,7 @@ dependencies = [
 name = "zed_zig"
 version = "0.1.5"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/zig.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/zig/src/zig.rs
+++ b/extensions/zig/src/zig.rs
@@ -61,21 +61,11 @@ impl ZigExtension {
             &language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-        // TODO: Once we're ready to release v0.0.7 of the Zed extension API we want to pin
-        // ZLS to a specific version with `zed::github_release_by_tag_name`.
         // We're pinning ZLS to a release that has `.tar.gz` assets, since the latest release does not have
         // them, at time of writing.
         //
         // ZLS tracking issue: https://github.com/zigtools/zls/issues/1879
-        // let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
-
-        let release = zed::latest_github_release(
-            "zigtools/zls",
-            zed::GithubReleaseOptions {
-                require_assets: true,
-                pre_release: false,
-            },
-        )?;
+        let release = zed::github_release_by_tag_name("zigtools/zls", "0.11.0")?;
 
         let asset_name = format!(
             "zls-{arch}-{os}.{extension}",


### PR DESCRIPTION
This PR updates the Zig extension to use v0.1.0 of the Zed extension API.

This allows us to pin ZLS to v0.11.0, as the more recent releases of ZLS don't have `.tar.gz` assets available.

Release Notes:

- N/A
