### PR TITLE
Revert tokenizer for custom OpenAI models

### DIFF
--- a/crates/language_model/src/provider/open_ai.rs
+++ b/crates/language_model/src/provider/open_ai.rs
@@ -370,7 +370,11 @@ pub fn count_open_ai_tokens(
                 })
                 .collect::<Vec<_>>();
 
-            tiktoken_rs::num_tokens_from_messages(model.id(), &messages)
+            if let open_ai::Model::Custom { .. } = model {
+                tiktoken_rs::num_tokens_from_messages("gpt-4", &messages)
+            } else {
+                tiktoken_rs::num_tokens_from_messages(model.id(), &messages)
+            }
         })
         .boxed()
 }


### PR DESCRIPTION
Fix for custom openai models tokenizer settings.
Accidentally broken in: https://github.com/zed-industries/zed/pull/17508/files

Release Notes:

- Fix for OpenAI compatible API tokenizers (Preview only)
