### PR TITLE
docs: Add copywriting and design tweaks

### DIFF
--- a/docs/src/assistant/assistant-panel.md
+++ b/docs/src/assistant/assistant-panel.md
@@ -9,8 +9,6 @@ To open the assistant panel, toggle the right dock by using the {#action workspa
 
 Once you have [configured a provider](./configuration.md#providers), you can interact with the provider's language models in a context editor.
 
-![](https://private-user-images.githubusercontent.com/1714999/359287532-abd8f918-e65f-44ce-a853-1e90f852e206.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjQxMDk2OTIsIm5iZiI6MTcyNDEwOTM5MiwicGF0aCI6Ii8xNzE0OTk5LzM1OTI4NzUzMi1hYmQ4ZjkxOC1lNjVmLTQ0Y2UtYTg1My0xZTkwZjg1MmUyMDYucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDgxOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA4MTlUMjMxNjMyWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MDhlMjZhMjI0NjM3M2JiZmEzMWU5ZWIwYWRjZjhkNTI3NTkyM2JlNmNjODcyMjg3YjkxNjIxNmI5ZTk1ZWRjZCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.NiiQkF65VvBKCJs_zNxmjpyvKGK6Hw1aIWA3Xc87XRs)
-
 To create a new context editor, press {#kb workspace::NewFile} or use the menu in the top right of the assistant panel and select the `New Context` option.
 
 In the context editor, select a model from one of the configured providers, type a message in the `You` block, and submit with {#kb assistant::Assist}.
@@ -49,7 +47,7 @@ Simple back-and-forth conversations work well with the assistant. However, there
 
 ### Editing a Context
 
-> **Note**: Wondering about Context vs Conversation? [Read more here](./contexts.md).
+> **Note**: Wondering about Context vs. Conversation? [Read more here](./contexts.md).
 
 The assistant gives you the flexibility to have control over the context. You can freely edit any previous text, including the responses from the assistant. If you want to remove a message block entirely, simply place your cursor at the beginning of the block and use the `delete` key. A typical workflow might involve making edits and adjustments throughout the context to refine your inquiry or provide additional information. Here's an example:
 

--- a/docs/src/code-of-conduct.md
+++ b/docs/src/code-of-conduct.md
@@ -114,15 +114,14 @@ the community.
 
 ## Attribution
 
+[homepage]: https://www.contributor-covenant.org
+
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
-[homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+For answers to common questions about this code of conduct, see [the Contributor Covenant FAQ](https://www.contributor-covenant.org/faq).
+For translations, see [Contributor Covenant Translations](https://www.contributor-covenant.org/translations).

--- a/docs/src/development/releases.md
+++ b/docs/src/development/releases.md
@@ -16,7 +16,7 @@ You will need write access to the Zed repository to do this:
 - Checkout `main` and ensure your working copy is clean.
 - Run `./script/bump-zed-minor-versions` and push the tags
   and branches as instructed.
-- Wait for the builds to appear at https://github.com/zed-industries/zed/releases (typically takes around 30 minutes)
+- Wait for the builds to appear on [the Releases tab on GitHub](https://github.com/zed-industries/zed/releases) (typically takes around 30 minutes)
 - While you're waiting:
   - Start creating the new release notes for preview. You can start with the output of `./script/get-preview-channel-changes`.
   - Start drafting the release tweets.
@@ -38,7 +38,7 @@ You will need write access to the Zed repository to do this:
 - After the commits are cherry-picked onto the branch, run `./script/trigger-release {preview|stable}`. This will bump the version numbers, create a new release tag, and kick off a release build.
   - This can also be run from the [GitHub Actions UI](https://github.com/zed-industries/zed/actions/workflows/bump_patch_version.yml):
     ![](https://github.com/zed-industries/zed/assets/1486634/9e31ae95-09e1-4c7f-9591-944f4f5b63ea)
-- Wait for the builds to appear at https://github.com/zed-industries/zed/releases (typically takes around 30 minutes)
+- Wait for the builds to appear on [the Releases tab on GitHub](https://github.com/zed-industries/zed/releases) (typically takes around 30 minutes)
 - Proof-read and edit the release notes as needed.
 - Download the artifacts for each release and test that you can run them locally.
 - Publish the release.

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -46,7 +46,7 @@ Prettier will also be used for TypeScript files by default. To disable this:
 
 ## Large projects
 
-`vtsls` may run out of memory on very large projects. We default the limit to 8092 (8 GiB) vs the default of 3072 but this may not be sufficient for you:
+`vtsls` may run out of memory on very large projects. We default the limit to 8092 (8 GiB) vs. the default of 3072 but this may not be sufficient for you:
 
 ```json
 {
@@ -66,7 +66,7 @@ Prettier will also be used for TypeScript files by default. To disable this:
 ## Inlay Hints
 
 Zed sets the following initialization options to make the language server send back inlay hints
-(when Zed has inlay hints enabled in the settings).
+(that is, when Zed has inlay hints enabled in the settings).
 
 You can override these settings in your configuration file:
 
@@ -88,8 +88,6 @@ You can override these settings in your configuration file:
     }
 }
 ```
-
-to override these settings.
 
 See [typescript-language-server inlayhints documentation](https://github.com/typescript-language-server/typescript-language-server?tab=readme-ov-file#inlay-hints-textdocumentinlayhint) for more information.
 

--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -4,11 +4,15 @@ Zed comes with a number of built-in themes, with more themes available as extens
 
 ## Selecting a Theme
 
-You can see what these are installed and preview them from the Theme Selector. You can open the Theme Selector from the command palette with "theme selector: Toggle" (bound to `cmd-k cmd-t` on macOS and `ctrl-k ctrl-t` on Linux). Selecting a theme by moving up and down will change the theme in real time and hitting enter will save it to your settings file.
+You can see what themes are installed and preview them via the Theme Selector, which you can open from the command palette with "theme selector: Toggle" (bound to `cmd-k cmd-t` on macOS and `ctrl-k ctrl-t` on Linux).
+
+Navigating through the theme list by moving up and down will change the theme in real time and hitting enter will save it to your settings file.
 
 ## Installing more Themes
 
-More themes are available from the Extensions page. You can open the Extensions page from the command palette with "zed: Extensions". Many popular themes have been ported to Zed, and if you're struggling to choose one, there's a third-party gallery hosted by https://zed-themes.com with visible previews for many of them.
+More themes are available from the Extensions page, which you can access via the command palette with "zed: Extensions" or the [Zed website](https://zed.dev/extensions).
+
+Many popular themes have been ported to Zed, and if you're struggling to choose one, visit [zed-themes.com](https://zed-themes.com), a third-party gallery with visible previews for many of them.
 
 ## Configuring a Theme
 
@@ -51,11 +55,9 @@ You can see which attributes are available to override by looking at the JSON fo
 
 You can store new themes locally, by placing them in the `~/.config/zed/themes` directory.
 
-For example, to create a new theme called `my-cool-theme`, you can create a file called `my-cool-theme.json` in that directory.
+For example, to create a new theme called `my-cool-theme`, you can create a file called `my-cool-theme.json` in that directory. It will be available in the theme selector the next time Zed loads.
 
-It will be available in the theme selector the next time Zed loads.
-
-You can find a lot of themes at [zed-themes.com](https://zed-themes.com).
+Find more themes at [zed-themes.com](https://zed-themes.com).
 
 ## Theme Development
 

--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -4,7 +4,7 @@ Zed comes with a number of built-in themes, with more themes available as extens
 
 ## Selecting a Theme
 
-You can see what themes are installed and preview them via the Theme Selector, which you can open from the command palette with "theme selector: Toggle" (bound to `cmd-k cmd-t` on macOS and `ctrl-k ctrl-t` on Linux).
+See what themes are installed and preview them via the Theme Selector, which you can open from the command palette with "theme selector: Toggle" (bound to `cmd-k cmd-t` on macOS and `ctrl-k ctrl-t` on Linux).
 
 Navigating through the theme list by moving up and down will change the theme in real time and hitting enter will save it to your settings file.
 
@@ -32,9 +32,9 @@ By default, Zed maintains two themes: one for light mode and one for dark mode. 
 
 ## Theme Overrides
 
-You can also override specific attributes of a theme, by using the `experimental.theme_overrides` setting.
+To override specific attributes of a theme, use the `experimental.theme_overrides` setting.
 
-For example, to override the background color of the editor and the font style of comments, you can add the following to your `settings.json` file:
+For example, to override the background color of the editor and the font style of comments, add the following to your `settings.json` file:
 
 ```json
 {
@@ -49,13 +49,13 @@ For example, to override the background color of the editor and the font style o
 }
 ```
 
-You can see which attributes are available to override by looking at the JSON format of your theme. For example, [here is the JSON format for the `One` themes](https://github.com/zed-industries/zed/blob/main/assets/themes/one/one.json).
+See which attributes are available to override by looking at the JSON format of your theme. For example, [here is the JSON format for the `One` themes](https://github.com/zed-industries/zed/blob/main/assets/themes/one/one.json).
 
 ## Local Themes
 
-You can store new themes locally, by placing them in the `~/.config/zed/themes` directory.
+Store new themes locally by placing them in the `~/.config/zed/themes` directory.
 
-For example, to create a new theme called `my-cool-theme`, you can create a file called `my-cool-theme.json` in that directory. It will be available in the theme selector the next time Zed loads.
+For example, to create a new theme called `my-cool-theme`, create a file called `my-cool-theme.json` in that directory. It will be available in the theme selector the next time Zed loads.
 
 Find more themes at [zed-themes.com](https://zed-themes.com).
 

--- a/docs/theme/css/general.css
+++ b/docs/theme/css/general.css
@@ -312,8 +312,10 @@ kbd {
   margin-block-start: 2em;
 }
 .footnote-definition {
-  font-size: 0.9em;
+  font-size: 1.4rem;
   margin: 0.5em 0;
+  border-bottom: 1px solid;
+  border-color: var(--border-light);
 }
 .footnote-definition p {
   display: inline;

--- a/docs/theme/css/general.css
+++ b/docs/theme/css/general.css
@@ -235,7 +235,7 @@ blockquote {
   margin: auto;
   margin-top: 1rem;
   padding: 1rem 1.25rem;
-  color: var(--fg);
+  color: #000;
   background-color: var(--quote-bg);
   border: 1px solid var(--quote-border);
 }
@@ -268,6 +268,7 @@ blockquote .warning:before {
 .warning {
   margin: auto;
   padding: 1rem 1.25rem;
+  color: #000;
   background-color: var(--warning-bg);
   border: 1px solid var(--warning-border);
 }

--- a/docs/theme/css/variables.css
+++ b/docs/theme/css/variables.css
@@ -19,6 +19,7 @@
   --title-color: hsl(220, 92%, 42%);
 
   --border: hsl(220, 13%, 80%);
+  --border-light: hsl(220, 13%, 90%);
   --border-hover: hsl(220, 13%, 70%);
 
   --sidebar-fg: hsl(0, 0%, 0%);

--- a/docs/theme/css/variables.css
+++ b/docs/theme/css/variables.css
@@ -14,7 +14,7 @@
   --code-font-size: 0.875em
     /* please adjust the ace font size accordingly in editor.js */;
 
-  --bg: hsl(48, 30%, 95%);
+  --bg: hsla(50, 25%, 96%);
   --fg: hsl(220, 13%, 34%);
   --title-color: hsl(220, 92%, 42%);
 


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/17505. This one contains a bit more copywriting adjustments. Figured we were using the "You can do x..." sentence shape quite frequently, so tried to kickstart reducing that slightly. There are also more images not loading in complement to the one I removed, but I'm not fully sure why that's the case.

--- 

Release Notes:

- N/A
