### PR TITLE
collab: Add `is_staff` to upstream rate limit spans

### DIFF
--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -249,6 +249,7 @@ async fn perform_completion(
             if let Some(rate_limit_info) = rate_limit_info {
                 tracing::info!(
                     target: "upstream rate limit",
+                    is_staff = claims.is_staff,
                     provider = params.provider.to_string(),
                     model = model,
                     tokens_remaining = rate_limit_info.tokens_remaining,


### PR DESCRIPTION
This PR adds the `is_staff` field to the `upstream rate limit` spans.

Since we use different API keys for staff vs non-staff, it will be useful to break down the rate limits accordingly.

Release Notes:

- N/A
