### PR TITLE
Refactor SearchSettings

### DIFF
--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -171,27 +171,6 @@ pub struct SearchSettings {
     pub regex: bool,
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
-pub struct SearchSettingsContent {
-    pub whole_word: Option<bool>,
-    pub case_sensitive: Option<bool>,
-    pub include_ignored: Option<bool>,
-    pub regex: Option<bool>,
-}
-
-impl Settings for SearchSettings {
-    const KEY: Option<&'static str> = Some("search");
-
-    type FileContent = SearchSettingsContent;
-
-    fn load(
-        sources: SettingsSources<Self::FileContent>,
-        _: &mut gpui::AppContext,
-    ) -> anyhow::Result<Self> {
-        sources.json_merge()
-    }
-}
-
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
     /// Whether the cursor blinks in the editor.

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -9,7 +9,7 @@ use any_vec::AnyVec;
 use collections::HashMap;
 use editor::{
     actions::{Tab, TabPrev},
-    DisplayPoint, Editor, EditorElement, EditorSettings, EditorStyle, SearchSettings,
+    DisplayPoint, Editor, EditorElement, EditorSettings, EditorStyle,
 };
 use futures::channel::oneshot;
 use gpui::{
@@ -22,7 +22,7 @@ use project::{
     search_history::{SearchHistory, SearchHistoryCursor},
 };
 use serde::Deserialize;
-use settings::{Settings, SettingsStore};
+use settings::Settings;
 use std::sync::Arc;
 use theme::ThemeSettings;
 
@@ -96,7 +96,6 @@ pub struct BufferSearchBar {
     scroll_handle: ScrollHandle,
     editor_scroll_handle: ScrollHandle,
     editor_needed_width: Pixels,
-    _subscriptions: Vec<Subscription>,
 }
 
 impl BufferSearchBar {
@@ -506,11 +505,7 @@ impl BufferSearchBar {
         cx.subscribe(&replacement_editor, Self::on_replacement_editor_event)
             .detach();
 
-        let search_options = SearchOptions::from_settings(&SearchSettings::get_global(cx));
-
-        let settings_subscription = cx.observe_global::<SettingsStore>(move |this, cx| {
-            this.default_options = SearchOptions::from_settings(&SearchSettings::get_global(cx));
-        });
+        let search_options = SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
 
         Self {
             query_editor,
@@ -537,7 +532,6 @@ impl BufferSearchBar {
             scroll_handle: ScrollHandle::new(),
             editor_scroll_handle: ScrollHandle::new(),
             editor_needed_width: px(0.),
-            _subscriptions: vec![settings_subscription],
         }
     }
 
@@ -610,6 +604,9 @@ impl BufferSearchBar {
         let Some(handle) = self.active_searchable_item.as_ref() else {
             return false;
         };
+
+        self.default_options = SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
+
         if self.default_options != self.search_options {
             self.search_options = self.default_options;
         }

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -4,7 +4,6 @@ use editor::SearchSettings;
 use gpui::{actions, Action, AppContext, IntoElement};
 use project::search::SearchQuery;
 pub use project_search::ProjectSearchView;
-use settings::Settings;
 use ui::{prelude::*, Tooltip};
 use ui::{ButtonStyle, IconButton};
 use workspace::notifications::NotificationId;
@@ -15,7 +14,6 @@ pub mod project_search;
 pub(crate) mod search_bar;
 
 pub fn init(cx: &mut AppContext) {
-    SearchSettings::register(cx);
     menu::init();
     buffer_search::init(cx);
     project_search::init(cx);


### PR DESCRIPTION
Related to #17179.

Simplify handling of search settings since there is no requirement to watch for settings.json changes and update search panels while they are opened.

Attn: @SomeoneToIgnore 

Per our discussion. Ran test on search crate. Ran `cargo fmt`.

Release Notes:

- N/A