### PR TITLE
vim: Fix gv after indent/toggle comments

### DIFF
--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -54,7 +54,7 @@ impl Vim {
                 );
                 starts.push(
                     map.buffer_snapshot
-                        .anchor_after(selection.start.to_offset(&map, Bias::Right)),
+                        .anchor_before(selection.start.to_offset(&map, Bias::Left)),
                 );
                 reversed.push(selection.reversed)
             }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -6,6 +6,7 @@ mod test;
 mod change_list;
 mod command;
 mod digraph;
+mod indent;
 mod insert;
 mod mode_indicator;
 mod motion;
@@ -289,6 +290,7 @@ impl Vim {
             motion::register(editor, cx);
             command::register(editor, cx);
             replace::register(editor, cx);
+            indent::register(editor, cx);
             object::register(editor, cx);
             visual::register(editor, cx);
             change_list::register(editor, cx);

--- a/crates/vim/test_data/test_indent_gv.json
+++ b/crates/vim/test_data/test_indent_gv.json
@@ -1,0 +1,8 @@
+{"SetOption":{"value":"shiftwidth=4"}}
+{"Put":{"state":"ˇhello\nworld\n"}}
+{"Key":"v"}
+{"Key":"j"}
+{"Key":">"}
+{"Key":"g"}
+{"Key":"v"}
+{"Get":{"state":"«    hello\n ˇ»   world\n","mode":"Visual"}}


### PR DESCRIPTION
Release Notes:

- vim: Fixed `gv` after > and < in visual mode

