### PR TITLE
collab panel: Unfocus filter editor on escape

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1395,15 +1395,22 @@ impl CollabPanel {
         cx.notify();
     }
 
+    fn reset_filter_editor_text(&mut self, cx: &mut ViewContext<Self>) -> bool {
+        self.filter_editor.update(cx, |editor, cx| {
+            if editor.buffer().read(cx).len(cx) > 0 {
+                editor.set_text("", cx);
+                true
+            } else {
+                false
+            }
+        })
+    }
+
     fn cancel(&mut self, _: &Cancel, cx: &mut ViewContext<Self>) {
         if self.take_editing_state(cx) {
             cx.focus_view(&self.filter_editor);
-        } else {
-            self.filter_editor.update(cx, |editor, cx| {
-                if editor.buffer().read(cx).len(cx) > 0 {
-                    editor.set_text("", cx);
-                }
-            });
+        } else if !self.reset_filter_editor_text(cx) {
+            self.focus_handle.focus(cx);
         }
 
         if self.context_menu.is_some() {


### PR DESCRIPTION
This has been bugging me for a while, because it meant I was stuck in the collab panel when I accidentally navigated there via keyboard shortcuts.

Now I can press esc and get out of that state.

Release Notes:

- Fixed `esc` not removing focus from the filter editor in the collaboration panel.

### Before

https://github.com/user-attachments/assets/3bebac03-0e6a-49b0-9823-d9f3190aa5d2


### After

https://github.com/user-attachments/assets/d04c309d-9d1c-44b6-abd3-d48f55207e31

