### PR TITLE
Ensure github-copilot config directory exists

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -1,10 +1,11 @@
+use std::fs;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::{sync::Arc, time::Duration};
 
+use ::fs::Fs;
 use anyhow::{anyhow, Result};
 use chrono::DateTime;
-use fs::Fs;
 use futures::{io::BufReader, stream::BoxStream, AsyncBufReadExt, AsyncReadExt, StreamExt};
 use gpui::{AppContext, AsyncAppContext, Global};
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
@@ -176,13 +177,16 @@ fn copilot_chat_config_path() -> &'static PathBuf {
     static COPILOT_CHAT_CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
 
     COPILOT_CHAT_CONFIG_DIR.get_or_init(|| {
-        if cfg!(target_os = "windows") {
+        let path = if cfg!(target_os = "windows") {
             home_dir().join("AppData").join("Local")
         } else {
             home_dir().join(".config")
         }
-        .join("github-copilot")
-        .join("hosts.json")
+        .join("github-copilot");
+
+        fs::create_dir_all(&path).expect("Failed to create copilot chat config directory");
+
+        path.join("hosts.json")
     })
 }
 


### PR DESCRIPTION
Closes #17501

Release Notes:

- Fixed a crash that could occur on launch when the GitHub Copilot configuration directory did not exist.

I'm not a rust expert, please tell me if anything is not good enough.