### PR TITLE
Update typos-cli to v1.24.6. Add scripts/check-spelling. Fix typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,7 @@ jobs:
         run: git clean -df
 
       - name: Check spelling
-        run: |
-          if ! cargo install --list | grep "typos-cli v$TYPOS_CLI_VERSION" > /dev/null; then
-            echo "Installing typos-cli@$TYPOS_CLI_VERSION..."
-            cargo install "typos-cli@$TYPOS_CLI_VERSION"
-          else
-            echo "typos-cli@$TYPOS_CLI_VERSION is already installed."
-          fi
-          typos
-        env:
-          TYPOS_CLI_VERSION: "1.23.3"
+        run: script/check-spelling
 
       - name: Run style checks
         uses: ./.github/actions/check_style

--- a/crates/collab/src/db/ids.rs
+++ b/crates/collab/src/db/ids.rs
@@ -104,7 +104,7 @@ pub enum ChannelRole {
     /// Admin can read/write and change permissions.
     #[sea_orm(string_value = "admin")]
     Admin,
-    /// Member can read/write, but not change pemissions.
+    /// Member can read/write, but not change permissions.
     #[sea_orm(string_value = "member")]
     #[default]
     Member,

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -337,7 +337,7 @@ impl InlayHintCache {
     /// If needed, queries LSP for new inlay hints, using the invalidation strategy given.
     /// To reduce inlay hint jumping, attempts to query a visible range of the editor(s) first,
     /// followed by the delayed queries of the same range above and below the visible one.
-    /// This way, concequent refresh invocations are less likely to trigger LSP queries for the invisible ranges.
+    /// This way, consequent refresh invocations are less likely to trigger LSP queries for the invisible ranges.
     pub(super) fn spawn_hint_refresh(
         &mut self,
         reason_description: &'static str,

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -337,7 +337,7 @@ impl InlayHintCache {
     /// If needed, queries LSP for new inlay hints, using the invalidation strategy given.
     /// To reduce inlay hint jumping, attempts to query a visible range of the editor(s) first,
     /// followed by the delayed queries of the same range above and below the visible one.
-    /// This way, consequent refresh invocations are less likely to trigger LSP queries for the invisible ranges.
+    /// This way, subsequent refresh invocations are less likely to trigger LSP queries for the invisible ranges.
     pub(super) fn spawn_hint_refresh(
         &mut self,
         reason_description: &'static str,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3025,7 +3025,7 @@ impl BufferSnapshot {
                 let mut start = text.len();
                 let end = start + buffer_range.len();
 
-                // When multiple names are captured, then the matcheable text
+                // When multiple names are captured, then the matchable text
                 // includes the whitespace in between the names.
                 if !name_ranges.is_empty() {
                     start -= 1;

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -382,7 +382,7 @@ async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
     let buffer = cx.new_model(|cx| Buffer::local(text, cx));
 
     // Spawn a task to format the buffer's whitespace.
-    // Pause so that the foratting task starts running.
+    // Pause so that the formatting task starts running.
     let format = buffer.update(cx, |buffer, cx| buffer.remove_trailing_whitespace(cx));
     smol::future::yield_now().await;
 

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -509,7 +509,7 @@ impl<D: PickerDelegate> Picker<D> {
             .on_mouse_up(
                 MouseButton::Right,
                 cx.listener(move |this, event: &MouseUpEvent, cx| {
-                    // We specficially want to use the platform key here, as
+                    // We specifically want to use the platform key here, as
                     // ctrl will already be held down for the tab switcher.
                     this.handle_click(ix, event.modifiers.platform, cx)
                 }),

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1619,7 +1619,7 @@ fn task_summary(task: &TaskState, error_code: Option<i32>) -> (bool, String, Str
 ///   the cursor's `point` is not updated to the new line and column values
 ///
 /// * ??? there could be more consequences, and any further "proper" streaming from the PTY might bug and/or panic.
-///   Still, concequent `append_text_to_term` invocations are possible and display the contents correctly.
+///   Still, consequent `append_text_to_term` invocations are possible and display the contents correctly.
 ///
 /// Despite the quirks, this is the simplest approach to appending text to the terminal: its alternative, `grid_mut` manipulations,
 /// do not properly set the scrolling state and display odd text after appending; also those manipulations are more tedious and error-prone.

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1619,7 +1619,7 @@ fn task_summary(task: &TaskState, error_code: Option<i32>) -> (bool, String, Str
 ///   the cursor's `point` is not updated to the new line and column values
 ///
 /// * ??? there could be more consequences, and any further "proper" streaming from the PTY might bug and/or panic.
-///   Still, consequent `append_text_to_term` invocations are possible and display the contents correctly.
+///   Still, subsequent `append_text_to_term` invocations are possible and display the contents correctly.
 ///
 /// Despite the quirks, this is the simplest approach to appending text to the terminal: its alternative, `grid_mut` manipulations,
 /// do not properly set the scrolling state and display odd text after appending; also those manipulations are more tedious and error-prone.

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -46,7 +46,7 @@ impl RenderOnce for AnyIcon {
 /// The decoration for an icon.
 ///
 /// For example, this can show an indicator, an "x",
-/// or a diagonal strkethrough to indicate something is disabled.
+/// or a diagonal strikethrough to indicate something is disabled.
 #[derive(Debug, PartialEq, Copy, Clone, EnumIter)]
 pub enum IconDecoration {
     Strikethrough,

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -176,7 +176,7 @@ pub fn monitor_main_thread_hangs(
     let background_executor = cx.background_executor();
     let telemetry_settings = *client::TelemetrySettings::get_global(cx);
 
-    // Initialize SIGUSR2 handler to send a backrace to a channel.
+    // Initialize SIGUSR2 handler to send a backtrace to a channel.
     let (backtrace_tx, backtrace_rx) = mpsc::channel();
     static BACKTRACE: Mutex<Vec<backtrace::Frame>> = Mutex::new(Vec::new());
     static BACKTRACE_SENDER: OnceLock<mpsc::Sender<()>> = OnceLock::new();

--- a/script/check-spelling
+++ b/script/check-spelling
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+TYPOS_CLI_VERSION=1.24.6
+
+if ! cargo install --list | grep "typos-cli v$TYPOS_CLI_VERSION" > /dev/null; then
+    echo "Installing typos-cli@$TYPOS_CLI_VERSION..."
+    cargo install "typos-cli@$TYPOS_CLI_VERSION"
+else
+    echo "typos-cli@$TYPOS_CLI_VERSION is already installed."
+fi
+typos


### PR DESCRIPTION
Release Notes:

- N/A
