### PR TITLE
collab: Fix writing LLM rate limit events to Clickhouse

### DIFF
--- a/crates/collab/src/clickhouse.rs
+++ b/crates/collab/src/clickhouse.rs
@@ -1,0 +1,28 @@
+use serde::Serialize;
+
+/// Writes the given rows to the specified Clickhouse table.
+pub async fn write_to_table<T: clickhouse::Row + Serialize + std::fmt::Debug>(
+    table: &str,
+    rows: &[T],
+    clickhouse_client: &clickhouse::Client,
+) -> anyhow::Result<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let mut insert = clickhouse_client.insert(table)?;
+
+    for event in rows {
+        insert.write(event).await?;
+    }
+
+    insert.end().await?;
+
+    let event_count = rows.len();
+    log::info!(
+        "wrote {event_count} {event_specifier} to '{table}'",
+        event_specifier = if event_count == 1 { "event" } else { "events" }
+    );
+
+    Ok(())
+}

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod auth;
+pub mod clickhouse;
 pub mod db;
 pub mod env;
 pub mod executor;
@@ -267,7 +268,7 @@ pub struct AppState {
     pub stripe_client: Option<Arc<stripe::Client>>,
     pub rate_limiter: Arc<RateLimiter>,
     pub executor: Executor,
-    pub clickhouse_client: Option<clickhouse::Client>,
+    pub clickhouse_client: Option<::clickhouse::Client>,
     pub config: Config,
 }
 
@@ -358,8 +359,8 @@ async fn build_blob_store_client(config: &Config) -> anyhow::Result<aws_sdk_s3::
     Ok(aws_sdk_s3::Client::new(&s3_config))
 }
 
-fn build_clickhouse_client(config: &Config) -> anyhow::Result<clickhouse::Client> {
-    Ok(clickhouse::Client::default()
+fn build_clickhouse_client(config: &Config) -> anyhow::Result<::clickhouse::Client> {
+    Ok(::clickhouse::Client::default()
         .with_url(
             config
                 .clickhouse_url


### PR DESCRIPTION
This PR fixes the writing of LLM rate limit events to Clickhouse.

We had a table in the table name: `llm_rate_limits` instead of `llm_rate_limit_events`.

I also extracted a helper function to write to Clickhouse so we can use it anywhere we need to.

Release Notes:

- N/A
