### PR TITLE
Improve Linux terminal keymap and context menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10993,6 +10993,7 @@ dependencies = [
  "ui",
  "util",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -613,11 +613,15 @@
       "ctrl-alt-space": "terminal::ShowCharacterPalette",
       "ctrl-shift-c": "terminal::Copy",
       "ctrl-insert": "terminal::Copy",
-      // "ctrl-a": "editor::SelectAll", // conflicts with readline
       "ctrl-shift-v": "terminal::Paste",
       "shift-insert": "terminal::Paste",
       "ctrl-enter": "assistant::InlineAssist",
+      // Overrides for conflicting keybindings
       "ctrl-w": ["terminal::SendKeystroke", "ctrl-w"],
+      "ctrl-shift-a": "editor::SelectAll",
+      "ctrl-shift-f": "buffer_search::Deploy",
+      "ctrl-shift-l": "terminal::Clear",
+      "ctrl-shift-w": "pane::CloseActiveItem",
       "ctrl-e": ["terminal::SendKeystroke", "ctrl-e"],
       "up": ["terminal::SendKeystroke", "up"],
       "pageup": ["terminal::SendKeystroke", "pageup"],
@@ -631,8 +635,7 @@
       "shift-up": "terminal::ScrollLineUp",
       "shift-down": "terminal::ScrollLineDown",
       "shift-home": "terminal::ScrollToTop",
-      "shift-end": "terminal::ScrollToBottom",
-      "ctrl-shift-f": "buffer_search::Deploy"
+      "shift-end": "terminal::ScrollToBottom"
     }
   }
 ]

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -474,8 +474,7 @@
   {
     "context": "!Terminal",
     "bindings": {
-      "ctrl-shift-c": "collab_panel::ToggleFocus",
-      "ctrl-shift-f": "buffer_search::Deploy"
+      "ctrl-shift-c": "collab_panel::ToggleFocus"
     }
   },
   {
@@ -632,7 +631,8 @@
       "shift-up": "terminal::ScrollLineUp",
       "shift-down": "terminal::ScrollLineDown",
       "shift-home": "terminal::ScrollToTop",
-      "shift-end": "terminal::ScrollToBottom"
+      "shift-end": "terminal::ScrollToBottom",
+      "ctrl-shift-f": "buffer_search::Deploy"
     }
   }
 ]

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -26,7 +26,7 @@ pub use context_store::*;
 use feature_flags::FeatureFlagAppExt;
 use fs::Fs;
 use gpui::Context as _;
