### PR TITLE
Fix missing on-mouseup when dragging the window on Linux

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -182,6 +182,12 @@ impl Render for TitleBar {
                             .on_mouse_down_out(cx.listener(move |this, _ev, _cx| {
                                 this.should_move = false;
                             }))
+                            .on_mouse_up(
+                                gpui::MouseButton::Left,
+                                cx.listener(move |this, _ev, _cx| {
+                                    this.should_move = false;
+                                }),
+                            )
                             .on_mouse_down(
                                 gpui::MouseButton::Left,
                                 cx.listener(move |this, _ev, _cx| {


### PR DESCRIPTION
Zed Hackathon entry :D

Release Notes:

- Fixed a bug where Zed would initiate a window move and then refuse to release the mouse.