### PR TITLE
Add a simple set of default colors to `gpui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
  "similar",
  "smallvec",
  "smol",
- "strum",
+ "strum 0.25.0",
  "telemetry_events",
  "terminal",
  "terminal_view",

--- a/crates/gpui/src/elements/common.rs
+++ b/crates/gpui/src/elements/common.rs
@@ -87,8 +87,8 @@ pub enum DefaultColor {
     Selected,
     /// Border color
     Border,
-    /// Seperator color
-    Seperator,
+    /// Separator color
+    Separator,
     /// Container color
     Container,
 }
@@ -102,7 +102,7 @@ impl DefaultColor {
             DefaultColor::Disabled => colors.disabled,
             DefaultColor::Selected => colors.selected,
             DefaultColor::Border => colors.border,
-            DefaultColor::Seperator => colors.separator,
+            DefaultColor::Separator => colors.separator,
             DefaultColor::Container => colors.container,
         }
     }

--- a/crates/gpui/src/elements/common.rs
+++ b/crates/gpui/src/elements/common.rs
@@ -4,7 +4,7 @@ use crate::{rgb, Hsla, Rgba, WindowAppearance};
 /// The appearance of the base gpui colors, used to style gpui elements
 ///
 /// Varries based on the system's current [WindowAppearance].
-pub enum DefaultThemeApperance {
+pub enum DefaultThemeAppearance {
     #[default]
     /// Use the set of colors for light appearances
     Light,
@@ -12,7 +12,7 @@ pub enum DefaultThemeApperance {
     Dark,
 }
 
-impl From<WindowAppearance> for DefaultThemeApperance {
+impl From<WindowAppearance> for DefaultThemeAppearance {
     fn from(appearance: WindowAppearance) -> Self {
         match appearance {
             WindowAppearance::Light | WindowAppearance::VibrantLight => Self::Light,
@@ -22,10 +22,10 @@ impl From<WindowAppearance> for DefaultThemeApperance {
 }
 
 /// Get the default colors for the given appearance
-pub fn colors(appearance: DefaultThemeApperance) -> DefaultColors {
+pub fn colors(appearance: DefaultThemeAppearance) -> DefaultColors {
     match appearance {
-        DefaultThemeApperance::Light => DefaultColors::light(),
-        DefaultThemeApperance::Dark => DefaultColors::dark(),
+        DefaultThemeAppearance::Light => DefaultColors::light(),
+        DefaultThemeAppearance::Dark => DefaultColors::dark(),
     }
 }
 

--- a/crates/gpui/src/elements/common.rs
+++ b/crates/gpui/src/elements/common.rs
@@ -38,7 +38,7 @@ pub struct DefaultColors {
     disabled: Rgba,
     selected: Rgba,
     border: Rgba,
-    seperator: Rgba,
+    separator: Rgba,
     container: Rgba,
 }
 
@@ -52,7 +52,7 @@ impl DefaultColors {
             selected: rgb(0x2457CA),
             background: rgb(0x222222),
             border: rgb(0x000000),
-            seperator: rgb(0xD9D9D9),
+            separator: rgb(0xD9D9D9),
             container: rgb(0x262626),
         }
     }
@@ -66,7 +66,7 @@ impl DefaultColors {
             disabled: rgb(0xB0B0B0),
             selected: rgb(0x2A63D9),
             border: rgb(0xD9D9D9),
-            seperator: rgb(0xE6E6E6),
+            separator: rgb(0xE6E6E6),
             container: rgb(0xF4F5F5),
         }
     }
@@ -102,7 +102,7 @@ impl DefaultColor {
             DefaultColor::Disabled => colors.disabled,
             DefaultColor::Selected => colors.selected,
             DefaultColor::Border => colors.border,
-            DefaultColor::Seperator => colors.seperator,
+            DefaultColor::Seperator => colors.separator,
             DefaultColor::Container => colors.container,
         }
     }

--- a/crates/gpui/src/elements/common.rs
+++ b/crates/gpui/src/elements/common.rs
@@ -33,35 +33,41 @@ pub fn colors(appearance: DefaultThemeApperance) -> DefaultColors {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DefaultColors {
     text: Rgba,
+    selected_text: Rgba,
     background: Rgba,
     disabled: Rgba,
     selected: Rgba,
     border: Rgba,
     seperator: Rgba,
+    container: Rgba,
 }
 
 impl DefaultColors {
     /// Get the default light colors
-    pub fn light() -> Self {
+    pub fn dark() -> Self {
         Self {
-            text: rgb(0xEAEAEA),
+            text: rgb(0xFFFFFF),
+            selected_text: rgb(0xFFFFFF),
             disabled: rgb(0x565656),
             selected: rgb(0x2457CA),
             background: rgb(0x222222),
             border: rgb(0x000000),
             seperator: rgb(0xD9D9D9),
+            container: rgb(0x262626),
         }
     }
 
     /// Get the default dark colors
-    pub fn dark() -> Self {
+    pub fn light() -> Self {
         Self {
-            text: rgb(0x272727),
+            text: rgb(0x252525),
+            selected_text: rgb(0xFFFFFF),
             background: rgb(0xFFFFFF),
             disabled: rgb(0xB0B0B0),
             selected: rgb(0x2A63D9),
             border: rgb(0xD9D9D9),
             seperator: rgb(0xE6E6E6),
+            container: rgb(0xF4F5F5),
         }
     }
 }
@@ -71,6 +77,8 @@ impl DefaultColors {
 pub enum DefaultColor {
     /// Text color
     Text,
+    /// Selected text color
+    SelectedText,
     /// Background color
     Background,
     /// Disabled color
@@ -81,17 +89,21 @@ pub enum DefaultColor {
     Border,
     /// Seperator color
     Seperator,
+    /// Container color
+    Container,
 }
 impl DefaultColor {
     /// Get the Rgb color for the given color type
     pub fn color(&self, colors: &DefaultColors) -> Rgba {
         match self {
             DefaultColor::Text => colors.text,
+            DefaultColor::SelectedText => colors.selected_text,
             DefaultColor::Background => colors.background,
             DefaultColor::Disabled => colors.disabled,
             DefaultColor::Selected => colors.selected,
             DefaultColor::Border => colors.border,
             DefaultColor::Seperator => colors.seperator,
+            DefaultColor::Container => colors.container,
         }
     }
 

--- a/crates/gpui/src/elements/common.rs
+++ b/crates/gpui/src/elements/common.rs
@@ -30,11 +30,14 @@ pub fn colors(appearance: DefaultThemeApperance) -> DefaultColors {
 }
 
 /// A collection of colors
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DefaultColors {
     text: Rgba,
     background: Rgba,
     disabled: Rgba,
     selected: Rgba,
+    border: Rgba,
+    seperator: Rgba,
 }
 
 impl DefaultColors {
@@ -45,16 +48,20 @@ impl DefaultColors {
             disabled: rgb(0x565656),
             selected: rgb(0x2457CA),
             background: rgb(0x222222),
+            border: rgb(0x000000),
+            seperator: rgb(0xD9D9D9),
         }
     }
 
     /// Get the default dark colors
     pub fn dark() -> Self {
         Self {
-            text: rgb(0x484848),
+            text: rgb(0x272727),
             background: rgb(0xFFFFFF),
             disabled: rgb(0xB0B0B0),
             selected: rgb(0x2A63D9),
+            border: rgb(0xD9D9D9),
+            seperator: rgb(0xE6E6E6),
         }
     }
 }
@@ -70,21 +77,26 @@ pub enum DefaultColor {
     Disabled,
     /// Selected color
     Selected,
+    /// Border color
+    Border,
+    /// Seperator color
+    Seperator,
 }
-
-impl DefaultColors {
+impl DefaultColor {
     /// Get the Rgb color for the given color type
-    pub fn color(&self, color: DefaultColor) -> Rgba {
-        match color {
-            DefaultColor::Text => self.text,
-            DefaultColor::Background => self.background,
-            DefaultColor::Disabled => self.disabled,
-            DefaultColor::Selected => self.selected,
+    pub fn color(&self, colors: &DefaultColors) -> Rgba {
+        match self {
+            DefaultColor::Text => colors.text,
+            DefaultColor::Background => colors.background,
+            DefaultColor::Disabled => colors.disabled,
+            DefaultColor::Selected => colors.selected,
+            DefaultColor::Border => colors.border,
+            DefaultColor::Seperator => colors.seperator,
         }
     }
 
     /// Get the Hsla color for the given color type
-    pub fn hsla(&self, color: DefaultColor) -> Hsla {
-        self.color(color).into()
+    pub fn hsla(&self, colors: &DefaultColors) -> Hsla {
+        self.color(&colors).into()
     }
 }

--- a/crates/gpui/src/elements/common.rs
+++ b/crates/gpui/src/elements/common.rs
@@ -1,0 +1,90 @@
+use crate::{rgb, Hsla, Rgba, WindowAppearance};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+/// The appearance of the base gpui colors, used to style gpui elements
+///
+/// Varries based on the system's current [WindowAppearance].
+pub enum DefaultThemeApperance {
+    #[default]
+    /// Use the set of colors for light appearances
+    Light,
+    /// Use the set of colors for dark appearances
+    Dark,
+}
+
+impl From<WindowAppearance> for DefaultThemeApperance {
+    fn from(appearance: WindowAppearance) -> Self {
+        match appearance {
+            WindowAppearance::Light | WindowAppearance::VibrantLight => Self::Light,
+            WindowAppearance::Dark | WindowAppearance::VibrantDark => Self::Dark,
+        }
+    }
+}
+
+/// Get the default colors for the given appearance
+pub fn colors(appearance: DefaultThemeApperance) -> DefaultColors {
+    match appearance {
+        DefaultThemeApperance::Light => DefaultColors::light(),
+        DefaultThemeApperance::Dark => DefaultColors::dark(),
+    }
+}
+
+/// A collection of colors
+pub struct DefaultColors {
+    text: Rgba,
+    background: Rgba,
+    disabled: Rgba,
+    selected: Rgba,
+}
+
+impl DefaultColors {
+    /// Get the default light colors
+    pub fn light() -> Self {
+        Self {
+            text: rgb(0xEAEAEA),
+            disabled: rgb(0x565656),
+            selected: rgb(0x2457CA),
+            background: rgb(0x222222),
+        }
+    }
+
+    /// Get the default dark colors
+    pub fn dark() -> Self {
+        Self {
+            text: rgb(0x484848),
+            background: rgb(0xFFFFFF),
+            disabled: rgb(0xB0B0B0),
+            selected: rgb(0x2A63D9),
+        }
+    }
+}
+
+/// A default gpui color
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
+pub enum DefaultColor {
+    /// Text color
+    Text,
+    /// Background color
+    Background,
+    /// Disabled color
+    Disabled,
+    /// Selected color
+    Selected,
+}
+
+impl DefaultColors {
+    /// Get the Rgb color for the given color type
+    pub fn color(&self, color: DefaultColor) -> Rgba {
+        match color {
+            DefaultColor::Text => self.text,
+            DefaultColor::Background => self.background,
+            DefaultColor::Disabled => self.disabled,
+            DefaultColor::Selected => self.selected,
+        }
+    }
+
+    /// Get the Hsla color for the given color type
+    pub fn hsla(&self, color: DefaultColor) -> Hsla {
+        self.color(color).into()
+    }
+}

--- a/crates/gpui/src/elements/mod.rs
+++ b/crates/gpui/src/elements/mod.rs
@@ -1,6 +1,7 @@
 mod anchored;
 mod animation;
 mod canvas;
+mod common;
 mod deferred;
 mod div;
 mod img;
@@ -13,6 +14,7 @@ mod uniform_list;
 pub use anchored::*;
 pub use animation::*;
 pub use canvas::*;
+pub use common::*;
 pub use deferred::*;
 pub use div::*;
 pub use img::*;

--- a/crates/storybook/src/stories.rs
+++ b/crates/storybook/src/stories.rs
@@ -1,5 +1,6 @@
 mod auto_height_editor;
 mod cursor;
+mod default_colors;
 mod focus;
 mod kitchen_sink;
 mod overflow_scroll;
@@ -11,6 +12,7 @@ mod with_rem_size;
 
 pub use auto_height_editor::*;
 pub use cursor::*;
+pub use default_colors::*;
 pub use focus::*;
 pub use kitchen_sink::*;
 pub use overflow_scroll::*;

--- a/crates/storybook/src/stories/default_colors.rs
+++ b/crates/storybook/src/stories/default_colors.rs
@@ -1,10 +1,10 @@
 use gpui::{
-    colors, div, prelude::*, rgb, DefaultColor, DefaultColors, DefaultThemeApperance, Hsla, Render,
-    Rgba, View, ViewContext, WindowContext,
+    colors, div, prelude::*, DefaultColor, DefaultThemeApperance, Hsla, Render, View, ViewContext,
+    WindowContext,
 };
 use story::Story;
 use strum::IntoEnumIterator;
-use ui::ActiveTheme;
+use ui::{h_flex, ActiveTheme};
 
 pub struct DefaultColorsStory;
 
@@ -25,7 +25,7 @@ impl Render for DefaultColorsStory {
                 let color_types = DefaultColor::iter()
                     .map(|color| {
                         let name = format!("{:?}", color);
-                        let rgba = colors.color(color);
+                        let rgba = color.hsla(&colors);
                         (name, rgba)
                     })
                     .collect::<Vec<_>>();
@@ -53,6 +53,14 @@ impl Render for DefaultColorsStory {
                             )
                             .child(Story::label(format!("{}: {:?}", name, color)))
                     }))
+                    .child(
+                        h_flex()
+                            .bg(DefaultColor::Background.hsla(&colors))
+                            .h_8()
+                            .w_24()
+                            .justify_center()
+                            .child("Text on background"),
+                    )
             }))
     }
 }

--- a/crates/storybook/src/stories/default_colors.rs
+++ b/crates/storybook/src/stories/default_colors.rs
@@ -37,7 +37,7 @@ impl Render for DefaultColorsStory {
                     .p_4()
                     .child(Story::label(format!("{:?} Appearance", appearance)))
                     .children(color_types.iter().map(|(name, color)| {
-                        let color: Hsla = color.clone();
+                        let color: Hsla = *color;
 
                         div()
                             .flex()

--- a/crates/storybook/src/stories/default_colors.rs
+++ b/crates/storybook/src/stories/default_colors.rs
@@ -1,0 +1,58 @@
+use gpui::{
+    colors, div, prelude::*, rgb, DefaultColor, DefaultColors, DefaultThemeApperance, Hsla, Render,
+    Rgba, View, ViewContext, WindowContext,
+};
+use story::Story;
+use strum::IntoEnumIterator;
+use ui::ActiveTheme;
+
+pub struct DefaultColorsStory;
+
+impl DefaultColorsStory {
+    pub fn view(cx: &mut WindowContext) -> View<Self> {
+        cx.new_view(|_cx| Self)
+    }
+}
+
+impl Render for DefaultColorsStory {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let appearances = [DefaultThemeApperance::Light, DefaultThemeApperance::Dark];
+
+        Story::container()
+            .child(Story::title("Default Colors"))
+            .children(appearances.iter().map(|&appearance| {
+                let colors = colors(appearance);
+                let color_types = DefaultColor::iter()
+                    .map(|color| {
+                        let name = format!("{:?}", color);
+                        let rgba = colors.color(color);
+                        (name, rgba)
+                    })
+                    .collect::<Vec<_>>();
+
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_4()
+                    .p_4()
+                    .child(Story::label(format!("{:?} Appearance", appearance)))
+                    .children(color_types.iter().map(|(name, color)| {
+                        let color: Hsla = color.clone().into();
+
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .w_12()
+                                    .h_12()
+                                    .bg(color)
+                                    .border_1()
+                                    .border_color(cx.theme().colors().border),
+                            )
+                            .child(Story::label(format!("{}: {:?}", name, color)))
+                    }))
+            }))
+    }
+}

--- a/crates/storybook/src/stories/default_colors.rs
+++ b/crates/storybook/src/stories/default_colors.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    colors, div, prelude::*, DefaultColor, DefaultThemeApperance, Hsla, Render, View, ViewContext,
+    colors, div, prelude::*, DefaultColor, DefaultThemeAppearance, Hsla, Render, View, ViewContext,
     WindowContext,
 };
 use story::Story;
@@ -16,7 +16,7 @@ impl DefaultColorsStory {
 
 impl Render for DefaultColorsStory {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let appearances = [DefaultThemeApperance::Light, DefaultThemeApperance::Dark];
+        let appearances = [DefaultThemeAppearance::Light, DefaultThemeAppearance::Dark];
 
         Story::container()
             .child(Story::title("Default Colors"))

--- a/crates/storybook/src/stories/default_colors.rs
+++ b/crates/storybook/src/stories/default_colors.rs
@@ -55,11 +55,34 @@ impl Render for DefaultColorsStory {
                     }))
                     .child(
                         h_flex()
-                            .bg(DefaultColor::Background.hsla(&colors))
-                            .h_8()
-                            .w_24()
-                            .justify_center()
-                            .child("Text on background"),
+                            .gap_1()
+                            .child(
+                                h_flex()
+                                    .bg(DefaultColor::Background.hsla(&colors))
+                                    .h_8()
+                                    .p_2()
+                                    .text_sm()
+                                    .text_color(DefaultColor::Text.hsla(&colors))
+                                    .child("Default Text"),
+                            )
+                            .child(
+                                h_flex()
+                                    .bg(DefaultColor::Container.hsla(&colors))
+                                    .h_8()
+                                    .p_2()
+                                    .text_sm()
+                                    .text_color(DefaultColor::Text.hsla(&colors))
+                                    .child("Text on Container"),
+                            )
+                            .child(
+                                h_flex()
+                                    .bg(DefaultColor::Selected.hsla(&colors))
+                                    .h_8()
+                                    .p_2()
+                                    .text_sm()
+                                    .text_color(DefaultColor::SelectedText.hsla(&colors))
+                                    .child("Selected Text"),
+                            ),
                     )
             }))
     }

--- a/crates/storybook/src/stories/default_colors.rs
+++ b/crates/storybook/src/stories/default_colors.rs
@@ -37,7 +37,7 @@ impl Render for DefaultColorsStory {
                     .p_4()
                     .child(Story::label(format!("{:?} Appearance", appearance)))
                     .children(color_types.iter().map(|(name, color)| {
-                        let color: Hsla = color.clone().into();
+                        let color: Hsla = color.clone();
 
                         div()
                             .flex()
@@ -51,7 +51,7 @@ impl Render for DefaultColorsStory {
                                     .border_1()
                                     .border_color(cx.theme().colors().border),
                             )
-                            .child(Story::label(format!("{}: {:?}", name, color)))
+                            .child(Story::label(format!("{}: {:?}", name, color.clone())))
                     }))
                     .child(
                         h_flex()

--- a/crates/storybook/src/story_selector.rs
+++ b/crates/storybook/src/story_selector.rs
@@ -20,6 +20,7 @@ pub enum ComponentStory {
     CollabNotification,
     ContextMenu,
     Cursor,
+    DefaultColors,
     Disclosure,
     Focus,
     Icon,
@@ -54,6 +55,7 @@ impl ComponentStory {
                 .into(),
             Self::ContextMenu => cx.new_view(|_| ui::ContextMenuStory).into(),
             Self::Cursor => cx.new_view(|_| crate::stories::CursorStory).into(),
+            Self::DefaultColors => DefaultColorsStory::view(cx).into(),
             Self::Disclosure => cx.new_view(|_| ui::DisclosureStory).into(),
             Self::Focus => FocusStory::view(cx).into(),
             Self::Icon => cx.new_view(|_| ui::IconStory).into(),
@@ -64,15 +66,15 @@ impl ComponentStory {
             Self::ListHeader => cx.new_view(|_| ui::ListHeaderStory).into(),
             Self::ListItem => cx.new_view(|_| ui::ListItemStory).into(),
             Self::OverflowScroll => cx.new_view(|_| crate::stories::OverflowScrollStory).into(),
+            Self::Picker => PickerStory::new(cx).into(),
             Self::Scroll => ScrollStory::view(cx).into(),
-            Self::Text => TextStory::view(cx).into(),
             Self::Tab => cx.new_view(|_| ui::TabStory).into(),
             Self::TabBar => cx.new_view(|_| ui::TabBarStory).into(),
+            Self::Text => TextStory::view(cx).into(),
             Self::ToggleButton => cx.new_view(|_| ui::ToggleButtonStory).into(),
             Self::ToolStrip => cx.new_view(|_| ui::ToolStripStory).into(),
             Self::ViewportUnits => cx.new_view(|_| crate::stories::ViewportUnitsStory).into(),
             Self::WithRemSize => cx.new_view(|_| crate::stories::WithRemSizeStory).into(),
-            Self::Picker => PickerStory::new(cx).into(),
         }
     }
 }


### PR DESCRIPTION
This PR adds an initial set of default colors to `gpui`. 

These will power default-styled gpui components (things like checkboxes, buttons, inputs, etc.), storybook, and give a very simple, appearance-aware set of colors out of the box for folks to build with.

These colors will evolve and be updated in the near future, they are literally pulled from Finder for now :)

The API might not be perfect, I focused on getting something in quickly that we can iterate on!

### Usage

```rs
use gpui::{colors, DefaultColor}

