### PR TITLE
docs: Fix example extension directory structure

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -32,8 +32,9 @@ my-extension/
   src/
     lib.rs
   languages/
-    config.toml
-    highlights.scm
+    my-language/
+      config.toml
+      highlights.scm
   themes/
     my-theme.json
 ```


### PR DESCRIPTION
Add language-specific subdirectory in example directory structure, since that's the requisite structure - see `extensions/languages.md`

Release Notes:

- N/A