### PR TITLE
windows: Fix regional indicator symbols broken

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1084,13 +1084,7 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
                 context
                     .index_converter
                     .advance_to_utf16_ix(context.utf16_index);
-                let is_emoji = {
-                    if color_font {
-                        is_color_glyph(font_face, id, color_font)
-                    } else {
-                        color_font
-                    }
-                };
+                let is_emoji = color_font && is_color_glyph(font_face, id, color_font);
                 glyphs.push(ShapedGlyph {
                     id,
                     position: point(px(context.width), px(0.0)),

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1448,18 +1448,16 @@ fn get_render_target_property(
 }
 
 fn is_color_glyph(font_face: &IDWriteFontFace3, glyph_id: GlyphId, color_font: bool) -> bool {
-    unsafe {
-        let Ok(face) = font_face.cast::<IDWriteFontFace4>() else {
-            return color_font;
-        };
-        let Some(format) = face
-            .GetGlyphImageFormats(glyph_id.0 as u16, 0, u32::MAX)
+    let Ok(face) = font_face.cast::<IDWriteFontFace4>() else {
+        return color_font;
+    };
+    let Some(format) = (unsafe {
+        face.GetGlyphImageFormats(glyph_id.0 as u16, 0, u32::MAX)
             .log_err()
-        else {
-            return color_font;
-        };
-        format != DWRITE_GLYPH_IMAGE_FORMATS_NONE
-    }
+    }) else {
+        return color_font;
+    };
+    format != DWRITE_GLYPH_IMAGE_FORMATS_NONE
 }
 
 const DEFAULT_LOCALE_NAME: PCWSTR = windows::core::w!("en-US");


### PR DESCRIPTION

Closes #18027


Unlike macOS, not all glyphs in color fonts are color glyphs, such as `🇩🇪` in `Segoe UI Emoji`. As a result, attempting to retrieve color information for these glyphs can cause an error, preventing the glyph from being rendered. 

This PR addresses the issue by setting the `is_emoji` variable to `false` for non-color glyphs within color fonts.



Release Notes:

- N/A
