### PR TITLE
outline_panel: Fix `j` and `k` not working in outline panel filter

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -521,7 +521,7 @@
     }
   },
   {
-    "context": "OutlinePanel",
+    "context": "OutlinePanel && not_editing",
     "bindings": {
       "escape": "menu::Cancel",
       "left": "outline_panel::CollapseSelectedEntry",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -528,7 +528,7 @@
     }
   },
   {
-    "context": "OutlinePanel",
+    "context": "OutlinePanel && not_editing",
     "bindings": {
       "escape": "menu::Cancel",
       "left": "outline_panel::CollapseSelectedEntry",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -489,7 +489,7 @@
     }
   },
   {
-    "context": "OutlinePanel",
+    "context": "OutlinePanel && not_editing",
     "bindings": {
       "j": "menu::SelectNext",
       "k": "menu::SelectPrev",

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -722,10 +722,16 @@ impl OutlinePanel {
         );
     }
 
-    fn dispatch_context(&self, _: &ViewContext<Self>) -> KeyContext {
+    fn dispatch_context(&self, cx: &ViewContext<Self>) -> KeyContext {
         let mut dispatch_context = KeyContext::new_with_defaults();
         dispatch_context.add("OutlinePanel");
         dispatch_context.add("menu");
+        let identifier = if self.filter_editor.focus_handle(cx).is_focused(cx) {
+            "editing"
+        } else {
+            "not_editing"
+        };
+        dispatch_context.add(identifier);
         dispatch_context
     }
 


### PR DESCRIPTION
Closes #17248

Release Notes:

- Fixed outline panel filter not working for certain Vim bindings ([#17248](https://github.com/zed-industries/zed/issues/17248))