### PR TITLE
Doc Fix: Shortcut of "Go forward" in key-bindings.md

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -426,7 +426,7 @@ TBD: Add Column with Linux shortcuts
 | Close clean items             | Pane           | `⌘ + K, U`              |
 | Close inactive items          | Pane           | `Alt + ⌘ + T`           |
 | Go back                       | Pane           | `Control + -`           |
-| Go forward                    | Pane           | `Control + _`           |
+| Go forward                    | Pane           | `Control + Shift + _`   |
 | Reopen closed item            | Pane           | `⌘ + Shift + T`         |
 | Split down                    | Pane           | `⌘ + K, Down`           |
 | Split left                    | Pane           | `⌘ + K, Left`           |


### PR DESCRIPTION
"Control + _"  =>  "Control + Shift + _"

Doc was edited so quickly using zed that caused a typo 😄


### shot
<img width="729" alt="image" src="https://github.com/user-attachments/assets/104af7da-1205-43fd-b721-ffab7312487b">


### doc url
https://zed.dev/docs/key-bindings


Release Notes:

- N/A
