### PR TITLE
Add a workflow step resolution view

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2729,11 +2729,11 @@ impl ContextEditor {
             .update(cx, |panel, _| panel.pane())
             .ok()??;
         let context = self.context.read(cx);
-        let langauge_registry = context.language_registry();
+        let language_registry = context.language_registry();
         let step = context.workflow_step_for_range(step_range)?;
         let resolution = step.resolution.clone();
         let view = cx.new_view(|cx| {
-            WorkflowStepView::new(self.context.clone(), resolution, langauge_registry, cx)
+            WorkflowStepView::new(self.context.clone(), resolution, language_registry, cx)
         });
         cx.deref_mut().defer(move |cx| {
             pane.update(cx, |pane, cx| {

--- a/crates/assistant/src/context_inspector.rs
+++ b/crates/assistant/src/context_inspector.rs
@@ -54,7 +54,10 @@ impl ContextInspector {
         let step = context.read(cx).workflow_step_for_range(range)?;
         let mut output = String::from("\n\n");
         match &step.resolution.read(cx).result {
-            Some(Ok(ResolvedWorkflowStep { title, suggestions })) => {
+            Some(Ok(ResolvedWorkflowStep {
+                title,
+                suggestion_groups: suggestions,
+            })) => {
                 writeln!(output, "Resolution:").ok()?;
                 writeln!(output, "  {title:?}").ok()?;
                 if suggestions.is_empty() {
@@ -189,26 +192,32 @@ fn pretty_print_workflow_suggestion(
 ) {
     use std::fmt::Write;
     let (range, description, position) = match suggestion {
-        WorkflowSuggestion::Update { range, description } => (Some(range), Some(description), None),
-        WorkflowSuggestion::CreateFile { description } => (None, Some(description), None),
+        WorkflowSuggestion::Update {
+            range, description, ..
+        } => (Some(range), Some(description), None),
+        WorkflowSuggestion::CreateFile { description, .. } => (None, Some(description), None),
         WorkflowSuggestion::AppendChild {
             position,
             description,
+            ..
         }
         | WorkflowSuggestion::InsertSiblingBefore {
             position,
             description,
+            ..
         }
         | WorkflowSuggestion::InsertSiblingAfter {
             position,
             description,
+            ..
         }
         | WorkflowSuggestion::PrependChild {
             position,
             description,
+            ..
         } => (None, Some(description), Some(position)),
 
-        WorkflowSuggestion::Delete { range } => (Some(range), None, None),
+        WorkflowSuggestion::Delete { range, .. } => (Some(range), None, None),
     };
     if let Some(description) = description {
         writeln!(out, "    Description: {description}").ok();

--- a/crates/assistant/src/workflow/step_view.rs
+++ b/crates/assistant/src/workflow/step_view.rs
@@ -1,0 +1,226 @@
+use std::sync::Arc;
+
+use super::WorkflowStepResolution;
+use crate::{Assist, Context};
+use editor::{
+    display_map::{BlockDisposition, BlockProperties, BlockStyle},
+    Editor, EditorEvent, ExcerptRange, MultiBuffer,
+};
+use gpui::{
+    div, AppContext, Context as _, EventEmitter, FocusableView, IntoElement, Model,
+    ParentElement as _, Render, SharedString, Styled as _, View, ViewContext, VisualContext as _,
+    WeakModel, WindowContext,
+};
+use language::{language_settings::SoftWrap, Anchor, Buffer, LanguageRegistry};
+use theme::ActiveTheme as _;
+use ui::{
+    h_flex, ButtonCommon as _, ButtonLike, ButtonStyle, Color, InteractiveElement as _, Label,
+    LabelCommon as _,
+};
+use workspace::{
+    item::{self, Item},
+    pane,
+    searchable::SearchableItemHandle,
+};
+
+pub struct WorkflowStepView {
+    step: WeakModel<WorkflowStepResolution>,
+    tool_output_buffer: Model<Buffer>,
+    editor: View<Editor>,
+}
+
+impl WorkflowStepView {
+    pub fn new(
+        context: Model<Context>,
+        step: Model<WorkflowStepResolution>,
+        language_registry: Arc<LanguageRegistry>,
+        cx: &mut ViewContext<Self>,
+    ) -> Self {
+        let tool_output_buffer = cx.new_model(|cx| Buffer::local(step.read(cx).output.clone(), cx));
+        let buffer = cx.new_model(|cx| {
+            let mut buffer = MultiBuffer::without_headers(0, language::Capability::ReadWrite);
+            buffer.push_excerpts(
+                context.read(cx).buffer().clone(),
+                [ExcerptRange {
+                    context: step.read(cx).tagged_range.clone(),
+                    primary: None,
+                }],
+                cx,
+            );
+            buffer.push_excerpts(
+                tool_output_buffer.clone(),
+                [ExcerptRange {
+                    context: Anchor::MIN..Anchor::MAX,
+                    primary: None,
+                }],
+                cx,
+            );
+            buffer
+        });
+
+        let buffer_snapshot = buffer.read(cx).snapshot(cx);
+        let output_excerpt = buffer_snapshot.excerpts().skip(1).next().unwrap().0;
+        let input_start_anchor = multi_buffer::Anchor::min();
+        let output_start_anchor = buffer_snapshot
+            .anchor_in_excerpt(output_excerpt, Anchor::MIN)
+            .unwrap();
+
+        let editor = cx.new_view(|cx| {
+            let mut editor = Editor::for_multibuffer(buffer.clone(), None, false, cx);
+            editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
+            editor.set_show_line_numbers(false, cx);
+            editor.set_show_git_diff_gutter(false, cx);
+            editor.set_show_code_actions(false, cx);
+            editor.set_show_runnables(false, cx);
+            editor.set_show_wrap_guides(false, cx);
+            editor.set_show_indent_guides(false, cx);
+            editor.set_read_only(true);
+            editor.insert_blocks(
+                [
+                    BlockProperties {
+                        position: input_start_anchor,
+                        height: 1,
+                        style: BlockStyle::Fixed,
+                        render: Box::new(|cx| section_header("Step Input", cx)),
+                        disposition: BlockDisposition::Above,
+                        priority: 0,
+                    },
+                    BlockProperties {
+                        position: output_start_anchor,
+                        height: 1,
+                        style: BlockStyle::Fixed,
+                        render: Box::new(|cx| section_header("Tool Output", cx)),
+                        disposition: BlockDisposition::Above,
+                        priority: 0,
+                    },
+                ],
+                None,
+                cx,
+            );
+            editor
+        });
+
+        cx.observe(&step, Self::step_updated).detach();
+        cx.observe_release(&step, Self::step_released).detach();
+
+        cx.spawn(|this, mut cx| async move {
+            if let Ok(language) = language_registry.language_for_name("JSON").await {
+                this.update(&mut cx, |this, cx| {
+                    this.tool_output_buffer.update(cx, |buffer, cx| {
+                        buffer.set_language(Some(language), cx);
+                    });
+                })
+                .ok();
+            }
+        })
+        .detach();
+
+        Self {
+            tool_output_buffer,
+            step: step.downgrade(),
+            editor,
+        }
+    }
+
+    fn step_updated(&mut self, step: Model<WorkflowStepResolution>, cx: &mut ViewContext<Self>) {
+        self.tool_output_buffer.update(cx, |buffer, cx| {
+            let text = step.read(cx).output.clone();
+            buffer.set_text(text, cx);
+        });
+        cx.notify();
+    }
+
+    fn step_released(&mut self, _: &mut WorkflowStepResolution, cx: &mut ViewContext<Self>) {
+        cx.emit(EditorEvent::Closed);
+    }
+
+    fn resolve(&mut self, _: &Assist, cx: &mut ViewContext<Self>) {
+        self.step
+            .update(cx, |step, cx| {
+                step.resolve(cx);
+            })
+            .ok();
+    }
+}
+
+fn section_header(
+    name: &'static str,
+    cx: &mut editor::display_map::BlockContext,
+) -> gpui::AnyElement {
+    h_flex()
+        .pl(cx.gutter_dimensions.full_width())
+        .h_11()
+        .w_full()
+        .relative()
+        .gap_1()
+        .child(
+            ButtonLike::new("role")
+                .style(ButtonStyle::Filled)
+                .child(Label::new(name).color(Color::Default)),
+        )
+        .into_any_element()
+}
+
+impl Render for WorkflowStepView {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        div()
+            .key_context("ContextEditor")
+            .on_action(cx.listener(Self::resolve))
+            .flex_grow()
+            .bg(cx.theme().colors().editor_background)
+            .child(self.editor.clone())
+    }
+}
+
+impl EventEmitter<EditorEvent> for WorkflowStepView {}
+
+impl FocusableView for WorkflowStepView {
+    fn focus_handle(&self, cx: &gpui::AppContext) -> gpui::FocusHandle {
+        self.editor.read(cx).focus_handle(cx)
+    }
+}
+
+impl Item for WorkflowStepView {
+    type Event = EditorEvent;
+
+    fn tab_content_text(&self, _cx: &WindowContext) -> Option<SharedString> {
+        Some("workflow step".into())
+    }
+
+    fn to_item_events(event: &Self::Event, mut f: impl FnMut(item::ItemEvent)) {
+        match event {
+            EditorEvent::Edited { .. } => {
+                f(item::ItemEvent::Edit);
+            }
+            EditorEvent::TitleChanged => {
+                f(item::ItemEvent::UpdateTab);
+            }
+            EditorEvent::Closed => f(item::ItemEvent::CloseItem),
+            _ => {}
+        }
+    }
+
+    fn tab_tooltip_text(&self, _cx: &AppContext) -> Option<SharedString> {
+        None
+    }
+
+    fn as_searchable(&self, _handle: &View<Self>) -> Option<Box<dyn SearchableItemHandle>> {
+        None
+    }
+
+    fn set_nav_history(&mut self, nav_history: pane::ItemNavHistory, cx: &mut ViewContext<Self>) {
+        self.editor.update(cx, |editor, cx| {
+            Item::set_nav_history(editor, nav_history, cx)
+        })
+    }
+
+    fn navigate(&mut self, data: Box<dyn std::any::Any>, cx: &mut ViewContext<Self>) -> bool {
+        self.editor
+            .update(cx, |editor, cx| Item::navigate(editor, data, cx))
+    }
+
+    fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
+        self.editor
+            .update(cx, |editor, cx| Item::deactivated(editor, cx))
+    }
+}

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -71,7 +71,7 @@ pub use language_registry::{
     PendingLanguageServer, QUERY_FILENAME_PREFIXES,
 };
 pub use lsp::LanguageServerId;
-pub use outline::{render_item, Outline, OutlineItem};
+pub use outline::*;
 pub use syntax_map::{OwnedSyntaxLayer, SyntaxLayer};
 pub use text::{AnchorRangeExt, LineEnding};
 pub use tree_sitter::{Node, Parser, Tree, TreeCursor};


### PR DESCRIPTION
You can now click on a step header (the words `Step 3`, etc) to open a new tab containing a dedicated view for the resolution of that step. This view looks similar to a context editor, and has sections for the step input, the streaming tool output, and the interpreted results.

Hitting `cmd-enter` in this view re-resolves the step.

https://github.com/user-attachments/assets/64d82cdb-e70f-4204-8697-b30df5a645d5



Release Notes:

- N/A
