### PR TITLE
ci: Explicitly set cache-provider for swatinem/rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
         uses: swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-provider: "buildjet"
 
       - name: Install Linux dependencies
         run: ./script/linux
@@ -143,6 +144,7 @@ jobs:
         uses: swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-provider: "github"
 
       - name: cargo clippy
         # Windows can't run shell scripts, so we need to use `cargo xtask`.

--- a/.github/workflows/publish_extension_cli.yml
+++ b/.github/workflows/publish_extension_cli.yml
@@ -24,6 +24,7 @@ jobs:
         uses: swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-provider: "github"
 
       - name: Configure linux
         shell: bash -euxo pipefail {0}


### PR DESCRIPTION
- Switches the Cache Dependencies step (`swatinem/rust-cache`) of Linux tests to use buildjet as `cache-provider`.  Explicitly add 'github' (the default cache provider) to other uses of `swatinem/rust-cache` for consistency. 

Release Notes:

- N/A
