### PR TITLE
php: Add more keywords

### DIFF
--- a/extensions/php/languages/php/highlights.scm
+++ b/extensions/php/languages/php/highlights.scm
@@ -75,8 +75,10 @@
 ; Keywords
 
 "abstract" @keyword
+"and" @keyword
 "as" @keyword
 "break" @keyword
+"callable" @keyword
 "case" @keyword
 "catch" @keyword
 "class" @keyword
@@ -91,6 +93,7 @@
 "elseif" @keyword
 "enum" @keyword
 "enddeclare" @keyword
+"endfor" @keyword
 "endforeach" @keyword
 "endif" @keyword
 "endswitch" @keyword
@@ -99,22 +102,28 @@
 "final" @keyword
 "readonly" @keyword
 "finally" @keyword
+"for" @keyword
 "foreach" @keyword
 "fn" @keyword
 "function" @keyword
 "global" @keyword
+"goto" @keyword
 "if" @keyword
 "implements" @keyword
 "include_once" @keyword
 "include" @keyword
+"instanceof" @keyword
 "insteadof" @keyword
 "interface" @keyword
 "match" @keyword
 "namespace" @keyword
 "new" @keyword
+"or" @keyword
+"print" @keyword
 "private" @keyword
 "protected" @keyword
 "public" @keyword
+"readonly" @keyword
 "require_once" @keyword
 "require" @keyword
 "return" @keyword
@@ -124,6 +133,8 @@
 "trait" @keyword
 "try" @keyword
 "use" @keyword
+"var" @keyword
 "while" @keyword
+"xor" @keyword
 "yield" @keyword
 "yield from" @keyword


### PR DESCRIPTION
This list should now be complete according to the official list at https://www.php.net/manual/en/reserved.keywords.php

Release Notes:

- N/A
