### PR TITLE
rust: Lookup rust-analyzer on PATH by default

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -57,12 +57,13 @@ impl LspAdapter for RustLspAdapter {
                         }
                         (Some(path.into()), None)
                     }
-                    (None, Some(true)) => {
+                    (None, Some(true)) | (None, None) => {
+                        // Try to lookup rust-analyzer in PATH by default.
                         let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
                         let env = delegate.shell_env().await;
                         (Some(path), Some(env))
                     }
-                    (None, Some(false)) | (None, None) => (None, None),
+                    (None, Some(false)) => (None, None),
                 };
                 path.map(|path| LanguageServerBinary {
                     path,


### PR DESCRIPTION
This is a highly and frequently requested change. Users are confused why rust-analyzer isn't used if it's on their `$PATH`.

Previously I didn't enable this by default, because rust-analyzer would complain about an "Unknown binary", like this

    Unknown binary 'rust-analyzer' in official toolchain '1.81-aarch64-apple-darwin'.\n

But turns out that only happens when you have installed rust-analyzer via the rustup toolchain, it's in your `$PATH`, and the `rust-toolchain.toml` of the repository doesn't mention it.

The fix is to delete `~/.cargo/bin/rust-analyzer` and, if preferred, use `rust-analyzer` by installing the binary manually.

Release Notes:

- Changed rust-analyzer support to lookup `rust-analyzer` binaries by default in `$PATH`. That changes the default value to something users requested.