### PR TITLE
Revert "Refactor lsp store (#17435)"

### DIFF
--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -688,7 +688,7 @@ impl LspLogView {
                 self.project
                     .read(cx)
                     .supplementary_language_servers(cx)
-                    .filter_map(|(server_id, name)| {
+                    .filter_map(|(&server_id, name)| {
                         let state = log_store.language_servers.get(&server_id)?;
                         Some(LogMenuItem {
                             server_id,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -643,13 +643,16 @@ impl Project {
 
             let environment = ProjectEnvironment::new(&worktree_store, env, cx);
             let lsp_store = cx.new_model(|cx| {
-                LspStore::new_local(
+                LspStore::new(
                     buffer_store.clone(),
                     worktree_store.clone(),
-                    environment.clone(),
+                    Some(environment.clone()),
                     languages.clone(),
                     Some(client.http_client()),
                     fs.clone(),
+                    None,
+                    None,
+                    None,
                     cx,
                 )
             });
@@ -709,89 +712,16 @@ impl Project {
         fs: Arc<dyn Fs>,
         cx: &mut AppContext,
     ) -> Model<Self> {
-        cx.new_model(|cx: &mut ModelContext<Self>| {
-            let (tx, rx) = mpsc::unbounded();
-            cx.spawn(move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx))
-                .detach();
-            let tasks = Inventory::new(cx);
-            let global_snippets_dir = paths::config_dir().join("snippets");
-            let snippets =
-                SnippetProvider::new(fs.clone(), BTreeSet::from_iter([global_snippets_dir]), cx);
-
-            let worktree_store = cx.new_model(|_| {
-                let mut worktree_store = WorktreeStore::new(false, fs.clone());
-                worktree_store.set_upstream_client(ssh.clone().into());
-                worktree_store
-            });
-            cx.subscribe(&worktree_store, Self::on_worktree_store_event)
-                .detach();
-
-            let buffer_store =
-                cx.new_model(|cx| BufferStore::new(worktree_store.clone(), None, cx));
-            cx.subscribe(&buffer_store, Self::on_buffer_store_event)
-                .detach();
-
-            let settings_observer = cx.new_model(|cx| {
-                SettingsObserver::new_ssh(ssh.clone().into(), worktree_store.clone(), cx)
-            });
-
-            let environment = ProjectEnvironment::new(&worktree_store, None, cx);
-            let lsp_store = cx.new_model(|cx| {
-                LspStore::new_remote(
-                    buffer_store.clone(),
-                    worktree_store.clone(),
-                    languages.clone(),
-                    ssh.clone().into(),
-                    0,
-                    cx,
-                )
-            });
-            cx.subscribe(&lsp_store, Self::on_lsp_store_event).detach();
-
-            let this = Self {
-                buffer_ordered_messages_tx: tx,
-                collaborators: Default::default(),
-                worktree_store,
-                buffer_store,
-                lsp_store,
-                current_lsp_settings: ProjectSettings::get_global(cx).lsp.clone(),
-                join_project_response_message_id: 0,
-                client_state: ProjectClientState::Local,
-                client_subscriptions: Vec::new(),
-                _subscriptions: vec![
-                    cx.observe_global::<SettingsStore>(Self::on_settings_changed),
-                    cx.on_release(Self::release),
-                ],
-                active_entry: None,
-                snippets,
-                languages,
-                client,
-                user_store,
-                settings_observer,
-                fs,
-                ssh_session: Some(ssh.clone()),
-                buffers_needing_diff: Default::default(),
-                git_diff_debouncer: DebouncedDelay::new(),
-                terminals: Terminals {
-                    local_handles: Vec::new(),
-                },
-                node: Some(node),
-                default_prettier: DefaultPrettier::default(),
-                prettiers_per_worktree: HashMap::default(),
-                prettier_instances: HashMap::default(),
-                tasks,
-                hosted_project_id: None,
-                dev_server_project_id: None,
-                search_history: Self::new_search_history(),
-                environment,
-                remotely_created_buffers: Default::default(),
-                last_formatting_failure: None,
-                buffers_being_formatted: Default::default(),
-                search_included_history: Self::new_search_history(),
-                search_excluded_history: Self::new_search_history(),
-            };
-
+        let this = Self::local(client, node, user_store, languages, fs, None, cx);
+        this.update(cx, |this, cx| {
             let client: AnyProtoClient = ssh.clone().into();
+
+            this.worktree_store.update(cx, |store, _cx| {
+                store.set_upstream_client(client.clone());
+            });
+            this.settings_observer = cx.new_model(|cx| {
+                SettingsObserver::new_ssh(ssh.clone().into(), this.worktree_store.clone(), cx)
+            });
 
             ssh.subscribe_to_entity(SSH_PROJECT_ID, &cx.handle());
             ssh.subscribe_to_entity(SSH_PROJECT_ID, &this.buffer_store);
@@ -805,8 +735,9 @@ impl Project {
             LspStore::init(&client);
             SettingsObserver::init(&client);
 
-            this
-        })
+            this.ssh_session = Some(ssh);
+        });
+        this
     }
 
     pub async fn remote(
@@ -889,12 +820,16 @@ impl Project {
             cx.new_model(|cx| BufferStore::new(worktree_store.clone(), Some(remote_id), cx))?;
 
         let lsp_store = cx.new_model(|cx| {
-            let mut lsp_store = LspStore::new_remote(
+            let mut lsp_store = LspStore::new(
                 buffer_store.clone(),
                 worktree_store.clone(),
+                None,
                 languages.clone(),
-                client.clone().into(),
-                remote_id,
+                Some(client.http_client()),
+                fs.clone(),
+                None,
+                Some(client.clone().into()),
+                Some(remote_id),
                 cx,
             );
             lsp_store.set_language_server_statuses_from_proto(response.payload.language_servers);
@@ -4850,7 +4785,7 @@ impl Project {
     pub fn supplementary_language_servers<'a>(
         &'a self,
         cx: &'a AppContext,
-    ) -> impl '_ + Iterator<Item = (LanguageServerId, LanguageServerName)> {
+    ) -> impl '_ + Iterator<Item = (&'a LanguageServerId, &'a LanguageServerName)> {
         self.lsp_store.read(cx).supplementary_language_servers()
     }
 

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -57,17 +57,18 @@ impl HeadlessProject {
         });
         let environment = project::ProjectEnvironment::new(&worktree_store, None, cx);
         let lsp_store = cx.new_model(|cx| {
-            let mut lsp_store = LspStore::new_local(
+            LspStore::new(
                 buffer_store.clone(),
                 worktree_store.clone(),
-                environment,
+                Some(environment),
                 languages,
                 None,
                 fs.clone(),
+                Some(session.clone().into()),
+                None,
+                Some(0),
                 cx,
-            );
-            lsp_store.shared(SSH_PROJECT_ID, session.clone().into(), cx);
-            lsp_store
+            )
         });
 
         let client: AnyProtoClient = session.clone().into();


### PR DESCRIPTION
This reverts commit 8a1e8e37bb659e261526d7d5d6340840294cf290 (PR #17435) because it creates a panic when joining a collab project.

Stack trace of the panic:

```
Thread "main" panicked with "ProjectLspAdapterDelegate cannot be constructedd on an ssh-remote yet" at crates/project/src/lsp_store.rs:6332:13
   0: backtrace::backtrace::libunwind::trace
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/libunwind.rs:116:5
      backtrace::backtrace::trace_unsynchronized::<<backtrace::capture::Backtrace>::create::{closure#0}>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/mod.rs:66:5
   1: backtrace::backtrace::trace::<<backtrace::capture::Backtrace>::create::{closure#0}>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/mod.rs:53:14
   2: <backtrace::capture::Backtrace>::create
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/capture.rs:197:9
   3: <backtrace::capture::Backtrace>::new
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/capture.rs:162:22
   4: zed::reliability::init_panic_hook::{closure#0}
             at /Users/thorstenball/work/zed/crates/zed/src/reliability.rs:58:29
   5: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/boxed.rs:2084:9
      std::panicking::rust_panic_with_hook
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:808:13
   6: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:667:13
   7: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:168:18
   8: rust_begin_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:665:5
   9: core::panicking::panic_fmt
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:74:14
  10: <project::lsp_store::ProjectLspAdapterDelegate>::new
             at /Users/thorstenball/work/zed/crates/project/src/lsp_store.rs:6332:13
  11: assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}::{closure#1}
             at /Users/thorstenball/work/zed/crates/assistant/src/assistant_panel.rs:5159:16
  12: <gpui::app::AppContext as gpui::Context>::update_model::<project::lsp_store::LspStore, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}::{closure#1}>::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1365:26
  13: <gpui::app::AppContext>::update::<core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, <gpui::app::AppContext as gpui::Context>::update_model<project::lsp_store::LspStore, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}::{closure#1}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:362:22
  14: <gpui::app::AppContext as gpui::Context>::update_model::<project::lsp_store::LspStore, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}::{closure#1}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1363:9
  15: <gpui::app::model_context::ModelContext<project::Project> as gpui::Context>::update_model::<project::lsp_store::LspStore, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}::{closure#1}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/model_context.rs:250:9
  16: <gpui::app::entity_map::Model<project::lsp_store::LspStore>>::update::<gpui::app::model_context::ModelContext<project::Project>, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}::{closure#1}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/entity_map.rs:422:9
  17: assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}
             at /Users/thorstenball/work/zed/crates/assistant/src/assistant_panel.rs:5158:9
  18: <gpui::app::AppContext as gpui::Context>::update_model::<project::Project, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}>::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1365:26
  19: <gpui::app::AppContext>::update::<core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, <gpui::app::AppContext as gpui::Context>::update_model<project::Project, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:362:22
  20: <gpui::app::AppContext as gpui::Context>::update_model::<project::Project, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1363:9
  21: <gpui::app::entity_map::Model<project::Project>>::update::<gpui::app::AppContext, core::result::Result<alloc::sync::Arc<dyn language::LspAdapterDelegate>, anyhow::Error>, assistant::assistant_panel::make_lsp_adapter_delegate::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/entity_map.rs:422:9
  22: assistant::assistant_panel::make_lsp_adapter_delegate
             at /Users/thorstenball/work/zed/crates/assistant/src/assistant_panel.rs:5152:5
  23: <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}
             at /Users/thorstenball/work/zed/crates/assistant/src/assistant_panel.rs:960:48
  24: <gpui::window::WindowContext as gpui::VisualContext>::update_view::<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:3940:22
  25: <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view::<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/app/async_context.rs:387:35
  26: <gpui::app::AppContext as gpui::Context>::update_window::<core::result::Result<(), anyhow::Error>, <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>::{closure#0}>::{closure#0}
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1396:26
  27: <gpui::app::AppContext>::update::<core::result::Result<core::result::Result<(), anyhow::Error>, anyhow::Error>, <gpui::app::AppContext as gpui::Context>::update_window<core::result::Result<(), anyhow::Error>, <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:362:22
  28: <gpui::app::AppContext as gpui::Context>::update_window::<core::result::Result<(), anyhow::Error>, <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:1387:9
  29: <gpui::app::async_context::AsyncAppContext as gpui::Context>::update_window::<core::result::Result<(), anyhow::Error>, <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/async_context.rs:91:9
  30: <gpui::app::async_context::AsyncWindowContext as gpui::Context>::update_window::<core::result::Result<(), anyhow::Error>, <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/async_context.rs:354:9
  31: <gpui::window::AnyWindowHandle>::update::<gpui::app::async_context::AsyncWindowContext, core::result::Result<(), anyhow::Error>, <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/window.rs:4800:9
  32: <gpui::app::async_context::AsyncWindowContext as gpui::VisualContext>::update_view::<assistant::assistant_panel::AssistantPanel, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app/async_context.rs:386:9
  33: <gpui::view::View<assistant::assistant_panel::AssistantPanel>>::update::<gpui::app::async_context::AsyncWindowContext, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/view.rs:76:9
  34: <gpui::view::WeakView<assistant::assistant_panel::AssistantPanel>>::update::<gpui::app::async_context::AsyncWindowContext, core::result::Result<(), anyhow::Error>, <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}::{closure#0}>
             at /Users/thorstenball/work/zed/crates/gpui/src/view.rs:192:12
  35: <assistant::assistant_panel::AssistantPanel>::new_context::{closure#1}::{closure#0}
             at /Users/thorstenball/work/zed/crates/assistant/src/assistant_panel.rs:957:17
  36: <core::pin::Pin<alloc::boxed::Box<dyn core::future::future::Future<Output = core::result::Result<(), anyhow::Error>>>> as core::future::future::Future>::poll
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/future/future.rs:123:9
  37: <<async_task::runnable::Builder<_>>::spawn_local::Checked<core::pin::Pin<alloc::boxed::Box<dyn core::future::future::Future<Output = core::result::Result<(), anyhow::Error>>>>> as core::future::future::Future>::poll
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-task-4.7.1/src/runnable.rs:455:26
  38: <async_task::raw::RawTask<<async_task::runnable::Builder<_>>::spawn_local::Checked<core::pin::Pin<alloc::boxed::Box<dyn core::future::future::Future<Output = core::result::Result<(), anyhow::Error>>>>>, core::result::Result<(), anyhow::Error>, <gpui::executor::ForegroundExecutor>::spawn::inner<core::result::Result<(), anyhow::Error>>::{closure#0}, ()>>::run
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-task-4.7.1/src/raw.rs:557:17
  39: <async_task::runnable::Runnable>::run
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-task-4.7.1/src/runnable.rs:781:18
  40: gpui::platform::mac::dispatcher::trampoline
             at /Users/thorstenball/work/zed/crates/gpui/src/platform/mac/dispatcher.rs:106:5
  41: <unknown>
  42: <unknown>
  43: <unknown>
  44: <unknown>
  45: <unknown>
  46: <unknown>
  47: <unknown>
  48: <unknown>
  49: <unknown>
  50: <unknown>
  51: <unknown>
  52: <unknown>
  53: <() as objc::message::MessageArguments>::invoke::<()>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/mod.rs:128:17
  54: objc::message::platform::send_unverified::<objc::runtime::Object, (), ()>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/apple/mod.rs:27:9
  55: objc::message::send_message::<objc::runtime::Object, (), ()>
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/objc-0.2.7/src/message/mod.rs:178:5
      <*mut objc::runtime::Object as cocoa::appkit::NSApplication>::run
             at /Users/thorstenball/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cocoa-0.26.0/src/appkit.rs:628:9
  56: <gpui::platform::mac::platform::MacPlatform as gpui::platform::Platform>::run
             at /Users/thorstenball/work/zed/crates/gpui/src/platform/mac/platform.rs:427:13
  57: <gpui::app::App>::run::<zed::main::{closure#3}>
             at /Users/thorstenball/work/zed/crates/gpui/src/app.rs:159:9
  58: zed::main
             at /Users/thorstenball/work/zed/crates/zed/src/main.rs:439:5
  59: <fn() as core::ops::function::FnOnce<()>>::call_once
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/ops/function.rs:250:5
  60: std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:152:18
  61: std::rt::lang_start::<()>::{closure#0}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:162:18
  62: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/ops/function.rs:284:13
      std::panicking
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:557:40
      std::panicking::try
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:521:19
      std::panic::catch_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panic.rs:350:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:141:48
      std::panicking::try::do_call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:557:40
      std::panicking::try
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:521:19
      std::panic::catch_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panic.rs:350:14
      std::rt::lang_start_internal
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:141:20
  63: std::rt::lang_start::<()>
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/rt.rs:161:17
  64: _main
```

Release Notes:

- N/A
