### PR TITLE
Add `hard_tabs: false` in project settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -38,6 +38,7 @@
       }
     }
   },
+  "hard_tabs": false,
   "formatter": "auto",
   "remove_trailing_whitespace_on_save": true,
   "ensure_final_newline_on_save": true


### PR DESCRIPTION
# Problem

I have a custom system-wide rustfmt configuration, and use tabs over spaces. So when I contribute to Zed, I will get lots of formatting errors.

# Proposition

- ~~Add rustfmt.toml (to specify that you are using the default rustfmt configuration, see https://github.com/rust-lang/cargo/issues/14442)~~
- Add `hard_tabs: false` to `.zed/settings.json` for people using tabs over spaces.

Release Notes:

- N/A
