### PR TITLE
project search: Increase perf up to 10x by batching `git status` calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13856,6 +13856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "smallvec",
  "smol",
  "sum_tree",
  "text",

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -15,13 +15,9 @@ impl GitStatus {
     pub(crate) fn new(
         git_binary: &Path,
         working_directory: &Path,
-        mut path_prefix: &Path,
+        path_prefixes: &[PathBuf],
     ) -> Result<Self> {
         let mut child = Command::new(git_binary);
-
-        if path_prefix == Path::new("") {
-            path_prefix = Path::new(".");
-        }
 
         child
             .current_dir(working_directory)
@@ -32,7 +28,13 @@ impl GitStatus {
                 "--untracked-files=all",
                 "-z",
             ])
-            .arg(path_prefix)
+            .args(path_prefixes.iter().map(|path_prefix| {
+                if *path_prefix == Path::new("") {
+                    Path::new(".")
+                } else {
+                    path_prefix
+                }
+            }))
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -41,6 +41,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
+smallvec.workspace = true
 smol.workspace = true
 sum_tree.workspace = true
 text.workspace = true


### PR DESCRIPTION
***Update**: after rebasing on top of https://github.com/zed-industries/zed/pull/16915/ (that also changed how search worked), the results are still good, but not 10x. Instead of going from 10s to 500ms, it goes from 10s to 3s.*

This improves the performance of project-wide search by an order of magnitude.

After digging in, @as-cii and I found that opening buffers was the bottleneck for project-wide search (since Zed opens, parses, ... buffers when finding them, which is something VS Code doesn't do, for example). So this PR improves the performance of opening multiple buffers at once.

It does this by doing two things:

- It batches scan-requests in the worktree. When we search, we search files in chunks of 64. Previously we'd handle all 64 scan requests separately. The new code checks if the scan requests can be batched and if so it, it does that.
- It batches `git status` calls when reloading the project entries for the opened buffers. Instead of calling `git status` for each file, it calls `git status` for a batch of files, and then extracts the status for each file.

(It has to be said that I think the slow performance on `main` has been a regression introduced over the last few months with the changes made to project/worktree/git. I don't think it was this slow ~5 months ago. But I also don't think it was this fast ~5 months ago.)

## Benchmarks

| Search | Before | After (without https://github.com/zed-industries/zed/pull/16915) | After (with https://github.com/zed-industries/zed/pull/16915)
|--------|--------|-------|------|
| `zed.dev` at `2b2a501192e78e`, searching for `<` (`4484` results) | 3.0s<br>2.9s<br>2.89s | 489ms<br>517ms<br>476ms | n/a |
| `zed.dev` at `2b2a501192e78e`, searching for `:` (`25886+` results) | 3.9s<br>3.9s<br>3.8s | 70ms<br>66ms<br>72ms | n/a |
| `zed` at `55dda0e6af`, searching for `<` (`10937+` results) | 10s<br>11s<br>12s | 500m<br>499ms<br>543ms | 3.4s<br>3.1s<br> |

(All results recorded after doing a warm-up run that would start language servers etc.)

Release Notes:

- Performance of project-wide search has been improved by up to 10x.
