### PR TITLE
Use the configured UI font size for the inline assistant

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1921,7 +1921,7 @@ impl PromptEditor {
             font_family: settings.ui_font.family.clone(),
             font_features: settings.ui_font.features.clone(),
             font_fallbacks: settings.ui_font.fallbacks.clone(),
-            font_size: rems(0.875).into(),
+            font_size: settings.ui_font_size.into(),
             font_weight: settings.ui_font.weight,
             line_height: relative(1.3),
             ..Default::default()


### PR DESCRIPTION
There's no reason to use a hardcoded font size here. I also considered making this configurable individually, but it seemed more complicated than it's worth.

Closes: #17537

Release Notes:

- Inline assistant now uses the configured UI font size