### PR TITLE
docs: Override `.cargo/config.toml`

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -21,10 +21,8 @@ jobs:
         with:
           mdbook-version: "0.4.37"
 
-      - name: Setup mold
-        uses: rui314/setup-mold@0bf4f07ef9048ec62a45f9dbf2f098afa49695f0 # v1
-        with:
-          mold-version: 2.32.0
+      - name: Set up default .cargo/config.toml
+        run: cp ./.cargo/collab-config.toml ./.cargo/config.toml
 
       - name: Build book
         run: |


### PR DESCRIPTION
Still trying to work through issues building the docs.

Trying to see if using a simpler Cargo config (that doesn't use `mold` flags) helps.

Release Notes:

- N/A
