### PR TITLE
Bump release_notes to v2 endpoint

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -268,7 +268,7 @@ fn view_release_notes_locally(workspace: &mut Workspace, cx: &mut ViewContext<Wo
 
     let client = client::Client::global(cx).http_client();
     let url = client.build_url(&format!(
-        "/api/release_notes/{}/{}",
+        "/api/release_notes/v2/{}/{}",
         release_channel.dev_name(),
         version
     ));


### PR DESCRIPTION
Partially addresses https://github.com/zed-industries/zed/issues/17527

<img width="1608" alt="SCR-20240919-rcik" src="https://github.com/user-attachments/assets/25057731-7da6-4b36-b51b-021c67e8736b">

Release Notes:

- Enhanced the `auto update: view release notes locally` feature to display release notes for each patch version associated with the installed minor version.