### PR TITLE
ruff: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14516,7 +14516,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruff"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/ruff/Cargo.toml
+++ b/extensions/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruff"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/ruff/extension.toml
+++ b/extensions/ruff/extension.toml
@@ -1,7 +1,7 @@
 id = "ruff"
 name = "Ruff"
 description = "Support for Ruff, the Python linter and formatter"
-version = "0.0.2"
+version = "0.1.0"
 schema_version = 1
 authors = []
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Ruff extension to v0.1.0.

Changes:

- https://github.com/zed-industries/zed/pull/15852
- https://github.com/zed-industries/zed/pull/16955
- https://github.com/zed-industries/zed/pull/17883

Release Notes:

- N/A
