### PR TITLE
Add a way to join all panes into one

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -149,6 +149,7 @@ actions!(
         GoBack,
         GoForward,
         JoinIntoNext,
+        JoinAll,
         ReopenClosedItem,
         SplitLeft,
         SplitUp,
@@ -188,6 +189,7 @@ pub enum Event {
         item_id: EntityId,
     },
     Split(SplitDirection),
+    JoinAll,
     JoinIntoNext,
     ChangeItemTitle,
     Focus,
@@ -220,6 +222,7 @@ impl fmt::Debug for Event {
                 .debug_struct("Split")
                 .field("direction", direction)
                 .finish(),
+            Event::JoinAll => f.write_str("JoinAll"),
             Event::JoinIntoNext => f.write_str("JoinIntoNext"),
             Event::ChangeItemTitle => f.write_str("ChangeItemTitle"),
             Event::Focus => f.write_str("Focus"),
@@ -677,6 +680,10 @@ impl Pane {
 
     fn join_into_next(&mut self, cx: &mut ViewContext<Self>) {
         cx.emit(Event::JoinIntoNext);
+    }
+
+    fn join_all(&mut self, cx: &mut ViewContext<Self>) {
+        cx.emit(Event::JoinAll);
     }
 
     fn history_updated(&mut self, cx: &mut ViewContext<Self>) {
@@ -1747,7 +1754,7 @@ impl Pane {
             self.workspace
                 .update(cx, |_, cx| {
                     cx.defer(move |this, cx| {
-                        this.move_item(pane.clone(), pane, id, destination_index, cx)
+                        this.move_item(&pane, &pane, id, destination_index, cx)
                     });
                 })
                 .ok()?;
@@ -1767,7 +1774,7 @@ impl Pane {
             self.workspace
                 .update(cx, |_, cx| {
                     cx.defer(move |this, cx| {
-                        this.move_item(pane.clone(), pane, id, destination_index, cx)
+                        this.move_item(&pane, &pane, id, destination_index, cx)
                     });
                 })
                 .ok()?;
@@ -2338,7 +2345,7 @@ impl Pane {
                             }
                         })
                     }
-                    workspace.move_item(from_pane.clone(), to_pane.clone(), item_id, ix, cx);
+                    workspace.move_item(&from_pane, &to_pane, item_id, ix, cx);
                 });
             })
             .log_err();
@@ -2545,6 +2552,7 @@ impl Render for Pane {
             .on_action(cx.listener(|pane, _: &GoBack, cx| pane.navigate_backward(cx)))
             .on_action(cx.listener(|pane, _: &GoForward, cx| pane.navigate_forward(cx)))
             .on_action(cx.listener(|pane, _: &JoinIntoNext, cx| pane.join_into_next(cx)))
+            .on_action(cx.listener(|pane, _: &JoinAll, cx| pane.join_all(cx)))
             .on_action(cx.listener(Pane::toggle_zoom))
             .on_action(cx.listener(|pane: &mut Pane, action: &ActivateItem, cx| {
                 pane.activate_item(action.0, true, true, cx);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3,6 +3,7 @@ use crate::{
         ClosePosition, Item, ItemHandle, ItemSettings, PreviewTabsSettings, TabContentParams,
         WeakItemHandle,
     },
+    move_item,
     notifications::NotifyResultExt,
     toolbar::Toolbar,
     workspace_settings::{AutosaveSetting, TabBarSettings, WorkspaceSettings},
@@ -1753,9 +1754,7 @@ impl Pane {
 
             self.workspace
                 .update(cx, |_, cx| {
-                    cx.defer(move |this, cx| {
-                        this.move_item(&pane, &pane, id, destination_index, cx)
-                    });
+                    cx.defer(move |_, cx| move_item(&pane, &pane, id, destination_index, cx));
                 })
                 .ok()?;
 
@@ -1773,9 +1772,7 @@ impl Pane {
 
             self.workspace
                 .update(cx, |_, cx| {
-                    cx.defer(move |this, cx| {
-                        this.move_item(&pane, &pane, id, destination_index, cx)
-                    });
+                    cx.defer(move |_, cx| move_item(&pane, &pane, id, destination_index, cx));
                 })
                 .ok()?;
 
@@ -2345,7 +2342,7 @@ impl Pane {
                             }
                         })
                     }
-                    workspace.move_item(&from_pane, &to_pane, item_id, ix, cx);
+                    move_item(&from_pane, &to_pane, item_id, ix, cx);
                 });
             })
             .log_err();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5933,6 +5933,7 @@ fn join_pane_into_active(active_pane: &View<Pane>, pane: &View<Pane>, cx: &mut W
 
 fn move_all_items(from_pane: &View<Pane>, to_pane: &View<Pane>, cx: &mut WindowContext<'_>) {
     let destination_is_different = from_pane != to_pane;
+    let mut moved_items = 0;
     for (item_ix, item_handle) in from_pane
         .read(cx)
         .items()
@@ -5940,11 +5941,13 @@ fn move_all_items(from_pane: &View<Pane>, to_pane: &View<Pane>, cx: &mut WindowC
         .map(|(ix, item)| (ix, item.clone()))
         .collect::<Vec<_>>()
     {
+        let ix = item_ix - moved_items;
         if destination_is_different {
             // Close item from previous pane
             from_pane.update(cx, |source, cx| {
-                source.remove_item_and_focus_on_pane(item_ix, false, to_pane.clone(), cx);
+                source.remove_item_and_focus_on_pane(ix, false, to_pane.clone(), cx);
             });
+            moved_items += 1;
         }
 
         // This automatically removes duplicate items in the pane


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17536
Closes https://github.com/zed-industries/zed/pull/17548


Release Notes:

- Added a way to join all panes into one with `pane::JoinAll` action ([#17536](https://github.com/zed-industries/zed/issues/17536))
