### PR TITLE
php: Remove invalid node types from highlights queries

### DIFF
--- a/extensions/php/languages/php/highlights.scm
+++ b/extensions/php/languages/php/highlights.scm
@@ -133,8 +133,5 @@
 "trait" @keyword
 "try" @keyword
 "use" @keyword
-"var" @keyword
 "while" @keyword
 "xor" @keyword
-"yield" @keyword
-"yield from" @keyword


### PR DESCRIPTION
This PR removes some invalid node types from the PHP highlights queries.

Release Notes:

- N/A
