### PR TITLE
file_finder: Notify user when picker an non-utf8 file

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -28,7 +28,7 @@ use std::{
 use text::Point;
 use ui::{prelude::*, HighlightedLabel, ListItem, ListItemSpacing};
 use util::{paths::PathWithPosition, post_inc, ResultExt};
-use workspace::{item::PreviewTabsSettings, ModalView, Workspace};
+use workspace::{item::PreviewTabsSettings, notifications::NotifyResultExt, ModalView, Workspace};
 
 actions!(file_finder, [SelectPrev]);
 
@@ -1003,7 +1003,7 @@ impl PickerDelegate for FileFinderDelegate {
                 let finder = self.file_finder.clone();
 
                 cx.spawn(|_, mut cx| async move {
-                    let item = open_task.await.log_err()?;
+                    let item = open_task.await.notify_async_err(&mut cx)?;
                     if let Some(row) = row {
                         if let Some(active_editor) = item.downcast::<Editor>() {
                             active_editor


### PR DESCRIPTION
notify user when using file finder picker an file which cannot open.

Release Notes:

- N/A
