### PR TITLE
vim: Add :y

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -21,7 +21,7 @@ use crate::{
         JoinLines,
     },
     state::Mode,
-    visual::VisualDeleteLine,
+    visual::{VisualDeleteLine, VisualYankLine},
     Vim,
 };
 
@@ -587,6 +587,7 @@ fn generate_commands(_: &AppContext) -> Vec<VimCommand> {
         VimCommand::new(("lN", "ext"), editor::actions::GoToPrevDiagnostic).count(),
         VimCommand::new(("j", "oin"), JoinLines).range(),
         VimCommand::new(("d", "elete"), VisualDeleteLine).range(),
+        VimCommand::new(("y", "ank"), VisualYankLine).range(),
         VimCommand::new(("sor", "t"), SortLinesCaseSensitive).range(),
         VimCommand::new(("sort i", ""), SortLinesCaseInsensitive).range(),
         VimCommand::str(("E", "xplore"), "project_panel::ToggleFocus"),

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -30,6 +30,7 @@ actions!(
         VisualDelete,
         VisualDeleteLine,
         VisualYank,
+        VisualYankLine,
         OtherEnd,
         SelectNext,
         SelectPrevious,
@@ -58,7 +59,12 @@ pub fn register(editor: &mut Editor, cx: &mut ViewContext<Vim>) {
         vim.record_current_action(cx);
         vim.visual_delete(true, cx);
     });
-    Vim::action(editor, cx, |vim, _: &VisualYank, cx| vim.visual_yank(cx));
+    Vim::action(editor, cx, |vim, _: &VisualYank, cx| {
+        vim.visual_yank(false, cx)
+    });
+    Vim::action(editor, cx, |vim, _: &VisualYankLine, cx| {
+        vim.visual_yank(true, cx)
+    });
 
     Vim::action(editor, cx, Vim::select_next);
     Vim::action(editor, cx, Vim::select_previous);
@@ -440,10 +446,11 @@ impl Vim {
         self.switch_mode(Mode::Normal, true, cx);
     }
 
-    pub fn visual_yank(&mut self, cx: &mut ViewContext<Self>) {
+    pub fn visual_yank(&mut self, line_mode: bool, cx: &mut ViewContext<Self>) {
         self.store_visual_marks(cx);
         self.update_editor(cx, |vim, editor, cx| {
-            let line_mode = editor.selections.line_mode;
+            let line_mode = line_mode || editor.selections.line_mode;
+            editor.selections.line_mode = line_mode;
             vim.yank_selections_content(editor, line_mode, cx);
             editor.change_selections(None, cx, |s| {
                 s.move_with(|map, selection| {
@@ -613,7 +620,7 @@ impl Vim {
                 self.stop_recording(cx);
                 self.visual_delete(false, cx)
             }
-            Some(Operator::Yank) => self.visual_yank(cx),
+            Some(Operator::Yank) => self.visual_yank(false, cx),
             _ => {} // Ignoring other operators
         }
     }


### PR DESCRIPTION
Closes #16937
Updates #17397

Release Notes:

- vim: Add `:y[ank]` 
