### PR TITLE
Revert "extension: Define capabilities in the extension manifest (#16953)"

### DIFF
--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -64,8 +64,6 @@ pub struct ExtensionManifest {
     #[serde(default)]
     pub authors: Vec<String>,
     #[serde(default)]
-    pub capabilities: Vec<ExtensionCapability>,
-    #[serde(default)]
     pub lib: LibManifestEntry,
 
     #[serde(default)]
@@ -82,28 +80,6 @@ pub struct ExtensionManifest {
     pub indexed_docs_providers: BTreeMap<Arc<str>, IndexedDocsProviderEntry>,
     #[serde(default)]
     pub snippets: Option<PathBuf>,
-}
-
-/// A capability for an extension.
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind")]
-pub enum ExtensionCapability {
-    /// The capability to download a file from a server.
-    #[serde(rename = "download-file")]
-    DownloadFile {
-        /// The host name of the server from which the file will be downloaded (e.g., `github.com`).
-        host: String,
-        /// The path prefix to the file that will be downloaded.
-        ///
-        /// Any path that starts with this prefix will be allowed.
-        path_prefix: String,
-    },
-    /// The capability to install a package from npm.
-    #[serde(rename = "npm:install")]
-    NpmInstall {
-        /// The name of the package.
-        package: String,
-    },
 }
 
 #[derive(Clone, Default, PartialEq, Eq, Debug, Deserialize, Serialize)]
@@ -210,7 +186,6 @@ fn manifest_from_old_manifest(
         repository: manifest_json.repository,
         authors: manifest_json.authors,
         schema_version: SchemaVersion::ZERO,
-        capabilities: Vec::new(),
         lib: Default::default(),
         themes: {
             let mut themes = manifest_json.themes.into_values().collect::<Vec<_>>();

--- a/crates/extension/src/extension_store_test.rs
+++ b/crates/extension/src/extension_store_test.rs
@@ -150,7 +150,6 @@ async fn test_extension_store(cx: &mut TestAppContext) {
                         authors: Vec::new(),
                         repository: None,
                         themes: Default::default(),
-                        capabilities: Vec::new(),
                         lib: Default::default(),
                         languages: vec!["languages/erb".into(), "languages/ruby".into()],
                         grammars: [
@@ -182,7 +181,6 @@ async fn test_extension_store(cx: &mut TestAppContext) {
                             "themes/monokai-pro.json".into(),
                             "themes/monokai.json".into(),
                         ],
-                        capabilities: Vec::new(),
                         lib: Default::default(),
                         languages: Default::default(),
                         grammars: BTreeMap::default(),
@@ -346,7 +344,6 @@ async fn test_extension_store(cx: &mut TestAppContext) {
                 authors: vec![],
                 repository: None,
                 themes: vec!["themes/gruvbox.json".into()],
-                capabilities: Vec::new(),
                 lib: Default::default(),
                 languages: Default::default(),
                 grammars: BTreeMap::default(),

--- a/extensions/gleam/extension.toml
+++ b/extensions/gleam/extension.toml
@@ -6,10 +6,6 @@ schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"
 
-capabilities = [
-    { kind = "download-file", host = "github.com", path_prefix = "gleam-lang/gleam" },
-]
-
 [language_servers.gleam]
 name = "Gleam LSP"
 language = "Gleam"


### PR DESCRIPTION
This PR reverts the addition of extension capabilities from #16953.

While these may end up being useful at some point, after some discussion they don't seem like the exact fit for what we're looking to do right now.

This reverts commit 8ec36f1e2bdea337236048170a356ec034eaa046.

Release Notes:

- N/A
