### PR TITLE
Fix block cursor obscuring placeholder text and editor text in some cases

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -67,7 +67,7 @@ use std::{
     sync::Arc,
 };
 use sum_tree::Bias;
-use theme::{ActiveTheme, PlayerColor};
+use theme::{ActiveTheme, Appearance, PlayerColor};
 use ui::prelude::*;
 use ui::{h_flex, ButtonLike, ButtonStyle, ContextMenu, Tooltip};
 use util::RangeExt;
@@ -1040,6 +1040,11 @@ impl EditorElement {
                                     })
                                     .unwrap_or(self.style.text.font());
 
+                                let color = match cx.theme().appearance {
+                                    Appearance::Dark => Hsla::black(),
+                                    Appearance::Light => Hsla::white(),
+                                };
+
                                 cx.text_system()
                                     .shape_line(
                                         text,
@@ -1047,7 +1052,7 @@ impl EditorElement {
                                         &[TextRun {
                                             len,
                                             font,
-                                            color: cx.theme().colors().editor_background,
+                                            color,
                                             background_color: None,
                                             strikethrough: None,
                                             underline: None,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1040,9 +1040,20 @@ impl EditorElement {
                                     })
                                     .unwrap_or(self.style.text.font());
 
-                                let color = match cx.theme().appearance {
-                                    Appearance::Dark => Hsla::black(),
-                                    Appearance::Light => Hsla::white(),
+                                // Invert the text color for the block cursor. Ensure that the text
+                                // color is opaque enough to be visible against the background color.
+                                //
+                                // 0.75 is an arbitrary threshold to determine if the background color is
+                                // opaque enough to use as a text color.
+                                //
+                                // TODO: In the future we should ensure themes have a `text_inverse` color.
+                                let color = if cx.theme().colors().editor_background.a < 0.75 {
+                                    match cx.theme().appearance {
+                                        Appearance::Dark => Hsla::black(),
+                                        Appearance::Light => Hsla::white(),
+                                    }
+                                } else {
+                                    cx.theme().colors().editor_background
                                 };
 
                                 cx.text_system()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1012,8 +1012,20 @@ impl EditorElement {
                         block_width = em_width;
                     }
                     let block_text = if let CursorShape::Block = selection.cursor_shape {
-                        snapshot.display_chars_at(cursor_position).next().and_then(
-                            |(character, _)| {
+                        snapshot
+                            .display_chars_at(cursor_position)
+                            .next()
+                            .or_else(|| {
+                                if cursor_column == 0 {
+                                    snapshot
+                                        .placeholder_text()
+                                        .and_then(|s| s.chars().next())
+                                        .map(|c| (c, cursor_position))
+                                } else {
+                                    None
+                                }
+                            })
+                            .and_then(|(character, _)| {
                                 let text = if character == '\n' {
                                     SharedString::from(" ")
                                 } else {
@@ -1042,8 +1054,7 @@ impl EditorElement {
                                         }],
                                     )
                                     .log_err()
-                            },
-                        )
+                            })
                     } else {
                         None
                     };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1047,7 +1047,7 @@ impl EditorElement {
                                         &[TextRun {
                                             len,
                                             font,
-                                            color: self.style.background,
+                                            color: cx.theme().colors().editor_background,
                                             background_color: None,
                                             strikethrough: None,
                                             underline: None,


### PR DESCRIPTION
This PR tries to fix a couple of problems with the block cursor (and only the block cursor) not encountered before https://github.com/zed-industries/zed/pull/17572 allowed user to change the cursor shape outside of vim mode and the terminal.

1. When the editor has placeholder text, the placeholder character is not shown because `block_text` does not look at placeholder text, only the display chars at the cursor.
<img width="178" alt="Screenshot 2024-09-19 at 9 24 14 PM" src="https://github.com/user-attachments/assets/19cbd5e4-8ca5-4df7-acbd-1a23631cfe7a">

2. `block_text` is displayed using `EditorElement.style.background`. This value is transparent black in some editors, causing *regular text* to be invisible. This happens with the filter text for the outline panel, for example
<img width="171" alt="Screenshot 2024-09-19 at 9 24 55 PM" src="https://github.com/user-attachments/assets/438f3c62-6680-4889-b55a-bccce5d958f2">


My fix for #2 is to use the theme's editor background instead. For the various built-in dark and light themes I tried, this seems to be a decent solution. I tried to use the inverse of the cursor color instead, namely `h -> (h + 0.5) % 1., l -> 1. - l` and other variations, but the result aren't great. Most themes favor a soft blue for the cursor and the inverse just ends up being soft brown and doesn't provide very good contrast. (Caveat: I have poor eyesight and this may be a me problem, but I think accessibility considerations apply.)

Here's how the fix using theme's editor background looks with gruvbox dark and Atelier Cave light

<img width="214" alt="Screenshot 2024-09-19 at 10 01 28 PM" src="https://github.com/user-attachments/assets/131a7d02-5b9d-486e-a8f0-9c164723c272">
<img width="146" alt="Screenshot 2024-09-19 at 10 01 56 PM" src="https://github.com/user-attachments/assets/befac383-d25c-4c24-b27a-01f092c030ec">



Release Notes:

- N/A
