### PR TITLE
Implement basic font-width support

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1901,6 +1901,7 @@ impl PromptEditor {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.ui_font.weight,
+            font_width: settings.ui_font.width,
             line_height: relative(1.3),
             ..Default::default()
         };

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -910,6 +910,7 @@ impl PromptLibrary {
                                                             .size()
                                                             .into(),
                                                         font_weight: settings.ui_font.weight,
+                                                        font_width: settings.ui_font.width,
                                                         line_height: relative(
                                                             settings.buffer_line_height.value(),
                                                         ),

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -924,6 +924,7 @@ impl PromptEditor {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.ui_font.weight,
+            font_width: settings.ui_font.width,
             line_height: relative(1.3),
             ..Default::default()
         };

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -64,6 +64,7 @@ impl Render for Breadcrumbs {
                 text_style.font_features = font.features;
                 text_style.font_style = font.style;
                 text_style.font_weight = font.weight;
+                text_style.font_width = font.width;
             }
             text_style.color = Color::Muted.color(cx);
 

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -535,6 +535,7 @@ impl Render for MessageEditor {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: TextSize::Small.rems(cx).into(),
             font_weight: settings.ui_font.weight,
+            font_width: settings.ui_font.width,
             font_style: FontStyle::Normal,
             line_height: relative(1.3),
             ..Default::default()

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2193,6 +2193,7 @@ impl CollabPanel {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.ui_font.weight,
+            font_width: settings.ui_font.width,
             font_style: FontStyle::Normal,
             line_height: relative(1.3),
             ..Default::default()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12535,6 +12535,7 @@ impl Render for Editor {
                 font_fallbacks: settings.ui_font.fallbacks.clone(),
                 font_size: rems(0.875).into(),
                 font_weight: settings.ui_font.weight,
+                font_width: settings.ui_font.width,
                 line_height: relative(settings.buffer_line_height.value()),
                 ..Default::default()
             },
@@ -12545,6 +12546,7 @@ impl Render for Editor {
                 font_fallbacks: settings.buffer_font.fallbacks.clone(),
                 font_size: settings.buffer_font_size(cx).into(),
                 font_weight: settings.buffer_font.weight,
+                font_width: settings.buffer_font.width,
                 line_height: relative(settings.buffer_line_height.value()),
                 ..Default::default()
             },
@@ -12955,6 +12957,7 @@ pub fn diagnostic_block_renderer(
         text_style.font_style = theme_settings.buffer_font.style;
         text_style.font_features = theme_settings.buffer_font.features.clone();
         text_style.font_weight = theme_settings.buffer_font.weight;
+        text_style.font_width = theme_settings.buffer_font.width;
 
         let multi_line_diagnostic = diagnostic.message.contains('\n');
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -522,6 +522,7 @@ async fn parse_blocks(
             let mut base_style = cx.text_style();
             base_style.refine(&TextStyleRefinement {
                 font_family: Some(buffer_font_family.clone()),
+                font_width: Some(settings.buffer_font.width),
                 color: Some(cx.theme().colors().editor_foreground),
                 ..Default::default()
             });

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -5,7 +5,9 @@ use crate::{
     display_map::{DisplayMap, DisplaySnapshot, ToDisplayPoint},
     DisplayPoint, Editor, EditorMode, FoldPlaceholder, MultiBuffer,
 };
-use gpui::{Context, Font, FontFeatures, FontStyle, FontWeight, Model, Pixels, ViewContext};
+use gpui::{
+    Context, Font, FontFeatures, FontStyle, FontWeight, FontWidth, Model, Pixels, ViewContext,
+};
 use project::Project;
 use util::test::{marked_text_offsets, marked_text_ranges};
 
@@ -29,6 +31,7 @@ pub fn marked_display_snapshot(
         features: FontFeatures::default(),
         fallbacks: None,
         weight: FontWeight::default(),
+        width: FontWidth::default(),
         style: FontStyle::default(),
     };
     let font_size: Pixels = 14usize.into();

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -819,6 +819,7 @@ impl ExtensionsPage {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.ui_font.weight,
+            font_width: settings.ui_font.width,
             line_height: relative(1.3),
             ..Default::default()
         };

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -513,7 +513,7 @@ fn font_into_properties(font: &crate::Font) -> font_kit::properties::Properties 
             crate::FontStyle::Oblique => font_kit::properties::Style::Oblique,
         },
         weight: font_kit::properties::Weight(font.weight.0),
-        stretch: Default::default(),
+        stretch: font.width.into(),
     }
 }
 

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     black, phi, point, quad, rems, size, AbsoluteLength, Bounds, ContentMask, Corners,
     CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, Hsla, Length, Pixels, Point,
+    FontFallbacks, FontFeatures, FontStyle, FontWeight, FontWidth, Hsla, Length, Pixels, Point,
     PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, WindowContext,
 };
 use collections::HashSet;
@@ -310,6 +310,9 @@ pub struct TextStyle {
     /// The font style, e.g. italic
     pub font_style: FontStyle,
 
+    /// The font width, e.g. expanded
+    pub font_width: FontWidth,
+
     /// The background color of the text
     pub background_color: Option<Hsla>,
 
@@ -341,6 +344,7 @@ impl Default for TextStyle {
             line_height: phi(),
             font_weight: FontWeight::default(),
             font_style: FontStyle::default(),
+            font_width: FontWidth::default(),
             background_color: None,
             underline: None,
             strikethrough: None,
@@ -358,6 +362,9 @@ impl TextStyle {
         }
         if let Some(style) = style.font_style {
             self.font_style = style;
+        }
+        if let Some(width) = style.font_width {
+            self.font_width = width;
         }
 
         if let Some(color) = style.color {
@@ -391,6 +398,7 @@ impl TextStyle {
             fallbacks: self.font_fallbacks.clone(),
             weight: self.font_weight,
             style: self.font_style,
+            width: self.font_width,
         }
     }
 
@@ -409,6 +417,7 @@ impl TextStyle {
                 fallbacks: self.font_fallbacks.clone(),
                 weight: self.font_weight,
                 style: self.font_style,
+                width: self.font_width,
             },
             color: self.color,
             background_color: self.background_color,
@@ -431,6 +440,9 @@ pub struct HighlightStyle {
     /// The font style, e.g. italic
     pub font_style: Option<FontStyle>,
 
+    /// The font width, e.g. expanded
+    pub font_width: Option<FontWidth>,
+
     /// The background color of the text
     pub background_color: Option<Hsla>,
 
@@ -451,6 +463,7 @@ impl Hash for HighlightStyle {
         self.color.hash(state);
         self.font_weight.hash(state);
         self.font_style.hash(state);
+        self.font_width.hash(state);
         self.background_color.hash(state);
         self.underline.hash(state);
         self.strikethrough.hash(state);
@@ -760,6 +773,7 @@ impl From<&TextStyle> for HighlightStyle {
             color: Some(other.color),
             font_weight: Some(other.font_weight),
             font_style: Some(other.font_style),
+            font_width: Some(other.font_width),
             background_color: other.background_color,
             underline: other.underline,
             strikethrough: other.strikethrough,

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,9 +1,9 @@
-use crate::TextStyleRefinement;
 use crate::{
     self as gpui, px, relative, rems, AbsoluteLength, AlignItems, CursorStyle, DefiniteLength,
     Fill, FlexDirection, FlexWrap, Font, FontStyle, FontWeight, Hsla, JustifyContent, Length,
     SharedString, StyleRefinement, WhiteSpace,
 };
+use crate::{FontWidth, TextStyleRefinement};
 pub use gpui_macros::{
     border_style_methods, box_shadow_style_methods, cursor_style_methods, margin_style_methods,
     overflow_style_methods, padding_style_methods, position_style_methods,
@@ -325,6 +325,14 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Set the font width of this element, this value cascades to its child elements.
+    fn font_width(mut self, width: FontWidth) -> Self {
+        self.text_style()
+            .get_or_insert_with(Default::default)
+            .font_width = Some(width);
+        self
+    }
+
     /// Set the background color of this element, this value cascades to its child elements.
     fn text_bg(mut self, bg: impl Into<Hsla>) -> Self {
         self.text_style()
@@ -509,6 +517,7 @@ pub trait Styled: Sized {
             fallbacks,
             weight,
             style,
+            width,
         } = font;
 
         let text_style = self.text_style().get_or_insert_with(Default::default);
@@ -516,6 +525,7 @@ pub trait Styled: Sized {
         text_style.font_features = Some(features);
         text_style.font_weight = Some(weight);
         text_style.font_style = Some(style);
+        text_style.font_width = Some(width);
         text_style.font_fallbacks = fallbacks;
 
         self

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -629,6 +629,52 @@ impl Display for FontStyle {
     }
 }
 
+/// The font width, from 0.5 to 2.0.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Deserialize, Serialize, JsonSchema)]
+pub struct FontWidth(pub f32);
+
+impl Default for FontWidth {
+    #[inline]
+    fn default() -> Self {
+        Self::NORMAL
+    }
+}
+
+impl Hash for FontWidth {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u32(u32::from_be_bytes(self.0.to_be_bytes()));
+    }
+}
+
+impl Eq for FontWidth {}
+
+impl FontWidth {
+    /// Ultra-condensed width (50%), the narrowest possible.
+    pub const ULTRA_CONDENSED: FontWidth = FontWidth(0.5);
+    /// Extra-condensed width (62.5%).
+    pub const EXTRA_CONDENSED: FontWidth = FontWidth(0.625);
+    /// Condensed width (75%).
+    pub const CONDENSED: FontWidth = FontWidth(0.75);
+    /// Semi-condensed width (87.5%).
+    pub const SEMI_CONDENSED: FontWidth = FontWidth(0.875);
+    /// Normal width (100%).
+    pub const NORMAL: FontWidth = FontWidth(1.0);
+    /// Semi-expanded width (112.5%).
+    pub const SEMI_EXPANDED: FontWidth = FontWidth(1.125);
+    /// Expanded width (125%).
+    pub const EXPANDED: FontWidth = FontWidth(1.25);
+    /// Extra-expanded width (150%).
+    pub const EXTRA_EXPANDED: FontWidth = FontWidth(1.5);
+    /// Ultra-expanded width (200%), the widest possible.
+    pub const ULTRA_EXPANDED: FontWidth = FontWidth(2.0);
+}
+
+impl From<FontWidth> for font_kit::properties::Stretch {
+    fn from(value: FontWidth) -> Self {
+        Self(value.0)
+    }
+}
+
 /// A styled run of text, for use in [`TextLayout`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextRun {
@@ -692,6 +738,9 @@ pub struct Font {
 
     /// The font style.
     pub style: FontStyle,
+
+    /// The font width.
+    pub width: FontWidth,
 }
 
 /// Get a [`Font`] for a given name.
@@ -702,6 +751,7 @@ pub fn font(family: impl Into<SharedString>) -> Font {
         weight: FontWeight::default(),
         style: FontStyle::default(),
         fallbacks: None,
+        width: FontWidth::default(),
     }
 }
 

--- a/crates/language/src/outline.rs
+++ b/crates/language/src/outline.rs
@@ -216,6 +216,7 @@ pub fn render_item<T>(
         font_fallbacks: settings.buffer_font.fallbacks.clone(),
         font_size: settings.buffer_font_size(cx).into(),
         font_weight: settings.buffer_font.weight,
+        font_width: settings.buffer_font.width,
         line_height: relative(1.),
         ..Default::default()
     };

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -9,8 +9,8 @@ use collections::BTreeMap;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt, TryStreamExt as _};
 use gpui::{
-    AnyView, AppContext, AsyncAppContext, FontStyle, ModelContext, Subscription, Task, TextStyle,
-    View, WhiteSpace,
+    AnyView, AppContext, AsyncAppContext, FontStyle, FontWidth, ModelContext, Subscription, Task,
+    TextStyle, View, WhiteSpace,
 };
 use http_client::HttpClient;
 use schemars::JsonSchema;
@@ -512,6 +512,7 @@ impl ConfigurationView {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.ui_font.weight,
+            font_width: FontWidth::default(),
             font_style: FontStyle::Normal,
             line_height: relative(1.3),
             background_color: None,

--- a/crates/language_model/src/provider/google.rs
+++ b/crates/language_model/src/provider/google.rs
@@ -4,8 +4,8 @@ use editor::{Editor, EditorElement, EditorStyle};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use google_ai::stream_generate_content;
 use gpui::{
-    AnyView, AppContext, AsyncAppContext, FontStyle, ModelContext, Subscription, Task, TextStyle,
-    View, WhiteSpace,
+    AnyView, AppContext, AsyncAppContext, FontStyle, FontWidth, ModelContext, Subscription, Task,
+    TextStyle, View, WhiteSpace,
 };
 use http_client::HttpClient;
 use schemars::JsonSchema;
@@ -397,6 +397,7 @@ impl ConfigurationView {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.ui_font.weight,
+            font_width: FontWidth::default(),
             font_style: FontStyle::Normal,
             line_height: relative(1.3),
             background_color: None,

--- a/crates/language_model/src/provider/open_ai.rs
+++ b/crates/language_model/src/provider/open_ai.rs
@@ -3,8 +3,8 @@ use collections::BTreeMap;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use gpui::{
-    AnyView, AppContext, AsyncAppContext, FontStyle, ModelContext, Subscription, Task, TextStyle,
-    View, WhiteSpace,
+    AnyView, AppContext, AsyncAppContext, FontStyle, FontWidth, ModelContext, Subscription, Task,
+    TextStyle, View, WhiteSpace,
 };
 use http_client::HttpClient;
 use open_ai::{
@@ -448,6 +448,7 @@ impl ConfigurationView {
             font_fallbacks: settings.ui_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.ui_font.weight,
+            font_width: FontWidth::default(),
             font_style: FontStyle::Normal,
             line_height: relative(1.3),
             background_color: None,

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -30,6 +30,7 @@ pub fn text_style(cx: &mut WindowContext) -> TextStyle {
     let font_family = settings.buffer_font.family;
     let font_features = settings.buffer_font.features;
     let font_weight = settings.buffer_font.weight;
+    let font_width = settings.buffer_font.width;
     let font_fallbacks = settings.buffer_font.fallbacks;
 
     let theme = cx.theme();
@@ -38,6 +39,7 @@ pub fn text_style(cx: &mut WindowContext) -> TextStyle {
         font_family,
         font_features,
         font_weight,
+        font_width,
         font_fallbacks,
         font_size: theme::get_buffer_font_size(cx).into(),
         font_style: FontStyle::Normal,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -117,6 +117,7 @@ impl BufferSearchBar {
             font_fallbacks: settings.buffer_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.buffer_font.weight,
+            font_width: settings.buffer_font.width,
             line_height: relative(1.3),
             ..Default::default()
         };

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1341,6 +1341,7 @@ impl ProjectSearchBar {
             font_fallbacks: settings.buffer_font.fallbacks.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.buffer_font.weight,
+            font_width: settings.buffer_font.width,
             line_height: relative(1.3),
             ..Default::default()
         };

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -1,6 +1,7 @@
 use collections::HashMap;
 use gpui::{
-    px, AbsoluteLength, AppContext, FontFallbacks, FontFeatures, FontWeight, Pixels, SharedString,
+    px, AbsoluteLength, AppContext, FontFallbacks, FontFeatures, FontWeight, FontWidth, Pixels,
+    SharedString,
 };
 use schemars::{gen::SchemaGenerator, schema::RootSchema, JsonSchema};
 use serde_derive::{Deserialize, Serialize};
@@ -30,6 +31,7 @@ pub struct TerminalSettings {
     pub font_fallbacks: Option<FontFallbacks>,
     pub font_features: Option<FontFeatures>,
     pub font_weight: Option<FontWeight>,
+    pub font_width: Option<FontWidth>,
     pub line_height: TerminalLineHeight,
     pub env: HashMap<String, String>,
     pub blinking: TerminalBlink,
@@ -123,6 +125,8 @@ pub struct TerminalSettingsContent {
     pub font_features: Option<FontFeatures>,
     /// Sets the terminal's font weight in CSS weight units 0-900.
     pub font_weight: Option<f32>,
+    /// Sets the terminal's font width in stretch from 0.5 to 2.0.
+    pub font_width: Option<f32>,
     /// Any key-value pairs added to this list will be added to the terminal's
     /// environment. Use `:` to separate multiple values.
     ///

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -634,6 +634,7 @@ impl Element for TerminalElement {
                     .clone();
 
                 let font_weight = terminal_settings.font_weight.unwrap_or_default();
+                let font_width = terminal_settings.font_width.unwrap_or_default();
 
                 let line_height = terminal_settings.line_height.value();
                 let font_size = terminal_settings.font_size;
@@ -647,6 +648,7 @@ impl Element for TerminalElement {
                     color: Some(theme.colors().link_text_hover),
                     font_weight: Some(font_weight),
                     font_style: None,
+                    font_width: None,
                     background_color: None,
                     underline: Some(UnderlineStyle {
                         thickness: px(1.0),
@@ -661,6 +663,7 @@ impl Element for TerminalElement {
                     font_family,
                     font_features,
                     font_weight,
+                    font_width,
                     font_fallbacks,
                     font_size: font_size.into(),
                     font_style: FontStyle::Normal,

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -3,8 +3,8 @@ use crate::{Appearance, SyntaxTheme, Theme, ThemeRegistry, ThemeStyleContent};
 use anyhow::Result;
 use derive_more::{Deref, DerefMut};
 use gpui::{
-    px, AppContext, Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, Global, Pixels,
-    Subscription, ViewContext, WindowContext,
+    px, AppContext, Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, FontWidth, Global,
+    Pixels, Subscription, ViewContext, WindowContext,
 };
 use refineable::Refineable;
 use schemars::{
@@ -254,6 +254,9 @@ pub struct ThemeSettingsContent {
     /// The weight of the UI font in CSS units from 100 to 900.
     #[serde(default)]
     pub ui_font_weight: Option<f32>,
+    /// The width of the UI font, from 0.5 to 2.0.
+    #[serde(default)]
+    pub ui_font_width: Option<f32>,
     /// The name of a font to use for rendering in text buffers.
     #[serde(default)]
     pub buffer_font_family: Option<String>,
@@ -266,6 +269,9 @@ pub struct ThemeSettingsContent {
     /// The weight of the editor font in CSS units from 100 to 900.
     #[serde(default)]
     pub buffer_font_weight: Option<f32>,
+    /// The width of the editor font from 0.5 to 2.0.
+    #[serde(default)]
+    pub buffer_font_width: Option<f32>,
     /// The buffer's line height.
     #[serde(default)]
     pub buffer_line_height: Option<BufferLineHeight>,
@@ -530,6 +536,7 @@ impl settings::Settings for ThemeSettings {
                     .map(|fallbacks| FontFallbacks::from_fonts(fallbacks.clone())),
                 weight: defaults.ui_font_weight.map(FontWeight).unwrap(),
                 style: Default::default(),
+                width: Default::default(),
             },
             buffer_font: Font {
                 family: defaults.buffer_font_family.as_ref().unwrap().clone().into(),
@@ -540,6 +547,7 @@ impl settings::Settings for ThemeSettings {
                     .map(|fallbacks| FontFallbacks::from_fonts(fallbacks.clone())),
                 weight: defaults.buffer_font_weight.map(FontWeight).unwrap(),
                 style: FontStyle::default(),
+                width: Default::default(),
             },
             buffer_font_size: defaults.buffer_font_size.unwrap().into(),
             buffer_line_height: defaults.buffer_line_height.unwrap(),
@@ -569,6 +577,9 @@ impl settings::Settings for ThemeSettings {
             if let Some(value) = value.buffer_font_weight {
                 this.buffer_font.weight = FontWeight(value);
             }
+            if let Some(value) = value.buffer_font_width {
+                this.buffer_font.width = FontWidth(value);
+            }
 
             if let Some(value) = value.ui_font_family.clone() {
                 this.ui_font.family = value.into();
@@ -581,6 +592,9 @@ impl settings::Settings for ThemeSettings {
             }
             if let Some(value) = value.ui_font_weight {
                 this.ui_font.weight = FontWeight(value);
+            }
+            if let Some(value) = value.ui_font_width {
+                this.ui_font.width = FontWidth(value);
             }
 
             if let Some(value) = &value.theme {

--- a/crates/ui/src/components/label/highlighted_label.rs
+++ b/crates/ui/src/components/label/highlighted_label.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use gpui::{FontWeight, HighlightStyle, StyledText};
+use gpui::{FontWeight, FontWidth, HighlightStyle, StyledText};
 
 use crate::{prelude::*, LabelCommon, LabelLike, LabelSize, LineHeightStyle};
 
@@ -31,6 +31,11 @@ impl LabelCommon for HighlightedLabel {
 
     fn weight(mut self, weight: FontWeight) -> Self {
         self.base = self.base.weight(weight);
+        self
+    }
+
+    fn width(mut self, width: FontWidth) -> Self {
+        self.base = self.base.width(width);
         self
     }
 

--- a/crates/ui/src/components/label/label.rs
+++ b/crates/ui/src/components/label/label.rs
@@ -1,4 +1,4 @@
-use gpui::{StyleRefinement, WindowContext};
+use gpui::{FontWidth, StyleRefinement, WindowContext};
 
 use crate::{prelude::*, LabelCommon, LabelLike, LabelSize, LineHeightStyle};
 
@@ -98,6 +98,11 @@ impl LabelCommon for Label {
 
     fn weight(mut self, weight: gpui::FontWeight) -> Self {
         self.base = self.base.weight(weight);
+        self
+    }
+
+    fn width(mut self, width: FontWidth) -> Self {
+        self.base = self.base.width(width);
         self
     }
 

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -1,4 +1,4 @@
-use gpui::{relative, AnyElement, FontWeight, StyleRefinement, Styled};
+use gpui::{relative, AnyElement, FontWeight, FontWidth, StyleRefinement, Styled};
 use settings::Settings;
 use smallvec::SmallVec;
 use theme::ThemeSettings;
@@ -30,6 +30,9 @@ pub trait LabelCommon {
     /// Sets the font weight of the label.
     fn weight(self, weight: FontWeight) -> Self;
 
+    /// Sets the font width of the label.
+    fn width(self, width: FontWidth) -> Self;
+
     /// Sets the line height style of the label using a [`LineHeightStyle`].
     fn line_height_style(self, line_height_style: LineHeightStyle) -> Self;
 
@@ -51,6 +54,7 @@ pub struct LabelLike {
     pub(super) base: Div,
     size: LabelSize,
     weight: Option<FontWeight>,
+    width: Option<FontWidth>,
     line_height_style: LineHeightStyle,
     pub(crate) color: Color,
     strikethrough: bool,
@@ -65,6 +69,7 @@ impl LabelLike {
             base: div(),
             size: LabelSize::Default,
             weight: None,
+            width: None,
             line_height_style: LineHeightStyle::default(),
             color: Color::Default,
             strikethrough: false,
@@ -94,6 +99,11 @@ impl LabelCommon for LabelLike {
 
     fn weight(mut self, weight: FontWeight) -> Self {
         self.weight = Some(weight);
+        self
+    }
+
+    fn width(mut self, width: FontWidth) -> Self {
+        self.width = Some(width);
         self
     }
 
@@ -161,6 +171,7 @@ impl RenderOnce for LabelLike {
             .when(self.italic, |this| this.italic())
             .text_color(color)
             .font_weight(self.weight.unwrap_or(settings.ui_font.weight))
+            .font_width(self.width.unwrap_or(settings.ui_font.width))
             .children(self.children)
     }
 }

--- a/crates/ui_input/src/ui_input.rs
+++ b/crates/ui_input/src/ui_input.rs
@@ -126,6 +126,7 @@ impl Render for TextField {
             font_features: settings.buffer_font.features.clone(),
             font_size: rems(0.875).into(),
             font_weight: settings.buffer_font.weight,
+            font_width: settings.buffer_font.width,
             font_style: FontStyle::Normal,
             line_height: relative(1.2),
             color: style.text_color,


### PR DESCRIPTION
This adds three new settings: `buffer_font_width`, `terminal.font_width`, and `ui_font_width`. They all take a float between 0.5 and 2.0, matching the `font-width` CSS property (and, more usefully, the way font width is represented in `cosmic_text` and `font-kit`).

A nice affordance here would be to support the usual array of string constants in the configuration, but that is probably beyond my knowledge, and definitely beyond what I have time for right now.

This works for me with some fairly minimal testing of Iosevka Extended on Linux (specifically, with the font width set to 1.5), but there are a couple of issues that I suspect would need to be addressed before this was mergeable:

1. I'm not actually 100% sure I got all the places where font styling is passed through the various components in the editor. The best I can say is that it _seems_ to work.
2. I've done zero testing of this outside of Linux, mostly because I only use Linux. Given that one of the modified files is in `gpui::platform::linux`, I'm going to guess that there are changes required to support other platforms.

Anyway, were the above to be addressed, this would fix #14096.

---

Release Notes:

- Added `buffer_font_width`, `terminal.font_width`, and `ui_font_width` settings to control the font width in editor buffers, terminal panes, and the UI, respectively. These values can be set to any value between 0.5 and 2.0, with 1.0 representing "normal" font width. Note that fonts that don't support multiple widths will always be rendered in their default width, no matter what these settings are set to.