### PR TITLE
assistant: Fix file slash command not allowing to select multiple files when pressing tab

### DIFF
--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -164,11 +164,7 @@ impl SlashCommand for FileSlashCommand {
                     Some(ArgumentCompletion {
                         label,
                         new_text: text,
-                        after_completion: if path_match.is_dir {
-                            AfterCompletion::Compose
-                        } else {
-                            AfterCompletion::Run
-                        },
+                        after_completion: AfterCompletion::Compose,
                         replace_previous_arguments: false,
                     })
                 })


### PR DESCRIPTION
Release Notes:

- Allow to add multiple files in a single `/file` command when pressing tab
