### PR TITLE
Revert "Improve Rust highlight queries (#16747)"

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -184,8 +184,3 @@
 ] @operator
 
 (lifetime) @lifetime
-
-(parameter (identifier) @variable.parameter)
-
-(attribute_item) @attribute
-(inner_attribute_item) @attribute

--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -5,11 +5,3 @@
 (macro_rule
   (token_tree) @content
   (#set! "language" "rust"))
-
-(block_comment
-  (doc_comment) @content
-  (#set! "language" "markdown"))
-
-(line_comment
-  (doc_comment) @content
-  (#set! "language" "markdown"))


### PR DESCRIPTION
Reverts https://github.com/zed-industries/zed/pull/16747 as it panics on certain cases where Zed have not panicked before.
Panic reproduction steps are described in https://github.com/zed-industries/zed/pull/16747#issuecomment-2317327367

Release Notes:

- N/A
