### PR TITLE
OpenAI: Fix GPT-4. Only include max_tokens when max_output_tokens provided

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -120,14 +120,10 @@ impl Model {
 
     pub fn max_output_tokens(&self) -> Option<u32> {
         match self {
-            Self::ThreePointFiveTurbo => Some(4096),
-            Self::Four => Some(8192),
-            Self::FourTurbo => Some(4096),
-            Self::FourOmni => Some(4096),
-            Self::FourOmniMini => Some(16384),
             Self::Custom {
                 max_output_tokens, ..
             } => *max_output_tokens,
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
PR #16381 broke GPT-4 (both via OpenAI and via zed.dev).
Other OpenAI models (4o, 3.5, turbo, etc) were unaffected.

<img width="380" alt="Screenshot 2024-08-30 at 13 12 55" src="https://github.com/user-attachments/assets/fe2c5e6e-8515-4384-acc7-b524fbb600c1">

With this change we will only include `max_tokens` on the request if the OpenAI custom definition from settings includes `max_output_tokens` and not on every request.

I believe the root cause of this is that GPT-4 (and only GPT-4) has a 8192 token context shared for both input and output.  So if you provide it 6k of context your output will be no larger than 2k tokens.  If you include `max_tokens` = 8192 on the request it will pre-emptively bail knowing it's actual output context will never exceed 2048.  As a result `max_output_tokens` for GPT-4 (and only og GPT-4) would need to be computed dynamically.

I verified this still works as expected via settings.

<img width="844" alt="Screenshot 2024-08-30 at 13 36 32" src="https://github.com/user-attachments/assets/6749b42e-28d8-49ed-b75f-4a646ce166a2">

Note, this is a little confusing because our setting for context length is `max_tokens` and our setting for limiting output is `max_output_tokens`. But on the OpenAI request you limit output tokens with the `max_tokens` parameter populated from `make_output_tokens` in our settings.

Release Notes:

- Fixed GPT-4 breakage (incorrect `max_output_tokens` handling).