### PR TITLE
vim: Fix ctrl-b not moving the cursor

### DIFF
--- a/crates/editor/src/scroll/scroll_amount.rs
+++ b/crates/editor/src/scroll/scroll_amount.rs
@@ -1,6 +1,18 @@
 use serde::Deserialize;
 use ui::{px, Pixels};
 
+#[derive(Debug)]
+pub enum ScrollDirection {
+    Upwards,
+    Downwards,
+}
+
+impl ScrollDirection {
+    pub fn is_upwards(&self) -> bool {
+        matches!(self, ScrollDirection::Upwards)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub enum ScrollAmount {
     // Scroll N lines (positive is towards the end of the document)
@@ -15,7 +27,7 @@ impl ScrollAmount {
             Self::Line(count) => *count,
             Self::Page(count) => {
                 // for full pages subtract one to leave an anchor line
-                if count.abs() == 1.0 {
+                if self.is_full_page() {
                     visible_line_count -= 1.0
                 }
                 (visible_line_count * count).trunc()
@@ -27,6 +39,21 @@ impl ScrollAmount {
         match self {
             ScrollAmount::Line(x) => px(line_height.0 * x),
             ScrollAmount::Page(x) => px(height.0 * x),
+        }
+    }
+
+    pub fn is_full_page(&self) -> bool {
+        match self {
+            ScrollAmount::Page(count) if count.abs() == 1.0 => true,
+            _ => false,
+        }
+    }
+
+    pub fn direction(&self) -> ScrollDirection {
+        match self {
+            Self::Line(amount) if amount.is_sign_positive() => ScrollDirection::Downwards,
+            Self::Page(amount) if amount.is_sign_positive() => ScrollDirection::Downwards,
+            _ => ScrollDirection::Upwards,
         }
     }
 }

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -115,7 +115,7 @@ fn scroll_editor(
             } else {
                 DisplayRow(top.row().0 + vertical_scroll_margin)
             };
-            let max_row = DisplayRow(map.max_point().row().0.max(top.row().0.saturating_add(
+            let max_row = DisplayRow(map.max_point().row().0.min(top.row().0.saturating_add(
                 (visible_line_count as u32).saturating_sub(1 + vertical_scroll_margin),
             )));
 

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -307,7 +307,7 @@ mod test {
         let visible_lines = 10;
         cx.set_scroll_height(visible_lines).await;
 
-        // We also turn off scrolloff, since that makes the tests more confusing.
+        // First test without vertical scroll margin
         cx.neovim.set_option(&format!("scrolloff={}", 0)).await;
         cx.update_global(|store: &mut SettingsStore, cx| {
             store.update_user_settings::<EditorSettings>(cx, |s| {
@@ -317,6 +317,31 @@ mod test {
 
         let content = "ˇ".to_owned() + &sample_text(26, 2, 'a');
         cx.set_shared_state(&content).await;
+
+        // scroll down: ctrl-f
+        cx.simulate_shared_keystrokes("ctrl-f").await;
+        cx.shared_state().await.assert_matches();
+
+        cx.simulate_shared_keystrokes("ctrl-f").await;
+        cx.shared_state().await.assert_matches();
+
+        // scroll up: ctrl-b
+        cx.simulate_shared_keystrokes("ctrl-b").await;
+        cx.shared_state().await.assert_matches();
+
+        cx.simulate_shared_keystrokes("ctrl-b").await;
+        cx.shared_state().await.assert_matches();
+
+        // Now go back to start of file, and test with vertical scroll margin
+        cx.simulate_shared_keystrokes("g g").await;
+        cx.shared_state().await.assert_matches();
+
+        cx.neovim.set_option(&format!("scrolloff={}", 3)).await;
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings::<EditorSettings>(cx, |s| {
+                s.vertical_scroll_margin = Some(3.0)
+            });
+        });
 
         // scroll down: ctrl-f
         cx.simulate_shared_keystrokes("ctrl-f").await;

--- a/crates/vim/test_data/test_ctrl_f_b.json
+++ b/crates/vim/test_data/test_ctrl_f_b.json
@@ -4,5 +4,9 @@
 {"Put":{"state":"ˇaa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz"}}
 {"Key":"ctrl-f"}
 {"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nˇii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"ctrl-f"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nˇqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"ctrl-b"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nˇrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
 {"Key":"ctrl-b"}
 {"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\nˇjj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}

--- a/crates/vim/test_data/test_ctrl_f_b.json
+++ b/crates/vim/test_data/test_ctrl_f_b.json
@@ -1,0 +1,8 @@
+{"SetOption":{"value":"scrolloff=3"}}
+{"SetOption":{"value":"lines=12"}}
+{"SetOption":{"value":"scrolloff=0"}}
+{"Put":{"state":"ˇaa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz"}}
+{"Key":"ctrl-f"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nˇii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"ctrl-b"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\nˇjj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}

--- a/crates/vim/test_data/test_ctrl_f_b.json
+++ b/crates/vim/test_data/test_ctrl_f_b.json
@@ -10,3 +10,15 @@
 {"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nˇrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
 {"Key":"ctrl-b"}
 {"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\nˇjj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"g"}
+{"Key":"g"}
+{"Get":{"state":"ˇaa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"SetOption":{"value":"scrolloff=3"}}
+{"Key":"ctrl-f"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nˇll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"ctrl-f"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\nˇtt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"ctrl-b"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\nˇoo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}
+{"Key":"ctrl-b"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\nˇgg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz","mode":"Normal"}}


### PR DESCRIPTION
Closes #17687

Release Notes:

- Fixed `ctrl-b` not moving the cursor.