### PR TITLE
Use JSONC for pyrightconfig.json

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -730,7 +730,13 @@
   //
   "file_types": {
     "JSON": ["flake.lock"],
-    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json", "tsconfig.json"]
+    "JSONC": [
+      "**/.zed/**/*.json",
+      "**/zed/**/*.json",
+      "**/Zed/**/*.json",
+      "tsconfig.json",
+      "pyrightconfig.json"
+    ]
   },
   // The extensions that Zed should automatically install on startup.
   //


### PR DESCRIPTION
Closes #16966

Release Notes:

- Improved detection of pyrightconfig.json as JSONC