### PR TITLE
language_model: Add tool results to message content

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -423,6 +423,14 @@ pub enum RequestContent {
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        is_error: bool,
+        content: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -261,11 +261,14 @@ pub fn count_anthropic_tokens(
 
                 for content in message.content {
                     match content {
-                        MessageContent::Text(string) => {
-                            string_contents.push_str(&string);
+                        MessageContent::Text(text) => {
+                            string_contents.push_str(&text);
                         }
                         MessageContent::Image(image) => {
                             tokens_from_images += image.estimate_tokens();
+                        }
+                        MessageContent::ToolResult(tool_result) => {
+                            string_contents.push_str(&tool_result.content);
                         }
                     }
                 }


### PR DESCRIPTION
This PR updates the message content for an LLM request to allow it contain tool results.

Release Notes:

- N/A
