### PR TITLE
language: Do not fetch diagnostics when iterating over text without language awareness

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1358,7 +1358,9 @@ impl Language {
                 });
             let highlight_maps = vec![grammar.highlight_map()];
             let mut offset = 0;
-            for chunk in BufferChunks::new(text, range, Some((captures, highlight_maps)), None) {
+            for chunk in
+                BufferChunks::new(text, range, Some((captures, highlight_maps)), false, None)
+            {
                 let end_offset = offset + chunk.text.len();
                 if let Some(highlight_id) = chunk.syntax_highlight_id {
                     if !highlight_id.is_default() {


### PR DESCRIPTION
This PR fixes a regression from  https://github.com/zed-industries/zed/pull/15646 where we've started fetching diagnostic spans unconditionally (whereas previously that wasn't done when iterating over raw text).

Closes #16764

Release Notes:

- Fixed performance regression in handling buffers with large quantities of diagnostics.

