### PR TITLE
collab: Look up users using `github_user_id` when backfilling

### DIFF
--- a/crates/collab/src/user_backfiller.rs
+++ b/crates/collab/src/user_backfiller.rs
@@ -75,8 +75,8 @@ impl UserBackfiller {
         for user in users_missing_github_user_created_at {
             match self
                 .fetch_github_user(&format!(
-                    "https://api.github.com/users/{}",
-                    user.github_login
+                    "https://api.github.com/user/{}",
+                    user.github_user_id
                 ))
                 .await
             {


### PR DESCRIPTION
This PR updates the user backfiller to look up the GitHub users using the `github_user_id` instead of `github_login`.

Release Notes:

- N/A
