### PR TITLE
Forbid signature popovers when completion menu is open

### DIFF
--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -149,7 +149,7 @@ impl Editor {
     }
 
     pub fn show_signature_help(&mut self, _: &ShowSignatureHelp, cx: &mut ViewContext<Self>) {
-        if self.pending_rename.is_some() {
+        if self.pending_rename.is_some() || self.has_active_completions_menu() {
             return;
         }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/16748

Release Notes:

- Fixed signature info popovers appearing when completion menu is open
