### PR TITLE
editor: Open file when double clicking line number in gutter

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -522,7 +522,6 @@ impl EditorElement {
             return;
         }
 
-
         let point_for_position =
             position_map.point_for_position(text_hitbox.bounds, event.position);
         let position = point_for_position.previous_valid;


### PR DESCRIPTION
Double clicking the line number in the gutter of a multibuffer (i.e.: in search results) opens the file at that line. Single click continues to act as a select. 

![Kapture 2024-09-11 at 21 12 37](https://github.com/user-attachments/assets/f306c1cf-f4c2-4d8c-9d0a-3bf4fe7b032b)

This is an ergonomic change that I think it makes it easier for the user to get to the file (and the line) they want from the multibuffer search results. I'm pretty sure vscode has this behavior so I had a habit of clicking the line number. 

cocredit shoutout to @osiewicz for the help. 

Release Notes:

- Added the ability to double click the line number in a multi-buffer (i.e.: in search results) and open the file at that line