### PR TITLE
chore: Bump Rust to 1.81

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 
-FROM rust:1.80-bookworm as builder
+FROM rust:1.81-bookworm as builder
 WORKDIR app
 COPY . .
 

--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -24,7 +24,7 @@ use wit_component::ComponentEncoder;
 ///
 /// Once Rust 1.78 is released, there will be a `wasm32-wasip2` target available, so we will
 /// not need the adapter anymore.
-const RUST_TARGET: &str = "wasm32-wasi";
+const RUST_TARGET: &str = "wasm32-wasip1";
 const WASI_ADAPTER_URL: &str =
     "https://github.com/bytecodealliance/wasmtime/releases/download/v18.0.2/wasi_snapshot_preview1.reactor.wasm";
 
@@ -158,7 +158,7 @@ impl ExtensionBuilder {
             &cargo_toml
                 .package
                 .name
-                // The wasm32-wasi target normalizes `-` in package names to `_` in the resulting `.wasm` file.
+                // The wasm32-wasip1 target normalizes `-` in package names to `_` in the resulting `.wasm` file.
                 .replace('-', "_"),
         ]);
         wasm_path.set_extension("wasm");

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -26,7 +26,7 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 - Install the Rust wasm toolchain:
 
   ```sh
-  rustup target add wasm32-wasi
+  rustup target add wasm32-wasip1
   ```
 
 ## Backend Dependencies

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -17,7 +17,7 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 - Install the Rust wasm toolchain:
 
   ```sh
-  rustup target add wasm32-wasi
+  rustup target add wasm32-wasip1
   ```
 
 - Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional component `MSVC v*** - VS YYYY C++ x64/x86 build tools` (`v***` is your VS version and `YYYY` is year when your VS was released)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "1.81"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
-targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi", "x86_64-pc-windows-msvc" ]
+targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasip1", "x86_64-pc-windows-msvc" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80"
+channel = "1.81"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "wasm32-wasi", "x86_64-pc-windows-msvc" ]


### PR DESCRIPTION
Blocked on https://github.com/rust-lang/docker-rust/pull/210

Release Notes:

- N/A
