### PR TITLE
Set `*_font_fallbacks` default to `None`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -28,7 +28,7 @@
   "buffer_font_family": "Zed Plex Mono",
   // Set the buffer text's font fallbacks, this will be merged with
   // the platform's default fallbacks.
-  "buffer_font_fallbacks": [],
+  "buffer_font_fallbacks": null,
   // The OpenType features to enable for text in the editor.
   "buffer_font_features": {
     // Disable ligatures:
@@ -54,7 +54,7 @@
   "ui_font_family": "Zed Plex Sans",
   // Set the UI's font fallbacks, this will be merged with the platform's
   // default font fallbacks.
-  "ui_font_fallbacks": [],
+  "ui_font_fallbacks": null,
   // The OpenType features to enable for text in the UI
   "ui_font_features": {
     // Disable ligatures:

--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -26,6 +26,10 @@ fn main() {
         let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);
         cx.open_window(
             WindowOptions {
+                titlebar: Some(TitlebarOptions {
+                    appears_transparent: true,
+                    ..Default::default()
+                }),
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },

--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -26,10 +26,6 @@ fn main() {
         let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);
         cx.open_window(
             WindowOptions {
-                titlebar: Some(TitlebarOptions {
-                    appears_transparent: true,
-                    ..Default::default()
-                }),
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },

--- a/crates/gpui/src/platform/mac/open_type.rs
+++ b/crates/gpui/src/platform/mac/open_type.rs
@@ -35,37 +35,6 @@ pub fn apply_features_and_fallbacks(
     fallbacks: Option<&FontFallbacks>,
 ) -> anyhow::Result<()> {
     unsafe {
-        // let fallback_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
-
-        // if let Some(fallbacks) = fallbacks {
-        //     for user_fallback in fallbacks.fallback_list() {
-        //         let name = CFString::from(user_fallback.as_str());
-        //         let fallback_desc =
-        //             CTFontDescriptorCreateWithNameAndSize(name.as_concrete_TypeRef(), 0.0);
-        //         CFArrayAppendValue(fallback_array, fallback_desc as _);
-        //         CFRelease(fallback_desc as _);
-        //     }
-        // }
-
-        // {
-        //     let preferred_languages: CFArray<CFString> =
-        //         CFArray::wrap_under_create_rule(CFLocaleCopyPreferredLanguages());
-
-        //     let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
-        //         font.native_font().as_concrete_TypeRef(),
-        //         preferred_languages.as_concrete_TypeRef(),
-        //     );
-        //     let default_fallbacks: CFArray<CTFontDescriptor> =
-        //         CFArray::wrap_under_create_rule(default_fallbacks);
-
-        //     default_fallbacks
-        //         .iter()
-        //         .filter(|desc| desc.font_path().is_some())
-        //         .map(|desc| {
-        //             CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
-        //         });
-        // }
-
         let mut keys = vec![kCTFontFeatureSettingsAttribute];
         let mut values = vec![generate_feature_array(features)];
         if let Some(fallbacks) = fallbacks {
@@ -77,9 +46,6 @@ pub fn apply_features_and_fallbacks(
                 ));
             }
         }
-        // let feature_array = generate_feature_array(features);
-        // let keys = [kCTFontFeatureSettingsAttribute, kCTFontCascadeListAttribute];
-        // let values = [feature_array, fallback_array];
         let attrs = CFDictionaryCreate(
             kCFAllocatorDefault,
             keys.as_ptr() as _,
@@ -88,11 +54,6 @@ pub fn apply_features_and_fallbacks(
             &kCFTypeDictionaryKeyCallBacks,
             &kCFTypeDictionaryValueCallBacks,
         );
-        for array in values.iter() {
-            CFRelease(array as *const _ as _);
-        }
-        // CFRelease(feature_array as *const _ as _);
-        // CFRelease(fallback_array as *const _ as _);
         let new_descriptor = CTFontDescriptorCreateWithAttributes(attrs);
         CFRelease(attrs as _);
         let new_descriptor = CTFontDescriptor::wrap_under_create_rule(new_descriptor);

--- a/crates/gpui/src/platform/mac/open_type.rs
+++ b/crates/gpui/src/platform/mac/open_type.rs
@@ -35,50 +35,61 @@ pub fn apply_features_and_fallbacks(
     fallbacks: Option<&FontFallbacks>,
 ) -> anyhow::Result<()> {
     unsafe {
-        let fallback_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+        // let fallback_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
 
+        // if let Some(fallbacks) = fallbacks {
+        //     for user_fallback in fallbacks.fallback_list() {
+        //         let name = CFString::from(user_fallback.as_str());
+        //         let fallback_desc =
+        //             CTFontDescriptorCreateWithNameAndSize(name.as_concrete_TypeRef(), 0.0);
+        //         CFArrayAppendValue(fallback_array, fallback_desc as _);
+        //         CFRelease(fallback_desc as _);
+        //     }
+        // }
+
+        // {
+        //     let preferred_languages: CFArray<CFString> =
+        //         CFArray::wrap_under_create_rule(CFLocaleCopyPreferredLanguages());
+
+        //     let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
+        //         font.native_font().as_concrete_TypeRef(),
+        //         preferred_languages.as_concrete_TypeRef(),
+        //     );
+        //     let default_fallbacks: CFArray<CTFontDescriptor> =
+        //         CFArray::wrap_under_create_rule(default_fallbacks);
+
+        //     default_fallbacks
+        //         .iter()
+        //         .filter(|desc| desc.font_path().is_some())
+        //         .map(|desc| {
+        //             CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
+        //         });
+        // }
+
+        let mut keys = vec![kCTFontFeatureSettingsAttribute];
+        let mut values = vec![generate_feature_array(features)];
         if let Some(fallbacks) = fallbacks {
-            for user_fallback in fallbacks.fallback_list() {
-                let name = CFString::from(user_fallback.as_str());
-                let fallback_desc =
-                    CTFontDescriptorCreateWithNameAndSize(name.as_concrete_TypeRef(), 0.0);
-                CFArrayAppendValue(fallback_array, fallback_desc as _);
-                CFRelease(fallback_desc as _);
+            if !fallbacks.fallback_list().is_empty() {
+                keys.push(kCTFontCascadeListAttribute);
+                values.push(generate_fallback_array());
             }
         }
-
-        {
-            let preferred_languages: CFArray<CFString> =
-                CFArray::wrap_under_create_rule(CFLocaleCopyPreferredLanguages());
-
-            let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
-                font.native_font().as_concrete_TypeRef(),
-                preferred_languages.as_concrete_TypeRef(),
-            );
-            let default_fallbacks: CFArray<CTFontDescriptor> =
-                CFArray::wrap_under_create_rule(default_fallbacks);
-
-            default_fallbacks
-                .iter()
-                .filter(|desc| desc.font_path().is_some())
-                .map(|desc| {
-                    CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
-                });
-        }
-
-        let feature_array = generate_feature_array(features);
-        let keys = [kCTFontFeatureSettingsAttribute, kCTFontCascadeListAttribute];
-        let values = [feature_array, fallback_array];
+        // let feature_array = generate_feature_array(features);
+        // let keys = [kCTFontFeatureSettingsAttribute, kCTFontCascadeListAttribute];
+        // let values = [feature_array, fallback_array];
         let attrs = CFDictionaryCreate(
             kCFAllocatorDefault,
             keys.as_ptr() as _,
             values.as_ptr() as _,
-            2,
+            keys.len() as u32,
             &kCFTypeDictionaryKeyCallBacks,
             &kCFTypeDictionaryValueCallBacks,
         );
-        CFRelease(feature_array as *const _ as _);
-        CFRelease(fallback_array as *const _ as _);
+        for array in values.iter() {
+            CFRelease(array as *const _ as _);
+        }
+        // CFRelease(feature_array as *const _ as _);
+        // CFRelease(fallback_array as *const _ as _);
         let new_descriptor = CTFontDescriptorCreateWithAttributes(attrs);
         CFRelease(attrs as _);
         let new_descriptor = CTFontDescriptor::wrap_under_create_rule(new_descriptor);
@@ -118,6 +129,38 @@ fn generate_feature_array(features: &FontFeatures) -> CFMutableArrayRef {
             CFRelease(dict as _);
         }
         feature_array
+    }
+}
+
+fn generate_fallback_array(fallbacks: &FontFallbacks) -> CFMutableArrayRef {
+    unsafe {
+        let fallback_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+        for user_fallback in fallbacks.fallback_list() {
+            let name = CFString::from(user_fallback.as_str());
+            let fallback_desc =
+                CTFontDescriptorCreateWithNameAndSize(name.as_concrete_TypeRef(), 0.0);
+            CFArrayAppendValue(fallback_array, fallback_desc as _);
+            CFRelease(fallback_desc as _);
+        }
+        {
+            let preferred_languages: CFArray<CFString> =
+                CFArray::wrap_under_create_rule(CFLocaleCopyPreferredLanguages());
+
+            let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
+                font.native_font().as_concrete_TypeRef(),
+                preferred_languages.as_concrete_TypeRef(),
+            );
+            let default_fallbacks: CFArray<CTFontDescriptor> =
+                CFArray::wrap_under_create_rule(default_fallbacks);
+
+            default_fallbacks
+                .iter()
+                .filter(|desc| desc.font_path().is_some())
+                .map(|desc| {
+                    CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
+                });
+        }
+        fallback_array
     }
 }
 

--- a/crates/gpui/src/platform/mac/open_type.rs
+++ b/crates/gpui/src/platform/mac/open_type.rs
@@ -71,7 +71,10 @@ pub fn apply_features_and_fallbacks(
         if let Some(fallbacks) = fallbacks {
             if !fallbacks.fallback_list().is_empty() {
                 keys.push(kCTFontCascadeListAttribute);
-                values.push(generate_fallback_array());
+                values.push(generate_fallback_array(
+                    fallbacks,
+                    font.native_font().as_concrete_TypeRef(),
+                ));
             }
         }
         // let feature_array = generate_feature_array(features);
@@ -81,7 +84,7 @@ pub fn apply_features_and_fallbacks(
             kCFAllocatorDefault,
             keys.as_ptr() as _,
             values.as_ptr() as _,
-            keys.len() as u32,
+            keys.len() as isize,
             &kCFTypeDictionaryKeyCallBacks,
             &kCFTypeDictionaryValueCallBacks,
         );
@@ -108,8 +111,7 @@ pub fn apply_features_and_fallbacks(
 
 fn generate_feature_array(features: &FontFeatures) -> CFMutableArrayRef {
     unsafe {
-        let mut feature_array =
-            CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+        let feature_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
         for (tag, value) in features.tag_value_list() {
             let keys = [kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue];
             let values = [
@@ -132,7 +134,7 @@ fn generate_feature_array(features: &FontFeatures) -> CFMutableArrayRef {
     }
 }
 
-fn generate_fallback_array(fallbacks: &FontFallbacks) -> CFMutableArrayRef {
+fn generate_fallback_array(fallbacks: &FontFallbacks, font_ref: CTFontRef) -> CFMutableArrayRef {
     unsafe {
         let fallback_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
         for user_fallback in fallbacks.fallback_list() {
@@ -142,25 +144,29 @@ fn generate_fallback_array(fallbacks: &FontFallbacks) -> CFMutableArrayRef {
             CFArrayAppendValue(fallback_array, fallback_desc as _);
             CFRelease(fallback_desc as _);
         }
-        {
-            let preferred_languages: CFArray<CFString> =
-                CFArray::wrap_under_create_rule(CFLocaleCopyPreferredLanguages());
-
-            let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
-                font.native_font().as_concrete_TypeRef(),
-                preferred_languages.as_concrete_TypeRef(),
-            );
-            let default_fallbacks: CFArray<CTFontDescriptor> =
-                CFArray::wrap_under_create_rule(default_fallbacks);
-
-            default_fallbacks
-                .iter()
-                .filter(|desc| desc.font_path().is_some())
-                .map(|desc| {
-                    CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
-                });
-        }
+        append_system_fallbacks(fallback_array, font_ref);
         fallback_array
+    }
+}
+
+fn append_system_fallbacks(fallback_array: CFMutableArrayRef, font_ref: CTFontRef) {
+    unsafe {
+        let preferred_languages: CFArray<CFString> =
+            CFArray::wrap_under_create_rule(CFLocaleCopyPreferredLanguages());
+
+        let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
+            font_ref,
+            preferred_languages.as_concrete_TypeRef(),
+        );
+        let default_fallbacks: CFArray<CTFontDescriptor> =
+            CFArray::wrap_under_create_rule(default_fallbacks);
+
+        default_fallbacks
+            .iter()
+            .filter(|desc| desc.font_path().is_some())
+            .map(|desc| {
+                CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
+            });
     }
 }
 


### PR DESCRIPTION
In the current `default.json`, `*_font_fallbacks=[]`, which results in the `fallbacks` value in the `Font` struct always being `Some(...)`. 

This PR introduces the following improvements:
1. Changed `*_font_fallbacks = []` to `*_font_fallbacks = null` in `default.json`.
2. Enhanced the macOS and Windows implementations.

Release Notes:

- N/A
