### PR TITLE
anthropic: Remove `cache_control` field from `ResponseContent`

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -450,18 +450,12 @@ pub enum RequestContent {
 #[serde(tag = "type")]
 pub enum ResponseContent {
     #[serde(rename = "text")]
-    Text {
-        text: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        cache_control: Option<CacheControl>,
-    },
+    Text { text: String },
     #[serde(rename = "tool_use")]
     ToolUse {
         id: String,
         name: String,
         input: serde_json::Value,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        cache_control: Option<CacheControl>,
     },
 }
 


### PR DESCRIPTION
This PR removes the `cache_control` field from the variants in `ResponseContent`.

This field is used on requests to control the caching behavior, but is not needed on content in the response.

Release Notes:

- N/A
