### PR TITLE
Fix file scrolling not working on linux X11

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -818,6 +818,18 @@ impl X11Client {
                         click_count: current_count,
                         first_mouse: false,
                     }));
+                } else if event.detail >= 4 && event.detail <= 5 {
+                    // https://stackoverflow.com/questions/15510472/scrollwheel-event-in-x11
+                    let scroll_direction = if event.detail == 4 { 1.0 } else { -1.0 };
+                    let scroll_y = SCROLL_LINES * scroll_direction;
+
+                    drop(state);
+                    window.handle_input(PlatformInput::ScrollWheel(crate::ScrollWheelEvent {
+                        position,
+                        delta: ScrollDelta::Lines(Point::new(0.0, scroll_y as f32)),
+                        modifiers,
+                        touch_phase: TouchPhase::Moved,
+                    }));
                 } else {
                     log::warn!("Unknown button press: {event:?}");
                 }


### PR DESCRIPTION
Users are reporting about unable to scroll code on Zed running on Linux X11. This is due to code to process scrolling ButtonPress events was removed. This commit attempts to fix this by partially reverting XI2 Smooth Scrolling for X11 - Attempt 2 (65b6e8a365ed05238d55b94afe5040bccbb8b7be).

Closes #15970

Release Notes:
* Fix file scrolling not working on linux X11
