### PR TITLE
Use dev icons for dev bundles

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -134,7 +134,7 @@ tree-sitter-rust.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 
 [package.metadata.bundle-dev]
-icon = ["resources/app-icon-preview@2x.png", "resources/app-icon-preview.png"]
+icon = ["resources/app-icon-dev@2x.png", "resources/app-icon-dev.png"]
 identifier = "dev.zed.Zed-Dev"
 name = "Zed Dev"
 osx_minimum_system_version = "10.15.7"


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/17486/ actually using the dev icons for dev bundles

Release Notes:

- N/A
