### PR TITLE
docs: Fix links on the Telemetry page

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -140,19 +140,19 @@ Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell 
 {
   "languages": {
     "Ruby": {
-      "language_servers": ["ruby-lsp", "!solargraph", "..."],
-    },
+      "language_servers": ["ruby-lsp", "!solargraph", "..."]
+    }
   },
   "lsp": {
     "ruby-lsp": {
       "initialization_options": {
         "enabledFeatures": {
           // This disables diagnostics
-          "diagnostics": false,
-        },
-      },
-    },
-  },
+          "diagnostics": false
+        }
+      }
+    }
+  }
 }
 ```
 

--- a/docs/src/telemetry.md
+++ b/docs/src/telemetry.md
@@ -31,7 +31,7 @@ Telemetry is sent from the application to our servers. Data is proxied through o
 
 Diagnostic events include debug information (stack traces) from crash reports. Reports are sent on the first application launch after the crash occurred. We've built dashboards that allow us to visualize the frequency and severity of issues experienced by users. Having these reports sent automatically allows us to begin implementing fixes without the user needing to file a report in our issue tracker. The plots in the dashboards also give us an informal measurement of the stability of Zed.
 
-You can see what data is sent when a panic occurs by inspecting the `Panic` struct in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L184) in the zed repo. You can find additional information in the [Debugging Crashes](./development/debugging-crashes.md) documentation.
+You can see what data is sent when a panic occurs by inspecting the `Panic` struct in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L184) in the Zed repo. You can find additional information in the [Debugging Crashes](./development/debugging-crashes.md) documentation.
 
 ### Usage Data (Metrics) {#metrics}
 
@@ -48,8 +48,8 @@ Usage Data is associated with a secure random telemetry ID which may be linked t
 
 You can audit the metrics data that Zed has reported by running the command {#action zed::OpenTelemetryLog} from the command palette, or clicking `Help > View Telemetry Log` in the application menu.
 
-You can see the full list of the event types and exactly the data sent for each by inspecting the `Event` enum and the associated structs in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L63] in the zed repo.
+You can see the full list of the event types and exactly the data sent for each by inspecting the `Event` enum and the associated structs in [crates/telemetry_events/src/telemetry_events.rs](https://github.com/zed-industries/zed/blob/main/crates/telemetry_events/src/telemetry_events.rs#L63) in the Zed repository.
 
 ## Concerns and Questions
 
-If you have concerns about telemetry, please feel free to open issues in our [Zed repository](https://github.com/zed-industries/zed/issues/new/choose).
+If you have concerns about telemetry, please feel free to [open an issue](https://github.com/zed-industries/zed/issues/new/choose).


### PR DESCRIPTION
This PR tweaks some broken links in the Telemetry page as well as capitalizing instances of "Zed".

Release Notes:

- N/A
