### PR TITLE
typescript: Highlight `is` predicate keyword & `...` spread pattern

### DIFF
--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -199,7 +199,7 @@
   "void"
   "while"
   "with"
-  "yield",
+  "yield"
 ] @keyword
 
 (template_substitution

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -181,6 +181,7 @@
   "import"
   "in"
   "instanceof"
+  "is"
   "let"
   "new"
   "of"
@@ -198,7 +199,7 @@
   "void"
   "while"
   "with"
-  "yield"
+  "yield",
 ] @keyword
 
 (template_substitution

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -198,7 +198,8 @@
   "void"
   "while"
   "with"
-  "yield"
+  "yield",
+  "is"
 ] @keyword
 
 (template_substitution

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -100,6 +100,7 @@
 ] @punctuation.delimiter
 
 [
+  "..."
   "-"
   "--"
   "-="

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -181,6 +181,7 @@
   "import"
   "in"
   "instanceof"
+  "is"
   "let"
   "new"
   "of"
@@ -198,8 +199,7 @@
   "void"
   "while"
   "with"
-  "yield",
-  "is"
+  "yield"
 ] @keyword
 
 (template_substitution


### PR DESCRIPTION
Release Notes:

- Fixed the `is` and `...` highlights for TypeScript