### PR TITLE
windows: Treat `pwsh` as `PowerShell`

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -891,7 +891,11 @@ fn to_windows_shell_variable(shell_type: WindowsShellType, input: String) -> Str
 
 #[cfg(target_os = "windows")]
 fn to_windows_shell_type(shell: &str) -> WindowsShellType {
-    if shell == "powershell" || shell.ends_with("powershell.exe") {
+    if shell == "powershell"
+        || shell.ends_with("powershell.exe")
+        || shell == "pwsh"
+        || shell.ends_with("pwsh.exe")
+    {
         WindowsShellType::Powershell
     } else if shell == "cmd" || shell.ends_with("cmd.exe") {
         WindowsShellType::Cmd


### PR DESCRIPTION
`pwsh` is the newer version of `PowerShell`, while the one that comes pre-installed on Windows is called `Windows PowerShell` and is an older version. I have no idea why Microsoft dose this and not updated the `Windows Powershell` on Windows.

Release Notes:

- N/A
