### PR TITLE
vim: Don't show inline completions in normal mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -470,6 +470,9 @@ struct BufferOffset(usize);
 // Addons allow storing per-editor state in other crates (e.g. Vim)
 pub trait Addon: 'static {
     fn extend_key_context(&self, _: &mut KeyContext, _: &AppContext) {}
+    fn should_show_inline_completions(&self, _: &AppContext) -> bool {
+        true
+    }
 
     fn to_any(&self) -> &dyn std::any::Any;
 }
@@ -2340,6 +2343,11 @@ impl Editor {
         cx: &AppContext,
     ) -> bool {
         if let Some(provider) = self.inline_completion_provider() {
+            for addon in self.addons.values() {
+                if !addon.should_show_inline_completions(cx) {
+                    return false;
+                }
+            }
             if let Some(show_inline_completions) = self.show_inline_completions_override {
                 show_inline_completions
             } else {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -91,8 +91,7 @@ pub fn init(cx: &mut AppContext) {
     VimSettings::register(cx);
     VimGlobals::register(cx);
 
-    cx.observe_new_views(|editor: &mut Editor, cx| Vim::register(editor, cx))
-        .detach();
+    cx.observe_new_views(Vim::register).detach();
 
     cx.observe_new_views(|workspace: &mut Workspace, _| {
         workspace.register_action(|workspace, _: &ToggleVimMode, cx| {
@@ -133,6 +132,11 @@ pub(crate) struct VimAddon {
 impl editor::Addon for VimAddon {
     fn extend_key_context(&self, key_context: &mut KeyContext, cx: &AppContext) {
         self.view.read(cx).extend_key_context(key_context)
+    }
+
+    fn should_show_inline_completions(&self, cx: &AppContext) -> bool {
+        let mode = self.view.read(cx).mode;
+        mode == Mode::Insert || mode == Mode::Replace
     }
 
     fn to_any(&self) -> &dyn std::any::Any {


### PR DESCRIPTION
This fixes an annoying bug I ran into, where supermaven completions would show up in normal mode.

cc @ConradIrwin not sure if this is the best way to fix this, but it seems like the neatest? On one hand, I didn't want to touch into Vim from the editor, and on the other I didn't want to add another boolean on the editor that flips on when in normal mode. So instead I extended the Addon interface.

Release Notes:

- Fixed inline completions (Copilot or Supermaven) showing up in Vim's normal mode.

