### PR TITLE
Fix `Workspace` references being leaked

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -134,8 +134,11 @@ impl InlineAssistant {
         })
         .detach();
 
-        let workspace = workspace.clone();
+        let workspace = workspace.downgrade();
         cx.observe_global::<SettingsStore>(move |cx| {
+            let Some(workspace) = workspace.upgrade() else {
+                return;
+            };
             let Some(terminal_panel) = workspace.read(cx).panel::<TerminalPanel>(cx) else {
                 return;
             };


### PR DESCRIPTION
We noticed that the `Workspace` was never released (along with the `Project` and everything that comes along with that) when closing a window.

After playing around with the LeakDetector and debugging with `cx.on_release()` callbacks, we found two culprits: the inline assistant and the outline panel.

Both held strong references to `View<Workspace>` after PR #16589 and PR #16845.

This PR changes both references to `WeakView<Workspace>` which fixes the leak but keeps the behaviour the same.

Release Notes:

- Fixed a possible memory leak when closing Zed windows that wouldn't lead to associated resources being cleaned up correctly.
