### PR TITLE
Apply `hint.background` and `predictive.background` colors from the theme

### DIFF
--- a/crates/assistant/src/prompt_library.rs
+++ b/crates/assistant/src/prompt_library.rs
@@ -923,10 +923,18 @@ impl PromptLibrary {
                                                     status: cx.theme().status().clone(),
                                                     inlay_hints_style: HighlightStyle {
                                                         color: Some(cx.theme().status().hint),
+                                                        background_color: Some(
+                                                            cx.theme().status().hint_background,
+                                                        ),
                                                         ..HighlightStyle::default()
                                                     },
                                                     suggestions_style: HighlightStyle {
                                                         color: Some(cx.theme().status().predictive),
+                                                        background_color: Some(
+                                                            cx.theme()
+                                                                .status()
+                                                                .predictive_background,
+                                                        ),
                                                         ..HighlightStyle::default()
                                                     },
                                                     ..EditorStyle::default()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10035,11 +10035,17 @@ impl Editor {
                                                 status: cx.editor_style.status.clone(),
                                                 inlay_hints_style: HighlightStyle {
                                                     color: Some(cx.theme().status().hint),
+                                                    background_color: Some(
+                                                        cx.theme().status().hint_background,
+                                                    ),
                                                     font_weight: Some(FontWeight::BOLD),
                                                     ..HighlightStyle::default()
                                                 },
                                                 suggestions_style: HighlightStyle {
                                                     color: Some(cx.theme().status().predictive),
+                                                    background_color: Some(
+                                                        cx.theme().status().predictive_background,
+                                                    ),
                                                     ..HighlightStyle::default()
                                                 },
                                                 ..EditorStyle::default()
@@ -12994,10 +13000,12 @@ impl Render for Editor {
                 status: cx.theme().status().clone(),
                 inlay_hints_style: HighlightStyle {
                     color: Some(cx.theme().status().hint),
+                    background_color: Some(cx.theme().status().hint_background),
                     ..HighlightStyle::default()
                 },
                 suggestions_style: HighlightStyle {
                     color: Some(cx.theme().status().predictive),
+                    background_color: Some(cx.theme().status().predictive_background),
                     ..HighlightStyle::default()
                 },
                 unnecessary_code_fade: ThemeSettings::get_global(cx).unnecessary_code_fade,


### PR DESCRIPTION
This PR updates the editor to respect the `hint.background` and `predictive.background` colors from the theme.

| Before                                                                                                                                             | After                                                                                                                                              |
| -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1624" alt="Screenshot 2024-09-17 at 4 21 53 PM" src="https://github.com/user-attachments/assets/5534d09b-1e22-4c6f-9d82-314796ed7d22"> | <img width="1624" alt="Screenshot 2024-09-17 at 4 21 43 PM" src="https://github.com/user-attachments/assets/6ec58cde-6115-4db4-be95-97c5f2f54b2d"> |

Closes https://github.com/zed-industries/zed/issues/17392.

Release Notes:

- Updated the editor to respect the `hint.background` and `predictive.background` colors from the theme.
