### PR TITLE
docs: Update telemetry documentation

### DIFF
--- a/crates/telemetry_events/src/telemetry_events.rs
+++ b/crates/telemetry_events/src/telemetry_events.rs
@@ -1,17 +1,24 @@
+/// Please see: [Telemetry in Zed](https://zed.dev/docs/telemetry) for additional documentation.
 use semantic_version::SemanticVersion;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, sync::Arc, time::Duration};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EventRequestBody {
+    /// Identifier unique to each Zed installation (differs for stable, preview, dev)
     pub installation_id: Option<String>,
+    /// Identifier unique to each logged in Zed user (randomly generated on first sign in)
     pub metrics_id: Option<String>,
+    /// Identifier unique to each Zed session (differs for each time you open Zed)
     pub session_id: Option<String>,
+    /// True for Zed staff, otherwise false
     pub is_staff: Option<bool>,
+    /// Zed version number
     pub app_version: String,
     pub os_name: String,
     pub os_version: Option<String>,
     pub architecture: String,
+    /// Zed release channel (stable, preview, dev)
     pub release_channel: Option<String>,
     pub events: Vec<EventWrapper>,
 }
@@ -25,6 +32,7 @@ impl EventRequestBody {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EventWrapper {
     pub signed_in: bool,
+    /// Duration between this event's timestamp and the timestamp of the first event in the current batch
     pub milliseconds_since_first_event: i64,
     #[serde(flatten)]
     pub event: Event,
@@ -70,13 +78,19 @@ pub enum Event {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EditorEvent {
+    /// The editor operation performed (open, save)
     pub operation: String,
+    /// The extension of the file that was opened or saved
     pub file_extension: Option<String>,
+    /// Whether the user is in vim mode or not
     pub vim_mode: bool,
+    /// Whether the user has copilot enabled or not
     pub copilot_enabled: bool,
+    /// Whether the user has copilot enabled for the language of the file opened or saved
     pub copilot_enabled_for_language: bool,
 }
 
+/// Deprecated since Zed v0.137.0 (2024-05-29). Replaced by InlineCompletionEvent.
 // Needed for clients sending old copilot_event types
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CopilotEvent {
@@ -87,6 +101,7 @@ pub struct CopilotEvent {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InlineCompletionEvent {
+    /// Provider of the completion suggestion (e.g. copilot, supermaven)
     pub provider: String,
     pub suggestion_accepted: bool,
     pub file_extension: Option<String>,
@@ -94,6 +109,7 @@ pub struct InlineCompletionEvent {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CallEvent {
+    /// Operation performed: invite/join call; begin/end screenshare; share/unshare project; etc
     pub operation: String,
     pub room_id: Option<u64>,
     pub channel_id: Option<u64>,
@@ -101,8 +117,11 @@ pub struct CallEvent {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AssistantEvent {
+    /// Unique random identifier for each assistant tab (None for inline assist)
     pub conversation_id: Option<String>,
+    /// The kind of assistant (Panel, Inline)
     pub kind: AssistantKind,
+    /// Name of the AI model used (gpt-4o, claude-3-5-sonnet, etc)
     pub model: String,
     pub response_latency: Option<Duration>,
     pub error_message: Option<String>,
@@ -171,6 +190,7 @@ pub struct HangReport {
     pub os_name: String,
     pub os_version: Option<String>,
     pub architecture: String,
+    /// Identifier unique to each Zed installation (differs for stable, preview, dev)
     pub installation_id: Option<String>,
 }
 
@@ -182,19 +202,27 @@ pub struct LocationData {
 
 #[derive(Serialize, Deserialize)]
 pub struct Panic {
+    /// The name of the thread that panicked
     pub thread: String,
+    /// The panic message
     pub payload: String,
+    /// The location of the panic (file, line number)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location_data: Option<LocationData>,
     pub backtrace: Vec<String>,
+    /// Zed version number
     pub app_version: String,
+    /// Zed release channel (stable, preview, dev)
     pub release_channel: String,
     pub os_name: String,
     pub os_version: Option<String>,
     pub architecture: String,
+    /// The time the panic occurred (UNIX millisecond timestamp)
     pub panicked_on: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Identifier unique to each Zed installation (differs for stable, preview, dev)
     pub installation_id: Option<String>,
+    /// Identifier unique to each Zed session (differs for each time you open Zed)
     pub session_id: String,
 }
 

--- a/docs/src/telemetry.md
+++ b/docs/src/telemetry.md
@@ -1,7 +1,5 @@
 # Telemetry in Zed
 
-**Up to date with v0.112.0**
-
 Zed collects anonymous telemetry data to help the team understand how people are using the application and to see what sort of issues they are experiencing.
 
 ## Configuring Telemetry Settings
@@ -31,118 +29,25 @@ Telemetry is sent from the application to our servers. Data is proxied through o
 
 Diagnostic events include debug information (stack traces) from crash reports. Reports are sent on the first application launch after the crash occurred. We've built dashboards that allow us to visualize the frequency and severity of issues experienced by users. Having these reports sent automatically allows us to begin implementing fixes without the user needing to file a report in our issue tracker. The plots in the dashboards also give us an informal measurement of the stability of Zed.
 
-When a panic occurs, the following data is sent:
+You can see what data is sent when a panic occurs by inspecting the `Panic` struct in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L184) in the zed repo. You can find additional information in the [Debugging Crashes](https://zed.dev/docs/development/debugging-crashes) documentation.
 
-#### PanicRequest
+### Usage Data (Metrics) {#metrics}
 
-- `panic`: The panic data
-- `token`: An identifier that is used to authenticate the request on zed.dev
+To improve Zed and understand how it is being used in the wild, Zed optionally collects usage data like the following:
 
-#### Panic
+- (a) file extensions of opened files;
+- (b) features and tools You use within the Editor;
+- (c) project statistics (e.g., number of files); and
+- (d) frameworks detected in Your projects
 
-- `thread`: The name of the thread that panicked
-- `payload`: The panic message
-- `location_data`: The location of the panic
-  - `file`
-  - `line`
-- `backtrace`: The backtrace of the panic
-- `app_version`: Zed's app version
-- `release_channel`: Zed's release channel
-  - `stable`
-  - `preview`
-  - `dev`
-- `os_name`: The name of your operating system
-- `os_version`: The version of your operating system
-- `architecture`: The architecture of your CPU
-- `panicked_on`: The time that the panic occurred
-- `installation_id`: An identifier that is unique to each installation of Zed (this differs for stable, preview, and dev builds)
-- `session_id`: An identifier that is unique to each Zed session (this differs for each time you open Zed)
+Usage Data does not include any of Your software code or sensitive project details. Metric events are reported over HTTPS, and requests are rate-limited to avoid using significant network bandwidth.
 
-### Metrics
-
-Zed also collects metric information based on user actions. Metric events are reported over HTTPS, and requests are rate-limited to avoid using significant network bandwidth. All data remains anonymous, and can't be related to specific Zed users.
-
-The following data is sent:
-
-#### ClickhouseEventRequestBody
-
-- `token`: An identifier that is used to authenticate the request on zed.dev
-- `installation_id`: An identifier that is unique to each installation of Zed (this differs for stable, preview, and dev builds)
-- `session_id`: An identifier that is unique to each Zed session (this differs for each time you open Zed)
-- `is_staff`: A boolean that indicates whether the user is a member of the Zed team or not
-- `app_version`: Zed's app version
-- `os_name`: The name of your operating system
-- `os_version`: The version of your operating system
-- `architecture`: The architecture of your CPU
-- `release_channel`: Zed's release channel
-  - `stable`
-  - `preview`
-  - `dev`
-- `events`: A vector of `ClickhouseEventWrapper`s
-
-#### ClickhouseEventWrapper
-
-- `signed_in`: A boolean that indicates whether the user is signed in or not
-- `event`: An enum, where each variant can be one of the following `ClickhouseEvent` variants:
-
-#### ClickhouseEvent
-
-- `editor`
-  - `operation`: The editor operation that was performed
-    - `open`
-    - `save`
-  - `file_extension`: The extension of the file that was opened or saved
-  - `vim_mode`: A boolean that indicates whether the user is in vim mode or not
-  - `copilot_enabled`: A boolean that indicates whether the user has copilot enabled or not
-  - `copilot_enabled_for_language`: A boolean that indicates whether the user has copilot enabled for the language of the file that was opened or saved
-  - `milliseconds_since_first_event`: Duration of time between this event's timestamp and the timestamp of the first event in the current batch
-- `copilot`
-  - `suggestion_accepted`: A boolean that indicates whether the suggestion was accepted or not
-  - `file_extension`: The file extension of the file that was opened or saved
-  - `milliseconds_since_first_event`: Same as above
-- `call`
-  - `operation`: The call operation that was performed
-    - `accept incoming`
-    - `decline incoming`
-    - `disable microphone`
-    - `disable screen share`
-    - `enable microphone`
-    - `enable screen share`
-    - `hang up`
-    - `invite`
-    - `join channel`
-    - `open channel notes`
-    - `share project`
-    - `unshare project`
-  - `room_id`: The ID of the room
-  - `channel_id`: The ID of the channel
-  - `milliseconds_since_first_event`: Same as above
-- `assistant`
-  - `conversation_id`: The ID of the conversation (for panel events only)
-  - `kind`: An enum with the following variants:
-    - `panel`
-    - `inline`
-  - `model`: The model that was used
-  - `milliseconds_since_first_event`: Same as above
-- `cpu`
-  - `usage_as_percentage`: The CPU usage
-  - `core_count`: The number of cores on the CPU
-  - `milliseconds_since_first_event`: Same as above
-- `memory`
-  - `memory_in_bytes`: The amount of memory used in bytes
-  - `virtual_memory_in_bytes`: The amount of virtual memory used in bytes
-  - `milliseconds_since_first_event`: Same as above
-- `app`
-  - `operation`: The app operation that was performed
-    - `first open`
-    - `open`
-    - `close`
-  - `milliseconds_since_first_event`: Same as above
+Usage Data is associated with a secure random telemetry ID which may be linked to Your email address. This linkage currently serves two purposes: (1) it allows Zed to analyze usage patterns over time while maintaining Your privacy; and (2) it enables Zed to reach out to specific user groups for feedback and improvement suggestions.
 
 You can audit the metrics data that Zed has reported by running the command `zed: open telemetry log` from the command palette, or clicking `Help > View Telemetry Log` in the application menu.
 
-The telemetry settings can also be configured via the `welcome` screen, which can be invoked via the `workspace: welcome` action in the command palette.
+You can see the full list of the event types and exactly the data sent for each by inspecting the `Event` enum and the associated structs in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L63] in the zed repo.
 
-### Concerns and Questions
+## Concerns and Questions
 
 If you have concerns about telemetry, please feel free to open issues in our [Zed repository](https://github.com/zed-industries/zed/issues/new/choose).


### PR DESCRIPTION
- Improve telemetry documentation following: #16478
- Add references to locations in code for Metrics and Panic telemetry
- Remove outdated documentation (ClickhouseEvent, ClickhouseEventWrapper, ClickhouseEventRequestBody)
- Migrate struct documentation from web docs to inline doc comments on struct members.

Release Notes:

- N/A
