### PR TITLE
nix: Fix gpu-lib/wayland binary patching on nix package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1724480904,
-        "narHash": "sha256-puBjYiWZMu/VhDk5ZQW88o/IlwsYuoqvCglOESolyBc=",
+        "lastModified": 1724740262,
+        "narHash": "sha256-cpFasbzOTlwLi4fNas6hDznVUdCJn/lMLxi7MAMG6hg=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "dba5ef499c684acae11a2661d0ed45017fe75b71",
+        "rev": "703efdd9b5c6a7d5824afa348a24fbbf8ff226be",
         "type": "github"
       },
       "original": {
@@ -45,23 +45,24 @@
       "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724224976,
-        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
         "type": "github"
       },
       "original": {
@@ -82,11 +83,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1724436261,
-        "narHash": "sha256-N6p1Qd7qgIATJz61JXAqV/rd8umeg0Uj1IawJCTdDlU=",
+        "lastModified": 1724666781,
+        "narHash": "sha256-nOQDgjTDlWe0/+Ptf3o2p6UrznQFHnXBHRV1ZAsSpe8=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "ab34fdd9f3367d1761991f78e3a7006a4d8d2b34",
+        "rev": "095926ea6f008477a15a2ec6b0b8797e2e5be0e5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
+    flake-compat.url = "github:edolstra/flake-compat";
   };
 
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -32,8 +32,11 @@
   in {
     packages = forAllSystems (pkgs: let
       craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.fenix.stable.toolchain);
+      rustPlatform = pkgs.makeRustPlatform {
+        inherit (pkgs.fenix.stable.toolchain) cargo rustc;
+      };
       nightlyBuild = pkgs.callPackage ./nix/build.nix {
-        inherit craneLib;
+        inherit craneLib rustPlatform;
       };
     in {
       zed-editor = nightlyBuild;
@@ -46,9 +49,12 @@
 
     formatter = forAllSystems (pkgs: pkgs.alejandra);
 
-    overlays.default = final: _prev: {
+    overlays.default = final: prev: {
       zed-editor = final.callPackage ./nix/build.nix {
         craneLib = (crane.mkLib final).overrideToolchain (p: p.fenix.stable.toolchain);
+        rustPlatform = final.makeRustPlatform {
+          inherit (final.fenix.stable.toolchain) cargo rustc;
+        };
       };
     };
   };

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -103,8 +103,8 @@
         else "";
 
       postFixup = ''
-        patchelf --add-rpath ${gpu-lib}/lib $out/bin/*
-        patchelf --add-rpath ${wayland}/lib $out/bin/*
+        patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*
+        patchelf --add-rpath ${wayland}/lib $out/libexec/*
       '';
 
       postInstall = ''

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,6 +1,7 @@
 {
   lib,
   craneLib,
+  rustPlatform,
   clang,
   llvmPackages_18,
   mold-wrapped,
@@ -48,6 +49,17 @@
     // {
       inherit src stdenv;
 
+      nativeBuildInputs = [
+        clang
+        copyDesktopItems
+        curl
+        mold-wrapped
+        perl
+        pkg-config
+        protobuf
+        rustPlatform.bindgenHook
+      ];
+
       buildInputs = [
         curl
         fontconfig
@@ -57,20 +69,11 @@
         sqlite
         zlib
         zstd
+
         alsa-lib
         libxkbcommon
         wayland
         xorg.libxcb
-      ];
-
-      nativeBuildInputs = [
-        clang
-        copyDesktopItems
-        curl
-        mold-wrapped
-        perl
-        pkg-config
-        protobuf
       ];
 
       ZSTD_SYS_USE_PKG_CONFIG = true;


### PR DESCRIPTION
Also, includes some cleanup -- adds missing flake-compat input and aligns the nix build module with how nixpkgs does it.

Release Notes:

- Fixed an issue on NixOS package where the wrong binaries were being patched, leading to missing Wayland libs when launching Zed