### PR TITLE
Revert changes to inline assist indentation logic and prompt

### DIFF
--- a/assets/prompts/content_prompt.hbs
+++ b/assets/prompts/content_prompt.hbs
@@ -1,426 +1,61 @@
-You are an expert developer assistant working in an AI-enabled text editor.
-Your task is to rewrite a specific section of the provided document based on a user-provided prompt.
+{{#if language_name}}
+Here's a file of {{language_name}} that I'm going to ask you to make an edit to.
+{{else}}
+Here's a file of text that I'm going to ask you to make an edit to.
+{{/if}}
 
-<guidelines>
-1. Scope: Modify only content within <rewrite_this> tags. Do not alter anything outside these boundaries.
-2. Precision: Make changes strictly necessary to fulfill the given prompt. Preserve all other content as-is.
-3. Seamless integration: Ensure rewritten sections flow naturally with surrounding text and maintain document structure.
-4. Tag exclusion: Never include <rewrite_this>, </rewrite_this>, <edit_here>, or <insert_here> tags in the output.
-5. Indentation: Maintain the original indentation level of the file in rewritten sections.
-6. Completeness: Rewrite the entire tagged section, even if only partial changes are needed. Avoid omissions or elisions.
-7. Insertions: Replace <insert_here></insert_here> tags with appropriate content as specified by the prompt.
-8. Code integrity: Respect existing code structure and functionality when making changes.
-9. Consistency: Maintain a uniform style and tone throughout the rewritten text.
-</guidelines>
+{{#if is_insert}}
+The point you'll need to insert at is marked with <insert_here></insert_here>.
+{{else}}
+The section you'll need to rewrite is marked with <rewrite_this></rewrite_this> tags.
+{{/if}}
 
-<examples>
-<example>
-<input>
 <document>
-use std::cell::Cell;
-use std::collections::HashMap;
-use std::cmp;
-
-<rewrite_this>
-<insert_here></insert_here>
-</rewrite_this>
-pub struct LruCache<K, V> {
-    /// The maximum number of items the cache can hold.
-    capacity: usize,
-    /// The map storing the cached items.
-    items: HashMap<K, V>,
-}
-
-// The rest of the implementation...
-</document>
-<prompt>
-doc this
-</prompt>
-</input>
-
-<incorrect_output failure="Over-generation. The text starting with `pub struct AabbTree<T> {` is *after* the rewrite_this tag">
-/// Represents an Axis-Aligned Bounding Box (AABB) tree data structure.
-///
-/// This structure is used for efficient spatial queries and collision detection.
-/// It organizes objects in a hierarchical tree structure based on their bounding boxes.
-///
-/// # Type Parameters
-///
-/// * `T`: The type of data associated with each node in the tree.
-pub struct AabbTree<T> {
-  root: Option<usize>,
-</incorrect_output>
-<corrected_output improvement="Generation stops before repeating content after the rewrite_this section">
-/// Represents an Axis-Aligned Bounding Box (AABB) tree data structure.
-///
-/// This structure is used for efficient spatial queries and collision detection.
-/// It organizes objects in a hierarchical tree structure based on their bounding boxes.
-///
-/// # Type Parameters
-///
-/// * `T`: The type of data associated with each node in the tree.
-</corrected_output>
-</example>
-
-<example>
-<input>
-<document>
-import math
-
-def calculate_circle_area(radius):
-    """Calculate the area of a circle given its radius."""
-    return math.pi * radius ** 2
-
-<rewrite_this>
-<insert_here></insert_here>
-</rewrite_this>
-class Circle:
-    def __init__(self, radius):
-        self.radius = radius
-
-    def area(self):
-        return math.pi * self.radius ** 2
-
-    def circumference(self):
-        return 2 * math.pi * self.radius
-
-# Usage example
-circle = Circle(5)
-print(f"Area: {circle.area():.2f}")
-print(f"Circumference: {circle.circumference():.2f}")
-</document>
-<prompt>
-write docs
-</prompt>
-</input>
-
-<incorrect_output failure="Over-generation. The text starting with `class Circle:` is *after* the rewrite_this tag">
-"""
-Represents a circle with methods to calculate its area and circumference.
-
-This class provides a simple way to work with circles in a geometric context.
-It allows for the creation of Circle objects with a specified radius and
-offers methods to compute the circle's area and circumference.
-
-Attributes:
-    radius (float): The radius of the circle.
-
-Methods:
-    area(): Calculates and returns the area of the circle.
-    circumference(): Calculates and returns the circumference of the circle.
-"""
-class Circle:
-</incorrect_output>
-<corrected_output improvement="Generation stops before repeating content after the rewrite_this section">
-"""
-Represents a circle with methods to calculate its area and circumference.
-
-This class provides a simple way to work with circles in a geometric context.
-It allows for the creation of Circle objects with a specified radius and
-offers methods to compute the circle's area and circumference.
-
-Attributes:
-    radius (float): The radius of the circle.
-
-Methods:
-    area(): Calculates and returns the area of the circle.
-    circumference(): Calculates and returns the circumference of the circle.
-"""
-</corrected_output>
-</example>
-
-<example>
-<input>
-<document>
-class BankAccount {
-  private balance: number;
-
-  constructor(initialBalance: number) {
-    this.balance = initialBalance;
-  }
-
-  <rewrite_this>
-  <insert_here></insert_here>
-  </rewrite_this>
-  deposit(amount: number): void {
-    if (amount > 0) {
-      this.balance += amount;
-    }
-  }
-
-  withdraw(amount: number): boolean {
-    if (amount > 0 && this.balance >= amount) {
-      this.balance -= amount;
-      return true;
-    }
-    return false;
-  }
-
-  getBalance(): number {
-    return this.balance;
-  }
-}
-
-// Usage
-const account = new BankAccount(1000);
-account.deposit(500);
-console.log(account.getBalance()); // 1500
-account.withdraw(200);
-console.log(account.getBalance()); // 1300
-</document>
-<prompt>
-//
-</prompt>
-</input>
-
-<incorrect_output failure="Over-generation. The text starting with `deposit(amount: number): void {` is *after* the rewrite_this tag">
-  /**
-   * Deposits the specified amount into the bank account.
-   *
-   * @param amount The amount to deposit. Must be a positive number.
-   * @throws Error if the amount is not positive.
-   */
-  deposit(amount: number): void {
-    if (amount > 0) {
-      this.balance += amount;
-    } else {
-      throw new Error("Deposit amount must be positive");
-    }
-  }
-</incorrect_output>
-<corrected_output improvement="Generation stops before repeating content after the rewrite_this section">
-  /**
-   * Deposits the specified amount into the bank account.
-   *
-   * @param amount The amount to deposit. Must be a positive number.
-   * @throws Error if the amount is not positive.
-   */
-</corrected_output>
-</example>
-
-<example>
-<input>
-<document>
-use std::collections::VecDeque;
-
-pub struct BinaryTree<T> {
-    root: Option<Node<T>>,
-}
-
-<rewrite_this>
-<insert_here></insert_here>
-</rewrite_this>
-struct Node<T> {
-    value: T,
-    left: Option<Box<Node<T>>>,
-    right: Option<Box<Node<T>>>,
-}
-</document>
-<prompt>
-derive clone
-</prompt>
-</input>
-
-<incorrect_output failure="Over-generation below the rewrite_this tags. Extra space between derive annotation and struct definition.">
-#[derive(Clone)]
-
-struct Node<T> {
-    value: T,
-    left: Option<Box<Node<T>>>,
-    right: Option<Box<Node<T>>>,
-}
-</incorrect_output>
-
-<incorrect_output failure="Over-generation above the rewrite_this tags">
-pub struct BinaryTree<T> {
-    root: Option<Node<T>>,
-}
-
-#[derive(Clone)]
-</incorrect_output>
-
-<incorrect_output failure="Over-generation below the rewrite_this tags">
-#[derive(Clone)]
-struct Node<T> {
-    value: T,
-    left: Option<Box<Node<T>>>,
-    right: Option<Box<Node<T>>>,
-}
-
-impl<T> Node<T> {
-    fn new(value: T) -> Self {
-        Node {
-            value,
-            left: None,
-            right: None,
-        }
-    }
-}
-</incorrect_output>
-<corrected_output improvement="Only includes the new content within the rewrite_this tags">
-#[derive(Clone)]
-</corrected_output>
-</example>
-
-<example>
-<input>
-<document>
-import math
-
-def calculate_circle_area(radius):
-    """Calculate the area of a circle given its radius."""
-    return math.pi * radius ** 2
-
-<rewrite_this>
-<insert_here></insert_here>
-</rewrite_this>
-class Circle:
-    def __init__(self, radius):
-        self.radius = radius
-
-    def area(self):
-        return math.pi * self.radius ** 2
-
-    def circumference(self):
-        return 2 * math.pi * self.radius
-
-# Usage example
-circle = Circle(5)
-print(f"Area: {circle.area():.2f}")
-print(f"Circumference: {circle.circumference():.2f}")
-</document>
-<prompt>
-add dataclass decorator
-</prompt>
-</input>
-
-<incorrect_output failure="Over-generation. The text starting with `class Circle:` is *after* the rewrite_this tag">
-@dataclass
-class Circle:
-    radius: float
-
-    def __init__(self, radius):
-        self.radius = radius
-
-    def area(self):
-        return math.pi * self.radius ** 2
-</incorrect_output>
-<corrected_output improvement="Generation stops before repeating content after the rewrite_this section">
-@dataclass
-</corrected_output>
-</example>
-
-<example>
-<input>
-<document>
-interface ShoppingCart {
-  items: string[];
-  total: number;
-}
-
-<rewrite_this>
-<insert_here></insert_here>class ShoppingCartManager {
-</rewrite_this>
-  private cart: ShoppingCart;
-
-  constructor() {
-    this.cart = { items: [], total: 0 };
-  }
-
-  addItem(item: string, price: number): void {
-    this.cart.items.push(item);
-    this.cart.total += price;
-  }
-
-  getTotal(): number {
-    return this.cart.total;
-  }
-}
-
-// Usage
-const manager = new ShoppingCartManager();
-manager.addItem("Book", 15.99);
-console.log(manager.getTotal()); // 15.99
-</document>
-<prompt>
-add readonly modifier
-</prompt>
-</input>
-
-<incorrect_output failure="Over-generation. The line starting with `    items: string[];` is *after* the rewrite_this tag">
-readonly interface ShoppingCart {
-  items: string[];
-  total: number;
-}
-
-class ShoppingCartManager {
-  private readonly cart: ShoppingCart;
-
-  constructor() {
-    this.cart = { items: [], total: 0 };
-  }
-</incorrect_output>
-<corrected_output improvement="Only includes the new content within the rewrite_this tags and integrates cleanly into surrounding code">
-readonly interface ShoppingCart {
-</corrected_output>
-</example>
-
-</examples>
-
-With these examples in mind, edit the following file:
-
-<document language="{{ language_name }}">
-{{{ document_content }}}
+{{{document_content}}}
 </document>
 
 {{#if is_truncated}}
-The provided document has been truncated (potentially mid-line) for brevity.
+The context around the relevant section has been truncated (possibly in the middle of a line) for brevity.
 {{/if}}
 
-<instructions>
-{{#if has_insertion}}
-Insert text anywhere you see marked with <insert_here></insert_here> tags. It's CRITICAL that you DO NOT include <insert_here> tags in your output.
-{{/if}}
-{{#if has_replacement}}
-Edit text that you see surrounded with <edit_here>...</edit_here> tags. It's CRITICAL that you DO NOT include <edit_here> tags in your output.
-{{/if}}
-Make no changes to the rewritten content outside these tags.
+{{#if is_insert}}
+You can't replace {{content_type}}, your answer will be inserted in place of the `<insert_here></insert_here>` tags. Don't include the insert_here tags in your output.
 
-<snippet language="{{ language_name }}" annotated="true">
-{{{ rewrite_section_prefix }}}
-<rewrite_this>
-{{{ rewrite_section_with_edits }}}
-</rewrite_this>
-{{{ rewrite_section_suffix }}}
-</snippet>
-
-Rewrite the lines enclosed within the <rewrite_this></rewrite_this> tags in accordance with the provided instructions and the prompt below.
+Generate {{content_type}} based on the following prompt:
 
 <prompt>
-{{{ user_prompt }}}
+{{{user_prompt}}}
 </prompt>
 
-Do not include <insert_here> or <edit_here> annotations in your output. Here is a clean copy of the snippet without annotations for your reference.
+Match the indentation in the original file in the inserted {{content_type}}, don't include any indentation on blank lines.
 
-<snippet>
-{{{ rewrite_section_prefix }}}
-{{{ rewrite_section }}}
-{{{ rewrite_section_suffix }}}
-</snippet>
-</instructions>
+Immediately start with the following format with no remarks:
 
-<guidelines_reminder>
-1. Focus on necessary changes: Modify only what's required to fulfill the prompt.
-2. Preserve context: Maintain all surrounding content as-is, ensuring the rewritten section seamlessly integrates with the existing document structure and flow.
-3. Exclude annotation tags: Do not output <rewrite_this>, </rewrite_this>, <edit_here>, or <insert_here> tags.
-4. Maintain indentation: Begin at the original file's indentation level.
-5. Complete rewrite: Continue until the entire section is rewritten, even if no further changes are needed.
-6. Avoid elisions: Always write out the full section without unnecessary omissions. NEVER say `// ...` or `// ...existing code` in your output.
-7. Respect content boundaries: Preserve code integrity.
-</guidelines_reminder>
+```
+\{{INSERTED_CODE}}
+```
+{{else}}
+Edit the section of {{content_type}} in <rewrite_this></rewrite_this> tags based on the following prompt:
+
+<prompt>
+{{{user_prompt}}}
+</prompt>
+
+{{#if rewrite_section}}
+And here's the section to rewrite based on that prompt again for reference:
+
+<rewrite_this>
+{{{rewrite_section}}}
+</rewrite_this>
+{{/if}}
+
+Only make changes that are necessary to fulfill the prompt, leave everything else as-is. All surrounding {{content_type}} will be preserved.
+
+Start at the indentation level in the original file in the rewritten {{content_type}}. Don't stop until you've rewritten the entire section, even if you have no more changes to make, always write out the whole section with no unnecessary elisions.
 
 Immediately start with the following format with no remarks:
 
 ```
 \{{REWRITTEN_CODE}}
 ```
+{{/if}}

--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -12,15 +12,11 @@ use util::ResultExt;
 pub struct ContentPromptContext {
     pub content_type: String,
     pub language_name: Option<String>,
+    pub is_insert: bool,
     pub is_truncated: bool,
     pub document_content: String,
     pub user_prompt: String,
-    pub rewrite_section: String,
-    pub rewrite_section_prefix: String,
-    pub rewrite_section_suffix: String,
-    pub rewrite_section_with_edits: String,
-    pub has_insertion: bool,
-    pub has_replacement: bool,
+    pub rewrite_section: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -46,54 +42,41 @@ pub struct PromptBuilder {
     handlebars: Arc<Mutex<Handlebars<'static>>>,
 }
 
-pub struct PromptOverrideContext<'a> {
-    pub dev_mode: bool,
-    pub fs: Arc<dyn Fs>,
-    pub cx: &'a mut gpui::AppContext,
-}
-
 impl PromptBuilder {
-    pub fn new(override_cx: Option<PromptOverrideContext>) -> Result<Self, Box<TemplateError>> {
+    pub fn new(
+        fs_and_cx: Option<(Arc<dyn Fs>, &gpui::AppContext)>,
+    ) -> Result<Self, Box<TemplateError>> {
         let mut handlebars = Handlebars::new();
         Self::register_templates(&mut handlebars)?;
 
         let handlebars = Arc::new(Mutex::new(handlebars));
 
-        if let Some(override_cx) = override_cx {
-            Self::watch_fs_for_template_overrides(override_cx, handlebars.clone());
+        if let Some((fs, cx)) = fs_and_cx {
+            Self::watch_fs_for_template_overrides(fs, cx, handlebars.clone());
         }
 
         Ok(Self { handlebars })
     }
 
     fn watch_fs_for_template_overrides(
-        PromptOverrideContext { dev_mode, fs, cx }: PromptOverrideContext,
+        fs: Arc<dyn Fs>,
+        cx: &gpui::AppContext,
         handlebars: Arc<Mutex<Handlebars<'static>>>,
     ) {
+        let templates_dir = paths::prompt_overrides_dir();
+
         cx.background_executor()
             .spawn(async move {
-                let templates_dir = if dev_mode {
-                    std::env::current_dir()
-                        .ok()
-                        .and_then(|pwd| {
-                            let pwd_assets_prompts = pwd.join("assets").join("prompts");
-                            pwd_assets_prompts.exists().then_some(pwd_assets_prompts)
-                        })
-                        .unwrap_or_else(|| paths::prompt_overrides_dir().clone())
-                } else {
-                    paths::prompt_overrides_dir().clone()
-                };
-
                 // Create the prompt templates directory if it doesn't exist
-                if !fs.is_dir(&templates_dir).await {
-                    if let Err(e) = fs.create_dir(&templates_dir).await {
+                if !fs.is_dir(templates_dir).await {
+                    if let Err(e) = fs.create_dir(templates_dir).await {
                         log::error!("Failed to create prompt templates directory: {}", e);
                         return;
                     }
                 }
 
                 // Initial scan of the prompts directory
-                if let Ok(mut entries) = fs.read_dir(&templates_dir).await {
+                if let Ok(mut entries) = fs.read_dir(templates_dir).await {
                     while let Some(Ok(file_path)) = entries.next().await {
                         if file_path.to_string_lossy().ends_with(".hbs") {
                             if let Ok(content) = fs.load(&file_path).await {
@@ -121,7 +104,7 @@ impl PromptBuilder {
                 }
 
                 // Watch for changes
-                let (mut changes, watcher) = fs.watch(&templates_dir, Duration::from_secs(1)).await;
+                let (mut changes, watcher) = fs.watch(templates_dir, Duration::from_secs(1)).await;
                 while let Some(changed_paths) = changes.next().await {
                     for changed_path in changed_paths {
                         if changed_path.extension().map_or(false, |ext| ext == "hbs") {
@@ -173,9 +156,7 @@ impl PromptBuilder {
         user_prompt: String,
         language_name: Option<&str>,
         buffer: BufferSnapshot,
-        transform_range: Range<usize>,
-        selected_ranges: Vec<Range<usize>>,
-        transform_context_range: Range<usize>,
+        range: Range<usize>,
     ) -> Result<String, RenderError> {
         let content_type = match language_name {
             None | Some("Markdown" | "Plain Text") => "text",
@@ -183,20 +164,21 @@ impl PromptBuilder {
         };
 
         const MAX_CTX: usize = 50000;
+        let is_insert = range.is_empty();
         let mut is_truncated = false;
 
-        let before_range = 0..transform_range.start;
+        let before_range = 0..range.start;
         let truncated_before = if before_range.len() > MAX_CTX {
             is_truncated = true;
-            transform_range.start - MAX_CTX..transform_range.start
+            range.start - MAX_CTX..range.start
         } else {
             before_range
         };
 
-        let after_range = transform_range.end..buffer.len();
+        let after_range = range.end..buffer.len();
         let truncated_after = if after_range.len() > MAX_CTX {
             is_truncated = true;
-            transform_range.end..transform_range.end + MAX_CTX
+            range.end..range.end + MAX_CTX
         } else {
             after_range
         };
@@ -205,74 +187,37 @@ impl PromptBuilder {
         for chunk in buffer.text_for_range(truncated_before) {
             document_content.push_str(chunk);
         }
-
-        document_content.push_str("<rewrite_this>\n");
-        for chunk in buffer.text_for_range(transform_range.clone()) {
-            document_content.push_str(chunk);
+        if is_insert {
+            document_content.push_str("<insert_here></insert_here>");
+        } else {
+            document_content.push_str("<rewrite_this>\n");
+            for chunk in buffer.text_for_range(range.clone()) {
+                document_content.push_str(chunk);
+            }
+            document_content.push_str("\n</rewrite_this>");
         }
-        document_content.push_str("\n</rewrite_this>");
-
         for chunk in buffer.text_for_range(truncated_after) {
             document_content.push_str(chunk);
         }
 
-        let mut rewrite_section = String::new();
-        for chunk in buffer.text_for_range(transform_range.clone()) {
-            rewrite_section.push_str(chunk);
-        }
-
-        let mut rewrite_section_prefix = String::new();
-        for chunk in buffer.text_for_range(transform_context_range.start..transform_range.start) {
-            rewrite_section_prefix.push_str(chunk);
-        }
-
-        let mut rewrite_section_suffix = String::new();
-        for chunk in buffer.text_for_range(transform_range.end..transform_context_range.end) {
-            rewrite_section_suffix.push_str(chunk);
-        }
-
-        let rewrite_section_with_edits = {
-            let mut section_with_selections = String::new();
-            let mut last_end = 0;
-            for selected_range in &selected_ranges {
-                if selected_range.start > last_end {
-                    section_with_selections.push_str(
-                        &rewrite_section[last_end..selected_range.start - transform_range.start],
-                    );
-                }
-                if selected_range.start == selected_range.end {
-                    section_with_selections.push_str("<insert_here></insert_here>");
-                } else {
-                    section_with_selections.push_str("<edit_here>");
-                    section_with_selections.push_str(
-                        &rewrite_section[selected_range.start - transform_range.start
-                            ..selected_range.end - transform_range.start],
-                    );
-                    section_with_selections.push_str("</edit_here>");
-                }
-                last_end = selected_range.end - transform_range.start;
+        let rewrite_section = if !is_insert {
+            let mut section = String::new();
+            for chunk in buffer.text_for_range(range.clone()) {
+                section.push_str(chunk);
             }
-            if last_end < rewrite_section.len() {
-                section_with_selections.push_str(&rewrite_section[last_end..]);
-            }
-            section_with_selections
+            Some(section)
+        } else {
+            None
         };
-
-        let has_insertion = selected_ranges.iter().any(|range| range.start == range.end);
-        let has_replacement = selected_ranges.iter().any(|range| range.start != range.end);
 
         let context = ContentPromptContext {
             content_type: content_type.to_string(),
             language_name: language_name.map(|s| s.to_string()),
+            is_insert,
             is_truncated,
             document_content,
             user_prompt,
             rewrite_section,
-            rewrite_section_prefix,
-            rewrite_section_suffix,
-            rewrite_section_with_edits,
-            has_insertion,
-            has_replacement,
         };
 
         self.handlebars.lock().render("content_prompt", &context)

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -187,12 +187,7 @@ fn init_common(app_state: Arc<AppState>, cx: &mut AppContext) -> Arc<PromptBuild
     );
     snippet_provider::init(cx);
     inline_completion_registry::init(app_state.client.telemetry().clone(), cx);
-    let prompt_builder = assistant::init(
-        app_state.fs.clone(),
-        app_state.client.clone(),
-        stdout_is_a_pty(),
-        cx,
-    );
+    let prompt_builder = assistant::init(app_state.fs.clone(), app_state.client.clone(), cx);
     repl::init(
         app_state.fs.clone(),
         app_state.client.telemetry().clone(),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1018,8 +1018,6 @@ fn open_settings_file(
 
 #[cfg(test)]
 mod tests {
-    use crate::stdout_is_a_pty;
-
     use super::*;
     use anyhow::anyhow;
     use assets::Assets;
@@ -3487,12 +3485,8 @@ mod tests {
                 app_state.fs.clone(),
                 cx,
             );
-            let prompt_builder = assistant::init(
-                app_state.fs.clone(),
-                app_state.client.clone(),
-                stdout_is_a_pty(),
-                cx,
-            );
+            let prompt_builder =
+                assistant::init(app_state.fs.clone(), app_state.client.clone(), cx);
             repl::init(
                 app_state.fs.clone(),
                 app_state.client.telemetry().clone(),


### PR DESCRIPTION
This PR reverts #16145 and subsequent changes.

This reverts commit a515442a365229155cde3de946e1b3eb244c0d36.

We still have issues with our approach to indentation in Python unfortunately, but this feels like a safer equilibrium than where we were.

Release Notes:

- Returned to our previous prompt for inline assist transformations, since recent changes were introducing issues.
