### PR TITLE
windows: Implement copy/paste images

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1183,7 +1183,7 @@ impl Image {
                 // TODO: Fix this
                 let pixmap = cx
                     .svg_renderer()
-                    .render_pixmap(&self.bytes, SvgSize::ScaleFactor(0.5))?;
+                    .render_pixmap(&self.bytes, SvgSize::ScaleFactor(1.0))?;
 
                 let buffer =
                     image::ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.take())

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1183,7 +1183,7 @@ impl Image {
                 // TODO: Fix this
                 let pixmap = cx
                     .svg_renderer()
-                    .render_pixmap(&self.bytes, SvgSize::ScaleFactor(1.0))?;
+                    .render_pixmap(&self.bytes, SvgSize::ScaleFactor(0.5))?;
 
                 let buffer =
                     image::ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.take())

--- a/crates/gpui/src/platform/windows.rs
+++ b/crates/gpui/src/platform/windows.rs
@@ -1,3 +1,4 @@
+mod clipboard;
 mod direct_write;
 mod dispatcher;
 mod display;
@@ -8,6 +9,7 @@ mod util;
 mod window;
 mod wrapper;
 
+pub(crate) use clipboard::*;
 pub(crate) use direct_write::*;
 pub(crate) use dispatcher::*;
 pub(crate) use display::*;

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -187,13 +187,11 @@ fn convert_image_to_png_format(bytes: &[u8], image_format: ImageFormat) -> Resul
 }
 
 fn read_from_clipboard_inner() -> Option<ClipboardItem> {
-    unsafe {
-        OpenClipboard(None).log_err()?;
-        find_best_match_format(|item_format| match format_to_type(item_format) {
-            ClipboardFormatType::Text => read_string_from_clipboard(),
-            ClipboardFormatType::Image => read_image_from_clipboard(item_format),
-        })
-    }
+    unsafe { OpenClipboard(None) }.log_err()?;
+    with_best_match_format(|item_format| match format_to_type(item_format) {
+        ClipboardFormatType::Text => read_string_from_clipboard(),
+        ClipboardFormatType::Image => read_image_from_clipboard(item_format),
+    })
 }
 
 // Here we enumerate all formats on clipboard, find the first one we can process.
