### PR TITLE
editor: Fix flaky navigation test

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9111,18 +9111,21 @@ impl Editor {
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<Navigated>> {
         let definition = self.go_to_definition_of_kind(GotoDefinitionKind::Symbol, false, cx);
-        let references = self.find_all_references(&FindAllReferences, cx);
-        cx.background_executor().spawn(async move {
+        cx.spawn(|editor, mut cx| async move {
             if definition.await? == Navigated::Yes {
                 return Ok(Navigated::Yes);
             }
-            if let Some(references) = references {
-                if references.await? == Navigated::Yes {
-                    return Ok(Navigated::Yes);
-                }
-            }
-
-            Ok(Navigated::No)
+            let Some(references) = editor.update(&mut cx, |editor, cx| {
+                editor.find_all_references(&FindAllReferences, cx)
+            })?
+            else {
+                return Ok(Navigated::No);
+            };
+            Ok(if references.await? == Navigated::Yes {
+                Navigated::Yes
+            } else {
+                Navigated::No
+            })
         })
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9115,17 +9115,12 @@ impl Editor {
             if definition.await? == Navigated::Yes {
                 return Ok(Navigated::Yes);
             }
-            let Some(references) = editor.update(&mut cx, |editor, cx| {
+            match editor.update(&mut cx, |editor, cx| {
                 editor.find_all_references(&FindAllReferences, cx)
-            })?
-            else {
-                return Ok(Navigated::No);
-            };
-            Ok(if references.await? == Navigated::Yes {
-                Navigated::Yes
-            } else {
-                Navigated::No
-            })
+            })? {
+                Some(references) => references.await,
+                None => Ok(Navigated::No),
+            }
         })
     }
 


### PR DESCRIPTION
This test was flaky because both tasks were started at the same time and the first one that would win, would navigate the editor.

Now the order is fixed, because the second task is only spawned after the first one.

Release Notes:

- N/A
