### PR TITLE
assistant: Prevent possible execution of generated terminal commands

### DIFF
--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -1005,7 +1005,7 @@ impl TerminalTransaction {
     }
 
     fn sanitize_input(input: String) -> String {
-        input.replace('\r', "").replace('\n', "")
+        input.replace(['\r', '\n'], "")
     }
 }
 

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -988,7 +988,7 @@ impl TerminalTransaction {
 
     pub fn push(&mut self, hunk: String, cx: &mut AppContext) {
         // Ensure that the assistant cannot accidentally execute commands that are streamed into the terminal
-        let input = hunk.replace(CARRIAGE_RETURN, " ");
+        let input = Self::sanitize_input(hunk);
         self.terminal
             .update(cx, |terminal, _| terminal.input(input));
     }
@@ -1002,6 +1002,10 @@ impl TerminalTransaction {
         self.terminal.update(cx, |terminal, _| {
             terminal.input(CARRIAGE_RETURN.to_string())
         });
+    }
+
+    fn sanitize_input(input: String) -> String {
+        input.replace('\r', "").replace('\n', "")
     }
 }
 


### PR DESCRIPTION
Closes #17424

Release Notes:

- Fixed an issue where commands generated by the terminal command could sometimes be executed without confirmation
