### PR TITLE
Fix bug where copying from assistant panel appends extra newline to clipboard

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3533,7 +3533,9 @@ impl ContextEditor {
                     for chunk in context.buffer().read(cx).text_for_range(range) {
                         text.push_str(chunk);
                     }
-                    text.push('\n');
+                    if message.offset_range.end < selection.range().end {
+                        text.push('\n');
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17661

Release Notes:

- Fixed a bug where copying from the assistant panel appended an additional newline to the end of the clipboard contents.