### PR TITLE
Add `exclusions_gitignore` to exclude files from worktree using gitignore

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -647,6 +647,8 @@
     "**/.classpath",
     "**/.settings"
   ],
+  // Use .gitignore to exclude files from the worktree.
+  "exclusions_gitignore": false,
   // Git gutter behavior configuration.
   "git": {
     // Control whether the git gutter is shown. May take 2 values:

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -63,11 +63,12 @@ use persistence::{
 use postage::stream::Stream;
 use project::{
     DirectoryLister, Project, ProjectEntryId, ProjectPath, ResolvedPath, Worktree, WorktreeId,
+    WorktreeSettings,
 };
 use remote::{ssh_session::ConnectionIdentifier, SshClientDelegate, SshConnectionOptions};
 use serde::Deserialize;
 use session::AppSession;
-use settings::Settings;
+use settings::{update_settings_file, Settings};
 use shared_screen::SharedScreen;
 use sqlez::{
     bindable::{Bind, Column, StaticColumnCount},
@@ -155,6 +156,7 @@ actions!(
         SaveWithoutFormat,
         ToggleBottomDock,
         ToggleCenteredLayout,
+        ToggleGitignore,
         ToggleLeftDock,
         ToggleRightDock,
         ToggleZoom,
@@ -4440,6 +4442,14 @@ impl Workspace {
                 }),
             )
             .on_action(cx.listener(Workspace::toggle_centered_layout))
+            .on_action(
+                cx.listener(|workspace: &mut Workspace, _: &ToggleGitignore, cx| {
+                    let fs = workspace.app_state().fs.clone();
+                    update_settings_file::<WorktreeSettings>(fs, cx, move |setting, _| {
+                        setting.exclusions_gitignore = !setting.exclusions_gitignore;
+                    });
+                }),
+            )
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -11,6 +11,7 @@ use util::paths::PathMatcher;
 pub struct WorktreeSettings {
     pub file_scan_exclusions: PathMatcher,
     pub private_files: PathMatcher,
+    pub exclusions_gitignore: bool,
 }
 
 impl WorktreeSettings {
@@ -45,6 +46,9 @@ pub struct WorktreeSettingsContent {
     /// Treat the files matching these globs as `.env` files.
     /// Default: [ "**/.env*" ]
     pub private_files: Option<Vec<String>>,
+
+    #[serde(default)]
+    pub exclusions_gitignore: bool,
 }
 
 impl Settings for WorktreeSettings {
@@ -59,11 +63,13 @@ impl Settings for WorktreeSettings {
         let result: WorktreeSettingsContent = sources.json_merge()?;
         let mut file_scan_exclusions = result.file_scan_exclusions.unwrap_or_default();
         let mut private_files = result.private_files.unwrap_or_default();
+        let exclusion = result.exclusions_gitignore;
         file_scan_exclusions.sort();
         private_files.sort();
         Ok(Self {
             file_scan_exclusions: path_matchers(&file_scan_exclusions, "file_scan_exclusions")?,
             private_files: path_matchers(&private_files, "private_files")?,
+            exclusions_gitignore: exclusion,
         })
     }
 }


### PR DESCRIPTION
⚠️ WIP ⚠️
 Closes: #17543

### Release Notes:

- **New Feature:** Introduced the ability to automatically remove files and directories from the Zed worktree that are specified in `.gitignore`.
- **Configuration Option:** This behavior can be controlled via the new `exclusions_gitignore` setting. By setting it to `true`, files listed in `.gitignore` will be excluded from the worktree.

```json
  "exclusions_gitignore": true
```
- **Toggle:** Ability to toggle this setting using the action `workspace::ToggleGitignore`

This results in a cleaner and easier to browse worktree for projects that generate a lot of object files like `xv6-riscv` or `linux` without needing to tweak `file_scan_exclusions` on `settings.json`

**Preview:**
- With `"exclusions_gitignore": false` (default, this is how zed currently looks) 
![gitignore-false](https://github.com/user-attachments/assets/670c8ef2-3141-4927-ab08-ba9346ae8d15)

- With `"exclusions_gitignore": true` 
![gitignore-true](https://github.com/user-attachments/assets/a50e06f0-0e8e-45c4-97e1-32f1e22d4762)
