### PR TITLE
docs: Use relative Markdown links

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -103,7 +103,7 @@ A common tool for formatting Python code is [Ruff](https://docs.astral.sh/ruff/)
 ## Virtual Environments in the Terminal {#terminal-detect_venv}
 
 Zed will also detect virtual environments and automatically activate them in terminal if available.
-See: [detect_venv documentation](https://zed.dev/docs/configuring-zed#terminal-detect_venv) for more.
+See: [detect_venv documentation](../configuring-zed.md#terminal-detect_venv) for more.
 
 <!--
 TBD: Expand Python Ruff docs.

--- a/docs/src/telemetry.md
+++ b/docs/src/telemetry.md
@@ -31,7 +31,7 @@ Telemetry is sent from the application to our servers. Data is proxied through o
 
 Diagnostic events include debug information (stack traces) from crash reports. Reports are sent on the first application launch after the crash occurred. We've built dashboards that allow us to visualize the frequency and severity of issues experienced by users. Having these reports sent automatically allows us to begin implementing fixes without the user needing to file a report in our issue tracker. The plots in the dashboards also give us an informal measurement of the stability of Zed.
 
-You can see what data is sent when a panic occurs by inspecting the `Panic` struct in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L184) in the zed repo. You can find additional information in the [Debugging Crashes](https://zed.dev/docs/development/debugging-crashes) documentation.
+You can see what data is sent when a panic occurs by inspecting the `Panic` struct in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L184) in the zed repo. You can find additional information in the [Debugging Crashes](./development/debugging-crashes.md) documentation.
 
 ### Usage Data (Metrics) {#metrics}
 


### PR DESCRIPTION
This PR updates some links in the docs to use relative Markdown links instead of absolute links.

This way the links work when running the docs locally.

Release Notes:

- N/A
