### PR TITLE
Don’t insert \n if the file is empty

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1494,6 +1494,10 @@ impl Buffer {
     /// no other whitespace.
     pub fn ensure_final_newline(&mut self, cx: &mut ModelContext<Self>) {
         let len = self.len();
+        if len == 0 {
+            return;
+        }
+
         let mut offset = len;
         for chunk in self.as_rope().reversed_chunks_in_range(0..len) {
             let non_whitespace_len = chunk

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1497,7 +1497,6 @@ impl Buffer {
         if len == 0 {
             return;
         }
-
         let mut offset = len;
         for chunk in self.as_rope().reversed_chunks_in_range(0..len) {
             let non_whitespace_len = chunk


### PR DESCRIPTION
I found that when I save the unsaved file, zed insert a '\n' at the end of file automatically(it is fine to me). But it is meaningless to do this for an empty file.

For example, there is an empty file:
<img width="376" alt="image" src="https://github.com/user-attachments/assets/340800ed-dec2-4685-b2a8-f81dc6fd0089">
Then I press ctrl+s to save the file.
before:
<img width="280" alt="image" src="https://github.com/user-attachments/assets/cb483931-71b9-4ba6-a811-489e5a1a271e">
now:
<img width="274" alt="image" src="https://github.com/user-attachments/assets/4ff56ede-3300-4c4a-b833-5bf28843fd68">


Release Notes:

- N/A
