### PR TITLE
Support extended keys on Mac (insert, f13-f19)

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -165,7 +165,7 @@ fn is_printable_key(key: &str) -> bool {
         "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12"
         | "f13" | "f14" | "f15" | "f16" | "f17" | "f18" | "f19" | "up" | "down" | "left"
         | "right" | "pageup" | "pagedown" | "home" | "end" | "delete" | "insert" | "escape"
-        | "backspace" | "pause" | "break" | "scrolllock" | "printscreen" | "sysrq" => false,
+        | "backspace" => false,
         _ => true,
     }
 }

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -162,9 +162,10 @@ impl Keystroke {
 
 fn is_printable_key(key: &str) -> bool {
     match key {
-        "up" | "down" | "left" | "right" | "pageup" | "pagedown" | "home" | "end" | "delete"
-        | "escape" | "backspace" | "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9"
-        | "f10" | "f11" | "f12" => false,
+        "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12"
+        | "f13" | "f14" | "f15" | "f16" | "f17" | "f18" | "f19" | "up" | "down" | "left"
+        | "right" | "pageup" | "pagedown" | "home" | "end" | "delete" | "insert" | "escape"
+        | "backspace" | "pause" | "break" | "scrolllock" | "printscreen" | "sysrq" => false,
         _ => true,
     }
 }

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -163,9 +163,9 @@ impl Keystroke {
 fn is_printable_key(key: &str) -> bool {
     match key {
         "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12"
-        | "f13" | "f14" | "f15" | "f16" | "f17" | "f18" | "f19" | "up" | "down" | "left"
-        | "right" | "pageup" | "pagedown" | "home" | "end" | "delete" | "insert" | "escape"
-        | "backspace" => false,
+        | "f13" | "f14" | "f15" | "f16" | "f17" | "f18" | "f19" | "backspace" | "delete"
+        | "left" | "right" | "up" | "down" | "pageup" | "pagedown" | "insert" | "home" | "end"
+        | "escape" => false,
         _ => true,
     }
 }

--- a/crates/gpui/src/platform/mac/events.rs
+++ b/crates/gpui/src/platform/mac/events.rs
@@ -56,6 +56,7 @@ pub fn key_to_native(key: &str) -> Cow<str> {
         "home" => NSHomeFunctionKey,
         "end" => NSEndFunctionKey,
         "delete" => NSDeleteFunctionKey,
+        "insert" => NSHelpFunctionKey,
         "f1" => NSF1FunctionKey,
         "f2" => NSF2FunctionKey,
         "f3" => NSF3FunctionKey,
@@ -68,6 +69,13 @@ pub fn key_to_native(key: &str) -> Cow<str> {
         "f10" => NSF10FunctionKey,
         "f11" => NSF11FunctionKey,
         "f12" => NSF12FunctionKey,
+        "f13" => NSF13FunctionKey,
+        "f14" => NSF14FunctionKey,
+        "f15" => NSF15FunctionKey,
+        "f16" => NSF16FunctionKey,
+        "f17" => NSF17FunctionKey,
+        "f18" => NSF18FunctionKey,
+        "f19" => NSF19FunctionKey,
         _ => return Cow::Borrowed(key),
     };
     Cow::Owned(String::from_utf16(&[code]).unwrap())
@@ -284,6 +292,8 @@ unsafe fn parse_keystroke(native_event: id) -> Keystroke {
         Some(NSHomeFunctionKey) => "home".to_string(),
         Some(NSEndFunctionKey) => "end".to_string(),
         Some(NSDeleteFunctionKey) => "delete".to_string(),
+        // Observed Insert==NSHelpFunctionKey not NSInsertFunctionKey.
+        Some(NSHelpFunctionKey) => "insert".to_string(),
         Some(NSF1FunctionKey) => "f1".to_string(),
         Some(NSF2FunctionKey) => "f2".to_string(),
         Some(NSF3FunctionKey) => "f3".to_string(),
@@ -296,6 +306,13 @@ unsafe fn parse_keystroke(native_event: id) -> Keystroke {
         Some(NSF10FunctionKey) => "f10".to_string(),
         Some(NSF11FunctionKey) => "f11".to_string(),
         Some(NSF12FunctionKey) => "f12".to_string(),
+        Some(NSF13FunctionKey) => "f13".to_string(),
+        Some(NSF14FunctionKey) => "f14".to_string(),
+        Some(NSF15FunctionKey) => "f15".to_string(),
+        Some(NSF16FunctionKey) => "f16".to_string(),
+        Some(NSF17FunctionKey) => "f17".to_string(),
+        Some(NSF18FunctionKey) => "f18".to_string(),
+        Some(NSF19FunctionKey) => "f19".to_string(),
         _ => {
             let mut chars_ignoring_modifiers_and_shift =
                 chars_for_modified_key(native_event.keyCode(), false, false);


### PR DESCRIPTION
Closes #16908

Release Notes:

- Improved support for extended keyboards on Mac (F13-F19, Insert)
