### PR TITLE
zed_extension_api: Use v0.2.0 WIT types

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -186,7 +186,7 @@ mod wit {
 
     wit_bindgen::generate!({
         skip: ["init-extension"],
-        path: "./wit/since_v0.1.0",
+        path: "./wit/since_v0.2.0",
     });
 }
 


### PR DESCRIPTION
This PR makes `zed_extension_api` use the WIT types from v0.2.0 of extension API.

A follow-up from #17795, since I had forgotten to do it there.

Release Notes:

- N/A
