### PR TITLE
cpp: Improve completion display

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -245,7 +245,6 @@ impl super::LspAdapter for CLspAdapter {
             }
             _ => {}
         }
-
         Some(CodeLabel::plain(label.to_string(), None))
     }
 

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -170,21 +170,22 @@ impl super::LspAdapter for CLspAdapter {
         match completion.kind {
             Some(lsp::CompletionItemKind::FIELD) if completion.detail.is_some() => {
                 let detail = completion.detail.as_ref().unwrap();
-                let fn_ptr_pos = detail.find("(*)");
-                let text = fn_ptr_pos.map_or(format!("{} {}", detail, label), |fn_ptr_pos| {
+                let fn_ptr_begin = detail.find("(*");
+                let fn_ptr_end = detail[fn_ptr_begin.unwrap_or(detail.len())..].find(')');
+                let text = fn_ptr_begin.map_or(format!("{} {}", detail, label), |fn_ptr_begin| {
                     let mut result = detail.to_owned();
-                    result.insert_str(fn_ptr_pos + 2, label);
+                    result.insert_str(fn_ptr_begin + fn_ptr_end.unwrap(), label);
                     result
                 });
                 let source = Rope::from(format!("struct S {{ {} }}", text).as_str());
                 let runs = language.highlight_text(&source, 11..11 + text.len());
-                let filter_start = if let Some(fn_ptr_pos) = fn_ptr_pos {
-                    fn_ptr_pos + 2
+                let filter_start = if let Some(fn_ptr_begin) = fn_ptr_begin {
+                    fn_ptr_begin + fn_ptr_end.unwrap()
                 } else {
                     detail.len() + 1
                 };
-                let filter_end = if let Some(fn_ptr_pos) = fn_ptr_pos {
-                    fn_ptr_pos + 2 + label.len()
+                let filter_end = if let Some(fn_ptr_begin) = fn_ptr_begin {
+                    fn_ptr_begin + fn_ptr_end.unwrap() + label.len()
                 } else {
                     text.len()
                 };
@@ -198,20 +199,21 @@ impl super::LspAdapter for CLspAdapter {
                 if completion.detail.is_some() =>
             {
                 let detail = completion.detail.as_ref().unwrap();
-                let fn_ptr_pos = detail.find("(*)");
-                let text = fn_ptr_pos.map_or(format!("{} {}", detail, label), |fn_ptr_pos| {
+                let fn_ptr_begin = detail.find("(*");
+                let fn_ptr_end = detail[fn_ptr_begin.unwrap_or(detail.len())..].find(')');
+                let text = fn_ptr_begin.map_or(format!("{} {}", detail, label), |fn_ptr_begin| {
                     let mut result = detail.to_owned();
-                    result.insert_str(fn_ptr_pos + 2, label);
+                    result.insert_str(fn_ptr_begin + fn_ptr_end.unwrap(), label);
                     result
                 });
                 let runs = language.highlight_text(&Rope::from(text.as_str()), 0..text.len());
-                let filter_start = if let Some(fn_ptr_pos) = fn_ptr_pos {
-                    fn_ptr_pos + 2
+                let filter_start = if let Some(fn_ptr_begin) = fn_ptr_begin {
+                    fn_ptr_begin + fn_ptr_end.unwrap()
                 } else {
                     detail.len() + 1
                 };
-                let filter_end = if let Some(fn_ptr_pos) = fn_ptr_pos {
-                    fn_ptr_pos + 2 + label.len()
+                let filter_end = if let Some(fn_ptr_begin) = fn_ptr_begin {
+                    fn_ptr_begin + fn_ptr_end.unwrap() + label.len()
                 } else {
                     text.len()
                 };

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -201,11 +201,9 @@ impl super::LspAdapter for CLspAdapter {
                     .map_or(None, |details| details.detail.as_ref());
                 let text = format!("{}{} -> {}", label, function_arguments.unwrap(), detail);
                 let runs = language.highlight_text(&Rope::from(text.as_str()), 0..text.len());
-                let filter_start = 0;
-                let filter_end = label.len();
 
                 return Some(CodeLabel {
-                    filter_range: filter_start..filter_end,
+                    filter_range: 0..label.len(),
                     text,
                     runs,
                 });
@@ -238,6 +236,7 @@ impl super::LspAdapter for CLspAdapter {
             _ => {}
         }
 
+        // Label details are useful for code snippets provided by the LSP
         let label_details = completion
             .label_details
             .as_ref()

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -199,7 +199,12 @@ impl super::LspAdapter for CLspAdapter {
                     .label_details
                     .as_ref()
                     .map_or(None, |details| details.detail.as_ref());
-                let text = format!("{}{} -> {}", label, function_arguments.unwrap(), detail);
+                let text = format!(
+                    "{}{} -> {}",
+                    label,
+                    function_arguments.unwrap_or(&String::default()),
+                    detail
+                );
                 let runs = language.highlight_text(&Rope::from(text.as_str()), 0..text.len());
 
                 return Some(CodeLabel {


### PR DESCRIPTION
Closes #17270 

* Function pointers should now match their source code definition.
* Functions and methods now display their parameters.
* Snippets provided by the LSP now have a description.

Before:
![completion_cpp_old](https://github.com/user-attachments/assets/0e17c594-c5f1-45d3-acb2-2c998513d896)

After:
![completion_cpp_new](https://github.com/user-attachments/assets/f93973e6-dc79-492f-8cc8-434e4a2c40f1)

Release Notes:

- N/A
