### PR TITLE
Limit the maximum value of user-configured ui_font_size

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1921,7 +1921,7 @@ impl PromptEditor {
             font_family: settings.ui_font.family.clone(),
             font_features: settings.ui_font.features.clone(),
             font_fallbacks: settings.ui_font.fallbacks.clone(),
-            font_size: settings.ui_font_size.into(),
+            font_size: settings.ui_font_size().into(),
             font_weight: settings.ui_font.weight,
             line_height: relative(1.3),
             ..Default::default()

--- a/crates/editor/src/blame_entry_tooltip.rs
+++ b/crates/editor/src/blame_entry_tooltip.rs
@@ -148,7 +148,7 @@ impl Render for BlameEntryTooltip {
             .as_ref()
             .and_then(|details| details.pull_request.clone());
 
-        let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
+        let ui_font_size = ThemeSettings::get_global(cx).ui_font_size();
         let message_max_height = cx.line_height() * 12 + (ui_font_size / 0.4);
 
         tooltip_container(cx, move |this, cx| {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -337,7 +337,7 @@ fn show_hover(
                         let mut base_text_style = cx.text_style();
                         base_text_style.refine(&TextStyleRefinement {
                             font_family: Some(settings.ui_font.family.clone()),
-                            font_size: Some(settings.ui_font_size.into()),
+                            font_size: Some(settings.ui_font_size().into()),
                             color: Some(cx.theme().colors().editor_foreground),
                             background_color: Some(gpui::transparent_black()),
 

--- a/crates/settings_ui/src/appearance_settings_controls.rs
+++ b/crates/settings_ui/src/appearance_settings_controls.rs
@@ -240,7 +240,7 @@ impl EditableSettingControl for UiFontSizeControl {
 
     fn read(cx: &AppContext) -> Self::Value {
         let settings = ThemeSettings::get_global(cx);
-        settings.ui_font_size
+        settings.ui_font_size()
     }
 
     fn apply(

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use util::ResultExt as _;
 
 const MIN_FONT_SIZE: Pixels = px(6.0);
+const MAX_FONT_SIZE: Pixels = px(100.0);
 const MIN_LINE_HEIGHT: f32 = 1.0;
 
 #[derive(
@@ -97,6 +98,11 @@ pub struct ThemeSettings {
 impl ThemeSettings {
     const DEFAULT_LIGHT_THEME: &'static str = "One Light";
     const DEFAULT_DARK_THEME: &'static str = "One Dark";
+
+    /// Returns the safety ui_font_size.
+    pub fn ui_font_size(&self) -> Pixels {
+        self.ui_font_size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
+    }
 
     /// Returns the name of the default theme for the given [`Appearance`].
     pub fn default_theme(appearance: Appearance) -> &'static str {
@@ -492,13 +498,13 @@ pub fn setup_ui_font(cx: &mut WindowContext) -> gpui::Font {
 }
 
 pub fn get_ui_font_size(cx: &WindowContext) -> Pixels {
-    let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
+    let ui_font_size = ThemeSettings::get_global(cx).ui_font_size();
     cx.try_global::<AdjustedUiFontSize>()
         .map_or(ui_font_size, |adjusted_size| adjusted_size.0)
 }
 
 pub fn adjust_ui_font_size(cx: &mut WindowContext, f: fn(&mut Pixels)) {
-    let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
+    let ui_font_size = ThemeSettings::get_global(cx).ui_font_size();
     let mut adjusted_size = cx
         .try_global::<AdjustedUiFontSize>()
         .map_or(ui_font_size, |adjusted_size| adjusted_size.0);

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -338,7 +338,7 @@ impl ContextMenuItem {
 
 impl Render for ContextMenu {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
+        let ui_font_size = ThemeSettings::get_global(cx).ui_font_size();
 
         div().occlude().elevation_2(cx).flex().flex_row().child(
             WithRemSize::new(ui_font_size).flex().child(

--- a/crates/ui/src/styles/spacing.rs
+++ b/crates/ui/src/styles/spacing.rs
@@ -78,7 +78,7 @@ impl Spacing {
     }
 
     pub fn px(self, cx: &WindowContext) -> Pixels {
-        let ui_font_size_f32: f32 = ThemeSettings::get_global(cx).ui_font_size.into();
+        let ui_font_size_f32: f32 = ThemeSettings::get_global(cx).ui_font_size().into();
 
         px(ui_font_size_f32 * self.spacing_ratio(cx))
     }

--- a/crates/ui/src/styles/typography.rs
+++ b/crates/ui/src/styles/typography.rs
@@ -136,7 +136,7 @@ impl TextSize {
             Self::Default => rems_from_px(14.),
             Self::Small => rems_from_px(12.),
             Self::XSmall => rems_from_px(10.),
-            Self::Ui => rems_from_px(theme_settings.ui_font_size.into()),
+            Self::Ui => rems_from_px(theme_settings.ui_font_size().into()),
             Self::Editor => rems_from_px(theme_settings.buffer_font_size.into()),
         }
     }


### PR DESCRIPTION
Release Notes:

- Fixed Limit the maximum value of user-configured ui_font_size to 100px

### Before:

https://github.com/user-attachments/assets/8af204c2-8800-4e47-a745-a4cf673a0856

### After:

https://github.com/user-attachments/assets/e39fb72e-9445-4c81-a9fc-f77ec636ec35

### Background:

I encountered an issue when I mistakenly set ui_font_size to `1234`, when i save the config.
the Zed editor unusable, causing the process to hang and generating numerous errors in the backend console. likes:

* SVG has an invalid size
* memory allocation of 7319755215802368 bytes failed

I suspect that the abnormal value for `ui_font_size` caused rendering issues in many components that depend on font size

Based on the configuration options of VS Code, the valid range for `ui_font_size` is between 6px and 100px. I decided to set the maximum value to 100px, even though I doubt users will actually set it that high; it's better than having no limit at all.


The VS Code 

![image](https://github.com/user-attachments/assets/e63f8805-a516-4e99-8041-cf2410c4e909)

