### PR TITLE
assistant: Add the "create your command" item

### DIFF
--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -228,9 +228,9 @@ impl<T: PopoverTrigger> RenderOnce for SlashCommandSelector<T> {
                                 .items_center()
                                 .gap_1()
                                 .child(div().font_buffer(cx).child(
-                                    Label::new("create-your-command").size(LabelSize::XSmall),
+                                    Label::new("create-your-command").size(LabelSize::Small),
                                 ))
-                                .child(Icon::new(IconName::ArrowUpRight).size(IconSize::Small)),
+                                .child(Icon::new(IconName::ArrowUpRight).size(IconSize::XSmall)),
                         )
                         .child(
                             Label::new("Learn how to create a custom command")

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -228,7 +228,7 @@ impl<T: PopoverTrigger> RenderOnce for SlashCommandSelector<T> {
                                 .items_center()
                                 .gap_1()
                                 .child(div().font_buffer(cx).child(
-                                    Label::new("create-your-command").size(LabelSize::Small),
+                                    Label::new("create-your-command").size(LabelSize::XSmall),
                                 ))
                                 .child(Icon::new(IconName::ArrowUpRight).size(IconSize::Small)),
                         )

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -226,8 +226,10 @@ impl<T: PopoverTrigger> RenderOnce for SlashCommandSelector<T> {
                             h_flex()
                                 .font_buffer(cx)
                                 .items_center()
-                                .gap_2()
-                                .child(Label::new("create-your-command").size(LabelSize::Small))
+                                .gap_1()
+                                .child(div().font_buffer(cx).child(
+                                    Label::new("create-your-command").size(LabelSize::Small),
+                                ))
                                 .child(Icon::new(IconName::ArrowUpRight).size(IconSize::Small)),
                         )
                         .child(

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -172,7 +172,6 @@ impl PickerDelegate for SlashCommandDelegate {
         cx: &mut ViewContext<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let command_info = self.filtered_commands.get(ix)?;
-        let theme = cx.theme();
 
         match command_info {
             SlashCommandEntry::Info(info) => Some(

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -220,10 +220,11 @@ impl<T: PopoverTrigger> RenderOnce for SlashCommandSelector<T> {
             })
             .chain([SlashCommandEntry::Advert {
                 name: "create-your-command".into(),
-                renderer: |_| {
+                renderer: |cx| {
                     v_flex()
                         .child(
                             h_flex()
+                                .font_buffer(cx)
                                 .items_center()
                                 .gap_2()
                                 .child(Label::new("create-your-command").size(LabelSize::Small))

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -524,7 +524,7 @@ impl<D: PickerDelegate> Picker<D> {
                     picker
                         .border_color(cx.theme().colors().border_variant)
                         .border_b_1()
-                        .pb(px(-1.0))
+                        .py(px(-1.0))
                 },
             )
     }


### PR DESCRIPTION
This PR adds an extra item to the slash command picker that links users to the doc that teaches how to create a custom one.

--- 

Release Notes:

- N/A
