### PR TITLE
project panel: Always show paste in context menu (and grey it out when it's disabled)

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -499,8 +499,12 @@ impl ProjectPanel {
                             .action("Copy", Box::new(Copy))
                             .action("Duplicate", Box::new(Duplicate))
                             // TODO: Paste should always be visible, cbut disabled when clipboard is empty
-                            .when(self.clipboard.as_ref().is_some(), |menu| {
-                                menu.action("Paste", Box::new(Paste))
+                            .map(|menu| {
+                                if self.clipboard.as_ref().is_some() {
+                                    menu.action("Paste", Box::new(Paste))
+                                } else {
+                                    menu.disabled_action("Paste", Box::new(Paste))
+                                }
                             })
                             .separator()
                             .action("Copy Path", Box::new(CopyPath))


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/df471567-bdb9-494b-96a5-84d1da47583f)

Release Notes:

- "Paste" is now always shown in project panel context menu.
