### PR TITLE
Don't highlight Python import names as type

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -2,24 +2,6 @@
 (attribute attribute: (identifier) @property)
 (type (identifier) @type)
 
-; Module imports
-
-(import_statement
-  (dotted_name (identifier) @type))
-
-(import_statement
-  (aliased_import
-    name: (dotted_name (identifier) @type)
-    alias: (identifier) @type))
-
-(import_from_statement
-  (dotted_name (identifier) @type))
-
-(import_from_statement
-  (aliased_import
-    name: (dotted_name (identifier) @type)
-    alias: (identifier) @type))
-
 ; Function calls
 
 (decorator) @function


### PR DESCRIPTION
Works on 
- #14892

Follow up to 
- #17473