### PR TITLE
go: Fix regression by restoring regex to match tests

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -518,7 +518,13 @@ impl ContextProvider for GoContextProvider {
                     GO_PACKAGE_TASK_VARIABLE.template_value(),
                     VariableName::Symbol.template_value(),
                 ),
-                command: format!("go test -run {}", VariableName::Symbol.template_value(),),
+                command: "go".into(),
+                args: vec![
+                    "test".into(),
+                    GO_PACKAGE_TASK_VARIABLE.template_value(),
+                    "-run".into(),
+                    format!("^{}\\$", VariableName::Symbol.template_value(),),
+                ],
                 tags: vec!["go-test".to_owned()],
                 cwd: package_cwd.clone(),
                 ..TaskTemplate::default()


### PR DESCRIPTION
This fixes a regression that snuck in with #17108.

When running a single test with `go test` the
regex wouldn't be used anymore.

This restores the old behavior.

Release Notes:

- Fixed a regression when running Go tests. A recent change dropped the regex used to match single test names when using `go test` in tasks to run tests. That could lead to more or the wrong tests being run. This restores the old behavior.
