### PR TITLE
docs: Add redirect from `/developing-zed` to `/development`

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -23,6 +23,7 @@ enable = false
 "/adding-new-languages.html" = "/docs/extensions/languages.html"
 "/language-model-integration.html" = "/docs/assistant/assistant.html"
 "/assistant.html" = "/docs/assistant/assistant.html"
+"/developing-zed.html" = "/docs/development.html"
 
 # Our custom preprocessor for expanding commands like `{#kb action::ActionName}`,
 # and other docs-related functions.


### PR DESCRIPTION
This PR adds a redirect from the old `/docs/developing-zed` page to the new `/docs/development` page.

Fixes https://github.com/zed-industries/zed/issues/16785.

Release Notes:

- N/A
