### PR TITLE
assistant: Propagate LLM stop reason upwards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "collections",
  "futures 0.3.30",
  "http_client",
  "isahc",

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/anthropic.rs"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-collections.workspace = true
 futures.workspace = true
 http_client.workspace = true
 isahc.workspace = true

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -5,7 +5,6 @@ use std::{pin::Pin, str::FromStr};
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
-use collections::HashMap;
 use futures::{io::BufReader, stream::BoxStream, AsyncBufReadExt, AsyncReadExt, Stream, StreamExt};
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use isahc::config::Configurable;
@@ -13,7 +12,7 @@ use isahc::http::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, EnumString};
 use thiserror::Error;
-use util::{maybe, ResultExt as _};
+use util::ResultExt as _;
 
 pub use supported_countries::*;
 
@@ -330,94 +329,6 @@ pub async fn stream_completion_with_rate_limit_info(
             ))),
         }
     }
-}
-
-pub fn extract_content_from_events(
-    events: Pin<Box<dyn Send + Stream<Item = Result<Event, AnthropicError>>>>,
-) -> impl Stream<Item = Result<ResponseContent, AnthropicError>> {
-    struct RawToolUse {
-        id: String,
-        name: String,
-        input_json: String,
-    }
-
-    struct State {
-        events: Pin<Box<dyn Send + Stream<Item = Result<Event, AnthropicError>>>>,
-        tool_uses_by_index: HashMap<usize, RawToolUse>,
-    }
-
-    futures::stream::unfold(
-        State {
-            events,
-            tool_uses_by_index: HashMap::default(),
-        },
-        |mut state| async move {
-            while let Some(event) = state.events.next().await {
-                match event {
-                    Ok(event) => match event {
-                        Event::ContentBlockStart {
-                            index,
-                            content_block,
-                        } => match content_block {
-                            ResponseContent::Text { text } => {
-                                return Some((Some(Ok(ResponseContent::Text { text })), state));
-                            }
-                            ResponseContent::ToolUse { id, name, .. } => {
-                                state.tool_uses_by_index.insert(
-                                    index,
-                                    RawToolUse {
-                                        id,
-                                        name,
-                                        input_json: String::new(),
-                                    },
-                                );
-
-                                return Some((None, state));
-                            }
-                        },
-                        Event::ContentBlockDelta { index, delta } => match delta {
-                            ContentDelta::TextDelta { text } => {
-                                return Some((Some(Ok(ResponseContent::Text { text })), state));
-                            }
-                            ContentDelta::InputJsonDelta { partial_json } => {
-                                if let Some(tool_use) = state.tool_uses_by_index.get_mut(&index) {
-                                    tool_use.input_json.push_str(&partial_json);
-                                    return Some((None, state));
-                                }
-                            }
-                        },
-                        Event::ContentBlockStop { index } => {
-                            if let Some(tool_use) = state.tool_uses_by_index.remove(&index) {
-                                return Some((
-                                    Some(maybe!({
-                                        Ok(ResponseContent::ToolUse {
-                                            id: tool_use.id,
-                                            name: tool_use.name,
-                                            input: serde_json::Value::from_str(
-                                                &tool_use.input_json,
-                                            )
-                                            .map_err(|err| anyhow!(err))?,
-                                        })
-                                    })),
-                                    state,
-                                ));
-                            }
-                        }
-                        Event::Error { error } => {
-                            return Some((Some(Err(AnthropicError::ApiError(error))), state));
-                        }
-                        _ => {}
-                    },
-                    Err(err) => {
-                        return Some((Some(Err(err)), state));
-                    }
-                }
-            }
-
-            None
-        },
-    )
-    .filter_map(|event| async move { event })
 }
 
 pub async fn extract_tool_args_from_events(

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1999,6 +1999,11 @@ impl Context {
                                     });
 
                                 match event {
+                                    LanguageModelCompletionEvent::Stop(reason) => match reason {
+                                        language_model::StopReason::ToolUse => {}
+                                        language_model::StopReason::EndTurn => {}
+                                        language_model::StopReason::MaxTokens => {}
+                                    },
                                     LanguageModelCompletionEvent::Text(chunk) => {
                                         buffer.edit(
                                             [(

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -55,8 +55,17 @@ pub struct LanguageModelCacheConfiguration {
 /// A completion event from a language model.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum LanguageModelCompletionEvent {
+    Stop(StopReason),
     Text(String),
     ToolUse(LanguageModelToolUse),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    EndTurn,
+    MaxTokens,
+    ToolUse,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -112,6 +121,7 @@ pub trait LanguageModel: Send + Sync {
                 .filter_map(|result| async move {
                     match result {
                         Ok(LanguageModelCompletionEvent::Text(text)) => Some(Ok(text)),
+                        Ok(LanguageModelCompletionEvent::Stop(_)) => None,
                         Ok(LanguageModelCompletionEvent::ToolUse(_)) => None,
                         Err(err) => Some(Err(err)),
                     }


### PR DESCRIPTION
This PR makes it so we propagate the `stop_reason` from Anthropic up to the Assistant so that we can take action based on it.

The `extract_content_from_events` function was moved from `anthropic` to the `anthropic` module in `language_model` since it is more useful if it is able to name the `LanguageModelCompletionEvent` type, as otherwise we'd need an additional layer of plumbing.

Release Notes:

- N/A
