### PR TITLE
docs: Install `libxkbcommon`

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Set up default .cargo/config.toml
         run: cp ./.cargo/collab-config.toml ./.cargo/config.toml
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxkbcommon-dev libxkbcommon-x11-dev
+
       - name: Build book
         run: |
           set -euo pipefail


### PR DESCRIPTION
This PR installs the development packages for `xkbcommon` and `xkbcommon-x11` that are needed for building the `docs_preprocessor`.

Release Notes:

- N/A
