### PR TITLE
repl: Refactor outputs for externalization

### DIFF
--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -38,6 +38,7 @@ use std::time::Duration;
 
 use gpui::{
     percentage, Animation, AnimationExt, AnyElement, ClipboardItem, Render, Transformation, View,
+    WeakView,
 };
 use runtimelib::{ExecutionState, JupyterMessageContent, MimeBundle, MimeType};
 use ui::{div, prelude::*, v_flex, IntoElement, Styled, Tooltip, ViewContext};
@@ -56,6 +57,7 @@ use plain::TerminalOutput;
 
 mod user_error;
 use user_error::ErrorView;
+use workspace::Workspace;
 
 /// When deciding what to render from a collection of mediatypes, we need to rank them in order of importance
 fn rank_mime_type(mimetype: &MimeType) -> usize {
@@ -193,13 +195,20 @@ pub enum ExecutionStatus {
 /// It can hold zero or more outputs, which the user
 /// sees as "the output" for a single execution.
 pub struct ExecutionView {
+    #[allow(unused)]
+    workspace: WeakView<Workspace>,
     pub outputs: Vec<Output>,
     pub status: ExecutionStatus,
 }
 
 impl ExecutionView {
-    pub fn new(status: ExecutionStatus, _cx: &mut ViewContext<Self>) -> Self {
+    pub fn new(
+        status: ExecutionStatus,
+        workspace: WeakView<Workspace>,
+        _cx: &mut ViewContext<Self>,
+    ) -> Self {
         Self {
+            workspace,
             outputs: Default::default(),
             status,
         }

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -5,7 +5,6 @@
 //!
 //! ## Key Components
 //!
-//! - `Output`: Represents a single output item, which can be of various types.
 //! - `OutputContent`: An enum that encapsulates different types of output content.
 //! - `ExecutionView`: Manages the display of outputs for a single execution.
 //! - `ExecutionStatus`: Represents the current status of an execution.
@@ -38,9 +37,10 @@ use std::time::Duration;
 
 use editor::Editor;
 use gpui::{
-    percentage, Animation, AnimationExt, AnyElement, ClipboardItem, Render, Transformation, View,
-    WeakView,
+    percentage, Animation, AnimationExt, AnyElement, ClipboardItem, Model, Render, Transformation,
+    View, WeakView,
 };
+use language::Buffer;
 use runtimelib::{ExecutionState, JupyterMessageContent, MimeBundle, MimeType};
 use ui::{div, prelude::*, v_flex, IntoElement, Styled, Tooltip, ViewContext};
 
@@ -73,40 +73,38 @@ fn rank_mime_type(mimetype: &MimeType) -> usize {
     }
 }
 
-pub(crate) trait SupportsClipboard {
+pub(crate) trait OutputContent {
     fn clipboard_content(&self, cx: &WindowContext) -> Option<ClipboardItem>;
-    fn has_clipboard_content(&self, cx: &WindowContext) -> bool;
+    fn has_clipboard_content(&self, _cx: &WindowContext) -> bool {
+        return false;
+    }
+    fn has_buffer_content(&self, _cx: &WindowContext) -> bool {
+        return false;
+    }
+    fn buffer_content(&mut self, _cx: &mut WindowContext) -> Option<Model<Buffer>> {
+        None
+    }
 }
 
-impl SupportsClipboard for OutputContent {
+impl<V: OutputContent + 'static> OutputContent for View<V> {
     fn clipboard_content(&self, cx: &WindowContext) -> Option<ClipboardItem> {
-        match self {
-            OutputContent::Plain { content, .. } => content.read(cx).clipboard_content(cx),
-            OutputContent::Stream { content, .. } => content.read(cx).clipboard_content(cx),
-            OutputContent::Image { content, .. } => content.read(cx).clipboard_content(cx),
-            OutputContent::ErrorOutput(error) => error.traceback.read(cx).clipboard_content(cx),
-            OutputContent::Message(_) => None,
-            OutputContent::Table { content, .. } => content.read(cx).clipboard_content(cx),
-            OutputContent::Markdown { content, .. } => content.read(cx).clipboard_content(cx),
-            OutputContent::ClearOutputWaitMarker => None,
-        }
+        self.read(cx).clipboard_content(cx)
     }
 
     fn has_clipboard_content(&self, cx: &WindowContext) -> bool {
-        match self {
-            OutputContent::Plain { content, .. } => content.read(cx).has_clipboard_content(cx),
-            OutputContent::Stream { content, .. } => content.read(cx).has_clipboard_content(cx),
-            OutputContent::Image { content, .. } => content.read(cx).has_clipboard_content(cx),
-            OutputContent::ErrorOutput(_) => true,
-            OutputContent::Message(_) => false,
-            OutputContent::Table { content, .. } => content.read(cx).has_clipboard_content(cx),
-            OutputContent::Markdown { content, .. } => content.read(cx).has_clipboard_content(cx),
-            OutputContent::ClearOutputWaitMarker => false,
-        }
+        self.read(cx).has_clipboard_content(cx)
+    }
+
+    fn has_buffer_content(&self, cx: &WindowContext) -> bool {
+        self.read(cx).has_buffer_content(cx)
+    }
+
+    fn buffer_content(&mut self, cx: &mut WindowContext) -> Option<Model<Buffer>> {
+        self.update(cx, |item, cx| item.buffer_content(cx))
     }
 }
 
-pub enum OutputContent {
+pub enum Output {
     Plain {
         content: View<TerminalOutput>,
         display_id: Option<String>,
@@ -131,11 +129,76 @@ pub enum OutputContent {
     ClearOutputWaitMarker,
 }
 
-impl OutputContent {
-    fn render(&self, cx: &mut ViewContext<ExecutionView>) -> Option<AnyElement> {
-        let el = match self {
-            // Note: in typical frontends we would show the execute_result.execution_count
-            // Here we can just handle either
+impl Output {
+    fn render_output_controls<V: OutputContent + 'static>(
+        v: View<V>,
+        workspace: WeakView<Workspace>,
+        cx: &mut ViewContext<ExecutionView>,
+    ) -> Option<AnyElement> {
+        if !v.has_clipboard_content(cx) && !v.has_buffer_content(cx) {
+            return None;
+        }
+
+        Some(
+            h_flex()
+                .pl_1()
+                .when(v.has_clipboard_content(cx), |el| {
+                    let v = v.clone();
+                    el.child(
+                        IconButton::new(ElementId::Name("copy-output".into()), IconName::Copy)
+                            .style(ButtonStyle::Transparent)
+                            .tooltip(move |cx| Tooltip::text("Copy Output", cx))
+                            .on_click(cx.listener(move |_, _, cx| {
+                                let clipboard_content = v.clipboard_content(cx);
+
+                                if let Some(clipboard_content) = clipboard_content.as_ref() {
+                                    cx.write_to_clipboard(clipboard_content.clone());
+                                }
+                            })),
+                    )
+                })
+                .when(v.has_buffer_content(cx), |el| {
+                    let v = v.clone();
+                    el.child(
+                        IconButton::new(
+                            ElementId::Name("open-in-buffer".into()),
+                            IconName::FileText,
+                        )
+                        .style(ButtonStyle::Transparent)
+                        .tooltip(move |cx| Tooltip::text("Open in Buffer", cx))
+                        .on_click(cx.listener({
+                            let workspace = workspace.clone();
+
+                            move |_, _, cx| {
+                                let buffer_content =
+                                    v.update(cx, |item, cx| item.buffer_content(cx));
+
+                                if let Some(buffer_content) = buffer_content.as_ref() {
+                                    let buffer = buffer_content.clone();
+                                    let editor = Box::new(cx.new_view(|cx| {
+                                        Editor::for_buffer(buffer.clone(), None, cx)
+                                    }));
+                                    workspace
+                                        .update(cx, |workspace, cx| {
+                                            workspace
+                                                .add_item_to_active_pane(editor, None, true, cx);
+                                        })
+                                        .ok();
+                                }
+                            }
+                        })),
+                    )
+                })
+                .into_any_element(),
+        )
+    }
+
+    fn render(
+        &self,
+        workspace: WeakView<Workspace>,
+        cx: &mut ViewContext<ExecutionView>,
+    ) -> impl IntoElement {
+        let content = match self {
             Self::Plain { content, .. } => Some(content.clone().into_any_element()),
             Self::Markdown { content, .. } => Some(content.clone().into_any_element()),
             Self::Stream { content, .. } => Some(content.clone().into_any_element()),
@@ -146,48 +209,73 @@ impl OutputContent {
             Self::ClearOutputWaitMarker => None,
         };
 
-        el
+        h_flex()
+            .w_full()
+            .items_start()
+            .child(div().flex_1().children(content))
+            .children(match self {
+                Self::Plain { content, .. } => {
+                    Self::render_output_controls(content.clone(), workspace.clone(), cx)
+                }
+                Self::Markdown { content, .. } => {
+                    Self::render_output_controls(content.clone(), workspace.clone(), cx)
+                }
+                Self::Stream { content, .. } => {
+                    Self::render_output_controls(content.clone(), workspace.clone(), cx)
+                }
+                Self::Image { content, .. } => {
+                    Self::render_output_controls(content.clone(), workspace.clone(), cx)
+                }
+                Self::ErrorOutput(err) => {
+                    Self::render_output_controls(err.traceback.clone(), workspace.clone(), cx)
+                }
+                Self::Message(_) => None,
+                Self::Table { content, .. } => {
+                    Self::render_output_controls(content.clone(), workspace.clone(), cx)
+                }
+                Self::ClearOutputWaitMarker => None,
+            })
     }
 
     pub fn display_id(&self) -> Option<String> {
         match self {
-            OutputContent::Plain { display_id, .. } => display_id.clone(),
-            OutputContent::Stream { .. } => None,
-            OutputContent::Image { display_id, .. } => display_id.clone(),
-            OutputContent::ErrorOutput(_) => None,
-            OutputContent::Message(_) => None,
-            OutputContent::Table { display_id, .. } => display_id.clone(),
-            OutputContent::Markdown { display_id, .. } => display_id.clone(),
-            OutputContent::ClearOutputWaitMarker => None,
+            Output::Plain { display_id, .. } => display_id.clone(),
+            Output::Stream { .. } => None,
+            Output::Image { display_id, .. } => display_id.clone(),
+            Output::ErrorOutput(_) => None,
+            Output::Message(_) => None,
+            Output::Table { display_id, .. } => display_id.clone(),
+            Output::Markdown { display_id, .. } => display_id.clone(),
+            Output::ClearOutputWaitMarker => None,
         }
     }
 
     pub fn new(data: &MimeBundle, display_id: Option<String>, cx: &mut WindowContext) -> Self {
         match data.richest(rank_mime_type) {
-            Some(MimeType::Plain(text)) => OutputContent::Plain {
+            Some(MimeType::Plain(text)) => Output::Plain {
                 content: cx.new_view(|cx| TerminalOutput::from(text, cx)),
                 display_id,
             },
             Some(MimeType::Markdown(text)) => {
                 let view = cx.new_view(|cx| MarkdownView::from(text.clone(), cx));
-                OutputContent::Markdown {
+                Output::Markdown {
                     content: view,
                     display_id,
                 }
             }
             Some(MimeType::Png(data)) | Some(MimeType::Jpeg(data)) => match ImageView::from(data) {
-                Ok(view) => OutputContent::Image {
+                Ok(view) => Output::Image {
                     content: cx.new_view(|_| view),
                     display_id,
                 },
-                Err(error) => OutputContent::Message(format!("Failed to load image: {}", error)),
+                Err(error) => Output::Message(format!("Failed to load image: {}", error)),
             },
-            Some(MimeType::DataTable(data)) => OutputContent::Table {
+            Some(MimeType::DataTable(data)) => Output::Table {
                 content: cx.new_view(|cx| TableView::new(data, cx)),
                 display_id,
             },
             // Any other media types are not supported
-            _ => OutputContent::Message("Unsupported media type".to_string()),
+            _ => Output::Message("Unsupported media type".to_string()),
         }
     }
 }
@@ -212,7 +300,7 @@ pub enum ExecutionStatus {
 pub struct ExecutionView {
     #[allow(unused)]
     workspace: WeakView<Workspace>,
-    pub outputs: Vec<OutputContent>,
+    pub outputs: Vec<Output>,
     pub status: ExecutionStatus,
 }
 
@@ -231,14 +319,14 @@ impl ExecutionView {
 
     /// Accept a Jupyter message belonging to this execution
     pub fn push_message(&mut self, message: &JupyterMessageContent, cx: &mut ViewContext<Self>) {
-        let output: OutputContent = match message {
-            JupyterMessageContent::ExecuteResult(result) => OutputContent::new(
+        let output: Output = match message {
+            JupyterMessageContent::ExecuteResult(result) => Output::new(
                 &result.data,
                 result.transient.as_ref().and_then(|t| t.display_id.clone()),
                 cx,
             ),
             JupyterMessageContent::DisplayData(result) => {
-                OutputContent::new(&result.data, result.transient.display_id.clone(), cx)
+                Output::new(&result.data, result.transient.display_id.clone(), cx)
             }
             JupyterMessageContent::StreamContent(result) => {
                 // Previous stream data will combine together, handling colors, carriage returns, etc
@@ -252,7 +340,7 @@ impl ExecutionView {
                 let terminal =
                     cx.new_view(|cx| TerminalOutput::from(&result.traceback.join("\n"), cx));
 
-                OutputContent::ErrorOutput(ErrorView {
+                Output::ErrorOutput(ErrorView {
                     ename: result.ename.clone(),
                     evalue: result.evalue.clone(),
                     traceback: terminal,
@@ -264,7 +352,7 @@ impl ExecutionView {
                         // Pager data comes in via `?` at the end of a statement in Python, used for showing documentation.
                         // Some UI will show this as a popup. For ease of implementation, it's included as an output here.
                         runtimelib::Payload::Page { data, .. } => {
-                            let output = OutputContent::new(data, None, cx);
+                            let output = Output::new(data, None, cx);
                             self.outputs.push(output);
                         }
 
@@ -297,7 +385,7 @@ impl ExecutionView {
                 }
 
                 // Create a marker to clear the output after we get in a new output
-                OutputContent::ClearOutputWaitMarker
+                Output::ClearOutputWaitMarker
             }
             JupyterMessageContent::Status(status) => {
                 match status.execution_state {
@@ -316,7 +404,7 @@ impl ExecutionView {
 
         // Check for a clear output marker as the previous output, so we can clear it out
         if let Some(output) = self.outputs.last() {
-            if let OutputContent::ClearOutputWaitMarker = output {
+            if let Output::ClearOutputWaitMarker = output {
                 self.outputs.clear();
             }
         }
@@ -337,7 +425,7 @@ impl ExecutionView {
         self.outputs.iter_mut().for_each(|output| {
             if let Some(other_display_id) = output.display_id().as_ref() {
                 if other_display_id == display_id {
-                    *output = OutputContent::new(data, Some(display_id.to_owned()), cx);
+                    *output = Output::new(data, Some(display_id.to_owned()), cx);
                     any = true;
                 }
             }
@@ -348,14 +436,10 @@ impl ExecutionView {
         }
     }
 
-    fn apply_terminal_text(
-        &mut self,
-        text: &str,
-        cx: &mut ViewContext<Self>,
-    ) -> Option<OutputContent> {
+    fn apply_terminal_text(&mut self, text: &str, cx: &mut ViewContext<Self>) -> Option<Output> {
         if let Some(last_output) = self.outputs.last_mut() {
             match last_output {
-                OutputContent::Stream {
+                Output::Stream {
                     content: last_stream,
                 } => {
                     // Don't need to add a new output, we already have a terminal output
@@ -372,7 +456,7 @@ impl ExecutionView {
             }
         }
 
-        Some(OutputContent::Stream {
+        Some(Output::Stream {
             content: cx.new_view(|cx| TerminalOutput::from(text, cx)),
         })
     }
@@ -429,94 +513,13 @@ impl Render for ExecutionView {
                 .into_any_element();
         }
 
-        let workspace = self.workspace.clone();
-
         div()
             .w_full()
-            .children(self.outputs.iter().enumerate().map(|(index, output)| {
-                h_flex()
-                    .w_full()
-                    .items_start()
-                    .child(
-                        div().flex_1().child(
-                            output
-                                .render(cx)
-                                .unwrap_or_else(|| div().into_any_element()),
-                        ),
-                    )
-                    .when(output.has_clipboard_content(cx), |el| {
-                        let clipboard_content = output.clipboard_content(cx).clone();
-
-                        let terminal = match output {
-                            OutputContent::Stream { content } => Some(content.clone()),
-                            _ => None,
-                        };
-
-                        el.child(
-                            v_flex()
-                                .pl_1()
-                                .child(
-                                    IconButton::new(
-                                        ElementId::Name(format!("copy-output-{}", index).into()),
-                                        IconName::Copy,
-                                    )
-                                    .style(ButtonStyle::Transparent)
-                                    .tooltip(move |cx| Tooltip::text("Copy Output", cx))
-                                    .on_click(cx.listener(
-                                        move |_, _, cx| {
-                                            if let Some(clipboard_content) =
-                                                clipboard_content.as_ref()
-                                            {
-                                                cx.write_to_clipboard(clipboard_content.clone());
-                                                // todo!(): let the user know that the content was copied
-                                            }
-                                        },
-                                    )),
-                                )
-                                .when_some(terminal, |el, terminal| {
-                                    el.child(
-                                        IconButton::new(
-                                            ElementId::Name(
-                                                format!("open-in-buffer--{}", index).into(),
-                                            ),
-                                            IconName::FileText,
-                                        )
-                                        .style(ButtonStyle::Transparent)
-                                        .tooltip(move |cx| Tooltip::text("Open in Buffer", cx))
-                                        .on_click(
-                                            cx.listener({
-                                                let workspace = workspace.clone();
-
-                                                move |_, _, cx| {
-                                                    // For now we'll only do this for terminal output
-
-                                                    let editor =
-                                                        terminal.update(cx, |terminal, cx| {
-                                                            let buffer = terminal.create_buffer(cx);
-                                                            Box::new(cx.new_view(|cx| {
-                                                                Editor::for_buffer(
-                                                                    buffer.clone(),
-                                                                    None,
-                                                                    cx,
-                                                                )
-                                                            }))
-                                                        });
-
-                                                    workspace
-                                                        .update(cx, |workspace, cx| {
-                                                            workspace.add_item_to_active_pane(
-                                                                editor, None, true, cx,
-                                                            );
-                                                        })
-                                                        .ok();
-                                                }
-                                            }),
-                                        ),
-                                    )
-                                }),
-                        )
-                    })
-            }))
+            .children(
+                self.outputs
+                    .iter()
+                    .map(|output| output.render(self.workspace.clone(), cx)),
+            )
             .children(match self.status {
                 ExecutionStatus::Executing => vec![status],
                 ExecutionStatus::Queued => vec![status],

--- a/crates/repl/src/outputs/image.rs
+++ b/crates/repl/src/outputs/image.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
 use base64::prelude::*;
-use gpui::{
-    img, AnyElement, ClipboardItem, Image, ImageFormat, Pixels, RenderImage, WindowContext,
-};
+use gpui::{img, ClipboardItem, Image, ImageFormat, Pixels, RenderImage, WindowContext};
 use std::sync::Arc;
 use ui::{div, prelude::*, IntoElement, Styled};
 
@@ -59,8 +57,10 @@ impl ImageView {
             image: Arc::new(gpui_image_data),
         });
     }
+}
 
-    pub fn render(&self, cx: &mut WindowContext) -> AnyElement {
+impl Render for ImageView {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let line_height = cx.line_height();
 
         let (height, width) = if self.height as f32 / line_height.0 == u8::MAX as f32 {
@@ -73,11 +73,7 @@ impl ImageView {
 
         let image = self.image.clone();
 
-        div()
-            .h(Pixels(height))
-            .w(Pixels(width))
-            .child(img(image))
-            .into_any_element()
+        div().h(Pixels(height)).w(Pixels(width)).child(img(image))
     }
 }
 

--- a/crates/repl/src/outputs/image.rs
+++ b/crates/repl/src/outputs/image.rs
@@ -4,7 +4,7 @@ use gpui::{img, ClipboardItem, Image, ImageFormat, Pixels, RenderImage, WindowCo
 use std::sync::Arc;
 use ui::{div, prelude::*, IntoElement, Styled};
 
-use crate::outputs::SupportsClipboard;
+use crate::outputs::OutputContent;
 
 /// ImageView renders an image inline in an editor, adapting to the line height to fit the image.
 pub struct ImageView {
@@ -77,7 +77,7 @@ impl Render for ImageView {
     }
 }
 
-impl SupportsClipboard for ImageView {
+impl OutputContent for ImageView {
     fn clipboard_content(&self, _cx: &WindowContext) -> Option<ClipboardItem> {
         Some(ClipboardItem::new_image(self.clipboard_image.as_ref()))
     }

--- a/crates/repl/src/outputs/markdown.rs
+++ b/crates/repl/src/outputs/markdown.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
-use gpui::{div, prelude::*, ClipboardItem, Task, ViewContext, WindowContext};
+use gpui::{div, prelude::*, ClipboardItem, Model, Task, ViewContext, WindowContext};
+use language::Buffer;
 use markdown_preview::{
     markdown_elements::ParsedMarkdown, markdown_parser::parse_markdown,
     markdown_renderer::render_markdown_block,
 };
 use ui::v_flex;
 
-use crate::outputs::SupportsClipboard;
+use crate::outputs::OutputContent;
 
 pub struct MarkdownView {
     raw_text: String,
@@ -41,13 +42,25 @@ impl MarkdownView {
     }
 }
 
-impl SupportsClipboard for MarkdownView {
+impl OutputContent for MarkdownView {
     fn clipboard_content(&self, _cx: &WindowContext) -> Option<ClipboardItem> {
         Some(ClipboardItem::new_string(self.raw_text.clone()))
     }
 
     fn has_clipboard_content(&self, _cx: &WindowContext) -> bool {
         true
+    }
+
+    fn has_buffer_content(&self, _cx: &WindowContext) -> bool {
+        true
+    }
+
+    fn buffer_content(&mut self, cx: &mut WindowContext) -> Option<Model<Buffer>> {
+        let buffer = cx.new_model(|cx| {
+            // todo!(): Bring in the language registry so we can set the language to markdown
+            Buffer::local(self.raw_text.clone(), cx).with_language(language::PLAIN_TEXT.clone(), cx)
+        });
+        Some(buffer)
     }
 }
 

--- a/crates/repl/src/outputs/table.rs
+++ b/crates/repl/src/outputs/table.rs
@@ -62,7 +62,7 @@ use settings::Settings;
 use theme::ThemeSettings;
 use ui::{div, prelude::*, v_flex, IntoElement, Styled};
 
-use crate::outputs::SupportsClipboard;
+use crate::outputs::OutputContent;
 
 /// TableView renders a static table inline in a buffer.
 /// It uses the https://specs.frictionlessdata.io/tabular-data-resource/ specification for data interchange.
@@ -284,7 +284,7 @@ impl Render for TableView {
     }
 }
 
-impl SupportsClipboard for TableView {
+impl OutputContent for TableView {
     fn clipboard_content(&self, _cx: &WindowContext) -> Option<ClipboardItem> {
         Some(self.cached_clipboard_content.clone())
     }

--- a/crates/repl/src/outputs/table.rs
+++ b/crates/repl/src/outputs/table.rs
@@ -87,7 +87,7 @@ fn cell_content(row: &Value, field: &str) -> String {
 const TABLE_Y_PADDING_MULTIPLE: f32 = 0.5;
 
 impl TableView {
-    pub fn new(table: TabularDataResource, cx: &mut WindowContext) -> Self {
+    pub fn new(table: &TabularDataResource, cx: &mut WindowContext) -> Self {
         let mut widths = Vec::with_capacity(table.schema.fields.len());
 
         let text_system = cx.text_system();
@@ -133,7 +133,7 @@ impl TableView {
         let cached_clipboard_content = Self::create_clipboard_content(&table);
 
         Self {
-            table,
+            table: table.clone(),
             widths,
             cached_clipboard_content: ClipboardItem::new_string(cached_clipboard_content),
         }
@@ -192,31 +192,6 @@ impl TableView {
         }
 
         markdown
-    }
-
-    pub fn render(&self, cx: &WindowContext) -> AnyElement {
-        let data = match &self.table.data {
-            Some(data) => data,
-            None => return div().into_any_element(),
-        };
-
-        let mut headings = serde_json::Map::new();
-        for field in &self.table.schema.fields {
-            headings.insert(field.name.clone(), Value::String(field.name.clone()));
-        }
-        let header = self.render_row(&self.table.schema, true, &Value::Object(headings), cx);
-
-        let body = data
-            .iter()
-            .map(|row| self.render_row(&self.table.schema, false, &row, cx));
-
-        v_flex()
-            .id("table")
-            .overflow_x_scroll()
-            .w_full()
-            .child(header)
-            .children(body)
-            .into_any_element()
     }
 
     pub fn render_row(
@@ -278,6 +253,33 @@ impl TableView {
         h_flex()
             .w(total_width)
             .children(row_cells)
+            .into_any_element()
+    }
+}
+
+impl Render for TableView {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let data = match &self.table.data {
+            Some(data) => data,
+            None => return div().into_any_element(),
+        };
+
+        let mut headings = serde_json::Map::new();
+        for field in &self.table.schema.fields {
+            headings.insert(field.name.clone(), Value::String(field.name.clone()));
+        }
+        let header = self.render_row(&self.table.schema, true, &Value::Object(headings), cx);
+
+        let body = data
+            .iter()
+            .map(|row| self.render_row(&self.table.schema, false, &row, cx));
+
+        v_flex()
+            .id("table")
+            .overflow_x_scroll()
+            .w_full()
+            .child(header)
+            .children(body)
             .into_any_element()
     }
 }

--- a/crates/repl/src/outputs/user_error.rs
+++ b/crates/repl/src/outputs/user_error.rs
@@ -1,4 +1,4 @@
-use gpui::{AnyElement, FontWeight, WindowContext};
+use gpui::{AnyElement, FontWeight, View, WindowContext};
 use ui::{h_flex, prelude::*, v_flex, Label};
 
 use crate::outputs::plain::TerminalOutput;
@@ -7,7 +7,7 @@ use crate::outputs::plain::TerminalOutput;
 pub struct ErrorView {
     pub ename: String,
     pub evalue: String,
-    pub traceback: TerminalOutput,
+    pub traceback: View<TerminalOutput>,
 }
 
 impl ErrorView {
@@ -41,7 +41,7 @@ impl ErrorView {
                         .py(padding)
                         .border_l_1()
                         .border_color(theme.status().error_border)
-                        .child(self.traceback.render(cx)),
+                        .child(self.traceback.clone()),
                 )
                 .into_any_element(),
         )


### PR DESCRIPTION
Working on addressing large outputs, refactored as part of it.


https://github.com/user-attachments/assets/48ea576c-e13a-4d09-b45a-4baa41bf6f72



Release Notes:

* repl: Added button to open full text output in a separate buffer