### PR TITLE
theme_importer: Fix broken compilation on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "async-tar"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c49359998a76e32ef6e870dbc079ebad8f1e53e8441c5dd39d27b44493fe331"
+checksum = "a42f905d4f623faf634bbd1e001e84e0efc24694afa64be9ad239bf6ca49e1f8"
 dependencies = [
  "async-std",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ async-dispatcher = "0.1"
 async-fs = "1.6"
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
 async-recursion = "1.0.0"
-async-tar = "0.4.2"
+async-tar = "0.5.0"
 async-trait = "0.1"
 async-tungstenite = "0.23"
 async-watch = "0.3.1"


### PR DESCRIPTION
Closes #12079

Update async-tar to 0.5.0. This fixes a compilation failure on Windows caused by the async-tar crate.

Release Notes:

- Fix theme_importer compilation failure on Windows