### PR TITLE
live_kit_client: Suppress `clippy::arc_with_non_send_sync`

### DIFF
--- a/crates/live_kit_client/src/live_kit_client.rs
+++ b/crates/live_kit_client/src/live_kit_client.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arc_with_non_send_sync)]
+
 use std::sync::Arc;
 
 #[cfg(all(target_os = "macos", not(any(test, feature = "test-support"))))]


### PR DESCRIPTION
This PR suppresses the [`clippy::arc_with_non_send_sync`](https://rust-lang.github.io/rust-clippy/master/index.html#/arc_with_non_send_sync), as there were some warnings that would—only sometimes—show up when running Clippy.

Release Notes:

- N/A
