### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5662,8 +5662,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "db",
+ "file_icons",
  "gpui",
  "project",
+ "settings",
  "ui",
  "workspace",
 ]


### PR DESCRIPTION
This PR updates `Cargo.lock`, as it was missed in #17063.

Release Notes:

- N/A
