### PR TITLE
assistant: Add the "your-command" item in the slash picker

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -40,7 +40,7 @@ use settings::{update_settings_file, Settings, SettingsStore};
 use slash_command::{
     context_server_command, default_command, diagnostics_command, docs_command, fetch_command,
     file_command, now_command, project_command, prompt_command, search_command, symbols_command,
-    tab_command, terminal_command, workflow_command,
+    tab_command, terminal_command, workflow_command, your_command,
 };
 use std::sync::Arc;
 pub(crate) use streaming_diff::*;
@@ -354,6 +354,7 @@ fn register_slash_commands(prompt_builder: Option<Arc<PromptBuilder>>, cx: &mut 
     slash_command_registry.register_command(terminal_command::TerminalSlashCommand, true);
     slash_command_registry.register_command(now_command::NowSlashCommand, false);
     slash_command_registry.register_command(diagnostics_command::DiagnosticsSlashCommand, true);
+    slash_command_registry.register_command(your_command::YourSlashCommand, true);
 
     if let Some(prompt_builder) = prompt_builder {
         slash_command_registry.register_command(

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -33,6 +33,7 @@ pub mod symbols_command;
 pub mod tab_command;
 pub mod terminal_command;
 pub mod workflow_command;
+pub mod your_command;
 
 pub(crate) struct SlashCommandCompletionProvider {
     cancel_flag: Mutex<Arc<AtomicBool>>,

--- a/crates/assistant/src/slash_command/your_command.rs
+++ b/crates/assistant/src/slash_command/your_command.rs
@@ -1,0 +1,65 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use anyhow::Result;
+use assistant_slash_command::{
+    ArgumentCompletion, SlashCommand, SlashCommandOutput, SlashCommandOutputSection,
+};
+use gpui::{Task, WeakView};
+use language::LspAdapterDelegate;
+use ui::prelude::*;
+use workspace::Workspace;
+
+pub(crate) struct YourSlashCommand;
+
+impl SlashCommand for YourSlashCommand {
+    fn name(&self) -> String {
+        "your-command".into()
+    }
+
+    fn description(&self) -> String {
+        "Insert docs about creating a custom command".into()
+    }
+
+    fn menu_text(&self) -> String {
+        "Insert docs about creating a custom command".into()
+    }
+
+    fn requires_argument(&self) -> bool {
+        false
+    }
+
+    fn accepts_arguments(&self) -> bool {
+        false
+    }
+
+    fn complete_argument(
+        self: Arc<Self>,
+        _arguments: &[String],
+        _cancel: Arc<AtomicBool>,
+        _workspace: Option<WeakView<Workspace>>,
+        _cx: &mut WindowContext,
+    ) -> Task<Result<Vec<ArgumentCompletion>>> {
+        Task::ready(Ok(Vec::new()))
+    }
+
+    fn run(
+        self: Arc<Self>,
+        _arguments: &[String],
+        _workspace: WeakView<Workspace>,
+        _delegate: Option<Arc<dyn LspAdapterDelegate>>,
+        cx: &mut WindowContext,
+    ) -> Task<Result<SlashCommandOutput>> {
+        cx.open_url("https://zed.dev/docs/extensions/slash-commands");
+
+        Task::ready(Ok(SlashCommandOutput {
+            text: "Slash commands docs".to_string(),
+            sections: vec![SlashCommandOutputSection {
+                range: 0..23,
+                icon: IconName::FileDoc,
+                label: "https://zed.dev/docs/extensions/slash-commands".into(),
+            }],
+            run_commands_in_text: false,
+        }))
+    }
+}

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -143,7 +143,7 @@ impl PickerDelegate for SlashCommandDelegate {
                 .spacing(ListItemSpacing::Sparse)
                 .selected(selected)
                 .child(
-                    h_flex().w_full().min_w(px(220.)).child(
+                    h_flex().w_full().min_w(px(260.)).child(
                         v_flex()
                             .child(
                                 Label::new(format!("/{}", command_info.name))


### PR DESCRIPTION
This PR (still a work-in-progress at the moment) adds a menu item in the slash picker that takes users to the docs where they can learn how to build a custom slash command. There are still UX details to iron out, though (soon).

---

Release Notes:

- N/A
