### PR TITLE
project: Use login shell to get environment per project

### DIFF
--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -219,7 +219,7 @@ async fn load_shell_environment(
     );
 
     let output = smol::process::Command::new(&shell)
-        .args(["-i", "-c", &command])
+        .args(["-l", "-i", "-c", &command])
         .envs(direnv_environment)
         .output()
         .await


### PR DESCRIPTION
This is a follow-up to #17075 to spawn a login shell when getting the environment for projects.

The reason why we didn't do it before is that we only used the environment for certain language servers and not a lot of other things, like tasks.

But with #17075 we now use the project more often and use it as the _base_ environment for tasks/terminals.

Before the change, terminals and tasks would inherit the Zed process' environment, including PATH and so on. After the change, we would set the environment, overwriting the PATH instead of merging. But the non-login shell environment is a subset of the login-shell environment.


Release Notes:

- Fixed environment variables used per project in terminals/tasks overwriting the base environment and not making use of a login-shell environment.