@@ -201,7 +199,7 @@ fn read_from_clipboard_inner() -> Option<ClipboardItem> {
 // Say copy a JPEG image from Word, there are serveral formats in clipboard:
 // Jpeg, Png, Svg
 // If we use `GetPriorityClipboardFormat` we will get Svg back, which is not what we want.
-fn find_best_match_format<F>(f: F) -> Option<ClipboardItem>
+fn with_best_match_format<F>(f: F) -> Option<ClipboardItem>
 where
     F: Fn(u32) -> Option<ClipboardEntry>,
 {

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -117,7 +117,6 @@ fn set_data_to_clipboard<T>(data: &[T], format: u32) -> Result<()> {
     unsafe {
         let global = GlobalAlloc(GMEM_MOVEABLE, data.len() * std::mem::size_of::<T>())?;
         let handle = GlobalLock(global);
-        // u_memcpy(handle as _, data.as_ptr(), data.len() as _);
         std::ptr::copy_nonoverlapping(data.as_ptr(), handle as _, data.len());
         let _ = GlobalUnlock(global);
         SetClipboardData(format, HANDLE(global.0))?;
@@ -130,14 +129,6 @@ fn write_image_to_clipboard(item: &Image) -> Result<()> {
         anyhow::bail!("Clipboard unsupported image format: {:?}", item.format);
     }
     set_data_to_clipboard(item.bytes(), *CLIPBOARD_PNG_FORMAT)?;
-    // unsafe {
-    //     let data = item.bytes();
-    //     let global = GlobalAlloc(GMEM_MOVEABLE, data.len())?;
-    //     let handle = GlobalLock(global);
-    //     std::ptr::copy_nonoverlapping(data.as_ptr(), handle as _, data.len());
-    //     let _ = GlobalUnlock(global);
-    //     SetClipboardData(*CLIPBOARD_PNG_FORMAT, HANDLE(global.0))?;
-    // }
     Ok(())
 }
 

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -166,7 +166,7 @@ fn write_string_to_clipboard(item: &ClipboardString) -> Result<()> {
 
 fn set_data_to_clipboard<T>(data: &[T], format: u32) -> Result<()> {
     unsafe {
-        let global = GlobalAlloc(GMEM_MOVEABLE, data.len() * std::mem::size_of::<T>())?;
+        let global = GlobalAlloc(GMEM_MOVEABLE, std::mem::size_of_val(data))?;
         let handle = GlobalLock(global);
         std::ptr::copy_nonoverlapping(data.as_ptr(), handle as _, data.len());
         let _ = GlobalUnlock(global);
@@ -308,9 +308,7 @@ fn read_hash_from_clipboard() -> Option<u64> {
 }
 
 fn read_metadata_from_clipboard() -> Option<String> {
-    if unsafe { IsClipboardFormatAvailable(*CLIPBOARD_METADATA_FORMAT).is_err() } {
-        return None;
-    }
+    unsafe { IsClipboardFormatAvailable(*CLIPBOARD_METADATA_FORMAT).log_err()? };
     let global = SmartGlobal::from_raw_ptr(
         unsafe { GetClipboardData(*CLIPBOARD_METADATA_FORMAT).log_err() }?.0,
     );
@@ -319,9 +317,7 @@ fn read_metadata_from_clipboard() -> Option<String> {
 }
 
 fn read_image_from_clipboard(format: u32) -> Option<ClipboardEntry> {
-    let Some(image_format) = format_number_to_image_format(format) else {
-        return None;
-    };
+    let image_format = format_number_to_image_format(format)?;
     read_image_for_type(format, *image_format)
 }
 

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -1,0 +1,212 @@
+use anyhow::Result;
+use itertools::Itertools;
+use util::ResultExt;
+use windows::Win32::{
+    Foundation::{HANDLE, HGLOBAL},
+    Globalization::u_memcpy,
+    System::{
+        DataExchange::{
+            CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard,
+            RegisterClipboardFormatW, SetClipboardData,
+        },
+        Memory::{GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE},
+        Ole::CF_UNICODETEXT,
+    },
+};
+use windows_core::PCWSTR;
+
+use crate::{hash, ClipboardEntry, ClipboardItem, ClipboardString, Image, ImageFormat};
+
+const CLIPBOARD_HASH_FORMAT: PCWSTR = windows::core::w!("GPUI internal text hash");
+const CLIPBOARD_METADATA_FORMAT: PCWSTR = windows::core::w!("GPUI internal metadata");
+const CLIPBOARD_PNG_FORMAT: PCWSTR = windows::core::w!("PNG");
+
+pub(crate) struct ClipboardFormatStore {
+    pub(crate) text: u32,
+    pub(crate) hash: u32,
+    pub(crate) metadata: u32,
+    pub(crate) png: u32,
+}
+
+impl ClipboardFormatStore {
+    pub(crate) fn new() -> Result<Self> {
+        let text = CF_UNICODETEXT.0 as u32;
+        let hash = register_clipboard_format(CLIPBOARD_HASH_FORMAT)?;
+        let metadata = register_clipboard_format(CLIPBOARD_PNG_FORMAT)?;
+        let png = register_clipboard_format(CLIPBOARD_PNG_FORMAT)?;
+        Ok(Self {
+            text,
+            hash,
+            metadata,
+            png,
+        })
+    }
+}
+
+fn register_clipboard_format(format: PCWSTR) -> Result<u32> {
+    let ret = unsafe { RegisterClipboardFormatW(format) };
+    if ret == 0 {
+        anyhow::bail!(
+            "Error when registering clipboard format: {}",
+            std::io::Error::last_os_error()
+        )
+    } else {
+        Ok(ret)
+    }
+}
+
+pub(crate) fn write_to_clipboard(item: ClipboardItem, format_store: &ClipboardFormatStore) {
+    write_to_clipboard_inner(item, format_store).log_err();
+    unsafe { CloseClipboard().log_err() };
+}
+
+pub(crate) fn read_from_clipboard(format_store: &ClipboardFormatStore) -> Option<ClipboardItem> {
+    let result = read_from_clipboard_inner(format_store).log_err();
+    unsafe { CloseClipboard().log_err() };
+    result
+}
+
+fn write_to_clipboard_inner(
+    item: ClipboardItem,
+    format_store: &ClipboardFormatStore,
+) -> Result<()> {
+    unsafe {
+        OpenClipboard(None)?;
+        EmptyClipboard()?;
+    }
+    for entry in item.entries() {
+        match entry {
+            ClipboardEntry::String(string) => {
+                write_string_to_clipboard(string, format_store)?;
+            }
+            ClipboardEntry::Image(image) => {
+                write_image_to_clipboard(image, format_store)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_string_to_clipboard(
+    item: &ClipboardString,
+    format_store: &ClipboardFormatStore,
+) -> Result<()> {
+    let encode_wide = item.text.encode_utf16().chain(Some(0)).collect_vec();
+    set_data_to_clipboard(&encode_wide, CF_UNICODETEXT.0 as u32)?;
+
+    if let Some(metadata) = item.metadata.as_ref() {
+        let hash_result = {
+            let hash = ClipboardString::text_hash(&item.text);
+            hash.to_ne_bytes()
+        };
+        let encode_wide =
+            unsafe { std::slice::from_raw_parts(hash_result.as_ptr().cast::<u16>(), 4) };
+        set_data_to_clipboard(encode_wide, format_store.hash)?;
+
+        let metadata_wide = metadata.encode_utf16().chain(Some(0)).collect_vec();
+        set_data_to_clipboard(&metadata_wide, format_store.metadata)?;
+    }
+    Ok(())
+}
+
+fn set_data_to_clipboard(data: &[u16], format: u32) -> Result<()> {
+    unsafe {
+        let global = GlobalAlloc(GMEM_MOVEABLE, data.len() * 2)?;
+        let handle = GlobalLock(global);
+        u_memcpy(handle as _, data.as_ptr(), data.len() as _);
+        let _ = GlobalUnlock(global);
+        SetClipboardData(format, HANDLE(global.0))?;
+    }
+    Ok(())
+}
+
+fn write_image_to_clipboard(item: &Image, format_store: &ClipboardFormatStore) -> Result<()> {
+    if item.format != ImageFormat::Png {
+        anyhow::bail!("Unsupported format: {:?}", item.format);
+    }
+    unsafe {
+        let data = item.bytes();
+        let global = GlobalAlloc(GMEM_MOVEABLE, data.len())?;
+        let handle = GlobalLock(global);
+        std::ptr::copy_nonoverlapping(data.as_ptr(), handle as _, data.len());
+        let _ = GlobalUnlock(global);
+        SetClipboardData(format_store.png, HANDLE(global.0))?;
+    }
+    Ok(())
+}
+
+fn read_from_clipboard_inner(format_store: &ClipboardFormatStore) -> Result<ClipboardItem> {
+    unsafe {
+        OpenClipboard(None)?;
+        let mut entries = Vec::new();
+        if let Some(string) = read_string_from_clipboard(format_store).log_err() {
+            entries.push(string);
+        }
+        if let Some(image) = read_image_from_clipboard(format_store).log_err() {
+            entries.push(image);
+        }
+        if entries.is_empty() {
+            anyhow::bail!("No content in clipboard");
+        } else {
+            Ok(ClipboardItem { entries })
+        }
+    }
+}
+
+fn read_string_from_clipboard(format_store: &ClipboardFormatStore) -> Result<ClipboardEntry> {
+    let text = unsafe {
+        let handle = GetClipboardData(CF_UNICODETEXT.0 as u32)?;
+        let text = PCWSTR(handle.0 as *const u16);
+        String::from_utf16_lossy(text.as_wide())
+    };
+    let Some(hash) = read_hash_from_clipboard(format_store) else {
+        return Ok(ClipboardEntry::String(ClipboardString::new(text)));
+    };
+    let Some(metadata) = read_metadata_from_clipboard(format_store) else {
+        return Ok(ClipboardEntry::String(ClipboardString::new(text)));
+    };
+    if hash == ClipboardString::text_hash(&text) {
+        Ok(ClipboardEntry::String(ClipboardString {
+            text,
+            metadata: Some(metadata),
+        }))
+    } else {
+        Ok(ClipboardEntry::String(ClipboardString::new(text)))
+    }
+}
+
+fn read_hash_from_clipboard(format_store: &ClipboardFormatStore) -> Option<u64> {
+    unsafe {
+        let handle = GetClipboardData(format_store.hash).log_err()?;
+        let raw_ptr = handle.0 as *const u16;
+        let hash_bytes: [u8; 8] = std::slice::from_raw_parts(raw_ptr.cast::<u8>(), 8)
+            .to_vec()
+            .try_into()
+            .log_err()?;
+        Some(u64::from_ne_bytes(hash_bytes))
+    }
+}
+
+fn read_metadata_from_clipboard(format_store: &ClipboardFormatStore) -> Option<String> {
+    unsafe {
+        let handle = GetClipboardData(format_store.metadata).log_err()?;
+        let text = PCWSTR(handle.0 as *const u16);
+        Some(String::from_utf16_lossy(text.as_wide()))
+    }
+}
+
+fn read_image_from_clipboard(format_store: &ClipboardFormatStore) -> Result<ClipboardEntry> {
+    unsafe {
+        let global = HGLOBAL(GetClipboardData(format_store.png)?.0);
+        let image_ptr = GlobalLock(global);
+        let iamge_size = GlobalSize(global);
+        let bytes = std::slice::from_raw_parts(image_ptr as *mut u8 as _, iamge_size).to_vec();
+        let _ = GlobalUnlock(global);
+        let id = hash(&bytes);
+        Ok(ClipboardEntry::Image(Image {
+            format: ImageFormat::Png,
+            bytes,
+            id,
+        }))
+    }
+}

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -44,15 +44,7 @@ static FORMATS_MAP: LazyLock<FxHashMap<u32, ClipboardFormatType>> = LazyLock::ne
     formats_map.insert(*CLIPBOARD_SVG_FORMAT, ClipboardFormatType::Image);
     formats_map
 });
-static FORMATS_NUMBER_MAP: LazyLock<FxHashMap<u32, ImageFormat>> = LazyLock::new(|| {
-    let mut formats_map = FxHashMap::default();
-    formats_map.insert(*CLIPBOARD_PNG_FORMAT, ImageFormat::Png);
-    formats_map.insert(*CLIPBOARD_GIF_FORMAT, ImageFormat::Gif);
-    formats_map.insert(*CLIPBOARD_JPG_FORMAT, ImageFormat::Jpeg);
-    formats_map.insert(*CLIPBOARD_SVG_FORMAT, ImageFormat::Svg);
-    formats_map
-});
-static ALL_FORMATS_SET: LazyLock<FxHashSet<u32>> = LazyLock::new(|| {
+static FORMATS_SET: LazyLock<FxHashSet<u32>> = LazyLock::new(|| {
     let mut formats_map = FxHashSet::default();
     formats_map.insert(CF_UNICODETEXT.0 as u32);
     formats_map.insert(*CLIPBOARD_PNG_FORMAT);
@@ -61,12 +53,12 @@ static ALL_FORMATS_SET: LazyLock<FxHashSet<u32>> = LazyLock::new(|| {
     formats_map.insert(*CLIPBOARD_SVG_FORMAT);
     formats_map
 });
-static IMAGE_FORMATS_SET: LazyLock<FxHashSet<u32>> = LazyLock::new(|| {
-    let mut formats_map = FxHashSet::default();
-    formats_map.insert(*CLIPBOARD_PNG_FORMAT);
-    formats_map.insert(*CLIPBOARD_GIF_FORMAT);
-    formats_map.insert(*CLIPBOARD_JPG_FORMAT);
-    formats_map.insert(*CLIPBOARD_SVG_FORMAT);
+static FORMATS_NUMBER_MAP: LazyLock<FxHashMap<u32, ImageFormat>> = LazyLock::new(|| {
+    let mut formats_map = FxHashMap::default();
+    formats_map.insert(*CLIPBOARD_PNG_FORMAT, ImageFormat::Png);
+    formats_map.insert(*CLIPBOARD_GIF_FORMAT, ImageFormat::Gif);
+    formats_map.insert(*CLIPBOARD_JPG_FORMAT, ImageFormat::Jpeg);
+    formats_map.insert(*CLIPBOARD_SVG_FORMAT, ImageFormat::Svg);
     formats_map
 });
 
@@ -217,7 +209,7 @@ where
     let mut clipboard_format = 0;
     for _ in 0..count {
         clipboard_format = unsafe { EnumClipboardFormats(clipboard_format) };
-        let Some(item_format) = ALL_FORMATS_SET.get(&clipboard_format) else {
+        let Some(item_format) = FORMATS_SET.get(&clipboard_format) else {
             continue;
         };
         if let Some(entry) = f(*item_format) {

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -26,21 +26,29 @@ static CLIPBOARD_HASH_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("GPUI internal text hash")));
 static CLIPBOARD_METADATA_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("GPUI internal metadata")));
-static CLIPBOARD_PNG_FORMAT: LazyLock<u32> =
-    LazyLock::new(|| register_clipboard_format(windows::core::w!("PNG")));
 static CLIPBOARD_GIF_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("GIF")));
+static CLIPBOARD_PNG_FORMAT: LazyLock<u32> =
+    LazyLock::new(|| register_clipboard_format(windows::core::w!("PNG")));
+static CLIPBOARD_JPG_FORMAT: LazyLock<u32> =
+    LazyLock::new(|| register_clipboard_format(windows::core::w!("JFIF")));
 
 // Helper format list
-static AVAILABLE_FORMATS: LazyLock<[u32; 3]> = LazyLock::new(|| {
+static AVAILABLE_FORMATS: LazyLock<[u32; 4]> = LazyLock::new(|| {
     [
         CF_UNICODETEXT.0 as u32,
-        *CLIPBOARD_PNG_FORMAT,
         *CLIPBOARD_GIF_FORMAT,
+        *CLIPBOARD_PNG_FORMAT,
+        *CLIPBOARD_JPG_FORMAT,
     ]
 });
-static AVAILABLE_IMAGE_FORMATS: LazyLock<[u32; 2]> =
-    LazyLock::new(|| [*CLIPBOARD_PNG_FORMAT, *CLIPBOARD_GIF_FORMAT]);
+static AVAILABLE_IMAGE_FORMATS: LazyLock<[u32; 3]> = LazyLock::new(|| {
+    [
+        *CLIPBOARD_GIF_FORMAT,
+        *CLIPBOARD_PNG_FORMAT,
+        *CLIPBOARD_JPG_FORMAT,
+    ]
+});
 
 // Helper struct
 static FORMATS_MAP: LazyLock<FxHashMap<u32, ClipboardFormatType>> = LazyLock::new(|| {
@@ -48,6 +56,7 @@ static FORMATS_MAP: LazyLock<FxHashMap<u32, ClipboardFormatType>> = LazyLock::ne
     formats_map.insert(CF_UNICODETEXT.0 as u32, ClipboardFormatType::Text);
     formats_map.insert(*CLIPBOARD_PNG_FORMAT, ClipboardFormatType::Image);
     formats_map.insert(*CLIPBOARD_GIF_FORMAT, ClipboardFormatType::Image);
+    formats_map.insert(*CLIPBOARD_JPG_FORMAT, ClipboardFormatType::Image);
     formats_map
 });
 
@@ -237,7 +246,8 @@ fn read_image_from_clipboard() -> Option<ClipboardEntry> {
         //         id,
         //     }))
         // } else if image_format == CF_DIB.0 as u32 {
-        read_gif(*CLIPBOARD_GIF_FORMAT)
+        // read_gif(*CLIPBOARD_GIF_FORMAT)
+        read_jpeg(*CLIPBOARD_JPG_FORMAT)
         // } else {
         // None
         // }
@@ -278,6 +288,22 @@ fn read_gif(image_format: u32) -> Option<ClipboardEntry> {
         let id = hash(&bytes);
         Some(ClipboardEntry::Image(Image {
             format: ImageFormat::Gif,
+            bytes,
+            id,
+        }))
+    }
+}
+
+fn read_jpeg(image_format: u32) -> Option<ClipboardEntry> {
+    unsafe {
+        let global = HGLOBAL(GetClipboardData(image_format).log_err()?.0);
+        let image_ptr = GlobalLock(global);
+        let iamge_size = GlobalSize(global);
+        let bytes = std::slice::from_raw_parts(image_ptr as *mut u8 as _, iamge_size).to_vec();
+        let _ = GlobalUnlock(global);
+        let id = hash(&bytes);
+        Some(ClipboardEntry::Image(Image {
+            format: ImageFormat::Jpeg,
             bytes,
             id,
         }))

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -296,7 +296,6 @@ fn read_image_from_clipboard(format: u32) -> Option<ClipboardEntry> {
     let Some(image_format) = format_number_to_image_format(format) else {
         return None;
     };
-    println!("==> image: {:?}", image_format);
     read_image_for_type(format, *image_format)
 }
 

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -28,24 +28,26 @@ static CLIPBOARD_METADATA_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("GPUI internal metadata")));
 static CLIPBOARD_PNG_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("PNG")));
+static CLIPBOARD_GIF_FORMAT: LazyLock<u32> =
+    LazyLock::new(|| register_clipboard_format(windows::core::w!("GIF")));
 
 // Helper format list
 static AVAILABLE_FORMATS: LazyLock<[u32; 3]> = LazyLock::new(|| {
     [
         CF_UNICODETEXT.0 as u32,
         *CLIPBOARD_PNG_FORMAT,
-        CF_DIB.0 as u32,
+        *CLIPBOARD_GIF_FORMAT,
     ]
 });
 static AVAILABLE_IMAGE_FORMATS: LazyLock<[u32; 2]> =
-    LazyLock::new(|| [*CLIPBOARD_PNG_FORMAT, CF_DIB.0 as u32]);
+    LazyLock::new(|| [*CLIPBOARD_PNG_FORMAT, *CLIPBOARD_GIF_FORMAT]);
 
 // Helper struct
 static FORMATS_MAP: LazyLock<FxHashMap<u32, ClipboardFormatType>> = LazyLock::new(|| {
     let mut formats_map = FxHashMap::default();
     formats_map.insert(CF_UNICODETEXT.0 as u32, ClipboardFormatType::Text);
     formats_map.insert(*CLIPBOARD_PNG_FORMAT, ClipboardFormatType::Image);
-    formats_map.insert(CF_DIB.0 as u32, ClipboardFormatType::Image);
+    formats_map.insert(*CLIPBOARD_GIF_FORMAT, ClipboardFormatType::Image);
     formats_map
 });
 
@@ -235,7 +237,7 @@ fn read_image_from_clipboard() -> Option<ClipboardEntry> {
         //         id,
         //     }))
         // } else if image_format == CF_DIB.0 as u32 {
-        bitmap::read_bitmap(CF_DIBV5.0 as u32)
+        read_gif(*CLIPBOARD_GIF_FORMAT)
         // } else {
         // None
         // }
@@ -266,65 +268,18 @@ fn check_available_formats(formats: &[u32]) -> Option<u32> {
     }
 }
 
-mod bitmap {
-    use util::ResultExt;
-    use windows::Win32::{
-        Foundation::HGLOBAL,
-        Graphics::Gdi::{
-            BITMAPFILEHEADER, BITMAPINFO, BITMAPINFOHEADER, BITMAPV5HEADER, BI_BITFIELDS, RGBQUAD,
-        },
-        System::{
-            DataExchange::GetClipboardData,
-            Memory::{GlobalLock, GlobalSize, GlobalUnlock},
-        },
-    };
-
-    use crate::{hash, ClipboardEntry, Image, ImageFormat};
-
-    pub(super) fn read_bitmap(image_format: u32) -> Option<ClipboardEntry> {
-        let global = HGLOBAL(unsafe { GetClipboardData(image_format).log_err() }?.0);
-        let image_ptr = unsafe { GlobalLock(global) };
-        let bitmap_info = unsafe { &*(image_ptr as *mut BITMAPV5HEADER) };
-        let dib_header_size = std::mem::size_of::<BITMAPV5HEADER>();
-        println!("{:#?}", bitmap_info);
-        let raw_bytes = {
-            let size = unsafe { GlobalSize(global) };
-            unsafe { std::slice::from_raw_parts(image_ptr as *mut u8, size) }
-        };
-
-        let mut file_header = vec![0u8; std::mem::size_of::<BITMAPFILEHEADER>()];
-        file_header[0] = b'B';
-        file_header[1] = b'M';
-        let total_size = file_header.len() + raw_bytes.len();
-        file_header[2..6].copy_from_slice(&(total_size as u32).to_le_bytes());
-        file_header[10..14].copy_from_slice(&(dib_header_size as u32).to_le_bytes());
-
-        let mut bitmap_data = file_header;
-        bitmap_data.extend_from_slice(raw_bytes);
-        let id = hash(&bitmap_data);
+fn read_gif(image_format: u32) -> Option<ClipboardEntry> {
+    unsafe {
+        let global = HGLOBAL(GetClipboardData(image_format).log_err()?.0);
+        let image_ptr = GlobalLock(global);
+        let iamge_size = GlobalSize(global);
+        let bytes = std::slice::from_raw_parts(image_ptr as *mut u8 as _, iamge_size).to_vec();
+        let _ = GlobalUnlock(global);
+        let id = hash(&bytes);
         Some(ClipboardEntry::Image(Image {
-            format: ImageFormat::Bmp,
-            bytes: bitmap_data,
+            format: ImageFormat::Gif,
+            bytes,
             id,
         }))
-    }
-
-    fn create_bitmap(width: i32, height: i32) {
-        if width == 0 || height == 0 {
-            return;
-        }
-        let header = BITMAPINFOHEADER {
-            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
-            biWidth: width,
-            biHeight: height,
-            biPlanes: todo!(),
-            biBitCount: todo!(),
-            biCompression: todo!(),
-            biSizeImage: todo!(),
-            biXPelsPerMeter: todo!(),
-            biYPelsPerMeter: todo!(),
-            biClrUsed: todo!(),
-            biClrImportant: todo!(),
-        };
     }
 }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -839,20 +839,11 @@ static PNG_FORMAT: LazyLock<u32> =
 
 fn read_image_from_clipboard() -> Result<ClipboardEntry> {
     unsafe {
-        let handle = GetClipboardData(*PNG_FORMAT)?;
-        let image_ptr = GlobalLock(HGLOBAL(handle.0));
-        // let image_info = &*(image_ptr as *mut BITMAPINFOHEADER);
-        // let image_size = image_info.biHeight as usize
-        //     * image_info.biWidth as usize
-        //     * (image_info.biBitCount as usize / 8);
-        let iamge_size = GlobalSize(HGLOBAL(handle.0));
-        // let data_handle = GetClipboardData(CF_HDROP.0 as u32).unwrap();
+        let global = HGLOBAL(GetClipboardData(*PNG_FORMAT)?.0);
+        let image_ptr = GlobalLock(global);
+        let iamge_size = GlobalSize(global);
         let bytes = std::slice::from_raw_parts(image_ptr as *mut u8 as _, iamge_size).to_vec();
-        // let bytes = Vec::from_raw_parts(
-        //     (handle.0 as *mut u8).add(image_info.biSize as usize),
-        //     image_size,
-        //     image_size,
-        // );
+        let _ = GlobalUnlock(global);
         let id = hash(&bytes);
         Ok(ClipboardEntry::Image(Image {
             format: ImageFormat::Png,

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -3,7 +3,7 @@ use std::{
     mem::ManuallyDrop,
     path::{Path, PathBuf},
     rc::Rc,
-    sync::{Arc, LazyLock},
+    sync::Arc,
 };
 
 use ::util::ResultExt;
@@ -16,25 +16,12 @@ use windows::{
     core::*,
     Win32::{
         Foundation::*,
-        Globalization::u_memcpy,
         Graphics::{
             Gdi::*,
             Imaging::{CLSID_WICImagingFactory, IWICImagingFactory},
         },
         Security::Credentials::*,
-        System::{
-            Com::*,
-            DataExchange::{
-                CloseClipboard, EmptyClipboard, GetClipboardData, GetPriorityClipboardFormat,
-                IsClipboardFormatAvailable, OpenClipboard, RegisterClipboardFormatW,
-                SetClipboardData,
-            },
-            LibraryLoader::*,
-            Memory::{GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE},
-            Ole::*,
-            SystemInformation::*,
-            Threading::*,
-        },
+        System::{Com::*, LibraryLoader::*, Ole::*, SystemInformation::*, Threading::*},
         UI::{Input::KeyboardAndMouse::*, Shell::*, WindowsAndMessaging::*},
     },
     UI::ViewManagement::UISettings,
@@ -50,8 +37,7 @@ pub(crate) struct WindowsPlatform {
     background_executor: BackgroundExecutor,
     foreground_executor: ForegroundExecutor,
     text_system: Arc<DirectWriteTextSystem>,
-    clipboard_hash_format: u32,
-    clipboard_metadata_format: u32,
+    clipboard_formats: ClipboardFormatStore,
     windows_version: WindowsVersion,
     bitmap_factory: ManuallyDrop<IWICImagingFactory>,
     validation_number: usize,
@@ -104,9 +90,8 @@ impl WindowsPlatform {
         let icon = load_icon().unwrap_or_default();
         let state = RefCell::new(WindowsPlatformState::new());
         let raw_window_handles = RwLock::new(SmallVec::new());
-        let clipboard_hash_format = register_clipboard_format(CLIPBOARD_HASH_FORMAT).unwrap();
-        let clipboard_metadata_format =
-            register_clipboard_format(CLIPBOARD_METADATA_FORMAT).unwrap();
+        let clipboard_formats =
+            ClipboardFormatStore::new().expect("Unable to register clipboard formats");
         let windows_version = WindowsVersion::new().expect("Error retrieve windows version");
         let validation_number = rand::random::<usize>();
 
@@ -117,8 +102,7 @@ impl WindowsPlatform {
             background_executor,
             foreground_executor,
             text_system,
-            clipboard_hash_format,
-            clipboard_metadata_format,
+            clipboard_formats,
             windows_version,
             bitmap_factory,
             validation_number,
@@ -466,15 +450,11 @@ impl Platform for WindowsPlatform {
     }
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
-        write_to_clipboard(
-            item,
-            self.clipboard_hash_format,
-            self.clipboard_metadata_format,
-        );
+        write_to_clipboard(item, &self.clipboard_formats);
     }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
-        read_from_clipboard(self.clipboard_hash_format, self.clipboard_metadata_format)
+        read_from_clipboard(&self.clipboard_formats)
     }
 
     fn write_credentials(&self, url: &str, username: &str, password: &[u8]) -> Task<Result<()>> {
@@ -682,180 +662,6 @@ fn should_auto_hide_scrollbars() -> Result<bool> {
     let ui_settings = UISettings::new()?;
     Ok(ui_settings.AutoHideScrollBars()?)
 }
-
-fn register_clipboard_format(format: PCWSTR) -> Result<u32> {
-    let ret = unsafe { RegisterClipboardFormatW(format) };
-    if ret == 0 {
-        Err(anyhow::anyhow!(
-            "Error when registering clipboard format: {}",
-            std::io::Error::last_os_error()
-        ))
-    } else {
-        Ok(ret)
-    }
-}
-
-fn write_to_clipboard(item: ClipboardItem, hash_format: u32, metadata_format: u32) {
-    write_to_clipboard_inner(item, hash_format, metadata_format).log_err();
-    unsafe { CloseClipboard().log_err() };
-}
-
-fn write_to_clipboard_inner(
-    item: ClipboardItem,
-    hash_format: u32,
-    metadata_format: u32,
-) -> Result<()> {
-    unsafe {
-        OpenClipboard(None)?;
-        EmptyClipboard()?;
-    }
-    for entry in item.entries() {
-        match entry {
-            ClipboardEntry::String(string) => {
-                write_string_to_clipboard(string, hash_format, metadata_format)?;
-            }
-            ClipboardEntry::Image(image) => {
-                write_image_to_clipboard(image)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-fn write_string_to_clipboard(
-    item: &ClipboardString,
-    hash_format: u32,
-    metadata_format: u32,
-) -> Result<()> {
-    let encode_wide = item.text.encode_utf16().chain(Some(0)).collect_vec();
-    set_data_to_clipboard(&encode_wide, CF_UNICODETEXT.0 as u32)?;
-
-    if let Some(metadata) = item.metadata.as_ref() {
-        let hash_result = {
-            let hash = ClipboardString::text_hash(&item.text);
-            hash.to_ne_bytes()
-        };
-        let encode_wide =
-            unsafe { std::slice::from_raw_parts(hash_result.as_ptr().cast::<u16>(), 4) };
-        set_data_to_clipboard(encode_wide, hash_format)?;
-
-        let metadata_wide = metadata.encode_utf16().chain(Some(0)).collect_vec();
-        set_data_to_clipboard(&metadata_wide, metadata_format)?;
-    }
-    Ok(())
-}
-
-fn set_data_to_clipboard(data: &[u16], format: u32) -> Result<()> {
-    unsafe {
-        let global = GlobalAlloc(GMEM_MOVEABLE, data.len() * 2)?;
-        let handle = GlobalLock(global);
-        u_memcpy(handle as _, data.as_ptr(), data.len() as _);
-        let _ = GlobalUnlock(global);
-        SetClipboardData(format, HANDLE(global.0))?;
-    }
-    Ok(())
-}
-
-fn write_image_to_clipboard(item: &Image) -> Result<()> {
-    unsafe {
-        let data = item.bytes();
-        let global = GlobalAlloc(GMEM_MOVEABLE, data.len())?;
-        let handle = GlobalLock(global);
-        std::ptr::copy_nonoverlapping(data.as_ptr(), handle as _, data.len());
-        let _ = GlobalUnlock(global);
-        SetClipboardData(CF_DIB.0 as u32, HANDLE(global.0))?;
-    }
-    Ok(())
-}
-
-fn read_from_clipboard(hash_format: u32, metadata_format: u32) -> Option<ClipboardItem> {
-    let result = read_from_clipboard_inner(hash_format, metadata_format).log_err();
-    unsafe { CloseClipboard().log_err() };
-    result
-}
-
-fn read_from_clipboard_inner(hash_format: u32, metadata_format: u32) -> Result<ClipboardItem> {
-    unsafe {
-        OpenClipboard(None)?;
-        let mut entries = Vec::new();
-        if let Some(string) = read_string_from_clipboard(hash_format, metadata_format).log_err() {
-            entries.push(string);
-        }
-        if let Some(image) = read_image_from_clipboard().log_err() {
-            entries.push(image);
-        }
-        if entries.is_empty() {
-            anyhow::bail!("No content in clipboard");
-        } else {
-            Ok(ClipboardItem { entries })
-        }
-    }
-}
-
-fn read_string_from_clipboard(hash_format: u32, metadata_format: u32) -> Result<ClipboardEntry> {
-    let text = unsafe {
-        let handle = GetClipboardData(CF_UNICODETEXT.0 as u32)?;
-        let text = PCWSTR(handle.0 as *const u16);
-        String::from_utf16_lossy(text.as_wide())
-    };
-    let Some(hash) = read_hash_from_clipboard(hash_format) else {
-        return Ok(ClipboardEntry::String(ClipboardString::new(text)));
-    };
-    let Some(metadata) = read_metadata_from_clipboard(metadata_format) else {
-        return Ok(ClipboardEntry::String(ClipboardString::new(text)));
-    };
-    if hash == ClipboardString::text_hash(&text) {
-        Ok(ClipboardEntry::String(ClipboardString {
-            text,
-            metadata: Some(metadata),
-        }))
-    } else {
-        Ok(ClipboardEntry::String(ClipboardString::new(text)))
-    }
-}
-
-fn read_hash_from_clipboard(hash_format: u32) -> Option<u64> {
-    unsafe {
-        let handle = GetClipboardData(hash_format).log_err()?;
-        let raw_ptr = handle.0 as *const u16;
-        let hash_bytes: [u8; 8] = std::slice::from_raw_parts(raw_ptr.cast::<u8>(), 8)
-            .to_vec()
-            .try_into()
-            .log_err()?;
-        Some(u64::from_ne_bytes(hash_bytes))
-    }
-}
-
-fn read_metadata_from_clipboard(metadata_format: u32) -> Option<String> {
-    unsafe {
-        let handle = GetClipboardData(metadata_format).log_err()?;
-        let text = PCWSTR(handle.0 as *const u16);
-        Some(String::from_utf16_lossy(text.as_wide()))
-    }
-}
-
-static PNG_FORMAT: LazyLock<u32> =
-    LazyLock::new(|| unsafe { RegisterClipboardFormatW(windows::core::w!("PNG")) });
-
-fn read_image_from_clipboard() -> Result<ClipboardEntry> {
-    unsafe {
-        let global = HGLOBAL(GetClipboardData(*PNG_FORMAT)?.0);
-        let image_ptr = GlobalLock(global);
-        let iamge_size = GlobalSize(global);
-        let bytes = std::slice::from_raw_parts(image_ptr as *mut u8 as _, iamge_size).to_vec();
-        let _ = GlobalUnlock(global);
-        let id = hash(&bytes);
-        Ok(ClipboardEntry::Image(Image {
-            format: ImageFormat::Png,
-            bytes,
-            id,
-        }))
-    }
-}
-
-// clipboard
-pub const CLIPBOARD_HASH_FORMAT: PCWSTR = windows::core::w!("zed-text-hash");
-pub const CLIPBOARD_METADATA_FORMAT: PCWSTR = windows::core::w!("zed-metadata");
 
 #[cfg(test)]
 mod tests {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -37,7 +37,6 @@ pub(crate) struct WindowsPlatform {
     background_executor: BackgroundExecutor,
     foreground_executor: ForegroundExecutor,
     text_system: Arc<DirectWriteTextSystem>,
-    clipboard_formats: ClipboardFormatStore,
     windows_version: WindowsVersion,
     bitmap_factory: ManuallyDrop<IWICImagingFactory>,
     validation_number: usize,
@@ -90,8 +89,6 @@ impl WindowsPlatform {
         let icon = load_icon().unwrap_or_default();
         let state = RefCell::new(WindowsPlatformState::new());
         let raw_window_handles = RwLock::new(SmallVec::new());
-        let clipboard_formats =
-            ClipboardFormatStore::new().expect("Unable to register clipboard formats");
         let windows_version = WindowsVersion::new().expect("Error retrieve windows version");
         let validation_number = rand::random::<usize>();
 
@@ -102,7 +99,6 @@ impl WindowsPlatform {
             background_executor,
             foreground_executor,
             text_system,
-            clipboard_formats,
             windows_version,
             bitmap_factory,
             validation_number,
@@ -450,11 +446,11 @@ impl Platform for WindowsPlatform {
     }
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
-        write_to_clipboard(item, &self.clipboard_formats);
+        write_to_clipboard(item);
     }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
-        read_from_clipboard(&self.clipboard_formats)
+        read_from_clipboard()
     }
 
     fn write_credentials(&self, url: &str, username: &str, password: &[u8]) -> Task<Result<()>> {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1061,7 +1061,7 @@ fn calculate_client_rect(
 }
 
 // https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-dragqueryfilew
-const DRAGDROP_GET_FILES_COUNT: u32 = 0xFFFFFFFF;
+pub(crate) const DRAGDROP_GET_FILES_COUNT: u32 = 0xFFFFFFFF;
 
 mod windows_renderer {
     use std::{num::NonZeroIsize, sync::Arc};

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -726,23 +726,11 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
                 }
                 let hdrop = idata.u.hGlobal.0 as *mut HDROP;
                 let mut paths = SmallVec::<[PathBuf; 2]>::new();
-                let file_count = DragQueryFileW(*hdrop, DRAGDROP_GET_FILES_COUNT, None);
-                for file_index in 0..file_count {
-                    let filename_length = DragQueryFileW(*hdrop, file_index, None) as usize;
-                    let mut buffer = vec![0u16; filename_length + 1];
-                    let ret = DragQueryFileW(*hdrop, file_index, Some(buffer.as_mut_slice()));
-                    if ret == 0 {
-                        log::error!("unable to read file name");
-                        continue;
+                with_file_names(*hdrop, |file_name| {
+                    if let Some(path) = PathBuf::from_str(&file_name).log_err() {
+                        paths.push(path);
                     }
-                    if let Some(file_name) =
-                        String::from_utf16(&buffer[0..filename_length]).log_err()
-                    {
-                        if let Some(path) = PathBuf::from_str(&file_name).log_err() {
-                            paths.push(path);
-                        }
-                    }
-                }
+                });
                 ReleaseStgMedium(&mut idata);
                 let mut cursor_position = POINT { x: pt.x, y: pt.y };
                 ScreenToClient(self.0.hwnd, &mut cursor_position)
@@ -1059,9 +1047,6 @@ fn calculate_client_rect(
         size: physical_size.to_pixels(scale_factor),
     }
 }
-
-// https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-dragqueryfilew
-pub(crate) const DRAGDROP_GET_FILES_COUNT: u32 = 0xFFFFFFFF;
 
 mod windows_renderer {
     use std::{num::NonZeroIsize, sync::Arc};

--- a/crates/gpui/src/platform/windows/wrapper.rs
+++ b/crates/gpui/src/platform/windows/wrapper.rs
@@ -1,6 +1,11 @@
 use std::ops::Deref;
 
-use windows::Win32::{Foundation::HANDLE, UI::WindowsAndMessaging::HCURSOR};
+use util::ResultExt;
+use windows::Win32::{
+    Foundation::{HANDLE, HGLOBAL},
+    System::Memory::{GlobalLock, GlobalSize, GlobalUnlock},
+    UI::WindowsAndMessaging::HCURSOR,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SafeHandle {
@@ -43,5 +48,32 @@ impl Deref for SafeCursor {
 
     fn deref(&self) -> &Self::Target {
         &self.raw
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SmartGlobal {
+    raw: HGLOBAL,
+}
+
+impl SmartGlobal {
+    pub(crate) fn from_raw_ptr(ptr: *mut std::ffi::c_void) -> Self {
+        Self { raw: HGLOBAL(ptr) }
+    }
+
+    pub(crate) fn lock(&self) -> *mut std::ffi::c_void {
+        unsafe { GlobalLock(self.raw) }
+    }
+
+    pub(crate) fn size(&self) -> usize {
+        unsafe { GlobalSize(self.raw) }
+    }
+}
+
+impl Drop for SmartGlobal {
+    fn drop(&mut self) {
+        unsafe {
+            GlobalUnlock(self.raw).log_err();
+        }
     }
 }


### PR DESCRIPTION
**Clipboard Behavior on Windows Under This PR:**

| User Action         | Zed’s Behavior                                      |
| ------------------- | -------------------------------------------------- |
| Paste PNG           | Worked                                             |
| Paste JPEG          | Worked                                             |
| Paste WebP          | Worked, but not in the way you expect (see Issue section below) |
| Paste GIF           | Partially worked (see Issue section below)            |
| Paste SVG           | Partially worked (see Issue section below)            |
| Paste BMP           | Worked, but not in the way you expect (see Issue section below) |
| Paste TIFF          | Worked, but not in the way you expect (see Issue section below) |
| Paste Files         | Worked, same behavior as macOS              |
| Copy image in Zed   | Not tested, as I couldn’t find a way to copy images |

---

**Differences Between the Windows and macOS Clipboard**

The clipboard functionality on Windows differs significantly from macOS. On macOS, there can be multiple items in the clipboard, whereas, on Windows, the clipboard holds only a single item. You can retrieve different formats from the clipboard, but they are all just different representations of the same item.

For example, when you copy a JPG image from Microsoft Word, the clipboard will contain data in several formats:

- Microsoft Office proprietary data
- JPG format data
- PNG format data
- SVG format data

Please note that these formats all represent the same image, just in different formats. This is due to compatibility concerns on Windows, as various applications support different formats. Ideally, multiple formats should be placed on the clipboard to support more software. However, in general, supporting PNG will cover 99% of software, like Chrome, which only supports PNG and BMP formats.

Additionally, since the clipboard on Windows only contains a single item, special handling is required when copying multiple objects, such as text and images. For instance, if you copy both text and an image simultaneously in Microsoft Word, Microsoft places the following data on the clipboard:

- Microsoft Office proprietary data containing a lot of content such as text fonts, sizes, italics, positioning, image size, content, etc.
- RTF data representing the above content in RTF format
- HTML data representing the content in HTML format
- Plain text data

Therefore, for the current `ClipboardItem` implementation, if there are multiple `ClipboardEntry` objects to be placed on the clipboard, RTF or HTML formats are required. This PR does not support this scenario, and only supports copying or pasting a single item from the clipboard.

---

**Known Issues**

- **WebP, BMP, TIFF**: These formats are not explicitly supported in this PR. However, as mentioned earlier, in most cases, there are corresponding PNG format data on the clipboard. This PR retrieves data via PNG format, so users copying images in these formats from other sources will still see the images displayed correctly.
  
- **GIF**: In this PR, GIFs are displayed, but for GIF images with multiple frames, the image will not animate and will freeze on a single frame. Since I observed the same behavior on macOS, I believe this is not an issue with this PR.

- **SVG**: In this PR, only the top-left corner of the SVG image is displayed. Again, I observed the same behavior on macOS, so I believe this issue is not specific to this PR.

--- 

I hope this provides a clearer understanding. Any feedback or suggestions on how to improve this are welcome.

Release Notes:

- N/A
