### PR TITLE
assistant: Support copy/pasting creases

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3292,7 +3292,7 @@ impl ContextEditor {
                     .snapshot(cx)
                     .crease_snapshot
                     .creases_in_range(
-                        MultiBufferRow(selection.start.row)..MultiBufferRow(selection.end.row),
+                        MultiBufferRow(selection.start.row)..MultiBufferRow(selection.end.row + 1),
                         &snapshot,
                     )
                     .filter_map(|crease| {

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3443,7 +3443,7 @@ impl ContextEditor {
                                     constrain_width: false,
                                     render: render_fold_icon_button(
                                         weak_editor.clone(),
-                                        metadata.crease.icon.clone(),
+                                        metadata.crease.icon,
                                         metadata.crease.label.clone(),
                                     ),
                                     merge_adjacent: false,

--- a/crates/editor/src/display_map/crease_map.rs
+++ b/crates/editor/src/display_map/crease_map.rs
@@ -1,10 +1,11 @@
 use collections::HashMap;
 use gpui::{AnyElement, IntoElement};
 use multi_buffer::{Anchor, AnchorRangeExt, MultiBufferRow, MultiBufferSnapshot, ToPoint};
+use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, ops::Range, sync::Arc};
 use sum_tree::{Bias, SeekTarget, SumTree};
 use text::Point;
-use ui::WindowContext;
+use ui::{IconName, SharedString, WindowContext};
 
 use crate::FoldPlaceholder;
 
@@ -49,6 +50,31 @@ impl CreaseSnapshot {
         return None;
     }
 
+    pub fn creases_in_range<'a>(
+        &'a self,
+        range: Range<MultiBufferRow>,
+        snapshot: &'a MultiBufferSnapshot,
+    ) -> impl '_ + Iterator<Item = &'a Crease> {
+        let start = snapshot.anchor_before(Point::new(range.start.0, 0));
+        let mut cursor = self.creases.cursor::<ItemSummary>();
+        cursor.seek(&start, Bias::Left, snapshot);
+
+        std::iter::from_fn(move || {
+            while let Some(item) = cursor.item() {
+                cursor.next(snapshot);
+                let crease_start = item.crease.range.start.to_point(snapshot);
+                let crease_end = item.crease.range.end.to_point(snapshot);
+                if crease_end.row > range.end.0 {
+                    continue;
+                }
+                if crease_start.row >= range.start.0 && crease_end.row < range.end.0 {
+                    return Some(&item.crease);
+                }
+            }
+            None
+        })
+    }
+
     pub fn crease_items_with_offsets(
         &self,
         snapshot: &MultiBufferSnapshot,
@@ -87,6 +113,14 @@ pub struct Crease {
     pub placeholder: FoldPlaceholder,
     pub render_toggle: RenderToggleFn,
     pub render_trailer: RenderTrailerFn,
+    pub metadata: Option<CreaseMetadata>,
+}
+
+/// Metadata about a [`Crease`], that is used for serialization.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreaseMetadata {
+    pub icon: IconName,
+    pub label: SharedString,
 }
 
 impl Crease {
@@ -124,7 +158,13 @@ impl Crease {
             render_trailer: Arc::new(move |row, folded, cx| {
                 render_trailer(row, folded, cx).into_any_element()
             }),
+            metadata: None,
         }
+    }
+
+    pub fn with_metadata(mut self, metadata: CreaseMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
     }
 }
 
@@ -303,5 +343,55 @@ mod test {
         assert!(crease_snapshot
             .query_row(MultiBufferRow(3), &snapshot)
             .is_none());
+    }
+
+    #[gpui::test]
+    fn test_creases_in_range(cx: &mut AppContext) {
+        let text = "line1\nline2\nline3\nline4\nline5\nline6\nline7";
+        let buffer = MultiBuffer::build_simple(text, cx);
+        let snapshot = buffer.read_with(cx, |buffer, cx| buffer.snapshot(cx));
+        let mut crease_map = CreaseMap::default();
+
+        let creases = [
+            Crease::new(
+                snapshot.anchor_before(Point::new(1, 0))..snapshot.anchor_after(Point::new(1, 5)),
+                FoldPlaceholder::test(),
+                |_row, _folded, _toggle, _cx| div(),
+                |_row, _folded, _cx| div(),
+            ),
+            Crease::new(
+                snapshot.anchor_before(Point::new(3, 0))..snapshot.anchor_after(Point::new(3, 5)),
+                FoldPlaceholder::test(),
+                |_row, _folded, _toggle, _cx| div(),
+                |_row, _folded, _cx| div(),
+            ),
+            Crease::new(
+                snapshot.anchor_before(Point::new(5, 0))..snapshot.anchor_after(Point::new(5, 5)),
+                FoldPlaceholder::test(),
+                |_row, _folded, _toggle, _cx| div(),
+                |_row, _folded, _cx| div(),
+            ),
+        ];
+        crease_map.insert(creases, &snapshot);
+
+        let crease_snapshot = crease_map.snapshot();
+
+        let range = MultiBufferRow(0)..MultiBufferRow(7);
+        let creases: Vec<_> = crease_snapshot.creases_in_range(range, &snapshot).collect();
+        assert_eq!(creases.len(), 3);
+
+        let range = MultiBufferRow(2)..MultiBufferRow(5);
+        let creases: Vec<_> = crease_snapshot.creases_in_range(range, &snapshot).collect();
+        assert_eq!(creases.len(), 1);
+        assert_eq!(creases[0].range.start.to_point(&snapshot).row, 3);
+
+        let range = MultiBufferRow(0)..MultiBufferRow(2);
+        let creases: Vec<_> = crease_snapshot.creases_in_range(range, &snapshot).collect();
+        assert_eq!(creases.len(), 1);
+        assert_eq!(creases[0].range.start.to_point(&snapshot).row, 1);
+
+        let range = MultiBufferRow(6)..MultiBufferRow(7);
+        let creases: Vec<_> = crease_snapshot.creases_in_range(range, &snapshot).collect();
+        assert_eq!(creases.len(), 0);
     }
 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6666,8 +6666,33 @@ impl Editor {
     }
 
     pub fn cut(&mut self, _: &Cut, cx: &mut ViewContext<Self>) {
+        let (text, clipboard_selections) = self.clipboard_selections(cx);
+        let selections = self.selections.all::<Point>(cx);
+
+        self.transact(cx, |this, cx| {
+            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
+                s.select(selections);
+            });
+            this.insert("", cx);
+            cx.write_to_clipboard(ClipboardItem::new_string_with_json_metadata(
+                text,
+                clipboard_selections,
+            ));
+        });
+    }
+
+    pub fn copy(&mut self, _: &Copy, cx: &mut ViewContext<Self>) {
+        let (text, clipboard_selections) = self.clipboard_selections(cx);
+
+        cx.write_to_clipboard(ClipboardItem::new_string_with_json_metadata(
+            text,
+            clipboard_selections,
+        ));
+    }
+
+    fn clipboard_selections(&self, cx: &AppContext) -> (String, Vec<ClipboardSelection>) {
         let mut text = String::new();
-        let buffer = self.buffer.read(cx).snapshot(cx);
+        let buffer = self.buffer.read(cx).read(cx);
         let mut selections = self.selections.all::<Point>(cx);
         let mut clipboard_selections = Vec::with_capacity(selections.len());
         {
@@ -6699,58 +6724,7 @@ impl Editor {
                 });
             }
         }
