### PR TITLE
docs: Remove unneeded theme links in index.hbs

### DIFF
--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -23,7 +23,6 @@
         <link rel="stylesheet" href="{{ path_to_root }}css/variables.css">
         <link rel="stylesheet" href="{{ path_to_root }}css/general.css">
         <link rel="stylesheet" href="{{ path_to_root }}css/chrome.css">
-        <link rel="stylesheet" href="{{ path_to_root }}plugins.css">
         {{#if print_enable}}
         <link rel="stylesheet" href="{{ path_to_root }}css/print.css" media="print">
         {{/if}}
@@ -252,10 +251,9 @@
         <script src="{{ path_to_root }}highlight.js"></script>
         <script src="{{ path_to_root }}book.js"></script>
 
-         <!-- Custom JS scripts -->
+        <!-- Custom JS scripts -->
         {{#each additional_js}}
         <script src="{{ ../path_to_root }}{{this}}"></script>
-        <script src="{{ path_to_root }}plugins.js"></script>
         {{/each}}
 
         {{#if is_print}}


### PR DESCRIPTION
PR #16501 introduced the new keybinding syntax for the docs and added Javascript- and CSS-files to the theme to implement the change. These new files were then referenced in the `book.toml` as well as added to the `index.hbs`.

However, the manually added links to these assets in the [`index.hbs`-file](https://github.com/zed-industries/zed/pull/16501/files#diff-8fde917c42f58487036335ccc9980f1467790fc1c257ec57a0c44bc5dfc3ef4f) are neither needed nor resolvable:

<img width="328" alt="grafik" src="https://github.com/user-attachments/assets/4a710b22-9274-4d27-96a8-6da59b0c9e68">


Therefore, this PR reverts the changes to the`index.hbs` - file, as the correct links to the needed assets are inserted via the `each`-directives from the `book.toml` respectively.

Release Notes:

- N/A
