### PR TITLE
nix: Fix (potential) glibc errors in dev shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -20,6 +20,8 @@ in
       wayland
       xorg.libxcb
       vulkan-loader
+      rustc
+      cargo
     ];
   in
     pkgs.mkShell.override {inherit stdenv;} {
@@ -35,10 +37,7 @@ in
       inherit buildInputs;
 
       shellHook = ''
-        export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath ([
-            pkgs.vulkan-loader
-          ]
-          ++ buildInputs)}:$LD_LIBRARY_PATH"
+        export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH"
         export PROTOC="${pkgs.protobuf}/bin/protoc"
       '';
 


### PR DESCRIPTION
Previously the rustc and cargo did were not declared dependencies supplied to devshell. This means that shell relied some impure cargo and rustc version found in the system. This lead to issues with GLIBC version on systems which have different GLIBC version globally.

This package exposes nixpkgs rustc and cargo version into the shell preventing issues with incompatibility.

Release Notes:

- N/A
