### PR TITLE
Use AppContext for UI font adjustments

### DIFF
--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -491,13 +491,13 @@ pub fn setup_ui_font(cx: &mut WindowContext) -> gpui::Font {
     ui_font
 }
 
-pub fn get_ui_font_size(cx: &WindowContext) -> Pixels {
+pub fn get_ui_font_size(cx: &AppContext) -> Pixels {
     let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
     cx.try_global::<AdjustedUiFontSize>()
         .map_or(ui_font_size, |adjusted_size| adjusted_size.0)
 }
 
-pub fn adjust_ui_font_size(cx: &mut WindowContext, f: fn(&mut Pixels)) {
+pub fn adjust_ui_font_size(cx: &mut AppContext, f: fn(&mut Pixels)) {
     let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
     let mut adjusted_size = cx
         .try_global::<AdjustedUiFontSize>()
@@ -513,7 +513,7 @@ pub fn has_adjusted_ui_font_size(cx: &mut AppContext) -> bool {
     cx.has_global::<AdjustedUiFontSize>()
 }
 
-pub fn reset_ui_font_size(cx: &mut WindowContext) {
+pub fn reset_ui_font_size(cx: &mut AppContext) {
     if cx.has_global::<AdjustedUiFontSize>() {
         cx.remove_global::<AdjustedUiFontSize>();
         cx.refresh();


### PR DESCRIPTION
Appologies if this PR is off base, I'm still not super familiar with the Zed codebase.

I was trying to integrate with
https://github.com/zed-industries/zed/pull/12940 
and found it awkward to hook up global bindings to adjust the UI font size due to the fact it takes a WindowContext. Looking at the API, it seemed odd that it took a WindowContext, yet the editor font methods take an AppContext.

I couldn't find a compelling reason for this to be tied to a WindowContext, so I personally think it makes sense to switch it.

This does have a behavior change, which hopefully is actually desirable:

Currently, if you have two open and visible Zed windows, and trigger a UI font adjustment in one, the non-active windows won't update. However, once you switch focus to the second one it will snap to the new UI font size. This is inconsistent with adjusting the editor font size, which applies to all open windows immediately.

Release Notes:

- N/A
