### PR TITLE
context_servers: Hide actions when no context servers are configured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,6 +2780,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
+ "command_palette_hooks",
  "futures 0.3.30",
  "gpui",
  "log",

--- a/crates/context_servers/Cargo.toml
+++ b/crates/context_servers/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/context_servers.rs"
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true
+command_palette_hooks.workspace = true
 futures.workspace = true
 gpui.workspace = true
 log.workspace = true

--- a/crates/context_servers/src/context_servers.rs
+++ b/crates/context_servers/src/context_servers.rs
@@ -12,6 +12,9 @@ pub use registry::*;
 
 actions!(context_servers, [Restart]);
 
+/// The namespace for the context servers actions.
+const CONTEXT_SERVERS_NAMESPACE: &'static str = "context_servers";
+
 pub fn init(cx: &mut AppContext) {
     log::info!("initializing context server client");
     manager::init(cx);


### PR DESCRIPTION
This PR filters out the context servers actions from the command palette when no context servers are configured.

Release Notes:

- N/A
