### PR TITLE
Revert "lsp: Watch paths outside of worktrees at language servers request  (#17173)

### DIFF
--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -123,7 +123,7 @@ impl PromptBuilder {
                         if params.fs.is_dir(parent_dir).await {
                             let (mut changes, _watcher) = params.fs.watch(parent_dir, Duration::from_secs(1)).await;
                             while let Some(changed_paths) = changes.next().await {
-                                if changed_paths.iter().any(|p| &p.path == &templates_dir) {
+                                if changed_paths.iter().any(|p| p == &templates_dir) {
                                     let mut log_message = format!("Prompt template overrides directory detected at {}", templates_dir.display());
                                     if let Ok(target) = params.fs.read_link(&templates_dir).await {
                                         log_message.push_str(" -> ");
@@ -162,18 +162,18 @@ impl PromptBuilder {
                     let mut combined_changes = futures::stream::select(changes, parent_changes);
 
                     while let Some(changed_paths) = combined_changes.next().await {
-                        if changed_paths.iter().any(|p| &p.path == &templates_dir) {
+                        if changed_paths.iter().any(|p| p == &templates_dir) {
                             if !params.fs.is_dir(&templates_dir).await {
                                 log::info!("Prompt template overrides directory removed. Restoring built-in prompt templates.");
                                 Self::register_built_in_templates(&mut handlebars.lock()).log_err();
                                 break;
                             }
                         }
-                        for event in changed_paths {
-                            if event.path.starts_with(&templates_dir) && event.path.extension().map_or(false, |ext| ext == "hbs") {
-                                log::info!("Reloading prompt template override: {}", event.path.display());
-                                if let Some(content) = params.fs.load(&event.path).await.log_err() {
-                                    let file_name = event.path.file_stem().unwrap().to_string_lossy();
+                        for changed_path in changed_paths {
+                            if changed_path.starts_with(&templates_dir) && changed_path.extension().map_or(false, |ext| ext == "hbs") {
+                                log::info!("Reloading prompt template override: {}", changed_path.display());
+                                if let Some(content) = params.fs.load(&changed_path).await.log_err() {
+                                    let file_name = changed_path.file_stem().unwrap().to_string_lossy();
                                     handlebars.lock().register_template_string(&file_name, content).log_err();
                                 }
                             }

--- a/crates/extension/src/extension_store.rs
+++ b/crates/extension/src/extension_store.rs
@@ -369,9 +369,9 @@ impl ExtensionStore {
             let installed_dir = this.installed_dir.clone();
             async move {
                 let (mut paths, _) = fs.watch(&installed_dir, FS_WATCH_LATENCY).await;
-                while let Some(events) = paths.next().await {
-                    for event in events {
-                        let Ok(event_path) = event.path.strip_prefix(&installed_dir) else {
+                while let Some(paths) = paths.next().await {
+                    for path in paths {
+                        let Ok(event_path) = path.strip_prefix(&installed_dir) else {
                             continue;
                         };
 

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -169,12 +169,7 @@ impl SnippetProvider {
 
             let (mut entries, _) = watcher.await;
             while let Some(entries) = entries.next().await {
-                process_updates(
-                    this.clone(),
-                    entries.into_iter().map(|event| event.path).collect(),
-                    cx.clone(),
-                )
-                .await?;
+                process_updates(this.clone(), entries, cx.clone()).await?;
             }
             Ok(())
         })

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1158,13 +1158,13 @@ fn watch_themes(fs: Arc<dyn fs::Fs>, cx: &mut AppContext) {
             .await;
 
         while let Some(paths) = events.next().await {
-            for event in paths {
-                if fs.metadata(&event.path).await.ok().flatten().is_some() {
+            for path in paths {
+                if fs.metadata(&path).await.ok().flatten().is_some() {
                     if let Some(theme_registry) =
                         cx.update(|cx| ThemeRegistry::global(cx).clone()).log_err()
                     {
                         if let Some(()) = theme_registry
-                            .load_user_theme(&event.path, fs.clone())
+                            .load_user_theme(&path, fs.clone())
                             .await
                             .log_err()
                         {
@@ -1194,10 +1194,8 @@ fn watch_languages(fs: Arc<dyn fs::Fs>, languages: Arc<LanguageRegistry>, cx: &m
     cx.spawn(|_| async move {
         let (mut events, _) = fs.watch(path.as_path(), Duration::from_millis(100)).await;
         while let Some(event) = events.next().await {
-            let has_language_file = event.iter().any(|event| {
-                event
-                    .path
-                    .extension()
+            let has_language_file = event.iter().any(|path| {
+                path.extension()
                     .map(|ext| ext.to_string_lossy().as_ref() == "scm")
                     .unwrap_or(false)
             });


### PR DESCRIPTION
This PR reverts #17173, as it introduced a segfault when opening any Gleam project and the language server starts up.

This reverts commit a850731b0ed61b0ef2a0173843b6daedf45327e8.

Release Notes:

- N/A
