### PR TITLE
remove text color blending and fix multiple background renderings on assistant panel

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -4228,12 +4228,7 @@ impl Render for ContextEditor {
             .on_action(cx.listener(ContextEditor::split))
             .size_full()
             .children(self.render_notice(cx))
-            .child(
-                div()
-                    .flex_grow()
-                    .bg(cx.theme().colors().editor_background)
-                    .child(self.editor.clone()),
-            )
+            .child(div().flex_grow().child(self.editor.clone()))
             .when_some(accept_terms, |this, element| {
                 this.child(
                     div()
@@ -4298,7 +4293,6 @@ impl Render for ContextEditor {
                         .w_full()
                         .border_t_1()
                         .border_color(cx.theme().colors().border_variant)
-                        .bg(cx.theme().colors().editor_background)
                         .child(
                             h_flex()
                                 .gap_2()
@@ -5076,7 +5070,6 @@ impl Render for ConfigurationView {
         let mut element = v_flex()
             .id("assistant-configuration-view")
             .track_focus(&self.focus_handle)
-            .bg(cx.theme().colors().editor_background)
             .size_full()
             .overflow_y_scroll()
             .child(

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -5070,6 +5070,7 @@ impl Render for ConfigurationView {
         let mut element = v_flex()
             .id("assistant-configuration-view")
             .track_focus(&self.focus_handle)
+            .bg(cx.theme().colors().editor_background)
             .size_full()
             .overflow_y_scroll()
             .child(

--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -923,9 +923,17 @@ impl PromptLibrary {
                                                     status: cx.theme().status().clone(),
                                                     inlay_hints_style: HighlightStyle {
                                                         color: Some(cx.theme().status().hint),
+                                                        background_color: Some(
+                                                            cx.theme().status().hint_background,
+                                                        ),
                                                         ..HighlightStyle::default()
                                                     },
                                                     suggestions_style: HighlightStyle {
+                                                        background_color: Some(
+                                                            cx.theme()
+                                                                .status()
+                                                                .predictive_background,
+                                                        ),
                                                         color: Some(cx.theme().status().predictive),
                                                         ..HighlightStyle::default()
                                                     },

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9836,10 +9836,16 @@ impl Editor {
                                                 status: cx.editor_style.status.clone(),
                                                 inlay_hints_style: HighlightStyle {
                                                     color: Some(cx.theme().status().hint),
+                                                    background_color: Some(
+                                                        cx.theme().status().hint_background,
+                                                    ),
                                                     font_weight: Some(FontWeight::BOLD),
                                                     ..HighlightStyle::default()
                                                 },
                                                 suggestions_style: HighlightStyle {
+                                                    background_color: Some(
+                                                        cx.theme().status().predictive_background,
+                                                    ),
                                                     color: Some(cx.theme().status().predictive),
                                                     ..HighlightStyle::default()
                                                 },
@@ -12791,10 +12797,12 @@ impl Render for Editor {
                 syntax: cx.theme().syntax().clone(),
                 status: cx.theme().status().clone(),
                 inlay_hints_style: HighlightStyle {
+                    background_color: Some(cx.theme().status().hint_background),
                     color: Some(cx.theme().status().hint),
                     ..HighlightStyle::default()
                 },
                 suggestions_style: HighlightStyle {
+                    background_color: Some(cx.theme().status().predictive_background),
                     color: Some(cx.theme().status().predictive),
                     ..HighlightStyle::default()
                 },

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -376,7 +376,7 @@ impl TextStyle {
         }
 
         if let Some(color) = style.color {
-            self.color = self.color.blend(color);
+            self.color = color;
         }
 
         if let Some(factor) = style.fade_out {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17599
Closes https://github.com/zed-industries/zed/issues/17392
Closes https://github.com/zed-industries/zed/issues/17608

Release Notes:

- Fixed issue where `hint.background` and `predictive.background` theme styles not displaying in editor
- Fixed issue where assistant panel would have `editor.background` applied multiple times leading to inconsistent behavior with transparent themes
- Fixed issue where `hint` and `predictive` text with alpha values would be blended with the `text` color.
- Removed text foreground color blending with colors to allow for alpha values within theme styles.

**Previous assistant context would apply two backgrounds**
![image](https://github.com/user-attachments/assets/c9e9f224-ce24-4b98-9878-84d4b03420fd)

**New assistant panel only applies one background**
![image](https://github.com/user-attachments/assets/49315940-9b76-4389-8ea2-dea4ad80fe2d)

**Old predictive transparent text styling**
- `predictive` theme style with opacity would be incorrectly blended with the white `text` color
- No `predictive.background` theme style applied
![image](https://github.com/user-attachments/assets/52e843e9-ff64-4d67-8e0f-35b154c96860)

**New predictive text styling**
- Supports `predictive` theme style with opacity
- Supports `predictive.background` theme style
![image](https://github.com/user-attachments/assets/dda45ea2-d50d-4580-9273-d89e942a04f1)
