### PR TITLE
inline completions: Add action to toggle inline completions

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1136,7 +1136,7 @@ impl InlineAssistant {
                     editor.set_show_gutter(false, cx);
                     editor.scroll_manager.set_forbid_vertical_scroll(true);
                     editor.set_read_only(true);
-                    editor.set_show_inline_completions(false);
+                    editor.set_show_inline_completions(Some(false), cx);
                     editor.highlight_rows::<DeletedLines>(
                         Anchor::min()..=Anchor::max(),
                         Some(cx.theme().status().deleted_background),

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -495,7 +495,7 @@ impl PromptLibrary {
                             editor.set_text(prompt_metadata.title.unwrap_or_default(), cx);
                             if prompt_id.is_built_in() {
                                 editor.set_read_only(true);
-                                editor.set_show_inline_completions(false);
+                                editor.set_show_inline_completions(Some(false), cx);
                             }
                             editor
                         });
@@ -510,7 +510,7 @@ impl PromptLibrary {
                             let mut editor = Editor::for_buffer(buffer, None, cx);
                             if prompt_id.is_built_in() {
                                 editor.set_read_only(true);
-                                editor.set_show_inline_completions(false);
+                                editor.set_show_inline_completions(Some(false), cx);
                             }
                             editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
                             editor.set_show_gutter(false, cx);

--- a/crates/assistant/src/workflow/step_view.rs
+++ b/crates/assistant/src/workflow/step_view.rs
@@ -78,7 +78,7 @@ impl WorkflowStepView {
             editor.set_show_wrap_guides(false, cx);
             editor.set_show_indent_guides(false, cx);
             editor.set_read_only(true);
-            editor.set_show_inline_completions(false);
+            editor.set_show_inline_completions(Some(false), cx);
             editor.insert_blocks(
                 [
                     BlockProperties {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -317,6 +317,7 @@ gpui::actions!(
         ToggleSelectionMenu,
         ToggleHunkDiff,
         ToggleInlayHints,
+        ToggleInlineCompletions,
         ToggleLineNumbers,
         ToggleRelativeLineNumbers,
         ToggleIndentGuides,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -347,6 +347,7 @@ impl EditorElement {
         register_action(view, cx, Editor::toggle_relative_line_numbers);
         register_action(view, cx, Editor::toggle_indent_guides);
         register_action(view, cx, Editor::toggle_inlay_hints);
+        register_action(view, cx, Editor::toggle_inline_completions);
         register_action(view, cx, hover_popover::hover);
         register_action(view, cx, Editor::reveal_in_finder);
         register_action(view, cx, Editor::copy_path);

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -782,7 +782,7 @@ fn editor_with_deleted_text(
         editor.set_show_gutter(false, cx);
         editor.scroll_manager.set_forbid_vertical_scroll(true);
         editor.set_read_only(true);
-        editor.set_show_inline_completions(false);
+        editor.set_show_inline_completions(Some(false), cx);
         editor.highlight_rows::<DiffRowHighlight>(
             Anchor::min()..=Anchor::max(),
             Some(deleted_color),

--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -186,7 +186,7 @@ impl FeedbackModal {
             );
             editor.set_show_gutter(false, cx);
             editor.set_show_indent_guides(false, cx);
-            editor.set_show_inline_completions(false);
+            editor.set_show_inline_completions(Some(false), cx);
             editor.set_vertical_scroll_margin(5, cx);
             editor.set_use_modal_editing(false);
             editor

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -647,7 +647,7 @@ impl LspLogView {
             editor.set_text(log_contents, cx);
             editor.move_to_end(&MoveToEnd, cx);
             editor.set_read_only(true);
-            editor.set_show_inline_completions(false);
+            editor.set_show_inline_completions(Some(false), cx);
             editor
         });
         let editor_subscription = cx.subscribe(


### PR DESCRIPTION
This adds a new action: `editor: toggle inline completions`.

It allows users to toggle inline completions on/off for the current buffer.

That toggling is not persistent and when the editor is closed, it's gone.

That makes it easy to disable inline completions for a single text buffer, for example, even if you want them on for other buffers.

When toggling on/off, the toggling also overwrites any language settings. So if you have inline completions disabled for Go buffers, toggling them on takes precedence over those settings.


Release Notes:

- Added a new editor action to allow toggling inline completions (Copilot, Supermaven) on and off for the current buffer, taking precedence over any settings.