### PR TITLE
ocaml: Fix indentation in files

### DIFF
--- a/extensions/ocaml/languages/dune/config.toml
+++ b/extensions/ocaml/languages/dune/config.toml
@@ -2,7 +2,7 @@ name = "Dune"
 grammar = "dune"
 path_suffixes = ["dune", "dune-project"]
 brackets = [
-  { start = "(", end = ")", close = true, newline = true },
-  { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] }
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] }
 ]
 tab_size = 2

--- a/extensions/ocaml/languages/dune/injections.scm
+++ b/extensions/ocaml/languages/dune/injections.scm
@@ -1,2 +1,2 @@
 ((ocaml_syntax) @injection.content
- (#set! injection.language "ocaml"))
+    (#set! injection.language "ocaml"))


### PR DESCRIPTION
This PR fixes the indentation in the Dune-related files after https://github.com/zed-industries/zed/pull/17886.

Release Notes:

- N/A
