### PR TITLE
Pass shell env to some language servers even if they are downloaded by zed

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::future::OptionFuture;
 use gpui::AppContext;
 use gpui::AsyncAppContext;
 use language::{ContextProvider, LanguageServerName, LspAdapter, LspAdapterDelegate};
@@ -197,7 +198,7 @@ async fn get_cached_server_binary(
     if server_path.exists() {
         Some(LanguageServerBinary {
             path: node.binary_path().await.log_err()?,
-            env: delegate.map(|delegate| delegate.shell_env().await),
+            env: OptionFuture::from(delegate.map(|delegate| delegate.shell_env())).await,
             arguments: server_binary_arguments(&server_path),
         })
     } else {


### PR DESCRIPTION
@mrnugget, I don't think that this breaks anything, but it allows the servers to work with local environments, so if someone has rust installed using direnv and use rust-analyzer installed by zed, it would work fine. I don't think there are any disadvantages of doing so, but if you know some, feel free to point them out

Release Notes:

- Pass environment to rust-analyzer, clangd, gopls and pyright even if they are downloaded by zed