### PR TITLE
Fix JavaScript and TypeScript HTML injections

### DIFF
--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -13,8 +13,8 @@
 
 (call_expression
   function: (identifier) @_name (#eq? @_name "html")
-  arguments: (template_string (string_fragment) @content
-                              (#set! "language" "html"))
+  arguments: (template_string) @content
+                              (#set! "language" "html")
 )
 
 (call_expression

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -17,8 +17,8 @@
 
 (call_expression
   function: (identifier) @_name (#eq? @_name "html")
-  arguments: (template_string (string_fragment) @content
-                              (#set! "language" "html"))
+  arguments: (template_string) @content
+                              (#set! "language" "html")
 )
 
 (call_expression
@@ -50,4 +50,3 @@
   arguments: (template_string (string_fragment) @content
                               (#set! "language" "yaml"))
 )
-


### PR DESCRIPTION
Fixes #16199

## Description

Recently added template string injections do not completely work for because any time there is an interpolation (`${// some js content}`) within an element, its closing tag is not highlighted properly:
![image](https://github.com/user-attachments/assets/e660894b-6e4b-4300-b8d9-2757fa235679)

This PR fixes the issue:
![image](https://github.com/user-attachments/assets/629a30c3-9b3a-4338-aee9-622dbb19581c)

Release Notes:

- Fixed incomplete syntax highlighting for HTML injections inside JavaScript template tags.

## Note

I'm a beginner with treesitter so I only modified the part for HTML usecase. 
Should the same solution be applied to other injections (`css`, `js`, etc.)?
