### PR TITLE
Remove unused `rusqlite` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,7 +388,6 @@ rsa = "0.9.6"
 runtimelib = { version = "0.15", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }
-rusqlite = { version = "0.29.0", features = ["blob", "array", "modern_sqlite"] }
 rustc-demangle = "0.1.23"
 rust-embed = { version = "8.4", features = ["include-exclude"] }
 schemars = { version = "0.8", features = ["impl_json_schema"] }


### PR DESCRIPTION
This PR removes the `rusqlite` dependency from our workspace `Cargo.toml`, as it wasn't being used anywhere.

Release Notes:

- N/A
