### PR TITLE
pane: Fix tooltips of navigation buttons

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -360,12 +360,7 @@ impl AssistantPanel {
                         }
                     }))
                     .tooltip(move |cx| {
-                        cx.new_view(|cx| {
-                            let keybind =
-                                KeyBinding::for_action_in(&DeployHistory, &focus_handle, cx);
-                            Tooltip::new("Open History").key_binding(keybind)
-                        })
-                        .into()
+                        Tooltip::for_action_in("Open History", &DeployHistory, &focus_handle, cx)
                     })
                     .selected(
                         pane.active_item()

--- a/crates/ui/src/components/tooltip.rs
+++ b/crates/ui/src/components/tooltip.rs
@@ -1,4 +1,4 @@
-use gpui::{Action, AnyView, IntoElement, Render, VisualContext};
+use gpui::{Action, AnyView, FocusHandle, IntoElement, Render, VisualContext};
 use settings::Settings;
 use theme::ThemeSettings;
 
@@ -34,6 +34,19 @@ impl Tooltip {
         .into()
     }
 
+    pub fn for_action_in(
+        title: impl Into<SharedString>,
+        action: &dyn Action,
+        focus_handle: &FocusHandle,
+        cx: &mut WindowContext,
+    ) -> AnyView {
+        cx.new_view(|cx| Self {
+            title: title.into(),
+            meta: None,
+            key_binding: KeyBinding::for_action_in(action, focus_handle, cx),
+        })
+        .into()
+    }
     pub fn with_meta(
         title: impl Into<SharedString>,
         action: Option<&dyn Action>,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1944,6 +1944,7 @@ impl Pane {
     }
 
     fn render_tab_bar(&mut self, cx: &mut ViewContext<'_, Pane>) -> impl IntoElement {
+        let focus_handle = self.focus_handle.clone();
         let navigate_backward = IconButton::new("navigate_backward", IconName::ArrowLeft)
             .shape(IconButtonShape::Square)
             .icon_size(IconSize::Small)
@@ -1952,7 +1953,10 @@ impl Pane {
                 move |_, cx| view.update(cx, Self::navigate_backward)
             })
             .disabled(!self.can_navigate_backward())
-            .tooltip(|cx| Tooltip::for_action("Go Back", &GoBack, cx));
+            .tooltip({
+                let focus_handle = focus_handle.clone();
+                move |cx| Tooltip::for_action_in("Go Back", &GoBack, &focus_handle, cx)
+            });
 
         let navigate_forward = IconButton::new("navigate_forward", IconName::ArrowRight)
             .shape(IconButtonShape::Square)
@@ -1962,7 +1966,10 @@ impl Pane {
                 move |_, cx| view.update(cx, Self::navigate_forward)
             })
             .disabled(!self.can_navigate_forward())
-            .tooltip(|cx| Tooltip::for_action("Go Forward", &GoForward, cx));
+            .tooltip({
+                let focus_handle = focus_handle.clone();
+                move |cx| Tooltip::for_action_in("Go Forward", &GoForward, &focus_handle, cx)
+            });
 
         TabBar::new("tab_bar")
             .track_scroll(self.tab_bar_scroll_handle.clone())


### PR DESCRIPTION
Tooltips for "Go Forward"/"Go Back" did not show the keybindings. Now they do.

Release Notes:

- N/A
