### PR TITLE
Minor improvements to release tooling

### DIFF
--- a/script/get-changes-since
+++ b/script/get-changes-since
@@ -1,13 +1,23 @@
 #!/usr/bin/env node --redirect-warnings=/dev/null
 
 const { execFileSync } = require("child_process");
-const { GITHUB_ACCESS_TOKEN } = process.env;
+var { GITHUB_ACCESS_TOKEN } = process.env;
 const PR_REGEX = /#\d+/; // Ex: matches on #4241
 const FIXES_REGEX = /(fixes|closes|completes) (.+[/#]\d+.*)$/im;
 
 main();
 
 async function main() {
+  if (!GITHUB_ACCESS_TOKEN) {
+    try {
+      GITHUB_ACCESS_TOKEN = execFileSync("gh", ["auth", "token"]).toString();
+    } catch (error) {
+      console.log(error);
+      console.log("No GITHUB_ACCESS_TOKEN, and no `gh auth token`");
+      process.exit(1);
+    }
+  }
+
   // Use form of: YYYY-MM-DD - 2023-01-09
   const startDate = new Date(process.argv[2]);
   const today = new Date();

--- a/script/get-changes-since
+++ b/script/get-changes-since
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --redirect-warnings=/dev/null
 
 const { execFileSync } = require("child_process");
-var { GITHUB_ACCESS_TOKEN } = process.env;
+let { GITHUB_ACCESS_TOKEN } = process.env;
 const PR_REGEX = /#\d+/; // Ex: matches on #4241
 const FIXES_REGEX = /(fixes|closes|completes) (.+[/#]\d+.*)$/im;
 

--- a/script/get-preview-channel-changes
+++ b/script/get-preview-channel-changes
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --redirect-warnings=/dev/null
 
 const { execFileSync } = require("child_process");
-var { GITHUB_ACCESS_TOKEN } = process.env;
+let { GITHUB_ACCESS_TOKEN } = process.env;
 const GITHUB_URL = "https://github.com";
 const SKIPPABLE_NOTE_REGEX = /^\s*-?\s*n\/?a\s*/ims;
 const PULL_REQUEST_WEB_URL = "https://github.com/zed-industries/zed/pull";

--- a/script/get-preview-channel-changes
+++ b/script/get-preview-channel-changes
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --redirect-warnings=/dev/null
 
 const { execFileSync } = require("child_process");
-const { GITHUB_ACCESS_TOKEN } = process.env;
+var { GITHUB_ACCESS_TOKEN } = process.env;
 const GITHUB_URL = "https://github.com";
 const SKIPPABLE_NOTE_REGEX = /^\s*-?\s*n\/?a\s*/ims;
 const PULL_REQUEST_WEB_URL = "https://github.com/zed-industries/zed/pull";
@@ -12,6 +12,16 @@ const DIVIDER = "-".repeat(80);
 main();
 
 async function main() {
+  if (!GITHUB_ACCESS_TOKEN) {
+    try {
+      GITHUB_ACCESS_TOKEN = execFileSync("gh", ["auth", "token"]).toString();
+    } catch (error) {
+      console.log(error);
+      console.log("No GITHUB_ACCESS_TOKEN, and no `gh auth token`");
+      process.exit(1);
+    }
+  }
+
   const STAFF_MEMBERS = new Set(
     (
       await (
@@ -44,16 +54,6 @@ async function main() {
 
   // Print the previous release
   console.log(`Changes from ${oldTag} to ${newTag}\n`);
-
-  if (!GITHUB_ACCESS_TOKEN) {
-    try {
-      GITHUB_ACCESS_TOKEN = execFileSync("gh", ["auth", "token"]).toString();
-    } catch (error) {
-      console.log(error);
-      console.log("No GITHUB_ACCESS_TOKEN, and no `gh auth token`");
-      process.exit(1);
-    }
-  }
 
   // Get the PRs merged between those two tags.
   const pullRequestNumbers = getPullRequestNumbers(oldTag, newTag);

--- a/script/lib/bump-version.sh
+++ b/script/lib/bump-version.sh
@@ -30,7 +30,7 @@ Locally committed and tagged ${package} version ${new_version}
 
 To push this:
 
-    git push origin ${branch_name} ${tag_name}
+    git push origin ${tag_name} ${branch_name}
 
 To undo this:
 


### PR DESCRIPTION
- bump-version.sh: Push tag before branch; speeds up release action runs (built from tag).
- get-changes: Fetch GITHUB_ACCESS_TOKEN via `gh auth token` if env var unset.

Release Notes:

- N/A
