### PR TITLE
repl: Upgrade runtimelib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9058,9 +9058,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d817764e3971867351e6103955b17d808f5330e9ef63aaaaab55bf8c664c1"
+checksum = "a7d76d28b882a7b889ebb04e79bc2b160b3061821ea596ff0f4a838fc7a76db0"
 dependencies = [
  "anyhow",
  "async-dispatcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,7 +383,7 @@ rand = "0.8.5"
 regex = "1.5"
 repair_json = "0.1.0"
 rsa = "0.9.6"
-runtimelib = { version = "0.14", default-features = false, features = [
+runtimelib = { version = "0.15", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }
 rusqlite = { version = "0.29.0", features = ["blob", "array", "modern_sqlite"] }


### PR DESCRIPTION
Upgrades runtimelib to bring in some fixes from https://github.com/runtimed/runtimed/pull/114 and https://github.com/runtimed/runtimed/pull/113 that work towards addressing issues interfacing with the Julia kernel.

Release Notes:

- N/A
