### PR TITLE
Add Python venv activation support for Windows and PowerShell

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -698,7 +698,7 @@
         // to the current working directory. We recommend overriding this
         // in your project's settings, rather than globally.
         "directories": [".env", "env", ".venv", "venv"],
-        // Can also be `csh`, `fish`, and `nushell`
+        // Can also be `csh`, `fish`, `nushell` and `power_shell`
         "activate_script": "default"
       }
     },

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -87,6 +87,7 @@ pub enum ActivateScript {
     Csh,
     Fish,
     Nushell,
+    PowerShell,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Release Notes:

- Add Python venv activation support for Windows and PowerShell

Additional:

I discovered a related bug on my Windows system. When first opening the project, it fails to detect the virtual environment folder `.venv`. After expanding the .venv folder in the Project Panel, it then becomes able to detect the virtual environment folder. However, I don't know how to fix it.