### PR TITLE
ruff: Fix wrong Ruff path on Windows

### DIFF
--- a/extensions/ruff/src/ruff.rs
+++ b/extensions/ruff/src/ruff.rs
@@ -89,7 +89,10 @@ impl RuffExtension {
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
         let version_dir = format!("ruff-{}", release.version);
-        let binary_path = format!("{version_dir}/{asset_stem}/ruff");
+        let binary_path = match platform {
+            zed::Os::Windows => format!("{version_dir}/ruff.exe"),
+            _ => format!("{version_dir}/{asset_stem}/ruff"),
+        };
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             zed::set_language_server_installation_status(


### PR DESCRIPTION
Log:

2024-09-16T22:32:04.7715712+08:00 [ERROR] failed to start language server "ruff": failed to spawn command. path: "...\\AppData\\Local\\Zed\\extensions\\work\\ruff\\ruff-0.6.5\\ruff-x86_64-pc-windows-msvc\\ruff"

The right path: `...\\AppData\\Local\\Zed\\extensions\\work\\ruff\\ruff-0.6.5\\ruff.exe`

Release Notes:

- N/A