### PR TITLE
extensions: Upgrade `zed_extension_api` to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14208,74 +14208,63 @@ name = "zed_astro"
 version = "0.1.0"
 dependencies = [
  "serde",
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_clojure"
 version = "0.0.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_csharp"
 version = "0.0.2"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_dart"
 version = "0.0.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_deno"
 version = "0.0.2"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_elixir"
 version = "0.0.9"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_elm"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_emmet"
 version = "0.0.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_erlang"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.6",
-]
-
-[[package]]
-name = "zed_extension_api"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
-dependencies = [
- "serde",
- "serde_json",
- "wit-bindgen",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -14310,56 +14299,56 @@ dependencies = [
 name = "zed_glsl"
 version = "0.1.0"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_haskell"
 version = "0.1.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_html"
 version = "0.1.2"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_lua"
 version = "0.0.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_ocaml"
 version = "0.0.2"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_php"
 version = "0.1.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_prisma"
 version = "0.0.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_purescript"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -14373,7 +14362,7 @@ dependencies = [
 name = "zed_ruff"
 version = "0.0.2"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -14381,42 +14370,42 @@ name = "zed_snippets"
 version = "0.0.5"
 dependencies = [
  "serde_json",
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_svelte"
 version = "0.0.3"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_terraform"
 version = "0.0.4"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_test_extension"
 version = "0.1.0"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_toml"
 version = "0.1.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zed_uiua"
 version = "0.0.1"
 dependencies = [
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -14424,7 +14413,7 @@ name = "zed_vue"
 version = "0.1.0"
 dependencies = [
  "serde",
- "zed_extension_api 0.0.6",
+ "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/extensions/astro/Cargo.toml
+++ b/extensions/astro/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/clojure/Cargo.toml
+++ b/extensions/clojure/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/clojure.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/csharp/Cargo.toml
+++ b/extensions/csharp/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/csharp.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/dart/Cargo.toml
+++ b/extensions/dart/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/dart.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/deno/Cargo.toml
+++ b/extensions/deno/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/deno.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/elixir/Cargo.toml
+++ b/extensions/elixir/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/elixir.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/elm/Cargo.toml
+++ b/extensions/elm/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/elm.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/emmet/Cargo.toml
+++ b/extensions/emmet/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/emmet.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/erlang/Cargo.toml
+++ b/extensions/erlang/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/erlang.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/glsl/Cargo.toml
+++ b/extensions/glsl/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/glsl.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/haskell.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/html/Cargo.toml
+++ b/extensions/html/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/html.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/lua/Cargo.toml
+++ b/extensions/lua/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/lua.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/ocaml/Cargo.toml
+++ b/extensions/ocaml/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/ocaml.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/php/Cargo.toml
+++ b/extensions/php/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/php.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/prisma/Cargo.toml
+++ b/extensions/prisma/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/prisma.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/purescript/Cargo.toml
+++ b/extensions/purescript/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/purescript.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/ruff/Cargo.toml
+++ b/extensions/ruff/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/ruff.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/snippets/Cargo.toml
+++ b/extensions/snippets/Cargo.toml
@@ -13,5 +13,5 @@ path = "src/snippets.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"
 serde_json = "1.0"

--- a/extensions/svelte/Cargo.toml
+++ b/extensions/svelte/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/svelte.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/terraform/Cargo.toml
+++ b/extensions/terraform/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/terraform.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/test-extension/Cargo.toml
+++ b/extensions/test-extension/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/test_extension.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/toml/Cargo.toml
+++ b/extensions/toml/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/toml.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/uiua/Cargo.toml
+++ b/extensions/uiua/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/uiua.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extensions/vue/Cargo.toml
+++ b/extensions/vue/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"


### PR DESCRIPTION
This PR updates the `zed_extension_api` to v0.1.0 for the extensions that live in this repo.

The changes in that version of additive, so none of the extensions need to change their usage in order to upgrade.

Release Notes:

- N/A
