### PR TITLE
Fix OpenAI key URL

### DIFF
--- a/crates/language_model/src/provider/open_ai.rs
+++ b/crates/language_model/src/provider/open_ai.rs
@@ -491,7 +491,7 @@ impl ConfigurationView {
 
 impl Render for ConfigurationView {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        const OPENAI_CONSOLE_URL: &str = "https://console.anthropic.com/settings/keys";
+        const OPENAI_CONSOLE_URL: &str = "https://platform.openai.com/api-keys";
         const INSTRUCTIONS: [&str; 6] = [
             "To use the assistant panel or inline assistant, you need to add your OpenAI API key.",
             " - You can create an API key at: ",


### PR DESCRIPTION
Update the create Open AI Key URL

Release Notes:

- Fixed a link in the Assistant panel to the OpenAI console.