### PR TITLE
vim: Sentence motion

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -29,6 +29,8 @@
       "shift-g": "vim::EndOfDocument",
       "{": "vim::StartOfParagraph",
       "}": "vim::EndOfParagraph",
+      "(": "vim::SentenceBackward",
+      ")": "vim::SentenceForward",
       "|": "vim::GoToColumn",
       // Word motions
       "w": "vim::NextWordStart",

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -4,7 +4,7 @@ use editor::{
         self, find_boundary, find_preceding_boundary_display_point, FindRange, TextLayoutDetails,
     },
     scroll::Autoscroll,
-    Anchor, Bias, DisplayPoint, Editor, RowExt, ToOffset, ToPoint,
+    Anchor, Bias, DisplayPoint, Editor, RowExt, ToOffset,
 };
 use gpui::{actions, impl_actions, px, ViewContext};
 use language::{char_kind, CharKind, Point, Selection, SelectionGoal};

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1528,16 +1528,6 @@ pub(crate) fn end_of_line(
         map.clip_point(map.next_line_boundary(point.to_point(map)).1, Bias::Left)
     }
 }
-/*
-A sentence is defined as ending at a '.', '!' or '?' followed by either the
-end of a line, or by a space or tab.  Any number of closing ')', ']', '"'
-and ''' characters may appear after the '.', '!' or '?' before the spaces,
-tabs or end of line.  OR \n\n
-boundary.
-
-                                                        paragraph
-A paragraph begins after each empty line.
-*/
 
 fn sentence_backwards(
     map: &DisplaySnapshot,
@@ -1563,20 +1553,18 @@ fn sentence_backwards(
             None
         };
 
-        let Some(start_of_next_sentence) = start_of_next_sentence else {
-            continue;
-        };
-
-        if start_of_next_sentence < start {
-            times = times.saturating_sub(1);
-        }
-        if times == 0 || offset == 0 {
-            return map.clip_point(
-                start_of_next_sentence
-                    .to_offset(&map.buffer_snapshot)
-                    .to_display_point(&map),
-                Bias::Left,
-            );
+        if let Some(start_of_next_sentence) = start_of_next_sentence {
+            if start_of_next_sentence < start {
+                times = times.saturating_sub(1);
+            }
+            if times == 0 || offset == 0 {
+                return map.clip_point(
+                    start_of_next_sentence
+                        .to_offset(&map.buffer_snapshot)
+                        .to_display_point(&map),
+                    Bias::Left,
+                );
+            }
         }
         if was_newline {
             start = offset;
@@ -1611,18 +1599,16 @@ fn sentence_forwards(map: &DisplaySnapshot, point: DisplayPoint, mut times: usiz
             None
         };
 
-        let Some(start_of_next_sentence) = start_of_next_sentence else {
-            continue;
-        };
-
-        times = times.saturating_sub(1);
-        if times == 0 {
-            return map.clip_point(
-                start_of_next_sentence
-                    .to_offset(&map.buffer_snapshot)
-                    .to_display_point(&map),
-                Bias::Right,
-            );
+        if let Some(start_of_next_sentence) = start_of_next_sentence {
+            times = times.saturating_sub(1);
+            if times == 0 {
+                return map.clip_point(
+                    start_of_next_sentence
+                        .to_offset(&map.buffer_snapshot)
+                        .to_display_point(&map),
+                    Bias::Right,
+                );
+            }
         }
 
         was_newline = ch == '\n' && chars.peek().is_some_and(|(c, _)| *c == '\n');

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1407,3 +1407,85 @@ async fn test_record_replay_recursion(cx: &mut gpui::TestAppContext) {
     cx.simulate_shared_keystrokes(".").await;
     cx.shared_state().await.assert_eq("ˇhello world"); // takes a _long_ time
 }
+
+#[gpui::test]
+async fn test_sentence_backwards(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state("hello.\n\n\nworˇld.").await;
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq("hello.\n\n\nˇworld.");
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq("hello.\n\nˇ\nworld.");
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq("ˇhello.\n\n\nworld.");
+
+    cx.set_shared_state("hello. worlˇd.").await;
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq("hello. ˇworld.");
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq("ˇhello. world.");
+
+    cx.set_shared_state(". helˇlo.").await;
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq(". ˇhello.");
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq(". ˇhello.");
+
+    cx.set_shared_state(indoc! {
+        "{
+            hello_world();
+        ˇ}"
+    })
+    .await;
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq(indoc! {
+        "ˇ{
+            hello_world();
+        }"
+    });
+
+    cx.set_shared_state(indoc! {
+        "Hello! World..?
+
+        \tHello! World... ˇ"
+    })
+    .await;
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq(indoc! {
+        "Hello! World..?
+
+        \tHello! ˇWorld... "
+    });
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq(indoc! {
+        "Hello! World..?
+
+        \tˇHello! World... "
+    });
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq(indoc! {
+        "Hello! World..?
+        ˇ
+        \tHello! World... "
+    });
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state().await.assert_eq(indoc! {
+        "Hello! ˇWorld..?
+
+        \tHello! World... "
+    });
+}
+
+#[gpui::test]
+async fn test_sentence_forwards(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state("helˇlo.\n\n\nworld.").await;
+    cx.simulate_shared_keystrokes(")").await;
+    cx.shared_state().await.assert_eq("hello.\nˇ\n\nworld.");
+    cx.simulate_shared_keystrokes(")").await;
+    cx.shared_state().await.assert_eq("hello.\n\n\nˇworld.");
+    cx.simulate_shared_keystrokes(")").await;
+    cx.shared_state().await.assert_eq("hello.\n\n\nworld.ˇ");
+}

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1487,5 +1487,7 @@ async fn test_sentence_forwards(cx: &mut gpui::TestAppContext) {
     cx.simulate_shared_keystrokes(")").await;
     cx.shared_state().await.assert_eq("hello.\n\n\nˇworld.");
     cx.simulate_shared_keystrokes(")").await;
-    cx.shared_state().await.assert_eq("hello.\n\n\nworld.ˇ");
+    cx.shared_state().await.assert_eq("hello.\n\n\nworldˇ.");
+
+    cx.set_shared_state("helˇlo.\n\n\nworld.").await;
 }

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1412,6 +1412,12 @@ async fn test_record_replay_recursion(cx: &mut gpui::TestAppContext) {
 async fn test_sentence_backwards(cx: &mut gpui::TestAppContext) {
     let mut cx = NeovimBackedTestContext::new(cx).await;
 
+    cx.set_shared_state("one\n\ntwo\nthree\nˇ\nfour").await;
+    cx.simulate_shared_keystrokes("(").await;
+    cx.shared_state()
+        .await
+        .assert_eq("one\n\nˇtwo\nthree\n\nfour");
+
     cx.set_shared_state("hello.\n\n\nworˇld.").await;
     cx.simulate_shared_keystrokes("(").await;
     cx.shared_state().await.assert_eq("hello.\n\n\nˇworld.");

--- a/crates/vim/test_data/test_sentence_backwards.json
+++ b/crates/vim/test_data/test_sentence_backwards.json
@@ -1,0 +1,10 @@
+{"Put":{"state":"one\n\ntwo\nthree\nˇ\nfour"}}
+{"Key":"("}
+{"Get":{"state":"one\n\nˇtwo\nthree\n\nfour","mode":"Normal"}}
+{"Put":{"state":"hello.\n\n\nworˇld."}}
+{"Key":"("}
+{"Get":{"state":"hello.\n\n\nˇworld.","mode":"Normal"}}
+{"Key":"("}
+{"Get":{"state":"hello.\n\nˇ\nworld.","mode":"Normal"}}
+{"Key":"("}
+{"Get":{"state":"ˇhello.\n\n\nworld.","mode":"Normal"}}

--- a/crates/vim/test_data/test_sentence_backwards.json
+++ b/crates/vim/test_data/test_sentence_backwards.json
@@ -8,3 +8,25 @@
 {"Get":{"state":"hello.\n\nˇ\nworld.","mode":"Normal"}}
 {"Key":"("}
 {"Get":{"state":"ˇhello.\n\n\nworld.","mode":"Normal"}}
+{"Put":{"state":"hello. worlˇd."}}
+{"Key":"("}
+{"Get":{"state":"hello. ˇworld.","mode":"Normal"}}
+{"Key":"("}
+{"Get":{"state":"ˇhello. world.","mode":"Normal"}}
+{"Put":{"state":". helˇlo."}}
+{"Key":"("}
+{"Get":{"state":". ˇhello.","mode":"Normal"}}
+{"Key":"("}
+{"Get":{"state":". ˇhello.","mode":"Normal"}}
+{"Put":{"state":"{\n    hello_world();\nˇ}"}}
+{"Key":"("}
+{"Get":{"state":"ˇ{\n    hello_world();\n}","mode":"Normal"}}
+{"Put":{"state":"Hello! World..?\n\n\tHello! World... ˇ"}}
+{"Key":"("}
+{"Get":{"state":"Hello! World..?\n\n\tHello! ˇWorld... ","mode":"Normal"}}
+{"Key":"("}
+{"Get":{"state":"Hello! World..?\n\n\tˇHello! World... ","mode":"Normal"}}
+{"Key":"("}
+{"Get":{"state":"Hello! World..?\nˇ\n\tHello! World... ","mode":"Normal"}}
+{"Key":"("}
+{"Get":{"state":"Hello! ˇWorld..?\n\n\tHello! World... ","mode":"Normal"}}

--- a/crates/vim/test_data/test_sentence_forwards.json
+++ b/crates/vim/test_data/test_sentence_forwards.json
@@ -1,0 +1,8 @@
+{"Put":{"state":"helˇlo.\n\n\nworld."}}
+{"Key":")"}
+{"Get":{"state":"hello.\nˇ\n\nworld.","mode":"Normal"}}
+{"Key":")"}
+{"Get":{"state":"hello.\n\n\nˇworld.","mode":"Normal"}}
+{"Key":")"}
+{"Get":{"state":"hello.\n\n\nworldˇ.","mode":"Normal"}}
+{"Put":{"state":"helˇlo.\n\n\nworld."}}

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -2,6 +2,8 @@
 
 Zed includes a vim emulation layer known as "vim mode". This document aims to describe how it works, and how to make the most out of it.
 
+  https://zed.dev/docs/vim
+
 ## Philosophy
 
 Vim mode in Zed is supposed to primarily "do what you expect": it mostly tries to copy vim exactly, but will use Zed-specific functionality when available to make things smoother.

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -2,8 +2,6 @@
 
 Zed includes a vim emulation layer known as "vim mode". This document aims to describe how it works, and how to make the most out of it.
 
-  https://zed.dev/docs/vim
-
 ## Philosophy
 
 Vim mode in Zed is supposed to primarily "do what you expect": it mostly tries to copy vim exactly, but will use Zed-specific functionality when available to make things smoother.


### PR DESCRIPTION
Closes #12161

Release Notes:

- vim: Added `(` and `)` for sentence motion
