### PR TITLE
Tweak footer design in the branch picker

### DIFF
--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -9,8 +9,8 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 use std::{ops::Not, sync::Arc};
 use ui::{
-    h_flex, v_flex, Button, ButtonCommon, Clickable, Color, HighlightedLabel, Label, LabelCommon,
-    LabelSize, ListItem, ListItemSpacing, Selectable,
+    prelude::*, Button, Clickable, Color, HighlightedLabel, Label, LabelCommon, LabelSize,
+    ListItem, ListItemSpacing, Selectable,
 };
 use util::ResultExt;
 use workspace::notifications::NotificationId;
@@ -300,11 +300,17 @@ impl PickerDelegate for BranchListDelegate {
 
         Some(
             h_flex()
-                .mr_3()
-                .pb_2()
+                .p_2()
+                .border_t_1()
+                .border_color(cx.theme().colors().border_variant)
+                .justify_end()
                 .child(h_flex().w_full())
                 .child(
-                    Button::new("branch-picker-create-branch-button", "Create branch")
+                    Button::new("branch-picker-create-branch-button", "Create Branch")
+                        .icon(IconName::Plus)
+                        .icon_size(IconSize::Small)
+                        .icon_color(Color::Muted)
+                        .icon_position(IconPosition::Start)
                         .on_click(cx.listener(|_, _, cx| {
                             cx.spawn(|picker, mut cx| async move {
                                 picker.update(&mut cx, |this, cx| {
@@ -330,7 +336,6 @@ impl PickerDelegate for BranchListDelegate {
                             })
                             .detach_and_log_err(cx);
                         }))
-                        .style(ui::ButtonStyle::Filled),
                 )
                 .into_any_element(),
         )

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -8,10 +8,7 @@ use gpui::{
 };
 use picker::{Picker, PickerDelegate};
 use std::{ops::Not, sync::Arc};
-use ui::{
-    prelude::*, Button, Clickable, Color, HighlightedLabel, Label, LabelCommon, LabelSize,
-    ListItem, ListItemSpacing, Selectable,
-};
+use ui::{prelude::*, HighlightedLabel, ListItem, ListItemSpacing};
 use util::ResultExt;
 use workspace::notifications::NotificationId;
 use workspace::{ModalView, Toast, Workspace};


### PR DESCRIPTION
This PR adds a small design touch-up to the footer that appears once you type out a branch name that doesn't exist and is thus available to be added as a new branch.

| Before | After |
|--------|--------|
| <img width="564" alt="Screenshot 2024-09-04 at 8 07 20 PM" src="https://github.com/user-attachments/assets/2ebe411a-770b-4fad-a9b3-185ac3cbde9b"> | <img width="564" alt="Screenshot 2024-09-04 at 8 07 29 PM" src="https://github.com/user-attachments/assets/fb0ee951-c674-4ab4-bca3-4b009efd5064"> | 

---

Release Notes:

- N/A
