### PR TITLE
docs: Use `json` to fix syntax highlighting

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1179,7 +1179,7 @@ Or to set a `socks5` proxy:
 - Setting: `search`
 - Default:
 
-```
+```json
 "search": {
   "whole_word": false,
   "case_sensitive": false,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1516,7 +1516,7 @@ The name of any font family installed on the user's system
 
 See Buffer Font Features
 
-```jsonc
+```json
 {
   "terminal": {
     "font_features": {
@@ -1537,7 +1537,7 @@ See Buffer Font Features
 
 1. Use a line height that's `comfortable` for reading, 1.618. (default)
 
-```jsonc
+```json
 {
   "terminal": {
     "line_height": "comfortable",
@@ -1547,7 +1547,7 @@ See Buffer Font Features
 
 2. Use a `standard` line height, 1.3. This option is useful for TUIs, particularly if they use box characters
 
-```jsonc
+```json
 {
   "terminal": {
     "line_height": "standard",
@@ -1557,7 +1557,7 @@ See Buffer Font Features
 
 3.  Use a custom line height.
 
-```jsonc
+```json
 {
   "terminal": {
     "line_height": {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1520,10 +1520,10 @@ See Buffer Font Features
 {
   "terminal": {
     "font_features": {
-      "calt": false,
+      "calt": false
       // See Buffer Font Features for more features
-    },
-  },
+    }
+  }
 }
 ```
 
@@ -1540,8 +1540,8 @@ See Buffer Font Features
 ```json
 {
   "terminal": {
-    "line_height": "comfortable",
-  },
+    "line_height": "comfortable"
+  }
 }
 ```
 
@@ -1550,8 +1550,8 @@ See Buffer Font Features
 ```json
 {
   "terminal": {
-    "line_height": "standard",
-  },
+    "line_height": "standard"
+  }
 }
 ```
 
@@ -1561,9 +1561,9 @@ See Buffer Font Features
 {
   "terminal": {
     "line_height": {
-      "custom": 2,
-    },
-  },
+      "custom": 2
+    }
+  }
 }
 ```
 

--- a/docs/src/languages/csharp.md
+++ b/docs/src/languages/csharp.md
@@ -17,9 +17,9 @@ The `OmniSharp` binary can be configured in a Zed settings file with:
     "omnisharp": {
       "binary": {
         "path": "/path/to/OmniSharp",
-        "args": ["optional", "additional", "args", "-lsp"],
-      },
-    },
-  },
+        "args": ["optional", "additional", "args", "-lsp"]
+      }
+    }
+  }
 }
 ```

--- a/docs/src/languages/csharp.md
+++ b/docs/src/languages/csharp.md
@@ -11,7 +11,7 @@ C# support is available through the [C# extension](https://github.com/zed-indust
 
 The `OmniSharp` binary can be configured in a Zed settings file with:
 
-```jsonc
+```json
 {
   "lsp": {
     "omnisharp": {

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -33,7 +33,7 @@ You can configure the use of [typescript-language-server](https://github.com/typ
 
 Prettier will also be used for TypeScript files by default. To disable this:
 
-```jsonc
+```json
 {
   "languages": {
     "TypeScript": {

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -37,10 +37,10 @@ Prettier will also be used for TypeScript files by default. To disable this:
 {
   "languages": {
     "TypeScript": {
-      "prettier": { "allowed": false },
-    },
+      "prettier": { "allowed": false }
+    }
     //...
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
This follows up the [issue with mdbook notpeter mentioned](https://github.com/zed-industries/zed/pull/17864#issuecomment-2353089065) by replacing `jsonc` where used in the docs with `json`.

Additionally, one missing `json` - highlight was added for the search-section.

Release Notes:

- N/A
