### PR TITLE
docs: Add terminal.detect_venv; only detect venv with bin subdir

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -690,7 +690,7 @@
         // Default directories to search for virtual environments, relative
         // to the current working directory. We recommend overriding this
         // in your project's settings, rather than globally.
-        "directories": [".venv", "venv"],
+        "directories": [".env", "env", ".venv", "venv"],
         // Can also be `csh`, `fish`, and `nushell`
         "activate_script": "default"
       }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -690,7 +690,7 @@
         // Default directories to search for virtual environments, relative
         // to the current working directory. We recommend overriding this
         // in your project's settings, rather than globally.
-        "directories": [".env", "env", ".venv", "venv"],
+        "directories": [".venv", "venv"],
         // Can also be `csh`, `fish`, and `nushell`
         "activate_script": "default"
       }

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -264,7 +264,8 @@ impl Project {
             .into_iter()
             .map(|virtual_environment_name| abs_path.join(virtual_environment_name))
             .find(|venv_path| {
-                self.find_worktree(&venv_path, cx)
+                let bin_path = venv_path.join("bin");
+                self.find_worktree(&bin_path, cx)
                     .and_then(|(worktree, relative_path)| {
                         worktree.read(cx).entry_for_path(&relative_path)
                     })

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1582,7 +1582,7 @@ See Buffer Font Features
 - Setting: `detect_venv`
 - Default:
 
-```
+```json
 {
   "terminal":
     "detect_venv": {
@@ -1607,6 +1607,7 @@ Disable with:
     "detect_venv": "off"
   }
 }
+```
 
 ## Terminal: Toolbar
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1278,7 +1278,12 @@ List of `integer` column numbers
     "blinking": "terminal_controlled",
     "copy_on_select": false,
     "dock": "bottom",
-    "detect"
+    "detect_venv": {
+      "on": {
+        "directories": [".env", "env", ".venv", "venv"],
+        "activate_script": "default"
+      }
+    }
     "env": {},
     "font_family": null,
     "font_features": null,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -209,25 +209,6 @@ For example, to use `Nerd Font` as a fallback, add the following to your setting
 The `left_padding` and `right_padding` options define the relative width of the
 left and right padding of the central pane from the workspace when the centered layout mode is activated. Valid values range is from `0` to `0.4`.
 
-## Detect Virtual Environments {#detect_venv}
-
-- Decription: Settings for detecting [Python Virtual Environments](https://docs.python.org/3/library/venv.html).
-- Setting: `detect_venv`
-- Default:
-
-```
-"detect_venv": {
-  "on": {
-    // Default directories to search for virtual environments, relative
-    // to the current working directory. We recommend overriding this
-    // in your project's settings, rather than globally.
-    "directories": [".venv", "venv"],
-    // Can also be `csh`, `fish`, and `nushell`
-    "activate_script": "default"
-  }
-}
-```
-
 ## Direnv Integration
 
 - Description: Settings for [direnv](https://direnv.net/) integration. Requires `direnv` to be installed. `direnv` integration currently only means that the environment variables set by a `direnv` configuration can be used to detect some language servers in `$PATH` instead of installing them.
@@ -1297,6 +1278,7 @@ List of `integer` column numbers
     "blinking": "terminal_controlled",
     "copy_on_select": false,
     "dock": "bottom",
+    "detect"
     "env": {},
     "font_family": null,
     "font_features": null,
@@ -1588,6 +1570,38 @@ See Buffer Font Features
   }
 }
 ```
+
+## Terminal: Detect Virtual Environments {#terminal-detect_venv}
+
+- Decription: Activate the [Python Virtual Environment](https://docs.python.org/3/library/venv.html), if one is found, in the terminal's working directory (as resolved by the working_directory and automatically activating the virtual environemtn
+- Setting: `detect_venv`
+- Default:
+
+```
+{
+  "terminal":
+    "detect_venv": {
+      "on": {
+        // Default directories to search for virtual environments, relative
+        // to the current working directory. We recommend overriding this
+        // in your project's settings, rather than globally.
+        "directories": [".venv", "venv"],
+        // Can also be `csh`, `fish`, and `nushell`
+        "activate_script": "default"
+      }
+    }
+  }
+}
+```
+
+Disable with:
+
+```json
+{
+  "terminal":
+    "detect_venv": "off"
+  }
+}
 
 ## Terminal: Toolbar
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -209,6 +209,25 @@ For example, to use `Nerd Font` as a fallback, add the following to your setting
 The `left_padding` and `right_padding` options define the relative width of the
 left and right padding of the central pane from the workspace when the centered layout mode is activated. Valid values range is from `0` to `0.4`.
 
+## Detect Virtual Environments {#detect_venv}
+
+- Decription: Settings for detecting [Python Virtual Environments](https://docs.python.org/3/library/venv.html).
+- Setting: `detect_venv`
+- Default:
+
+```
+"detect_venv": {
+  "on": {
+    // Default directories to search for virtual environments, relative
+    // to the current working directory. We recommend overriding this
+    // in your project's settings, rather than globally.
+    "directories": [".venv", "venv"],
+    // Can also be `csh`, `fish`, and `nushell`
+    "activate_script": "default"
+  }
+}
+```
+
 ## Direnv Integration
 
 - Description: Settings for [direnv](https://direnv.net/) integration. Requires `direnv` to be installed. `direnv` integration currently only means that the environment variables set by a `direnv` configuration can be used to detect some language servers in `$PATH` instead of installing them.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1578,7 +1578,7 @@ See Buffer Font Features
 
 ## Terminal: Detect Virtual Environments {#terminal-detect_venv}
 
-- Decription: Activate the [Python Virtual Environment](https://docs.python.org/3/library/venv.html), if one is found, in the terminal's working directory (as resolved by the working_directory and automatically activating the virtual environemtn
+- Description: Activate the [Python Virtual Environment](https://docs.python.org/3/library/venv.html), if one is found, in the terminal's working directory (as resolved by the working_directory and automatically activating the virtual environemtn
 - Setting: `detect_venv`
 - Default:
 

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -100,10 +100,10 @@ The Pyright language server does not provide code formatting or linting. If you 
 
 A common tool for formatting Python code is [Ruff](https://docs.astral.sh/ruff/). It is another tool written in Rust, an extremely fast Python linter and code formatter. It is available through the [Ruff extension](https://github.com/zed-industries/zed/tree/main/extensions/ruff/). To configure the Ruff extension to work within Zed, see the setup documentation [here](https://docs.astral.sh/ruff/editors/setup/#zed).
 
-## Virtual Environments in the Terminal {#terminal-venv}
+## Virtual Environments in the Terminal {#terminal-detect_venv}
 
 Zed will also detect virtual enviornments and automatically activate them in terminal if available.
-See: [detect_venv documentation](https://zed.dev/docs/configuring-zed#detect_venv) for more.
+See: [detect_venv documentation](https://zed.dev/docs/configuring-zed#terminal-detect_venv) for more.
 
 <!--
 TBD: Expand Python Ruff docs.

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -100,6 +100,11 @@ The Pyright language server does not provide code formatting or linting. If you 
 
 A common tool for formatting Python code is [Ruff](https://docs.astral.sh/ruff/). It is another tool written in Rust, an extremely fast Python linter and code formatter. It is available through the [Ruff extension](https://github.com/zed-industries/zed/tree/main/extensions/ruff/). To configure the Ruff extension to work within Zed, see the setup documentation [here](https://docs.astral.sh/ruff/editors/setup/#zed).
 
+## Virtual Environments in the Terminal {#terminal-venv}
+
+Zed will also detect virtual enviornments and automatically activate them in terminal if available.
+See: [detect_venv documentation](https://zed.dev/docs/configuring-zed#detect_venv) for more.
+
 <!--
 TBD: Expand Python Ruff docs.
 TBD: Ruff pyproject.toml, ruff.toml docs. `ruff.configuration`.

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -102,7 +102,7 @@ A common tool for formatting Python code is [Ruff](https://docs.astral.sh/ruff/)
 
 ## Virtual Environments in the Terminal {#terminal-detect_venv}
 
-Zed will also detect virtual enviornments and automatically activate them in terminal if available.
+Zed will also detect virtual environments and automatically activate them in terminal if available.
 See: [detect_venv documentation](https://zed.dev/docs/configuring-zed#terminal-detect_venv) for more.
 
 <!--


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17420

- Add docs for terminal.detect_venv
- Only detect venv with bin subdir

Previously: 
- https://github.com/zed-industries/zed/pull/15989

Release Notes:

- N/A