### PR TITLE
Adding Iran to supported_countries.rs

### DIFF
--- a/crates/open_ai/src/supported_countries.rs
+++ b/crates/open_ai/src/supported_countries.rs
@@ -104,6 +104,7 @@ static SUPPORTED_COUNTRIES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "IS", // Iceland
         "IN", // India
         "ID", // Indonesia
+        "IR", // Iran
         "IQ", // Iraq
         "IE", // Ireland
         "IL", // Israel


### PR DESCRIPTION
Adding Iran to `supported_countries.rs` of `crates/open_ai/src`.

Closes #16844