### PR TITLE
assistant: Only push text content if not empty with image content

### DIFF
--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -307,7 +307,6 @@ impl LanguageModelRequest {
                     let anthropic_message_content: Vec<anthropic::Content> = message
                         .content
                         .into_iter()
-                        // TODO: filter out the empty messages in the message construction step
                         .filter_map(|content| match content {
                             MessageContent::Text(t) if !t.is_empty() => {
                                 Some(anthropic::Content::Text {


### PR DESCRIPTION
If you submit an image with empty space above it and text below, it will fail with this error:

![image](https://github.com/user-attachments/assets/a4a2265e-815f-48b5-b09e-e178fce82ef7)

Now instead it fails with an error about needing a message.

<img width="640" alt="image" src="https://github.com/user-attachments/assets/72b267eb-b288-40a5-a829-750121ff16cc">

It will however work with text above and empty text below the image now.

Release Notes:

- Improved conformance with Anthropic Images in Chat Completions API
