### PR TITLE
Fix tests broken by 17734

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4131,7 +4131,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                 line_comments: vec!["// ".into(), "/// ".into()],
                 ..LanguageConfig::default()
             },
-            Some(tree_sitter_rust::language()),
+            Some(tree_sitter_rust::LANGUAGE.into()),
         ));
         cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
 


### PR DESCRIPTION
Tests on main started breaking following https://github.com/zed-industries/zed/commit/bc5ed1334ff019e026cbf7a6bbad4a8c2c5d68df from:
- https://github.com/zed-industries/zed/pull/17734

First breakage: https://github.com/zed-industries/zed/actions/runs/10894059586/job/30230118999

Release Notes:

- N/A
