### PR TITLE
Fix text system will meet crash on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1,11 +1,11 @@
 use std::{borrow::Cow, sync::Arc};
 
+use ::util::ResultExt;
 use anyhow::{anyhow, Result};
 use collections::HashMap;
 use itertools::Itertools;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use smallvec::SmallVec;
-use util::ResultExt;
 use windows::{
     core::*,
     Win32::{
@@ -542,7 +542,6 @@ impl DirectWriteState {
                     length: (utf16_end - utf16_start) as u32,
                 };
                 layout.SetTypography(&font_info.features, text_range)?;
-
                 layout
             };
 


### PR DESCRIPTION
Release Notes:

- Fixed text system will meet crash on Windows.

-------

This because we recently added text ellipsis to Extension UI, but the TextSytem for the Windows implementation is not handled the correct char indexes.

This changes to use `StringIndexConverter` (From the macOS implementation).

cc @JunkuiZhang 

Crash error:

> Open the Extension UI, and resize window to min size, then crash happen.

```bash
Thread "main" panicked with "byte index 34 is not a char boundary; it is inside '…' (bytes 32..35) of `Author: Jason Lee <huacnlee@gmail.co…`" at crates\gpui\src\platform\windows\direct_write.rs:536:41
```

