### PR TITLE
Fix the rendering of warning text in our docs

### DIFF
--- a/docs/theme/css/general.css
+++ b/docs/theme/css/general.css
@@ -268,7 +268,7 @@ blockquote .warning:before {
 .warning {
   margin: auto;
   padding: 1rem 1.25rem;
-  color: #000;
+  color: var(--fg);
   background-color: var(--warning-bg);
   border: 1px solid var(--warning-border);
 }


### PR DESCRIPTION
cc: @danilo-leal 

Before:

<img width="753" alt="Screenshot 2024-09-17 at 10 53 13 AM" src="https://github.com/user-attachments/assets/43a2ef89-4a90-46d4-9e90-350fdd1b46bb">

After:

<img width="759" alt="Screenshot 2024-09-17 at 10 53 35 AM" src="https://github.com/user-attachments/assets/49f2a250-d339-4f61-afda-3ed87181b018">

Light mode:

<img width="757" alt="Screenshot 2024-09-17 at 10 54 17 AM" src="https://github.com/user-attachments/assets/4d425e9b-3f97-44c4-ba86-d84dc7349060">

Release Notes:

- N/A