### PR TITLE
vim: Move cursor to the current screen

### DIFF
--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -513,6 +513,14 @@ impl Editor {
         Ordering::Greater
     }
 
+    pub fn get_screen_top(&self, cx: &mut AppContext) -> DisplayPoint {
+        let snapshot = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+        self.scroll_manager
+            .anchor
+            .anchor
+            .to_display_point(&snapshot)
+    }
+
     pub fn read_scroll_position_from_db(
         &mut self,
         item_id: u64,


### PR DESCRIPTION
Before moving the cursor, check the cursor position, if the position is not on the current screen, move the cursor to the current screen.

Closes #16715

Release Notes:

- N/A
