### PR TITLE
Revert "vim: Don't show inline completions in normal mode (#17137)"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -470,9 +470,6 @@ struct BufferOffset(usize);
 // Addons allow storing per-editor state in other crates (e.g. Vim)
 pub trait Addon: 'static {
     fn extend_key_context(&self, _: &mut KeyContext, _: &AppContext) {}
-    fn should_show_inline_completions(&self, _: &AppContext) -> bool {
-        true
-    }
 
     fn to_any(&self) -> &dyn std::any::Any;
 }
@@ -2343,11 +2340,6 @@ impl Editor {
         cx: &AppContext,
     ) -> bool {
         if let Some(provider) = self.inline_completion_provider() {
-            for addon in self.addons.values() {
-                if !addon.should_show_inline_completions(cx) {
-                    return false;
-                }
-            }
             if let Some(show_inline_completions) = self.show_inline_completions_override {
                 show_inline_completions
             } else {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -91,7 +91,8 @@ pub fn init(cx: &mut AppContext) {
     VimSettings::register(cx);
     VimGlobals::register(cx);
 
-    cx.observe_new_views(Vim::register).detach();
+    cx.observe_new_views(|editor: &mut Editor, cx| Vim::register(editor, cx))
+        .detach();
 
     cx.observe_new_views(|workspace: &mut Workspace, _| {
         workspace.register_action(|workspace, _: &ToggleVimMode, cx| {
@@ -132,11 +133,6 @@ pub(crate) struct VimAddon {
 impl editor::Addon for VimAddon {
     fn extend_key_context(&self, key_context: &mut KeyContext, cx: &AppContext) {
         self.view.read(cx).extend_key_context(key_context)
-    }
-
-    fn should_show_inline_completions(&self, cx: &AppContext) -> bool {
-        let mode = self.view.read(cx).mode;
-        mode == Mode::Insert || mode == Mode::Replace
     }
 
     fn to_any(&self) -> &dyn std::any::Any {


### PR DESCRIPTION
This reverts commit 9206561662e8382e14f4ddf4db9f43ec64cf5972.

It lead to this panic:

```
Thread "main" panicked with "invalid SecondaryMap key used" at /Users/thorstenball/work/zed/crates/gpui/src/app/entity_map.rs:120:22
   0: backtrace::backtrace::libunwind::trace
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/libunwind.rs:116:5
      backtrace::backtrace::trace_unsynchronized::<<backtrace::capture::Backtrace>::create::{closure#0}>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/mod.rs:66:5
   1: backtrace::backtrace::trace::<<backtrace::capture::Backtrace>::create::{closure#0}>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/mod.rs:53:14
   2: <backtrace::capture::Backtrace>::create
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/capture.rs:197:9
   3: <backtrace::capture::Backtrace>::new
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/capture.rs:162:22
   4: zed::reliability::init_panic_hook::{closure#0}
             at /Users/thorstenball/work/zed/crates/zed/src/reliability.rs:58:29
   5: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/alloc/src/boxed.rs:2077:9
      std::panicking::rust_panic_with_hook
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:799:13
   6: std::panicking::begin_panic::<&str>::{closure#0}
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:694:9
   7: std::sys_common::backtrace::__rust_end_short_backtrace::<std::panicking::begin_panic<&str>::{closure#0}, !>
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/sys_common/backtrace.rs:171:18
   8: std::panicking::begin_panic::<&str>
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:693:12
   9: <slotmap::secondary::SecondaryMap<gpui::app::entity_map::EntityId, alloc::boxed::Box<dyn core::any::Any>> as core::ops::index::Index<gpui::app::entity_map::EntityId>>::index
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/slotmap-1.0.7/src/secondary.rs:866:21
  10: <gpui::app::entity_map::EntityMap>::read::<vim::Vim>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/entity_map.rs:120:22
  11: <gpui::app::entity_map::Model<vim::Vim>>::read
             at /Users/thorstenball/work/zed/crates/gpui/src/app/entity_map.rs:397:9
  12: <gpui::view::View<vim::Vim>>::read
             at /Users/thorstenball/work/zed/crates/gpui/src/view.rs:81:9
  13: <vim::VimAddon as editor::Addon>::should_show_inline_completions
             at /Users/thorstenball/work/zed/crates/vim/src/vim.rs:138:20
  14: <editor::Editor>::should_show_inline_completions
             at /Users/thorstenball/work/zed/crates/editor/src/editor.rs:2347:21
  15: <editor::Editor>::refresh_inline_completion
             at /Users/thorstenball/work/zed/crates/editor/src/editor.rs:4988:17
  16: <editor::Editor>::undo
             at /Users/thorstenball/work/zed/crates/editor/src/editor.rs:6868:13
  17: vim::normal::register::{closure#7}::{closure#0}
             at /Users/thorstenball/work/zed/crates/vim/src/normal.rs:176:17
  18: <vim::Vim>::update_editor::<(), vim::normal::register::{closure#7}::{closure#0}>::{closure#0}
             at /Users/thorstenball/work/zed/crates/vim/src/vim.rs:693:45
  19: <gpui::window::WindowContext as gpui::VisualContext>::update_view::<editor::Editor, (), <vim::Vim>::update_editor<(), vim::normal::register::{closure#7}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:3890:22
  20: <gpui::window::ViewContext<vim::Vim> as gpui::VisualContext>::update_view::<editor::Editor, (), <vim::Vim>::update_editor<(), vim::normal::register::{closure#7}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:4522:9
  21: <gpui::view::View<editor::Editor>>::update::<gpui::window::ViewContext<vim::Vim>, (), <vim::Vim>::update_editor<(), vim::normal::register::{closure#7}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/view.rs:76:9
  22: <vim::Vim>::update_editor::<(), vim::normal::register::{closure#7}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/vim/src/vim.rs:693:14
  23: vim::normal::register::{closure#7}
             at /Users/thorstenball/work/zed/crates/vim/src/normal.rs:174:9
  24: <gpui::window::ViewContext<vim::Vim>>::listener::<vim::normal::Undo, vim::normal::register::{closure#7}>::{closure#0}::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:4444:40
  25: <gpui::window::WindowContext as gpui::VisualContext>::update_view::<vim::Vim, (), <gpui::window::ViewContext<vim::Vim>>::listener<vim::normal::Undo, vim::normal::register::{closure#7}>::{closure#0}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:3890:22
  26: <gpui::view::View<vim::Vim>>::update::<gpui::window::WindowContext, (), <gpui::window::ViewContext<vim::Vim>>::listener<vim::normal::Undo, vim::normal::register::{closure#7}>::{closure#0}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/view.rs:76:9
  27: <gpui::view::WeakView<vim::Vim>>::update::<gpui::window::WindowContext, (), <gpui::window::ViewContext<vim::Vim>>::listener<vim::normal::Undo, vim::normal::register::{closure#7}>::{closure#0}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/view.rs:192:12
  28: <gpui::window::ViewContext<vim::Vim>>::listener::<vim::normal::Undo, vim::normal::register::{closure#7}>::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:4444:13
  29: <editor::Editor>::register_action::<vim::normal::Undo, <gpui::window::ViewContext<vim::Vim>>::listener<vim::normal::Undo, vim::normal::register::{closure#7}>::{closure#0}>::{closure#0}::{closure#0}
             at /Users/thorstenball/work/zed/crates/editor/src/editor.rs:12053:25
  30: <gpui::window::WindowContext>::dispatch_action_on_node
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:3514:21
  31: <gpui::window::WindowContext>::dispatch_key_event
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:3303:13
  32: <gpui::window::WindowContext>::dispatch_event
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:3131:13
  33: <gpui::window::Window>::new::{closure#10}::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:776:46
  34: <gpui::app::AppContext as gpui::Context>::update_window::<gpui::window::DispatchEventResult, <gpui::window::Window>::new::{closure#10}::{closure#0}>::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1396:26
  35: <gpui::app::AppContext>::update::<core::result::Result<gpui::window::DispatchEventResult, anyhow::Error>, <gpui::app::AppContext as gpui::Context>::update_window<gpui::window::DispatchEventResult, <gpui::window::Window>::new::{closure#10}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:362:22
  36: <gpui::app::AppContext as gpui::Context>::update_window::<gpui::window::DispatchEventResult, <gpui::window::Window>::new::{closure#10}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1387:9
  37: <gpui::app::async_context::AsyncAppContext as gpui::Context>::update_window::<gpui::window::DispatchEventResult, <gpui::window::Window>::new::{closure#10}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/async_context.rs:91:9
  38: <gpui::window::AnyWindowHandle>::update::<gpui::app::async_context::AsyncAppContext, gpui::window::DispatchEventResult, <gpui::window::Window>::new::{closure#10}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:4750:9
  39: <gpui::window::Window>::new::{closure#10}
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:775:17
  40: <alloc::boxed::Box<dyn core::ops::function::FnMut<(gpui::interactive::PlatformInput,), Output = gpui::window::DispatchEventResult>> as core::ops::function::FnMut<(gpui::interactive::PlatformInput,)>>::call_mut
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/alloc/src/boxed.rs:2070:9
  41: gpui::platform::mac::window::handle_key_event
             at /Users/thorstenball/work/zed/crates/gpui/src/platform/mac/window.rs:1300:32
  42: gpui::platform::mac::window::handle_key_down
             at /Users/thorstenball/work/zed/crates/gpui/src/platform/mac/window.rs:1212:5
  43: <unknown>
  44: <unknown>
  45: <unknown>
  46: <unknown>
  47: <unknown>
  48: <() as objc::message::MessageArguments>::invoke::<()>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/mod.rs:128:17
  49: objc::message::platform::send_unverified::<objc::runtime::Object, (), ()>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/apple/mod.rs:27:9
  50: objc::message::send_message::<objc::runtime::Object, (), ()>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/mod.rs:178:5
      <*mut objc::runtime::Object as cocoa::appkit::NSApplication>::run
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cocoa-0.26.0/src/appkit.rs:628:9
  51: <gpui::platform::mac::platform::MacPlatform as gpui::platform::Platform>::run
             at /Users/thorstenball/work/zed/crates/gpui/src/platform/mac/platform.rs:427:13
  52: <gpui::app::App>::run::<zed::main::{closure#3}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:159:9
  53: zed::main
             at /Users/thorstenball/work/zed/crates/zed/src/main.rs:439:5
  54: <fn() as core::ops::function::FnOnce<()>>::call_once
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:250:5
  55: std::sys_common::backtrace::__rust_begin_short_backtrace::<fn(), ()>
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/sys_common/backtrace.rs:155:18
  56: std::rt::lang_start::<()>::{closure#0}
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/rt.rs:159:18
  57: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:284:13
      std::panicking::try::do_call
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:559:40
      std::panicking::try
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:523:19
      std::panic::catch_unwind
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panic.rs:149:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/rt.rs:141:48
      std::panicking::try::do_call
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:559:40
      std::panicking::try
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:523:19
      std::panic::catch_unwind
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panic.rs:149:14
      std::rt::lang_start_internal
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/rt.rs:141:20
  58: std::rt::lang_start::<()>
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/rt.rs:158:17
  59: _main
```

Release Notes:

- N/A
