### PR TITLE
Wrap terminal commands in single quotation marks instead of backticks

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1596,7 +1596,7 @@ fn task_summary(task: &TaskState, error_code: Option<i32>) -> (bool, String, Str
         }
     };
     let escaped_command_label = task.command_label.replace("\r\n", "\r").replace('\n', "\r");
-    let command_line = format!("{TASK_DELIMITER}Command: '{escaped_command_label}'");
+    let command_line = format!("{TASK_DELIMITER}Command: {escaped_command_label}");
     (success, task_line, command_line)
 }
 

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -397,7 +397,7 @@ impl TerminalPanel {
 
         #[cfg(not(target_os = "windows"))]
         {
-            spawn_task.command_label = format!("{shell} -i -c `{}`", spawn_task.command_label);
+            spawn_task.command_label = format!("{shell} -i -c '{}'", spawn_task.command_label);
         }
         #[cfg(target_os = "windows")]
         {
@@ -405,14 +405,14 @@ impl TerminalPanel {
 
             match windows_shell_type {
                 WindowsShellType::Powershell => {
-                    spawn_task.command_label = format!("{shell} -C `{}`", spawn_task.command_label)
+                    spawn_task.command_label = format!("{shell} -C '{}'", spawn_task.command_label)
                 }
                 WindowsShellType::Cmd => {
-                    spawn_task.command_label = format!("{shell} /C `{}`", spawn_task.command_label)
+                    spawn_task.command_label = format!("{shell} /C '{}'", spawn_task.command_label)
                 }
                 WindowsShellType::Other => {
                     spawn_task.command_label =
-                        format!("{shell} -i -c `{}`", spawn_task.command_label)
+                        format!("{shell} -i -c '{}'", spawn_task.command_label)
                 }
             }
         }


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/ffe8b036-297a-414e-92af-28a0230d3d25)
after:
![image](https://github.com/user-attachments/assets/0cf22775-69ae-4320-b9bd-6b78fe01571f)

Since I often copy the output commands to run in the command line, using backticks can cause errors because, in shell, backticks mean passing the execution result of the command inside them to the -c option. Therefore, I replace backticks with single quotes here.
![image](https://github.com/user-attachments/assets/f1f809fe-c10a-423a-87a2-58148962d8b0)

Release Notes:

- Fix display of task commands to not use backticks 
