### PR TITLE
Let script/bundle-linux preserve RUSTFLAGS

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -42,7 +42,7 @@ target_triple=${host_line#*: }
 script/generate-licenses
 
 # Build binary in release mode
-export RUSTFLAGS="-C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
+export RUSTFLAGS="$RUSTFLAGS -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
 cargo build --release --target "${target_triple}" --package zed --package cli --package remote_server
 
 # Strip the binary of all debug symbols


### PR DESCRIPTION
Example usage:

    RUSTFLAGS="--cfg gles" ./script/install-linux

Release Notes:
- N/A