-use gpui::{actions, impl_actions, AppContext, Global, SharedString, UpdateGlobal};
+use gpui::{actions, AppContext, Global, SharedString, UpdateGlobal};
 use indexed_docs::IndexedDocsRegistry;
 pub(crate) use inline_assistant::*;
 use language_model::{
@@ -68,13 +68,6 @@ actions!(
 );
 
 const DEFAULT_CONTEXT_LINES: usize = 50;
-
-#[derive(Clone, Default, Deserialize, PartialEq)]
-pub struct InlineAssist {
-    prompt: Option<String>,
-}
-
-impl_actions!(assistant, [InlineAssist]);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct MessageId(clock::Lamport);

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -12,10 +12,10 @@ use crate::{
     slash_command_picker,
     terminal_inline_assistant::TerminalInlineAssistant,
     Assist, CacheStatus, ConfirmCommand, Context, ContextEvent, ContextId, ContextStore,
-    CycleMessageRole, DeployHistory, DeployPromptLibrary, InlineAssist, InlineAssistId,
-    InlineAssistant, InsertIntoEditor, MessageStatus, ModelSelector, PendingSlashCommand,
-    PendingSlashCommandStatus, QuoteSelection, RemoteContextMetadata, SavedContextMetadata, Split,
-    ToggleFocus, ToggleModelSelector, WorkflowStepResolution, WorkflowStepView,
+    CycleMessageRole, DeployHistory, DeployPromptLibrary, InlineAssistId, InlineAssistant,
+    InsertIntoEditor, MessageStatus, ModelSelector, PendingSlashCommand, PendingSlashCommandStatus,
+    QuoteSelection, RemoteContextMetadata, SavedContextMetadata, Split, ToggleFocus,
+    ToggleModelSelector, WorkflowStepResolution, WorkflowStepView,
 };
 use crate::{ContextStoreEvent, ModelPickerDelegate};
 use anyhow::{anyhow, Result};
@@ -82,6 +82,7 @@ use workspace::{
     ToolbarItemView, Workspace,
 };
 use workspace::{searchable::SearchableItemHandle, NewFile};
+use zed_actions::InlineAssist;
 
 pub fn init(cx: &mut AppContext) {
     workspace::FollowableViewRegistry::register::<ContextEditor>(cx);
@@ -107,27 +108,10 @@ pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(
         |terminal_panel: &mut TerminalPanel, cx: &mut ViewContext<TerminalPanel>| {
             let settings = AssistantSettings::get_global(cx);
-            if !settings.enabled {
-                return;
-            }
-
-            terminal_panel.register_tab_bar_button(cx.new_view(|_| InlineAssistTabBarButton), cx);
+            terminal_panel.asssistant_enabled(settings.enabled, cx);
         },
     )
     .detach();
-}
-
-struct InlineAssistTabBarButton;
-
-impl Render for InlineAssistTabBarButton {
-    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        IconButton::new("terminal_inline_assistant", IconName::ZedAssistant)
-            .icon_size(IconSize::Small)
-            .on_click(cx.listener(|_, _, cx| {
-                cx.dispatch_action(InlineAssist::default().boxed_clone());
-            }))
-            .tooltip(move |cx| Tooltip::for_action("Inline Assist", &InlineAssist::default(), cx))
-    }
 }
 
 pub enum AssistantPanelEvent {

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1,6 +1,7 @@
 use crate::{
-    humanize_token_count, prompts::PromptBuilder, AssistantPanel, AssistantPanelEvent,
-    CharOperation, LineDiff, LineOperation, ModelSelector, StreamingDiff,
+    assistant_settings::AssistantSettings, humanize_token_count, prompts::PromptBuilder,
+    AssistantPanel, AssistantPanelEvent, CharOperation, LineDiff, LineOperation, ModelSelector,
+    StreamingDiff,
 };
 use anyhow::{anyhow, Context as _, Result};
 use client::{telemetry::Telemetry, ErrorExt};
@@ -35,7 +36,7 @@ use language_model::{
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
 use rope::Rope;
-use settings::Settings;
+use settings::{Settings, SettingsStore};
 use smol::future::FutureExt;
 use std::{
     cmp,
@@ -47,6 +48,7 @@ use std::{
     task::{self, Poll},
     time::{Duration, Instant},
 };
+use terminal_view::terminal_panel::TerminalPanel;
 use theme::ThemeSettings;
 use ui::{prelude::*, CheckboxWithLabel, IconButtonShape, Popover, Tooltip};
 use util::{RangeExt, ResultExt};
@@ -129,6 +131,18 @@ impl InlineAssistant {
     pub fn register_workspace(&mut self, workspace: &View<Workspace>, cx: &mut WindowContext) {
         cx.subscribe(workspace, |_, event, cx| {
             Self::update_global(cx, |this, cx| this.handle_workspace_event(event, cx));
+        })
+        .detach();
+
+        let workspace = workspace.clone();
+        cx.observe_global::<SettingsStore>(move |cx| {
+            let Some(terminal_panel) = workspace.read(cx).panel::<TerminalPanel>(cx) else {
+                return;
+            };
+            let enabled = AssistantSettings::get_global(cx).enabled;
+            terminal_panel.update(cx, |terminal_panel, cx| {
+                terminal_panel.asssistant_enabled(enabled, cx)
+            });
         })
         .detach();
     }

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -1,6 +1,4 @@
-use crate::{
-    slash_command::SlashCommandCompletionProvider, AssistantPanel, InlineAssist, InlineAssistant,
-};
+use crate::{slash_command::SlashCommandCompletionProvider, AssistantPanel, InlineAssistant};
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use collections::{HashMap, HashSet};
@@ -44,6 +42,7 @@ use ui::{
 use util::{ResultExt, TryFutureExt};
 use uuid::Uuid;
 use workspace::Workspace;
+use zed_actions::InlineAssist;
 
 actions!(
     prompt_library,

--- a/crates/quick_action_bar/src/quick_action_bar.rs
+++ b/crates/quick_action_bar/src/quick_action_bar.rs
@@ -1,5 +1,5 @@
 use assistant::assistant_settings::AssistantSettings;
-use assistant::{AssistantPanel, InlineAssist};
+use assistant::AssistantPanel;
 use editor::actions::{
     AddSelectionAbove, AddSelectionBelow, DuplicateLineDown, GoToDiagnostic, GoToHunk,
     GoToPrevDiagnostic, GoToPrevHunk, MoveLineDown, MoveLineUp, SelectAll, SelectLargerSyntaxNode,
@@ -20,6 +20,7 @@ use ui::{
 use workspace::{
     item::ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
 };
+use zed_actions::InlineAssist;
 
 mod repl_menu;
 mod toggle_markdown_preview;

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -36,6 +36,7 @@ theme.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -33,6 +33,7 @@ use workspace::{
 };
 
 use anyhow::Result;
+use zed_actions::InlineAssist;
 
 const TERMINAL_PANEL_KEY: &str = "TerminalPanel";
 
@@ -68,7 +69,8 @@ pub struct TerminalPanel {
     _subscriptions: Vec<Subscription>,
     deferred_tasks: HashMap<TaskId, Task<()>>,
     enabled: bool,
-    additional_tab_bar_buttons: Vec<AnyView>,
+    assistant_enabled: bool,
+    assistant_tab_bar_button: Option<AnyView>,
 }
 
 impl TerminalPanel {
@@ -154,23 +156,25 @@ impl TerminalPanel {
             deferred_tasks: HashMap::default(),
             _subscriptions: subscriptions,
             enabled,
-            additional_tab_bar_buttons: Vec::new(),
+            assistant_enabled: false,
+            assistant_tab_bar_button: None,
         };
         this.apply_tab_bar_buttons(cx);
         this
     }
 
-    pub fn register_tab_bar_button(
-        &mut self,
-        button: impl Into<AnyView>,
-        cx: &mut ViewContext<Self>,
-    ) {
-        self.additional_tab_bar_buttons.push(button.into());
+    pub fn asssistant_enabled(&mut self, enabled: bool, cx: &mut ViewContext<Self>) {
+        self.assistant_enabled = enabled;
+        if enabled {
+            self.assistant_tab_bar_button = Some(cx.new_view(|_| InlineAssistTabBarButton).into());
+        } else {
+            self.assistant_tab_bar_button = None;
+        }
         self.apply_tab_bar_buttons(cx);
     }
 
     fn apply_tab_bar_buttons(&self, cx: &mut ViewContext<Self>) {
-        let additional_buttons = self.additional_tab_bar_buttons.clone();
+        let assistant_tab_bar_button = self.assistant_tab_bar_button.clone();
         self.pane.update(cx, |pane, cx| {
             pane.set_render_tab_bar_buttons(cx, move |pane, cx| {
                 if !pane.has_focus(cx) && !pane.context_menu_focused(cx) {
@@ -179,7 +183,7 @@ impl TerminalPanel {
                 let focus_handle = pane.focus_handle(cx);
                 let right_children = h_flex()
                     .gap_2()
-                    .children(additional_buttons.clone())
+                    .children(assistant_tab_bar_button.clone())
                     .child(
                         PopoverMenu::new("terminal-tab-bar-popover-menu")
                             .trigger(
@@ -686,6 +690,10 @@ impl TerminalPanel {
     fn has_no_terminals(&self, cx: &WindowContext) -> bool {
         self.pane.read(cx).items_len() == 0 && self.pending_terminals_to_add == 0
     }
+
+    pub fn assistant_enabled(&self) -> bool {
+        self.assistant_enabled
+    }
 }
 
 async fn wait_for_terminals_tasks(
@@ -848,6 +856,19 @@ impl Panel for TerminalPanel {
 
     fn pane(&self) -> Option<View<Pane>> {
         Some(self.pane.clone())
+    }
+}
+
+struct InlineAssistTabBarButton;
+
+impl Render for InlineAssistTabBarButton {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        IconButton::new("terminal_inline_assistant", IconName::ZedAssistant)
+            .icon_size(IconSize::Small)
+            .on_click(cx.listener(|_, _, cx| {
+                cx.dispatch_action(InlineAssist::default().boxed_clone());
+            }))
+            .tooltip(move |cx| Tooltip::for_action("Inline Assist", &InlineAssist::default(), cx))
     }
 }
 

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -40,3 +40,10 @@ actions!(
         ResetUiFontSize
     ]
 );
+
+#[derive(Clone, Default, Deserialize, PartialEq)]
+pub struct InlineAssist {
+    pub prompt: Option<String>,
+}
+
+impl_actions!(assistant, [InlineAssist]);


### PR DESCRIPTION
Follow-up https://github.com/zed-industries/zed/pull/16085 that fixes the search deploy to be actually a part of the terminal-related bindings.

Part of https://github.com/zed-industries/zed/issues/16839

Also 

* fixes few other bindings to use `shift` and avoid conflicts with the existing key bindings.
* adds terminal inline assist to the context menu and makes both the menu and the button to dynamically adjust to `assist.enabled` settings change

It is still unclear to me, why certain labels for certain bindings are wrong (it's still showing `ctrl-w` for closing the terminal tab, and `shift-insert` instead of `ctrl-shift-v` for Paste, while Insert is near and has a `ctrl-shift-c` binding shown) but at least the keys work now.

Release notes: 
- Improved Linux terminal keymap and context menu
