### PR TITLE
lsp: Use project-local settings if available

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -6,7 +6,7 @@ use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 pub use language::*;
 use lsp::LanguageServerBinary;
 use project::project_settings::{BinarySettings, ProjectSettings};
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use smol::fs::{self, File};
 use std::{any::Any, env::consts, path::PathBuf, sync::Arc};
 use util::{fs::remove_matching, maybe, ResultExt};
@@ -29,10 +29,16 @@ impl super::LspAdapter for CLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(Self::SERVER_NAME)
-                .and_then(|s| s.binary.clone())
+            ProjectSettings::get(
+                Some(SettingsLocation {
+                    worktree_id: delegate.worktree_id(),
+                    path: delegate.worktree_root_path(),
+                }),
+                cx,
+            )
+            .lsp
+            .get(Self::SERVER_NAME)
+            .and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -5,8 +5,7 @@ use gpui::AsyncAppContext;
 use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 pub use language::*;
 use lsp::LanguageServerBinary;
-use project::project_settings::{BinarySettings, ProjectSettings};
-use settings::{Settings, SettingsLocation};
+use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
 use smol::fs::{self, File};
 use std::{any::Any, env::consts, path::PathBuf, sync::Arc};
 use util::{fs::remove_matching, maybe, ResultExt};
@@ -29,16 +28,7 @@ impl super::LspAdapter for CLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            ProjectSettings::get(
-                Some(SettingsLocation {
-                    worktree_id: delegate.worktree_id(),
-                    path: delegate.worktree_root_path(),
-                }),
-                cx,
-            )
-            .lsp
-            .get(Self::SERVER_NAME)
-            .and_then(|s| s.binary.clone())
+            language_server_settings(delegate, Self::SERVER_NAME, cx).and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -8,7 +8,7 @@ use lsp::LanguageServerBinary;
 use project::project_settings::{BinarySettings, ProjectSettings};
 use regex::Regex;
 use serde_json::json;
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use smol::{fs, process};
 use std::{
     any::Any,
@@ -71,10 +71,16 @@ impl super::LspAdapter for GoLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(Self::SERVER_NAME)
-                .and_then(|s| s.binary.clone())
+            ProjectSettings::get(
+                Some(SettingsLocation {
+                    worktree_id: delegate.worktree_id(),
+                    path: delegate.worktree_root_path(),
+                }),
+                cx,
+            )
+            .lsp
+            .get(Self::SERVER_NAME)
+            .and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -5,10 +5,9 @@ use gpui::{AppContext, AsyncAppContext, Task};
 use http_client::github::latest_github_release;
 pub use language::*;
 use lsp::LanguageServerBinary;
-use project::project_settings::{BinarySettings, ProjectSettings};
+use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
 use regex::Regex;
 use serde_json::json;
-use settings::{Settings, SettingsLocation};
 use smol::{fs, process};
 use std::{
     any::Any,
@@ -71,16 +70,7 @@ impl super::LspAdapter for GoLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            ProjectSettings::get(
-                Some(SettingsLocation {
-                    worktree_id: delegate.worktree_id(),
-                    path: delegate.worktree_root_path(),
-                }),
-                cx,
-            )
-            .lsp
-            .get(Self::SERVER_NAME)
-            .and_then(|s| s.binary.clone())
+            language_server_settings(delegate, Self::SERVER_NAME, cx).and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -8,6 +8,7 @@ use node_runtime::NodeRuntime;
 use project::project_settings::ProjectSettings;
 use serde_json::Value;
 use settings::Settings;
+use settings::SettingsLocation;
 use std::{
     any::Any,
     borrow::Cow,
@@ -177,15 +178,21 @@ impl LspAdapter for PythonLspAdapter {
 
     async fn workspace_configuration(
         self: Arc<Self>,
-        _: &Arc<dyn LspAdapterDelegate>,
+        adapter: &Arc<dyn LspAdapterDelegate>,
         cx: &mut AsyncAppContext,
     ) -> Result<Value> {
         cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(Self::SERVER_NAME)
-                .and_then(|s| s.settings.clone())
-                .unwrap_or_default()
+            ProjectSettings::get(
+                Some(SettingsLocation {
+                    worktree_id: adapter.worktree_id(),
+                    path: adapter.worktree_root_path(),
+                }),
+                cx,
+            )
+            .lsp
+            .get(Self::SERVER_NAME)
+            .and_then(|s| s.settings.clone())
+            .unwrap_or_default()
         })
     }
 }

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -5,10 +5,9 @@ use gpui::AsyncAppContext;
 use language::{ContextProvider, LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::LanguageServerBinary;
 use node_runtime::NodeRuntime;
-use project::project_settings::ProjectSettings;
+use project::lsp_store::language_server_settings;
 use serde_json::Value;
-use settings::Settings;
-use settings::SettingsLocation;
+
 use std::{
     any::Any,
     borrow::Cow,
@@ -182,17 +181,9 @@ impl LspAdapter for PythonLspAdapter {
         cx: &mut AsyncAppContext,
     ) -> Result<Value> {
         cx.update(|cx| {
-            ProjectSettings::get(
-                Some(SettingsLocation {
-                    worktree_id: adapter.worktree_id(),
-                    path: adapter.worktree_root_path(),
-                }),
-                cx,
-            )
-            .lsp
-            .get(Self::SERVER_NAME)
-            .and_then(|s| s.settings.clone())
-            .unwrap_or_default()
+            language_server_settings(adapter.as_ref(), Self::SERVER_NAME, cx)
+                .and_then(|s| s.settings.clone())
+                .unwrap_or_default()
         })
     }
 }

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -9,7 +9,7 @@ use language_settings::all_language_settings;
 use lsp::LanguageServerBinary;
 use project::project_settings::{BinarySettings, ProjectSettings};
 use regex::Regex;
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use smol::fs::{self, File};
 use std::{
     any::Any,
@@ -40,10 +40,16 @@ impl LspAdapter for RustLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(Self::SERVER_NAME)
-                .and_then(|s| s.binary.clone())
+            ProjectSettings::get(
+                Some(SettingsLocation {
+                    worktree_id: delegate.worktree_id(),
+                    path: delegate.worktree_root_path(),
+                }),
+                cx,
+            )
+            .lsp
+            .get(Self::SERVER_NAME)
+            .and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -7,9 +7,8 @@ use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 pub use language::*;
 use language_settings::all_language_settings;
 use lsp::LanguageServerBinary;
-use project::project_settings::{BinarySettings, ProjectSettings};
+use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
 use regex::Regex;
-use settings::{Settings, SettingsLocation};
 use smol::fs::{self, File};
 use std::{
     any::Any,
@@ -40,16 +39,7 @@ impl LspAdapter for RustLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            ProjectSettings::get(
-                Some(SettingsLocation {
-                    worktree_id: delegate.worktree_id(),
-                    path: delegate.worktree_root_path(),
-                }),
-                cx,
-            )
-            .lsp
-            .get(Self::SERVER_NAME)
-            .and_then(|s| s.binary.clone())
+            language_server_settings(delegate, Self::SERVER_NAME, cx).and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -11,7 +11,7 @@ use node_runtime::NodeRuntime;
 use project::project_settings::ProjectSettings;
 use project::ContextProviderWithTasks;
 use serde_json::{json, Value};
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use smol::{fs, io::BufReader, stream::StreamExt};
 use std::{
     any::Any,
@@ -236,14 +236,20 @@ impl LspAdapter for TypeScriptLspAdapter {
 
     async fn workspace_configuration(
         self: Arc<Self>,
-        _: &Arc<dyn LspAdapterDelegate>,
+        delegate: &Arc<dyn LspAdapterDelegate>,
         cx: &mut AsyncAppContext,
     ) -> Result<Value> {
         let override_options = cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(Self::SERVER_NAME)
-                .and_then(|s| s.initialization_options.clone())
+            ProjectSettings::get(
+                Some(SettingsLocation {
+                    worktree_id: delegate.worktree_id(),
+                    path: delegate.worktree_root_path(),
+                }),
+                cx,
+            )
+            .lsp
+            .get(Self::SERVER_NAME)
+            .and_then(|s| s.initialization_options.clone())
         })?;
         if let Some(options) = override_options {
             return Ok(options);
@@ -334,11 +340,17 @@ impl LspAdapter for EsLintLspAdapter {
         let workspace_root = delegate.worktree_root_path();
 
         let eslint_user_settings = cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(Self::SERVER_NAME)
-                .and_then(|s| s.settings.clone())
-                .unwrap_or_default()
+            ProjectSettings::get(
+                Some(SettingsLocation {
+                    worktree_id: delegate.worktree_id(),
+                    path: delegate.worktree_root_path(),
+                }),
+                cx,
+            )
+            .lsp
+            .get(Self::SERVER_NAME)
+            .and_then(|s| s.settings.clone())
+            .unwrap_or_default()
         })?;
 
         let mut code_action_on_save = json!({

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -5,10 +5,7 @@ use gpui::AsyncAppContext;
 use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::{CodeActionKind, LanguageServerBinary};
 use node_runtime::NodeRuntime;
-use project::{
-    lsp_store::language_server_settings,
-    project_settings::BinarySettings,
-};
+use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
 use serde_json::{json, Value};
 use std::{
     any::Any,

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -75,10 +75,16 @@ impl LspAdapter for VtslsLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            ProjectSettings::get_global(cx)
-                .lsp
-                .get(SERVER_NAME)
-                .and_then(|s| s.binary.clone())
+            ProjectSettings::get(
+                Some(SettingsLocation {
+                    worktree_id: delegate.worktree_id(),
+                    path: delegate.worktree_root_path(),
+                }),
+                cx,
+            )
+            .lsp
+            .get(SERVER_NAME)
+            .and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3,7 +3,7 @@ use crate::{
     environment::ProjectEnvironment,
     lsp_command::{self, *},
     lsp_ext_command,
-    project_settings::ProjectSettings,
+    project_settings::{LspSettings, ProjectSettings},
     relativize_path, resolve_path,
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
     yarn::YarnPathStore,
@@ -7035,6 +7035,23 @@ impl HttpClient for BlockedHttpClient {
         None
     }
 }
+
+pub fn language_server_settings<'a, 'b: 'a>(
+    delegate: &'a dyn LspAdapterDelegate,
+    language: &str,
+    cx: &'b AppContext,
+) -> Option<&'a LspSettings> {
+    ProjectSettings::get(
+        Some(SettingsLocation {
+            worktree_id: delegate.worktree_id(),
+            path: delegate.worktree_root_path(),
+        }),
+        cx,
+    )
+    .lsp
+    .get(language)
+}
+
 #[async_trait]
 impl LspAdapterDelegate for ProjectLspAdapterDelegate {
     fn show_notification(&self, message: &str, cx: &mut AppContext) {


### PR DESCRIPTION

Release Notes:

- Changed built-in language support (Rust, Go, C, YAML, ...) to lookup language-server specific settings locally in project directory first before falling back to global value.
