### PR TITLE
git blame gutter: Use smallest possible space

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13007,8 +13007,12 @@ impl EditorSnapshot {
                 .map(|max_author_length| {
                     // Length of the author name, but also space for the commit hash,
                     // the spacing and the timestamp.
-                    let max_char_count =
-                        max_author_length.min(GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED) + 22;
+                    let max_char_count = max_author_length
+                        .min(GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED)
+                        + "ea278cc".len()
+                        + "60 minutes ago".len()
+                        + 3;
+
                     em_width * max_char_count
                 });
 
@@ -13024,9 +13028,9 @@ impl EditorSnapshot {
         };
 
         let right_padding = if gutter_settings.folds && show_line_numbers {
-            em_width * 4.0
-        } else if gutter_settings.folds {
             em_width * 3.0
+        } else if gutter_settings.folds {
+            em_width * 2.0
         } else if show_line_numbers {
             em_width
         } else {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12970,6 +12970,7 @@ impl EditorSnapshot {
         font_size: Pixels,
         em_width: Pixels,
         em_advance: Pixels,
+        column_pixels: Pixels,
         max_line_number_width: Pixels,
         cx: &AppContext,
     ) -> GutterDimensions {
@@ -13013,7 +13014,7 @@ impl EditorSnapshot {
                         + "60 minutes ago".len()
                         + 3;
 
-                    em_width * max_char_count
+                    column_pixels * max_char_count
                 });
 
         let mut left_padding = git_blame_entries_width.unwrap_or(Pixels::ZERO);
@@ -13028,9 +13029,9 @@ impl EditorSnapshot {
         };
 
         let right_padding = if gutter_settings.folds && show_line_numbers {
-            em_width * 3.0
+            em_width * 4.0
         } else if gutter_settings.folds {
-            em_width * 2.0
+            em_width * 3.0
         } else if show_line_numbers {
             em_width
         } else {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13007,12 +13007,9 @@ impl EditorSnapshot {
                 .map(|max_author_length| {
                     // Length of the author name, but also space for the commit hash,
                     // the spacing and the timestamp.
-                    let chars = max_author_length.min(GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED)
-                        + "0d10a42".len()
-                        + "44 minutes ago".len()
-                        + 1;
-                    dbg!(em_width);
-                    (em_width * dbg!(chars)) + (chars as f32 * px(1.5))
+                    let max_char_count =
+                        max_author_length.min(GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED) + 22;
+                    em_width * max_char_count
                 });
 
         let mut left_padding = git_blame_entries_width.unwrap_or(Pixels::ZERO);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12970,7 +12970,6 @@ impl EditorSnapshot {
         font_size: Pixels,
         em_width: Pixels,
         em_advance: Pixels,
-        column_pixels: Pixels,
         max_line_number_width: Pixels,
         cx: &AppContext,
     ) -> GutterDimensions {
@@ -13010,11 +13009,11 @@ impl EditorSnapshot {
                     // the spacing and the timestamp.
                     let max_char_count = max_author_length
                         .min(GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED)
-                        + "ea278cc".len()
-                        + "60 minutes ago".len()
-                        + 4;
+                        + 7 // length of commit sha
+                        + 14 // length of max relative timestamp ("60 minutes ago")
+                        + 4; // gaps and margins
 
-                    column_pixels * max_char_count
+                    em_advance * max_char_count
                 });
 
         let mut left_padding = git_blame_entries_width.unwrap_or(Pixels::ZERO);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -663,7 +663,7 @@ pub struct EditorSnapshot {
     show_git_diff_gutter: Option<bool>,
     show_code_actions: Option<bool>,
     show_runnables: Option<bool>,
-    render_git_blame_gutter: bool,
+    git_blame_gutter_max_author_length: Option<usize>,
     pub display_snapshot: DisplaySnapshot,
     pub placeholder_text: Option<Arc<str>>,
     is_focused: bool,
@@ -673,7 +673,7 @@ pub struct EditorSnapshot {
     gutter_hovered: bool,
 }
 
-const GIT_BLAME_GUTTER_WIDTH_CHARS: f32 = 53.;
+const GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED: usize = 20;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct GutterDimensions {
@@ -2211,6 +2211,19 @@ impl Editor {
     }
 
     pub fn snapshot(&mut self, cx: &mut WindowContext) -> EditorSnapshot {
+        let git_blame_gutter_max_author_length = self
+            .render_git_blame_gutter(cx)
+            .then(|| {
+                if let Some(blame) = self.blame.as_ref() {
+                    let max_author_length =
+                        blame.update(cx, |blame, cx| blame.max_author_length(cx));
+                    Some(max_author_length)
+                } else {
+                    None
+                }
+            })
+            .flatten();
+
         EditorSnapshot {
             mode: self.mode,
             show_gutter: self.show_gutter,
@@ -2218,7 +2231,7 @@ impl Editor {
             show_git_diff_gutter: self.show_git_diff_gutter,
             show_code_actions: self.show_code_actions,
             show_runnables: self.show_runnables,
-            render_git_blame_gutter: self.render_git_blame_gutter(cx),
+            git_blame_gutter_max_author_length,
             display_snapshot: self.display_map.update(cx, |map, cx| map.snapshot(cx)),
             scroll_anchor: self.scroll_manager.anchor(),
             ongoing_scroll: self.scroll_manager.ongoing_scroll(),
@@ -12989,9 +13002,18 @@ impl EditorSnapshot {
 
         let show_runnables = self.show_runnables.unwrap_or(gutter_settings.runnables);
 
-        let git_blame_entries_width = self
-            .render_git_blame_gutter
-            .then_some(em_width * GIT_BLAME_GUTTER_WIDTH_CHARS);
+        let git_blame_entries_width =
+            self.git_blame_gutter_max_author_length
+                .map(|max_author_length| {
+                    // Length of the author name, but also space for the commit hash,
+                    // the spacing and the timestamp.
+                    let chars = max_author_length.min(GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED)
+                        + "0d10a42".len()
+                        + "44 minutes ago".len()
+                        + 1;
+                    dbg!(em_width);
+                    (em_width * dbg!(chars)) + (chars as f32 * px(1.5))
+                });
 
         let mut left_padding = git_blame_entries_width.unwrap_or(Pixels::ZERO);
         left_padding += if show_code_actions || show_runnables {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13012,7 +13012,7 @@ impl EditorSnapshot {
                         .min(GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED)
                         + "ea278cc".len()
                         + "60 minutes ago".len()
-                        + 3;
+                        + 4;
 
                     column_pixels * max_char_count
                 });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4896,7 +4896,6 @@ impl Element for EditorElement {
                         let editor_handle = cx.view().clone();
                         let max_line_number_width =
                             self.max_line_number_width(&editor.snapshot(cx), cx);
-                        let column_pixels = self.column_pixels(1, cx);
                         cx.request_measured_layout(
                             Style::default(),
                             move |known_dimensions, available_space, cx| {
@@ -4906,7 +4905,6 @@ impl Element for EditorElement {
                                             editor,
                                             max_lines,
                                             max_line_number_width,
-                                            column_pixels,
                                             known_dimensions,
                                             available_space.width,
                                             cx,
@@ -4972,7 +4970,6 @@ impl Element for EditorElement {
                         font_size,
                         em_width,
                         em_advance,
-                        self.column_pixels(1, cx),
                         self.max_line_number_width(&snapshot, cx),
                         cx,
                     );
@@ -6261,7 +6258,6 @@ fn compute_auto_height_layout(
     editor: &mut Editor,
     max_lines: usize,
     max_line_number_width: Pixels,
-    column_pixels: Pixels,
     known_dimensions: Size<Option<Pixels>>,
     available_width: AvailableSpace,
     cx: &mut ViewContext<Editor>,
@@ -6299,7 +6295,6 @@ fn compute_auto_height_layout(
         font_size,
         em_width,
         em_advance,
-        column_pixels,
         max_line_number_width,
         cx,
     );

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4246,6 +4246,7 @@ fn render_blame_entry(
         .id(("blame", ix))
         .text_color(cx.theme().status().hint)
         .pr_2()
+        .gap_2()
         .child(
             h_flex()
                 .items_center()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4895,6 +4895,7 @@ impl Element for EditorElement {
                         let editor_handle = cx.view().clone();
                         let max_line_number_width =
                             self.max_line_number_width(&editor.snapshot(cx), cx);
+                        let column_pixels = self.column_pixels(1, cx);
                         cx.request_measured_layout(
                             Style::default(),
                             move |known_dimensions, available_space, cx| {
@@ -4904,6 +4905,7 @@ impl Element for EditorElement {
                                             editor,
                                             max_lines,
                                             max_line_number_width,
+                                            column_pixels,
                                             known_dimensions,
                                             available_space.width,
                                             cx,
@@ -4952,7 +4954,12 @@ impl Element for EditorElement {
                     let font_id = cx.text_system().resolve_font(&style.text.font());
                     let font_size = style.text.font_size.to_pixels(cx.rem_size());
                     let line_height = style.text.line_height_in_pixels(cx.rem_size());
-                    let em_width = self.column_pixels(1, cx);
+                    let em_width = cx
+                        .text_system()
+                        .typographic_bounds(font_id, font_size, 'm')
+                        .unwrap()
+                        .size
+                        .width;
                     let em_advance = cx
                         .text_system()
                         .advance(font_id, font_size, 'm')
@@ -4964,6 +4971,7 @@ impl Element for EditorElement {
                         font_size,
                         em_width,
                         em_advance,
+                        self.column_pixels(1, cx),
                         self.max_line_number_width(&snapshot, cx),
                         cx,
                     );
@@ -6252,6 +6260,7 @@ fn compute_auto_height_layout(
     editor: &mut Editor,
     max_lines: usize,
     max_line_number_width: Pixels,
+    column_pixels: Pixels,
     known_dimensions: Size<Option<Pixels>>,
     available_width: AvailableSpace,
     cx: &mut ViewContext<Editor>,
@@ -6289,6 +6298,7 @@ fn compute_auto_height_layout(
         font_size,
         em_width,
         em_advance,
+        column_pixels,
         max_line_number_width,
         cx,
     );

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1448,7 +1448,6 @@ impl EditorElement {
         let start_x = em_width;
 
         let mut last_used_color: Option<(PlayerColor, Oid)> = None;
-        println!("em_width: {:?}, width: {:?}", em_width, width);
 
         let shaped_lines = blamed_rows
             .into_iter()
@@ -4241,22 +4240,20 @@ fn render_blame_entry(
 
     h_flex()
         .w_full()
+        .justify_between()
         .font_family(style.text.font().family)
         .line_height(style.text.line_height)
         .id(("blame", ix))
-        .children([
-            div()
-                .text_color(sha_color.cursor)
-                .child(short_commit_id)
-                .mr_2(),
-            div()
-                .w_full()
-                .h_flex()
-                .justify_between()
-                .text_color(cx.theme().status().hint)
-                .child(name)
-                .child(relative_timestamp),
-        ])
+        .text_color(cx.theme().status().hint)
+        .pr_2()
+        .child(
+            h_flex()
+                .items_center()
+                .gap_2()
+                .child(div().text_color(sha_color.cursor).child(short_commit_id))
+                .child(name),
+        )
+        .child(relative_timestamp)
         .on_mouse_down(MouseButton::Right, {
             let blame_entry = blame_entry.clone();
             let details = details.clone();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4231,8 +4231,6 @@ fn render_blame_entry(
     let author_name = blame_entry.author.as_deref().unwrap_or("<no name>");
     let name = util::truncate_and_trailoff(author_name, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED);
 
-    dbg!(name.len() + short_commit_id.len() + relative_timestamp.len());
-
     let details = blame.read(cx).details_for_entry(&blame_entry);
 
     let workspace = editor.read(cx).workspace.as_ref().map(|(w, _)| w.clone());
@@ -4243,7 +4241,6 @@ fn render_blame_entry(
 
     h_flex()
         .w_full()
-        .debug_bg_green()
         .font_family(style.text.font().family)
         .line_height(style.text.line_height)
         .id(("blame", ix))
@@ -4251,16 +4248,14 @@ fn render_blame_entry(
             div()
                 .text_color(sha_color.cursor)
                 .child(short_commit_id)
-                .mr_2()
-                .debug_bg_blue(),
+                .mr_2(),
             div()
-                .debug_bg_yellow()
                 .w_full()
                 .h_flex()
                 .justify_between()
                 .text_color(cx.theme().status().hint)
-                .child(div().debug_bg_red().child(name))
-                .child(div().debug_bg_cyan().child(relative_timestamp)),
+                .child(name)
+                .child(relative_timestamp),
         ])
         .on_mouse_down(MouseButton::Right, {
             let blame_entry = blame_entry.clone();
@@ -4960,12 +4955,7 @@ impl Element for EditorElement {
                     let font_id = cx.text_system().resolve_font(&style.text.font());
                     let font_size = style.text.font_size.to_pixels(cx.rem_size());
                     let line_height = style.text.line_height_in_pixels(cx.rem_size());
-                    let em_width = cx
-                        .text_system()
-                        .typographic_bounds(font_id, font_size, 'm')
-                        .unwrap()
-                        .size
-                        .width;
+                    let em_width = self.column_pixels(1, cx);
                     let em_advance = cx
                         .text_system()
                         .advance(font_id, font_size, 'm')

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -207,6 +207,27 @@ impl GitBlame {
         })
     }
 
+    pub fn max_author_length(&mut self, cx: &mut ModelContext<Self>) -> usize {
+        self.sync(cx);
+
+        let mut max_author_length = 0;
+
+        for entry in self.entries.iter() {
+            let author_len = entry
+                .blame
+                .as_ref()
+                .and_then(|entry| entry.author.as_ref())
+                .map(|author| author.len());
+            if let Some(author_len) = author_len {
+                if author_len > max_author_length {
+                    max_author_length = author_len;
+                }
+            }
+        }
+
+        max_author_length
+    }
+
     pub fn blur(&mut self, _: &mut ModelContext<Self>) {
         self.focused = false;
     }


### PR DESCRIPTION
Before:
![screenshot-2024-09-26-15 00 20@2x](https://github.com/user-attachments/assets/f6706325-5bef-404e-a0b4-63a5121969fa)

After:

![screenshot-2024-09-26-15 02 24@2x](https://github.com/user-attachments/assets/739d0831-0b4a-457f-917e-10f3a662e74d)


Release Notes:

- Improved the git blame gutter to take up only the space required to display the longest git author name in the current file.
