### PR TITLE
collab: Add missing dependencies for building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,28 @@ ARG CARGO_PROFILE_RELEASE_PANIC=abort
 ARG GITHUB_SHA
 
 ENV GITHUB_SHA=$GITHUB_SHA
+
+# At some point in the past 3 weeks, additional dependencies on `xkbcommon` and
+# `xkbcommon-x11` were introduced into collab.
+#
+# Now when we try to build collab for the Docker image, it fails with the following
+# error:
+#
+# ```
+# 985.3   = note: /usr/bin/ld: cannot find -lxkbcommon: No such file or directory
+# 985.3           /usr/bin/ld: cannot find -lxkbcommon-x11: No such file or directory
+# 985.3           collect2: error: ld returned 1 exit status
+# ```
+#
+# The last successful deploys were at:
+# - Staging: `4f408ec65a3867278322a189b4eb20f1ab51f508`
+# - Production: `fc4c533d0a8c489e5636a4249d2b52a80039fbd7`
+#
+# Installing these as a temporary workaround, but I think ideally we'd want to figure
+# out what caused them to be included in the first place.
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends libxkbcommon-dev libxkbcommon-x11-dev
+
 RUN --mount=type=cache,target=./script/node_modules \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
This PR adds some missing dependencies to the Docker image that are now needed in order to build collab.

When trying to build the docker image at 761129e3739efacb7b8763eaa0fa8a109e935447 it fails with the following error:

```
985.3   = note: /usr/bin/ld: cannot find -lxkbcommon: No such file or directory
985.3           /usr/bin/ld: cannot find -lxkbcommon-x11: No such file or directory
985.3           collect2: error: ld returned 1 exit status
985.3           
985.3 
985.4 error: could not compile `collab` (bin "collab") due to 1 previous error
```

The last time we built the Docker image for collab was:

- Staging: 4f408ec65a3867278322a189b4eb20f1ab51f508
- Production: fc4c533d0a8c489e5636a4249d2b52a80039fbd7

Release Notes:

- N/A
