### PR TITLE
docs: Fix link to prompting guide

### DIFF
--- a/docs/src/assistant/commands.md
+++ b/docs/src/assistant/commands.md
@@ -25,7 +25,7 @@ Slash commands enhance the assistant's capabilities. Begin by typing a `/` at th
 
 ## `/default`
 
-Read more about `/default` in the [Prompting: Editing the Default Prompt](./assistant/prompting.md#default-prompt) section.
+Read more about `/default` in the [Prompting: Editing the Default Prompt](./prompting.md#default-prompt) section.
 
 Usage: `/default`
 


### PR DESCRIPTION
This PR fixes the link to the prompting guide, since it was broken in 048be73b22922af8633cf68cd6a12cd46893ea0d and 4e0124010dcedcade05b1a82a62cda4400a11294.

Release Notes:

- N/A
