### PR TITLE
Update doc comments with tabs.file_icons default

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -79,7 +79,7 @@ pub struct ItemSettingsContent {
     close_position: Option<ClosePosition>,
     /// Whether to show the file icon for a tab.
     ///
-    /// Default: true
+    /// Default: false
     file_icons: Option<bool>,
 }
 


### PR DESCRIPTION
The diff only contains doc comments changes, however I expect this also fixes generating JSON Schema which generated by [schemars](https://github.com/GREsau/schemars/blob/092dc17ae4831d42974653588cebcc089d07493e/docs/examples/6-doc_comments.md).

This default value is actually true at first.

1818fef32f24f24f082c6f34a4c3100add6d328c

However, it was changed in the following commit.

bf7e474bbcc2fadf002adb273e2584c77c1573e3

Closes #17628

Release Notes:

- Fixed JSON Schema for `tabs.file_icons` default value
