### PR TITLE
Prioritize nearby files in the File Finder

### DIFF
--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -97,6 +97,7 @@ pub fn match_fixed_path_set(
     query: &str,
     smart_case: bool,
     max_results: usize,
+    relative_to: Option<&Path>,
 ) -> Vec<PathMatch> {
     let lowercase_query = query.to_lowercase().chars().collect::<Vec<_>>();
     let query = query.chars().collect::<Vec<_>>();
@@ -124,7 +125,9 @@ pub fn match_fixed_path_set(
             is_dir: candidate.is_dir,
             path: Arc::from(candidate.path),
             path_prefix: Arc::default(),
-            distance_to_relative_ancestor: usize::MAX,
+            distance_to_relative_ancestor: relative_to.as_ref().map_or(usize::MAX, |relative_to| {
+                distance_between_paths(candidate.path, relative_to)
+            }),
         },
     );
     results


### PR DESCRIPTION
Release Notes:

- Improved the file picker so that nearby files are shown above distant ones

---

Zed's current file finder ranking algorithm currently only considers relative distance from the active file when there's a _perfect tie_ of match scores. In a large codebase, match score ties are quite rare, making relative distance very rarely affect File Finder results.

Unfortunately, I work in a fairly large codebase, and the File Finder often places irrelevant files at the top *even* when my query is a very good match for another file in the directory I'm currently working in. It makes the file picker significantly less useful to me.

This PR updates the ranking algorithm for the file picker so that relative distance from the active file is taken into account when ordering items. (This change also brings the behavior of the file picker in line with what people coming from VSCode might expect.)

Here are a few before/after screenshots (note the file tree on the left):

_Before_
![CleanShot 2024-08-31 at 22 40 30@2x](https://github.com/user-attachments/assets/a77d0055-bf0b-4f13-862f-39af83593a34)

_After_
![CleanShot 2024-08-31 at 22 41 07@2x](https://github.com/user-attachments/assets/3063de5c-3613-41e1-9aff-d0582a2b3357)

_Before_
![CleanShot 2024-08-31 at 22 41 51@2x](https://github.com/user-attachments/assets/0b9d1b6b-029e-4c44-9077-06a5170f4231)

_After_
![CleanShot 2024-08-31 at 22 42 07@2x](https://github.com/user-attachments/assets/2fcc3275-7c22-4534-b187-1898e820ec25)

(Note that I also updated one other test that started failing after I updated `distance_to_relative_ancestor` in `PathMatch`; I believe the updated version should reflect the desired behavior where history items are shown on top, followed by other search matches.)