### PR TITLE
docs: Fix how Tailwind CSS is spelled

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -102,7 +102,7 @@
 - [Scheme](./languages/scheme.md)
 - [Svelte](./languages/svelte.md)
 - [Swift](./languages/swift.md)
-- [TailwindCSS](./languages/tailwindcss.md)
+- [Tailwind CSS](./languages/tailwindcss.md)
 - [Terraform](./languages/terraform.md)
 - [TOML](./languages/toml.md)
 - [TypeScript](./languages/typescript.md)

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -1,4 +1,4 @@
-# TailWind CSS
+# Tailwind CSS
 
 Tailwind CSS support is built into Zed.
 
@@ -11,7 +11,7 @@ Tailwind CSS support is built into Zed.
 TBD: Document Tailwind CSS Configuration
 -->
 
-Languages which can be used with Tailwind CSS in Zed
+Languages which can be used with Tailwind CSS in Zed:
 
 - [Astro](./astro.md)
 - [CSS](./css.md)


### PR DESCRIPTION
Super pedantic (😬) but just a tiny PR to fix it: not "TailWind" or "TailwindCSS" (without spaces).

---

Release Notes:

- N/A
