### PR TITLE
linux: Remove `inode/directory` from supported MIME types

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -10,7 +10,7 @@ Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
 Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
-MimeType=text/plain;application/x-zerosize;inode/directory;x-scheme-handler/zed;
+MimeType=text/plain;application/x-zerosize;x-scheme-handler/zed;
 Actions=NewWorkspace;
 
 [Desktop Action NewWorkspace]


### PR DESCRIPTION
At the moment Zed is handled as default file browser which causes applications like RustRover to open Zed when instead it should open the Gnome files app. And Zed is probably not intended to be an replacement to the Gnome files app for example.

I'm also currently waiting to fix the issue that Zed is not displayed as an "Application" when using "Open with..." on Arch Linux. Which is caused by not setting `APP_ARGS` which should have the value `%F`

Release Notes:

- Linux: Zed will no longer be marked as the default file browser
