### PR TITLE
settings: Show notification when user/project settings fail to parse

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1153,6 +1153,13 @@ mod tests {
     }
 
     #[test]
+    fn test_formatter_deserialization_invalid() {
+        let raw_auto = "{\"formatter\": {}}";
+        let result: Result<LanguageSettingsContent, _> = serde_json::from_str(raw_auto);
+        assert!(result.is_err());
+    }
+
+    #[test]
     pub fn test_resolve_language_servers() {
         fn language_server_names(names: &[&str]) -> Vec<LanguageServerName> {
             names

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -13,7 +13,9 @@ pub use editable_setting_control::*;
 pub use json_schema::*;
 pub use keymap_file::KeymapFile;
 pub use settings_file::*;
-pub use settings_store::{Settings, SettingsLocation, SettingsSources, SettingsStore};
+pub use settings_store::{
+    InvalidSettingsError, Settings, SettingsLocation, SettingsSources, SettingsStore,
+};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
 pub struct WorktreeId(usize);


### PR DESCRIPTION
Closes #16876

We only ever showed parsing errors, but not if something failed to deserialize.

Basically, if you had a stray `,` somewhere, we'd show a notification for user errors, but only squiggly lines if you had a `[]` instead of a `{}`.

The squiggly lines would only show up when there were schema errors.

In the case of `formatter` settings, for example, if someone put in a `{}` instead of `[]`, we'd never show anything.

With this change we always show a notification if parsing user or project settings fails.

(Right now, the error message might still be bad, but that's a separate change)


Release Notes:

- Added a notification to warn users if their user settings or project-local settings failed to deserialize.

Demo:

https://github.com/user-attachments/assets/e5c48165-f2f7-4b5c-9c6d-6ea74f678683



