### PR TITLE
ci: Move collab deploys back to DigitalOcean runners

### DIFF
--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -61,7 +61,8 @@ jobs:
       - style
       - tests
     runs-on:
-      - buildjet-16vcpu-ubuntu-2204
+      - self-hosted
+      - deploy
     steps:
       - name: Add Rust to the PATH
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -88,7 +89,8 @@ jobs:
     needs:
       - publish
     runs-on:
-      - buildjet-16vcpu-ubuntu-2204
+      - self-hosted
+      - deploy
 
     steps:
       - name: Sign into Kubernetes


### PR DESCRIPTION
This PR moves the collab deployment steps in CI back to the DigitalOcean runners temporarily, so that we can deploy collab.

Release Notes:

- N/A
