### PR TITLE
assistant: Fix `"New Context"` behavior when focused in editor

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -63,6 +63,7 @@ actions!(
         DeployHistory,
         DeployPromptLibrary,
         ConfirmCommand,
+        NewContext,
         ToggleModelSelector,
     ]
 );

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -924,12 +924,15 @@ impl AssistantPanel {
             });
 
             self.show_context(editor.clone(), cx);
-            self.pane.update(cx, |pane, cx| {
-                let items: Vec<_> = pane.items().collect();
-                if !items.is_empty() {
-                    pane.activate_item(items.len() - 1, true, true, cx);
-                }
-            });
+            let workspace = self.workspace.clone();
+            cx.spawn(move |_, mut cx| async move {
+                workspace
+                    .update(&mut cx, |workspace, cx| {
+                        workspace.focus_panel::<AssistantPanel>(cx);
+                    })
+                    .ok();
+            })
+            .detach();
             Some(editor)
         }
     }

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -96,7 +96,9 @@ pub fn init(cx: &mut AppContext) {
                 .register_action(ContextEditor::quote_selection)
                 .register_action(ContextEditor::insert_selection)
                 .register_action(AssistantPanel::show_configuration)
-                .register_action(AssistantPanel::create_new_context);
+                .register_action(|workspace, _: &NewContext, cx| {
+                    AssistantPanel::create_new_context(workspace, cx);
+                });
         },
     )
     .detach();
@@ -854,11 +856,7 @@ impl AssistantPanel {
         }
     }
 
-    pub fn create_new_context(
-        workspace: &mut Workspace,
-        _: &InlineAssist,
-        cx: &mut ViewContext<Workspace>,
-    ) {
+    pub fn create_new_context(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
         if let Some(panel) = workspace.panel::<AssistantPanel>(cx) {
             panel.update(cx, |panel, cx| {
                 panel.new_context(cx);

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -53,7 +53,6 @@ use multi_buffer::MultiBufferRow;
 use picker::{Picker, PickerDelegate};
 use project::{Project, ProjectLspAdapterDelegate};
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
-use serde_json::Value;
 use settings::{update_settings_file, Settings};
 use smol::stream::StreamExt;
 use std::{
@@ -80,33 +79,7 @@ use workspace::{
 use workspace::{searchable::SearchableItemHandle, NewFile};
 use zed_actions::InlineAssist;
 
-pub struct NewContext;
-
-impl Action for NewContext {
-    fn boxed_clone(&self) -> Box<dyn Action> {
-        Box::new(NewContext)
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn partial_eq(&self, _other: &dyn Action) -> bool {
-        true // Since NewContext has no fields, all instances are equal
-    }
-
-    fn name(&self) -> &'static str {
-        "New Context"
-    }
-
-    fn debug_name() -> &'static str {
-        "NewContext"
-    }
-
-    fn build(_json: Value) -> Result<Box<dyn gpui::Action>, anyhow::Error> {
-        Ok(Box::new(NewContext))
-    }
-}
+gpui::actions!(assistant_panel, [NewContext]);
 
 pub fn init(cx: &mut AppContext) {
     workspace::FollowableViewRegistry::register::<ContextEditor>(cx);

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -96,9 +96,7 @@ pub fn init(cx: &mut AppContext) {
                 .register_action(ContextEditor::quote_selection)
                 .register_action(ContextEditor::insert_selection)
                 .register_action(AssistantPanel::show_configuration)
-                .register_action(|workspace, _: &NewContext, cx| {
-                    AssistantPanel::create_new_context(workspace, cx);
-                });
+                .register_action(AssistantPanel::create_new_context);
         },
     )
     .detach();
@@ -856,7 +854,11 @@ impl AssistantPanel {
         }
     }
 
-    pub fn create_new_context(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
+    pub fn create_new_context(
+        workspace: &mut Workspace,
+        _: &InlineAssist,
+        cx: &mut ViewContext<Workspace>,
+    ) {
         if let Some(panel) = workspace.panel::<AssistantPanel>(cx) {
             panel.update(cx, |panel, cx| {
                 panel.new_context(cx);

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -68,6 +68,7 @@ use ui::{
     ListItemSpacing, PopoverMenu, PopoverMenuHandle, Tooltip,
 };
 use util::ResultExt;
+use workspace::searchable::SearchableItemHandle;
 use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
     item::{self, FollowableItem, Item, ItemHandle},
@@ -76,7 +77,6 @@ use workspace::{
     Pane, Save, ShowConfiguration, ToggleZoom, ToolbarItemEvent, ToolbarItemLocation,
     ToolbarItemView, Workspace,
 };
-use workspace::{searchable::SearchableItemHandle, NewFile};
 use zed_actions::InlineAssist;
 
 pub fn init(cx: &mut AppContext) {
@@ -338,7 +338,7 @@ impl AssistantPanel {
                 workspace.project().clone(),
                 Default::default(),
                 None,
-                NewFile.boxed_clone(),
+                NewContext.boxed_clone(),
                 cx,
             );
             pane.set_can_split(false, cx);
@@ -1211,7 +1211,7 @@ impl Render for AssistantPanel {
         v_flex()
             .key_context("AssistantPanel")
             .size_full()
-            .on_action(cx.listener(|this, _: &workspace::NewFile, cx| {
+            .on_action(cx.listener(|this, _: &NewContext, cx| {
                 this.new_context(cx);
             }))
             .on_action(

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -14,7 +14,7 @@ use crate::{
     Assist, CacheStatus, ConfirmCommand, Context, ContextEvent, ContextId, ContextStore,
     ContextStoreEvent, CycleMessageRole, DeployHistory, DeployPromptLibrary, InlineAssistId,
     InlineAssistant, InsertIntoEditor, Message, MessageId, MessageMetadata, MessageStatus,
-    ModelPickerDelegate, ModelSelector, PendingSlashCommand, PendingSlashCommandStatus,
+    ModelPickerDelegate, ModelSelector, NewContext, PendingSlashCommand, PendingSlashCommandStatus,
     QuoteSelection, RemoteContextMetadata, SavedContextMetadata, Split, ToggleFocus,
     ToggleModelSelector, WorkflowStepResolution,
 };
@@ -78,8 +78,6 @@ use workspace::{
 };
 use workspace::{searchable::SearchableItemHandle, NewFile};
 use zed_actions::InlineAssist;
-
-gpui::actions!(assistant_panel, [NewContext]);
 
 pub fn init(cx: &mut AppContext) {
     workspace::FollowableViewRegistry::register::<ContextEditor>(cx);

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -96,9 +96,7 @@ pub fn init(cx: &mut AppContext) {
                 .register_action(ContextEditor::quote_selection)
                 .register_action(ContextEditor::insert_selection)
                 .register_action(AssistantPanel::show_configuration)
-                .register_action(|workspace, _: &NewContext, cx| {
-                    AssistantPanel::create_new_context(workspace, cx);
-                });
+                .register_action(AssistantPanel::create_new_context);
         },
     )
     .detach();
@@ -856,7 +854,11 @@ impl AssistantPanel {
         }
     }
 
-    pub fn create_new_context(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
+    pub fn create_new_context(
+        workspace: &mut Workspace,
+        _: &NewContext,
+        cx: &mut ViewContext<Workspace>,
+    ) {
         if let Some(panel) = workspace.panel::<AssistantPanel>(cx) {
             panel.update(cx, |panel, cx| {
                 panel.new_context(cx);


### PR DESCRIPTION
Closes #16676

Release Notes:

- assistant: fix `New Context` opening a new file when focused in the editor pane.
