### PR TITLE
Pass through Anthropic cache configuration when using Zed provider

### DIFF
--- a/crates/language_model/src/provider/cloud.rs
+++ b/crates/language_model/src/provider/cloud.rs
@@ -445,6 +445,21 @@ impl LanguageModel for CloudLanguageModel {
         self.model.max_token_count()
     }
 
+    fn cache_configuration(&self) -> Option<LanguageModelCacheConfiguration> {
+        match &self.model {
+            CloudModel::Anthropic(model) => {
+                model
+                    .cache_configuration()
+                    .map(|cache| LanguageModelCacheConfiguration {
+                        max_cache_anchors: cache.max_cache_anchors,
+                        should_speculate: cache.should_speculate,
+                        min_total_token: cache.min_total_token,
+                    })
+            }
+            CloudModel::OpenAi(_) | CloudModel::Google(_) | CloudModel::Zed(_) => None,
+        }
+    }
+
     fn count_tokens(
         &self,
         request: LanguageModelRequest,


### PR DESCRIPTION
This PR makes it so the model's cache configuration gets passed through from the base model when using the Zed provider.

Release Notes:

- Fixed caching for Anthropic models when using the Zed provider.
