### PR TITLE
Bump vtsls memory limits

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -226,6 +226,9 @@ impl LspAdapter for VtslsLspAdapter {
             "suggest": {
                 "completeFunctionCalls": true
             },
+            "tsserver": {
+                "maxTsServerMemory": 8092
+            },
             "inlayHints": {
                 "parameterNames": {
                     "enabled": "all",

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -46,7 +46,7 @@ Prettier will also be used for TypeScript files by default. To disable this:
 
 ## Large projects
 
-`vtsls` may run out of memory on very large projects. You can configure this limit by passing the following options to the language server:
+`vtsls` may run out of memory on very large projects. We default the limit to 8092 (8 GiB) vs the default of 3072 but this may not be sufficient for you:
 
 ```json
 {
@@ -54,9 +54,9 @@ Prettier will also be used for TypeScript files by default. To disable this:
     "vtsls": {
       "initialization_options": {
         // For TypeScript:
-        "typescript": { "tsserver": { "maxTsServerMemory": 8092 } },
+        "typescript": { "tsserver": { "maxTsServerMemory": 16184 } },
         // For JavaScript:
-        "javascript": { "tsserver": { "maxTsServerMemory": 8092 } }
+        "javascript": { "tsserver": { "maxTsServerMemory": 16184 } }
       }
     }
   }


### PR DESCRIPTION
Release Notes:

- Bump the default memory limit for vtsls from 3GiB to 8GiB
