### PR TITLE
Fix line truncate crash on Windows

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -314,6 +314,29 @@ impl TextLayout {
                     (text.clone(), false)
                 };
                 if truncated {
+                    //----------------------------------------------
+                    // Case 0: Normal
+                    // Text: abcdefghijkl
+                    // Runs: Run0 { len: 12, ... }
+                    //
+                    // Truncate res: abcd… (truncate_at = 4)
+                    // Run res: Run0 { string: abcd…, len: 7, ... }
+                    // ---------------------------------------------
+                    // Case 1: Drop some runs
+                    // Text: abcdefghijkl
+                    // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
+                    //
+                    // Truncate res: abcdef… (truncate_at = 6)
+                    // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: ef…, len:
+                    // 5, ... }
+                    // ----------------------------------------------
+                    // Case 2: Truncate at start of some run
+                    // Text: abcdefghijkl
+                    // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
+                    //
+                    // Truncate res: abcdefgh… (truncate_at = 8)
+                    // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: efgh, len:
+                    // 5, ... }, Run2 { string: …, len: 3, ... }
                     let mut truncate_at = text.len() - ELLIPSIS.len();
                     let mut run_end = None;
                     for (run_index, run) in runs.iter_mut().enumerate() {

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -314,7 +314,7 @@ impl TextLayout {
                     (text.clone(), false)
                 };
                 if truncated {
-                    let mut truncate_at = text.len() - 3;
+                    let mut truncate_at = text.len() - ELLIPSIS.len();
                     // let mut drop_unused_run = None;
                     let mut run_index = 0;
                     let mut iter = runs.iter_mut().peekable();
@@ -322,7 +322,7 @@ impl TextLayout {
                         if run.len <= truncate_at {
                             truncate_at -= run.len;
                         } else {
-                            run.len = truncate_at + 3;
+                            run.len = truncate_at + ELLIPSIS.len();
                             if iter.peek().is_some() {
                                 run_index += 1;
                                 break;

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -315,23 +315,20 @@ impl TextLayout {
                 };
                 if truncated {
                     let mut truncate_at = text.len() - ELLIPSIS.len();
-                    // let mut drop_unused_run = None;
-                    let mut run_index = 0;
-                    let mut iter = runs.iter_mut().peekable();
-                    while let Some(run) = iter.next() {
+                    let mut run_end = None;
+                    for (run_index, run) in runs.iter_mut().enumerate() {
                         if run.len <= truncate_at {
                             truncate_at -= run.len;
                         } else {
                             run.len = truncate_at + ELLIPSIS.len();
-                            if iter.peek().is_some() {
-                                run_index += 1;
-                                break;
-                            }
+                            run_end = Some(run_index);
+                            break;
                         }
-                        run_index += 1;
                     }
-                    if run_index < runs.len() {
-                        runs = runs[..run_index].to_vec();
+                    if let Some(run_end) = run_end {
+                        if run_end + 1 < runs.len() {
+                            runs = runs[..run_end + 1].to_vec();
+                        }
                     }
                 }
 

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -336,7 +336,7 @@ impl TextLayout {
                     //
                     // Truncate res: abcdefgh… (truncate_at = 8)
                     // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: efgh, len:
-                    // 5, ... }, Run2 { string: …, len: 3, ... }
+                    // 4, ... }, Run2 { string: …, len: 3, ... }
                     let mut truncate_at = text.len() - ELLIPSIS.len();
                     let mut run_end = None;
                     for (run_index, run) in runs.iter_mut().enumerate() {
@@ -344,14 +344,12 @@ impl TextLayout {
                             truncate_at -= run.len;
                         } else {
                             run.len = truncate_at + ELLIPSIS.len();
-                            run_end = Some(run_index);
+                            run_end = Some(run_index + 1);
                             break;
                         }
                     }
                     if let Some(run_end) = run_end {
-                        if run_end + 1 < runs.len() {
-                            runs = runs[..run_end + 1].to_vec();
-                        }
+                        runs.truncate(run_end);
                     }
                 }
 

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -305,53 +305,11 @@ impl TextLayout {
                 }
 
                 let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
-                let (text, truncated) = if let Some(truncate_width) = truncate_width {
-                    (
-                        line_wrapper.truncate_line(text.clone(), truncate_width, ellipsis),
-                        true,
-                    )
+                let text = if let Some(truncate_width) = truncate_width {
+                    line_wrapper.truncate_line(text.clone(), truncate_width, ellipsis, &mut runs)
                 } else {
-                    (text.clone(), false)
+                    text.clone()
                 };
-                if truncated {
-                    //----------------------------------------------
-                    // Case 0: Normal
-                    // Text: abcdefghijkl
-                    // Runs: Run0 { len: 12, ... }
-                    //
-                    // Truncate res: abcd… (truncate_at = 4)
-                    // Run res: Run0 { string: abcd…, len: 7, ... }
-                    // ---------------------------------------------
-                    // Case 1: Drop some runs
-                    // Text: abcdefghijkl
-                    // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
-                    //
-                    // Truncate res: abcdef… (truncate_at = 6)
-                    // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: ef…, len:
-                    // 5, ... }
-                    // ----------------------------------------------
-                    // Case 2: Truncate at start of some run
-                    // Text: abcdefghijkl
-                    // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
-                    //
-                    // Truncate res: abcdefgh… (truncate_at = 8)
-                    // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: efgh, len:
-                    // 4, ... }, Run2 { string: …, len: 3, ... }
-                    let mut truncate_at = text.len() - ELLIPSIS.len();
-                    let mut run_end = None;
-                    for (run_index, run) in runs.iter_mut().enumerate() {
-                        if run.len <= truncate_at {
-                            truncate_at -= run.len;
-                        } else {
-                            run.len = truncate_at + ELLIPSIS.len();
-                            run_end = Some(run_index + 1);
-                            break;
-                        }
-                    }
-                    if let Some(run_end) = run_end {
-                        runs.truncate(run_end);
-                    }
-                }
 
                 let Some(lines) = cx
                     .text_system()

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -314,7 +314,26 @@ impl TextLayout {
                     (text.clone(), false)
                 };
                 if truncated {
-                    runs[0].len = text.len();
+                    let mut match_len = text.len();
+                    // let mut drop_unused_run = None;
+                    let mut run_index = 0;
+                    let mut iter = runs.iter_mut().peekable();
+                    while let Some(run) = iter.next() {
+                        if run.len < match_len {
+                            match_len -= run.len;
+                        } else if run.len == match_len {
+                            if iter.peek().is_some() {
+                                run_index += 1;
+                                break;
+                            }
+                        } else {
+                            run.len = match_len;
+                        }
+                        run_index += 1;
+                    }
+                    if run_index < runs.len() {
+                        runs = runs[..run_index].to_vec();
+                    }
                 }
 
                 let Some(lines) = cx

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -263,7 +263,7 @@ impl TextLayout {
             .line_height
             .to_pixels(font_size.into(), cx.rem_size());
 
-        let runs = if let Some(runs) = runs {
+        let mut runs = if let Some(runs) = runs {
             runs
         } else {
             vec![text_style.to_run(text.len())]
@@ -305,11 +305,17 @@ impl TextLayout {
                 }
 
                 let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
-                let text = if let Some(truncate_width) = truncate_width {
-                    line_wrapper.truncate_line(text.clone(), truncate_width, ellipsis)
+                let (text, truncated) = if let Some(truncate_width) = truncate_width {
+                    (
+                        line_wrapper.truncate_line(text.clone(), truncate_width, ellipsis),
+                        true,
+                    )
                 } else {
-                    text.clone()
+                    (text.clone(), false)
                 };
+                if truncated {
+                    runs[0].len = text.len();
+                }
 
                 let Some(lines) = cx
                     .text_system()

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -314,20 +314,19 @@ impl TextLayout {
                     (text.clone(), false)
                 };
                 if truncated {
-                    let mut match_len = text.len();
+                    let mut truncate_at = text.len() - 3;
                     // let mut drop_unused_run = None;
                     let mut run_index = 0;
                     let mut iter = runs.iter_mut().peekable();
                     while let Some(run) = iter.next() {
-                        if run.len < match_len {
-                            match_len -= run.len;
-                        } else if run.len == match_len {
+                        if run.len <= truncate_at {
+                            truncate_at -= run.len;
+                        } else {
+                            run.len = truncate_at + 3;
                             if iter.peek().is_some() {
                                 run_index += 1;
                                 break;
                             }
-                        } else {
-                            run.len = match_len;
                         }
                         run_index += 1;
                     }

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -452,6 +452,40 @@ mod tests {
     }
 
     #[test]
+    fn test_update_run_after_truncation() {
+        fn perform_test(result: &str, run_lens: &[usize], result_run_lens: &[usize]) {
+            let mut dummy_runs = generate_test_runs(run_lens);
+            update_runs_after_truncation(result, "…", &mut dummy_runs);
+            for (run, result_len) in dummy_runs.iter().zip(result_run_lens) {
+                assert_eq!(run.len, *result_len);
+            }
+        }
+        // Case 0: Normal
+        // Text: abcdefghijkl
+        // Runs: Run0 { len: 12, ... }
+        //
+        // Truncate res: abcd… (truncate_at = 4)
+        // Run res: Run0 { string: abcd…, len: 7, ... }
+        perform_test("abcd…", &[12], &[7]);
+        // Case 1: Drop some runs
+        // Text: abcdefghijkl
+        // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
+        //
+        // Truncate res: abcdef… (truncate_at = 6)
+        // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: ef…, len:
+        // 5, ... }
+        perform_test("abcdef…", &[4, 4, 4], &[4, 5]);
+        // Case 2: Truncate at start of some run
+        // Text: abcdefghijkl
+        // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
+        //
+        // Truncate res: abcdefgh… (truncate_at = 8)
+        // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: efgh, len:
+        // 4, ... }, Run2 { string: …, len: 3, ... }
+        perform_test("abcdefgh…", &[4, 4, 4], &[4, 4, 3]);
+    }
+
+    #[test]
     fn test_is_word_char() {
         #[track_caller]
         fn assert_word(word: &str) {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -196,29 +196,6 @@ impl LineWrapper {
     }
 }
 
-//----------------------------------------------
-// Case 0: Normal
-// Text: abcdefghijkl
-// Runs: Run0 { len: 12, ... }
-//
-// Truncate res: abcd… (truncate_at = 4)
-// Run res: Run0 { string: abcd…, len: 7, ... }
-// ---------------------------------------------
-// Case 1: Drop some runs
-// Text: abcdefghijkl
-// Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
-//
-// Truncate res: abcdef… (truncate_at = 6)
-// Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: ef…, len:
-// 5, ... }
-// ----------------------------------------------
-// Case 2: Truncate at start of some run
-// Text: abcdefghijkl
-// Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
-//
-// Truncate res: abcdefgh… (truncate_at = 8)
-// Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: efgh, len:
-// 4, ... }, Run2 { string: …, len: 3, ... }
 fn update_runs_after_truncation(result: &str, ellipsis: &str, runs: &mut Vec<TextRun>) {
     let mut truncate_at = result.len() - ellipsis.len();
     let mut run_end = None;

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -1,4 +1,4 @@
-use crate::{px, FontId, FontRun, Pixels, PlatformTextSystem, SharedString};
+use crate::{px, FontId, FontRun, Pixels, PlatformTextSystem, SharedString, TextRun};
 use collections::HashMap;
 use std::{iter, sync::Arc};
 
@@ -104,6 +104,7 @@ impl LineWrapper {
         line: SharedString,
         truncate_width: Pixels,
         ellipsis: Option<&str>,
+        runs: &mut Vec<TextRun>,
     ) -> SharedString {
         let mut width = px(0.);
         let mut ellipsis_width = px(0.);
@@ -124,15 +125,51 @@ impl LineWrapper {
             width += char_width;
 
             if width.floor() > truncate_width {
-                return SharedString::from(format!(
-                    "{}{}",
-                    &line[..truncate_ix],
-                    ellipsis.unwrap_or("")
-                ));
+                let ellipsis = ellipsis.unwrap_or("");
+                let result = SharedString::from(format!("{}{}", &line[..truncate_ix], ellipsis));
+                //----------------------------------------------
+                // Case 0: Normal
+                // Text: abcdefghijkl
+                // Runs: Run0 { len: 12, ... }
+                //
+                // Truncate res: abcd… (truncate_at = 4)
+                // Run res: Run0 { string: abcd…, len: 7, ... }
+                // ---------------------------------------------
+                // Case 1: Drop some runs
+                // Text: abcdefghijkl
+                // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
+                //
+                // Truncate res: abcdef… (truncate_at = 6)
+                // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: ef…, len:
+                // 5, ... }
+                // ----------------------------------------------
+                // Case 2: Truncate at start of some run
+                // Text: abcdefghijkl
+                // Runs: Run0 { len: 4, ... }, Run1 { len: 4, ... }, Run2 { len: 4, ... }
+                //
+                // Truncate res: abcdefgh… (truncate_at = 8)
+                // Runs res: Run0 { string: abcd, len: 4, ... }, Run1 { string: efgh, len:
+                // 4, ... }, Run2 { string: …, len: 3, ... }
+                let mut truncate_at = result.len() - ellipsis.len();
+                let mut run_end = None;
+                for (run_index, run) in runs.iter_mut().enumerate() {
+                    if run.len <= truncate_at {
+                        truncate_at -= run.len;
+                    } else {
+                        run.len = truncate_at + ellipsis.len();
+                        run_end = Some(run_index + 1);
+                        break;
+                    }
+                }
+                if let Some(run_end) = run_end {
+                    runs.truncate(run_end);
+                }
+
+                return result;
             }
         }
 
-        line.clone()
+        line
     }
 
     pub(crate) fn is_word_char(c: char) -> bool {


### PR DESCRIPTION
Closes #17267

We should update the `len` of `runs` when truncating. cc @huacnlee 

Release Notes:

- N/A
