### PR TITLE
Upgrade `pulldown_cmark` to v0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6137,7 +6137,7 @@ dependencies = [
  "lsp",
  "parking_lot",
  "postage",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.1",
  "rand 0.8.5",
  "regex",
  "rpc",
@@ -6657,7 +6657,7 @@ dependencies = [
  "linkify",
  "log",
  "node_runtime",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.1",
  "settings",
  "theme",
  "ui",
@@ -6677,7 +6677,7 @@ dependencies = [
  "linkify",
  "log",
  "pretty_assertions",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.1",
  "theme",
  "ui",
  "workspace",
@@ -6772,7 +6772,7 @@ dependencies = [
  "once_cell",
  "opener",
  "pathdiff",
- "pulldown-cmark",
+ "pulldown-cmark 0.10.3",
  "regex",
  "serde",
  "serde_json",
@@ -8620,6 +8620,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666f0f59e259aea2d72e6012290c09877a780935cc3c18b1ceded41f3890d59c"
+dependencies = [
+ "bitflags 2.6.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pulldown-cmark-escape"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9197,7 +9208,7 @@ dependencies = [
  "gpui",
  "language",
  "linkify",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.1",
  "theme",
  "ui",
  "util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,7 +380,7 @@ pretty_assertions = "1.3.0"
 prost = "0.9"
 prost-build = "0.9"
 prost-types = "0.9"
-pulldown-cmark = { version = "0.10.0", default-features = false }
+pulldown-cmark = { version = "0.12.0", default-features = false }
 rand = "0.8.5"
 regex = "1.5"
 repair_json = "0.1.0"

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -663,7 +663,7 @@ impl Element for MarkdownElement {
                         builder.pop_div();
                         builder.pop_text_style()
                     }
-                    MarkdownTagEnd::BlockQuote => {
+                    MarkdownTagEnd::BlockQuote(_kind) => {
                         builder.pop_text_style();
                         builder.pop_div()
                     }

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -83,6 +83,7 @@ pub fn parse_markdown(text: &str) -> Vec<(Range<usize>, MarkdownEvent)> {
             pulldown_cmark::Event::TaskListMarker(checked) => {
                 events.push((range, MarkdownEvent::TaskListMarker(checked)))
             }
+            pulldown_cmark::Event::InlineMath(_) | pulldown_cmark::Event::DisplayMath(_) => {}
         }
     }
     events
@@ -271,7 +272,7 @@ impl From<pulldown_cmark::Tag<'_>> for MarkdownTag {
                     attrs,
                 }
             }
-            pulldown_cmark::Tag::BlockQuote => MarkdownTag::BlockQuote,
+            pulldown_cmark::Tag::BlockQuote(_kind) => MarkdownTag::BlockQuote,
             pulldown_cmark::Tag::CodeBlock(kind) => match kind {
                 pulldown_cmark::CodeBlockKind::Indented => {
                     MarkdownTag::CodeBlock(CodeBlockKind::Indented)
@@ -316,6 +317,11 @@ impl From<pulldown_cmark::Tag<'_>> for MarkdownTag {
             },
             pulldown_cmark::Tag::HtmlBlock => MarkdownTag::HtmlBlock,
             pulldown_cmark::Tag::MetadataBlock(kind) => MarkdownTag::MetadataBlock(kind),
+            pulldown_cmark::Tag::DefinitionList
+            | pulldown_cmark::Tag::DefinitionListTitle
+            | pulldown_cmark::Tag::DefinitionListDefinition => {
+                unimplemented!("definition lists are not yet supported")
+            }
         }
     }
 }

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -139,7 +139,7 @@ impl<'a> MarkdownParser<'a> {
                     let list = self.parse_list(order).await;
                     Some(list)
                 }
-                Tag::BlockQuote => {
+                Tag::BlockQuote(_kind) => {
                     self.cursor += 1;
                     let block_quote = self.parse_block_quote().await;
                     Some(vec![ParsedMarkdownElement::BlockQuote(block_quote)])
@@ -654,10 +654,10 @@ impl<'a> MarkdownParser<'a> {
                 // Record that we're in a nested block quote and continue parsing.
                 // We don't need to advance the cursor since the next
                 // call to `parse_block` will handle it.
-                Event::Start(Tag::BlockQuote) => {
+                Event::Start(Tag::BlockQuote(_kind)) => {
                     nested_depth += 1;
                 }
-                Event::End(TagEnd::BlockQuote) => {
+                Event::End(TagEnd::BlockQuote(_kind)) => {
                     nested_depth -= 1;
                     if nested_depth == 0 {
                         self.cursor += 1;


### PR DESCRIPTION
This PR upgrades `pulldown_cmark` to v0.12.

There were a few breaking changes that needed to be accounted for:

- The `BlockQuote` variant now has a `kind` attached. Right now we're ignoring it.
- `pulldown_cmark` now emits tags for definition lists. This codepath has been left unimplemented, for now.

### Release Notes

<details>
<summary>raphlinus/pulldown-cmark (pulldown-cmark)</summary>

### [`v0.12.1`](https://redirect.github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.12.1): 0.12.1

[Compare Source](https://redirect.github.com/raphlinus/pulldown-cmark/compare/v0.12.0...v0.12.1)

##### Security

-   Fix O(n\*\*2) comment parser by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/941](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/941)

##### New features

-   impl From<CowStr> for String by [@&#8203;oconnor663](https://redirect.github.com/oconnor663) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/943](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/943)

##### Developers

-   Make dos-fuzzer part of the workspace by [@&#8203;kdarkhan](https://redirect.github.com/kdarkhan) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/945](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/945)

##### New Contributors

-   [@&#8203;oconnor663](https://redirect.github.com/oconnor663) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/943](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/943)
-   [@&#8203;kdarkhan](https://redirect.github.com/kdarkhan) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/945](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/945)

**Full Changelog**: https://github.com/pulldown-cmark/pulldown-cmark/compare/v0.12.0...v0.12.1

### [`v0.12.0`](https://redirect.github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.12.0): 0.12.0

[Compare Source](https://redirect.github.com/raphlinus/pulldown-cmark/compare/v0.11.3...v0.12.0)

Thanks to all contributors! This release mainly adds the long awaited commonmark-hs description lists (under a flag) and enables the blockquote kind in `TagEnd` reverted in 0.11.2.

#### Breaking changes

-   feat: re-add kind for BlockQuote in TagEnd by [@&#8203;Martin1887](https://redirect.github.com/Martin1887) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/940](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/940)
-   Refactor TextMergeStream by [@&#8203;ollpu](https://redirect.github.com/ollpu) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/931](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/931)

#### New features

-   Implement commonmark-hs compatible definition lists by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/915](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/915)

#### Other changes

-   Rename superlinear time fuzzer to `dos-fuzzer` by [@&#8203;ollpu](https://redirect.github.com/ollpu) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/938](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/938)

**Full Changelog**: https://github.com/pulldown-cmark/pulldown-cmark/compare/v0.11.2...v0.12.0

### [`v0.11.3`](https://redirect.github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.11.3): 0.11.3

[Compare Source](https://redirect.github.com/raphlinus/pulldown-cmark/compare/v0.11.2...v0.11.3)

#### Security

-   Fix O(n\*\*2) comment parser by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/944](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/944)

**Full Changelog**: https://github.com/pulldown-cmark/pulldown-cmark/compare/v0.11.2...v0.11.3

### [`v0.11.2`](https://redirect.github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.11.2)

[Compare Source](https://redirect.github.com/raphlinus/pulldown-cmark/compare/v0.11.1...v0.11.2)

Revert BlockQuote kind to avoid breaking change.

### [`v0.11.1`](https://redirect.github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.11.1)

[Compare Source](https://redirect.github.com/raphlinus/pulldown-cmark/compare/v0.11.0...v0.11.1)

Thanks to all people involved in this release! The main change of this release is the reduction of the MSRV to 1.71.1, but it also includes a lot of bug fixes and a new mdBook for user-friendly documentation.

#### Breaking changes

-   Add BlockQuoteKind to BlockQuote TagEnd by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/926](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/926) (reverted in v0.11.2)

#### What's Changed

-   fix: CowStr deserialization when escaping by [@&#8203;aatifsyed](https://redirect.github.com/aatifsyed) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/895](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/895)
-   fix(test): fix generating spec tests doesn't work on Windows due to line-endings by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/903](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/903)
-   feat: add `-G` CLI option to enable GFM support by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/905](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/905)
-   feat: set `DefaultBrokenLinkCallback` as the default broken link callback of `OffsetIter` by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/901](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/901)
-   chore(doc): use `cargo add` to instruct how to install this crate as dependency by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/904](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/904)
-   fix typo by [@&#8203;jmbhughes](https://redirect.github.com/jmbhughes) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/909](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/909)
-   Fix parsing blocks inside alert body by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/908](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/908)
-   fuzz: fix building fuzzer and improve fuzzing coverage by enabling more parse options by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/910](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/910)
-   fix: fix warnings reported from nightly rustc by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/911](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/911)
-   fix: fix infinite loop when metadata delimiter is indented by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/913](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/913)
-   Raise the link cutoff from 5 to 32 by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/917](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/917)
-   Reduce MSRV to 1.71.1 by separating benchmarks into a new crate with CI enhancements by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/916](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/916)
-   Add guide book and deploy script for it by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/883](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/883)
-   ci: fix deploying the document to GitHub Pages and make the deploy job faster by [@&#8203;rhysd](https://redirect.github.com/rhysd) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/920](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/920)
-   Fix lone task list item bug by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/924](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/924)
-   Fix offset range around footnotes that look like images by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/925](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/925)
-   Update old footnote format to interrupt paragraph by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/928](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/928)
-   Fix confusing bug with back-to-back footnotes by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/930](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/930)
-   Add reproduction cases for [#&#8203;927](https://redirect.github.com/raphlinus/pulldown-cmark/issues/927) by [@&#8203;zoni](https://redirect.github.com/zoni) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/929](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/929)
-   Add regression test for [#&#8203;655](https://redirect.github.com/raphlinus/pulldown-cmark/issues/655) by [@&#8203;ollpu](https://redirect.github.com/ollpu) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/932](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/932)
-   Renovate the superlinear time fuzzer by [@&#8203;ollpu](https://redirect.github.com/ollpu) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/935](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/935)

#### New Contributors

-   [@&#8203;aatifsyed](https://redirect.github.com/aatifsyed) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/895](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/895)
-   [@&#8203;jmbhughes](https://redirect.github.com/jmbhughes) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/909](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/909)
-   [@&#8203;zoni](https://redirect.github.com/zoni) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/929](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/929)

**Full Changelog**: https://github.com/pulldown-cmark/pulldown-cmark/compare/v0.11.0...v0.11.1

### [`v0.11.0`](https://redirect.github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.11.0): 0.11.0

[Compare Source](https://redirect.github.com/raphlinus/pulldown-cmark/compare/v0.10.3...v0.11.0)

##### Finally, the so long awaited math mode is here! Enable the option to use it.

This release also includes other improvements and bugfixes, please see the changelog below for more details. Thanks to all contributors that has made possible this release!

#### Breaking changes

-   Change `write_to_html` to allow `fmt::Write` by [@&#8203;stepantubanov](https://redirect.github.com/stepantubanov) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/870](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/870)

#### New features

-   Math mode

#### Bugfixes

-   \[0.11] Don't exit `scan_attribute` with the ix pointing at block quote by [@&#8203;notriddle](https://redirect.github.com/notriddle) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/873](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/873)
-   (Re)introduce simd feature to pulldown-cmark-escape by [@&#8203;ollpu](https://redirect.github.com/ollpu) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/880](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/880)
-   fix: remove unnecessary end_newline set by [@&#8203;tomcur](https://redirect.github.com/tomcur) in [https://github.com/pulldown-cmark/pulldown-cmark/pull/885](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/885)

#### New Contributors

-   [@&#8203;duskmoon314](https://redirect.github.com/duskmoon314) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/874](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/874)
-   [@&#8203;stepantubanov](https://redirect.github.com/stepantubanov) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/870](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/870)
-   [@&#8203;tomcur](https://redirect.github.com/tomcur) made their first contribution in [https://github.com/pulldown-cmark/pulldown-cmark/pull/885](https://redirect.github.com/pulldown-cmark/pulldown-cmark/pull/885)

**Full Changelog**: https://github.com/pulldown-cmark/pulldown-cmark/compare/v0.10.3...v0.11.0

</details>

Release Notes:

- N/A
