### PR TITLE
file_finder: Fix crash in new_path_prompt

### DIFF
--- a/crates/file_finder/src/new_path_prompt.rs
+++ b/crates/file_finder/src/new_path_prompt.rs
@@ -107,8 +107,10 @@ impl Match {
 
         if let Some(path_match) = &self.path_match {
             text.push_str(&path_match.path.to_string_lossy());
+            let mut whole_path = PathBuf::from(path_match.path_prefix.to_string());
+            whole_path = whole_path.join(path_match.path.clone());
             for (range, style) in highlight_ranges(
-                &path_match.path.to_string_lossy(),
+                &whole_path.to_string_lossy(),
                 &path_match.positions,
                 gpui::HighlightStyle::color(Color::Accent.color(cx)),
             ) {


### PR DESCRIPTION
Closes #16919 

repro step:
  - add two worktree
  - modify settings `"use_system_path_prompts" : false`
  - `ctrl-n` create new file, typing any chars.
  - `ctrl-s` save file
  - typing any char, crashed.

Release Notes:

- Fixed crash when setting `"use_system_path_prompts": false` or in remote project with two or more worktree.
