### PR TITLE
editor: Remove unneeded blank lines in rewrap test cases

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4270,7 +4270,6 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                 } else {
                     //
                 }
-
             }
         "};
 
@@ -4284,7 +4283,6 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                 } else {
                     //
                 }
-
             }
         "};
 


### PR DESCRIPTION
This PR removes some unneeded blank lines from some of the test cases for `editor::Rewrap`.

These weren't meaningful to the test, and their presence could be confusing.

Release Notes:

- N/A
