### PR TITLE
context_servers: Remove context_type from ResourceContent

### DIFF
--- a/crates/context_servers/src/types.rs
+++ b/crates/context_servers/src/types.rs
@@ -239,7 +239,6 @@ pub struct Resource {
 pub struct ResourceContent {
     pub uri: Url,
     pub mime_type: Option<String>,
-    pub content_type: String,
     pub text: Option<String>,
     pub data: Option<String>,
 }


### PR DESCRIPTION
This is removed in the protocol

Release Notes:

- N/A
