### PR TITLE
Auto deploy collab staging daily

### DIFF
--- a/.github/workflows/bump_collab_staging.yml
+++ b/.github/workflows/bump_collab_staging.yml
@@ -1,9 +1,9 @@
 name: Bump collab-staging Tag
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # Fire every day at 16:00 UTC (At the start of the US workday)
+    - cron: "0 16 * * *"
 
 jobs:
   update-collab-staging-tag:


### PR DESCRIPTION
This should avoid us breaking the collab build and not noticing for a month

Release Notes:

- N/A
