### PR TITLE
Make selection more consistent across languages

### DIFF
--- a/crates/languages/src/css/config.toml
+++ b/crates/languages/src/css/config.toml
@@ -9,6 +9,5 @@ brackets = [
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]
-word_characters = ["-"]
 block_comment = ["/* ", " */"]
 prettier_parser_name = "css"

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -25,5 +25,4 @@ block_comment = ["{/* ", " */}"]
 opt_into_language_servers = ["emmet-language-server"]
 
 [overrides.string]
-word_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]

--- a/crates/languages/src/markdown-inline/config.toml
+++ b/crates/languages/src/markdown-inline/config.toml
@@ -1,7 +1,6 @@
 name = "Markdown-Inline"
 grammar = "markdown-inline"
 path_suffixes = []
-word_characters = ["-"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },

--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -1,7 +1,6 @@
 name = "Markdown"
 grammar = "markdown"
 path_suffixes = ["md", "mdx", "mdwn", "markdown"]
-word_characters = ["-"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -24,5 +24,4 @@ block_comment = ["{/* ", " */}"]
 opt_into_language_servers = ["emmet-language-server"]
 
 [overrides.string]
-word_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]


### PR DESCRIPTION
Currently our selection behavior differs depending on the language of the file. CSS/JS/TSX/Markdown jump over `-` for word selections while in all other modes stop at `-` boundaries.

I believe the purpose of this was to allow easier selection of kebab-case-css-selectors but it's very surprising to keyboard/mouse selections have multiple behaviors.

See: https://x.com/MaxRovensky/status/1829134984415674783  

These were originally added in:
- https://github.com/zed-industries/zed/commit/a35b3f39c5c692a5d6ab1df7c1f26d933f3fb601
- https://github.com/zed-industries/zed/commit/fc457d45f5f529fa4d0ade52c48b62516baa388c
- https://github.com/zed-industries/zed/commit/35b7787e02c1b544fd8cfb94551382543f69da11
- https://github.com/zed-industries/zed/pull/7514

Our selection behavior differs from VSCode for CSS:

[!video](https://github.com/user-attachments/assets/2794ce04-0a4d-4daf-8d2e-c839b1ff5100)



Release Notes:

- Remove "-" from word_character for CSS/JS/TSX/Markdown