### PR TITLE
Reuse workspace on new journal entry command if possible

### DIFF
--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -101,7 +101,7 @@ pub fn new_journal_entry(workspace: &Workspace, cx: &mut WindowContext) {
     let mut open_new_workspace = true;
     'outer: for worktree in worktrees.iter() {
         let worktree_root = worktree.read(cx).abs_path();
-        if worktree.read(cx).root_name() == "journal" {
+        if *worktree_root == journal_dir_clone {
             open_new_workspace = false;
             break;
         }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use workspace::{AppState, ItemHandle, OpenVisible, Workspace};
+use workspace::{AppState, OpenVisible, Workspace};
 
 actions!(journal, [NewJournalEntry]);
 

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -77,6 +77,7 @@ pub fn new_journal_entry(workspace: &mut Workspace, cx: &mut WindowContext) {
             return;
         }
     };
+    let journal_dir_clone = journal_dir.clone();
 
     let now = Local::now();
     let month_dir = journal_dir
@@ -98,15 +99,17 @@ pub fn new_journal_entry(workspace: &mut Workspace, cx: &mut WindowContext) {
 
     let worktrees = workspace.visible_worktrees(cx).collect::<Vec<_>>();
     let mut open_new_workspace = true;
-    for worktree in worktrees.iter() {
+    'outer: for worktree in worktrees.iter() {
+        let worktree_root = worktree.read(cx).abs_path();
         if worktree.read(cx).root_name() == "journal" {
             open_new_workspace = false;
             break;
         }
         for directory in worktree.read(cx).directories(true, 1) {
-            if directory.path.ends_with("journal") {
+            let full_directory_path = worktree_root.join(&directory.path);
+            if full_directory_path.ends_with(&journal_dir_clone) {
                 open_new_workspace = false;
-                break;
+                break 'outer;
             }
         }
     }

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -60,15 +60,15 @@ pub fn init(_: Arc<AppState>, cx: &mut AppContext) {
 
     cx.observe_new_views(
         |workspace: &mut Workspace, _cx: &mut ViewContext<Workspace>| {
-            workspace.register_action(|mut workspace, _: &NewJournalEntry, cx| {
-                new_journal_entry(&mut workspace, cx);
+            workspace.register_action(|workspace, _: &NewJournalEntry, cx| {
+                new_journal_entry(&workspace, cx);
             });
         },
     )
     .detach();
 }
 
-pub fn new_journal_entry(workspace: &mut Workspace, cx: &mut WindowContext) {
+pub fn new_journal_entry(workspace: &Workspace, cx: &mut WindowContext) {
     let settings = JournalSettings::get_global(cx);
     let journal_dir = match journal_dir(settings.path.as_ref().unwrap()) {
         Some(journal_dir) => journal_dir,


### PR DESCRIPTION
Closes #6783

With this PR, the `journal: new journal entry` command only opens a new workspace if the current workspace does not already contain the `journal` directory. Both the root of the work tree and all its subdirectories are checked.

This does not yet check for the day's file specifically, as suggested [here](https://github.com/zed-industries/zed/issues/6783#issuecomment-2268509463).

I'm new to writing Rust code in production (as well as contributing in general), so any feedback is much appreciated!

Release Notes:

- Reuse workspace on `journal: new journal entry` command if possible
