### PR TITLE
collab: Add support for reading boolean values from `.env.toml`

### DIFF
--- a/crates/collab/src/env.rs
+++ b/crates/collab/src/env.rs
@@ -32,6 +32,7 @@ fn add_vars(env_content: String, vars: &mut Vec<(String, String)>) -> Result<()>
             toml::Value::String(value) => value,
             toml::Value::Integer(value) => value.to_string(),
             toml::Value::Float(value) => value.to_string(),
+            toml::Value::Boolean(value) => value.to_string(),
             _ => panic!("unsupported TOML value in .env.toml for key {}", key),
         };
         vars.push((key, value));


### PR DESCRIPTION
This PR adds support for reading boolean values from `.env.toml`, since it wasn't supported previously.

Release Notes:

- N/A