-
-        self.transact(cx, |this, cx| {
-            this.change_selections(Some(Autoscroll::fit()), cx, |s| {
-                s.select(selections);
-            });
-            this.insert("", cx);
-            cx.write_to_clipboard(ClipboardItem::new_string_with_json_metadata(
-                text,
-                clipboard_selections,
-            ));
-        });
-    }
-
-    pub fn copy(&mut self, _: &Copy, cx: &mut ViewContext<Self>) {
-        let selections = self.selections.all::<Point>(cx);
-        let buffer = self.buffer.read(cx).read(cx);
-        let mut text = String::new();
-
-        let mut clipboard_selections = Vec::with_capacity(selections.len());
-        {
-            let max_point = buffer.max_point();
-            let mut is_first = true;
-            for selection in selections.iter() {
-                let mut start = selection.start;
-                let mut end = selection.end;
-                let is_entire_line = selection.is_empty() || self.selections.line_mode;
-                if is_entire_line {
-                    start = Point::new(start.row, 0);
-                    end = cmp::min(max_point, Point::new(end.row + 1, 0));
-                }
-                if is_first {
-                    is_first = false;
-                } else {
-                    text += "\n";
-                }
-                let mut len = 0;
-                for chunk in buffer.text_for_range(start..end) {
-                    text.push_str(chunk);
-                    len += chunk.len();
-                }
-                clipboard_selections.push(ClipboardSelection {
-                    len,
-                    is_entire_line,
-                    first_line_indent: buffer.indent_size_for_line(MultiBufferRow(start.row)).len,
-                });
-            }
-        }
-
-        cx.write_to_clipboard(ClipboardItem::new_string_with_json_metadata(
-            text,
-            clipboard_selections,
-        ));
+        (text, clipboard_selections)
     }
 
     pub fn do_paste(


### PR DESCRIPTION

https://github.com/user-attachments/assets/78a2572d-8e8f-4206-9680-dcd884e7bbbd

Release Notes:

- Added support for copying and pasting slash commands in the assistant panel
