### PR TITLE
Welcome tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13273,6 +13273,7 @@ dependencies = [
  "util",
  "vim",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -17,11 +17,11 @@ test-support = []
 [dependencies]
 anyhow.workspace = true
 client.workspace = true
-inline_completion_button.workspace = true
 db.workspace = true
 extensions_ui.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+inline_completion_button.workspace = true
 install_cli.workspace = true
 picker.workspace = true
 project.workspace = true
@@ -33,6 +33,7 @@ ui.workspace = true
 util.workspace = true
 vim.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -81,9 +81,9 @@ impl Render for WelcomePage {
                     .child(
                         svg()
                             .path("icons/logo_96.svg")
-                            .text_color(cx.theme().colors().icon_muted)
-                            .w(px(64.))
-                            .h(px(64.))
+                            .text_color(cx.theme().colors().icon_disabled)
+                            .w(px(80.))
+                            .h(px(80.))
                             .mx_auto(),
                     )
                     .child(

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -25,6 +25,7 @@ pub use multibuffer_hint::*;
 actions!(welcome, [ResetHints]);
 
 pub const FIRST_OPEN: &str = "first_open";
+pub const DOCS_URL: &str = "https://zed.dev/docs/";
 
 pub fn init(cx: &mut AppContext) {
     BaseKeymap::register(cx);
@@ -74,27 +75,22 @@ impl Render for WelcomePage {
             .track_focus(&self.focus_handle)
             .child(
                 v_flex()
-                    .w_96()
-                    .gap_4()
+                    .w_80()
+                    .gap_6()
                     .mx_auto()
                     .child(
                         svg()
                             .path("icons/logo_96.svg")
-                            .text_color(gpui::white())
-                            .w(px(96.))
-                            .h(px(96.))
+                            .text_color(cx.theme().colors().icon_muted)
+                            .w(px(64.))
+                            .h(px(64.))
                             .mx_auto(),
-                    )
-                    .child(
-                        h_flex()
-                            .justify_center()
-                            .child(Label::new("Code at the speed of thought")),
                     )
                     .child(
                         v_flex()
                             .gap_2()
                             .child(
-                                Button::new("choose-theme", "Choose a theme")
+                                Button::new("choose-theme", "Choose Theme")
                                     .full_width()
                                     .on_click(cx.listener(|this, _, cx| {
                                         this.telemetry.report_app_event(
@@ -112,7 +108,7 @@ impl Render for WelcomePage {
                                     })),
                             )
                             .child(
-                                Button::new("choose-keymap", "Choose a keymap")
+                                Button::new("choose-keymap", "Choose Keymap")
                                     .full_width()
                                     .on_click(cx.listener(|this, _, cx| {
                                         this.telemetry.report_app_event(
@@ -129,6 +125,27 @@ impl Render for WelcomePage {
                                             .ok();
                                     })),
                             )
+                            .child(
+                                Button::new("edit settings", "Edit Settings")
+                                    .full_width()
+                                    .on_click(cx.listener(|this, _, cx| {
+                                        this.telemetry.report_app_event(
+                                            "welcome page: edit settings".to_string(),
+                                        );
+                                        cx.dispatch_action(Box::new(zed_actions::OpenSettings));
+                                    })),
+                            )
+                            .child(Button::new("view docs", "View Docs").full_width().on_click(
+                                cx.listener(|this, _, cx| {
+                                    this.telemetry
+                                        .report_app_event("welcome page: view docs".to_string());
+                                    cx.open_url(DOCS_URL);
+                                }),
+                            )),
+                    )
+                    .child(
+                        v_flex()
+                            .gap_2()
                             .when(cfg!(target_os = "macos"), |el| {
                                 el.child(
                                     Button::new("install-cli", "Install the CLI")
@@ -304,7 +321,7 @@ impl Item for WelcomePage {
     type Event = ItemEvent;
 
     fn tab_content_text(&self, _cx: &WindowContext) -> Option<SharedString> {
-        Some("Welcome to Zed!".into())
+        Some("Welcome".into())
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {


### PR DESCRIPTION
This PR adds "Open Settings" and "Open Docs" to the welcome page, as well as some minor design polish.

The welcome page needs a full redesign at some point so I didn't too to much here in terms of structure/content.

Before | After:

![CleanShot 2024-09-16 at 08 12 23@2x](https://github.com/user-attachments/assets/722175ec-d129-4060-827f-f02f572115da)

---

Release Notes:

- Improved welcome page design and added additional links.