### PR TITLE
Fix arm buildjet

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -33,6 +33,7 @@ if [[ -n $apt ]]; then
     elfutils
     libsqlite3-dev
   )
+  $maysudo "$apt" update
   $maysudo "$apt" install -y "${deps[@]}"
   exit 0
 fi


### PR DESCRIPTION
Run `apt-get update` before `apt-get install` on Linux.

Hopefully will fix building on Linux Arm ([example failure](https://github.com/zed-industries/zed/actions/runs/10927430729/job/30333989397))

<img width="1273" alt="Screenshot 2024-09-18 at 14 12 40" src="https://github.com/user-attachments/assets/bd2504b8-7571-4d4d-a95b-b89ac2731c9c">

Release Notes:

- N/A
