### PR TITLE
docs: Switch proxy example to socks5h not socks5

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1029,7 +1029,7 @@
   // environment variables.
   //
   // Examples:
-  //   - "proxy": "socks5://localhost:10808"
+  //   - "proxy": "socks5h://localhost:10808"
   //   - "proxy": "http://127.0.0.1:10809"
   "proxy": null,
   // Set to configure aliases for the command palette.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1127,10 +1127,10 @@ The following URI schemes are supported:
 
 - `http`
 - `https`
-- `socks4`
-- `socks4a`
-- `socks5`
-- `socks5h`
+- `socks4` - SOCKS4 proxy with local DNS
+- `socks4a` - SOCKS4 proxy with remote DNS
+- `socks5` - SOCKS5 proxy with local DNS
+- `socks5h` - SOCKS5 proxy with remote DNS
 
 `http` will be used when no scheme is specified.
 
@@ -1148,7 +1148,7 @@ Or to set a `socks5` proxy:
 
 ```json
 {
-  "proxy": "socks5://localhost:10808"
+  "proxy": "socks5h://localhost:10808"
 }
 ```
 


### PR DESCRIPTION
Very rarely when you have a SOCKS proxy configured do you want local DNS.
`socks5` does local DNS. `socks5h` does remote DNS.

Release Notes:

- N/A
