### PR TITLE
Add ability to scroll and center item

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1218,7 +1218,7 @@ impl ProjectPanel {
 
     fn autoscroll(&mut self, cx: &mut ViewContext<Self>) {
         if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
-            self.scroll_handle.scroll_to_item(index);
+            self.scroll_handle.scroll_center_item(index);
             cx.notify();
         }
     }


### PR DESCRIPTION
Release Notes:

- Added ability to scroll and center item in project panel. Currently when scroll to item is called the item will be at the bottom or at the top of the project panel.

Demo:

https://github.com/user-attachments/assets/15f3075b-5608-440b-a1ea-a69881f391fd