### PR TITLE
Fix casing of "macOS"

### DIFF
--- a/assets/keymaps/macos/atom.json
+++ b/assets/keymaps/macos/atom.json
@@ -1,4 +1,4 @@
-// Default Keymap (Atom) for Zed on MacOS
+// Default Keymap (Atom) for Zed on macOS
 [
   {
     "bindings": {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -233,7 +233,7 @@ unsafe fn build_classes() {
 pub(crate) fn convert_mouse_position(position: NSPoint, window_height: Pixels) -> Point<Pixels> {
     point(
         px(position.x as f32),
-        // MacOS screen coordinates are relative to bottom left
+        // macOS screen coordinates are relative to bottom left
         window_height - px(position.y as f32),
     )
 }
@@ -1307,7 +1307,7 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
 
             if !handled && is_held {
                 if let Some(text) = previous_keydown_inserted_text {
-                    // MacOS IME is a bit funky, and even when you've told it there's nothing to
+                    // macOS IME is a bit funky, and even when you've told it there's nothing to
                     // enter it will still swallow certain keys (e.g. 'f', 'j') and not others
                     // (e.g. 'n'). This is a problem for certain kinds of views, like the terminal.
                     with_input_handler(this, |input_handler| {

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -9,7 +9,7 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 - Install [Rust](https://www.rust-lang.org/tools/install)
 - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) from the macOS App Store, or from the [Apple Developer](https://developer.apple.com/download/all/) website. Note this requires a developer account.
 
-> Ensure you launch XCode after installing, and install the MacOS components, which is the default option.
+> Ensure you launch XCode after installing, and install the macOS components, which is the default option.
 
 - Install [Xcode command line tools](https://developer.apple.com/xcode/resources/)
 

--- a/docs/src/extensions/installing-extensions.md
+++ b/docs/src/extensions/installing-extensions.md
@@ -1,6 +1,6 @@
 # Installing Extensions
 
-You can search for extensions by launching the Zed Extension Gallery by pressing `cmd-shift-x` (MacOS) or `ctrl-shift-x` (Linux), opening the command palette and selecting `zed: extensions` or by selecting "Zed > Extensions" from the menu bar.
+You can search for extensions by launching the Zed Extension Gallery by pressing `cmd-shift-x` (macOS) or `ctrl-shift-x` (Linux), opening the command palette and selecting `zed: extensions` or by selecting "Zed > Extensions" from the menu bar.
 
 Here you can view the extensions that you currently have installed or search and install new ones.
 

--- a/docs/src/fonts.md
+++ b/docs/src/fonts.md
@@ -41,7 +41,7 @@ Previously, Zed shipped with `Zed Mono` and `Zed Sans`, customized versions of t
 Here's how you can use the old Zed fonts instead of `Zed Plex Mono` and `Zed Plex Sans`:
 
 1. Download [zed-app-fonts-1.2.0.zip](https://github.com/zed-industries/zed-fonts/releases/download/1.2.0/zed-app-fonts-1.2.0.zip) from the [zed-fonts releases](https://github.com/zed-industries/zed-fonts/releases) page.
-2. Open MacOS `Font Book.app`
+2. Open macOS `Font Book.app`
 3. Unzip the file and drag the `ttf` files into the Font Book app.
 4. Update your settings `ui_font_family` and `buffer_font_family` to use `Zed Mono` or `Zed Sans` in your `settings.json` file.
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -4,7 +4,7 @@ Welcome to Zed! We are excited to have you. Here is a jumping-off point to getti
 
 ## Download Zed
 
-### MacOS
+### macOS
 
 You can obtain the stable builds via the [download page](https://zed.dev/download). If you want to download our preview build, you can find it on its [releases page](https://zed.dev/releases/preview) After the first manual installation, Zed will periodically check for and install updates automatically for you.
 

--- a/docs/src/languages/bash.md
+++ b/docs/src/languages/bash.md
@@ -11,7 +11,7 @@ Report issues to: [https://github.com/d1y/bash.zed/issues](https://github.com/d1
 The bash-language-server support shellcheck. But you need to install it manually:
 
 ```sh
-# MacOS
+# macOS
 brew install shellcheck
 
 # Ubuntu/Debian

--- a/docs/src/languages/json.md
+++ b/docs/src/languages/json.md
@@ -8,7 +8,7 @@ JSON support is available natively in Zed.
 ## JSONC
 
 Zed also supports a super-set of JSON called JSONC, which allows single line comments (`//`) in JSON files.
-While editing these files you can use `cmd-/` (MacOS) or `ctrl-/` (Linux) to toggle comments on the current line or selection.
+While editing these files you can use `cmd-/` (macOS) or `ctrl-/` (Linux) to toggle comments on the current line or selection.
 
 <!--
 TBD: JSONC Example for how to use `file_types`

--- a/docs/src/languages/luau.md
+++ b/docs/src/languages/luau.md
@@ -19,7 +19,7 @@ To support automatically formatting your code, you can use [JohnnyMorganz/StyLua
 Install with:
 
 ```sh
-# MacOS via HomeBrew
+# macOS via HomeBrew
 brew install stylua
 # Or via Cargo
 cargo install stylua --features lua52,lua53,lua54,luau

--- a/docs/src/repl.md
+++ b/docs/src/repl.md
@@ -70,7 +70,7 @@ style.use('ggplot')
 
 <div class="warning">
 
-On MacOS, your system Python will _not_ work. Either set up [pyenv](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation) or use a virtual environment.
+On macOS, your system Python will _not_ work. Either set up [pyenv](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation) or use a virtual environment.
 
 </div>
 


### PR DESCRIPTION
This PR fixes a number of spots in English contexts (docs, comments, etc.) where we were using "MacOS" instead of "macOS".

Release Notes:

- N/A
