### PR TITLE
collab: Upsert users by `github_user_id` instead of `github_login`

### DIFF
--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -21,11 +21,11 @@ impl Database {
                 ..Default::default()
             })
             .on_conflict(
-                OnConflict::column(user::Column::GithubLogin)
+                OnConflict::column(user::Column::GithubUserId)
                     .update_columns([
                         user::Column::Admin,
                         user::Column::EmailAddress,
-                        user::Column::GithubUserId,
+                        user::Column::GithubLogin,
                     ])
                     .to_owned(),
             )


### PR DESCRIPTION
This PR makes it so users are upserted by their `github_user_id` instead of by their `github_login`.

The `github_user_id` is a stable identifier that does not change, while the `github_login` can change.

In practice we were already using `get_or_create_user_by_github_account`, which already checks for an existing user with a `github_user_id` first, so this change doesn't result in a change in behavior.

This change is primarily for correctness in the event that `create_user` is called directly, as we want to be upserting by the stable identifier.

Release Notes:

- N/A
