### PR TITLE
Force Vue and Svelte language servers to be the first in the list for their languages

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -838,6 +838,7 @@
       "language_servers": ["starpls", "!buck2-lsp", "..."]
     },
     "Svelte": {
+      "language_servers": ["svelte-language-server", "..."],
       "prettier": {
         "allowed": true,
         "plugins": ["prettier-plugin-svelte"]
@@ -861,6 +862,7 @@
       }
     },
     "Vue.js": {
+      "language_servers": ["vue-language-server", "..."],
       "prettier": {
         "allowed": true
       }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -158,6 +158,24 @@ pub struct CachedLspAdapter {
     cached_binary: futures::lock::Mutex<Option<LanguageServerBinary>>,
 }
 
+impl Debug for CachedLspAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedLspAdapter")
+            .field("name", &self.name)
+            .field(
+                "disk_based_diagnostic_sources",
+                &self.disk_based_diagnostic_sources,
+            )
+            .field(
+                "disk_based_diagnostics_progress_token",
+                &self.disk_based_diagnostics_progress_token,
+            )
+            .field("language_ids", &self.language_ids)
+            .field("reinstall_attempt_count", &self.reinstall_attempt_count)
+            .finish_non_exhaustive()
+    }
+}
+
 impl CachedLspAdapter {
     pub fn new(adapter: Arc<dyn LspAdapter>) -> Arc<Self> {
         let name = adapter.name();


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/15624

Fixes https://github.com/zed-industries/zed/issues/13769
Fixes https://github.com/zed-industries/zed/issues/16469

This way, those are considered "primary" and serve all LSP requests like go to definition. Before, Tailwind language server was first and returned nothing for all LSP requests.

- Fixed Vue and Svelte languages integrations not handling LSP requests properly ([#13769](https://github.com/zed-industries/zed/issues/13769)) ([#16469](https://github.com/zed-industries/zed/issues/16469))