### PR TITLE
editor: Highlight bad unicode characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,6 +3678,7 @@ dependencies = [
  "parking_lot",
  "project",
  "rand 0.8.5",
+ "regex",
  "release_channel",
  "rpc",
  "schemars",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -56,6 +56,7 @@ ordered-float.workspace = true
 parking_lot.workspace = true
 project.workspace = true
 rand.workspace = true
+regex.workspace = true
 rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -22,6 +22,7 @@ mod editor_settings;
 mod editor_settings_controls;
 mod element;
 mod git;
+mod highlight_bad_unicode;
 mod highlight_matching_bracket;
 mod hover_links;
 mod hover_popover;
@@ -81,6 +82,7 @@ use gpui::{
     UTF16Selection, UnderlineStyle, UniformListScrollHandle, View, ViewContext, ViewInputHandler,
     VisualContext, WeakFocusHandle, WeakView, WindowContext,
 };
+use highlight_bad_unicode::refresh_invalid_character_highlight;
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HoverState};
 use hunk_diff::ExpandedHunks;
@@ -2495,6 +2497,7 @@ impl Editor {
             }
             self.refresh_code_actions(cx);
             self.refresh_document_highlights(cx);
+            refresh_invalid_character_highlight(self, cx);
             refresh_matching_bracket_highlights(self, cx);
             self.discard_inline_completion(false, cx);
             linked_editing_ranges::refresh_linked_ranges(self, cx);

--- a/crates/editor/src/highlight_bad_unicode.rs
+++ b/crates/editor/src/highlight_bad_unicode.rs
@@ -1,0 +1,57 @@
+use crate::Editor;
+use gpui::ViewContext;
+use language::BufferSnapshot;
+use regex::Regex;
+use std::ops::Range;
+
+enum BadUniCodeCharacter {}
+
+pub fn search(re: &Regex, buffer: &BufferSnapshot) -> Vec<Range<usize>> {
+    let mut matches = Vec::new();
+    let rope = buffer.as_rope().clone();
+    let text = rope.to_string();
+    let mut current_start = None;
+    let mut current_end = None;
+
+    for mat in re.find_iter(&text) {
+        match (current_start, current_end) {
+            (None, None) => {
+                current_start = Some(mat.start());
+                current_end = Some(mat.end());
+            }
+            (Some(start), Some(end)) => {
+                if mat.start() <= end {
+                    current_end = Some(mat.end().max(end));
+                } else {
+                    matches.push(start..end);
+                    current_start = Some(mat.start());
+                    current_end = Some(mat.end());
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+    if let (Some(start), Some(end)) = (current_start, current_end) {
+        matches.push(start..end);
+    }
+
+    matches
+}
+
+pub fn refresh_invalid_character_highlight(editor: &mut Editor, cx: &mut ViewContext<Editor>) {
+    let buffer = editor.buffer().read(cx).snapshot(cx);
+    let re = Regex::new(r"[\u{200B}\u{200C}\u{200D}\u{200E}\u{200F}\u{0000}-\u{0009}\u{000B}-\u{000C}\u{000E}-\u{001F}\u{007F}-\u{009F}\u{20E3}\u{20DD}]").unwrap();
+    let mut ranges = Vec::new();
+    if let Some((_, _, excerpt_buffer)) = buffer.as_singleton() {
+        ranges.extend(
+            search(&re, excerpt_buffer)
+                .into_iter()
+                .map(|matched_range| {
+                    buffer.anchor_after(matched_range.start)
+                        ..buffer.anchor_before(matched_range.end)
+                }),
+        )
+    }
+
+    editor.highlight_background::<BadUniCodeCharacter>(&ranges, |theme| theme.editor_invisible, cx);
+}


### PR DESCRIPTION
Closes #16310 

Release Notes:
added bad unicode highlights in a document

GPUI is unable to render unicode characters which causes undefined behavior during highlighting any suggestions/changes/help/fix will really help

![image](https://github.com/user-attachments/assets/ba3a1f57-f2ca-49a5-80cb-76c30768a992)

