### PR TITLE
theme: Fix casing of "ANSI" in doc comments

### DIFF
--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -421,7 +421,7 @@ pub struct ThemeColorsContent {
     #[serde(rename = "terminal.foreground")]
     pub terminal_foreground: Option<String>,
 
-    /// Terminal ansi background color.
+    /// Terminal ANSI background color.
     #[serde(rename = "terminal.ansi.background")]
     pub terminal_ansi_background: Option<String>,
 

--- a/crates/theme/src/styles/colors.rs
+++ b/crates/theme/src/styles/colors.rs
@@ -183,10 +183,8 @@ pub struct ThemeColors {
     pub terminal_bright_foreground: Hsla,
     /// Dim terminal foreground color.
     pub terminal_dim_foreground: Hsla,
-
-    /// Terminal ansi background color.
+    /// Terminal ANSI background color.
     pub terminal_ansi_background: Hsla,
-
     /// Black ANSI terminal color.
     pub terminal_ansi_black: Hsla,
     /// Bright black ANSI terminal color.


### PR DESCRIPTION
This PR fixes the casing of "ANSI" in some doc comments after #17611.

Release Notes:

- N/A
