### PR TITLE
Update bundle-linux: Use git rev-parse --short option

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -32,7 +32,7 @@ version="$(script/get-crate-version zed)"
 # Set RELEASE_VERSION so it's compiled into GPUI and it knows about the version.
 export RELEASE_VERSION="${version}"
 
-commit=$(git rev-parse HEAD | cut -c 1-7)
+commit=$(git rev-parse --short HEAD)
 
 version_info=$(rustc --version --verbose)
 host_line=$(echo "$version_info" | grep host)


### PR DESCRIPTION
Avoids cut subshell.

Used elsewhere, so should be fine
- https://github.com/zed-industries/zed/blob/174e12568669e70abb15934597a3f5df335eaf08/.github/workflows/release_nightly.yml#L85

Release Notes:

- N/A