### PR TITLE
clojure: Recognize basilisp extension - `.lpy`

### DIFF
--- a/extensions/clojure/languages/clojure/config.toml
+++ b/extensions/clojure/languages/clojure/config.toml
@@ -1,6 +1,6 @@
 name = "Clojure"
 grammar = "clojure"
-path_suffixes = ["clj", "cljs", "cljc", "cljd", "edn", "bb"]
+path_suffixes = ["clj", "cljs", "cljc", "cljd", "edn", "bb", "lpy"]
 line_comments = [";; "]
 autoclose_before = "}])"
 brackets = [


### PR DESCRIPTION
add the [basilisp](https://basilisp.readthedocs.io/en/latest/index.html) `lpy` file extension. 

Release Notes:

- N/A
