### PR TITLE
windows: Remove the use of `DispatcherQueue` and fix `FileSaveDialog` unresponsive issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,6 +514,7 @@ features = [
     "Win32_UI_Input_Ime",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
     "Win32_UI_WindowsAndMessaging",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,7 +484,6 @@ features = [
     "implement",
     "Foundation_Numerics",
     "Storage",
-    "System",
     "System_Threading",
     "UI_ViewManagement",
     "Wdk_System_SystemServices",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -50,7 +50,7 @@ parking = "2.0.0"
 parking_lot.workspace = true
 postage.workspace = true
 profiling.workspace = true
-rand = { optional = true, workspace = true}
+rand = { optional = true, workspace = true }
 raw-window-handle = "0.6"
 refineable.workspace = true
 resvg = { version = "0.41.0", default-features = false }
@@ -110,6 +110,7 @@ blade-graphics.workspace = true
 blade-macros.workspace = true
 blade-util.workspace = true
 bytemuck = "1"
+flume = "0.11"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 as-raw-xcb-connection = "1"
@@ -117,7 +118,6 @@ ashpd.workspace = true
 calloop = "0.13.0"
 calloop-wayland-source = "0.3.0"
 cosmic-text = { git = "https://github.com/pop-os/cosmic-text", rev = "542b20c" }
-flume = "0.11"
 wayland-backend = { version = "0.3.3", features = ["client_system", "dlopen"] }
 wayland-client = { version = "0.31.2" }
 wayland-cursor = "0.31.1"

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -177,6 +177,9 @@ fn handle_timer_msg(
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
     if wparam.0 == SIZE_MOVE_LOOP_TIMER_ID {
+        for runnable in state_ptr.main_receiver.drain() {
+            runnable.run();
+        }
         handle_paint_msg(handle, state_ptr)
     } else {
         None

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -8,6 +8,7 @@ use std::{
 
 use ::util::ResultExt;
 use anyhow::{anyhow, Context, Result};
+use async_task::Runnable;
 use futures::channel::oneshot::{self, Receiver};
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -46,6 +47,8 @@ pub(crate) struct WindowsPlatform {
     raw_window_handles: RwLock<SmallVec<[HWND; 4]>>,
     // The below members will never change throughout the entire lifecycle of the app.
     icon: HICON,
+    main_receiver: flume::Receiver<Runnable>,
+    dispatch_event: HANDLE,
     background_executor: BackgroundExecutor,
     foreground_executor: ForegroundExecutor,
     text_system: Arc<DirectWriteTextSystem>,
@@ -89,7 +92,9 @@ impl WindowsPlatform {
         unsafe {
             OleInitialize(None).expect("unable to initialize Windows OLE");
         }
-        let dispatcher = Arc::new(WindowsDispatcher::new());
+        let (main_sender, main_receiver) = flume::unbounded::<Runnable>();
+        let dispatch_event = unsafe { CreateEventW(None, false, false, None) }.unwrap();
+        let dispatcher = Arc::new(WindowsDispatcher::new(main_sender, dispatch_event));
         let background_executor = BackgroundExecutor::new(dispatcher.clone());
         let foreground_executor = ForegroundExecutor::new(dispatcher);
         let bitmap_factory = ManuallyDrop::new(unsafe {
@@ -113,6 +118,8 @@ impl WindowsPlatform {
             state,
             raw_window_handles,
             icon,
+            main_receiver,
+            dispatch_event,
             background_executor,
             foreground_executor,
             text_system,
@@ -176,6 +183,13 @@ impl WindowsPlatform {
 
         lock.is_empty()
     }
+
+    #[inline]
+    fn run_foreground_tasks(&self) {
+        for runnable in self.main_receiver.drain() {
+            runnable.run();
+        }
+    }
 }
 
 impl Platform for WindowsPlatform {
@@ -197,16 +211,21 @@ impl Platform for WindowsPlatform {
         begin_vsync(*vsync_event);
         'a: loop {
             let wait_result = unsafe {
-                MsgWaitForMultipleObjects(Some(&[*vsync_event]), false, INFINITE, QS_ALLINPUT)
+                MsgWaitForMultipleObjects(
+                    Some(&[*vsync_event, self.dispatch_event]),
+                    false,
+                    INFINITE,
+                    QS_ALLINPUT,
+                )
             };
 
             match wait_result {
                 // compositor clock ticked so we should draw a frame
-                WAIT_EVENT(0) => {
-                    self.redraw_all();
-                }
+                WAIT_EVENT(0) => self.redraw_all(),
+                // foreground tasks are dispatched
+                WAIT_EVENT(1) => self.run_foreground_tasks(),
                 // Windows thread messages are posted
-                WAIT_EVENT(1) => {
+                WAIT_EVENT(2) => {
                     let mut msg = MSG::default();
                     unsafe {
                         while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
@@ -230,6 +249,8 @@ impl Platform for WindowsPlatform {
                             }
                         }
                     }
+                    // foreground tasks may have been queued in the message handlers
+                    self.run_foreground_tasks();
                 }
                 _ => {
                     log::error!("Something went wrong while waiting {:?}", wait_result);
@@ -328,6 +349,7 @@ impl Platform for WindowsPlatform {
             lock.current_cursor,
             self.windows_version,
             self.validation_number,
+            self.main_receiver.clone(),
         )?;
         drop(lock);
         let handle = window.get_raw_handle();

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -12,6 +12,7 @@ use std::{
 
 use ::util::ResultExt;
 use anyhow::{Context, Result};
+use async_task::Runnable;
 use futures::channel::oneshot::{self, Receiver};
 use itertools::Itertools;
 use raw_window_handle as rwh;
@@ -63,6 +64,7 @@ pub(crate) struct WindowsWindowStatePtr {
     pub(crate) executor: ForegroundExecutor,
     pub(crate) windows_version: WindowsVersion,
     pub(crate) validation_number: usize,
+    pub(crate) main_receiver: flume::Receiver<Runnable>,
 }
 
 impl WindowsWindowState {
@@ -226,6 +228,7 @@ impl WindowsWindowStatePtr {
             executor: context.executor.clone(),
             windows_version: context.windows_version,
             validation_number: context.validation_number,
+            main_receiver: context.main_receiver.clone(),
         }))
     }
 }
@@ -253,6 +256,7 @@ struct WindowCreateContext {
     current_cursor: HCURSOR,
     windows_version: WindowsVersion,
     validation_number: usize,
+    main_receiver: flume::Receiver<Runnable>,
 }
 
 impl WindowsWindow {
@@ -264,6 +268,7 @@ impl WindowsWindow {
         current_cursor: HCURSOR,
         windows_version: WindowsVersion,
         validation_number: usize,
+        main_receiver: flume::Receiver<Runnable>,
     ) -> Result<Self> {
         let classname = register_wnd_class(icon);
         let hide_title_bar = params
@@ -305,6 +310,7 @@ impl WindowsWindow {
             current_cursor,
             windows_version,
             validation_number,
+            main_receiver,
         };
         let lpparam = Some(&context as *const _ as *const _);
         let creation_result = unsafe {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -263,13 +263,16 @@ impl WindowsWindow {
     pub(crate) fn new(
         handle: AnyWindowHandle,
         params: WindowParams,
-        icon: HICON,
-        executor: ForegroundExecutor,
-        current_cursor: HCURSOR,
-        windows_version: WindowsVersion,
-        validation_number: usize,
-        main_receiver: flume::Receiver<Runnable>,
+        creation_info: WindowCreationInfo,
     ) -> Result<Self> {
+        let WindowCreationInfo {
+            icon,
+            executor,
+            current_cursor,
+            windows_version,
+            validation_number,
+            main_receiver,
+        } = creation_info;
         let classname = register_wnd_class(icon);
         let hide_title_bar = params
             .titlebar


### PR DESCRIPTION

Closes #17069, closes #12410, closes #16352


With the help of @kennykerr (Creator of C++/WinRT and the crate `windows-rs`, Engineer on the Windows team at Microsoft) and @riverar (Windows Development expert), we discovered that this bug only occurs when an IME with a candidate window, such as Microsoft Pinyin IME, is active. In this case, the `FileSaveDialog` becomes unresponsive—while the dialog itself appears to be functioning, it doesn't accept any mouse or keyboard input.

After a period of debugging and testing, I found that this issue only arises when using `DispatcherQueue` to dispatch runnables on the UI thread. After @kennykerr’s further investigation, Kenny identified that this is a bug with `DispatcherQueue`, and he recommended to avoid using `DispatcherQueue`. Given the uncertainty about whether Microsoft will address this bug in the foreseeable future, I have removed the use of `DispatcherQueue`.

Co-authored-by: Kenny <kenny@kennykerr.ca>

Release Notes:

- N/A
