### PR TITLE
context_servers: Log errors from detached context server tasks

### DIFF
--- a/crates/context_servers/src/context_servers.rs
+++ b/crates/context_servers/src/context_servers.rs
@@ -30,7 +30,9 @@ fn restart_servers(_workspace: &mut Workspace, _action: &Restart, cx: &mut ViewC
     let model = ContextServerManager::global(&cx);
     cx.update_model(&model, |manager, cx| {
         for server in manager.servers() {
-            manager.restart_server(&server.id, cx).detach();
+            manager
+                .restart_server(&server.id, cx)
+                .detach_and_log_err(cx);
         }
     });
 }

--- a/crates/context_servers/src/manager.rs
+++ b/crates/context_servers/src/manager.rs
@@ -266,11 +266,11 @@ pub fn init(cx: &mut AppContext) {
 
             log::trace!("servers_to_add={:?}", servers_to_add);
             for config in servers_to_add {
-                manager.add_server(config, cx).detach();
+                manager.add_server(config, cx).detach_and_log_err(cx);
             }
 
             for id in servers_to_remove {
-                manager.remove_server(&id, cx).detach();
+                manager.remove_server(&id, cx).detach_and_log_err(cx);
             }
         })
     })


### PR DESCRIPTION
Logged several of the detached tasks that before would silently fail if the context server wasn't in compliance.

Release Notes:

- N/A
