### PR TITLE
rust: Fix doc comment highlighting

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -139,7 +139,6 @@
 ] @comment.doc
 
 [
-  "!"
   "!="
   "%"
   "%="
@@ -159,7 +158,6 @@
   ".."
   "..="
   "..."
-  "/"
   "/="
   ":"
   ";"
@@ -182,6 +180,10 @@
   "||"
   "?"
 ] @operator
+
+; Avoid highlighting these as operators when used in doc comments
+(unary_expression "!" @operator)
+operator: "/" @operator
 
 (lifetime) @lifetime
 

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -181,7 +181,7 @@
   "?"
 ] @operator
 
-; Avoid highlighting these as operators when used in doc comments
+; Avoid highlighting these as operators when used in doc comments.
 (unary_expression "!" @operator)
 operator: "/" @operator
 


### PR DESCRIPTION
This PR fixes an issue where `/` and `!` in Rust doc comments were being incorrectly highlighted as operators after #17734.

We solve this by removing them from the operators list and using more scoped queries to highlight them.

Release Notes:

- N/A
