### PR TITLE
Improve CSS highlighting for property_name

### DIFF
--- a/crates/languages/src/css/highlights.scm
+++ b/crates/languages/src/css/highlights.scm
@@ -35,9 +35,10 @@
   (class_name)
   (id_name)
   (namespace_name)
-  (property_name)
   (feature_name)
 ] @property
+
+(property_name) @constant
 
 (function_name) @function
 
@@ -75,4 +76,17 @@
 [
   ","
   ":"
+  "."
+  "::"
+  ";"
+  "#"
 ] @punctuation.delimiter
+
+[
+  "{"
+  ")"
+  "("
+  "}"
+  "["
+  "]"
+] @punctuation.bracket


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17093

After / Before in the default One Dark
<img width="863" alt="image" src="https://github.com/user-attachments/assets/046c0539-d3ce-4435-9e4a-6fe2ea74157f">

Release Notes:

- Improve highlighting for property names in CSS
