### PR TITLE
assistant: Remove outdated comment

### DIFF
--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1977,7 +1977,6 @@ impl Context {
                                 );
                             });
 
-                            // Use `inclusive = false` as edits might occur at the end of a parsed step.
                             cx.emit(ContextEvent::StreamedCompletion);
 
                             Some(())


### PR DESCRIPTION
This used to appear on a call to `prune_invalid_workflow_steps`, but that method doesn't exist anymore.

Release Notes:

- N/A
