### PR TITLE
Fix Supermaven crash when handling non-ASCII text

### DIFF
--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -5,12 +5,7 @@ use editor::{CompletionProposal, Direction, InlayProposal, InlineCompletionProvi
 use futures::StreamExt as _;
 use gpui::{AppContext, EntityId, Model, ModelContext, Task};
 use language::{language_settings::all_language_settings, Anchor, Buffer, BufferSnapshot};
-use std::{
-    ops::{AddAssign, Range},
-    path::Path,
-    sync::Arc,
-    time::Duration,
-};
+use std::{ops::Range, path::Path, sync::Arc, time::Duration};
 use text::{ToOffset, ToPoint};
 
 pub const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);

--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -73,7 +73,7 @@ fn completion_state_from_diff(
         match k {
             Some(k) => {
                 if k != 0 {
-                    let utf8_ix = compl_chars[..compl_char_ix + k + 1]
+                    let utf8_ix = compl_chars[..compl_char_ix + k]
                         .iter()
                         .map(|c| c.len_utf8())
                         .sum::<usize>();
@@ -103,9 +103,11 @@ fn completion_state_from_diff(
                     offset + 1,
                     snapshot.clip_offset(offset + 1, text::Bias::Right)
                 );
-                compl_utf8_ix += 1;
-                buffer_utf8_ix += 1;
+                compl_utf8_ix = clip_offset(completion_text, compl_utf8_ix + 1, text::Bias::Right);
+                buffer_utf8_ix = clip_offset(&buffer_text, buffer_utf8_ix + 1, text::Bias::Right);
                 offset = snapshot.clip_offset(offset + 1, text::Bias::Right);
+                compl_char_ix += 1;
+                buffer_char_ix += 1;
             }
             None => {
                 // there are no more matching completions, so drop the remaining

--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -80,15 +80,20 @@ fn completion_state_from_diff(
                         completion_text.is_char_boundary(i),
                         completion_text.is_char_boundary(i + k)
                     );
-                    println!("  => diff {}<->{}, {}<->{}", i, start, i + k, end);
+                    println!("    => diff {}<->{}, {}<->{}", i, start, i + k, end);
                     inlays.push(InlayProposal::Suggestion(
                         snapshot.anchor_after(offset),
                         completion_text[start..end].into(),
                     ));
                 }
+                println!(
+                    "=> 2, {}<->{}",
+                    offset + 1,
+                    snapshot.clip_offset(offset + 1, text::Bias::Right)
+                );
                 i += k + 1;
                 j += 1;
-                offset.add_assign(1);
+                offset = snapshot.clip_offset(offset + 1, text::Bias::Right);
             }
             None => {
                 // there are no more matching completions, so drop the remaining

--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -86,26 +86,10 @@ fn completion_state_from_diff(
         }
     }
 
-    // println!(
-    //     "=> 2 {},{}",
-    //     completion_text.is_char_boundary(compl_utf8_ix),
-    //     completion_text.is_char_boundary(completion_text.len())
-    // );
     if buffer_ix_converter.utf8_ix == buffer_ix_converter.text.len()
         && compl_ix_converter.utf8_ix < completion_text.len()
     {
         // there is leftover completion text, so drop it as an inlay.
-        // let start = clip_offset(completion_text, compl_utf8_ix, text::Bias::Right);
-        // let end = clip_offset(completion_text, completion_text.len(), text::Bias::Left);
-        // println!(
-        //     "   => diff {}<->{}, {}<->{}",
-        //     compl_utf8_ix,
-        //     start,
-        //     completion_text.len(),
-        //     end
-        // );
-        // let start = compl_utf8_ix;
-        // let end = completion_text.len();
         inlays.push(InlayProposal::Suggestion(
             snapshot.anchor_after(offset),
             completion_text[compl_ix_converter.utf8_ix..completion_text.len()].into(),


### PR DESCRIPTION
Closes #18027


Fixed the issue where Supermaven would crash when handling non-ASCII text.

In #17578, the problem was as follows:
- There was no distinction between `char_index` and `utf8_index`. In fact, they are only equal when dealing with ASCII strings. For non-ASCII strings, they are often different, leading to crashes. For example:
```rust
let text = "你好";
text.len(); // Outputs 6
text.chars().count(); // Outputs 2
```
- When updating the `Anchor` of `BufferSnapshot`, it would simply add 1, without considering the non-ASCII character problem.

This PR introduces `StringIndexConverter` to address these issues. Additionally, I'm unsure whether other inline completion providers have similar issues. I currently can't test with Copilot since my GitHub student pack hasn't been approved yet.

Release Notes:

- Fixed the issue where Supermaven would crash when handling non-ASCII text ([#18027](https://github.com/zed-industries/zed/issues/18027)).
