### PR TITLE
zed: Add cli arg to allocconsole on Windows in windows_subsystem "windows" mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13937,6 +13937,7 @@ dependencies = [
  "uuid",
  "vim",
  "welcome",
+ "windows 0.58.0",
  "winresource",
  "workspace",
  "zed_actions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -499,6 +499,7 @@ features = [
     "Win32_Security",
     "Win32_Security_Credentials",
     "Win32_Storage_FileSystem",
+    "Win32_System_Console",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_DataExchange",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -112,6 +112,9 @@ welcome.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows.workspace = true
+
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource = "0.1"
 


### PR DESCRIPTION
This PR adds a flag `--win-console` when compiling on windows. (flag name and flag description can be changed if it's not desirable, let me know!)

When compiled on release for windows, `windows_subsystem` is set to `"windows"`, which opens the program without a console. This causes the nice side effect of there being no weird console popup when running a gui application. However, it also causes there to be no terminal output _even_ if you launched the program from a terminal.

Sometimes terminal output is desired so we can see what's going on (this is, after all, why we compiled in `"console"` mode when compiling in debug mode). This flag does an `AllocConsole` when compiled in release mode on Windows and directs Zed's stdout/stderr to that console window so we can see its output. Since this flag is opt-in, the console will not display for anyone unless they specifically enable this mode.

While `AttachConsole` acts as if the app had been compiled in `"console"` mode (it directs stdout/stderr to the parent console), it unfortunately is bugged and interleaves the output in the terminal as well as writing over the terminals standard input, which can be very confusing and messy. This is why we use `AllocConsole` instead, since it behaves properly.

_Note: This does not really allow help text when using `-h`, because the window will just close really quickly. This is solvable by manually handling clap help parsing and including an exception for this case to pause until user hits enter. But this is currently not implemented)_

![image](https://github.com/user-attachments/assets/dadfaa9a-3573-4556-871a-28f1af6a3e22)

Release Notes:

- Add cli arg to spawn console on Windows when compiled in windows_subsystem "windows" mode