### PR TITLE
docs: Fix casing of "Homebrew"

### DIFF
--- a/docs/src/languages/luau.md
+++ b/docs/src/languages/luau.md
@@ -19,7 +19,7 @@ To support automatically formatting your code, you can use [JohnnyMorganz/StyLua
 Install with:
 
 ```sh
-# macOS via HomeBrew
+# macOS via Homebrew
 brew install stylua
 # Or via Cargo
 cargo install stylua --features lua52,lua53,lua54,luau


### PR DESCRIPTION
This PR fixes the casing of "Homebrew" in the docs.

The "b" should not be capitalized.

Release Notes:

- N/A
