### PR TITLE
docs: Fix possessive "its" typos

### DIFF
--- a/docs/src/assistant/commands.md
+++ b/docs/src/assistant/commands.md
@@ -103,5 +103,5 @@ Usage: `/workflow`
 
 ## Extensibility
 
-A Zed extension can expose custom slash commands in it's API; this means that you too can have your own slash commands.
+A Zed extension can expose custom slash commands in its API; this means that you too can have your own slash commands.
 Click [here](../extensions/slash-commands.md) to find out how to define them.

--- a/docs/src/assistant/prompting.md
+++ b/docs/src/assistant/prompting.md
@@ -31,7 +31,7 @@ You can also use the `prompt-library: toggle` command.
 
 ### Managing Prompts
 
-Once a prompt is selected, you can edit it directly in the editor. It's title can be changed from the editor title bar as well.
+Once a prompt is selected, you can edit it directly in the editor. Its title can be changed from the editor title bar as well.
 
 Prompts can be duplicated, deleted, or added to the default prompt using the buttons in the prompt editor.
 

--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -79,7 +79,7 @@ Thank you for taking on the task of packaging Zed!
 
 Zed has two main binaries:
 
-- You will need to build `crates/cli` and make it's binary available in `$PATH` with the name `zed`.
+- You will need to build `crates/cli` and make its binary available in `$PATH` with the name `zed`.
 - You will need to build `crates/zed` and put it at `$PATH/to/cli/../../libexec/zed-editor`. For example, if you are going to put the cli at `~/.local/bin/zed` put zed at `~/.local/libexec/zed-editor`. As some linux distributions (notably Arch) discourage the use of `libexec`, you can also put this binary at `$PATH/to/cli/../../lib/zed/zed-editor` (e.g. `~/.local/lib/zed/zed-editor`) instead.
 - If you are going to provide a `.desktop` file you can find a template in `crates/zed/resources/zed.desktop.in`, and use `envsubst` to populate it with the values required. This file should also be renamed to `$APP_ID.desktop` so that the file [follows the FreeDesktop standards](https://github.com/zed-industries/zed/issues/12707#issuecomment-2168742761).
 - You will need to ensure that the necessary libraries are installed. You can get the current list by [inspecting the built binary](https://github.com/zed-industries/zed/blob/059a4141b756cf4afac4c977afc488539aec6470/script/bundle-linux#L65-L70) on your system.

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -94,7 +94,7 @@ The same task modal opened via `task: spawn` supports arbitrary bash-like comman
 
 Task modal will persist list of those command for current Zed session, `task: rerun` will also rerun such tasks if they were the last ones spawned.
 
-You can also adjust currently selected task in a modal (`tab` is a default key binding). Doing so will put it's command into a prompt that can then be edited & spawned as an oneshot task.
+You can also adjust currently selected task in a modal (`tab` is a default key binding). Doing so will put its command into a prompt that can then be edited & spawned as an oneshot task.
 
 ### Ephemeral tasks
 


### PR DESCRIPTION
This PR fixes a number of typos where possessive "its" wasn't being used properly.

Release Notes:

- N/A
