### PR TITLE
vim: Revert 'Y' to yank to end of line

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -214,7 +214,7 @@
       "shift-d": "vim::DeleteToEndOfLine",
       "shift-j": "vim::JoinLines",
       "y": ["vim::PushOperator", "Yank"],
-      "shift-y": "vim::YankToEndOfLine",
+      "shift-y": "vim::YankLine",
       "i": "vim::InsertBefore",
       "shift-i": "vim::InsertFirstNonWhitespace",
       "a": "vim::InsertAfter",

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -52,7 +52,6 @@ actions!(
         DeleteToEndOfLine,
         Yank,
         YankLine,
-        YankToEndOfLine,
         ChangeCase,
         ConvertToUpperCase,
         ConvertToLowerCase,
@@ -77,7 +76,6 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut ViewContext<Vim>) {
     Vim::action(editor, cx, Vim::convert_to_upper_case);
     Vim::action(editor, cx, Vim::convert_to_lower_case);
     Vim::action(editor, cx, Vim::yank_line);
-    Vim::action(editor, cx, Vim::yank_to_end_of_line);
     Vim::action(editor, cx, Vim::toggle_comments);
     Vim::action(editor, cx, Vim::paste);
 
@@ -426,18 +424,6 @@ impl Vim {
     fn yank_line(&mut self, _: &YankLine, cx: &mut ViewContext<Self>) {
         let count = self.take_count(cx);
         self.yank_motion(motion::Motion::CurrentLine, count, cx)
-    }
-
-    fn yank_to_end_of_line(&mut self, _: &YankToEndOfLine, cx: &mut ViewContext<Self>) {
-        self.record_current_action(cx);
-        let count = self.take_count(cx);
-        self.yank_motion(
-            motion::Motion::EndOfLine {
-                display_lines: false,
-            },
-            count,
-            cx,
-        )
     }
 
     fn toggle_comments(&mut self, _: &ToggleComments, cx: &mut ViewContext<Self>) {
@@ -1406,15 +1392,6 @@ mod test {
             indoc! {"assert_bindinˇg"},
             indoc! {"asserˇt_binding"},
         );
-    }
-
-    #[gpui::test]
-    async fn test_shift_y(cx: &mut gpui::TestAppContext) {
-        let mut cx = NeovimBackedTestContext::new(cx).await;
-
-        cx.set_shared_state("helˇlo\n").await;
-        cx.simulate_shared_keystrokes("shift-y").await;
-        cx.shared_clipboard().await.assert_eq("lo");
     }
 
     #[gpui::test]

--- a/crates/vim/test_data/test_shift_y.json
+++ b/crates/vim/test_data/test_shift_y.json
@@ -1,4 +1,0 @@
-{"Put":{"state":"helˇlo\n"}}
-{"Key":"shift-y"}
-{"Get":{"state":"helˇlo\n","mode":"Normal"}}
-{"ReadRegister":{"name":"\"","value":"lo"}}


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17549

Release Notes:
- vim: Reverted `Y` to vim behavior. If you want the neovim version (as a built in mapping to `y$`) you must configure it in your [settings](https://zed.dev/docs/vim).