### PR TITLE
Avoid unwrap of Worktree::root_entry in resolve_path_in_worktrees

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7875,7 +7875,7 @@ impl Project {
                 for candidate in candidates.iter() {
                     let path = worktree
                         .update(&mut cx, |worktree, _| {
-                            let root_entry_path = &worktree.root_entry().unwrap().path;
+                            let root_entry_path = &worktree.root_entry()?.path;
 
                             let resolved = resolve_path(&root_entry_path, candidate);
 


### PR DESCRIPTION
It looks like this unwrap was introduced in https://github.com/zed-industries/zed/pull/16534.

I think a worktree's `root_entry` can be null if it represents a non-existent file that has not yet been saved. I hit a panic due to the `unwrap` a couple of times on nightly.

Release Notes:

- N/A
