### PR TITLE
anthropic: Use separate `Content` type in requests and responses

### DIFF
--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -304,17 +304,17 @@ impl LanguageModelRequest {
                     } else {
                         None
                     };
-                    let anthropic_message_content: Vec<anthropic::Content> = message
+                    let anthropic_message_content: Vec<anthropic::RequestContent> = message
                         .content
                         .into_iter()
                         .filter_map(|content| match content {
                             MessageContent::Text(t) if !t.is_empty() => {
-                                Some(anthropic::Content::Text {
+                                Some(anthropic::RequestContent::Text {
                                     text: t,
                                     cache_control,
                                 })
                             }
-                            MessageContent::Image(i) => Some(anthropic::Content::Image {
+                            MessageContent::Image(i) => Some(anthropic::RequestContent::Image {
                                 source: anthropic::ImageSource {
                                     source_type: "base64".to_string(),
                                     media_type: "image/png".to_string(),


### PR DESCRIPTION
This PR splits the `Content` type for Anthropic into two new types: `RequestContent` and `ResponseContent`.

As I was going through the Anthropic API docs it seems that there are different types of content that can be sent in requests vs what can be returned in responses.

Using a separate type for each case tells the story a bit better and makes it easier to understand, IMO.

Release Notes:

- N/A
