### PR TITLE
markdown: Handle definition lists in parser

### DIFF
--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -232,6 +232,10 @@ pub enum MarkdownTag {
 
     /// A metadata block.
     MetadataBlock(MetadataBlockKind),
+
+    DefinitionList,
+    DefinitionListTitle,
+    DefinitionListDefinition,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -317,11 +321,9 @@ impl From<pulldown_cmark::Tag<'_>> for MarkdownTag {
             },
             pulldown_cmark::Tag::HtmlBlock => MarkdownTag::HtmlBlock,
             pulldown_cmark::Tag::MetadataBlock(kind) => MarkdownTag::MetadataBlock(kind),
-            pulldown_cmark::Tag::DefinitionList
-            | pulldown_cmark::Tag::DefinitionListTitle
-            | pulldown_cmark::Tag::DefinitionListDefinition => {
-                unimplemented!("definition lists are not yet supported")
-            }
+            pulldown_cmark::Tag::DefinitionList => MarkdownTag::DefinitionList,
+            pulldown_cmark::Tag::DefinitionListTitle => MarkdownTag::DefinitionListTitle,
+            pulldown_cmark::Tag::DefinitionListDefinition => MarkdownTag::DefinitionListDefinition,
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/17607.

This PR makes it so the Markdown parser can handle Markdown containing definition lists.

Note that this is just parser support, we aren't yet doing anything with the definition lists themselves.

Release Notes:

- N/A
