### PR TITLE
Remove reference to Copilot plugin

### DIFF
--- a/crates/language_model/src/provider/copilot_chat.rs
+++ b/crates/language_model/src/provider/copilot_chat.rs
@@ -320,7 +320,7 @@ impl Render for ConfigurationView {
                     |svg, delta| svg.with_transformation(Transformation::rotate(percentage(delta))),
                 );
 
-            const ERROR_LABEL: &str = "Copilot Chat requires the Copilot plugin to be available and running. Please ensure Copilot is running and try again, or use a different Assistant provider.";
+            const ERROR_LABEL: &str = "Copilot Chat requires an active GitHub Copilot subscription. Please ensure Copilot is configured and try again, or use a different Assistant provider.";
 
             match &self.copilot_status {
                 Some(status) => match status {


### PR DESCRIPTION
Users in #16842 were confused by reference in error to non-existent 'Copilot plugin'.

Release Notes:

- N/A
