### PR TITLE
yaml: Add single quotes to list of brackets

### DIFF
--- a/crates/languages/src/yaml/config.toml
+++ b/crates/languages/src/yaml/config.toml
@@ -7,6 +7,7 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
 ]
 
 auto_indent_using_last_non_empty_line = false


### PR DESCRIPTION
Closes #16854

Release Notes:

- Single quotes are now auto-closable in YAML files
