### PR TITLE
ocaml: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14481,7 +14481,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ocaml"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/ocaml/Cargo.toml
+++ b/extensions/ocaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ocaml"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/ocaml/extension.toml
+++ b/extensions/ocaml/extension.toml
@@ -1,7 +1,7 @@
 id = "ocaml"
 name = "OCaml"
 description = "OCaml support."
-version = "0.0.2"
+version = "0.1.0"
 schema_version = 1
 authors = ["Rashid Almheiri <69181766+huwaireb@users.noreply.github.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the OCaml extension to v0.1.0.

Changes:

- https://github.com/zed-industries/zed/pull/16955
- https://github.com/zed-industries/zed/pull/17886

Release Notes:

- N/A
