### PR TITLE
Remove block step from delete comments workflow

### DIFF
--- a/.github/workflows/delete_comments.yml
+++ b/.github/workflows/delete_comments.yml
@@ -31,15 +31,3 @@ jobs:
               repo: context.repo.repo,
               comment_id: commentId
             });
-
-      - name: Block user if comment contains any of the specific strings
-        if: steps.check_comment.outputs.result == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const userId = context.payload.comment.user.id;
-            await github.rest.users.block({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              user_id: userId
-            });


### PR DESCRIPTION
The block step wasn't working, and it also appears that most of these spam comments are coming from compromised accounts, so I think just deleting the comments is okay for now.

Release Notes:

- N/A
