### PR TITLE
lsp: Treat unrooted paths as relative to the worktree root

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3499,7 +3499,7 @@ impl LspStore {
                                             .to_owned();
                                         let path = if Path::new(path).components().next().is_none()
                                         {
-                                            Arc::from(Path::new("/"))
+                                            Arc::from(Path::new(worktree_root_path))
                                         } else {
                                             PathBuf::from(path).into()
                                         };


### PR DESCRIPTION
gopls would send us watch patterns like `**/*.mod` and we'd fall back to watching `/`.

Release Notes:
- Fix file watching for go projects resorting to watching the fs root.
