### PR TITLE
fix(file-command): correct path handling on Windows for /file command

### DIFF
--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -519,7 +519,7 @@ mod custom_path_matcher {
                 .zip(self.sources_with_trailing_slash.iter())
                 .any(|(source, with_slash)| {
                     let as_bytes = other_path.as_os_str().as_encoded_bytes();
-                    let with_slash = if source.ends_with("/") {
+                    let with_slash = if source.ends_with(std::path::MAIN_SEPARATOR_STR) {
                         source.as_bytes()
                     } else {
                         with_slash.as_bytes()


### PR DESCRIPTION
This fix ensures proper folder path processing on Windows platforms during AI interactions by using platform-specific path separators.

- Use std::path::MAIN_SEPARATOR_STR instead of hardcoded forward slash
- Improve cross-platform compatibility for the /file command
- Resolve path-related issues for Windows users in AI interactions

Release Notes:

- Fixed: File path handling for /file command on Windows platforms