### PR TITLE
zig: Bump to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14161,7 +14161,7 @@ dependencies = [
 
 [[package]]
 name = "zed_zig"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_zig"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -1,7 +1,7 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.2.0"
+version = "0.3.0"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Zig extension to v0.3.0

Changes:

- #16645

Release Notes:

- N/A
