### PR TITLE
ruby: Bump version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14442,7 +14442,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruby"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/ruby/Cargo.toml
+++ b/extensions/ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
**Changelog:**
- Replace default tasks with a stub message (#16752)
- Update tree-sitter grammar for the Ruby language (#16892)
- Rename `rbs` to `RBS` (#16893)
- Upgrade `zed_extension_api` to v0.1.0 (#16907)

Release Notes:

- N/A
