### PR TITLE
vim: Add more diff stuff

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -321,6 +321,8 @@
       "ctrl-t": "vim::Indent",
       "ctrl-d": "vim::Outdent",
       "ctrl-k": ["vim::PushOperator", { "Digraph": {} }],
+      "ctrl-p": "editor::ShowCompletions",
+      "ctrl-n": "editor::ShowCompletions",
       "ctrl-r": ["vim::PushOperator", "Register"]
     }
   },
@@ -392,7 +394,9 @@
     "context": "vim_operator == d",
     "bindings": {
       "d": "vim::CurrentLine",
-      "s": ["vim::PushOperator", "DeleteSurrounds"]
+      "s": ["vim::PushOperator", "DeleteSurrounds"],
+      "o": "editor::ToggleHunkDiff", // "d o"
+      "p": "editor::RevertSelectedHunks" // "d p"
     }
   },
   {

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -586,6 +586,8 @@ fn generate_commands(_: &AppContext) -> Vec<VimCommand> {
         VimCommand::new(("lp", "revious"), editor::actions::GoToPrevDiagnostic).count(),
         VimCommand::new(("lN", "ext"), editor::actions::GoToPrevDiagnostic).count(),
         VimCommand::new(("j", "oin"), JoinLines).range(),
+        VimCommand::new(("dif", "fupdate"), editor::actions::ToggleHunkDiff).range(),
+        VimCommand::new(("rev", "ert"), editor::actions::RevertSelectedHunks).range(),
         VimCommand::new(("d", "elete"), VisualDeleteLine).range(),
         VimCommand::new(("sor", "t"), SortLinesCaseSensitive).range(),
         VimCommand::new(("sort i", ""), SortLinesCaseInsensitive).range(),


### PR DESCRIPTION
Release Notes:

- vim: Added `:diff` and `:revert` (that work with `'<,'>`) to open the selected diff and revert it.
- vim: Added `d o` to open the diff and `d p` to revert (spiritually similar to vim's do/dp, though obviously not the same)
- vim: Added `ctrl-p` and `ctrl-n` to summon the autocomplete menu in insert mode.
