### PR TITLE
fs: Fix atomic_write failing on windows if destination is in different drive than the temp dir

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -351,6 +351,16 @@ impl Fs for RealFs {
                 // invalid cross-device link error, and XDG_CACHE_DIR for fallback.
                 // See https://github.com/zed-industries/zed/pull/8437 for more details.
                 NamedTempFile::new_in(path.parent().unwrap_or(&paths::temp_dir()))
+            } else if cfg!(target_os = "windows") {
+                // If temp dir is set to a different drive than the destination,
+                // we receive error:
+                //
+                // failed to persist temporary file:
+                // The system cannot move the file to a different disk drive. (os error 17)
+                //
+                // So we use the directory of the destination as a temp dir to avoid it.
+                // https://github.com/zed-industries/zed/issues/16571
+                NamedTempFile::new_in(path.parent().unwrap_or(&paths::temp_dir()))
             } else {
                 NamedTempFile::new()
             }?;


### PR DESCRIPTION
I have my system temp dir on a different drive than the default, so this error was spammed in the logs. This also broke Zed in many ways, one of which was the AI system failing to work since it couldn't save settings.
```
2024-08-20T22:39:54.0660708-07:00 [ERROR] Failed to write settings to file "\\\\?\\C:\\Users\\myuser\\AppData\\Roaming\\Zed\\settings.json"
Caused by:

0: failed to persist temporary file: The system cannot move the file to a different disk drive. (os error 17)

1: The system cannot move the file to a different disk drive. (os error 17)
```

Note: This problem is probably present on MacOS due to the requirement of the underlying api being used. I do not have Mac, so I cannot test this. This PR only solves this issue on Windows.

Closes #16571

Release Notes:

- fix atomic_write failing on windows if destination is on a different drive than the OS's temp dir.