### PR TITLE
collab: Attach `user_id` to LLM spans

### DIFF
--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -138,7 +138,9 @@ async fn validate_api_token<B>(mut req: Request<B>, next: Next<B>) -> impl IntoR
                 ));
             }
 
-            tracing::Span::current().record("authn.jti", &claims.jti);
+            tracing::Span::current()
+                .record("user_id", claims.user_id)
+                .record("authn.jti", &claims.jti);
 
             req.extensions_mut().insert(claims);
             Ok::<_, Error>(next.run(req).await.into_response())

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -150,6 +150,7 @@ async fn main() -> Result<()> {
                             "http_request",
                             method = ?request.method(),
                             matched_path,
+                            user_id = tracing::field::Empty,
                             authn.jti = tracing::field::Empty
                         )
                     })


### PR DESCRIPTION
This PR updates the LLM service to attach the user ID to the spans.

Release Notes:

- N/A
