### PR TITLE
Revert "Improve Python syntax highlighting (#12868)"

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -1,24 +1,5 @@
-(parameter (identifier) @variable)
 (attribute attribute: (identifier) @property)
 (type (identifier) @type)
-
-; Module imports
-
-(import_statement
-  (dotted_name (identifier) @type))
-
-(import_statement
-  (aliased_import
-    name: (dotted_name (identifier) @type)
-    alias: (identifier) @type))
-
-(import_from_statement
-  (dotted_name (identifier) @type))
-
-(import_from_statement
-  (aliased_import
-    name: (dotted_name (identifier) @type)
-    alias: (identifier) @type))
 
 ; Function calls
 
@@ -63,13 +44,9 @@
   (float)
 ] @number
 
-; Self references
-
-[
-  (parameters (identifier) @variable.special)
-  (attribute (identifier) @variable.special)
-  (#match? @variable.special "^self$")
-]
+; Variables
+(assignment
+  left: (identifier) @variable)
 
 (comment) @comment
 (string) @string


### PR DESCRIPTION
This reverts commit ba59e6631474899e8b61075a16351770743ebd83 because

- it's wrong to highlight import names as `type`, they are variables/functions, not types necessarily
- I don't like highlighting arguments in a function definition as `variable`
- I personally don't like highlighting `self`, VS Code doesn't do it either

Works on #14892