### PR TITLE
windows: Fix can not set folder for `FileSaveDialog`

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -661,13 +661,17 @@ fn file_open_dialog(options: PathPromptOptions) -> Result<Option<Vec<PathBuf>>> 
 }
 
 fn file_save_dialog(directory: PathBuf) -> Result<Option<PathBuf>> {
+    println!("=> Directory: {}", directory.display());
     let dialog: IFileSaveDialog = unsafe { CoCreateInstance(&FileSaveDialog, None, CLSCTX_ALL)? };
     if !directory.to_string_lossy().is_empty() {
         if let Some(full_path) = directory.canonicalize().log_err() {
-            let full_path = full_path.to_string_lossy().to_string();
-            if !full_path.is_empty() {
+            println!("  => full path: {}", full_path.display());
+            let full_path = full_path.to_string_lossy();
+            let full_path_str = full_path.trim_start_matches("\\\\?\\");
+            if !full_path_str.is_empty() {
                 let path_item: IShellItem =
-                    unsafe { SHCreateItemFromParsingName(&HSTRING::from(&full_path), None)? };
+                    unsafe { SHCreateItemFromParsingName(&HSTRING::from(full_path_str), None)? };
+                println!("  => 1");
                 unsafe { dialog.SetFolder(&path_item).log_err() };
             }
         }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -661,17 +661,14 @@ fn file_open_dialog(options: PathPromptOptions) -> Result<Option<Vec<PathBuf>>> 
 }
 
 fn file_save_dialog(directory: PathBuf) -> Result<Option<PathBuf>> {
-    println!("=> Directory: {}", directory.display());
     let dialog: IFileSaveDialog = unsafe { CoCreateInstance(&FileSaveDialog, None, CLSCTX_ALL)? };
     if !directory.to_string_lossy().is_empty() {
         if let Some(full_path) = directory.canonicalize().log_err() {
-            println!("  => full path: {}", full_path.display());
             let full_path = full_path.to_string_lossy();
             let full_path_str = full_path.trim_start_matches("\\\\?\\");
             if !full_path_str.is_empty() {
                 let path_item: IShellItem =
                     unsafe { SHCreateItemFromParsingName(&HSTRING::from(full_path_str), None)? };
-                println!("  => 1");
                 unsafe { dialog.SetFolder(&path_item).log_err() };
             }
         }


### PR DESCRIPTION
Closes #17622
Closes #17682

The story here is that `SHCreateItemFromParsingName` dose not accept UNC path.

Video:


https://github.com/user-attachments/assets/f4f7f671-5ab5-4965-9158-e7a79ac02654



Release Notes:

- N/A
