### PR TITLE
gpui: Fix performance of app menu opening with large # of windows

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3389,7 +3389,7 @@ impl<'a> WindowContext<'a> {
         self.window.pending_input.is_some()
     }
 
-    fn clear_pending_keystrokes(&mut self) {
+    pub(crate) fn clear_pending_keystrokes(&mut self) {
         self.window.pending_input.take();
     }
 


### PR DESCRIPTION
This is officially my weirdest performance fix to date; With large # of windows opening app menu could take a lot of time (we're talking few seconds with 9 windows, a minute with 10 windows). The fix is to make one method pub(crate).. What?

<img width="981" alt="image" src="https://github.com/user-attachments/assets/83b26154-0acd-43ef-84b3-4b85cde36120">

We were spending most of the time on clear_pending_keystrokes, which - funnily enough - called itself recursively. It turned out we have two methods; `AppContext::clear_pending_keystrokes` and WindowContext::clear_pending_keystrokes. The former calls the latter, but - due to the fact that `WindowContext::clear_pending_keystrokes` is private and `WindowContext` derefs to `AppContext` - `AppContext` one ended up actually calling itself! The fix is plain and simple - marking WindowContext one as pub(crate), so that it gets picked up as a method to call over `AppContext::clear_pending_keystrokes`.

Closes #16895



Release Notes:

- Fixed app menu performance slowdowns when there are multiple windows open.
