### PR TITLE
docs: Add section on updating extensions

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -84,7 +84,7 @@ If you already have a published extension with the same name installed, your dev
 
 ## Publishing your extension
 
-To publish an extension, open a PR to [this repo](https://github.com/zed-industries/extensions).
+To publish an extension, open a PR to [the `zed-industries/extensions` repo](https://github.com/zed-industries/extensions).
 
 In your PR, do the following:
 
@@ -100,3 +100,17 @@ version = "0.0.1"
 3. Run `pnpm sort-extensions` to ensure `extensions.toml` and `.gitmodules` are sorted
 
 Once your PR is merged, the extension will be packaged and published to the Zed extension registry.
+
+> Extension IDs and names should not contain `zed` or `Zed`, since they are all Zed extensions.
+
+## Updating an extension
+
+To update an extension, open a PR to [the `zed-industries/extensions` repo](https://github.com/zed-industries/extensions).
+
+In your PR do the following:
+
+1. Update the extension's submodule to the commit of the new version.
+2. Update the `version` field for the extension in `extensions.toml`
+   - Make sure the `version` matches the one set in `extension.toml` at the particular commit.
+
+If you'd like to automate this process, there is a [community GitHub Action](https://github.com/huacnlee/zed-extension-action) you can use.


### PR DESCRIPTION
This PR adds a section to the extension docs on how to update an extension.

Moving this over from the docs that used to live in the extensions repo so that we can have them all in one place.

Release Notes:

- N/A
