### PR TITLE
workspace: Fix weird behavior when save replaces the existing open file

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1556,8 +1556,16 @@ impl Pane {
                         .update(cx, |workspace, cx| workspace.prompt_for_new_path(cx))
                 })??;
                 if let Some(abs_path) = abs_path.await.ok().flatten() {
-                    pane.update(cx, |_, cx| item.save_as(project, abs_path, cx))?
-                        .await?;
+                    pane.update(cx, |pane, cx| {
+                        if let Some(item) = pane.item_for_path(abs_path.clone(), cx) {
+                            if let Some(idx) = pane.index_for_item(&*item) {
+                                pane.remove_item(idx, false, false, cx);
+                            }
+                        }
+
+                        item.save_as(project, abs_path, cx)
+                    })?
+                    .await?;
                 } else {
                     return Ok(false);
                 }


### PR DESCRIPTION
Fixes this weird behavior:
  - open an file, like `test.rs`
  - `ctrl-n` create an new buffer
  - `ctrl-s` save new buffer with name `test.rs`, select replace old file.
  - the older open file also exist, this is weird.

Release Notes:

- Fix weird behavior when save replaces the existing open file, using the new pane replace old pane.
