### PR TITLE
Use `@tag.doctype` for HTML doctype highlights

### DIFF
--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -123,6 +123,7 @@ This query marks strings, object keys, and numbers for highlighting. The followi
 | @string.special          | Captures special strings               |
 | @string.special.symbol   | Captures special symbols               |
 | @tag                     | Captures tags                          |
+| @tag.doctype             | Captures doctypes (e.g., in HTML)      |
 | @text.literal            | Captures literal text                  |
 | @title                   | Captures titles                        |
 | @type                    | Captures types                         |

--- a/extensions/astro/languages/astro/highlights.scm
+++ b/extensions/astro/languages/astro/highlights.scm
@@ -1,6 +1,6 @@
 (tag_name) @tag
 (erroneous_end_tag_name) @keyword
-(doctype) @constant
+(doctype) @tag.doctype
 (attribute_name) @property
 (attribute_value) @string
 (comment) @comment

--- a/extensions/elixir/languages/heex/highlights.scm
+++ b/extensions/elixir/languages/heex/highlights.scm
@@ -27,7 +27,7 @@
 "=" @operator
 
 ; HEEx inherits the DOCTYPE tag from HTML
-(doctype) @constant
+(doctype) @tag.doctype
 
 (comment) @comment
 

--- a/extensions/html/languages/html/highlights.scm
+++ b/extensions/html/languages/html/highlights.scm
@@ -1,6 +1,6 @@
 (tag_name) @tag
 (erroneous_end_tag_name) @keyword
-(doctype) @constant
+(doctype) @tag.doctype
 (attribute_name) @property
 (attribute_value) @string
 (comment) @comment

--- a/extensions/html/languages/html/highlights.scm
+++ b/extensions/html/languages/html/highlights.scm
@@ -1,4 +1,4 @@
-(tag_name) @keyword
+(tag_name) @tag
 (erroneous_end_tag_name) @keyword
 (doctype) @constant
 (attribute_name) @property


### PR DESCRIPTION
This PR updates the following extensions to use the `@tag.doctype` selector for highlighting HTML doctypes:

- Astro
- Elixir (HEEx)
- HTML

Additionally, it also changes the base selector for HTML tags from `@keyword` to `@tag`.

| Before                                                                                                                                            | After                                                                                                                                             |
| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="308" alt="Screenshot 2024-09-18 at 2 04 41 PM" src="https://github.com/user-attachments/assets/818d98ba-fce7-4683-b67f-61c86543831c"> | <img width="358" alt="Screenshot 2024-09-18 at 2 05 00 PM" src="https://github.com/user-attachments/assets/5071db7c-e0bf-44df-8959-38275833833b"> |

Extracted this from https://github.com/zed-industries/zed/pull/16723.

Release Notes:

- N/A
