### PR TITLE
Fix log timestamps not using local timezone 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13904,6 +13904,7 @@ dependencies = [
  "terminal_view",
  "theme",
  "theme_selector",
+ "time",
  "tree-sitter-md",
  "tree-sitter-rust",
  "ui",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -96,6 +96,7 @@ tab_switcher.workspace = true
 supermaven.workspace = true
 task.workspace = true
 tasks_ui.workspace = true
+time.workspace =  true
 telemetry_events.workspace = true
 terminal_view.workspace = true
 theme.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -8,6 +8,7 @@ mod zed;
 
 use anyhow::{anyhow, Context as _, Result};
 use assistant::PromptBuilder;
+use chrono::Offset;
 use clap::{command, Parser};
 use cli::FORCE_CLI_MODE_ENV_VAR_NAME;
 use client::{parse_zed_link, Client, DevServerToken, UserStore};
@@ -44,6 +45,7 @@ use std::{
     sync::Arc,
 };
 use theme::{ActiveTheme, SystemAppearance, ThemeRegistry, ThemeSettings};
+use time::UtcOffset;
 use util::{maybe, parse_env_output, ResultExt, TryFutureExt};
 use uuid::Uuid;
 use welcome::{show_welcome_view, BaseKeymap, FIRST_OPEN};
@@ -882,7 +884,10 @@ fn init_logger() {
                 let mut config_builder = ConfigBuilder::new();
 
                 config_builder.set_time_format_rfc3339();
-                config_builder.set_time_offset_to_local().log_err();
+                let local_offset = chrono::Local::now().offset().fix().local_minus_utc();
+                if let Ok(offset) = UtcOffset::from_whole_seconds(local_offset) {
+                    config_builder.set_time_offset(offset);
+                }
 
                 #[cfg(target_os = "linux")]
                 {


### PR DESCRIPTION
Get time offset by time crate will fail if there are mutli threads. So call `config_builder.set_time_offset_to_local()` is useless.

Closes #16397

after:
<img width="664" alt="image" src="https://github.com/user-attachments/assets/2b15fa06-c411-44f9-9ea1-871d25eb577f">

Release Notes:

- Fixed Local Timezone not showing Zed.log