### PR TITLE
ruby: Rename "rbs" language to "RBS"

### DIFF
--- a/extensions/ruby/languages/rbs/config.toml
+++ b/extensions/ruby/languages/rbs/config.toml
@@ -1,4 +1,4 @@
-name = "rbs"
+name = "RBS"
 grammar = "rbs"
 path_suffixes = ["rbs"]
 autoclose_before = "]})"


### PR DESCRIPTION
Rename rbs to RBS. This is primarily a UX change, as the proper name for the Ruby Type Signature language is RBS, not rbs.

Screenshots:

Before:
![CleanShot 2024-08-26 at 18 28 45@2x](https://github.com/user-attachments/assets/c6773fe5-f071-47c7-91b3-27f448ce3b2a)

After:

![CleanShot 2024-08-26 at 18 29 44@2x](https://github.com/user-attachments/assets/ddd8859e-6cbc-4a6f-8485-2b663a76420f)


Release Notes:

- N/A
