### PR TITLE
context_servers: Normalize the line endings of context servers

### DIFF
--- a/crates/assistant/src/slash_command/context_server_command.rs
+++ b/crates/assistant/src/slash_command/context_server_command.rs
@@ -11,6 +11,7 @@ use gpui::{Task, WeakView, WindowContext};
 use language::LspAdapterDelegate;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use text::LineEnding;
 use ui::{IconName, SharedString};
 use workspace::Workspace;
 
@@ -81,10 +82,14 @@ impl SlashCommand for ContextServerSlashCommand {
                     return Err(anyhow!("Context server not initialized"));
                 };
                 let result = protocol.run_prompt(&prompt_name, prompt_args).await?;
+                let mut prompt = result.prompt;
+
+                // We must normalize the line endings here, since servers might return CR characters.
+                LineEnding::normalize(&mut prompt);
 
                 Ok(SlashCommandOutput {
                     sections: vec![SlashCommandOutputSection {
-                        range: 0..(result.prompt.len()),
+                        range: 0..(prompt.len()),
                         icon: IconName::ZedAssistant,
                         label: SharedString::from(
                             result
@@ -92,7 +97,7 @@ impl SlashCommand for ContextServerSlashCommand {
                                 .unwrap_or(format!("Result from {}", prompt_name)),
                         ),
                     }],
-                    text: result.prompt,
+                    text: prompt,
                     run_commands_in_text: false,
                 })
             })


### PR DESCRIPTION
Context servers might return CR characters, which are not acceptable in Zed and cause ranges to be invalidated. We need to normalize them.

Closes #17109

Release Notes:

- context_servers: Fixed an issue where context servers returning a carriage return character would result in a panic.
