### PR TITLE
Workflow prompt tweaks

### DIFF
--- a/assets/prompts/edit_workflow.hbs
+++ b/assets/prompts/edit_workflow.hbs
@@ -6,7 +6,6 @@ named Zed, which is where they will have entered this prompt and will be seeing 
 <instructions>
 - Use the language of the file for code fence blocks unless otherwise specified.
 - Include a code or file action in each step.
-- Only put code in separate steps if it should either go in separate files, or in different (non-contiguous) places in the same file.
 - Provide error handling and input validation where appropriate.
 - Adapt explanations based on the user's perceived level of expertise.
 - Include comments in code examples to enhance understanding.

--- a/assets/prompts/edit_workflow.hbs
+++ b/assets/prompts/edit_workflow.hbs
@@ -1,5 +1,5 @@
 <workflow>
-Guide the user through code changes in numbered steps that focus on individual functions, type definitions, etc.
+Guide the user through code changes in numbered steps where each step focuses on a single individual function, type definition, etc.
 Surround each distinct step in a <step></step> XML tag. The user will be performing these steps in a code editor
 named Zed, which is where they will have entered this prompt and will be seeing the response.
 

--- a/crates/language/src/outline.rs
+++ b/crates/language/src/outline.rs
@@ -89,7 +89,6 @@ impl<T> Outline<T> {
 
     /// Find the most similar symbol to the provided query using normalized Levenshtein distance.
     pub fn find_most_similar(&self, symbol: &str) -> Option<(SymbolPath, &OutlineItem<T>)> {
-        dbg!(&symbol);
         // Sometimes the model incorrectly includes a space or colon in the query,
         // e.g. in Elm, Roc, etc. it might say `foo : ...` because it's trying to include the symbol's type,
         // which isn't part of the symbol and won't be in the outline. Trim the first space and anything after it.


### PR DESCRIPTION
These are some tweaks to workflow prompts to fix some situations I encountered where the workflow emitted one giant step.

Also fixes the scenario where it looks for an entire type definition in the outline, instead of just a symbol.