### PR TITLE
ruby: Update tree-sitter grammar for the Ruby language

### DIFF
--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -20,7 +20,7 @@ languages = ["Ruby"]
 
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
-commit = "dc2d7d6b50f9975bc3c35bbec0ba11b2617b736b"
+commit = "7dbc1e2d0e2d752577655881f73b4573f3fe85d4"
 
 [grammars.embedded_template]
 repository = "https://github.com/tree-sitter/tree-sitter-embedded-template"


### PR DESCRIPTION
Closes [#7776](https://github.com/zed-industries/zed/issues/7776)

Hi, this pull request updates the tree-sitter grammar for the Ruby language.

The changes between two version do not have any breaking change: https://github.com/tree-sitter/tree-sitter-ruby/compare/dc2d7d6b50f9975bc3c35bbec0ba11b2617b736b..7dbc1e2d0e2d752577655881f73b4573f3fe85d4

Release Notes:

- N/A
