### PR TITLE
docs: Update the example custom API URL for the Assistant

### DIFF
--- a/docs/src/assistant/configuration.md
+++ b/docs/src/assistant/configuration.md
@@ -214,7 +214,7 @@ To do so, add the following to your Zed `settings.json`:
 {
   "language_models": {
     "some-provider": {
-      "api_url": "http://localhost:11434/v1"
+      "api_url": "http://localhost:11434"
     }
   }
 }


### PR DESCRIPTION
This PR updates the docs showcasing how to use a custom API URL for the Assistant to only use a base URL (without a path).

Closes #17431.

Release Notes:

- N/A
