### PR TITLE
Refine symbolic link project tooltip

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2298,7 +2298,7 @@ impl ProjectPanel {
                                 .id("symlink_icon")
                                 .pr_3()
                                 .tooltip(move |cx| {
-                                    Tooltip::text(format!("{path} • Symbolic Link"), cx)
+                                    Tooltip::with_meta(format!("{path}"), None, "Symbolic Link", cx)
                                 })
                                 .child(
                                     Icon::new(IconName::ArrowUpRight)

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2298,7 +2298,7 @@ impl ProjectPanel {
                                 .id("symlink_icon")
                                 .pr_3()
                                 .tooltip(move |cx| {
-                                    Tooltip::with_meta(format!("{path}"), None, "Symbolic Link", cx)
+                                    Tooltip::with_meta(path.to_string(), None, "Symbolic Link", cx)
                                 })
                                 .child(
                                     Icon::new(IconName::ArrowUpRight)

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2767,7 +2767,6 @@ impl Render for ProjectPanel {
                 .track_focus(&self.focus_handle)
                 .child(
                     Button::new("open_project", "Open a project")
-                        .style(ButtonStyle::Filled)
                         .full_width()
                         .key_binding(KeyBinding::for_action(&workspace::Open, cx))
                         .on_click(cx.listener(|this, _, cx| {


### PR DESCRIPTION
This PR uses the tooltip with meta to display the info that a project panel item is actually a symbolic link.

| Before | After |
|--------|--------|
| <img width="826" alt="Screenshot 2024-09-16 at 11 20 15 AM" src="https://github.com/user-attachments/assets/7823f1f2-ed92-4b9a-b95e-c0777cb32387"> | <img width="638" alt="Screenshot 2024-09-16 at 11 19 12 AM" src="https://github.com/user-attachments/assets/5d441ba5-6741-482c-bf2a-ec7e172953df"> | 

Release Notes:

- N/A
