### PR TITLE
Fix OpenPathPrompt locally with tilde

### DIFF
--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -236,7 +236,12 @@ impl PickerDelegate for OpenPathDelegate {
         let Some(candidate) = directory_state.match_candidates.get(*m) else {
             return;
         };
-        let result = Path::new(&directory_state.path).join(&candidate.string);
+        let result = Path::new(
+            self.lister
+                .resolve_tilde(&directory_state.path, cx)
+                .as_ref(),
+        )
+        .join(&candidate.string);
         if let Some(tx) = self.tx.take() {
             tx.send(Some(vec![result])).ok();
         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -91,7 +91,7 @@ use smol::channel::{Receiver, Sender};
 use snippet::Snippet;
 use snippet_provider::SnippetProvider;
 use std::{
-    borrow::{Borrow, Cow},
+    borrow::Cow,
     cell::RefCell,
     cmp::Ordering,
     convert::TryInto,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -91,7 +91,7 @@ use smol::channel::{Receiver, Sender};
 use snippet::Snippet;
 use snippet_provider::SnippetProvider;
 use std::{
-    borrow::Cow,
+    borrow::{Borrow, Cow},
     cell::RefCell,
     cmp::Ordering,
     convert::TryInto,
@@ -662,6 +662,14 @@ impl DirectoryLister {
         match self {
             DirectoryLister::Local(_) => true,
             DirectoryLister::Project(project) => project.read(cx).is_local_or_ssh(),
+        }
+    }
+
+    pub fn resolve_tilde<'a>(&self, path: &'a String, cx: &AppContext) -> Cow<'a, str> {
+        if self.is_local(cx) {
+            shellexpand::tilde(path)
+        } else {
+            Cow::from(path)
         }
     }
 


### PR DESCRIPTION
Release Notes:

- Fixed a panic opening a file in ~/ with `use_system_prompts: false`
