### PR TITLE
Update nightly tag every night

### DIFF
--- a/.github/workflows/bump_nightly_tag.yml
+++ b/.github/workflows/bump_nightly_tag.yml
@@ -1,0 +1,23 @@
+name: Update Nightly Tag
+
+on:
+  schedule:
+    # Fire every day at 7:00am UTC (Roughly before EU workday and after US workday)
+    - cron: "0 7 * * *"
+
+jobs:
+  update-nightly-tag:
+    if: github.repository_owner == 'zed-industries'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update nightly tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag -f nightly
+          git push origin nightly --force

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -1,9 +1,6 @@
 name: Release Nightly
 
 on:
-  schedule:
-    # Fire every day at 7:00am UTC (Roughly before EU workday and after US workday)
-    - cron: "0 7 * * *"
   push:
     tags:
       - "nightly"


### PR DESCRIPTION
Previous `release_nightly` workflow would trigger every night or on push to the `nightly` tag, which means `nightly` tag wasn't always in sync with the nightly we bundle. This change syncs the tag up with the bundled releases.

Release Notes:

- N/A
