### PR TITLE
editor: Fix cursor_shape regression by not setting it to "bar"

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -121,8 +121,8 @@
   //  4. A box drawn around the following character
   //     "hollow"
   //
-  // Default: bar
-  "cursor_shape": "bar",
+  // Default: not set, defaults to "bar"
+  "cursor_shape": null,
   // How to highlight the current line in the editor.
   //
   // 1. Don't highlight the current line:

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1904,7 +1904,9 @@ impl Editor {
             linked_editing_range_task: Default::default(),
             pending_rename: Default::default(),
             searchable: true,
-            cursor_shape: EditorSettings::get_global(cx).cursor_shape,
+            cursor_shape: EditorSettings::get_global(cx)
+                .cursor_shape
+                .unwrap_or_default(),
             current_line_highlight: None,
             autoindent_mode: Some(AutoindentMode::EachLine),
             collapse_matches: false,
@@ -11820,7 +11822,9 @@ impl Editor {
             cx,
         );
         let editor_settings = EditorSettings::get_global(cx);
-        self.cursor_shape = editor_settings.cursor_shape;
+        if let Some(cursor_shape) = editor_settings.cursor_shape {
+            self.cursor_shape = cursor_shape;
+        }
         self.scroll_manager.vertical_scroll_margin = editor_settings.vertical_scroll_margin;
         self.show_breadcrumbs = editor_settings.toolbar.breadcrumbs;
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -7,7 +7,7 @@ use settings::{Settings, SettingsSources};
 #[derive(Deserialize, Clone)]
 pub struct EditorSettings {
     pub cursor_blink: bool,
-    pub cursor_shape: CursorShape,
+    pub cursor_shape: Option<CursorShape>,
     pub current_line_highlight: CurrentLineHighlight,
     pub hover_popover_enabled: bool,
     pub show_completions_on_input: bool,
@@ -182,7 +182,7 @@ pub struct EditorSettingsContent {
     /// Cursor shape for the default editor.
     /// Can be "bar", "block", "underscore", or "hollow".
     ///
-    /// Default: bar
+    /// Default: None
     pub cursor_shape: Option<CursorShape>,
     /// How to highlight the current line in the editor.
     ///


### PR DESCRIPTION
This fixes the regression introduced here: https://github.com/zed-industries/zed/pull/17572#issuecomment-2355632615

Essentially: instead of always setting the value when saving settings, we don't set it by default, but fall back to the default value if it's not set.

That fixes Vim mode's cursor being overwritten when settings change.

Release Notes:

- N/A
