### PR TITLE
Allow Windows to target MSVC ABI

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "1.80"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
-targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi" ]
+targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi", "x86_64-pc-windows-msvc" ]


### PR DESCRIPTION
Closes #16205 

- Updates toolchain.toml
- Allows Windows to target the msvc ABI - targetting the gnu toolchain on windows will break key-input since it fails to generate a functional work directory. - errors in question are attached

![grafik](https://github.com/user-attachments/assets/7b335c27-a256-4f1b-9a89-1eb1cfdfe1f6)

While the actual issue behind that won't be fixed adding msvc as a toolchain is something that should be done nontheless (and works as a workaround at the moment)
one little note: should we specify this in the windows build portion of the Readme (e.g that gnu fails to work properly) or should we fix the underlying problem?
the readme has the following content but some people dont use msvc by default (me included) - so this is something that should be mentioned - if wanted i can commit it into this PR or create a new one.

> Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional component MSVC v*** - VS YYYY C++ x64/x86 build tools (v*** is your VS version and YYYY is year when your VS was released)

Release Notes:

- N/A