### PR TITLE
ruby: Upgrade `zed_extension_api` to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14116,7 +14116,7 @@ dependencies = [
 name = "zed_ruby"
 version = "0.1.0"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/extensions/ruby/Cargo.toml
+++ b/extensions/ruby/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/ruby.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"


### PR DESCRIPTION
This pull request upgrades the Ruby extension to use v0.1.0 of the Zed extension API.

Release Notes:

- N/A
