### PR TITLE
Regenerate terms.rtf fixing Privacy Policy link

### DIFF
--- a/script/terms/terms.rtf
+++ b/script/terms/terms.rtf
@@ -101,7 +101,7 @@ Usage Data is associated with a secure random telemetry ID which may be linked t
 \f1\b \cf0 3.3.5. Privacy Policy\
 \pard\pardeftab720\sa240\partightenfactor0
 
-\f0\b0 \cf0 You and Zed are bound by the terms and conditions contained in the Zed Privacy Policy which is incorporated by reference hereto. The Zed Privacy Policy is available at the following URL: {\field{\*\fldinst{HYPERLINK "https://zed.dev/privacy"}}{\fldrslt \cf3 \ul \ulc3 \strokec3 https://zed.dev/privacy-policy}}.\
+\f0\b0 \cf0 You and Zed are bound by the terms and conditions contained in the Zed Privacy Policy which is incorporated by reference hereto. The Zed Privacy Policy is available at the following URL: {\field{\*\fldinst{HYPERLINK "https://zed.dev/privacy-policy"}}{\fldrslt \cf3 \ul \ulc3 \strokec3 https://zed.dev/privacy-policy}}.\
 \pard\pardeftab720\sa298\partightenfactor0
 
 \f1\b\fs36 \cf0 4. TERM AND TERMINATION\
@@ -212,6 +212,6 @@ Usage Data is associated with a secure random telemetry ID which may be linked t
 \f0\b0\fs24 \cf0 This Agreement is the complete and exclusive statement of the mutual understanding of the parties and supersedes and cancels all previous written and oral agreements, communications, and other understandings relating to the subject matter of this Agreement, and all waivers and modifications must be in a writing signed by both parties, except as otherwise provided herein. Any term or provision of this Agreement held to be illegal or unenforceable shall be, to the fullest extent possible, interpreted so as to be construed as valid, but in any event the validity or enforceability of the remainder hereof shall not be affected.\
 \pard\pardeftab720\sa240\partightenfactor0
 
-\f1\b \cf0 DATE: August 16, 2024
+\f1\b \cf0 DATE: August 19, 2024
 \f0\b0 \
 }


### PR DESCRIPTION
Release Notes:

- Fixed link to Privacy Policy in terms displayed by MacOS DMG (thanks Eamon Sisk).
