### PR TITLE
Hide Markdown-Inline language from users with a new 'hidden' flag on language configs

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -17,7 +17,7 @@ mod syntax_map;
 mod task_context;
 
 #[cfg(test)]
-mod buffer_tests;
+pub mod buffer_tests;
 pub mod markdown;
 
 use crate::language_settings::SoftWrap;
@@ -627,6 +627,10 @@ pub struct LanguageConfig {
     /// If there's a parser name in the language settings, that will be used instead.
     #[serde(default)]
     pub prettier_parser_name: Option<String>,
+    /// If true, this language is only for syntax highlighting via an injection into other
+    /// languages, but should not appear to the user as a distinct language.
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, JsonSchema)]
@@ -713,6 +717,7 @@ impl Default for LanguageConfig {
             tab_size: None,
             soft_wrap: None,
             prettier_parser_name: None,
+            hidden: false,
         }
     }
 }
@@ -1414,6 +1419,10 @@ impl Language {
 }
 
 impl LanguageScope {
+    pub fn language_name(&self) -> Arc<str> {
+        self.language.config.name.clone()
+    }
+
     pub fn collapsed_placeholder(&self) -> &str {
         self.language.config.collapsed_placeholder.as_ref()
     }

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{LanguageConfig, LanguageMatcher};
+use crate::{
+    buffer_tests::{markdown_inline_lang, markdown_lang},
+    LanguageConfig, LanguageMatcher,
+};
 use gpui::AppContext;
 use rand::rngs::StdRng;
 use std::{env, ops::Range, sync::Arc};
@@ -1229,39 +1232,6 @@ fn rust_lang() -> Language {
     .unwrap()
 }
 
-fn markdown_lang() -> Language {
-    Language::new(
-        LanguageConfig {
-            name: "Markdown".into(),
-            matcher: LanguageMatcher {
-                path_suffixes: vec!["md".into()],
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        Some(tree_sitter_md::language()),
-    )
-    .with_injection_query(
-        r#"
-            (fenced_code_block
-                (info_string
-                    (language) @language)
-                (code_fence_content) @content)
-        "#,
-    )
-    .unwrap()
-}
-
-fn markdown_inline_lang() -> Language {
-    Language::new(
-        LanguageConfig {
-            name: "Markdown-Inline".into(),
-            ..LanguageConfig::default()
-        },
-        Some(tree_sitter_md::inline_language()),
-    )
-}
-
 fn elixir_lang() -> Language {
     Language::new(
         LanguageConfig {
@@ -1327,7 +1297,7 @@ fn assert_layers_for_range(
     expected_layers: &[&str],
 ) {
     let layers = syntax_map
-        .layers_for_range(range, &buffer)
+        .layers_for_range(range, &buffer, true)
         .collect::<Vec<_>>();
     assert_eq!(
         layers.len(),

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -782,8 +782,13 @@ fn test_empty_combined_injections_inside_injections(cx: &mut AppContext) {
         &buffer,
         Point::new(0, 0)..Point::new(5, 0),
         &[
+            // Markdown document
             "(document (section (fenced_code_block (fenced_code_block_delimiter) (info_string (language)) (block_continuation) (code_fence_content (block_continuation)) (fenced_code_block_delimiter)) (paragraph (inline))))",
+            // ERB template in the code block
             "(template...",
+            // Markdown inline content
+            "(inline)",
+            // HTML within the ERB
             "(document (text))",
             // The ruby syntax tree should be empty, since there are
             // no interpolations in the ERB template.

--- a/crates/languages/src/markdown-inline/config.toml
+++ b/crates/languages/src/markdown-inline/config.toml
@@ -1,14 +1,3 @@
 name = "Markdown-Inline"
 grammar = "markdown-inline"
-path_suffixes = []
-brackets = [
-    { start = "{", end = "}", close = true, newline = true },
-    { start = "[", end = "]", close = true, newline = true },
-    { start = "(", end = ")", close = true, newline = true },
-    { start = "<", end = ">", close = true, newline = true },
-    { start = "\"", end = "\"", close = false, newline = false },
-    { start = "'", end = "'", close = false, newline = false },
-    { start = "`", end = "`", close = false, newline = false },
-]
-
-tab_size = 2
+hidden = true


### PR DESCRIPTION
/cc @mrnugget 

Release Notes:

- Fixed an issue where toggling inline completions in a markdown file did not work correctly
