### PR TITLE
Add missing cmake dependency to Nix build

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -28,6 +28,7 @@
   stdenvAdapters,
   nix-gitignore,
   withGLES ? false,
+  cmake,
 }: let
   includeFilter = path: type: let
     baseName = baseNameOf (toString path);
@@ -58,6 +59,7 @@
         pkg-config
         protobuf
         rustPlatform.bindgenHook
+        cmake
       ];
 
       buildInputs = [


### PR DESCRIPTION
cmake is required during build of dependecies and thus needs to be supplied in nativeBuildInputs (dependecies required for build not during runtime).

This fixes (sandboxed) nix builds of the project.

Release Notes:

- N/A
