### PR TITLE
Fix opening file with colon

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -174,7 +174,7 @@ impl PathWithPosition {
     /// });
     /// ```
     ///
-    /// # Expected parsing results when encounter ill-formated inputs.
+    /// # Expected parsing results when encounter ill-formatted inputs.
     /// ```
     /// # use util::paths::PathWithPosition;
     /// # use std::path::PathBuf;
@@ -502,11 +502,7 @@ mod tests {
                 column: None,
             }
         );
-    }
 
-    #[test]
-    #[cfg(not(target_os = "windows"))]
-    fn path_with_position_parse_posix_path_with_suffix() {
         assert_eq!(
             PathWithPosition::parse_str("crates/file_finder/src/file_finder.rs:1902:13:"),
             PathWithPosition {


### PR DESCRIPTION
Closes #14100

Release Notes:

- Fixed unable to open file with a colon from Zed CLI

-----

I didn't make change to tests for the first two commits. I changed them to easily find offending test cases. Behavior changes are in last commit message.

In the last commit, I changed how `PathWithPosition` should intreprete file paths. If my assumptions are off, please advise so that I can make another approach.

I also believe further constraints would be better for `PathWithPosition`'s intention. But people can make future improvements to `PathWithPosition`.