### PR TITLE
language_model: Remove unused `impl` for `MessageContent`

### DIFF
--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -174,16 +174,6 @@ pub enum MessageContent {
     ToolResult(LanguageModelToolResult),
 }
 
-impl MessageContent {
-    pub fn as_string(&self) -> &str {
-        match self {
-            MessageContent::Text(text) => text.as_str(),
-            MessageContent::Image(_) => "",
-            MessageContent::ToolResult(tool_result) => tool_result.content.as_str(),
-        }
-    }
-}
-
 impl From<String> for MessageContent {
     fn from(value: String) -> Self {
         MessageContent::Text(value)


### PR DESCRIPTION
This PR removes an unused `impl` for the `MessageContent` type.

Release Notes:

- N/A
