### PR TITLE
docs: Set up mold for `docs_preprocessor`

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           mdbook-version: "0.4.37"
 
+      - name: Setup mold
+        uses: rui314/setup-mold@0bf4f07ef9048ec62a45f9dbf2f098afa49695f0 # v1
+        with:
+          mold-version: 2.32.0
+
       - name: Build book
         run: |
           set -euo pipefail


### PR DESCRIPTION
This PR sets up `mold` in the GitHub Action for deploying the docs, since we need it to build `docs_preprocessor` due to the flags we use on Linux.

Release Notes:

- N/A
