### PR TITLE
ci: Fix collab deploys

### DIFF
--- a/.github/workflows/bump_collab_staging.yml
+++ b/.github/workflows/bump_collab_staging.yml
@@ -1,0 +1,23 @@
+name: Bump collab-staging Tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-collab-staging-tag:
+    if: github.repository_owner == 'zed-industries'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Update collab-staging tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag -f collab-staging
+          git push origin collab-staging --force

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -61,8 +61,7 @@ jobs:
       - style
       - tests
     runs-on:
-      - self-hosted
-      - deploy
+      - buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Add Rust to the PATH
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -89,8 +88,7 @@ jobs:
     needs:
       - publish
     runs-on:
-      - self-hosted
-      - deploy
+      - buildjet-16vcpu-ubuntu-2204
 
     steps:
       - name: Sign into Kubernetes

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+  # DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
 jobs:
   style:
@@ -63,8 +63,13 @@ jobs:
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
     steps:
-      - name: Add Rust to the PATH
-        run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      # - name: Add Rust to the PATH
+      #   run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Sign into DigitalOcean docker registry
         run: doctl registry login
@@ -91,6 +96,11 @@ jobs:
       - buildjet-16vcpu-ubuntu-2204
 
     steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
       - name: Sign into Kubernetes
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 ${{ secrets.CLUSTER_NAME }}
 

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -11,55 +11,55 @@ env:
   # DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
 jobs:
-  style:
-    name: Check formatting and Clippy lints
-    runs-on:
-      - self-hosted
-      - test
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          clean: false
-          fetch-depth: 0
+  # style:
+  #   name: Check formatting and Clippy lints
+  #   runs-on:
+  #     - self-hosted
+  #     - test
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+  #       with:
+  #         clean: false
+  #         fetch-depth: 0
 
-      - name: Run style checks
-        uses: ./.github/actions/check_style
+  #     - name: Run style checks
+  #       uses: ./.github/actions/check_style
 
-      - name: Run clippy
-        run: ./script/clippy
+  #     - name: Run clippy
+  #       run: ./script/clippy
 
-  tests:
-    name: Run tests
-    runs-on:
-      - self-hosted
-      - test
-    needs: style
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          clean: false
-          fetch-depth: 0
+  # tests:
+  #   name: Run tests
+  #   runs-on:
+  #     - self-hosted
+  #     - test
+  #   needs: style
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+  #       with:
+  #         clean: false
+  #         fetch-depth: 0
 
-      - name: Install cargo nextest
-        shell: bash -euxo pipefail {0}
-        run: |
-          cargo install cargo-nextest
+  #     - name: Install cargo nextest
+  #       shell: bash -euxo pipefail {0}
+  #       run: |
+  #         cargo install cargo-nextest
 
-      - name: Limit target directory size
-        shell: bash -euxo pipefail {0}
-        run: script/clear-target-dir-if-larger-than 100
+  #     - name: Limit target directory size
+  #       shell: bash -euxo pipefail {0}
+  #       run: script/clear-target-dir-if-larger-than 100
 
-      - name: Run tests
-        shell: bash -euxo pipefail {0}
-        run: cargo nextest run --package collab --no-fail-fast
+  #     - name: Run tests
+  #       shell: bash -euxo pipefail {0}
+  #       run: cargo nextest run --package collab --no-fail-fast
 
   publish:
     name: Publish collab server image
-    needs:
-      - style
-      - tests
+    # needs:
+    #   - style
+    #   # - tests
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
     steps:

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -8,64 +8,60 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  # DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
 jobs:
-  # style:
-  #   name: Check formatting and Clippy lints
-  #   runs-on:
-  #     - self-hosted
-  #     - test
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-  #       with:
-  #         clean: false
-  #         fetch-depth: 0
+  style:
+    name: Check formatting and Clippy lints
+    runs-on:
+      - self-hosted
+      - test
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          clean: false
+          fetch-depth: 0
 
-  #     - name: Run style checks
-  #       uses: ./.github/actions/check_style
+      - name: Run style checks
+        uses: ./.github/actions/check_style
 
-  #     - name: Run clippy
-  #       run: ./script/clippy
+      - name: Run clippy
+        run: ./script/clippy
 
-  # tests:
-  #   name: Run tests
-  #   runs-on:
-  #     - self-hosted
-  #     - test
-  #   needs: style
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-  #       with:
-  #         clean: false
-  #         fetch-depth: 0
+  tests:
+    name: Run tests
+    runs-on:
+      - self-hosted
+      - test
+    needs: style
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          clean: false
+          fetch-depth: 0
 
-  #     - name: Install cargo nextest
-  #       shell: bash -euxo pipefail {0}
-  #       run: |
-  #         cargo install cargo-nextest
+      - name: Install cargo nextest
+        shell: bash -euxo pipefail {0}
+        run: |
+          cargo install cargo-nextest
 
-  #     - name: Limit target directory size
-  #       shell: bash -euxo pipefail {0}
-  #       run: script/clear-target-dir-if-larger-than 100
+      - name: Limit target directory size
+        shell: bash -euxo pipefail {0}
+        run: script/clear-target-dir-if-larger-than 100
 
-  #     - name: Run tests
-  #       shell: bash -euxo pipefail {0}
-  #       run: cargo nextest run --package collab --no-fail-fast
+      - name: Run tests
+        shell: bash -euxo pipefail {0}
+        run: cargo nextest run --package collab --no-fail-fast
 
   publish:
     name: Publish collab server image
-    # needs:
-    #   - style
-    #   # - tests
+    needs:
+      - style
+      - tests
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
     steps:
-      # - name: Add Rust to the PATH
-      #   run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -96,6 +96,11 @@ jobs:
       - buildjet-16vcpu-ubuntu-2204
 
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          clean: false
+
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:


### PR DESCRIPTION
This PR fixes issues with deploying collab.

We reverted 4882a75971abafa89467e779466749086d7d3f96—as the DigitalOcean runners are gone now—and moved back to BuildJet.

We needed to make some changes to the deployment jobs to setup `doctl`.

This PR also adds an automatic bump of the `collab-staging` tag on merges to `main`. This should help catch issues with collab deploys earlier.

Release Notes:

- N/A
