### PR TITLE
Add stray UI tweaks on the task picker

### DIFF
--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -511,6 +511,8 @@ impl PickerDelegate for TasksModalDelegate {
                 .justify_between()
                 .rounded_b_md()
                 .bg(cx.theme().colors().ghost_element_selected)
+                .border_t_1()
+                .border_color(cx.theme().colors().border_variant)
                 .child(
                     left_button
                         .map(|(label, action)| {

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -410,7 +410,7 @@ impl PickerDelegate for TasksModalDelegate {
 
         Some(
             ListItem::new(SharedString::from(format!("tasks-modal-{ix}")))
-                .inset(false)
+                .inset(true)
                 .start_slot::<Icon>(icon)
                 .end_slot::<AnyElement>(history_run_icon)
                 .spacing(ListItemSpacing::Sparse)

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -448,7 +448,7 @@ impl PickerDelegate for TasksModalDelegate {
                                     picker.refresh(cx);
                                 }))
                                 .tooltip(|cx| {
-                                    Tooltip::text("Delete previously scheduled task", cx)
+                                    Tooltip::text("Delete Previously Scheduled Task", cx)
                                 }),
                         );
                         item.end_hover_slot(delete_button)
@@ -499,7 +499,7 @@ impl PickerDelegate for TasksModalDelegate {
             .last_scheduled_task(None)
             .is_some()
         {
-            Some(("Rerun last task", Rerun::default().boxed_clone()))
+            Some(("Rerun Last Task", Rerun::default().boxed_clone()))
         } else {
             None
         };
@@ -535,9 +535,9 @@ impl PickerDelegate for TasksModalDelegate {
                         .boxed_clone();
                         this.children(KeyBinding::for_action(&*action, cx).map(|keybind| {
                             let spawn_oneshot_label = if current_modifiers.secondary() {
-                                "Spawn oneshot without history"
+                                "Spawn Oneshot Without History"
                             } else {
-                                "Spawn oneshot"
+                                "Spawn Oneshot"
                             };
 
                             Button::new("spawn-onehshot", spawn_oneshot_label)
@@ -549,9 +549,9 @@ impl PickerDelegate for TasksModalDelegate {
                         this.children(KeyBinding::for_action(&menu::SecondaryConfirm, cx).map(
                             |keybind| {
                                 let label = if is_recent_selected {
-                                    "Rerun without history"
+                                    "Rerun Without History"
                                 } else {
-                                    "Spawn without history"
+                                    "Spawn Without History"
                                 };
                                 Button::new("spawn", label)
                                     .label_size(LabelSize::Small)


### PR DESCRIPTION
This PR adds tiny UI tweaks to the task picker. Just making sure it is consistent with other pickers throughout Zed.

| Before | After |
|--------|--------|
| <img width="577" alt="Screenshot 2024-09-19 at 12 07 44 PM" src="https://github.com/user-attachments/assets/c0f010a3-6e08-47ee-9997-9df2b203977c"> | <img width="577" alt="Screenshot 2024-09-19 at 12 07 09 PM" src="https://github.com/user-attachments/assets/74baf191-4dd9-4765-b2fd-2390d4cb31c6"> | 

Release Notes:

- N/A
