### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/src/assistant/commands.md
+++ b/docs/src/assistant/commands.md
@@ -9,7 +9,7 @@ Slash commands enhance the assistant's capabilities. Begin by typing a `/` at th
 - `/fetch`: Fetches the content of a webpage and inserts it into the context
 - `/file`: Inserts a single file or a directory of files into the context
 - `/now`: Inserts the current date and time into the context
-- `/prompt`: Adds a custom-configured prompt to the context ([see Prompt Library](/docs/assistant/prompting#prompt-library))
+- `/prompt`: Adds a custom-configured prompt to the context ([see Prompt Library](./prompting#prompt-library))
 - `/symbols`: Inserts the current tab's active symbols into the context
 - `/tab`: Inserts the content of the active tab or all open tabs into the context
 - `/terminal`: Inserts a select number of lines of output from the terminal
@@ -25,7 +25,7 @@ Slash commands enhance the assistant's capabilities. Begin by typing a `/` at th
 
 ## `/default`
 
-Read more about `/default` in the [Prompting: Editing the Default Prompt](/assistant/prompting.md#default-prompt) section.
+Read more about `/default` in the [Prompting: Editing the Default Prompt](./prompting.md#default-prompt) section.
 
 Usage: `/default`
 

--- a/docs/src/assistant/prompting.md
+++ b/docs/src/assistant/prompting.md
@@ -75,11 +75,11 @@ You can manually add the default prompt using the `/default` command.
 
 ## Commands in Prompts
 
-[Commands](/assistant/commands.md) can be used in prompts to insert dynamic content or perform actions. For example, if you want to create a prompt where it is important for the model to know the date, you can use the `/now` command to insert the current date.
+[Commands](./commands.md) can be used in prompts to insert dynamic content or perform actions. For example, if you want to create a prompt where it is important for the model to know the date, you can use the `/now` command to insert the current date.
 
 > **Note:** Slash commands in prompts **must** be on their own line.
 
-See the [Commands](/assistant/commands.md) docs for more information on commands, and what slash commands are available.
+See the [Commands](./commands.md) docs for more information on commands, and what slash commands are available.
 
 ### Example:
 


### PR DESCRIPTION
This PR fixes some broken links in the docs.

All internal links within the docs should be relative links so that mdBook can resolve them to another page and generate the appropriate URL.

Release Notes:

- N/A
