### PR TITLE
context_servers: Pass env variables from settings

### DIFF
--- a/crates/context_servers/src/manager.rs
+++ b/crates/context_servers/src/manager.rs
@@ -39,6 +39,7 @@ pub struct ServerConfig {
     pub id: String,
     pub executable: String,
     pub args: Vec<String>,
+    pub env: Option<HashMap<String, String>>,
 }
 
 impl Settings for ContextServerSettings {
@@ -70,13 +71,13 @@ impl ContextServer {
     }
 
     async fn start(&self, cx: &AsyncAppContext) -> anyhow::Result<()> {
-        log::info!("starting context server {}", self.config.id);
+        log::info!("starting context server {}", self.config.id,);
         let client = Client::new(
             client::ContextServerId(self.config.id.clone()),
             client::ModelContextServerBinary {
                 executable: Path::new(&self.config.executable).to_path_buf(),
                 args: self.config.args.clone(),
-                env: None,
+                env: self.config.env.clone(),
             },
             cx.clone(),
         )?;


### PR DESCRIPTION
Users can now pass an env dictionary of string: string mappings to a context server binary.

Release Notes:

- context_servers: Settings now allow the configuration of env variables that are passed to the server process
