### PR TITLE
editor: Render documentation popovers using UI font

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1173,6 +1173,7 @@ impl CompletionsMenu {
                                     None
                                 } else {
                                     Some(
+                                        // TODO: Use UI font
                                         Label::new(text.clone())
                                             .ml_4()
                                             .size(LabelSize::Small)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1173,7 +1173,6 @@ impl CompletionsMenu {
                                     None
                                 } else {
                                     Some(
-                                        // TODO: Use UI font
                                         Label::new(text.clone())
                                             .ml_4()
                                             .size(LabelSize::Small)

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -518,19 +518,22 @@ async fn parse_blocks(
     let rendered_block = cx
         .new_view(|cx| {
             let settings = ThemeSettings::get_global(cx);
+            let ui_font_family = settings.ui_font.family.clone();
             let buffer_font_family = settings.buffer_font.family.clone();
-            let mut base_style = cx.text_style();
-            base_style.refine(&TextStyleRefinement {
-                font_family: Some(buffer_font_family.clone()),
+
+            let mut base_text_style = cx.text_style();
+            base_text_style.refine(&TextStyleRefinement {
+                font_family: Some(ui_font_family.clone()),
                 color: Some(cx.theme().colors().editor_foreground),
                 ..Default::default()
             });
 
             let markdown_style = MarkdownStyle {
-                base_text_style: base_style,
-                code_block: StyleRefinement::default().mt(rems(1.)).mb(rems(1.)),
+                base_text_style,
+                code_block: StyleRefinement::default().my(rems(1.)).font_buffer(cx),
                 inline_code: TextStyleRefinement {
                     background_color: Some(cx.theme().colors().background),
+                    font_family: Some(buffer_font_family),
                     ..Default::default()
                 },
                 rule_color: Color::Muted.color(cx),


### PR DESCRIPTION
This PR updates the documentation popovers to render non-code using the UI font:

<img width="603" alt="Screenshot 2024-09-12 at 11 10 46 AM" src="https://github.com/user-attachments/assets/c5be0676-0f0f-4ff6-8a96-76b44684e1cf">

<img width="347" alt="Screenshot 2024-09-12 at 11 21 12 AM" src="https://github.com/user-attachments/assets/842ba922-9837-45c1-9cf2-846fe8362f99">

Requested by @davidbarsky.

Release Notes:

- Changed documentation popovers to render Markdown prose using the UI font instead of the buffer font. Code blocks still using the buffer font.
