### PR TITLE
elixir: Bump to v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13988,7 +13988,7 @@ dependencies = [
 
 [[package]]
 name = "zed_elixir"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "zed_extension_api 0.0.6",
 ]

--- a/extensions/elixir/Cargo.toml
+++ b/extensions/elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_elixir"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/elixir/extension.toml
+++ b/extensions/elixir/extension.toml
@@ -1,7 +1,7 @@
 id = "elixir"
 name = "Elixir"
 description = "Elixir support."
-version = "0.0.7"
+version = "0.0.8"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Elixir extension to v0.0.8.

Changes:

- #16382

Release Notes:

- N/A
