### PR TITLE
gpui: Improve underline appearance

### DIFF
--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -488,8 +488,8 @@ fn fs_underline(input: UnderlineVarying) -> @location(0) vec4<f32> {
 
     let half_thickness = underline.thickness * 0.5;
     let st = (input.position.xy - underline.bounds.origin) / underline.bounds.size.y - vec2<f32>(0.0, 0.5);
-    let frequency = M_PI_F * 3.0 * underline.thickness / 8.0;
-    let amplitude = 1.0 / (2.0 * underline.thickness);
+    let frequency = M_PI_F * 3.0 * underline.thickness / 3.0;
+    let amplitude = 1.0 / (4.0 * underline.thickness);
     let sine = sin(st.x * frequency) * amplitude;
     let dSine = cos(st.x * frequency) * amplitude * frequency;
     let distance = (st.y - sine) / sqrt(1.0 + dSine * dSine);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17595

I slightly changed the fragment shader of wavy underline so that it looks like the usual one:
![image](https://github.com/user-attachments/assets/2e7fd479-8144-43af-b656-3b93dedae5aa)

**Before:**
![image](https://github.com/user-attachments/assets/7c176cf4-7138-4be0-9394-cb1355b998ab)

**After:**
![image](https://github.com/user-attachments/assets/13519c6b-a171-4833-a2bc-6904f3b57999)

I would also suggest increasing the underline depending on the size of the text so that it remains proportional to it.

Release Notes:

- Improved underline appearance
