### PR TITLE
windows: Fix `tailwind-language-server`

### DIFF
--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -265,7 +265,7 @@ fn print_tree(root_dir: &str, dir: &Path, indent: usize) {
     if dir.is_dir() {
         // Print the directory name with indentation
         let dir_name = dir.to_string_lossy();
-        let dir_name_short = dir_name.trim_start_matches(&root_dir);
+        let dir_name_short = dir_name.trim_start_matches(root_dir);
         println!("{:indent$}{}", "", dir_name_short, indent = indent);
 
         // Iterate over the directory entries

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -123,6 +123,9 @@ impl LspAdapter for TailwindLspAdapter {
                 .await?;
         }
 
+        let root_dir = container_dir.to_str().unwrap();
+        print_tree(root_dir, &container_dir, 0);
+
         #[cfg(target_os = "windows")]
         {
             let env_path = self.node.node_environment_path().await?;
@@ -256,4 +259,25 @@ async fn get_cached_server_binary(
     })
     .await
     .log_err()
+}
+
+fn print_tree(root_dir: &str, dir: &Path, indent: usize) {
+    if dir.is_dir() {
+        // Print the directory name with indentation
+        let dir_name = dir.to_string_lossy();
+        let dir_name_short = dir_name.trim_start_matches(&root_dir);
+        println!("{:indent$}{}", "", dir_name_short, indent = indent);
+
+        // Iterate over the directory entries
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                // Recursively print directories and files
+                print_tree(root_dir, &path, indent + 4);
+            }
+        }
+    } else if let Some(name) = dir.file_name() {
+        // Print file name
+        println!("{:indent$}{}", "", name.to_string_lossy(), indent = indent);
+    }
 }

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -30,7 +30,13 @@ fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
 
 #[cfg(target_os = "windows")]
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
-    vec!["-File".into(), server_path.into(), "--stdio".into()]
+    vec![
+        "-ExecutionPolicy".into(),
+        "Bypass".into(),
+        "-File".into(),
+        server_path.into(),
+        "--stdio".into(),
+    ]
 }
 
 pub struct TailwindLspAdapter {


### PR DESCRIPTION
Closes #17741

I'm not sure why, but ever since `tailwind` was upgraded to `0.24`, there have been occasional errors indicating that the `.ps1` file could not be found. After reviewing the `.ps1` script, it appears that it simply starts the server using `node`. This PR directly using the method from the script to start the server with `node`.


Co-authored-by: Anay <me@anayparaswani.dev>


Release Notes:

- N/A
