### PR TITLE
Reorganize the context menu a bit

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -161,19 +161,20 @@ pub fn deploy_context_menu(
         ui::ContextMenu::build(cx, |menu, _cx| {
             let builder = menu
                 .on_blur_subscription(Subscription::new(|| {}))
-                .action("Rename Symbol", Box::new(Rename))
                 .action("Go to Definition", Box::new(GoToDefinition))
                 .action("Go to Declaration", Box::new(GoToDeclaration))
                 .action("Go to Type Definition", Box::new(GoToTypeDefinition))
                 .action("Go to Implementation", Box::new(GoToImplementation))
                 .action("Find All References", Box::new(FindAllReferences))
+                .separator()
+                .action("Rename Symbol", Box::new(Rename))
+                .action("Format Buffer", Box::new(Format))
                 .action(
                     "Code Actions",
                     Box::new(ToggleCodeActions {
                         deployed_from_indicator: None,
                     }),
                 )
-                .action("Format Buffer", Box::new(Format))
                 .separator()
                 .action("Cut", Box::new(Cut))
                 .action("Copy", Box::new(Copy))


### PR DESCRIPTION
Follow up to #16080 
The idea is that the current context menu became a bit top-heavy over time. Let's reorganisze it into four sections:
1. Finding symbols
2. Editing using lsp and similar
3. Copy/Cut/Paste
4. Getting file location

Release Notes:

- Reorganized context menu to be a bit less top heavy and have more logical parts 

Before (a giant part on top and two small ones on the bottom):
<img width="248" alt="Screenshot 2024-08-23 at 21 02 33" src="https://github.com/user-attachments/assets/87a136c7-df16-4032-ba02-dea087fd8445">

After (much more balanced):
<img width="250" alt="Screenshot 2024-08-23 at 21 01 28" src="https://github.com/user-attachments/assets/4aa48b8a-99f3-4315-b325-625a47ecd5b8">
