### PR TITLE
Detect 'MD' extension as Markdown

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -1,6 +1,6 @@
 name = "Markdown"
 grammar = "markdown"
-path_suffixes = ["md", "mdx", "mdwn", "markdown"]
+path_suffixes = ["md", "mdx", "mdwn", "markdown", "MD"]
 word_characters = ["-"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/18120

Release Notes:

- N/A
