### PR TITLE
Add diagnostic information to context of inline assistant

### DIFF
--- a/assets/prompts/content_prompt.hbs
+++ b/assets/prompts/content_prompt.hbs
@@ -48,7 +48,6 @@ And here's the section to rewrite based on that prompt again for reference:
 {{{rewrite_section}}}
 </rewrite_this>
 
-{{REWRITTEN_CODE}}
 {{#if diagnostic_errors}}
 {{#each diagnostic_errors}}
 <diagnostic_error>

--- a/assets/prompts/content_prompt.hbs
+++ b/assets/prompts/content_prompt.hbs
@@ -47,6 +47,18 @@ And here's the section to rewrite based on that prompt again for reference:
 <rewrite_this>
 {{{rewrite_section}}}
 </rewrite_this>
+
+{{REWRITTEN_CODE}}
+{{#if diagnostic_errors}}
+{{#each diagnostic_errors}}
+<diagnostic_error>
+    <line_number>{{line_number}}</line_number>
+    <error_message>{{error_message}}</error_message>
+    <code_content>{{code_content}}</code_content>
+</diagnostic_error>
+{{/each}}
+{{/if}}
+
 {{/if}}
 
 Only make changes that are necessary to fulfill the prompt, leave everything else as-is. All surrounding {{content_type}} will be preserved.

--- a/crates/assistant/src/prompts.rs
+++ b/crates/assistant/src/prompts.rs
@@ -4,12 +4,19 @@ use fs::Fs;
 use futures::StreamExt;
 use gpui::AssetSource;
 use handlebars::{Handlebars, RenderError};
-use language::{BufferSnapshot, LanguageName};
+use language::{BufferSnapshot, LanguageName, Point};
 use parking_lot::Mutex;
 use serde::Serialize;
 use std::{ops::Range, path::PathBuf, sync::Arc, time::Duration};
 use text::LineEnding;
 use util::ResultExt;
+
+#[derive(Serialize)]
+pub struct ContentPromptDiagnosticContext {
+    pub line_number: usize,
+    pub error_message: String,
+    pub code_content: String,
+}
 
 #[derive(Serialize)]
 pub struct ContentPromptContext {
@@ -20,6 +27,7 @@ pub struct ContentPromptContext {
     pub document_content: String,
     pub user_prompt: String,
     pub rewrite_section: Option<String>,
+    pub diagnostic_errors: Vec<ContentPromptDiagnosticContext>,
 }
 
 #[derive(Serialize)]
@@ -259,6 +267,17 @@ impl PromptBuilder {
         } else {
             None
         };
+        let diagnostics = buffer.diagnostics_in_range::<_, Point>(range, false);
+        let diagnostic_errors: Vec<ContentPromptDiagnosticContext> = diagnostics
+            .map(|entry| {
+                let start = entry.range.start;
+                ContentPromptDiagnosticContext {
+                    line_number: (start.row + 1) as usize,
+                    error_message: entry.diagnostic.message.clone(),
+                    code_content: buffer.text_for_range(entry.range.clone()).collect(),
+                }
+            })
+            .collect();
 
         let context = ContentPromptContext {
             content_type: content_type.to_string(),
@@ -268,8 +287,8 @@ impl PromptBuilder {
             document_content,
             user_prompt,
             rewrite_section,
+            diagnostic_errors,
         };
-
         self.handlebars.lock().render("content_prompt", &context)
     }
 


### PR DESCRIPTION
Release Notes:

- Added Diagnostic information to inline assistant.  This enables users to just say "Fix this" and have the model know what the errors are.
