### PR TITLE
Some UI tweaks on Extension Card

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -454,16 +454,27 @@ impl ExtensionsPage {
                 h_flex()
                     .justify_between()
                     .child(
-                        Label::new(format!(
-                            "{}: {}",
-                            if extension.authors.len() > 1 {
-                                "Authors"
-                            } else {
-                                "Author"
-                            },
-                            extension.authors.join(", ")
-                        ))
-                        .size(LabelSize::Small),
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Person)
+                                    .size(IconSize::XSmall)
+                                    .color(Color::Default),
+                            )
+                            .child(
+                                Label::new(format!(
+                                    "{}",
+                                    extension
+                                        .authors
+                                        .iter()
+                                        .map(|author| {
+                                            author.split('<').next().unwrap().trim().to_string()
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                ))
+                                .size(LabelSize::Small),
+                            ),
                     )
                     .child(Label::new("<>").size(LabelSize::Small)),
             )
@@ -549,23 +560,44 @@ impl ExtensionsPage {
                 h_flex()
                     .justify_between()
                     .child(
-                        Label::new(format!(
-                            "{}: {}",
-                            if extension.manifest.authors.len() > 1 {
-                                "Authors"
-                            } else {
-                                "Author"
-                            },
-                            extension.manifest.authors.join(", ")
-                        ))
-                        .size(LabelSize::Small),
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Person)
+                                    .size(IconSize::XSmall)
+                                    .color(Color::Default),
+                            )
+                            .child(
+                                Label::new(format!(
+                                    "{}",
+                                    extension
+                                        .manifest
+                                        .authors
+                                        .iter()
+                                        .map(|author| {
+                                            author.split('<').next().unwrap().trim().to_string()
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                ))
+                                .size(LabelSize::Small),
+                            ),
                     )
                     .child(
-                        Label::new(format!(
-                            "Downloads: {}",
-                            extension.download_count.to_formatted_string(&Locale::en)
-                        ))
-                        .size(LabelSize::Small),
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Download)
+                                    .size(IconSize::XSmall)
+                                    .color(Color::Default),
+                            )
+                            .child(
+                                Label::new(format!(
+                                    "{}",
+                                    extension.download_count.to_formatted_string(&Locale::en)
+                                ))
+                                .size(LabelSize::Small),
+                            ),
                     ),
             )
             .child(

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -462,8 +462,7 @@ impl ExtensionsPage {
                                     .color(Color::Default),
                             )
                             .child(
-                                Label::new(format!(
-                                    "{}",
+                                Label::new(
                                     extension
                                         .authors
                                         .iter()
@@ -472,7 +471,8 @@ impl ExtensionsPage {
                                         })
                                         .collect::<Vec<_>>()
                                         .join(", ")
-                                ))
+                                        .to_string(),
+                                )
                                 .size(LabelSize::Small),
                             ),
                     )
@@ -568,8 +568,7 @@ impl ExtensionsPage {
                                     .color(Color::Default),
                             )
                             .child(
-                                Label::new(format!(
-                                    "{}",
+                                Label::new(
                                     extension
                                         .manifest
                                         .authors
@@ -579,7 +578,8 @@ impl ExtensionsPage {
                                         })
                                         .collect::<Vec<_>>()
                                         .join(", ")
-                                ))
+                                        .to_string(),
+                                )
                                 .size(LabelSize::Small),
                             ),
                     )
@@ -592,10 +592,12 @@ impl ExtensionsPage {
                                     .color(Color::Default),
                             )
                             .child(
-                                Label::new(format!(
-                                    "{}",
-                                    extension.download_count.to_formatted_string(&Locale::en)
-                                ))
+                                Label::new(
+                                    extension
+                                        .download_count
+                                        .to_formatted_string(&Locale::en)
+                                        .to_string(),
+                                )
                                 .size(LabelSize::Small),
                             ),
                     ),


### PR DESCRIPTION
This PR replaces text with existing Zed icons in the extension card. These ideas are inspired by the Zed extension website.

It replace following texts:
- "Author" and adds a person icon
- "Downloads" and adds download icon

And it also crops out the names of extension developer

### Screenshot

![Screenshot_20240825_121718](https://github.com/user-attachments/assets/dc05d4ee-342c-43d6-9f8b-250ff5c122ff)


Release Notes:

- N/A
