### PR TITLE
linux: Add an option to disable middle-click paste

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -223,6 +223,8 @@
     // Whether to show diagnostic indicators in the scrollbar.
     "diagnostics": true
   },
+  // Enable middle-click paste on Linux.
+  "linux_middle_click_paste": true,
   // What to do when multibuffer is double clicked in some of its excerpts
   // (parts of singleton buffers).
   // May take 2 values:

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -224,7 +224,7 @@
     "diagnostics": true
   },
   // Enable middle-click paste on Linux.
-  "linux_middle_click_paste": true,
+  "middle_click_paste": true,
   // What to do when multibuffer is double clicked in some of its excerpts
   // (parts of singleton buffers).
   // May take 2 values:

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -23,7 +23,7 @@ pub struct EditorSettings {
     pub multi_cursor_modifier: MultiCursorModifier,
     pub redact_private_values: bool,
     pub expand_excerpt_lines: u32,
-    pub linux_middle_click_paste: bool,
+    pub middle_click_paste: bool,
     #[serde(default)]
     pub double_click_in_multibuffer: DoubleClickInMultibuffer,
     pub search_wrap: bool,
@@ -237,7 +237,7 @@ pub struct EditorSettingsContent {
     /// Whether to enable middle-click paste on Linux
     ///
     /// Default: true
-    pub linux_middle_click_paste: Option<bool>,
+    pub middle_click_paste: Option<bool>,
 
     /// What to do when multibuffer is double clicked in some of its excerpts
     /// (parts of singleton buffers).

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -23,6 +23,7 @@ pub struct EditorSettings {
     pub multi_cursor_modifier: MultiCursorModifier,
     pub redact_private_values: bool,
     pub expand_excerpt_lines: u32,
+    pub linux_middle_click_paste: bool,
     #[serde(default)]
     pub double_click_in_multibuffer: DoubleClickInMultibuffer,
     pub search_wrap: bool,
@@ -232,6 +233,11 @@ pub struct EditorSettingsContent {
     ///
     /// Default: 3
     pub expand_excerpt_lines: Option<u32>,
+
+    /// Whether to enable middle-click paste on Linux
+    ///
+    /// Default: true
+    pub linux_middle_click_paste: Option<bool>,
 
     /// What to do when multibuffer is double clicked in some of its excerpts
     /// (parts of singleton buffers).

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -647,7 +647,9 @@ impl EditorElement {
             if !text_hitbox.is_hovered(cx) || editor.read_only(cx) {
                 return;
             }
-
+            if !EditorSettings::get_global(cx).linux_middle_click_paste {
+                return;
+            }
             #[cfg(target_os = "linux")]
             if let Some(text) = cx.read_from_primary().and_then(|item| item.text()) {
                 let point_for_position =

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -647,26 +647,26 @@ impl EditorElement {
             if !text_hitbox.is_hovered(cx) || editor.read_only(cx) {
                 return;
             }
-            if !EditorSettings::get_global(cx).linux_middle_click_paste {
-                return;
-            }
-            #[cfg(target_os = "linux")]
-            if let Some(text) = cx.read_from_primary().and_then(|item| item.text()) {
-                let point_for_position =
-                    position_map.point_for_position(text_hitbox.bounds, event.position);
-                let position = point_for_position.previous_valid;
 
-                editor.select(
-                    SelectPhase::Begin {
-                        position,
-                        add: false,
-                        click_count: 1,
-                    },
-                    cx,
-                );
-                editor.insert(&text, cx);
+            #[cfg(target_os = "linux")]
+            if EditorSettings::get_global(cx).middle_click_paste {
+                if let Some(text) = cx.read_from_primary().and_then(|item| item.text()) {
+                    let point_for_position =
+                        position_map.point_for_position(text_hitbox.bounds, event.position);
+                    let position = point_for_position.previous_valid;
+
+                    editor.select(
+                        SelectPhase::Begin {
+                            position,
+                            add: false,
+                            click_count: 1,
+                        },
+                        cx,
+                    );
+                    editor.insert(&text, cx);
+                }
+                cx.stop_propagation()
             }
-            cx.stop_propagation()
         }
     }
 


### PR DESCRIPTION
Release Notes:

- Added an editor setting to toggle Linux middle-click pasting (enabled by default)
