### PR TITLE
docs: Document usage of deno fmt

### DIFF
--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -26,7 +26,8 @@ To use the Deno Language Server with TypeScript and TSX files, you will likely w
         "!typescript-language-server",
         "!vtsls",
         "!eslint"
-      ]
+      ],
+      "formatter": "language_server"
     },
     "TSX": {
       "language_servers": [
@@ -34,7 +35,8 @@ To use the Deno Language Server with TypeScript and TSX files, you will likely w
         "!typescript-language-server",
         "!vtsls",
         "!eslint"
-      ]
+      ],
+      "formatter": "language_server"
     }
   }
 }


### PR DESCRIPTION
Release Notes:

- N/A

Deno comes with a built-in formatter, `deno fmt`.  Currently, this setting appears to default to using the built-in formatter without explicitly stating that.

It would be helpful to clarify in the settings description that the default formatter leverages `deno fmt`.  This makes it clearer for users what to expect and how formatting is handled out of the box. 