### PR TITLE
Bump collab min version to 0.134

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -78,8 +78,6 @@ use tracing::{
     info_span, instrument, Instrument,
 };
 
-use self::connection_pool::VersionedMessage;
-
 pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 // kubernetes gives terminated pods 10s to shutdown gracefully. After they're gone, we can clean up old resources.
@@ -507,7 +505,7 @@ impl Server {
                 forward_mutating_project_request::<proto::ApplyCompletionAdditionalEdits>,
             ))
             .add_request_handler(user_handler(
-                forward_versioned_mutating_project_request::<proto::OpenNewBuffer>,
+                forward_mutating_project_request::<proto::OpenNewBuffer>,
             ))
             .add_request_handler(user_handler(
                 forward_mutating_project_request::<proto::ResolveCompletionDocumentation>,
@@ -549,7 +547,7 @@ impl Server {
                 forward_mutating_project_request::<proto::OnTypeFormatting>,
             ))
             .add_request_handler(user_handler(
-                forward_versioned_mutating_project_request::<proto::SaveBuffer>,
+                forward_mutating_project_request::<proto::SaveBuffer>,
             ))
             .add_request_handler(user_handler(
                 forward_mutating_project_request::<proto::BlameBuffer>,
@@ -3039,45 +3037,6 @@ where
         .await
         .host_for_mutating_project_request(project_id, session.connection_id, session.user_id())
         .await?;
-    let payload = session
-        .peer
-        .forward_request(session.connection_id, host_connection_id, request)
-        .await?;
-    response.send(payload)?;
-    Ok(())
-}
-
-/// forward a project request to the host. These requests are disallowed
-/// for guests.
-async fn forward_versioned_mutating_project_request<T>(
-    request: T,
-    response: Response<T>,
-    session: UserSession,
-) -> Result<()>
-where
-    T: EntityMessage + RequestMessage + VersionedMessage,
-{
-    let project_id = ProjectId::from_proto(request.remote_entity_id());
-
-    let host_connection_id = session
-        .db()
-        .await
-        .host_for_mutating_project_request(project_id, session.connection_id, session.user_id())
-        .await?;
-    if let Some(host_version) = session
-        .connection_pool()
-        .await
-        .connection(host_connection_id)
-        .map(|c| c.zed_version)
-    {
-        if let Some(min_required_version) = request.required_host_version() {
-            if min_required_version > host_version {
-                return Err(anyhow!(ErrorCode::RemoteUpgradeRequired
-                    .with_tag("required", &min_required_version.to_string())))?;
-            }
-        }
-    }
-
     let payload = session
         .peer
         .forward_request(session.connection_id, host_connection_id, request)

--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -32,11 +32,7 @@ impl fmt::Display for ZedVersion {
 
 impl ZedVersion {
     pub fn can_collaborate(&self) -> bool {
-        self.0 >= SemanticVersion::new(0, 129, 2)
-    }
-
-    pub fn with_save_as() -> ZedVersion {
-        ZedVersion(SemanticVersion::new(0, 134, 0))
+        self.0 >= SemanticVersion::new(0, 134, 0)
     }
 
     pub fn with_list_directory() -> ZedVersion {
@@ -45,28 +41,6 @@ impl ZedVersion {
 
     pub fn with_search_candidates() -> ZedVersion {
         ZedVersion(SemanticVersion::new(0, 151, 0))
-    }
-}
-
-pub trait VersionedMessage {
-    fn required_host_version(&self) -> Option<ZedVersion> {
-        None
-    }
-}
-
-impl VersionedMessage for proto::SaveBuffer {
-    fn required_host_version(&self) -> Option<ZedVersion> {
-        if self.new_path.is_some() {
-            Some(ZedVersion::with_save_as())
-        } else {
-            None
-        }
-    }
-}
-
-impl VersionedMessage for proto::OpenNewBuffer {
-    fn required_host_version(&self) -> Option<ZedVersion> {
-        Some(ZedVersion::with_save_as())
     }
 }
 


### PR DESCRIPTION
0.05% of requests use a version less than this today; and it lets us get
  rid of a bunch of versioning we no longer need.

Release Notes:

- N/A
