### PR TITLE
assistant: Add basic tool invocation

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2108,12 +2108,7 @@ impl ContextEditor {
                         let task = tool.run(tool_use.input, self.workspace.clone(), cx);
 
                         self.context.update(cx, |context, cx| {
-                            context.insert_tool_output(
-                                tool_use.id.clone(),
-                                tool_use.source_range,
-                                task,
-                                cx,
-                            );
+                            context.insert_tool_output(tool_use.id.clone(), task, cx);
                         });
                     }
                 }

--- a/crates/assistant/src/tools/now_tool.rs
+++ b/crates/assistant/src/tools/now_tool.rs
@@ -44,6 +44,7 @@ impl Tool for NowTool {
         _workspace: WeakView<workspace::Workspace>,
         _cx: &mut WindowContext,
     ) -> Task<Result<String>> {
+        dbg!("running now tool");
         let input: FileToolInput = match serde_json::from_value(input) {
             Ok(input) => input,
             Err(err) => return Task::ready(Err(anyhow!(err))),

--- a/crates/assistant/src/tools/now_tool.rs
+++ b/crates/assistant/src/tools/now_tool.rs
@@ -44,7 +44,6 @@ impl Tool for NowTool {
         _workspace: WeakView<workspace::Workspace>,
         _cx: &mut WindowContext,
     ) -> Task<Result<String>> {
-        dbg!("running now tool");
         let input: FileToolInput = match serde_json::from_value(input) {
             Ok(input) => input,
             Err(err) => return Task::ready(Err(anyhow!(err))),

--- a/crates/assistant_tool/src/tool_registry.rs
+++ b/crates/assistant_tool/src/tool_registry.rs
@@ -66,4 +66,9 @@ impl ToolRegistry {
     pub fn tools(&self) -> Vec<Arc<dyn Tool>> {
         self.state.read().tools.values().cloned().collect()
     }
+
+    /// Returns the [`Tool`] with the given name.
+    pub fn tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.state.read().tools.get(name).cloned()
+    }
 }


### PR DESCRIPTION
This PR adds the initial groundwork for invoking tools in response to tool uses from the model.

Tool uses are run when the model responds with a `stop_reason` of `tool_use`.

Currently the tool results are just inserted as text into the user message. We'll want to include these as `tool_result` content on the message, but Claude seems to understand it regardless.

Release Notes:

- N/A
