### PR TITLE
supermaven: Fix incorrect offset calculation

### DIFF
--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -77,10 +77,10 @@ fn completion_state_from_diff(
                         snapshot.anchor_after(offset),
                         completion_text[i..i + k].into(),
                     ));
-                    offset.add_assign(j);
                 }
                 i += k + 1;
                 j += 1;
+                offset.add_assign(1);
             }
             None => {
                 // there are no more matching completions, so drop the remaining


### PR DESCRIPTION
Fixes a bug in https://github.com/zed-industries/zed/pull/17578 when computing the offset. Specifically, `offset.add_assign()` should be incremented on every loop match instead of only when the completion text is found.

Before:

![image](https://github.com/user-attachments/assets/cc09dbf9-03e8-4453-a1c7-11f838c1d959)

After:

![image](https://github.com/user-attachments/assets/f3513769-d9e1-451f-97dc-b9ad3a57ce3a)

Release Notes:

- Fixed a wrong offset calculation in the Supermaven inline completion provider.