### PR TITLE
Add instruction for metal to Getting Started

### DIFF
--- a/crates/gpui/README.md
+++ b/crates/gpui/README.md
@@ -5,7 +5,9 @@ for Rust, designed to support a wide variety of applications.
 
 ## Getting Started
 
-GPUI is still in active development as we work on the Zed code editor and isn't yet on crates.io. You'll also need to use the latest version of stable rust and be on macOS. Add the following to your Cargo.toml:
+GPUI is still in active development as we work on the Zed code editor and isn't yet on crates.io. You'll also need to use the latest version of stable rust and be on macOS. If `xcrun metal` is _unable to find utility "metal"_, install `xcode` and run `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`.
+
+Add the following to your Cargo.toml:
 
 ```toml
 gpui = { git = "https://github.com/zed-industries/zed" }


### PR DESCRIPTION
gpui requires "metal", but it's not installed on a new system. The instruction should resolve a stumbling block for other newcomers like me, and comes from https://github.com/gfx-rs/gfx/issues/2309#issuecomment-413695219