### PR TITLE
Improve C++ Tree-sitter queries

### DIFF
--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -2,6 +2,10 @@
 (field_identifier) @property
 (namespace_identifier) @namespace
 
+(concept_definition
+    (identifier) @concept)
+
+
 (call_expression
   function: (qualified_identifier
     name: (identifier) @function))
@@ -64,6 +68,14 @@
 
 (auto) @type
 (type_identifier) @type
+type :(primitive_type) @type.primitive
+
+(requires_clause
+    constraint: (template_type
+        name: (type_identifier) @concept))
+
+(attribute
+    name: (identifier) @keyword)
 
 ((identifier) @constant
  (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
@@ -119,7 +131,6 @@
   "using"
   "virtual"
   "while"
-  (primitive_type)
   (sized_type_specifier)
   (storage_class_specifier)
   (type_qualifier)


### PR DESCRIPTION
I made a few tree-sitter queries for improving the highlighting of C++. 

There is one query that I'm not totally certain about and would appreciate some feedback on it, the one that concerns attributes.

Many editor only highlight the identifier as a keyword (This is the behavior implemented in this commit), while others, for example the tree-sitter plugin for neovim, tags the entire attribute for highlighting (double brackets included). I don't know which one is preferable. Here are screenshots of the two versions:

![image](https://github.com/user-attachments/assets/4e1b92c8-adc7-4900-a5b1-dc43c98f4c67)

![image](https://github.com/user-attachments/assets/290a13e3-5cb3-45cb-b6d9-3dc3e6a8af2d)


Release Notes:


- Fixed C++ attributes identifiers being wrongly highlighed through the tag "variable"
- C++ attribute identifiers (nodiscard,deprecated, noreturn, etc.. ) are now highlighted through the tag "keyword"
- Changed C++ primitives types (void, bool, int, size_t, etc.. ) to no longer be highlighted with the tag "keyword", they can now be highlighted by the tag "type.primitive".
- Added a tag "concept"  for highlighting C++ concept identifiers. (This tag name has been chosen to be the same than the one returned by clangd's semantic tokens)
