### PR TITLE
docs: Document configuring binary path for `clangd`

### DIFF
--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -5,6 +5,21 @@ C++ support is available natively in Zed.
 - Tree Sitter: [tree-sitter/tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp)
 - Language Server: [clangd/clangd](https://github.com/clangd/clangd)
 
-<--!
-TBD: Add some C++ Docs
--->
+## Binary
+
+You can configure which `clangd` binary Zed should use.
+
+To use a binary in a custom location, add the following to your `settings.json`:
+
+```json
+{
+  "lsp": {
+    "clangd": {
+      "binary": {
+        "path": "/path/to/clangd",
+        "args": []
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
This PR adds documentation for how to configure the binary path for `clangd`.

Release Notes:

- N/A
