### PR TITLE
elixir: Add support for `property` macro in runnables

### DIFF
--- a/extensions/elixir/languages/elixir/runnables.scm
+++ b/extensions/elixir/languages/elixir/runnables.scm
@@ -7,7 +7,7 @@
     (#set! tag elixir-test)
 )
 
-; Modules containing at least one `describe`, `test` and `property.
+; Modules containing at least one `describe`, `test` and `property`.
 ; This matches the ExUnit test style.
 (
     (call

--- a/extensions/elixir/languages/elixir/runnables.scm
+++ b/extensions/elixir/languages/elixir/runnables.scm
@@ -1,19 +1,19 @@
-; Macros `describe` and `test`.
+; Macros `describe`, `test` and `property`.
 ; This matches the ExUnit test style.
 (
     (call
-        target: (identifier) @run (#any-of? @run "describe" "test")
+        target: (identifier) @run (#any-of? @run "describe" "test" "property")
     ) @_elixir-test
     (#set! tag elixir-test)
 )
 
-; Modules containing at least one `describe` or `test`.
+; Modules containing at least one `describe`, `test` and `property.
 ; This matches the ExUnit test style.
 (
     (call
         target: (identifier) @run (#eq? @run "defmodule")
         (do_block
-            (call target: (identifier) @_keyword (#any-of? @_keyword "describe" "test"))
+            (call target: (identifier) @_keyword (#any-of? @_keyword "describe" "test" "property"))
         )
     ) @_elixir-module-test
     (#set! tag elixir-module-test)


### PR DESCRIPTION
Closes #16984 

Release Notes:

- Added support for `property` tests in runnables for Elixir