### PR TITLE
editor: Fix an error when cut with vim visual line select

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6677,7 +6677,11 @@ impl Editor {
                 let is_entire_line = selection.is_empty() || self.selections.line_mode;
                 if is_entire_line {
                     selection.start = Point::new(selection.start.row, 0);
-                    selection.end = cmp::min(max_point, Point::new(selection.end.row + 1, 0));
+                    if selection.end.column != 0 {
+                        selection.end = cmp::min(max_point, Point::new(selection.end.row + 1, 0));
+                    } else {
+                        selection.end = cmp::min(max_point, selection.end);
+                    }
                     selection.goal = SelectionGoal::None;
                 }
                 if is_first {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6677,10 +6677,10 @@ impl Editor {
                 let is_entire_line = selection.is_empty() || self.selections.line_mode;
                 if is_entire_line {
                     selection.start = Point::new(selection.start.row, 0);
-                    if selection.end.column != 0 {
-                        selection.end = cmp::min(max_point, Point::new(selection.end.row + 1, 0));
-                    } else {
+                    if !selection.is_empty() && selection.end.column == 0 {
                         selection.end = cmp::min(max_point, selection.end);
+                    } else {
+                        selection.end = cmp::min(max_point, Point::new(selection.end.row + 1, 0));
                     }
                     selection.goal = SelectionGoal::None;
                 }


### PR DESCRIPTION
Becuause in vim visual mode, we will always select next char, hit [here](https://github.com/zed-industries/zed/blob/66ef31882341852229c74996867916fbd4a2fe2a/crates/vim/src/visual.rs#L174), when using editor method
for `cut` this selection, will hit this error.

Closes #17585 

Release Notes:

- N/A
