### PR TITLE
Fix different kinds values used for `worktree_id`

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -3324,7 +3324,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.read(cx).id().to_usize())
+                .local_settings(worktree_b.read(cx).id())
                 .collect::<Vec<_>>(),
             &[
                 (Path::new("").into(), r#"{"tab_size":2}"#.to_string()),
@@ -3343,7 +3343,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.read(cx).id().to_usize())
+                .local_settings(worktree_b.read(cx).id())
                 .collect::<Vec<_>>(),
             &[
                 (Path::new("").into(), r#"{}"#.to_string()),
@@ -3372,7 +3372,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.read(cx).id().to_usize())
+                .local_settings(worktree_b.read(cx).id())
                 .collect::<Vec<_>>(),
             &[
                 (Path::new("a").into(), r#"{"tab_size":8}"#.to_string()),
@@ -3404,7 +3404,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.read(cx).id().to_usize())
+                .local_settings(worktree_b.read(cx).id())
                 .collect::<Vec<_>>(),
             &[(Path::new("a").into(), r#"{"hard_tabs":true}"#.to_string()),]
         )

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -3324,7 +3324,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.entity_id().as_u64() as _)
+                .local_settings(worktree_b.read(cx).id().to_usize())
                 .collect::<Vec<_>>(),
             &[
                 (Path::new("").into(), r#"{"tab_size":2}"#.to_string()),
@@ -3343,7 +3343,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.entity_id().as_u64() as _)
+                .local_settings(worktree_b.read(cx).id().to_usize())
                 .collect::<Vec<_>>(),
             &[
                 (Path::new("").into(), r#"{}"#.to_string()),
@@ -3372,7 +3372,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.entity_id().as_u64() as _)
+                .local_settings(worktree_b.read(cx).id().to_usize())
                 .collect::<Vec<_>>(),
             &[
                 (Path::new("a").into(), r#"{"tab_size":8}"#.to_string()),
@@ -3404,7 +3404,7 @@ async fn test_local_settings(
         let store = cx.global::<SettingsStore>();
         assert_eq!(
             store
-                .local_settings(worktree_b.entity_id().as_u64() as _)
+                .local_settings(worktree_b.read(cx).id().to_usize())
                 .collect::<Vec<_>>(),
             &[(Path::new("a").into(), r#"{"hard_tabs":true}"#.to_string()),]
         )

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1250,7 +1250,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn worktree_id(&self) -> usize {
+        fn worktree_id(&self, _: &AppContext) -> usize {
             0
         }
 

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1250,8 +1250,8 @@ mod tests {
             unimplemented!()
         }
 
-        fn worktree_id(&self, _: &AppContext) -> usize {
-            0
+        fn worktree_id(&self, _: &AppContext) -> settings::WorktreeId {
+            settings::WorktreeId::from_usize(0)
         }
 
         fn is_private(&self) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -116,7 +116,7 @@ use parking_lot::{Mutex, RwLock};
 use project::project_settings::{GitGutterSetting, ProjectSettings};
 use project::{
     CodeAction, Completion, CompletionIntent, FormatTrigger, Item, Location, Project, ProjectPath,
-    ProjectTransaction, TaskSourceKind, WorktreeId,
+    ProjectTransaction, TaskSourceKind,
 };
 use rand::prelude::*;
 use rpc::{proto::*, ErrorExt};
@@ -8742,7 +8742,7 @@ impl Editor {
             let (worktree_id, file) = project
                 .buffer_for_id(runnable.buffer, cx)
                 .and_then(|buffer| buffer.read(cx).file())
-                .map(|file| (WorktreeId::from_usize(file.worktree_id(cx)), file.clone()))
+                .map(|file| (file.worktree_id(cx), file.clone()))
                 .unzip();
 
             (project.task_inventory().clone(), worktree_id, file)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -123,7 +123,7 @@ use rpc::{proto::*, ErrorExt};
 use scroll::{Autoscroll, OngoingScroll, ScrollAnchor, ScrollManager, ScrollbarAutoHide};
 use selections_collection::{resolve_multiple, MutableSelectionsCollection, SelectionsCollection};
 use serde::{Deserialize, Serialize};
-use settings::{update_settings_file, Settings, SettingsStore};
+use settings::{update_settings_file, Settings, SettingsLocation, SettingsStore};
 use smallvec::SmallVec;
 use snippet::Snippet;
 use std::{
@@ -8742,7 +8742,7 @@ impl Editor {
             let (worktree_id, file) = project
                 .buffer_for_id(runnable.buffer, cx)
                 .and_then(|buffer| buffer.read(cx).file())
-                .map(|file| (WorktreeId::from_usize(file.worktree_id()), file.clone()))
+                .map(|file| (WorktreeId::from_usize(file.worktree_id(cx)), file.clone()))
                 .unzip();
 
             (project.task_inventory().clone(), worktree_id, file)
@@ -11421,7 +11421,14 @@ impl Editor {
             .redacted_ranges(search_range, |file| {
                 if let Some(file) = file {
                     file.is_private()
-                        && EditorSettings::get(Some(file.as_ref().into()), cx).redact_private_values
+                        && EditorSettings::get(
+                            Some(SettingsLocation {
+                                worktree_id: file.worktree_id(cx),
+                                path: file.path().as_ref(),
+                            }),
+                            cx,
+                        )
+                        .redact_private_values
                 } else {
                     false
                 }

--- a/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
@@ -1,6 +1,6 @@
 use crate::wasm_host::{wit::ToWasmtimeResult, WasmState};
 use ::http_client::AsyncBody;
-use ::settings::Settings;
+use ::settings::{Settings, WorktreeId};
 use anyhow::{anyhow, bail, Context, Result};
 use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
@@ -76,7 +76,7 @@ impl HostWorktree for WasmState {
         delegate: Resource<Arc<dyn LspAdapterDelegate>>,
     ) -> wasmtime::Result<u64> {
         let delegate = self.table.get(&delegate)?;
-        Ok(delegate.worktree_id())
+        Ok(delegate.worktree_id().to_proto())
     }
 
     async fn root_path(
@@ -393,7 +393,7 @@ impl ExtensionImports for WasmState {
                 let location = location
                     .as_ref()
                     .map(|location| ::settings::SettingsLocation {
-                        worktree_id: location.worktree_id as usize,
+                        worktree_id: WorktreeId::from_proto(location.worktree_id),
                         path: Path::new(&location.path),
                     });
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -361,7 +361,7 @@ pub trait File: Send + Sync {
     /// Returns the id of the worktree to which this file belongs.
     ///
     /// This is needed for looking up project-specific settings.
-    fn worktree_id(&self) -> usize;
+    fn worktree_id(&self, cx: &AppContext) -> usize;
 
     /// Returns whether the file has been deleted.
     fn is_deleted(&self) -> bool;
@@ -4172,7 +4172,7 @@ impl File for TestFile {
         self.path().file_name().unwrap_or(self.root_name.as_ref())
     }
 
-    fn worktree_id(&self) -> usize {
+    fn worktree_id(&self, _: &AppContext) -> usize {
         0
     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -27,6 +27,7 @@ use gpui::{
 use lsp::LanguageServerId;
 use parking_lot::Mutex;
 use serde_json::Value;
+use settings::WorktreeId;
 use similar::{ChangeTag, TextDiff};
 use smallvec::SmallVec;
 use smol::future::yield_now;
@@ -361,7 +362,7 @@ pub trait File: Send + Sync {
     /// Returns the id of the worktree to which this file belongs.
     ///
     /// This is needed for looking up project-specific settings.
-    fn worktree_id(&self, cx: &AppContext) -> usize;
+    fn worktree_id(&self, cx: &AppContext) -> WorktreeId;
 
     /// Returns whether the file has been deleted.
     fn is_deleted(&self) -> bool;
@@ -4172,8 +4173,8 @@ impl File for TestFile {
         self.path().file_name().unwrap_or(self.root_name.as_ref())
     }
 
-    fn worktree_id(&self, _: &AppContext) -> usize {
-        0
+    fn worktree_id(&self, _: &AppContext) -> WorktreeId {
+        WorktreeId::from_usize(0)
     }
 
     fn is_deleted(&self) -> bool {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -38,6 +38,7 @@ use schemars::{
 };
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use settings::WorktreeId;
 use smol::future::FutureExt as _;
 use std::num::NonZeroU32;
 use std::{
@@ -280,7 +281,7 @@ impl CachedLspAdapter {
 pub trait LspAdapterDelegate: Send + Sync {
     fn show_notification(&self, message: &str, cx: &mut AppContext);
     fn http_client(&self) -> Arc<dyn HttpClient>;
-    fn worktree_id(&self) -> u64;
+    fn worktree_id(&self) -> WorktreeId;
     fn worktree_root_path(&self) -> &Path;
     fn update_status(&self, language: LanguageServerName, status: LanguageServerBinaryStatus);
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -20,15 +20,6 @@ use settings::{add_references_to_properties, Settings, SettingsLocation, Setting
 use std::{num::NonZeroU32, path::Path, sync::Arc};
 use util::serde::default_true;
 
-impl<'a> From<&'a dyn File> for SettingsLocation<'a> {
-    fn from(val: &'a dyn File) -> Self {
-        SettingsLocation {
-            worktree_id: val.worktree_id(),
-            path: val.path().as_ref(),
-        }
-    }
-}
-
 /// Initializes the language settings.
 pub fn init(cx: &mut AppContext) {
     AllLanguageSettings::register(cx);
@@ -49,7 +40,10 @@ pub fn all_language_settings<'a>(
     file: Option<&Arc<dyn File>>,
     cx: &'a AppContext,
 ) -> &'a AllLanguageSettings {
-    let location = file.map(|f| f.as_ref().into());
+    let location = file.map(|f| SettingsLocation {
+        worktree_id: f.worktree_id(cx),
+        path: f.path().as_ref(),
+    });
     AllLanguageSettings::get(location, cx)
 }
 

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -135,7 +135,7 @@ impl LspAdapter for YamlLspAdapter {
         cx: &mut AsyncAppContext,
     ) -> Result<Value> {
         let location = SettingsLocation {
-            worktree_id: delegate.worktree_id() as usize,
+            worktree_id: delegate.worktree_id(),
             path: delegate.worktree_root_path(),
         };
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4250,7 +4250,7 @@ impl LspStore {
 
         let project_settings = ProjectSettings::get(
             Some(SettingsLocation {
-                worktree_id: worktree_id.to_usize(),
+                worktree_id,
                 path: Path::new(""),
             }),
             cx,
@@ -6408,8 +6408,8 @@ impl LspAdapterDelegate for ProjectLspAdapterDelegate {
         self.http_client.clone()
     }
 
-    fn worktree_id(&self) -> u64 {
-        self.worktree.id().to_proto()
+    fn worktree_id(&self) -> WorktreeId {
+        self.worktree.id()
     }
 
     fn worktree_root_path(&self) -> &Path {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4250,7 +4250,7 @@ impl LspStore {
 
         let project_settings = ProjectSettings::get(
             Some(SettingsLocation {
-                worktree_id: worktree_id.to_proto() as usize,
+                worktree_id: worktree_id.to_usize(),
                 path: Path::new(""),
             }),
             cx,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1606,7 +1606,7 @@ impl Project {
             self.worktree_store.update(cx, |worktree_store, cx| {
                 for worktree in worktree_store.worktrees() {
                     store
-                        .clear_local_settings(worktree.read(cx).id().to_usize(), cx)
+                        .clear_local_settings(worktree.read(cx).id(), cx)
                         .log_err();
                 }
             });
@@ -5186,7 +5186,7 @@ impl EventEmitter<Event> for Project {}
 impl<'a> From<&'a ProjectPath> for SettingsLocation<'a> {
     fn from(val: &'a ProjectPath) -> Self {
         SettingsLocation {
-            worktree_id: val.worktree_id.to_usize(),
+            worktree_id: val.worktree_id,
             path: val.path.as_ref(),
         }
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -37,7 +37,7 @@ use futures::{
 
 use git::{blame::Blame, repository::GitRepository};
 use gpui::{
-    AnyModel, AppContext, AsyncAppContext, BorrowAppContext, Context, Entity, EventEmitter, Model,
+    AnyModel, AppContext, AsyncAppContext, BorrowAppContext, Context, EventEmitter, Model,
     ModelContext, SharedString, Task, WeakModel, WindowContext,
 };
 use itertools::Itertools;
@@ -1606,7 +1606,7 @@ impl Project {
             self.worktree_store.update(cx, |worktree_store, cx| {
                 for worktree in worktree_store.worktrees() {
                     store
-                        .clear_local_settings(worktree.entity_id().as_u64() as usize, cx)
+                        .clear_local_settings(worktree.read(cx).id().to_usize(), cx)
                         .log_err();
                 }
             });

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -249,7 +249,7 @@ impl SettingsObserver {
         let store = cx.global::<SettingsStore>();
         for worktree in self.worktree_store.read(cx).worktrees() {
             let worktree_id = worktree.read(cx).id().to_proto();
-            for (path, content) in store.local_settings(worktree.read(cx).id().to_usize()) {
+            for (path, content) in store.local_settings(worktree.read(cx).id()) {
                 downstream_client
                     .send(proto::UpdateWorktreeSettings {
                         project_id,
@@ -421,12 +421,7 @@ impl SettingsObserver {
         cx.update_global::<SettingsStore, _>(|store, cx| {
             for (directory, file_content) in settings_contents {
                 store
-                    .set_local_settings(
-                        worktree_id.to_usize(),
-                        directory.clone(),
-                        file_content.as_deref(),
-                        cx,
-                    )
+                    .set_local_settings(worktree_id, directory.clone(), file_content.as_deref(), cx)
                     .log_err();
                 if let Some(downstream_client) = &self.downstream_client {
                     downstream_client

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -249,7 +249,7 @@ impl SettingsObserver {
         let store = cx.global::<SettingsStore>();
         for worktree in self.worktree_store.read(cx).worktrees() {
             let worktree_id = worktree.read(cx).id().to_proto();
-            for (path, content) in store.local_settings(worktree.entity_id().as_u64() as usize) {
+            for (path, content) in store.local_settings(worktree.read(cx).id().to_usize()) {
                 downstream_client
                     .send(proto::UpdateWorktreeSettings {
                         project_id,
@@ -416,13 +416,13 @@ impl SettingsObserver {
         settings_contents: impl IntoIterator<Item = (Arc<Path>, Option<String>)>,
         cx: &mut ModelContext<Self>,
     ) {
-        let worktree_id = worktree.entity_id();
+        let worktree_id = worktree.read(cx).id();
         let remote_worktree_id = worktree.read(cx).id();
         cx.update_global::<SettingsStore, _>(|store, cx| {
             for (directory, file_content) in settings_contents {
                 store
                     .set_local_settings(
-                        worktree_id.as_u64() as usize,
+                        worktree_id.to_usize(),
                         directory.clone(),
                         file_content.as_deref(),
                         cx,

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -579,15 +579,16 @@ impl ContextProvider for BasicContextProvider {
         if !selected_text.trim().is_empty() {
             task_variables.insert(VariableName::SelectedText, selected_text);
         }
-        let worktree_abs_path = buffer
-            .file()
-            .map(|file| WorktreeId::from_usize(file.worktree_id(cx)))
-            .and_then(|worktree_id| {
-                self.project
-                    .read(cx)
-                    .worktree_for_id(worktree_id, cx)
-                    .map(|worktree| worktree.read(cx).abs_path())
-            });
+        let worktree_abs_path =
+            buffer
+                .file()
+                .map(|file| file.worktree_id(cx))
+                .and_then(|worktree_id| {
+                    self.project
+                        .read(cx)
+                        .worktree_for_id(worktree_id, cx)
+                        .map(|worktree| worktree.read(cx).abs_path())
+                });
         if let Some(worktree_path) = worktree_abs_path {
             task_variables.insert(
                 VariableName::WorktreeRoot,

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -581,7 +581,7 @@ impl ContextProvider for BasicContextProvider {
         }
         let worktree_abs_path = buffer
             .file()
-            .map(|file| WorktreeId::from_usize(file.worktree_id()))
+            .map(|file| WorktreeId::from_usize(file.worktree_id(cx)))
             .and_then(|worktree_id| {
                 self.project
                     .read(cx)

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -103,7 +103,7 @@ impl Project {
         if let Some(path) = path.as_ref() {
             if let Some((worktree, _)) = self.find_worktree(path, cx) {
                 settings_location = Some(SettingsLocation {
-                    worktree_id: worktree.read(cx).id().to_usize(),
+                    worktree_id: worktree.read(cx).id(),
                     path,
                 });
             }

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -242,7 +242,7 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
         assert_eq!(
             AllLanguageSettings::get(
                 Some(SettingsLocation {
-                    worktree_id: worktree_id.into(),
+                    worktree_id,
                     path: Path::new("src/lib.rs")
                 }),
                 cx

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -6,7 +6,7 @@ mod settings_store;
 
 use gpui::AppContext;
 use rust_embed::RustEmbed;
-use std::{borrow::Cow, str};
+use std::{borrow::Cow, fmt, str};
 use util::asset_str;
 
 pub use editable_setting_control::*;
@@ -14,6 +14,39 @@ pub use json_schema::*;
 pub use keymap_file::KeymapFile;
 pub use settings_file::*;
 pub use settings_store::{Settings, SettingsLocation, SettingsSources, SettingsStore};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
+pub struct WorktreeId(usize);
+
+impl From<WorktreeId> for usize {
+    fn from(value: WorktreeId) -> Self {
+        value.0
+    }
+}
+
+impl WorktreeId {
+    pub fn from_usize(handle_id: usize) -> Self {
+        Self(handle_id)
+    }
+
+    pub fn from_proto(id: u64) -> Self {
+        Self(id as usize)
+    }
+
+    pub fn to_proto(&self) -> u64 {
+        self.0 as u64
+    }
+
+    pub fn to_usize(&self) -> usize {
+        self.0
+    }
+}
+
+impl fmt::Display for WorktreeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
 
 #[derive(RustEmbed)]
 #[folder = "../../assets"]

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -151,9 +151,12 @@ impl<'a, T: Serialize> SettingsSources<'a, T> {
     }
 }
 
+// TODO kb move the id into core crate?
+type WorktreeId = usize;
+
 #[derive(Clone, Copy, Debug)]
 pub struct SettingsLocation<'a> {
-    pub worktree_id: usize,
+    pub worktree_id: WorktreeId,
     pub path: &'a Path,
 }
 
@@ -163,7 +166,7 @@ pub struct SettingsStore {
     raw_default_settings: serde_json::Value,
     raw_user_settings: serde_json::Value,
     raw_extension_settings: serde_json::Value,
-    raw_local_settings: BTreeMap<(usize, Arc<Path>), serde_json::Value>,
+    raw_local_settings: BTreeMap<(WorktreeId, Arc<Path>), serde_json::Value>,
     tab_size_callback: Option<(
         TypeId,
         Box<dyn Fn(&dyn Any) -> Option<usize> + Send + Sync + 'static>,
@@ -179,7 +182,7 @@ impl Global for SettingsStore {}
 #[derive(Debug)]
 struct SettingValue<T> {
     global_value: Option<T>,
-    local_values: Vec<(usize, Arc<Path>, T)>,
+    local_values: Vec<(WorktreeId, Arc<Path>, T)>,
 }
 
 trait AnySettingValue: 'static + Send + Sync {
@@ -193,7 +196,7 @@ trait AnySettingValue: 'static + Send + Sync {
     ) -> Result<Box<dyn Any>>;
     fn value_for_path(&self, path: Option<SettingsLocation>) -> &dyn Any;
     fn set_global_value(&mut self, value: Box<dyn Any>);
-    fn set_local_value(&mut self, root_id: usize, path: Arc<Path>, value: Box<dyn Any>);
+    fn set_local_value(&mut self, root_id: WorktreeId, path: Arc<Path>, value: Box<dyn Any>);
     fn json_schema(
         &self,
         generator: &mut SchemaGenerator,
@@ -519,7 +522,7 @@ impl SettingsStore {
     /// Add or remove a set of local settings via a JSON string.
     pub fn set_local_settings(
         &mut self,
-        root_id: usize,
+        root_id: WorktreeId,
         path: Arc<Path>,
         settings_content: Option<&str>,
         cx: &mut AppContext,
@@ -552,13 +555,16 @@ impl SettingsStore {
     }
 
     /// Add or remove a set of local settings via a JSON string.
-    pub fn clear_local_settings(&mut self, root_id: usize, cx: &mut AppContext) -> Result<()> {
+    pub fn clear_local_settings(&mut self, root_id: WorktreeId, cx: &mut AppContext) -> Result<()> {
         self.raw_local_settings.retain(|k, _| k.0 != root_id);
         self.recompute_values(Some((root_id, "".as_ref())), cx)?;
         Ok(())
     }
 
-    pub fn local_settings(&self, root_id: usize) -> impl '_ + Iterator<Item = (Arc<Path>, String)> {
+    pub fn local_settings(
+        &self,
+        root_id: WorktreeId,
+    ) -> impl '_ + Iterator<Item = (Arc<Path>, String)> {
         self.raw_local_settings
             .range((root_id, Path::new("").into())..(root_id + 1, Path::new("").into()))
             .map(|((_, path), content)| (path.clone(), serde_json::to_string(content).unwrap()))
@@ -673,12 +679,12 @@ impl SettingsStore {
 
     fn recompute_values(
         &mut self,
-        changed_local_path: Option<(usize, &Path)>,
+        changed_local_path: Option<(WorktreeId, &Path)>,
         cx: &mut AppContext,
     ) -> Result<()> {
         // Reload the global and local values for every setting.
         let mut project_settings_stack = Vec::<DeserializedSetting>::new();
-        let mut paths_stack = Vec::<Option<(usize, &Path)>>::new();
+        let mut paths_stack = Vec::<Option<(WorktreeId, &Path)>>::new();
         for setting_value in self.setting_values.values_mut() {
             let default_settings = setting_value.deserialize_setting(&self.raw_default_settings)?;
 
@@ -859,7 +865,7 @@ impl<T: Settings> AnySettingValue for SettingValue<T> {
         self.global_value = Some(*value.downcast().unwrap());
     }
 
-    fn set_local_value(&mut self, root_id: usize, path: Arc<Path>, value: Box<dyn Any>) {
+    fn set_local_value(&mut self, root_id: WorktreeId, path: Arc<Path>, value: Box<dyn Any>) {
         let value = *value.downcast().unwrap();
         match self
             .local_values

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -514,7 +514,7 @@ impl<T: Item> ItemHandle for View<T> {
         if let Some(project_path) = self.project_path(cx) {
             WorkspaceSettings::get(
                 Some(SettingsLocation {
-                    worktree_id: project_path.worktree_id.to_usize(),
+                    worktree_id: project_path.worktree_id,
                     path: &project_path.path,
                 }),
                 cx,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -514,7 +514,7 @@ impl<T: Item> ItemHandle for View<T> {
         if let Some(project_path) = self.project_path(cx) {
             WorkspaceSettings::get(
                 Some(SettingsLocation {
-                    worktree_id: project_path.worktree_id.into(),
+                    worktree_id: project_path.worktree_id.to_usize(),
                     path: &project_path.path,
                 }),
                 cx,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -385,9 +385,9 @@ impl Worktree {
         });
 
         cx.new_model(move |cx: &mut ModelContext<Worktree>| {
-            let worktree_id = cx.handle().entity_id().as_u64();
+            let worktree_id = cx.handle().read(cx).id().to_usize();
             let settings_location = Some(SettingsLocation {
-                worktree_id: worktree_id as usize,
+                worktree_id,
                 path: Path::new(EMPTY_PATH),
             });
 
@@ -3123,8 +3123,8 @@ impl language::File for File {
             .unwrap_or_else(|| OsStr::new(&self.worktree.read(cx).root_name))
     }
 
-    fn worktree_id(&self) -> usize {
-        self.worktree.entity_id().as_u64() as usize
+    fn worktree_id(&self, cx: &AppContext) -> usize {
+        self.worktree.read(cx).id().to_usize()
     }
 
     fn is_deleted(&self) -> bool {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -37,6 +37,7 @@ use postage::{
     watch,
 };
 use rpc::proto::{self, AnyProtoClient};
+pub use settings::WorktreeId;
 use settings::{Settings, SettingsLocation, SettingsStore};
 use smallvec::{smallvec, SmallVec};
 use smol::channel::{self, Sender};
@@ -67,15 +68,6 @@ pub use worktree_settings::WorktreeSettings;
 pub const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
 #[cfg(not(feature = "test-support"))]
 pub const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
-pub struct WorktreeId(usize);
-
-impl From<WorktreeId> for usize {
-    fn from(value: WorktreeId) -> Self {
-        value.0
-    }
-}
 
 /// A set of local or remote files that are being opened as part of a project.
 /// Responsible for tracking related FS (for local)/collab (for remote) events and corresponding updates.
@@ -385,24 +377,6 @@ impl Worktree {
         });
 
         cx.new_model(move |cx: &mut ModelContext<Worktree>| {
-            let worktree_id = cx.handle().read(cx).id().to_usize();
-            let settings_location = Some(SettingsLocation {
-                worktree_id,
-                path: Path::new(EMPTY_PATH),
-            });
-
-            let settings = WorktreeSettings::get(settings_location, cx).clone();
-            cx.observe_global::<SettingsStore>(move |this, cx| {
-                if let Self::Local(this) = this {
-                    let settings = WorktreeSettings::get(settings_location, cx).clone();
-                    if settings != this.settings {
-                        this.settings = settings;
-                        this.restart_background_scanners(cx);
-                    }
-                }
-            })
-            .detach();
-
             let mut snapshot = LocalSnapshot {
                 ignores_by_parent_abs_path: Default::default(),
                 git_repositories: Default::default(),
@@ -427,6 +401,24 @@ impl Worktree {
                     fs.as_ref(),
                 );
             }
+
+            let worktree_id = snapshot.id();
+            let settings_location = Some(SettingsLocation {
+                worktree_id,
+                path: Path::new(EMPTY_PATH),
+            });
+
+            let settings = WorktreeSettings::get(settings_location, cx).clone();
+            cx.observe_global::<SettingsStore>(move |this, cx| {
+                if let Self::Local(this) = this {
+                    let settings = WorktreeSettings::get(settings_location, cx).clone();
+                    if settings != this.settings {
+                        this.settings = settings;
+                        this.restart_background_scanners(cx);
+                    }
+                }
+            })
+            .detach();
 
             let (scan_requests_tx, scan_requests_rx) = channel::unbounded();
             let (path_prefixes_to_scan_tx, path_prefixes_to_scan_rx) = channel::unbounded();
@@ -2978,30 +2970,6 @@ async fn build_gitignore(abs_path: &Path, fs: &dyn Fs) -> Result<Gitignore> {
     Ok(builder.build()?)
 }
 
-impl WorktreeId {
-    pub fn from_usize(handle_id: usize) -> Self {
-        Self(handle_id)
-    }
-
-    pub fn from_proto(id: u64) -> Self {
-        Self(id as usize)
-    }
-
-    pub fn to_proto(&self) -> u64 {
-        self.0 as u64
-    }
-
-    pub fn to_usize(&self) -> usize {
-        self.0
-    }
-}
-
-impl fmt::Display for WorktreeId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 impl Deref for Worktree {
     type Target = Snapshot;
 
@@ -3123,8 +3091,8 @@ impl language::File for File {
             .unwrap_or_else(|| OsStr::new(&self.worktree.read(cx).root_name))
     }
 
-    fn worktree_id(&self, cx: &AppContext) -> usize {
-        self.worktree.read(cx).id().to_usize()
+    fn worktree_id(&self, cx: &AppContext) -> WorktreeId {
+        self.worktree.read(cx).id()
     }
 
     fn is_deleted(&self) -> bool {


### PR DESCRIPTION
During editorconfig settings rework, I've stumbled onto the fact that we use different kinds of digits for `worktree_id`:

<img width="1075" alt="different_ids" src="https://github.com/user-attachments/assets/54e5208a-f70d-4ceb-845f-ddb9b42aeb91">

This PR forces all related places to use `WorktreeId` instead of `usize` and fixes all discrepancies.
For that, `WorktreeId` was moved into `settings` crate and used instead of `usize`s.

Release Notes:

- N/A
