### PR TITLE
A set of small fixes

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -2,11 +2,15 @@
   {
     "label": "clippy",
     "command": "./script/clippy",
-    "args": []
+    "args": [],
+    "allow_concurrent_runs": true,
+    "use_new_terminal": false
   },
   {
     "label": "cargo run --profile release-fast",
     "command": "cargo",
-    "args": ["run", "--profile", "release-fast"]
+    "args": ["run", "--profile", "release-fast"],
+    "allow_concurrent_runs": true,
+    "use_new_terminal": false
   }
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,6 +545,7 @@ zed = { codegen-units = 16 }
 
 [profile.release-fast]
 inherits = "release"
+debug = "full"
 lto = false
 codegen-units = 16
 

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -512,10 +512,6 @@ mod custom_path_matcher {
             })
         }
 
-        pub fn sources(&self) -> &[String] {
-            &self.sources
-        }
-
         pub fn is_match<P: AsRef<Path>>(&self, other: P) -> bool {
             let other_path = other.as_ref();
             self.sources

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -774,6 +774,7 @@ impl BladeRenderer {
     }
 
     /// Required to compile on macOS, but not currently supported.
+    #[cfg_attr(any(target_os = "linux", target_os = "windows"), allow(dead_code))]
     pub fn fps(&self) -> f32 {
         0.0
     }


### PR DESCRIPTION
* Linux Clippy lints fixed
* Zed local tasks are now simpler to rerun
* Zed's `release-fast` build profile keeps the debug info so it's possible to properly debug things without altering the sources

Release Notes:

- N/A
