### PR TITLE
Handle Wayland connection error with logging and exit

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -406,7 +406,13 @@ fn wl_output_version(version: u32) -> u32 {
 
 impl WaylandClient {
     pub(crate) fn new() -> Self {
-        let conn = Connection::connect_to_env().unwrap();
+        let conn = match Connection::connect_to_env() {
+            Ok(c) => c,
+            Err(err) => {
+                log::error!("Failed to connect to Wayland server: {}", err);
+                std::process::exit(1);
+            }
+        };
 
         let (globals, mut event_queue) =
             registry_queue_init::<WaylandClientStatePtr>(&conn).unwrap();


### PR DESCRIPTION
Related #17199 

Release notes: 
- Currently, if Zed is launched on Linux with `WAYLAND_DISPLAY` env var set but not in a Wayland session, it will panic. This PR changes that behavior to logging the issue and exiting gracefully.

I did notice, however, that since the panic occurs during the creation of `gpui::Application` early in Zed's initialization (within the first few lines of `main` in the `zed` crate), there's no way to notify the CLI that Zed failed to launch. As a result, the CLI hangs and never exits when this happens. Hence, only when running `zed --foreground` will the error be displayed to the user.