### PR TITLE
blade: Update to bf40d4f to fix crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,8 +1644,8 @@ dependencies = [
 
 [[package]]
 name = "blade-graphics"
-version = "0.4.0"
-source = "git+https://github.com/kvark/blade?rev=b37a9a994709d256f4634efd29281c78ba89071a#b37a9a994709d256f4634efd29281c78ba89071a"
+version = "0.5.0"
+source = "git+https://github.com/kvark/blade?rev=bf40d4f91fb56031e8676376dba2fc021b3e8eaf#bf40d4f91fb56031e8676376dba2fc021b3e8eaf"
 dependencies = [
  "ash",
  "ash-window",
@@ -1674,8 +1674,8 @@ dependencies = [
 
 [[package]]
 name = "blade-macros"
-version = "0.2.1"
-source = "git+https://github.com/kvark/blade?rev=b37a9a994709d256f4634efd29281c78ba89071a#b37a9a994709d256f4634efd29281c78ba89071a"
+version = "0.3.0"
+source = "git+https://github.com/kvark/blade?rev=bf40d4f91fb56031e8676376dba2fc021b3e8eaf#bf40d4f91fb56031e8676376dba2fc021b3e8eaf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1685,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "blade-util"
 version = "0.1.0"
-source = "git+https://github.com/kvark/blade?rev=b37a9a994709d256f4634efd29281c78ba89071a#b37a9a994709d256f4634efd29281c78ba89071a"
+source = "git+https://github.com/kvark/blade?rev=bf40d4f91fb56031e8676376dba2fc021b3e8eaf#bf40d4f91fb56031e8676376dba2fc021b3e8eaf"
 dependencies = [
  "blade-graphics",
  "bytemuck",
@@ -4784,9 +4784,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+checksum = "f865cbd94bd355b89611211e49508da98a1fce0ad755c1e8448fb96711b24528"
 dependencies = [
  "js-sys",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ members = [
     # Tooling
     #
 
-    "tooling/xtask"
+    "tooling/xtask",
 ]
 default-members = ["crates/zed"]
 
@@ -322,9 +322,9 @@ async-watch = "0.3.1"
 async_zip = { version = "0.0.17", features = ["deflate", "deflate64"] }
 base64 = "0.22"
 bitflags = "2.6.0"
-blade-graphics = { git = "https://github.com/kvark/blade", rev = "b37a9a994709d256f4634efd29281c78ba89071a" }
-blade-macros = { git = "https://github.com/kvark/blade", rev = "b37a9a994709d256f4634efd29281c78ba89071a" }
-blade-util = { git = "https://github.com/kvark/blade", rev = "b37a9a994709d256f4634efd29281c78ba89071a" }
+blade-graphics = { git = "https://github.com/kvark/blade", rev = "bf40d4f91fb56031e8676376dba2fc021b3e8eaf" }
+blade-macros = { git = "https://github.com/kvark/blade", rev = "bf40d4f91fb56031e8676376dba2fc021b3e8eaf" }
+blade-util = { git = "https://github.com/kvark/blade", rev = "bf40d4f91fb56031e8676376dba2fc021b3e8eaf" }
 cargo_metadata = "0.18"
 cargo_toml = "0.20"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -336,6 +336,17 @@ impl BladePipelines {
             }),
         }
     }
+
+    fn destroy(&mut self, gpu: &gpu::Context) {
+        gpu.destroy_render_pipeline(&mut self.quads);
+        gpu.destroy_render_pipeline(&mut self.shadows);
+        gpu.destroy_render_pipeline(&mut self.path_rasterization);
+        gpu.destroy_render_pipeline(&mut self.paths);
+        gpu.destroy_render_pipeline(&mut self.underlines);
+        gpu.destroy_render_pipeline(&mut self.mono_sprites);
+        gpu.destroy_render_pipeline(&mut self.poly_sprites);
+        gpu.destroy_render_pipeline(&mut self.surfaces);
+    }
 }
 
 pub struct BladeSurfaceConfig {
@@ -438,6 +449,7 @@ impl BladeRenderer {
             self.wait_for_gpu();
             self.surface_config.transparent = transparent;
             let surface_info = self.gpu.resize(self.surface_config);
+            self.pipelines.destroy(&self.gpu);
             self.pipelines = BladePipelines::new(&self.gpu, surface_info);
             self.alpha_mode = surface_info.alpha;
         }
@@ -538,8 +550,10 @@ impl BladeRenderer {
     pub fn destroy(&mut self) {
         self.wait_for_gpu();
         self.atlas.destroy();
+        self.gpu.destroy_sampler(self.atlas_sampler);
         self.instance_belt.destroy(&self.gpu);
         self.gpu.destroy_command_encoder(&mut self.command_encoder);
+        self.pipelines.destroy(&self.gpu);
     }
 
     pub fn draw(


### PR DESCRIPTION
See https://github.com/zed-industries/zed/issues/17005

This PR updates Blade to fix a regression from https://github.com/zed-industries/zed/commit/d1dceef945a51f6b34405b078b2cda96cd84c7eb, and also properly destroys all Vulkan objects (verified by enabling Vulkan validation in the source code, in both Wayland and X11).

Release Notes:

- Linux: Fixed crash when closing windows on Wayland.

NOTE: This is 0.151.x only because 0.152.x contains an unrelated blade bump; we need to merge both into 0.152.x and 0.153.x
