### PR TITLE
Add a way to configure default search options

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -279,8 +279,13 @@
   "relative_line_numbers": false,
   // If 'search_wrap' is disabled, search result do not wrap around the end of the file.
   "search_wrap": true,
-  // Search mode to use by default. Can be "text" or "regex"
-  "search_mode": "text",
+  // Search options to enable by default.
+  "search_defaults": {
+    "whole_word": false,
+    "case_sensitive": false,
+    "include_ignored": false,
+    "regex": false
+  },
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -279,6 +279,8 @@
   "relative_line_numbers": false,
   // If 'search_wrap' is disabled, search result do not wrap around the end of the file.
   "search_wrap": true,
+  // Search mode to use by default. Can be "text" or "regex"
+  "search_mode": "text",
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -280,7 +280,7 @@
   // If 'search_wrap' is disabled, search result do not wrap around the end of the file.
   "search_wrap": true,
   // Search options to enable by default when opening new project and buffer searches.
-  "search_defaults": {
+  "search": {
     "whole_word": false,
     "case_sensitive": false,
     "include_ignored": false,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -279,7 +279,7 @@
   "relative_line_numbers": false,
   // If 'search_wrap' is disabled, search result do not wrap around the end of the file.
   "search_wrap": true,
-  // Search options to enable by default.
+  // Search options to enable by default when opening new project and buffer searches.
   "search_defaults": {
     "whole_word": false,
     "case_sensitive": false,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -59,7 +59,7 @@ use convert_case::{Case, Casing};
 use debounced_delay::DebouncedDelay;
 use display_map::*;
 pub use display_map::{DisplayPoint, FoldPlaceholder};
-pub use editor_settings::{CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchMode};
+pub use editor_settings::{CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchDefaults};
 pub use editor_settings_controls::*;
 use element::LineWithInvisibles;
 pub use element::{

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -59,7 +59,7 @@ use convert_case::{Case, Casing};
 use debounced_delay::DebouncedDelay;
 use display_map::*;
 pub use display_map::{DisplayPoint, FoldPlaceholder};
-pub use editor_settings::{CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine};
+pub use editor_settings::{CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchMode};
 pub use editor_settings_controls::*;
 use element::LineWithInvisibles;
 pub use element::{

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -59,7 +59,9 @@ use convert_case::{Case, Casing};
 use debounced_delay::DebouncedDelay;
 use display_map::*;
 pub use display_map::{DisplayPoint, FoldPlaceholder};
-pub use editor_settings::{CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchSettings};
+pub use editor_settings::{
+    CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchSettings,
+};
 pub use editor_settings_controls::*;
 use element::LineWithInvisibles;
 pub use element::{

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -59,7 +59,7 @@ use convert_case::{Case, Casing};
 use debounced_delay::DebouncedDelay;
 use display_map::*;
 pub use display_map::{DisplayPoint, FoldPlaceholder};
-pub use editor_settings::{CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchDefaults};
+pub use editor_settings::{CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchSettings};
 pub use editor_settings_controls::*;
 use element::LineWithInvisibles;
 pub use element::{

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -27,6 +27,8 @@ pub struct EditorSettings {
     #[serde(default)]
     pub double_click_in_multibuffer: DoubleClickInMultibuffer,
     pub search_wrap: bool,
+    #[serde(default)]
+    pub search_mode: SearchMode,
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub jupyter: Jupyter,
@@ -155,6 +157,15 @@ pub enum ScrollBeyondLastLine {
     VerticalScrollMargin,
 }
 
+/// Default search mode, text or regex
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchMode {
+    #[default]
+    Text,
+    Regex,
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
     /// Whether the cursor blinks in the editor.
@@ -248,6 +259,11 @@ pub struct EditorSettingsContent {
     ///
     /// Default: true
     pub search_wrap: Option<bool>,
+
+    /// Default search mode, (text or regex)
+    ///
+    /// Default: text
+    pub search_mode: Option<SearchMode>,
 
     /// Whether to automatically show a signature help pop-up or not.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -28,7 +28,7 @@ pub struct EditorSettings {
     pub double_click_in_multibuffer: DoubleClickInMultibuffer,
     pub search_wrap: bool,
     #[serde(default)]
-    pub search: SearchDefaults,
+    pub search: SearchSettings,
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub jupyter: Jupyter,
@@ -159,7 +159,7 @@ pub enum ScrollBeyondLastLine {
 
 /// Default options for buffer and project search items.
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-pub struct SearchDefaults {
+pub struct SearchSettings {
     #[serde(default)]
     pub whole_word: bool,
     #[serde(default)]
@@ -267,7 +267,7 @@ pub struct EditorSettingsContent {
     /// Defaults to use when opening a new buffer and project search items.
     ///
     /// Default: nothing is enabled
-    pub search: Option<SearchDefaults>,
+    pub search: Option<SearchSettings>,
 
     /// Whether to automatically show a signature help pop-up or not.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -28,7 +28,7 @@ pub struct EditorSettings {
     pub double_click_in_multibuffer: DoubleClickInMultibuffer,
     pub search_wrap: bool,
     #[serde(default)]
-    pub search_mode: SearchMode,
+    pub search_defaults: SearchDefaults,
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub jupyter: Jupyter,
@@ -157,13 +157,18 @@ pub enum ScrollBeyondLastLine {
     VerticalScrollMargin,
 }
 
-/// Default search mode, text or regex
-#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+/// Default match options; all false
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum SearchMode {
-    #[default]
-    Text,
-    Regex,
+pub struct SearchDefaults {
+    #[serde(default)]
+    pub whole_word: bool,
+    #[serde(default)]
+    pub case_sensitive: bool,
+    #[serde(default)]
+    pub include_ignored: bool,
+    #[serde(default)]
+    pub regex: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -260,10 +265,10 @@ pub struct EditorSettingsContent {
     /// Default: true
     pub search_wrap: Option<bool>,
 
-    /// Default search mode, (text or regex)
+    /// Defaults for search options (case sensitive, whole word, include ignored, regex)
     ///
-    /// Default: text
-    pub search_mode: Option<SearchMode>,
+    /// Default: all false
+    pub search_defaults: Option<SearchDefaults>,
 
     /// Whether to automatically show a signature help pop-up or not.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -28,7 +28,7 @@ pub struct EditorSettings {
     pub double_click_in_multibuffer: DoubleClickInMultibuffer,
     pub search_wrap: bool,
     #[serde(default)]
-    pub search_defaults: SearchDefaults,
+    pub search: SearchDefaults,
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub jupyter: Jupyter,
@@ -159,7 +159,6 @@ pub enum ScrollBeyondLastLine {
 
 /// Default options for buffer and project search items.
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
 pub struct SearchDefaults {
     #[serde(default)]
     pub whole_word: bool,
@@ -268,7 +267,7 @@ pub struct EditorSettingsContent {
     /// Defaults to use when opening a new buffer and project search items.
     ///
     /// Default: nothing is enabled
-    pub search_defaults: Option<SearchDefaults>,
+    pub search: Option<SearchDefaults>,
 
     /// Whether to automatically show a signature help pop-up or not.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -265,7 +265,7 @@ pub struct EditorSettingsContent {
     /// Default: true
     pub search_wrap: Option<bool>,
 
-    /// Defaults for search options (case sensitive, whole word, include ignored, regex)
+    /// Defaults to use when opening a new buffer and project search items.
     ///
     /// Default: nothing is enabled
     pub search_defaults: Option<SearchDefaults>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -267,7 +267,7 @@ pub struct EditorSettingsContent {
 
     /// Defaults for search options (case sensitive, whole word, include ignored, regex)
     ///
-    /// Default: all false
+    /// Default: nothing is enabled
     pub search_defaults: Option<SearchDefaults>,
 
     /// Whether to automatically show a signature help pop-up or not.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -157,7 +157,7 @@ pub enum ScrollBeyondLastLine {
     VerticalScrollMargin,
 }
 
-/// Default match options; all false
+/// Default options for buffer and project search items.
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct SearchDefaults {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -170,6 +170,27 @@ pub struct SearchSettings {
     pub regex: bool,
 }
 
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+pub struct SearchSettingsContent {
+    pub whole_word: Option<bool>,
+    pub case_sensitive: Option<bool>,
+    pub include_ignored: Option<bool>,
+    pub regex: Option<bool>,
+}
+
+impl Settings for SearchSettings {
+    const KEY: Option<&'static str> = Some("search");
+
+    type FileContent = SearchSettingsContent;
+
+    fn load(
+        sources: SettingsSources<Self::FileContent>,
+        _: &mut gpui::AppContext,
+    ) -> anyhow::Result<Self> {
+        sources.json_merge()
+    }
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
     /// Whether the cursor blinks in the editor.

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -9,7 +9,7 @@ use any_vec::AnyVec;
 use collections::HashMap;
 use editor::{
     actions::{Tab, TabPrev},
-    DisplayPoint, Editor, EditorElement, EditorSettings, EditorStyle,
+    DisplayPoint, Editor, EditorElement, EditorSettings, EditorStyle, SearchMode
 };
 use futures::channel::oneshot;
 use gpui::{
@@ -504,6 +504,11 @@ impl BufferSearchBar {
         let replacement_editor = cx.new_view(|cx| Editor::single_line(cx));
         cx.subscribe(&replacement_editor, Self::on_replacement_editor_event)
             .detach();
+        let search_options = if EditorSettings::get_global(cx).search_mode == SearchMode::Regex {
+            SearchOptions::REGEX
+        } else {
+            SearchOptions::NONE
+        };
 
         Self {
             query_editor,
@@ -514,8 +519,8 @@ impl BufferSearchBar {
             active_searchable_item_subscription: None,
             active_match_index: None,
             searchable_items_with_matches: Default::default(),
-            default_options: SearchOptions::NONE,
-            search_options: SearchOptions::NONE,
+            default_options: search_options,
+            search_options: search_options,
             pending_search: None,
             query_contains_error: false,
             dismissed: true,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -70,7 +70,6 @@ pub enum Event {
 }
 
 pub fn init(cx: &mut AppContext) {
-    SearchSettings::register(cx);
     cx.observe_new_views(|workspace: &mut Workspace, _| BufferSearchBar::register(workspace))
         .detach();
 }
@@ -1186,6 +1185,7 @@ mod tests {
             language::init(cx);
             Project::init_settings(cx);
             theme::init(theme::LoadThemes::JustBase, cx);
+            crate::init(cx);
         });
     }
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -9,7 +9,7 @@ use any_vec::AnyVec;
 use collections::HashMap;
 use editor::{
     actions::{Tab, TabPrev},
-    DisplayPoint, Editor, EditorElement, EditorSettings, EditorStyle, SearchMode
+    DisplayPoint, Editor, EditorElement, EditorSettings, EditorStyle
 };
 use futures::channel::oneshot;
 use gpui::{
@@ -504,11 +504,7 @@ impl BufferSearchBar {
         let replacement_editor = cx.new_view(|cx| Editor::single_line(cx));
         cx.subscribe(&replacement_editor, Self::on_replacement_editor_event)
             .detach();
-        let search_options = if EditorSettings::get_global(cx).search_mode == SearchMode::Regex {
-            SearchOptions::REGEX
-        } else {
-            SearchOptions::NONE
-        };
+        let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search_defaults);
 
         Self {
             query_editor,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -504,7 +504,7 @@ impl BufferSearchBar {
         let replacement_editor = cx.new_view(|cx| Editor::single_line(cx));
         cx.subscribe(&replacement_editor, Self::on_replacement_editor_event)
             .detach();
-        let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search_defaults);
+        let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search);
 
         Self {
             query_editor,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -70,7 +70,7 @@ pub enum Event {
 }
 
 pub fn init(cx: &mut AppContext) {
-   SearchSettings::register(cx);
+    SearchSettings::register(cx);
     cx.observe_new_views(|workspace: &mut Workspace, _| BufferSearchBar::register(workspace))
         .detach();
 }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -516,7 +516,7 @@ impl BufferSearchBar {
             active_match_index: None,
             searchable_items_with_matches: Default::default(),
             default_options: search_options,
-            search_options: search_options,
+            search_options,
             pending_search: None,
             query_contains_error: false,
             dismissed: true,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -504,7 +504,8 @@ impl BufferSearchBar {
         let replacement_editor = cx.new_view(|cx| Editor::single_line(cx));
         cx.subscribe(&replacement_editor, Self::on_replacement_editor_event)
             .detach();
-        let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search);
+        let search_options = SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
+
 
         Self {
             query_editor,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -507,17 +507,10 @@ impl BufferSearchBar {
         cx.subscribe(&replacement_editor, Self::on_replacement_editor_event)
             .detach();
 
-        let mut search_settings = *SearchSettings::get_global(cx);
-        let search_options = SearchOptions::from_settings(&search_settings);
+        let search_options = SearchOptions::from_settings(&SearchSettings::get_global(cx));
 
         let settings_subscription = cx.observe_global::<SettingsStore>(move |this, cx| {
-            let new_settings = *SearchSettings::get_global(cx);
-            if search_settings != new_settings {
-                this.default_options = SearchOptions::from_settings(&new_settings);
-                this.search_options = this.default_options;
-                search_settings = new_settings;
-                cx.notify();
-            }
+            this.default_options = SearchOptions::from_settings(&SearchSettings::get_global(cx));
         });
 
         Self {
@@ -617,6 +610,9 @@ impl BufferSearchBar {
         let Some(handle) = self.active_searchable_item.as_ref() else {
             return false;
         };
+        if self.default_options != self.search_options {
+            self.search_options = self.default_options;
+        }
 
         self.dismissed = false;
         handle.search_bar_visibility_changed(true, cx);

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -9,6 +9,7 @@ use editor::{
     items::active_match_index,
     scroll::{Autoscroll, Axis},
     Anchor, Editor, EditorElement, EditorEvent, EditorSettings, EditorStyle, MultiBuffer,
+    SearchMode,
     MAX_TAB_TITLE_LEN,
 };
 use futures::StreamExt;
@@ -628,7 +629,12 @@ impl ProjectSearchView {
         let (mut options, filters_enabled) = if let Some(settings) = settings {
             (settings.search_options, settings.filters_enabled)
         } else {
-            (SearchOptions::NONE, false)
+            let search_options = if EditorSettings::get_global(cx).search_mode == SearchMode::Regex {
+                SearchOptions::REGEX
+            } else {
+                SearchOptions::NONE
+            };
+            (search_options, false)
         };
 
         {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -632,7 +632,8 @@ impl ProjectSearchView {
         let (mut options, filters_enabled) = if let Some(settings) = settings {
             (settings.search_options, settings.filters_enabled)
         } else {
-            let search_options = SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
+            let search_options =
+                SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
             (search_options, false)
         };
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -8,7 +8,7 @@ use editor::{
     actions::SelectAll,
     items::active_match_index,
     scroll::{Autoscroll, Axis},
-    Anchor, Editor, EditorElement, EditorEvent, EditorSettings, EditorStyle, MultiBuffer, SearchSettings,
+    Anchor, Editor, EditorElement, EditorEvent, EditorSettings, EditorStyle, MultiBuffer,
     MAX_TAB_TITLE_LEN,
 };
 use futures::StreamExt;
@@ -20,8 +20,12 @@ use gpui::{
 };
 use language::Buffer;
 use menu::Confirm;
-use project::{search::SearchQuery, search_history::SearchHistoryCursor, Project, ProjectPath};
-use settings::{Settings, SettingsStore};
+use project::{
+    search::{SearchQuery},
+    search_history::SearchHistoryCursor,
+    Project, ProjectPath,
+};
+use settings::Settings;
 use std::{
     any::{Any, TypeId},
     mem,
@@ -56,7 +60,6 @@ impl Global for ActiveSettings {}
 
 pub fn init(cx: &mut AppContext) {
     cx.set_global(ActiveSettings::default());
-    SearchSettings::register(cx);
     cx.observe_new_views(|workspace: &mut Workspace, _cx| {
         register_workspace_action(workspace, move |search_bar, _: &FocusSearch, cx| {
             search_bar.focus_search(cx);
@@ -629,17 +632,7 @@ impl ProjectSearchView {
         let (mut options, filters_enabled) = if let Some(settings) = settings {
             (settings.search_options, settings.filters_enabled)
         } else {
-            let mut search_settings = *SearchSettings::get_global(cx);
-            let settings_subscription = cx.observe_global::<SettingsStore>(move |this, cx| {
-                let new_settings = *SearchSettings::get_global(cx);
-                if search_settings != new_settings {
-                    this.search_options = SearchOptions::from_settings(&new_settings);
-                    search_settings = new_settings;
-                    cx.notify();
-                }
-            });
-            subscriptions.push(settings_subscription);
-            let search_options = SearchOptions::from_settings(&search_settings);
+            let search_options = SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
             (search_options, false)
         };
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -628,7 +628,7 @@ impl ProjectSearchView {
         let (mut options, filters_enabled) = if let Some(settings) = settings {
             (settings.search_options, settings.filters_enabled)
         } else {
-            let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search_defaults);
+            let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search);
             (search_options, false)
         };
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -9,7 +9,6 @@ use editor::{
     items::active_match_index,
     scroll::{Autoscroll, Axis},
     Anchor, Editor, EditorElement, EditorEvent, EditorSettings, EditorStyle, MultiBuffer,
-    SearchMode,
     MAX_TAB_TITLE_LEN,
 };
 use futures::StreamExt;
@@ -629,11 +628,7 @@ impl ProjectSearchView {
         let (mut options, filters_enabled) = if let Some(settings) = settings {
             (settings.search_options, settings.filters_enabled)
         } else {
-            let search_options = if EditorSettings::get_global(cx).search_mode == SearchMode::Regex {
-                SearchOptions::REGEX
-            } else {
-                SearchOptions::NONE
-            };
+            let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search_defaults);
             (search_options, false)
         };
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -20,11 +20,7 @@ use gpui::{
 };
 use language::Buffer;
 use menu::Confirm;
-use project::{
-    search::{SearchInputKind, SearchQuery},
-    search_history::SearchHistoryCursor,
-    Project, ProjectPath,
-};
+use project::{search::SearchQuery, search_history::SearchHistoryCursor, Project, ProjectPath};
 use settings::Settings;
 use std::{
     any::{Any, TypeId},
@@ -3388,7 +3384,7 @@ pub mod tests {
             editor::init(cx);
             workspace::init_settings(cx);
             Project::init_settings(cx);
-            super::init(cx);
+            crate::init(cx);
         });
     }
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -628,7 +628,7 @@ impl ProjectSearchView {
         let (mut options, filters_enabled) = if let Some(settings) = settings {
             (settings.search_options, settings.filters_enabled)
         } else {
-            let search_options = SearchOptions::from_defaults(&EditorSettings::get_global(cx).search);
+            let search_options = SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
             (search_options, false)
         };
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -21,7 +21,7 @@ use gpui::{
 use language::Buffer;
 use menu::Confirm;
 use project::{
-    search::{SearchQuery},
+    search::{SearchInputKind, SearchQuery},
     search_history::SearchHistoryCursor,
     Project, ProjectPath,
 };

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -7,6 +7,7 @@ use ui::{prelude::*, Tooltip};
 use ui::{ButtonStyle, IconButton};
 use workspace::notifications::NotificationId;
 use workspace::{Toast, Workspace};
+use editor::SearchDefaults;
 
 pub mod buffer_search;
 pub mod project_search;
@@ -90,6 +91,15 @@ impl SearchOptions {
         options.set(SearchOptions::CASE_SENSITIVE, query.case_sensitive());
         options.set(SearchOptions::INCLUDE_IGNORED, query.include_ignored());
         options.set(SearchOptions::REGEX, query.is_regex());
+        options
+    }
+
+    pub fn from_defaults(defaults: &SearchDefaults) -> SearchOptions {
+        let mut options = SearchOptions::NONE;
+        options.set(SearchOptions::WHOLE_WORD, defaults.whole_word);
+        options.set(SearchOptions::CASE_SENSITIVE, defaults.case_sensitive);
+        options.set(SearchOptions::INCLUDE_IGNORED, defaults.include_ignored);
+        options.set(SearchOptions::REGEX, defaults.regex);
         options
     }
 

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -4,6 +4,7 @@ use editor::SearchSettings;
 use gpui::{actions, Action, AppContext, IntoElement};
 use project::search::SearchQuery;
 pub use project_search::ProjectSearchView;
+use settings::Settings;
 use ui::{prelude::*, Tooltip};
 use ui::{ButtonStyle, IconButton};
 use workspace::notifications::NotificationId;
@@ -14,6 +15,7 @@ pub mod project_search;
 pub(crate) mod search_bar;
 
 pub fn init(cx: &mut AppContext) {
+    SearchSettings::register(cx);
     menu::init();
     buffer_search::init(cx);
     project_search::init(cx);

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -1,5 +1,6 @@
 use bitflags::bitflags;
 pub use buffer_search::BufferSearchBar;
+use editor::SearchSettings;
 use gpui::{actions, Action, AppContext, IntoElement};
 use project::search::SearchQuery;
 pub use project_search::ProjectSearchView;
@@ -7,7 +8,6 @@ use ui::{prelude::*, Tooltip};
 use ui::{ButtonStyle, IconButton};
 use workspace::notifications::NotificationId;
 use workspace::{Toast, Workspace};
-use editor::SearchSettings;
 
 pub mod buffer_search;
 pub mod project_search;

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -7,7 +7,7 @@ use ui::{prelude::*, Tooltip};
 use ui::{ButtonStyle, IconButton};
 use workspace::notifications::NotificationId;
 use workspace::{Toast, Workspace};
-use editor::SearchDefaults;
+use editor::SearchSettings;
 
 pub mod buffer_search;
 pub mod project_search;
@@ -94,12 +94,12 @@ impl SearchOptions {
         options
     }
 
-    pub fn from_defaults(defaults: &SearchDefaults) -> SearchOptions {
+    pub fn from_settings(settings: &SearchSettings) -> SearchOptions {
         let mut options = SearchOptions::NONE;
-        options.set(SearchOptions::WHOLE_WORD, defaults.whole_word);
-        options.set(SearchOptions::CASE_SENSITIVE, defaults.case_sensitive);
-        options.set(SearchOptions::INCLUDE_IGNORED, defaults.include_ignored);
-        options.set(SearchOptions::REGEX, defaults.regex);
+        options.set(SearchOptions::WHOLE_WORD, settings.whole_word);
+        options.set(SearchOptions::CASE_SENSITIVE, settings.case_sensitive);
+        options.set(SearchOptions::INCLUDE_IGNORED, settings.include_ignored);
+        options.set(SearchOptions::REGEX, settings.regex);
         options
     }
 

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -16,12 +16,12 @@ impl VimTestContext {
             return;
         }
         cx.update(|cx| {
-            search::init(cx);
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);
             release_channel::init(SemanticVersion::default(), cx);
             command_palette::init(cx);
             crate::init(cx);
+            search::init(cx);
         });
     }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3437,6 +3437,7 @@ mod tests {
             );
             tasks_ui::init(cx);
             initialize_workspace(app_state.clone(), prompt_builder, cx);
+            search::init(cx);
             app_state
         })
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/4646

```json
// Search options to enable by default when opening new project and buffer searches.
"search": {
  "whole_word": false,
  "case_sensitive": false,
  "include_ignored": false,
  "regex": false
}
```

Release Notes:

- Added `search` settings section to configure default options enabled in buffer and project searches ([#4646](https://github.com/zed-industries/zed/issues/4646))