### PR TITLE
blade: Align rasterized path bounds to whole pixels

### DIFF
--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -481,7 +481,11 @@ impl BladeRenderer {
         let mut vertices_by_texture_id = HashMap::default();
 
         for path in paths {
-            let clipped_bounds = path.bounds.intersect(&path.content_mask.bounds);
+            let clipped_bounds = path
+                .bounds
+                .intersect(&path.content_mask.bounds)
+                .map_origin(|origin| origin.floor())
+                .map_size(|size| size.ceil());
             let tile = self.atlas.allocate_for_rendering(
                 clipped_bounds.size.map(Into::into),
                 AtlasTextureKind::Path,


### PR DESCRIPTION
Related: https://github.com/zed-industries/zed/pull/15822

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4c4ed1e7-b639-44ce-b318-8cdaaee809ee)| ![image](https://github.com/user-attachments/assets/c2757528-eef3-4d21-9522-39b2597a96b7) |
| ![image](https://github.com/user-attachments/assets/b70ee108-bea6-4e5e-9583-392d1163d236) | ![image](https://github.com/user-attachments/assets/aefc1f0c-7bba-4287-a3f9-bbb9befb6a4c) |

Release Notes:

- N/A
