### PR TITLE
theme_importer: Temporarily patch async-tar compilation failure on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11047,6 +11047,7 @@ name = "theme_importer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-std",
  "clap",
  "gpui",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,6 +314,14 @@ async-dispatcher = "0.1"
 async-fs = "1.6"
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
 async-recursion = "1.0.0"
+# this requirement on async-std and unstable feature is here because async-tar depends on it,
+# but on windows they use a feature only available on unstable, but do not enable this feature in their Cargo.toml.
+# this causes a compile error on windows. this exploits cargo's feature unification to temporarily patch the issue
+#
+# while an issue was made in their repo, it seems unlikely they will fix it anytime soon, even if a pr is submitted
+# https://github.com/zed-industries/zed/issues/12079
+# https://github.com/dignifiedquire/async-tar/issues/48
+async-std = { version = "1.12.0", features = ["unstable"] }
 async-tar = "0.4.2"
 async-trait = "0.1"
 async-tungstenite = "0.23"

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -24,3 +24,9 @@ simplelog.workspace= true
 strum = { workspace = true, features = ["derive"] }
 theme.workspace = true
 vscode_theme = "0.2.0"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+# import async-std to cause the fix to async-tar be compiled in
+# https://github.com/zed-industries/zed/issues/12079
+# https://github.com/dignifiedquire/async-tar/issues/48
+async-std.workspace = true


### PR DESCRIPTION
Closes #12079

This adds a dependency on `async-std` + its `unstable` feature, even though we do not use `async-std` in Zed.

The reason why is because `async-tar` fails to build on windows due to not enabling the `unstable` feature of `async-std`. We exploit cargo's feature unification to patch this problem temporarily. This apparently shows up in the `theme_importer` crate which refuses to build on windows as a result.

While an issue was made in the `async-tar` repo, it is unlikely to be fixed anytime soon since the maintainer has been unresponsive.

ref: https://github.com/dignifiedquire/async-tar/issues/48

```rs
error[E0433]: failed to resolve: could not find `fs` in `windows`
   --> C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\async-tar-0.4.2\src\entry.rs:588:41
    |
588 |                 async_std::os::windows::fs::symlink_file(src, dst).await
    |                                         ^^ could not find `fs` in `windows`
    |
note: found an item that was configured out
   --> C:\Users\user\.cargo\registry\src\index.crates.io-6f17d22bba15001f\async-std-1.12.0\src\os\windows\mod.rs:9:13
    |
9   |     pub mod fs;
    |
```

Alternatives: Fork `async-tar` as a Zed repo and patch it ourselves, then use this version instead of the one from Cargo. But given that this is a single simple case, I don't think it requires something so drastic. 

Release Notes:

- N/A
