### PR TITLE
repl: Set up a way to copy output from the REPL

### DIFF
--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -30,7 +30,7 @@ impl AssetSource for () {
 
 /// A unique identifier for the image cache
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct ImageId(usize);
+pub struct ImageId(pub(crate) usize);
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub(crate) struct RenderImageParams {

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -30,7 +30,7 @@ impl AssetSource for () {
 
 /// A unique identifier for the image cache
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct ImageId(pub(crate) usize);
+pub struct ImageId(pub usize);
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub(crate) struct RenderImageParams {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -23,7 +23,7 @@ mod windows;
 use crate::{
     point, Action, AnyWindowHandle, AppContext, AsyncWindowContext, BackgroundExecutor, Bounds,
     DevicePixels, DispatchEventResult, Font, FontId, FontMetrics, FontRun, ForegroundExecutor,
-    GPUSpecs, GlyphId, ImageSource, Keymap, LineLayout, Pixels, PlatformInput, Point,
+    GPUSpecs, GlyphId, ImageId, ImageSource, Keymap, LineLayout, Pixels, PlatformInput, Point,
     RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Scene, SharedString, Size,
     SvgSize, Task, TaskLabel, WindowContext, DEFAULT_WINDOW_SIZE,
 };
@@ -1013,6 +1013,19 @@ impl ClipboardItem {
             entries: vec![ClipboardEntry::String(
                 ClipboardString::new(text).with_json_metadata(metadata),
             )],
+        }
+    }
+
+    /// Create a new ClipboardItem::Image with the given image with no associated metadata
+    pub fn new_image_from_bytes(bytes: Vec<u8>, format: ImageFormat, id: ImageId) -> Self {
+        let image = Image {
+            bytes,
+            format,
+            id: id.0 as u64,
+        };
+
+        Self {
+            entries: vec![ClipboardEntry::Image(image)],
         }
     }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -23,7 +23,7 @@ mod windows;
 use crate::{
     point, Action, AnyWindowHandle, AppContext, AsyncWindowContext, BackgroundExecutor, Bounds,
     DevicePixels, DispatchEventResult, Font, FontId, FontMetrics, FontRun, ForegroundExecutor,
-    GPUSpecs, GlyphId, ImageId, ImageSource, Keymap, LineLayout, Pixels, PlatformInput, Point,
+    GPUSpecs, GlyphId, ImageSource, Keymap, LineLayout, Pixels, PlatformInput, Point,
     RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Scene, SharedString, Size,
     SvgSize, Task, TaskLabel, WindowContext, DEFAULT_WINDOW_SIZE,
 };
@@ -1017,15 +1017,9 @@ impl ClipboardItem {
     }
 
     /// Create a new ClipboardItem::Image with the given image with no associated metadata
-    pub fn new_image_from_bytes(bytes: Vec<u8>, format: ImageFormat, id: ImageId) -> Self {
-        let image = Image {
-            bytes,
-            format,
-            id: id.0 as u64,
-        };
-
+    pub fn new_image(image: &Image) -> Self {
         Self {
-            entries: vec![ClipboardEntry::Image(image)],
+            entries: vec![ClipboardEntry::Image(image.clone())],
         }
     }
 
@@ -1097,10 +1091,11 @@ pub enum ImageFormat {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Image {
     /// The image format the bytes represent (e.g. PNG)
-    format: ImageFormat,
+    pub format: ImageFormat,
     /// The raw image bytes
-    bytes: Vec<u8>,
-    id: u64,
+    pub bytes: Vec<u8>,
+    /// The unique ID for the image
+    pub id: u64,
 }
 
 impl Hash for Image {

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -14,7 +14,7 @@ use runtimelib::{ExecutionState, JupyterMessageContent, MimeBundle, MimeType};
 use serde_json::Value;
 use settings::Settings;
 use theme::ThemeSettings;
-use ui::{div, prelude::*, v_flex, IntoElement, Styled, ViewContext};
+use ui::{div, prelude::*, v_flex, IntoElement, Styled, Tooltip, ViewContext};
 
 use markdown_preview::{
     markdown_elements::ParsedMarkdown, markdown_parser::parse_markdown,
@@ -789,30 +789,34 @@ impl Render for ExecutionView {
         div()
             .w_full()
             .children(self.outputs.iter().enumerate().map(|(index, output)| {
-                div()
-                    .relative()
+                h_flex()
                     .w_full()
+                    .items_start()
                     .child(
-                        output
-                            .content
-                            .render(cx)
-                            .unwrap_or_else(|| div().into_any_element()),
+                        div().flex_1().child(
+                            output
+                                .content
+                                .render(cx)
+                                .unwrap_or_else(|| div().into_any_element()),
+                        ),
                     )
                     .when(output.has_clipboard_content(cx), |el| {
                         let clipboard_content = output.clipboard_content(cx);
 
                         el.child(
-                            div().child(
-                                Button::new(
+                            div().pl_1().child(
+                                IconButton::new(
                                     ElementId::Name(format!("copy-output-{}", index).into()),
-                                    "Copy",
+                                    IconName::Copy,
                                 )
                                 .style(ButtonStyle::Transparent)
+                                .tooltip(move |cx| Tooltip::text("Copy Output", cx))
                                 .on_click(cx.listener(
                                     move |_, _, cx| {
                                         if let Some(clipboard_content) = clipboard_content.as_ref()
                                         {
                                             cx.write_to_clipboard(clipboard_content.clone());
+                                            // todo!(): let the user know that the content was copied
                                         }
                                     },
                                 )),

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -1,6 +1,6 @@
 use crate::outputs::ExecutionView;
-use alacritty_terminal::{term::Config, vte::ansi::Processor};
-use gpui::{canvas, size, AnyElement, FontStyle, TextStyle, WhiteSpace};
+use alacritty_terminal::{grid::Dimensions as _, term::Config, vte::ansi::Processor};
+use gpui::{canvas, size, AnyElement, ClipboardItem, FontStyle, TextStyle, WhiteSpace};
 use settings::Settings as _;
 use std::mem;
 use terminal::ZedListener;
@@ -116,6 +116,19 @@ impl TerminalOutput {
 
             // self.parser.advance(&mut self.handler, *byte);
         }
+    }
+
+    pub fn clipboard_content(&self, cx: &WindowContext) -> Option<ClipboardItem> {
+        let start = alacritty_terminal::index::Point::new(
+            alacritty_terminal::index::Line(0),
+            alacritty_terminal::index::Column(0),
+        );
+        let end = alacritty_terminal::index::Point::new(
+            alacritty_terminal::index::Line(self.handler.screen_lines() as i32 - 1),
+            alacritty_terminal::index::Column(self.handler.columns() - 1),
+        );
+        let text = self.handler.bounds_to_string(start, end);
+        Some(ClipboardItem::new_string(text.trim().into()))
     }
 
     pub fn render(&self, cx: &mut ViewContext<ExecutionView>) -> AnyElement {

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -118,7 +118,7 @@ impl TerminalOutput {
         }
     }
 
-    pub fn clipboard_content(&self, cx: &WindowContext) -> Option<ClipboardItem> {
+    pub fn clipboard_content(&self, _cx: &WindowContext) -> Option<ClipboardItem> {
         let start = alacritty_terminal::index::Point::new(
             alacritty_terminal::index::Line(0),
             alacritty_terminal::index::Column(0),

--- a/crates/repl/src/stdio.rs
+++ b/crates/repl/src/stdio.rs
@@ -1,4 +1,4 @@
-use crate::outputs::ExecutionView;
+use crate::outputs::{ExecutionView, SupportsClipboard};
 use alacritty_terminal::{grid::Dimensions as _, term::Config, vte::ansi::Processor};
 use gpui::{canvas, size, AnyElement, ClipboardItem, FontStyle, TextStyle, WhiteSpace};
 use settings::Settings as _;
@@ -118,19 +118,6 @@ impl TerminalOutput {
         }
     }
 
-    pub fn clipboard_content(&self, _cx: &WindowContext) -> Option<ClipboardItem> {
-        let start = alacritty_terminal::index::Point::new(
-            alacritty_terminal::index::Line(0),
-            alacritty_terminal::index::Column(0),
-        );
-        let end = alacritty_terminal::index::Point::new(
-            alacritty_terminal::index::Line(self.handler.screen_lines() as i32 - 1),
-            alacritty_terminal::index::Column(self.handler.columns() - 1),
-        );
-        let text = self.handler.bounds_to_string(start, end);
-        Some(ClipboardItem::new_string(text.trim().into()))
-    }
-
     pub fn render(&self, cx: &mut ViewContext<ExecutionView>) -> AnyElement {
         let text_style = text_style(cx);
         let text_system = cx.text_system();
@@ -192,5 +179,24 @@ impl TerminalOutput {
         // We must set the height explicitly for the editor block to size itself correctly
         .h(height)
         .into_any_element()
+    }
+}
+
+impl SupportsClipboard for TerminalOutput {
+    fn clipboard_content(&self, _cx: &WindowContext) -> Option<ClipboardItem> {
+        let start = alacritty_terminal::index::Point::new(
+            alacritty_terminal::index::Line(0),
+            alacritty_terminal::index::Column(0),
+        );
+        let end = alacritty_terminal::index::Point::new(
+            alacritty_terminal::index::Line(self.handler.screen_lines() as i32 - 1),
+            alacritty_terminal::index::Column(self.handler.columns() - 1),
+        );
+        let text = self.handler.bounds_to_string(start, end);
+        Some(ClipboardItem::new_string(text.trim().into()))
+    }
+
+    fn has_clipboard_content(&self, _cx: &WindowContext) -> bool {
+        true
     }
 }


### PR DESCRIPTION
Closes #15494

Simple copy button to copy an individual output since selection is a bit more work.

<img width="790" alt="image" src="https://github.com/user-attachments/assets/4a7d8b69-70cc-428e-8fe3-b95386d341ee">


Release Notes:

- repl: Copy output from the REPL using a button