### PR TITLE
Allow for explicit elisions in the search string for workflow edits

### DIFF
--- a/assets/prompts/edit_workflow.hbs
+++ b/assets/prompts/edit_workflow.hbs
@@ -55,6 +55,8 @@ This tag contains the path to the file that will be changed. It can be an existi
 
 This tag contains a search string to locate in the source file, e.g. `pub fn baz() {`. If not provided, the new content will be inserted at the top of the file. Make sure to produce a string that exists in the source file and that isn't ambiguous. When there's ambiguity, add more lines to the search to eliminate it.
 
+The search string must match the original file.
+
 ### `<description>` (required)
 
 This tag contains a single-line description of the edit that should be made at the given location.


### PR DESCRIPTION
⚠️ WIP ⚠️ 

This PR is exploring the idea of introducing an explicit XML tag `<etc />` for the model to elide content when it is writing a large `<search>` string, in order to update a large range of code. This is to prevent the model from writing a comment like `// additional code...`, which could break the matching.

My thought is that the semantic of `<etc />` could be that it always matches zero or more entire syntax nodes  (as opposed to starting or ending in the middle of a node). This keeps it very language-agnostic, but allows for intuitive shorthand for matching.

The hope is that this is pretty self-explanatory, but gives the model a concise way to match on a large range

* `fn new(<etc />) -> Self {<etc />}`
* `impl Foo { <etc /> }`

Release Notes:

- N/A
