### PR TITLE
Clamp `tab_size` setting between 1 and 16

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1026,7 +1026,15 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
         }
     }
 
-    merge(&mut settings.tab_size, src.tab_size);
+    if let Some(tab_size) = src.tab_size {
+        /*
+        The tab size should be between 1 and 16.
+        max tab size value same as jetbrains settings value
+        */
+        let tab_size = tab_size.get().clamp(1, 16);
+        merge(&mut settings.tab_size, NonZeroU32::new(tab_size));
+    }
+
     merge(&mut settings.hard_tabs, src.hard_tabs);
     merge(&mut settings.soft_wrap, src.soft_wrap);
     merge(&mut settings.use_autoclose, src.use_autoclose);

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1026,14 +1026,10 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
         }
     }
 
-    if let Some(tab_size) = src.tab_size {
-        /*
-        The tab size should be between 1 and 16.
-        max tab size value same as jetbrains settings value
-        */
-        let tab_size = tab_size.get().clamp(1, 16);
-        merge(&mut settings.tab_size, NonZeroU32::new(tab_size));
-    }
+    merge(&mut settings.tab_size, src.tab_size);
+    settings.tab_size = settings
+        .tab_size
+        .clamp(NonZeroU32::new(1).unwrap(), NonZeroU32::new(16).unwrap());
 
     merge(&mut settings.hard_tabs, src.hard_tabs);
     merge(&mut settings.soft_wrap, src.soft_wrap);


### PR DESCRIPTION
Release Notes:

- Changed `tab_size` setting to require values be between 1 and 16 (inclusive).


### jetbrains settings 

#### Max value
![image](https://github.com/user-attachments/assets/54b772fd-e670-4d77-b3e9-757b08659f55)

When the maximum value is exceeded, the configuration box turns red to remind the user

![image](https://github.com/user-attachments/assets/fcdb6313-be97-4528-b654-5900bcaeafec)

If the user still saves, jetbrains does not process it and resets it to the system default value of 4

<img width="700" alt="image" src="https://github.com/user-attachments/assets/a76b1cba-d23f-4a32-95ee-f05d208ca186">

Without restrictions, I feel not good. Here is a random setting of a relatively large value


https://github.com/user-attachments/assets/c3bdf262-ba08-4bc2-996a-5ad2a37c567f



