### PR TITLE
docs: Use `jsonc` to fix syntax highlighting

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -2,7 +2,7 @@
 
 Zed supports ways to spawn (and rerun) commands using its integrated terminal to output the results. These commands can read a limited subset of Zed state (such as a path to the file currently being edited or selected text).
 
-```json
+```jsonc
 [
   {
     "label": "Example task",


### PR DESCRIPTION
Regular JSON doesn't support comments and thus, the highlighting of the code block is all broken. Using `jsonc` fixes this.

Release Notes:

- N/A