### PR TITLE
Fix parenthesis matching for file links in terminal

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -425,7 +425,7 @@ impl TerminalBuilder {
         // Optional suffix matches MSBuild diagnostic suffixes for path parsing in PathLikeWithPosition
         // https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks
         let word_regex =
-            RegexSearch::new(r#"[\$\+\w.\[\]:/\\@\-~]+(?:\((?:\d+|\d+,\d+)\))?"#).unwrap();
+            RegexSearch::new(r#"[\$\+\w.\[\]:/\\@\-~()]+(?:\((?:\d+|\d+,\d+)\))?"#).unwrap();
 
         let terminal = Terminal {
             task,


### PR DESCRIPTION
Closes #17391 

Release Notes:

- Fixed parenthesis matching for file links in terminal ([#17391](https://github.com/zed-industries/zed/issues/17391))
