### PR TITLE
docs: Reference latest version of `zed_extension_api`

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -53,7 +53,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"
 ```
 
 Make sure to use the latest version of the [`zed_extension_api`](https://crates.io/crates/zed_extension_api) available on crates.io.


### PR DESCRIPTION
This PR updates the extension docs to reference the latest version of the `zed_extension_api`.

Release Notes:

- N/A
