### PR TITLE
preview tabs: Toggle preview tab when saving

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1595,8 +1595,13 @@ impl Pane {
             }
 
             if can_save {
-                pane.update(cx, |_, cx| item.save(should_format, project, cx))?
-                    .await?;
+                pane.update(cx, |pane, cx| {
+                    if pane.is_active_preview_item(item.item_id()) {
+                        pane.set_preview_item_id(None, cx);
+                    }
+                    item.save(should_format, project, cx)
+                })?
+                .await?;
             } else if can_save_as {
                 let abs_path = pane.update(cx, |pane, cx| {
                     pane.workspace


### PR DESCRIPTION

Release Notes:

- Saving a preview tab will now mark it as a permanent tab 
