### PR TITLE
vtsls: Enable Inlay Hints by default for JavaScript #17232

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -221,40 +221,38 @@ impl LspAdapter for VtslsLspAdapter {
         adapter: &Arc<dyn LspAdapterDelegate>,
     ) -> Result<Option<serde_json::Value>> {
         let tsdk_path = Self::tsdk_path(&adapter).await;
-        Ok(Some(json!({
-            "typescript": {
-                "tsdk": tsdk_path,
-                "suggest": {
-                    "completeFunctionCalls": true
+        let config = serde_json::json!({
+            "tsdk": tsdk_path,
+            "suggest": {
+                "completeFunctionCalls": true
+            },
+            "inlayHints": {
+                "parameterNames": {
+                    "enabled": "all",
+                    "suppressWhenArgumentMatchesName": false
                 },
-                "inlayHints": {
-                    "parameterNames": {
-                        "enabled": "all",
-                        "suppressWhenArgumentMatchesName": false,
-                    },
-                    "parameterTypes": {
-                        "enabled": true
-                    },
-                    "variableTypes": {
-                        "enabled": true,
-                        "suppressWhenTypeMatchesName": false,
-                    },
-                    "propertyDeclarationTypes": {
-                        "enabled": true,
-                    },
-                    "functionLikeReturnTypes": {
-                        "enabled": true,
-                    },
-                    "enumMemberValues": {
-                        "enabled": true,
-                    }
+                "parameterTypes": {
+                    "enabled": true
+                },
+                "variableTypes": {
+                    "enabled": true,
+                    "suppressWhenTypeMatchesName": false
+                },
+                "propertyDeclarationTypes": {
+                    "enabled": true
+                },
+                "functionLikeReturnTypes": {
+                    "enabled": true
+                },
+                "enumMemberValues": {
+                    "enabled": true
                 }
-            },
-            "javascript": {
-                "suggest": {
-                    "completeFunctionCalls": true
-                }
-            },
+            }
+        });
+
+        Ok(Some(json!({
+            "typescript": config,
+            "javascript": config,
             "vtsls": {
                 "experimental": {
                     "completion": {


### PR DESCRIPTION
Closes #17232

Release Notes:

- Fixed inlay hints not being enabled for JavaScript when using the `vtsls` language server. (They were enabled by default for TypeScript)