### PR TITLE
danger: Don't look for `#NNNN`, as it's not specific enough

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -37,7 +37,7 @@ if (!hasReleaseNotes) {
 }
 
 const ISSUE_LINK_PATTERN = new RegExp(
-  "(?:https://github\\.com/[\\w-]+/[\\w-]+/issues/\\d+|#\\d+)",
+  "https://github\\.com/[\\w-]+/[\\w-]+/issues/\\d+",
   "g",
 );
 


### PR DESCRIPTION
This PR updates the regex we use to search for issues to not search for `#NNNN`, as it's not specific enough.

It currently catches issue numbers from other repos, which are then linked to random Zed issues/PRs that happen to have the same number:

<img width="935" alt="Screenshot 2024-08-15 at 3 50 29 PM" src="https://github.com/user-attachments/assets/b779e503-3027-43e2-b355-e81d8d094694">

As well as catching PRs:

<img width="924" alt="Screenshot 2024-08-15 at 3 48 59 PM" src="https://github.com/user-attachments/assets/6c2f7594-9234-4454-97da-5a33a1844892">

Given that:

1. We can't distinguish any given `#NNNN` as an issue _and_ can't ensure it belongs to the Zed repo
2. Any issue/PR referenced as `#NNNN` will already create a backlink

It seems that looking for these is causing more noise than signal.

Release Notes:

- N/A
