### PR TITLE
danger: Use a regular message for notice about GitHub Issue links

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -1,4 +1,4 @@
-import { danger, warn } from "danger";
+import { danger, message, warn } from "danger";
 const { prHygiene } = require("danger-plugin-pr-hygiene");
 
 prHygiene({
@@ -44,7 +44,7 @@ const ISSUE_LINK_PATTERN = new RegExp(
 const includesIssueUrl = ISSUE_LINK_PATTERN.test(body);
 
 if (includesIssueUrl) {
-  const matches = body.match(ISSUE_LINK_PATTERN);
+  const matches = body.match(ISSUE_LINK_PATTERN) ?? [];
   const issues = matches
     .map((match) =>
       match
@@ -53,7 +53,7 @@ if (includesIssueUrl) {
     )
     .filter((issue, index, self) => self.indexOf(issue) === index);
 
-  warn(
+  message(
     [
       "This PR includes links to the following GitHub Issues: " +
         issues.map((issue) => `#${issue}`).join(", "),


### PR DESCRIPTION
This PR make it so Danger will use a regular message—as opposed to a warning—for notices about GitHub issue links.

There are still some false-positives getting flagged, so showing a warning is a bit too aggressive.

Release Notes:

- N/A
