### PR TITLE
assistant: Add foundation for receiving tool uses from Anthropic models

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -335,7 +335,7 @@ pub fn extract_text_from_events(
 ) -> impl Stream<Item = Result<String, AnthropicError>> {
     response.filter_map(|response| async move {
         match response {
-            Ok(response) => match response {
+            Ok(response) => match dbg!(response) {
                 Event::ContentBlockStart { content_block, .. } => match content_block {
                     Content::Text { text, .. } => Some(Ok(text)),
                     _ => None,

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -2048,7 +2048,8 @@ impl Context {
 
         LanguageModelRequest {
             messages: request_messages,
-            stop: vec![],
+            tools: Vec::new(),
+            stop: Vec::new(),
             temperature: 1.0,
         }
     }
@@ -2398,7 +2399,8 @@ impl Context {
                 }));
             let request = LanguageModelRequest {
                 messages: messages.collect(),
-                stop: vec![],
+                tools: Vec::new(),
+                stop: Vec::new(),
                 temperature: 1.0,
             };
 

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1931,7 +1931,30 @@ impl Context {
         // Compute which messages to cache, including the last one.
         self.mark_cache_anchors(&model.cache_configuration(), false, cx);
 
-        let request = self.to_completion_request(cx);
+        let mut request = self.to_completion_request(cx);
+        // TODO: Hard-coded tool.
+        request
+            .tools
+            .push(language_model::LanguageModelRequestTool {
+                name: "get_weather".to_string(),
+                description: "Get the current weather in a given location".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA"
+                        },
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                            "description": "The unit of temperature, either \"celsius\" or \"fahrenheit\""
+                        }
+                    },
+                    "required": ["location"]
+                }),
+            });
+
         let assistant_message = self
             .insert_message_after(last_message_id, Role::Assistant, MessageStatus::Pending, cx)
             .unwrap();

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1931,30 +1931,7 @@ impl Context {
         // Compute which messages to cache, including the last one.
         self.mark_cache_anchors(&model.cache_configuration(), false, cx);
 
-        let mut request = self.to_completion_request(cx);
-        // TODO: Hard-coded tool.
-        request
-            .tools
-            .push(language_model::LanguageModelRequestTool {
-                name: "get_weather".to_string(),
-                description: "Get the current weather in a given location".to_string(),
-                input_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "location": {
-                            "type": "string",
-                            "description": "The city and state, e.g. San Francisco, CA"
-                        },
-                        "unit": {
-                            "type": "string",
-                            "enum": ["celsius", "fahrenheit"],
-                            "description": "The unit of temperature, either \"celsius\" or \"fahrenheit\""
-                        }
-                    },
-                    "required": ["location"]
-                }),
-            });
-
+        let request = self.to_completion_request(cx);
         let assistant_message = self
             .insert_message_after(last_message_id, Role::Assistant, MessageStatus::Pending, cx)
             .unwrap();

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -2413,6 +2413,7 @@ impl Codegen {
 
         Ok(LanguageModelRequest {
             messages,
+            tools: Vec::new(),
             stop: vec!["|END|>".to_string()],
             temperature,
         })

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -794,6 +794,7 @@ impl PromptLibrary {
                                         content: vec![body.to_string().into()],
                                         cache: false,
                                     }],
+                                    tools: Vec::new(),
                                     stop: Vec::new(),
                                     temperature: 1.,
                                 },

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -282,6 +282,7 @@ impl TerminalInlineAssistant {
 
         Ok(LanguageModelRequest {
             messages,
+            tools: Vec::new(),
             stop: Vec::new(),
             temperature: 1.0,
         })

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -370,7 +370,7 @@ impl LanguageModel for AnthropicModel {
         let request = self.stream_completion(request, cx);
         let future = self.request_limiter.stream(async move {
             let response = request.await.map_err(|err| anyhow!(err))?;
-            Ok(anthropic::extract_text_from_events(response))
+            Ok(anthropic::extract_content_from_events(response))
         });
         async move {
             Ok(future

--- a/crates/language_model/src/provider/cloud.rs
+++ b/crates/language_model/src/provider/cloud.rs
@@ -515,7 +515,7 @@ impl LanguageModel for CloudLanguageModel {
                         },
                     )
                     .await?;
-                    Ok(anthropic::extract_text_from_events(
+                    Ok(anthropic::extract_content_from_events(
                         response_lines(response).map_err(AnthropicError::Other),
                     ))
                 });

--- a/crates/language_model/src/provider/cloud.rs
+++ b/crates/language_model/src/provider/cloud.rs
@@ -515,9 +515,9 @@ impl LanguageModel for CloudLanguageModel {
                         },
                     )
                     .await?;
-                    Ok(anthropic::extract_content_from_events(
+                    Ok(anthropic::extract_content_from_events(Box::pin(
                         response_lines(response).map_err(AnthropicError::Other),
-                    ))
+                    )))
                 });
                 async move {
                     Ok(future

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -231,7 +231,6 @@ pub struct LanguageModelRequestTool {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct LanguageModelRequest {
     pub messages: Vec<LanguageModelRequestMessage>,
-    // pub tool_choice: TODO
     pub tools: Vec<LanguageModelRequestTool>,
     pub stop: Vec<String>,
     pub temperature: f32,

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -221,9 +221,18 @@ impl LanguageModelRequestMessage {
     }
 }
 
+#[derive(Debug, PartialEq, Hash, Clone, Serialize, Deserialize)]
+pub struct LanguageModelRequestTool {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct LanguageModelRequest {
     pub messages: Vec<LanguageModelRequestMessage>,
+    // pub tool_choice: TODO
+    pub tools: Vec<LanguageModelRequestTool>,
     pub stop: Vec<String>,
     pub temperature: f32,
 }
@@ -355,7 +364,15 @@ impl LanguageModelRequest {
             messages: new_messages,
             max_tokens: max_output_tokens,
             system: Some(system_message),
-            tools: Vec::new(),
+            tools: self
+                .tools
+                .into_iter()
+                .map(|tool| anthropic::Tool {
+                    name: tool.name,
+                    description: tool.description,
+                    input_schema: tool.input_schema,
+                })
+                .collect(),
             tool_choice: None,
             metadata: None,
             stop_sequences: Vec::new(),


### PR DESCRIPTION
This PR updates the Assistant with support for receiving tool uses from Anthropic models and capturing them as text in the context editor.

This is just laying the foundation for tool use. We don't yet fulfill the tool uses yet, or define any tools for the model to use.

Here's an example of what it looks like using the example `get_weather` tool from the Anthropic docs:

<img width="644" alt="Screenshot 2024-08-30 at 1 51 13 PM" src="https://github.com/user-attachments/assets/3614f953-0689-423c-8955-b146729ea638">

Release Notes:

- N/A
