### PR TITLE
Make Vim movement to end of line configurable

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -73,7 +73,7 @@ pub fn right(map: &DisplaySnapshot, mut point: DisplayPoint) -> DisplayPoint {
 /// if that point is already at the end of line.
 pub fn saturating_right(map: &DisplaySnapshot, mut point: DisplayPoint) -> DisplayPoint {
     *point.column_mut() += 1;
-    map.clip_point(point, Bias::Right)
+    map.clip_ignoring_line_ends(point, Bias::Right)
 }
 
 /// Returns a display point for the preceding displayed line (which might be a soft-wrapped line).

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1549,7 +1549,7 @@ pub(crate) fn end_of_line(
             Bias::Left,
         )
     } else {
-        map.clip_point(map.next_line_boundary(point.to_point(map)).1, Bias::Left)
+        map.clip_ignoring_line_ends(map.next_line_boundary(point.to_point(map)).1, Bias::Left)
     }
 }
 


### PR DESCRIPTION
Release Notes:

- Add ability to configure Vim movement when moving to the right