### PR TITLE
project_panel: Set scrollbar track background from theme

### DIFF
--- a/crates/project_panel/src/scrollbar.rs
+++ b/crates/project_panel/src/scrollbar.rs
@@ -77,7 +77,7 @@ impl gpui::Element for ProjectPanelScrollbar {
     ) {
         cx.with_content_mask(Some(ContentMask { bounds }), |cx| {
             let colors = cx.theme().colors();
-            let scrollbar_background = colors.scrollbar_track_border;
+            let scrollbar_background = colors.scrollbar_track_background;
             let thumb_background = colors.scrollbar_thumb_background;
             cx.paint_quad(gpui::fill(bounds, scrollbar_background));
 


### PR DESCRIPTION
This was previously using the value for the scrollbar border, instead of the background.

I noticed this while trying out a new Zed theme.

Release Notes:

- Updated project panel scrollbar to respect the `scrollbar.track.background` from the theme.

| Before | After |
| --- | ---- |
| <img width="281" alt="Screenshot 2024-08-20 at 2 46 23 PM" src="https://github.com/user-attachments/assets/46d48e75-f472-4060-bcd7-9c2f7d97963d"> | <img width="280" alt="Screenshot 2024-08-20 at 2 46 37 PM" src="https://github.com/user-attachments/assets/081038a4-4337-4c9f-9a95-93497003fb56"> |
