### PR TITLE
extension: Remove `tooltip_text` from `SlashCommandManifestEntry`

### DIFF
--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -137,7 +137,6 @@ impl LanguageServerManifestEntry {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct SlashCommandManifestEntry {
     pub description: String,
-    pub tooltip_text: String,
     pub requires_argument: bool,
 }
 

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -1216,7 +1216,10 @@ impl ExtensionStore {
                                 command: crate::wit::SlashCommand {
                                     name: slash_command_name.to_string(),
                                     description: slash_command.description.to_string(),
-                                    tooltip_text: slash_command.tooltip_text.to_string(),
+                                    // We don't currently expose this as a configurable option, as it currently drives
+                                    // the `menu_text` on the `SlashCommand` trait, which is not used for slash commands
+                                    // defined in extensions, as they are not able to be added to the menu.
+                                    tooltip_text: String::new(),
                                     requires_argument: slash_command.requires_argument,
                                 },
                                 extension: wasm_extension.clone(),

--- a/docs/src/extensions/slash-commands.md
+++ b/docs/src/extensions/slash-commands.md
@@ -18,19 +18,16 @@ For example, here is an extension that provides two slash commands: `/echo` and 
 [slash_commands.echo]
 description = "echoes the provided input"
 requires_argument = true
-tooltip_text = ""
 
 [slash_commands.pick-one]
 description = "pick one of three options"
 requires_argument = true
-tooltip_text = ""
 ```
 
 Each slash command may define the following properties:
 
 - `description`: A description of the slash command that will be shown when completing available commands.
 - `requires_argument`: Indicates whether a slash command requires at least one argument to run.
-- `tooltip_text`: Currently unused.
 
 ## Implementing slash command behavior
 


### PR DESCRIPTION
This PR removes the `tooltip_text` field from `SlashCommandManifestEntry`s.

The `tooltip_text` is currently only used to set the `menu_text` on a slash command, which is only used for featured slash commands.

Since slash commands from extensions are not currently able to be featured, we don't need extension authors to provide this field in the manifest.

This is a backwards-compatible change.

Release Notes:

- N/A
