### PR TITLE
zed_extension_api: Start a list of pending changes

### DIFF
--- a/crates/extension_api/PENDING_CHANGES.md
+++ b/crates/extension_api/PENDING_CHANGES.md
@@ -1,0 +1,12 @@
+# Pending Changes
+
+This is a list of pending changes to the Zed extension API that require a breaking change.
+
+This list should be updated as we notice things that should be changed so that we can batch them up in a single release.
+
+## vNext
+
+### Slash Commands
+
+- Rename `SlashCommand.tooltip_text` to `SlashCommand.menu_text`
+  - We may even want to remove it entirely, as right now this is only used for featured slash commands, and slash commands defined by extensions aren't currently able to be featured.


### PR DESCRIPTION
This PR starts a list of pending changes for the Zed extension API.

We'll want to keep this list updated as we note things that we want to change in the next version of the extension API. This will help with batching breaking changes together so that we're not constantly creating new versions of the extension API for one-off changes.

Release Notes:

- N/A
