### PR TITLE
Disable definition lists in Markdown

### DIFF
--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -166,6 +166,7 @@ pub async fn parse_markdown_block(
     let mut list_stack = Vec::new();
 
     let mut options = pulldown_cmark::Options::all();
+    options.remove(pulldown_cmark::Options::ENABLE_DEFINITION_LIST);
     options.remove(pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
 
     for event in Parser::new_ext(markdown, options) {
@@ -384,6 +385,7 @@ public: void format(const int &, const std::tm &, int &dest)
 "#;
 
         let mut options = pulldown_cmark::Options::all();
+        options.remove(pulldown_cmark::Options::ENABLE_DEFINITION_LIST);
         options.remove(pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
 
         let parser = pulldown_cmark::Parser::new_ext(input, options);

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -5,10 +5,13 @@ use pulldown_cmark::{Alignment, HeadingLevel, LinkType, MetadataBlockKind, Optio
 use std::ops::Range;
 
 pub fn parse_markdown(text: &str) -> Vec<(Range<usize>, MarkdownEvent)> {
+    let mut options = Options::all();
+    options.remove(pulldown_cmark::Options::ENABLE_DEFINITION_LIST);
+
     let mut events = Vec::new();
     let mut within_link = false;
     let mut within_metadata = false;
-    for (pulldown_event, mut range) in Parser::new_ext(text, Options::all()).into_offset_iter() {
+    for (pulldown_event, mut range) in Parser::new_ext(text, options).into_offset_iter() {
         if within_metadata {
             if let pulldown_cmark::Event::End(pulldown_cmark::TagEnd::MetadataBlock { .. }) =
                 pulldown_event

--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -11,7 +11,9 @@ pub async fn parse_markdown(
     file_location_directory: Option<PathBuf>,
     language_registry: Option<Arc<LanguageRegistry>>,
 ) -> ParsedMarkdown {
-    let options = Options::all();
+    let mut options = Options::all();
+    options.remove(pulldown_cmark::Options::ENABLE_DEFINITION_LIST);
+
     let parser = Parser::new_ext(markdown_input, options);
     let parser = MarkdownParser::new(
         parser.into_offset_iter().collect(),

--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -195,7 +195,9 @@ pub fn render_markdown_mut(
     let mut current_language = None;
     let mut list_stack = Vec::new();
 
-    let options = Options::all();
+    let mut options = Options::all();
+    options.remove(pulldown_cmark::Options::ENABLE_DEFINITION_LIST);
+
     for (event, source_range) in Parser::new_ext(block, options).into_offset_iter() {
         let prev_len = text.len();
         match event {


### PR DESCRIPTION
This PR disables definition list support in `pulldown_cmark`, as it is has been causing a number of issues.

I opened an issue upstream with the panic we were seeing: https://github.com/pulldown-cmark/pulldown-cmark/issues/957.

Release Notes:

- N/A
