### PR TITLE
context_servers: Add ability to provide labels for prompt outputs

### DIFF
--- a/crates/assistant/src/slash_command/context_server_command.rs
+++ b/crates/assistant/src/slash_command/context_server_command.rs
@@ -84,11 +84,15 @@ impl SlashCommand for ContextServerSlashCommand {
 
                 Ok(SlashCommandOutput {
                     sections: vec![SlashCommandOutputSection {
-                        range: 0..result.len(),
+                        range: 0..(result.prompt.len()),
                         icon: IconName::ZedAssistant,
-                        label: SharedString::from(format!("Result from {}", prompt_name)),
+                        label: SharedString::from(
+                            result
+                                .description
+                                .unwrap_or(format!("Result from {}", prompt_name)),
+                        ),
                     }],
-                    text: result,
+                    text: result.prompt,
                     run_commands_in_text: false,
                 })
             })

--- a/crates/context_servers/src/protocol.rs
+++ b/crates/context_servers/src/protocol.rs
@@ -112,7 +112,7 @@ impl InitializedContextServerProtocol {
         &self,
         prompt: P,
         arguments: HashMap<String, String>,
-    ) -> Result<String> {
+    ) -> Result<types::PromptsGetResponse> {
         self.check_capability(ServerCapability::Prompts)?;
 
         let params = types::PromptsGetParams {
@@ -125,7 +125,7 @@ impl InitializedContextServerProtocol {
             .request(types::RequestType::PromptsGet.as_str(), params)
             .await?;
 
-        Ok(response.prompt)
+        Ok(response)
     }
 }
 

--- a/crates/context_servers/src/types.rs
+++ b/crates/context_servers/src/types.rs
@@ -102,6 +102,7 @@ pub struct ResourcesListResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptsGetResponse {
+    pub description: Option<String>,
     pub prompt: String,
 }
 


### PR DESCRIPTION
Server can now include an optional description in a `prompts/get` response. Zed will displayed the description as label of the slash command.

Release Notes:

- context_servers: Servers can provide an optional description in `prompts/get` responses that is displayed as the slash command label.