### PR TITLE
Add GH action to delete and block malware comments

### DIFF
--- a/.github/workflows/delete-comments.yml
+++ b/.github/workflows/delete-comments.yml
@@ -1,0 +1,45 @@
+name: Delete Mediafire Comments
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  delete_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for specific strings in comment
+        id: check_comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = context.payload.comment.body;
+            const triggerStrings = ['www.mediafire.com', 'Download', 'changeme'];
+            return triggerStrings.some(triggerString => comment.includes(triggerString));
+
+      - name: Delete comment if it contains any of the specific strings
+        if: steps.check_comment.outputs.result == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentId = context.payload.comment.id;
+            await github.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: commentId
+            });
+
+      - name: Block user if comment contains any of the specific strings
+        if: steps.check_comment.outputs.result == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const userId = context.payload.comment.user.id;
+            await github.users.block({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              user_id: userId
+            });


### PR DESCRIPTION
Adds a GitHub action to detect, delete, and block comments linking to mediafire malware campaign.

Release Notes:

- N/A
