### PR TITLE
Let Ubuntu Dock show app icon

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -8,6 +8,7 @@ TryExec=$APP_CLI
 StartupNotify=$DO_STARTUP_NOTIFY
 Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
+StartupWMClass=$APP_ID
 Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
 MimeType=text/plain;application/x-zerosize;inode/directory;x-scheme-handler/zed;


### PR DESCRIPTION
Closes #16503, #16694

Release Notes:

- Properly show app icon in Ubuntu dock