### PR TITLE
vim: Fix blackhole register

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -218,23 +218,25 @@ impl VimGlobals {
                 let yanked = current.clone();
                 self.registers.insert('"', yanked);
             } else {
-                self.registers.insert('"', content.clone());
                 match lower {
                     '_' | ':' | '.' | '%' | '#' | '=' | '/' => {}
                     '+' => {
+                        self.registers.insert('"', content.clone());
                         cx.write_to_clipboard(content.into());
                     }
                     '*' => {
+                        self.registers.insert('"', content.clone());
                         #[cfg(target_os = "linux")]
                         cx.write_to_primary(content.into());
                         #[cfg(not(target_os = "linux"))]
                         cx.write_to_clipboard(content.into());
                     }
                     '"' => {
-                        self.registers.insert('0', content.clone());
-                        self.registers.insert('"', content);
+                        self.registers.insert('"', content.clone());
+                        self.registers.insert('0', content);
                     }
                     _ => {
+                        self.registers.insert('"', content.clone());
                         self.registers.insert(lower, content);
                     }
                 }

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1424,5 +1424,15 @@ async fn test_record_replay_recursion(cx: &mut gpui::TestAppContext) {
     cx.simulate_shared_keystrokes(".").await;
     cx.simulate_shared_keystrokes(".").await;
     cx.simulate_shared_keystrokes(".").await;
-    cx.shared_state().await.assert_eq("ˇhello world"); // takes a _long_ time
+    cx.shared_state().await.assert_eq("ˇhello world");
+}
+
+#[gpui::test]
+async fn test_blackhole_register(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state("ˇhello world").await;
+    cx.simulate_shared_keystrokes("d i w \" _ d a w").await;
+    cx.simulate_shared_keystrokes("p").await;
+    cx.shared_state().await.assert_eq("hellˇo");
 }

--- a/crates/vim/test_data/test_blackhole_register.json
+++ b/crates/vim/test_data/test_blackhole_register.json
@@ -1,0 +1,11 @@
+{"Put":{"state":"ˇhello world"}}
+{"Key":"d"}
+{"Key":"i"}
+{"Key":"w"}
+{"Key":"\""}
+{"Key":"_"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Key":"p"}
+{"Get":{"state":"hellˇo","mode":"Normal"}}


### PR DESCRIPTION
Closes: #17306

Release Notes:

- vim: Fixed `"_` register writes overwriting `"` register.
