### PR TITLE
Add option to set split direction

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -67,9 +67,9 @@
   // The factor to grow the active pane by. Defaults to 1.0
   // which gives the same size as all other panes.
   "active_pane_magnification": 1.0,
-  // Comment A
+  // The direction that you want to split panes horizontally. Defaults to "up"
   "pane_split_direction_horizontal": "up",
-  //Comment B
+  // The direction that you want to split panes horizontally. Defaults to "left"
   "pane_split_direction_vertical": "left",
   // Centered layout related settings.
   "centered_layout": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -67,6 +67,10 @@
   // The factor to grow the active pane by. Defaults to 1.0
   // which gives the same size as all other panes.
   "active_pane_magnification": 1.0,
+  // Comment A
+  "pane_split_direction_horizontal": "up",
+  //Comment B
+  "pane_split_direction_vertical": "left",
   // Centered layout related settings.
   "centered_layout": {
     // The relative width of the left padding of the central pane from the

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -523,8 +523,8 @@ fn generate_commands(_: &AppContext) -> Vec<VimCommand> {
             save_intent: Some(SaveIntent::Overwrite),
         }),
         VimCommand::new(("cq", "uit"), zed_actions::Quit),
-        VimCommand::new(("sp", "lit"), workspace::SplitUp),
-        VimCommand::new(("vs", "plit"), workspace::SplitLeft),
+        VimCommand::new(("sp", "lit"), workspace::SplitHorizontal),
+        VimCommand::new(("vs", "plit"), workspace::SplitVertical),
         VimCommand::new(
             ("bd", "elete"),
             workspace::CloseActiveItem {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4,7 +4,10 @@ use crate::{
         WeakItemHandle,
     },
     toolbar::Toolbar,
-    workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings},
+    workspace_settings::{
+        AutosaveSetting, PaneSplitDirectionHorizontal, PaneSplitDirectionVertical, TabBarSettings,
+        WorkspaceSettings,
+    },
     CloseWindow, CopyPath, CopyRelativePath, NewFile, NewTerminal, OpenInTerminal, OpenTerminal,
     OpenVisible, SplitDirection, ToggleFileFinder, ToggleProjectSymbols, ToggleZoom, Workspace,
 };
@@ -2209,12 +2212,23 @@ impl Render for Pane {
             }))
             .on_action(cx.listener(|pane, _: &SplitLeft, cx| pane.split(SplitDirection::Left, cx)))
             .on_action(cx.listener(|pane, _: &SplitUp, cx| pane.split(SplitDirection::Up, cx)))
-            .on_action(
-                cx.listener(|pane, _: &SplitHorizontal, cx| pane.split(SplitDirection::Down, cx)),
-            )
-            .on_action(
-                cx.listener(|pane, _: &SplitVertical, cx| pane.split(SplitDirection::Right, cx)),
-            )
+            .on_action(cx.listener(|pane, _: &SplitHorizontal, cx| {
+                let split_direction =
+                    WorkspaceSettings::get(None, cx).pane_split_direction_horizontal;
+                match split_direction {
+                    PaneSplitDirectionHorizontal::Down => pane.split(SplitDirection::Down, cx),
+                    _ => pane.split(SplitDirection::Up, cx),
+                }
+            }))
+            .on_action(cx.listener(|pane, _: &SplitVertical, cx| {
+                let split_direction =
+                    WorkspaceSettings::get(None, cx).pane_split_direction_vertical;
+
+                match split_direction {
+                    PaneSplitDirectionVertical::Right => pane.split(SplitDirection::Right, cx),
+                    _ => pane.split(SplitDirection::Left, cx),
+                }
+            }))
             .on_action(
                 cx.listener(|pane, _: &SplitRight, cx| pane.split(SplitDirection::Right, cx)),
             )

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -151,6 +151,8 @@ actions!(
         SplitUp,
         SplitRight,
         SplitDown,
+        SplitHorizontal,
+        SplitVertical,
         TogglePreviewTab,
     ]
 );
@@ -2207,6 +2209,12 @@ impl Render for Pane {
             }))
             .on_action(cx.listener(|pane, _: &SplitLeft, cx| pane.split(SplitDirection::Left, cx)))
             .on_action(cx.listener(|pane, _: &SplitUp, cx| pane.split(SplitDirection::Up, cx)))
+            .on_action(
+                cx.listener(|pane, _: &SplitHorizontal, cx| pane.split(SplitDirection::Down, cx)),
+            )
+            .on_action(
+                cx.listener(|pane, _: &SplitVertical, cx| pane.split(SplitDirection::Right, cx)),
+            )
             .on_action(
                 cx.listener(|pane, _: &SplitRight, cx| pane.split(SplitDirection::Right, cx)),
             )

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -8,6 +8,8 @@ use settings::{Settings, SettingsSources};
 #[derive(Deserialize)]
 pub struct WorkspaceSettings {
     pub active_pane_magnification: f32,
+    pub pane_split_direction_horizontal: PaneSplitDirectionHorizontal,
+    pub pane_split_direction_vertical: PaneSplitDirectionVertical,
     pub centered_layout: CenteredLayoutSettings,
     pub confirm_quit: bool,
     pub show_call_status_icon: bool,
@@ -61,6 +63,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: `1.0`
     pub active_pane_magnification: Option<f32>,
+    //TODO: Add some comment
+    pub pane_split_direction_horizontal: Option<PaneSplitDirectionHorizontal>,
+    //TODO: Add some comment
+    pub pane_split_direction_vertical: Option<PaneSplitDirectionVertical>,
     // Centered layout related settings.
     pub centered_layout: Option<CenteredLayoutSettings>,
     /// Whether or not to prompt the user to confirm before closing the application.
@@ -129,6 +135,20 @@ pub enum AutosaveSetting {
     OnFocusChange,
     /// Autosave when the active window changes.
     OnWindowChange,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PaneSplitDirectionHorizontal {
+    Up,
+    Down,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PaneSplitDirectionVertical {
+    Left,
+    Right,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -63,9 +63,13 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: `1.0`
     pub active_pane_magnification: Option<f32>,
-    //TODO: Add some comment
+    // Direction to split horizontally.
+    //
+    // Default: "up"
     pub pane_split_direction_horizontal: Option<PaneSplitDirectionHorizontal>,
-    //TODO: Add some comment
+    // Direction to split vertically.
+    //
+    // Default: "left"
     pub pane_split_direction_vertical: Option<PaneSplitDirectionVertical>,
     // Centered layout related settings.
     pub centered_layout: Option<CenteredLayoutSettings>,


### PR DESCRIPTION
This adds an option to set the split direction for both the horizontal splits, and the vertical splits.

A couple of things to look for when reviewing:

* The `derive` keywords on the Enums were copy pasted, no clue what they should be
* Tried adding tests for this, but got stuck.

Co-authored with @Tobbe

Fixes: https://github.com/zed-industries/zed/issues/11342