### PR TITLE
Ubuntu 22 (Linux arm runner) fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
       - name: Set up Clang
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-10 clang-10 build-essential cmake pkg-config libasound2-dev libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libssl-dev libsqlite3-dev libzstd-dev libvulkan1 libgit2-dev
+          sudo apt-get install -y llvm-11 clang-11 build-essential cmake pkg-config libasound2-dev libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libssl-dev libsqlite3-dev libzstd-dev libvulkan1 libgit2-dev
           echo "/usr/lib/llvm-10/bin" >> $GITHUB_PATH
 
       - uses: rui314/setup-mold@0bf4f07ef9048ec62a45f9dbf2f098afa49695f0 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  bundle-linux-aarch64:
+  bundle-linux-aarch64: # this runs on ubuntu22.04
     timeout-minutes: 60
     name: Create arm64 Linux bundle
     runs-on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
       - name: Set up Clang
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-16 clang-15 build-essential cmake pkg-config libasound2-dev libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libssl-dev libsqlite3-dev libzstd-dev libvulkan1 libgit2-dev
+          sudo apt-get install -y llvm-15 clang-15 build-essential cmake pkg-config libasound2-dev libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libssl-dev libsqlite3-dev libzstd-dev libvulkan1 libgit2-dev
           echo "/usr/lib/llvm-10/bin" >> $GITHUB_PATH
 
       - uses: rui314/setup-mold@0bf4f07ef9048ec62a45f9dbf2f098afa49695f0 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
       - name: Set up Clang
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-11 clang-11 build-essential cmake pkg-config libasound2-dev libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libssl-dev libsqlite3-dev libzstd-dev libvulkan1 libgit2-dev
+          sudo apt-get install -y llvm-16 clang-15 build-essential cmake pkg-config libasound2-dev libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libssl-dev libsqlite3-dev libzstd-dev libvulkan1 libgit2-dev
           echo "/usr/lib/llvm-10/bin" >> $GITHUB_PATH
 
       - uses: rui314/setup-mold@0bf4f07ef9048ec62a45f9dbf2f098afa49695f0 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y llvm-15 clang-15 build-essential cmake pkg-config libasound2-dev libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libssl-dev libsqlite3-dev libzstd-dev libvulkan1 libgit2-dev
-          echo "/usr/lib/llvm-10/bin" >> $GITHUB_PATH
+          echo "/usr/lib/llvm-15/bin" >> $GITHUB_PATH
 
       - uses: rui314/setup-mold@0bf4f07ef9048ec62a45f9dbf2f098afa49695f0 # v1
         with:

--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -12,14 +12,19 @@ We also offer a preview build of Zed which receives updates about a week ahead o
 curl -f https://zed.dev/install.sh | ZED_CHANNEL=preview sh
 ```
 
-The Zed installed by the script does not work on systems that:
+The Zed installed by the script works best on systems that:
 
-- have no Vulkan compatible GPU available (for example Linux on an M-series macBook)
-- have no system-wide glibc (for example on NixOS or Alpine by default)
-- have a glibc older than version 2.29 (for example Amazon Linux 2 or Ubuntu 18 and earlier)
-- use an architecture other than 64-bit Intel or 64-bit ARM (for example a 32-bit or RISC-V machine)
+- have a Vulkan compatible GPU available (for example Linux on an M-series macBook)
+- have a system-wide glibc (NixOS and Alpine do not by default)
+  - x86_64 (Intel/AMD): glibc version >= 2.29 (Ubuntu 20 and newer; Amazon Linux >2023)
+  - aarch64 (ARM): glibc version >= 2.35 (Ubuntu 22 and newer)
 
 Both Nix and Alpine have third-party Zed packages available (though they are currently a few weeks out of date). If you'd like to use our builds they do work if you install a glibc compatibility layer. On NixOS you can try [nix-ld](https://github.com/Mic92/nix-ld), and on Alpine [gcompat](https://wiki.alpinelinux.org/wiki/Running_glibc_programs).
+
+You will need to build from source for:
+  - architectures other than 64-bit Intel or 64-bit ARM (for example a 32-bit or RISC-V machine)
+  - Amazon Linux 2 on x86_64
+  - Rocky Linux 9.3
 
 ## Other ways to install Zed on Linux
 

--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -22,9 +22,10 @@ The Zed installed by the script works best on systems that:
 Both Nix and Alpine have third-party Zed packages available (though they are currently a few weeks out of date). If you'd like to use our builds they do work if you install a glibc compatibility layer. On NixOS you can try [nix-ld](https://github.com/Mic92/nix-ld), and on Alpine [gcompat](https://wiki.alpinelinux.org/wiki/Running_glibc_programs).
 
 You will need to build from source for:
-  - architectures other than 64-bit Intel or 64-bit ARM (for example a 32-bit or RISC-V machine)
-  - Amazon Linux 2 on x86_64
-  - Rocky Linux 9.3
+
+- architectures other than 64-bit Intel or 64-bit ARM (for example a 32-bit or RISC-V machine)
+- Amazon Linux 2 on x86_64
+- Rocky Linux 9.3
 
 ## Other ways to install Zed on Linux
 


### PR DESCRIPTION
Our GitHub Actions Linux ARM hosted runner was running Ubuntu 20 was EOL'd.

This gets builds working on the Ubuntu 22 Linux ARM runner which have spun to replace the EOL'd one. It pushes forward our Glibc requirement for Linux ARM users (was >= 2.29, now >= 2.35; sorry!) but also uses a newer version of clang/llvm (was 10, now 15; yay!).

Release Notes:

- Linux ARM binaries now require glibc >= 2.35 (was >= 2.29).