### PR TITLE
terminal: Override default working directory to be home dir

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -331,6 +331,8 @@ impl TerminalBuilder {
             release_channel::AppVersion::global(cx).to_string(),
         );
 
+        let working_directory = working_directory.or_else(|| Some(util::paths::home_dir().clone()));
+
         let pty_options = {
             let alac_shell = match shell.clone() {
                 Shell::System => None,


### PR DESCRIPTION
If there is not a specific project directory, the terminal defaults to `/`.

The `working_directory` setting goes through some processing, and then eventually gets passed through to the `alacritty_terminal` crate to actually handle the terminal.

It seems that alacritty, if no working directory is set (`None`), will default to the directory of the foreground process. If Zed is not run from the command line with a directory argument, or doesn't have a project directory, the running directory would be /, so terminals open at root.

Zed's various `working_directory` options all fall back to the default `None`. This change replaces that `None` with the user's home directory. Relying on alacritty to do that with the default could potentially disrupt Zed functionality if their functionality ever changes.

Closes #15969

Release Notes:

- Fixed: use home directory if the project cannot be determined (#15969)

There are several ways to resolve this, and I'm not completely sure this is the correct way. The idea is to deal with a `None` value in Zed instead of Alacritty. Alacritty defaults could change, and this change is agnostic of that.

My concern is that `util::paths::home_dir()` panics if the homedir can't be determined, which would crash at some arbitrary point when the user starts the terminal. Something can still result in `None` would allow alacritty to choose its default and avoid a panic.

Happy to iterate on this and find something that fixes both scenarios, but this seemed the simplest for now.




