### PR TITLE
Update C++ Tree-sitter queries

### DIFF
--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -1,9 +1,32 @@
 (identifier) @variable
 (field_identifier) @property
+(namespace_identifier) @namespace
 
 (call_expression
   function: (qualified_identifier
     name: (identifier) @function))
+
+(call_expression
+  (qualified_identifier
+    (identifier) @function.call))
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (identifier) @function.call)))
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function.call))))
+
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function.call)))) @_parent
+  (#has-ancestor? @_parent call_expression))
 
 (call_expression
   function: (identifier) @function)


### PR DESCRIPTION

Closes #16443 

Release Notes:

- Fixed C++ functions being wrongly tagged as variables when called after two or more scope resolution operators.
- Added a "namespace" tag for highlighting purposes

Before : 
![image](https://github.com/user-attachments/assets/743b8407-4e62-4549-9c6a-ed6608ea7e43)
After : 
![image](https://github.com/user-attachments/assets/de563621-e722-463c-97a1-a99b925f126e)

