### PR TITLE
Improve Rust highlight queries

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -184,3 +184,8 @@
 ] @operator
 
 (lifetime) @lifetime
+
+(parameter (identifier) @variable.parameter)
+
+(attribute_item) @attribute
+(inner_attribute_item) @attribute


### PR DESCRIPTION
See #16747.

Removed markdown injections so that only the rust highlights are implemented

Release Notes:

- Improved Rust syntax highlighting queries.

