### PR TITLE
Add uninstall option in install.sh script

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -12,6 +12,12 @@ main() {
     channel="${ZED_CHANNEL:-stable}"
     temp="$(mktemp -d "/tmp/zed-XXXXXX")"
 
+    [ "$operation" = install ] || [ "$operation" = uninstall ] || {
+        echo "Unknown operation '$operation'"
+        echo "Available operations: 'install' 'uninstall'"
+        exit 1
+    }
+
     if [ "$platform" = "Darwin" ]; then
         platform="macos"
     elif [ "$platform" = "Linux" ]; then

--- a/script/install.sh
+++ b/script/install.sh
@@ -108,9 +108,10 @@ linux() {
         ;;
     esac
 
-    # Unpack
     rm -rf "$HOME/.local/zed$suffix.app"
+
     [ "$operation" = install ] && {
+        # Unpack
         mkdir -p "$HOME/.local/zed$suffix.app" && tar -xzf "$temp/zed-linux-$arch.tar.gz" -C "$HOME/.local/"
 
         # Setup ~/.local directories
@@ -124,22 +125,27 @@ linux() {
             ln -sf "$HOME/.local/zed$suffix.app/bin/cli" "$HOME/.local/bin/zed"
         fi
     }
+
     [ "$operation" = uninstall ] && rm -f "$HOME/.local/bin/zed"
 
     # Copy .desktop file
     desktop_file_path="$HOME/.local/share/applications/${appid}.desktop"
+
     [ "$operation" = install ] && {
         cp "$HOME/.local/zed$suffix.app/share/applications/zed$suffix.desktop" "${desktop_file_path}"
         sed -i "s|Icon=zed|Icon=$HOME/.local/zed$suffix.app/share/icons/hicolor/512x512/apps/zed.png|g" "${desktop_file_path}"
         sed -i "s|Exec=zed|Exec=$HOME/.local/zed$suffix.app/libexec/zed-editor|g" "${desktop_file_path}"
     }
+
     [ "$operation" = uninstall ] && rm -f "$desktop_file_path"
+
     return 0
 }
 
 macos() {
     echo "Downloading Zed"
     curl "https://zed.dev/api/releases/$channel/latest/Zed-$arch.dmg" > "$temp/Zed-$arch.dmg"
+
     hdiutil attach -quiet "$temp/Zed-$arch.dmg" -mountpoint "$temp/mount"
     app="$(cd "$temp/mount/"; echo *.app)"
 
@@ -161,6 +167,7 @@ macos() {
     }
 
     [ "$operation" = uninstall ] && rm -f "$HOME/.local/bin/zed"
+
     return 0
 }
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -46,11 +46,11 @@ main() {
         }
     elif which wget >/dev/null 2>&1; then
         curl () {
-    	    wget -O- "$@"
+            wget -O- "$@"
         }
     else
-    	echo "Could not find 'curl' or 'wget' in your path"
-    	exit 1
+        echo "Could not find 'curl' or 'wget' in your path"
+        exit 1
     fi
 
     "$platform" "$@"
@@ -77,7 +77,7 @@ main() {
 
         echo "To run Zed now, '~/.local/bin/zed'"
     else
-	    echo "Uninstall completed."
+        echo "Uninstall completed."
     fi
 }
 


### PR DESCRIPTION
Can be used like

```sh
# install
curl https://zed.dev/install.sh | sh
# uninstall
curl https://zed.dev/install.sh | sh -s uninstall
```

Or locally, within the repo:

```sh
cat ./script/install.sh | sh -s uninstall
```

fixes gh-14306

answers gh-14267

Release Notes:

- Add uninstall option in install.sh script, use `curl https://zed.dev/install.sh | sh -s uninstall`
