### PR TITLE
Improve CSS highlights

### DIFF
--- a/crates/languages/src/css/highlights.scm
+++ b/crates/languages/src/css/highlights.scm
@@ -22,7 +22,6 @@
 [
   (tag_name)
   (nesting_selector)
-  (universal_selector)
 ] @tag
 
 (universal_selector ("*") @tag)
@@ -74,7 +73,7 @@
   (float_value)
 ] @number
 
-(unit) @number.unit
+(unit) @keyword
 
 [
   ","

--- a/crates/languages/src/css/highlights.scm
+++ b/crates/languages/src/css/highlights.scm
@@ -1,12 +1,6 @@
 (comment) @comment
 
 [
-  (tag_name)
-  (nesting_selector)
-  (universal_selector)
-] @tag
-
-[
   "~"
   ">"
   "+"
@@ -25,20 +19,29 @@
   "only"
 ] @operator
 
+[
+  (tag_name)
+  (nesting_selector)
+  (universal_selector)
+] @tag
+
+(universal_selector ("*") @tag)
+
 (attribute_selector (plain_value) @string)
 
 (attribute_name) @attribute
-(pseudo_element_selector (tag_name) @attribute)
-(pseudo_class_selector (class_name) @attribute)
 
 [
   (class_name)
   (id_name)
   (namespace_name)
   (feature_name)
-] @property
+] @attribute
 
-(property_name) @constant
+(pseudo_element_selector (tag_name) @tag)
+(pseudo_class_selector (class_name) @function)
+
+(property_name) @property
 
 (function_name) @function
 
@@ -61,7 +64,7 @@
   (to)
   (from)
   (important)
-]  @keyword
+] @keyword
 
 (string_value) @string
 (color_value) @string.special
@@ -71,7 +74,7 @@
   (float_value)
 ] @number
 
-(unit) @type
+(unit) @number.unit
 
 [
   ","


### PR DESCRIPTION
Changes:
1. Selector like `div:nth-child(1)` use `@function`
2. Property use `@property` instead of `@constant`
3. Fix universal selector be overwritten by `@operator`
4. Class and id selectors use `@attribute` instead of `@property`
5. `unit` use `@number.unit` instead of `@type`

Release Notes:

- N/A