### PR TITLE
docs: Fix delayed git inline blame example

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -893,7 +893,7 @@ To interpret all `.c` files as C++, files called `MyLockFile` as TOML and files 
 {
   "git": {
     "inline_blame": {
-      "enabled": false,
+      "enabled": true,
       "delay_ms": 500
     }
   }


### PR DESCRIPTION
Fixes docs example. Otherwise the inline git blame is fully disabled instead of delayed.

Release Notes:

- N/A