### PR TITLE
Remove `tooltip_text` from extension manifests

### DIFF
--- a/extensions/gleam/extension.toml
+++ b/extensions/gleam/extension.toml
@@ -17,6 +17,5 @@ commit = "426e67087fd62be5f4533581b5916b2cf010fb5b"
 [slash_commands.gleam-project]
 description = "Returns information about the current Gleam project."
 requires_argument = false
-tooltip_text = "Insert Gleam project data"
 
 [indexed_docs_providers.gleam-hexdocs]

--- a/extensions/slash-commands-example/extension.toml
+++ b/extensions/slash-commands-example/extension.toml
@@ -9,9 +9,7 @@ repository = "https://github.com/zed-industries/zed"
 [slash_commands.echo]
 description = "echoes the provided input"
 requires_argument = true
-tooltip_text = "Echoes the provided input"
 
 [slash_commands.pick-one]
 description = "pick one of three options"
 requires_argument = true
-tooltip_text = "Pick one of three options"


### PR DESCRIPTION
This PR removes the `tooltip_text` from the extension manifests.

We stopped reading this value in #16306, as it wasn't being used, so we don't need to include it in the manifest anymore.

Release Notes:

- N/A
