### PR TITLE
Adding Iran to supported_countries.rs

### DIFF
--- a/crates/anthropic/src/supported_countries.rs
+++ b/crates/anthropic/src/supported_countries.rs
@@ -98,6 +98,7 @@ static SUPPORTED_COUNTRIES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "IS", // Iceland
         "IN", // India
         "ID", // Indonesia
+        "IR", // Iran
         "IQ", // Iraq
         "IE", // Ireland
         "IL", // Israel


### PR DESCRIPTION
Adding Iran to `supported_countries.rs` of `crates/anthropic/src`.

Closes #16844