### PR TITLE
lsp: Fix noisy logs when starting language servers

### DIFF
--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -833,7 +833,7 @@ impl LanguageRegistry {
     ) -> Option<PendingLanguageServer> {
         let server_id = self.state.write().next_language_server_id();
         log::info!(
-            "starting language server {:?}, path: {root_path:?}, id: {server_id}",
+            "attempting to start language server {:?}, path: {root_path:?}, id: {server_id}",
             adapter.name.0
         );
 

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -272,7 +272,7 @@ impl LanguageServer {
         };
 
         log::info!(
-            "starting language server. binary path: {:?}, working directory: {:?}, args: {:?}",
+            "starting language server process. binary path: {:?}, working directory: {:?}, args: {:?}",
             binary.path,
             working_dir,
             &binary.arguments

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -26,7 +26,6 @@ use gpui::{
     Task, WeakModel,
 };
 use http_client::{AsyncBody, Error, HttpClient, Request, Response, Uri};
-use itertools::Itertools;
 use language::{
     language_settings::{
         all_language_settings, language_settings, AllLanguageSettings, LanguageSettings,
@@ -4488,14 +4487,6 @@ impl LspStore {
                 desired_language_server.0
             );
         }
-
-        log::info!(
-            "starting language servers for {language}: {adapters}",
-            adapters = enabled_lsp_adapters
-                .iter()
-                .map(|adapter| adapter.name.0.as_ref())
-                .join(", ")
-        );
 
         for adapter in &enabled_lsp_adapters {
             self.start_language_server(worktree, adapter.clone(), language.clone(), cx);


### PR DESCRIPTION
We would log every time we'd lookup a language server for a file and we'd also log "starting language server" even though we were about to only download it and not start it.


Release Notes:

- N/A
