### PR TITLE
Add pane activation bindings for Sublime Text keymap

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -41,7 +41,16 @@
     "context": "Pane",
     "bindings": {
       "f4": "search::SelectNextMatch",
-      "shift-f4": "search::SelectPrevMatch"
+      "shift-f4": "search::SelectPrevMatch",
+      "alt-1": ["pane::ActivateItem", 0],
+      "alt-2": ["pane::ActivateItem", 1],
+      "alt-3": ["pane::ActivateItem", 2],
+      "alt-4": ["pane::ActivateItem", 3],
+      "alt-5": ["pane::ActivateItem", 4],
+      "alt-6": ["pane::ActivateItem", 5],
+      "alt-7": ["pane::ActivateItem", 6],
+      "alt-8": ["pane::ActivateItem", 7],
+      "alt-9": "pane::ActivateLastItem"
     }
   },
   {

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -45,7 +45,16 @@
     "context": "Pane",
     "bindings": {
       "f4": "search::SelectNextMatch",
-      "shift-f4": "search::SelectPrevMatch"
+      "shift-f4": "search::SelectPrevMatch",
+      "cmd-1": ["pane::ActivateItem", 0],
+      "cmd-2": ["pane::ActivateItem", 1],
+      "cmd-3": ["pane::ActivateItem", 2],
+      "cmd-4": ["pane::ActivateItem", 3],
+      "cmd-5": ["pane::ActivateItem", 4],
+      "cmd-6": ["pane::ActivateItem", 5],
+      "cmd-7": ["pane::ActivateItem", 6],
+      "cmd-8": ["pane::ActivateItem", 7],
+      "cmd-9": "pane::ActivateLastItem"
     }
   },
   {


### PR DESCRIPTION
- Sublime Default (Linux)
  <img width="629" alt="Sublime Text 2024-08-27 10 45 51" src="https://github.com/user-attachments/assets/e58208d3-919a-4083-9070-6dd31dd21231">
- Sublime Default (macOS)
  <img width="654" alt="Sublime Text 2024-08-27 10 46 00" src="https://github.com/user-attachments/assets/1d23369f-1cf0-4f9c-99c6-aff9b557c81e">

In Sublime Text, users can switch between tabs by using `cmd` (on macOS) or `alt` (on Linux) combined with the numbers 1 through 9. However, in Zed, even when the `base_keymap` is set to Sublime Text, the default behavior still follows the VS Code method, where `cmd`+`1~9` is used. I have adjusted this setting to match the actual behavior of Sublime Text.

Release Notes:

- Improved Sublime keymap: Support for switching to individual tabs with `cmd-1` thru `cmd-9` (MacOS) and `alt-1` thru `alt-9` (Linux) matching Sublime behavior.