### PR TITLE
Bump heed version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5059,9 +5059,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620033c8c8edfd2f53e6f99a30565eb56a33b42c468e3ad80e21d85fb93bafb0"
+checksum = "7d4f449bab7320c56003d37732a917e18798e2f1709d80263face2b4f9436ddb"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -6316,9 +6316,9 @@ dependencies = [
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de7e761853c15ca72821d9f928d7bb123ef4c05377c4e7ab69fa1c742f91d24"
+checksum = "472c3760e2a8d0f61f322fb36788021bb36d573c502b50fa3e2bcaac3ec326c9"
 dependencies = [
  "cc",
  "doxygen-rs",


### PR DESCRIPTION
My issue:
I was not able to build it with mingw backend on windows. After investigating I realized, that whole problem is within the lmdb library of heed crate. So I went into lmdb [to fix issue there](https://git.openldap.org/openldap/openldap/-/commit/9c9d34558cc438f99aebd1ab58f83fd7faeabc0a). Later I went to heed crate, to apply those changes([here](https://github.com/meilisearch/heed/pull/269) and [here](https://github.com/meilisearch/heed/pull/276)). And now I need for zed to adapt new heed version

Release Notes:

- N/A