### PR TITLE
elixir: Make files required by elixir-ls executable

### DIFF
--- a/extensions/elixir/src/language_servers/elixir_ls.rs
+++ b/extensions/elixir/src/language_servers/elixir_ls.rs
@@ -55,13 +55,11 @@ impl ElixirLs {
 
         let (platform, _arch) = zed::current_platform();
         let version_dir = format!("elixir-ls-{}", release.version);
-        let binary_path = format!(
-            "{version_dir}/language_server.{extension}",
-            extension = match platform {
-                zed::Os::Mac | zed::Os::Linux => "sh",
-                zed::Os::Windows => "bat",
-            }
-        );
+        let extension = match platform {
+            zed::Os::Mac | zed::Os::Linux => "sh",
+            zed::Os::Windows => "bat",
+        };
+        let binary_path = format!("{version_dir}/language_server.{extension}");
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             zed::set_language_server_installation_status(
@@ -75,6 +73,10 @@ impl ElixirLs {
                 zed::DownloadedFileType::Zip,
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
+
+            zed::make_file_executable(&binary_path)?;
+            zed::make_file_executable(&format!("{version_dir}/launch.{extension}"))?;
+            zed::make_file_executable(&format!("{version_dir}/debug_adapter.{extension}"))?;
 
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;


### PR DESCRIPTION
Closes:

- #15802

This PR fixes an issue in the `elixir-ls` language server installation where some of the required scripts was not being made executable when installed from GitHub.

Release Notes:

- N/A
