### PR TITLE
context_servers: Return messages from prompts/get

### DIFF
--- a/crates/assistant/src/slash_command/context_server_command.rs
+++ b/crates/assistant/src/slash_command/context_server_command.rs
@@ -230,7 +230,7 @@ fn format_messages(messages: &[SamplingMessage]) -> String {
             .iter()
             .map(|msg| {
                 match &msg.content {
-                    SamplingContent::Text(text) => text,
+                    SamplingContent::Text { text } => text,
                     SamplingContent::Image { .. } => "", // Ignore images for now
                 }
             })
@@ -245,7 +245,7 @@ fn format_messages(messages: &[SamplingMessage]) -> String {
                     SamplingRole::Assistant => "Assistant",
                 };
                 let content = match &msg.content {
-                    SamplingContent::Text(text) => text,
+                    SamplingContent::Text { text } => text,
                     SamplingContent::Image { .. } => "",
                 };
                 format!("{}: {}", role, content)

--- a/crates/context_servers/src/types.rs
+++ b/crates/context_servers/src/types.rs
@@ -160,10 +160,11 @@ pub enum SamplingRole {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type", content = "content")]
+#[serde(tag = "type")]
 pub enum SamplingContent {
     #[serde(rename = "text")]
-    Text(String),
+    Text { text: String },
+    // Keep the Image variant if it's still needed
     #[serde(rename = "image")]
     Image { data: String, mime_type: String },
 }

--- a/crates/context_servers/src/types.rs
+++ b/crates/context_servers/src/types.rs
@@ -147,9 +147,32 @@ pub struct ResourcesListResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SamplingMessage {
+    pub role: SamplingRole,
+    pub content: SamplingContent,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SamplingRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", content = "content")]
+pub enum SamplingContent {
+    #[serde(rename = "text")]
+    Text(String),
+    #[serde(rename = "image")]
+    Image { data: String, mime_type: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptsGetResponse {
     pub description: Option<String>,
-    pub prompt: String,
+    pub messages: Vec<SamplingMessage>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This is a change in protocol. Since the protocol is marked as experimental, we don't just yet bump the version. We now return messages with user or assistant roles from prompt/get. In zed, we do the 'easy' thing at the moment and create a simple text that says `Assistant:`/`User:` respectively. The right fix would be to change the way we render slash command and allow for proper User/Assistant labels. I chose to not do this here, as it's a complicated change that likely needs to bake longer and I likely need help from someone at Zed to implement it.

The reasoning behind changing this, as this in the future would allow to nicely move complete existing conversations between Zed, e.g. claude.ai, which i think would be very useful in the future, e.g. imagine a world where someone create an artifact in claude.ai and pulls it into Zed + conversation.

Release Notes:

- N/A