### PR TITLE
ruby: Replace default tasks with a stub message

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -231,3 +231,59 @@ end
 <%= link_to "Hello", "/hello", class: "pl-2 <completion here>" %>
 <a href="/hello" class="pl-2 <completion here>">Hello</a>
 ```
+
+## Running tests
+
+To run tests in your Ruby project, you can set up custom tasks in your local `.zed/tasks.json` configuration file. These tasks can be defined to work with different test frameworks like Minitest, RSpec, quickdraw, and tldr. Below are some examples of how to set up these tasks to run your tests from within your editor.
+
+### Minitest
+
+```json
+[
+  {
+    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
+    "command": "bundle exec rails",
+    "args": ["test", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
+    "tags": ["ruby-test"]
+  }
+]
+```
+
+### RSpec
+
+```json
+[
+  {
+    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
+    "command": "bundle exec rspec",
+    "args": ["\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
+    "tags": ["ruby-test"]
+  }
+]
+```
+
+### quickdraw
+
+```json
+[
+  {
+    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
+    "command": "bundle exec qt",
+    "args": ["\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
+    "tags": ["ruby-test"]
+  }
+]
+```
+
+### tldr
+
+```json
+[
+  {
+    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
+    "command": "bundle exec tldr",
+    "args": ["\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
+    "tags": ["ruby-test"]
+  }
+]
+```

--- a/extensions/ruby/languages/ruby/runnables.scm
+++ b/extensions/ruby/languages/ruby/runnables.scm
@@ -2,51 +2,49 @@
 ; Minitest: https://github.com/zidhuss/neotest-minitest/blob/main/lua/neotest-minitest/init.lua
 ; RSpec: https://github.com/olimorris/neotest-rspec/blob/main/lua/neotest-rspec/init.lua
 
-; Minitest
-;; Rails unit tests
+; Tests that inherit from a specific class
 (
     (class
         name: [
           (constant) @run
           (scope_resolution scope: (constant) name: (constant) @run)
         ]
-        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase|Minitest::Test)$"))
-    ) @_minitest-test
-    (#set! tag minitest-test)
+        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase|Minitest::Test|TLDR)$"))
+    ) @_ruby-test
+    (#set! tag ruby-test)
 )
 
 (
     (call
         method: (identifier) @run (#eq? @run "test")
         arguments: (argument_list (string (string_content) @_name))
-    ) @_minitest-test
-    (#set! tag minitest-test)
+    ) @_ruby-test
+    (#set! tag ruby-test)
 )
 
 ; Methods that begin with test_
 (
     (method
         name: (identifier) @run (#match? @run "^test_")
-    ) @_minitest-test
-    (#set! tag minitest-test)
+    ) @_ruby-test
+    (#set! tag ruby-test)
 )
 
 ; System tests that inherit from ApplicationSystemTestCase
 (
     (class
         name: (constant) @run (superclass) @superclass (#match? @superclass "(ApplicationSystemTestCase)$")
-    ) @_minitest-test
-    (#set! tag minitest-test)
+    ) @_ruby-test
+    (#set! tag ruby-test)
 )
 
-; RSpec
 ; Examples
 (
     (call
        method: (identifier) @run (#any-of? @run "describe" "context" "it" "its" "specify")
        arguments: (argument_list . (_) @_name)
-    ) @_rspec-test
-    (#set! tag rspec-test)
+    ) @_ruby-test
+    (#set! tag ruby-test)
 )
 
 ; Examples (one-liner syntax)
@@ -55,6 +53,6 @@
         method: (identifier) @run (#any-of? @run "it" "its" "specify")
         block: (_) @_name
         !arguments
-    ) @_rspec-test
-    (#set! tag rspec-test)
+    ) @_ruby-test
+    (#set! tag ruby-test)
 )

--- a/extensions/ruby/languages/ruby/tasks.json
+++ b/extensions/ruby/languages/ruby/tasks.json
@@ -1,8 +1,7 @@
 [
   {
-    "label": "rspec $ZED_RELATIVE_FILE:$ZED_ROW",
-    "command": "./bin/rspec",
-    "args": ["\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
-    "tags": ["rspec-test"]
+    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
+    "command": "echo 'To run tests, configure tasks in your \".zed/tasks.json\" file as described in the Ruby extension documentation.'",
+    "tags": ["ruby-test"]
   }
 ]


### PR DESCRIPTION
The Ruby world has many testing frameworks:

- Minitest
- RSpec
- quickdraw
- tldr
- and many others.

Attempting to support all of them through a single `tasks.json` file is a challenging task and nearly impossible. All testing frameworks have different running options and commands. It's still possible to use tree-sitter queries to detect runnables in Ruby code but Zed lacks the ability to detect the testing framework in a project that can be used to detect the correct commands to run tests or runnables. The end user knows the correct command and it's wise to delegate creating the command to them. It would be a bit strange to leave the user without any guidance, so this commit adds example tasks for various Ruby testing frameworks.

Closes #12579

Here is the screenshot how it looks:

![CleanShot 2024-07-01 at 19 37 08@2x](https://github.com/zed-industries/zed/assets/1894248/e9659822-6c02-4afb-a0e4-e9966b9fb2f5)


Release Notes:

- N/A
