### PR TITLE
Use buffer font for the inline assistant

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1465,7 +1465,7 @@ impl Render for PromptEditor {
             .border_y_1()
             .border_color(cx.theme().status().info_border)
             .size_full()
-            .py(cx.line_height() / 2.)
+            .py(cx.line_height() / 2.5)
             .on_action(cx.listener(Self::confirm))
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(Self::move_up))

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1918,11 +1918,11 @@ impl PromptEditor {
             } else {
                 cx.theme().colors().text
             },
-            line_height: relative(1.3),
             font_family: settings.buffer_font.family.clone(),
             font_fallbacks: settings.buffer_font.fallbacks.clone(),
             font_size: settings.buffer_font_size.into(),
             font_weight: settings.buffer_font.weight,
+            line_height: relative(settings.buffer_line_height.value()),
             ..Default::default()
         };
         EditorElement::new(

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1918,12 +1918,11 @@ impl PromptEditor {
             } else {
                 cx.theme().colors().text
             },
-            font_family: settings.ui_font.family.clone(),
-            font_features: settings.ui_font.features.clone(),
-            font_fallbacks: settings.ui_font.fallbacks.clone(),
-            font_size: settings.ui_font_size.into(),
-            font_weight: settings.ui_font.weight,
             line_height: relative(1.3),
+            font_family: settings.buffer_font.family.clone(),
+            font_fallbacks: settings.buffer_font.fallbacks.clone(),
+            font_size: settings.buffer_font_size.into(),
+            font_weight: settings.buffer_font.weight,
             ..Default::default()
         };
         EditorElement::new(


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17738

This PR is motivated by having also noticed what the issue above mentions. Looked it further and it does seem the inline assistant had a slightly bigger font-size even though it was using the configured UI font-size as per https://github.com/zed-industries/zed/pull/17542. I'm not sure why that was, technically speaking. However, I ended up realizing that, given we're within the editor, it'd make more sense to use the buffer font instead. With this change, the size mismatch seems to be gone.

<img width="900" alt="Screenshot 2024-09-16 at 2 13 28 PM" src="https://github.com/user-attachments/assets/fe2f3096-d5dd-4986-ba96-f2ca7578d84d">

Release Notes:

- N/A
