### PR TITLE
docs: Reword "Extensibility" section of slash command docs

### DIFF
--- a/docs/src/assistant/commands.md
+++ b/docs/src/assistant/commands.md
@@ -103,5 +103,6 @@ Usage: `/workflow`
 
 ## Extensibility
 
-A Zed extension can expose custom slash commands in its API; this means that you too can have your own slash commands.
-Click [here](../extensions/slash-commands.md) to find out how to define them.
+Additional slash commands can be provided by extensions.
+
+See [Extension: Slash Commands](../extensions/slash-commands.md) to learn how to create your own.


### PR DESCRIPTION
This PR rewords the "Extensibility" section of the slash command docs.

Release Notes:

- N/A
