### PR TITLE
svelte: Revert Tree-sitter grammar upgrade

### DIFF
--- a/extensions/svelte/extension.toml
+++ b/extensions/svelte/extension.toml
@@ -12,4 +12,4 @@ language = "Svelte"
 
 [grammars.svelte]
 repository = "https://github.com/Himujjal/tree-sitter-svelte"
-commit = "038dea960b58a88d3a8e916e81399d6bfed50ef8"
+commit = "b08d070e303d2a385d6d0ab3add500f8fa514443"

--- a/extensions/svelte/languages/svelte/highlights.scm
+++ b/extensions/svelte/languages/svelte/highlights.scm
@@ -1,8 +1,15 @@
 ; Special identifiers
 ;--------------------
 
+; Treat capitalized tag names as constructors and types
+((tag_name) @type
+ (#match? @type "^[A-Z]"))
+
+; Regular (lowercase) tag names
+((tag_name) @tag
+ (#match? @tag "^[a-z]"))
+
 ; TODO:
-(tag_name) @tag
 (attribute_name) @property
 (erroneous_end_tag_name) @keyword
 (comment) @comment


### PR DESCRIPTION
Closes: #17310

This PR https://github.com/zed-industries/zed/pull/17364 broke my svelte code, downgrading to the previous commit SHA `b08d070e303d2a385d6d0ab3add500f8fa514443` fixes the issue.

Until the following issue is resolved, the commit SHA should not be updated

- tree-sitter-svelte issue I filed: https://github.com/Himujjal/tree-sitter-svelte/issues/61

Release Notes:

- N/A

