### PR TITLE
x11: Fix preedit for CJK and partially fix unresponsive keyboard with xim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14033,7 +14033,7 @@ dependencies = [
 [[package]]
 name = "xim"
 version = "0.4.0"
-source = "git+https://github.com/npmania/xim-rs?rev=27132caffc5b9bc9c432ca4afad184ab6e7c16af#27132caffc5b9bc9c432ca4afad184ab6e7c16af"
+source = "git+https://github.com/XDeme1/xim-rs?rev=d50d461764c2213655cd9cf65a0ea94c70d3c4fd#d50d461764c2213655cd9cf65a0ea94c70d3c4fd"
 dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.14.5",
@@ -14046,7 +14046,7 @@ dependencies = [
 [[package]]
 name = "xim-ctext"
 version = "0.3.0"
-source = "git+https://github.com/npmania/xim-rs?rev=27132caffc5b9bc9c432ca4afad184ab6e7c16af#27132caffc5b9bc9c432ca4afad184ab6e7c16af"
+source = "git+https://github.com/XDeme1/xim-rs?rev=d50d461764c2213655cd9cf65a0ea94c70d3c4fd#d50d461764c2213655cd9cf65a0ea94c70d3c4fd"
 dependencies = [
  "encoding_rs",
 ]
@@ -14054,7 +14054,7 @@ dependencies = [
 [[package]]
 name = "xim-parser"
 version = "0.2.1"
-source = "git+https://github.com/npmania/xim-rs?rev=27132caffc5b9bc9c432ca4afad184ab6e7c16af#27132caffc5b9bc9c432ca4afad184ab6e7c16af"
+source = "git+https://github.com/XDeme1/xim-rs?rev=d50d461764c2213655cd9cf65a0ea94c70d3c4fd#d50d461764c2213655cd9cf65a0ea94c70d3c4fd"
 dependencies = [
  "bitflags 2.6.0",
 ]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -143,7 +143,7 @@ xkbcommon = { git = "https://github.com/ConradIrwin/xkbcommon-rs", rev = "fcbb46
     "wayland",
     "x11",
 ] }
-xim = { git = "https://github.com/npmania/xim-rs", rev = "27132caffc5b9bc9c432ca4afad184ab6e7c16af", features = [
+xim = { git = "https://github.com/XDeme1/xim-rs", rev = "d50d461764c2213655cd9cf65a0ea94c70d3c4fd", features = [
     "x11rb-xcb",
     "x11rb-client",
 ] }

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -644,10 +644,9 @@ impl X11Client {
                 window.set_active(true);
                 let mut state = self.0.borrow_mut();
                 state.keyboard_focused_window = Some(event.event);
-                state
-                    .xim_handler
-                    .as_mut()
-                    .map(|handler| handler.window = event.event);
+                if let Some(handler) = state.xim_handler.as_mut() {
+                    handler.window = event.event;
+                }
                 drop(state);
                 self.enable_ime();
             }

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -585,8 +585,8 @@ impl X11Client {
         let mut state = self.0.borrow_mut();
         state.composing = false;
         if let Some(mut ximc) = state.ximc.take() {
-            let handler = state.xim_handler.as_ref().unwrap();
-            ximc.reset_ic(handler.im_id, handler.ic_id).ok();
+            let xim_handler = state.xim_handler.as_ref().unwrap();
+            ximc.reset_ic(xim_handler.im_id, xim_handler.ic_id).ok();
             state.ximc = Some(ximc);
         }
     }

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -644,6 +644,10 @@ impl X11Client {
                 window.set_active(true);
                 let mut state = self.0.borrow_mut();
                 state.keyboard_focused_window = Some(event.event);
+                state
+                    .xim_handler
+                    .as_mut()
+                    .map(|handler| handler.window = event.event);
                 drop(state);
                 self.enable_ime();
             }
@@ -966,10 +970,6 @@ impl X11Client {
                 window.set_hovered(true);
                 let mut state = self.0.borrow_mut();
                 state.mouse_focused_window = Some(event.event);
-                state
-                    .xim_handler
-                    .as_mut()
-                    .map(|handler| handler.window = event.event);
             }
             Event::XinputLeave(event) if event.mode == xinput::NotifyMode::NORMAL => {
                 self.0.borrow_mut().scroll_x = None; // Set last scroll to `None` so that a large delta isn't created if scrolling is done outside the window (the valuator is global)

--- a/crates/gpui/src/platform/linux/x11/xim_handler.rs
+++ b/crates/gpui/src/platform/linux/x11/xim_handler.rs
@@ -48,12 +48,7 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
     ) -> Result<(), ClientError> {
         let ic_attributes = client
             .build_ic_attributes()
-            .push(
-                AttributeName::InputStyle,
-                InputStyle::PREEDIT_CALLBACKS
-                    | InputStyle::STATUS_NOTHING
-                    | InputStyle::PREEDIT_NONE,
-            )
+            .push(AttributeName::InputStyle, InputStyle::PREEDIT_CALLBACKS)
             .push(AttributeName::ClientWindow, self.window)
             .push(AttributeName::FocusWindow, self.window)
             .build();
@@ -108,15 +103,6 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
 
     fn handle_close(&mut self, client: &mut C, _input_method_id: u16) -> Result<(), ClientError> {
         client.disconnect()
-    }
-
-    fn handle_destroy_ic(
-        &mut self,
-        client: &mut C,
-        input_method_id: u16,
-        _input_context_id: u16,
-    ) -> Result<(), ClientError> {
-        client.close(input_method_id)
     }
 
     fn handle_preedit_draw(


### PR DESCRIPTION
Closes #15833
Related to [#12495 comment](https://github.com/zed-industries/zed/pull/12495#issuecomment-2328356125)

Destroying and recreating the Input context was the only way to reset the IME but it's making the keyboard unresponsive sometimes due to a XIM error.

The keyboard will still be unresponsive if you close your IME while using zed, but I don't know how to fix this.

* Fixed preedit drawing for CJK
* Fixed unresponsive keyboard by properly implementing reset_ic in `xim-rs`

Release Notes:

- N/A