fn auto(cx: &WindowContext) -> {
  // Init the full set of DefaultColors
  let colors = colors(cx.appearance());
  // Use a color
  // It will automatically give you the correct color for the system's
  // current appearance.
  let background = DefaultColor::Background.hsla(&colors)
}

fn manual() -> {
  // Init the full sets of DefaultColors
  let light_colors = DefaultColors::light();
  let dark_colors = DefaultColors::dark();
  // Use a color
  // Maybe for some fancy inverted element
  let background = DefaultColor::Background.hsla(&light_colors)
  let inverted_background = DefaultColor::Background.hsla(&dark_colors)
  let inverted_text = DefaultColor::Text.hsla(&dark_colors)
}

```

Note: We need `cx` for the auto way as we need to get the system appearance from the App/Window/ViewContext via `cx.appearance()`.

### Example

You can run `script/storybook default_colors` to open the Default Colors story:

| Light | Dark |
|-------|------|
| ![CleanShot 2024-08-29 at 16 19 20@2x](https://github.com/user-attachments/assets/80369de4-8926-4b30-80f5-f81a8a7b9531) | ![CleanShot 2024-08-29 at 16 19 33@2x](https://github.com/user-attachments/assets/fd7a2aae-27e6-460f-a054-8f37623dc96d) |


Release Notes:

- N/A
