### PR TITLE
repl: Apply border for error output on left

### DIFF
--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -257,17 +257,31 @@ impl ErrorView {
 
         Some(
             v_flex()
-                .w_full()
-                .px(padding)
-                .py(padding)
-                .border_1()
-                .border_color(theme.status().error_border)
+                .gap_3()
                 .child(
                     h_flex()
-                        .font_weight(FontWeight::BOLD)
-                        .child(format!("{}: {}", self.ename, self.evalue)),
+                        .font_buffer(cx)
+                        .child(
+                            Label::new(format!("{}: ", self.ename.clone()))
+                                // .size(LabelSize::Large)
+                                .color(Color::Error)
+                                .weight(FontWeight::BOLD),
+                        )
+                        .child(
+                            Label::new(self.evalue.clone())
+                                // .size(LabelSize::Large)
+                                .weight(FontWeight::BOLD),
+                        ),
                 )
-                .child(self.traceback.render(cx))
+                .child(
+                    div()
+                        .w_full()
+                        .px(padding)
+                        .py(padding)
+                        .border_l_1()
+                        .border_color(theme.status().error_border)
+                        .child(self.traceback.render(cx)),
+                )
                 .into_any_element(),
         )
     }


### PR DESCRIPTION
Before:

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/0eb18b44-1571-462d-b845-ef23bf6aaa3a">

After:

<img width="1255" alt="image" src="https://github.com/user-attachments/assets/a04e9798-4a88-4c2b-ae14-2bd2f79dcd7c">



Release Notes:

- N/A
