### PR TITLE
assistant: Remove meta description from quote selection tooltip

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3745,17 +3745,15 @@ impl Render for ContextEditor {
                                         })
                                         .tooltip(move |cx| {
                                             cx.new_view(|cx| {
-                                                Tooltip::new("Insert Selection")
-                                                    .meta("Press to quote via keyboard")
-                                                    .key_binding(focus_handle.as_ref().and_then(
-                                                        |handle| {
-                                                            KeyBinding::for_action_in(
-                                                                &QuoteSelection,
-                                                                &handle,
-                                                                cx,
-                                                            )
-                                                        },
-                                                    ))
+                                                Tooltip::new("Insert Selection").key_binding(
+                                                    focus_handle.as_ref().and_then(|handle| {
+                                                        KeyBinding::for_action_in(
+                                                            &QuoteSelection,
+                                                            &handle,
+                                                            cx,
+                                                        )
+                                                    }),
+                                                )
                                             })
                                             .into()
                                         }),


### PR DESCRIPTION
The original idea was for the keybinding to be within the description, but given it's already inline with the title, I figure we don't need this anymore—cleaning it up a bit!

--- 

Release Notes:

- N/A
