### PR TITLE
Don't use a mix of tabs and spaces

### DIFF
--- a/docs/src/languages/luau.md
+++ b/docs/src/languages/luau.md
@@ -29,13 +29,13 @@ Then add the following to your Zed `settings.json`:
 
 ```json
   "languages": {
-		"Luau": {
-			"formatter": {
-				"external": {
-					"command": "stylua",
-					"arguments": ["-"]
-				}
-			}
-		}
-	}
+    "Luau": {
+      "formatter": {
+        "external": {
+          "command": "stylua",
+          "arguments": ["-"]
+        }
+      }
+    }
+  }
 ```

--- a/script/install.sh
+++ b/script/install.sh
@@ -39,11 +39,11 @@ main() {
         }
     elif which wget >/dev/null 2>&1; then
         curl () {
-    	    wget -O- "$@"
+            wget -O- "$@"
         }
     else
-    	echo "Could not find 'curl' or 'wget' in your path"
-    	exit 1
+        echo "Could not find 'curl' or 'wget' in your path"
+        exit 1
     fi
 
     "$platform" "$@"


### PR DESCRIPTION
This PR fixes some spots in the docs and the `install.sh` script that were using a mix of tabs and spaces.

We should just be using spaces.

Release Notes:

- N/A
