### PR TITLE
pane: Do not autopin new item created as a neighbour of pinned tab

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -831,13 +831,14 @@ impl Pane {
                 }
             }
         }
-        // If no destination index is specified, add or move the item after the active item.
+        // If no destination index is specified, add or move the item after the
+        // active item (or at the start of tab bar, if the active item is pinned)
         let mut insertion_index = {
             cmp::min(
                 if let Some(destination_index) = destination_index {
                     destination_index
                 } else {
-                    self.active_item_index + 1
+                    cmp::max(self.active_item_index + 1, self.pinned_count())
                 },
                 self.items.len(),
             )


### PR DESCRIPTION
When I used editor::NewFile or ProjectSearch from a pinned tab, the resulting new tab would be pinned (and the last pinned tab would be pushed off). This PR fixes it by always storing new tabs outside of the pinned area if there's no destination index for the new tab.

Release Notes:

- Fixed tab bar not preserving pinned tab state when an editor::NewFile action is executed.
