### PR TITLE
story: Remove unneeded `lib.name`

### DIFF
--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 license = "GPL-3.0-or-later"
 
 [lib]
-name = "story"
 path = "src/story.rs"
 
 [lints]


### PR DESCRIPTION
This PR removes the `lib.name` field from the `story` crate's `Cargo.toml`, as it is not needed.

Release Notes:

- N/A
