### PR TITLE
collab: Override Cargo configuration in the `Dockerfile`

### DIFF
--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -75,9 +75,6 @@ jobs:
         with:
           clean: false
 
-      - name: Set up default .cargo/config.toml
-        run: cp ./.cargo/collab-config.toml ./.cargo/config.toml
-
       - name: Build docker image
         run: docker build . --build-arg GITHUB_SHA=$GITHUB_SHA --tag registry.digitalocean.com/zed/collab:$GITHUB_SHA
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM rust:1.81-bookworm as builder
 WORKDIR app
 COPY . .
 
+# Replace the Cargo configuration with the one used by collab.
+COPY ./.cargo/collab-config.toml ./.cargo/config.toml
+
 # Compile collab server
 ARG CARGO_PROFILE_RELEASE_PANIC=abort
 ARG GITHUB_SHA


### PR DESCRIPTION
This PR moves the override for the Cargo configuration for collab into the `Dockerfile` rather than having it be something some in the external environment.

This makes it possible to build the Docker image locally without having to replace `.cargo/config.toml` with the contents of `.cargo/collab-config.toml`.

Release Notes:

- N/A
