### PR TITLE
Allow spaces in range queries

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -628,7 +628,7 @@ pub fn command_interceptor(mut input: &str, cx: &AppContext) -> Option<CommandIn
 
     let (range, query) = VimCommand::parse_range(input);
     let range_prefix = input[0..(input.len() - query.len())].to_string();
-    let query = query.as_str();
+    let query = query.as_str().trim();
 
     let action = if range.is_some() && query == "" {
         Some(


### PR DESCRIPTION
Updates #17397

Release Notes:

- vim: Fixed parsing of commands with ranges `:3 d`.
