### PR TITLE
Flatten `General` and `Assistant` navigation in docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,11 +3,11 @@
 # General
 
 - [Getting Started](./getting-started.md)
-  - [System Requirements](./system-requirements.md)
-  - [Linux](./linux.md)
-  - [Windows](./windows.md)
-  - [Telemetry](./telemetry.md)
-  - [Additional Learning Materials](./additional-learning-materials.md)
+- [System Requirements](./system-requirements.md)
+- [Linux](./linux.md)
+- [Windows](./windows.md)
+- [Telemetry](./telemetry.md)
+- [Additional Learning Materials](./additional-learning-materials.md)
 
 # Configuration
 
@@ -32,13 +32,13 @@
 
 # Assistant
 
-- [Assistant](./assistant/assistant.md)
-  - [Configuration](./assistant/configuration.md)
-  - [Assistant Panel](./assistant/assistant-panel.md)
-  - [Contexts](./assistant/contexts.md)
-  - [Inline Assistant](./assistant/inline-assistant.md)
-  - [Commands](./assistant/commands.md)
-  - [Prompts](./assistant/prompting.md)
+- [Overview](./assistant/assistant.md)
+- [Configuration](./assistant/configuration.md)
+- [Assistant Panel](./assistant/assistant-panel.md)
+- [Contexts](./assistant/contexts.md)
+- [Inline Assistant](./assistant/inline-assistant.md)
+- [Commands](./assistant/commands.md)
+- [Prompts](./assistant/prompting.md)
 
 # Extensions
 


### PR DESCRIPTION
This PR flattens out the docs nav, so sections like General and Assistant have a single level of navigation items.

Also renames the `Assistant` page -> `Overview` to be more consistent with other sections.

| Before | After |
|--------|-------|
| ![CleanShot 2024-08-26 at 11 23 28@2x](https://github.com/user-attachments/assets/06fb9e46-8667-457e-b187-3c2ce2b60369) | ![CleanShot 2024-08-26 at 11 23 01@2x](https://github.com/user-attachments/assets/1173d75a-53d1-435b-8d1a-c37f28a363d4) |


Release Notes:

- N/A
