### PR TITLE
Add Postgrest to Docker Compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -33,5 +33,31 @@ services:
     volumes:
       - ./livekit.yaml:/livekit.yaml
 
+  postgrest_app:
+    image: postgrest/postgrest
+    container_name: postgrest_app
+    ports:
+      - 8081:8081
+    environment:
+      PGRST_DB_URI: postgres://postgres@postgres:5432/zed
+    volumes:
+      - ./crates/collab/postgrest_app.conf:/etc/postgrest.conf
+    command: postgrest /etc/postgrest.conf
+    depends_on:
+      - postgres
+
+  postgrest_llm:
+    image: postgrest/postgrest
+    container_name: postgrest_llm
+    ports:
+      - 8082:8082
+    environment:
+      PGRST_DB_URI: postgres://postgres@postgres:5432/zed_llm
+    volumes:
+      - ./crates/collab/postgrest_llm.conf:/etc/postgrest.conf
+    command: postgrest /etc/postgrest.conf
+    depends_on:
+      - postgres
+
 volumes:
   postgres_data:

--- a/crates/collab/postgrest_app.conf
+++ b/crates/collab/postgrest_app.conf
@@ -1,4 +1,4 @@
-db-uri = "postgres://postgres@localhost/zed_llm"
-server-port = 8082
+db-uri = "postgres://postgres@localhost/zed"
+server-port = 8081
 jwt-secret = "the-postgrest-jwt-secret-for-authorization"
 log-level = "info"

--- a/crates/collab/postgrest_llm.conf
+++ b/crates/collab/postgrest_llm.conf
@@ -1,4 +1,4 @@
-db-uri = "postgres://postgres@localhost/zed"
-server-port = 8081
+db-uri = "postgres://postgres@localhost/zed_llm"
+server-port = 8082
 jwt-secret = "the-postgrest-jwt-secret-for-authorization"
 log-level = "info"


### PR DESCRIPTION
This PR adds two Postgrest containers—one for the app database and one for the LLM database—to the Docker Compose cluster.

Also fixed an issue where `postgres_app.conf` and `postgres_llm.conf` had been switched.

Release Notes:

- N/A
