### PR TITLE
vim: Disable inline completions if not Insert/Replace mode

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1061,6 +1061,7 @@ impl Vim {
             editor.set_input_enabled(vim.editor_input_enabled());
             editor.set_autoindent(vim.should_autoindent());
             editor.selections.line_mode = matches!(vim.mode, Mode::VisualLine);
+            editor.set_inline_completions_enabled(matches!(vim.mode, Mode::Insert | Mode::Replace));
         });
         cx.notify()
     }


### PR DESCRIPTION
This is a follow-up to

- https://github.com/zed-industries/zed/pull/17137
- https://github.com/zed-industries/zed/pull/17138 (revert of #17137)

and it does what I originally thought I wouldn't have to do: add another boolean to `Editor`.

cc @ConradIrwin 
Release Notes:

- Fixed inline completions (Copilot or Supermaven) showing up in Vim's normal mode.
