### PR TITLE
collab: Mark RunPod environment variables as optional in Kubernetes template

### DIFF
--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -154,11 +154,13 @@ spec:
                 secretKeyRef:
                   name: runpod
                   key: api_key
+                  optional: true
             - name: RUNPOD_API_SUMMARY_URL
               valueFrom:
                 secretKeyRef:
                   name: runpod
                   key: summary
+                  optional: true
             - name: BLOB_STORE_ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This PR marks the RunPod environment variables as optional in the Kubernetes template so that we can deploy without them being present.

Collab is already accounting for their absence.

Release Notes:

- N/A
