### PR TITLE
scripts: Fix bundle-linux when RUSTFLAGS is unset

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -42,7 +42,7 @@ target_triple=${host_line#*: }
 script/generate-licenses
 
 # Build binary in release mode
-export RUSTFLAGS="$RUSTFLAGS -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
+export RUSTFLAGS="${RUSTFLAGS:-} -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
 cargo build --release --target "${target_triple}" --package zed --package cli --package remote_server
 
 # Strip the binary of all debug symbols


### PR DESCRIPTION
The install-linux script fails to build when the RUSTFLAGS environment variable is not set. Bash attempts to expand an empty variable and fails due to the prior set -u

Closes #17217

Release Notes:
- N/A