### PR TITLE
windows: Fix missing title bar on `prompt library`

### DIFF
--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -100,7 +100,7 @@ pub fn open_prompt_library(
                     WindowOptions {
                         titlebar: Some(TitlebarOptions {
                             title: Some("Prompt Library".into()),
-                            appears_transparent: true,
+                            appears_transparent: !cfg!(windows),
                             traffic_light_position: Some(point(px(9.0), px(9.0))),
                         }),
                         window_bounds: Some(WindowBounds::Windowed(bounds)),


### PR DESCRIPTION
Closes #16297

It seems that currently we can't draw custom title bar. I have checked the `title_bar` crate, it seems to be `zed` only.

Before:

![Screenshot 2024-08-16 004350](https://github.com/user-attachments/assets/e11aa0bb-9d3e-47d5-b488-d3b8220158cc)

After:

![Screenshot 2024-08-16 004235](https://github.com/user-attachments/assets/028b4eb2-c878-4ea7-87e3-22817caefa00)


Release Notes:

- N/A
