### PR TITLE
gpui: Fix `show: false` support on Windows to create an invisible window

### DIFF
--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -75,95 +75,80 @@ impl Render for WindowDemo {
             .justify_center()
             .items_center()
             .gap_2()
-            .child(button("Normal", {
-                let window_bounds = window_bounds;
-                move |cx| {
-                    cx.open_window(
-                        WindowOptions {
-                            window_bounds: Some(window_bounds),
-                            ..Default::default()
-                        },
-                        |cx| {
-                            cx.new_view(|_cx| SubWindow {
-                                custom_titlebar: false,
-                            })
-                        },
-                    )
-                    .unwrap();
-                }
+            .child(button("Normal", move |cx| {
+                cx.open_window(
+                    WindowOptions {
+                        window_bounds: Some(window_bounds),
+                        ..Default::default()
+                    },
+                    |cx| {
+                        cx.new_view(|_cx| SubWindow {
+                            custom_titlebar: false,
+                        })
+                    },
+                )
+                .unwrap();
             }))
-            .child(button("Popup", {
-                let window_bounds = window_bounds;
-                move |cx| {
-                    cx.open_window(
-                        WindowOptions {
-                            window_bounds: Some(window_bounds),
-                            kind: WindowKind::PopUp,
-                            ..Default::default()
-                        },
-                        |cx| {
-                            cx.new_view(|_cx| SubWindow {
-                                custom_titlebar: false,
-                            })
-                        },
-                    )
-                    .unwrap();
-                }
+            .child(button("Popup", move |cx| {
+                cx.open_window(
+                    WindowOptions {
+                        window_bounds: Some(window_bounds),
+                        kind: WindowKind::PopUp,
+                        ..Default::default()
+                    },
+                    |cx| {
+                        cx.new_view(|_cx| SubWindow {
+                            custom_titlebar: false,
+                        })
+                    },
+                )
+                .unwrap();
             }))
-            .child(button("Custom Titlebar", {
-                let window_bounds = window_bounds;
-                move |cx| {
-                    cx.open_window(
-                        WindowOptions {
-                            titlebar: None,
-                            window_bounds: Some(window_bounds),
-                            ..Default::default()
-                        },
-                        |cx| {
-                            cx.new_view(|_cx| SubWindow {
-                                custom_titlebar: true,
-                            })
-                        },
-                    )
-                    .unwrap();
-                }
+            .child(button("Custom Titlebar", move |cx| {
+                cx.open_window(
+                    WindowOptions {
+                        titlebar: None,
+                        window_bounds: Some(window_bounds),
+                        ..Default::default()
+                    },
+                    |cx| {
+                        cx.new_view(|_cx| SubWindow {
+                            custom_titlebar: true,
+                        })
+                    },
+                )
+                .unwrap();
             }))
-            .child(button("Invisible", {
-                let window_bounds = window_bounds;
-                move |cx| {
-                    cx.open_window(
-                        WindowOptions {
-                            show: false,
-                            window_bounds: Some(window_bounds),
-                            ..Default::default()
-                        },
-                        |cx| {
-                            cx.new_view(|_cx| SubWindow {
-                                custom_titlebar: false,
-                            })
-                        },
-                    )
-                    .unwrap();
-                }
+            .child(button("Invisible", move |cx| {
+                cx.open_window(
+                    WindowOptions {
+                        show: false,
+                        window_bounds: Some(window_bounds),
+                        ..Default::default()
+                    },
+                    |cx| {
+                        cx.new_view(|_cx| SubWindow {
+                            custom_titlebar: false,
+                        })
+                    },
+                )
+                .unwrap();
             }))
-            .child(button("Unmovable", {
-                let window_bounds = window_bounds;
-                move |cx| {
-                    cx.open_window(
-                        WindowOptions {
-                            is_movable: false,
-                            titlebar: None,
-                            window_bounds: Some(window_bounds),
-                            ..Default::default()
-                        },
-                        |cx| {
-                            cx.new_view(|_cx| SubWindow {
-                                custom_titlebar: false,
-                            })
-                        },
-                    )
-                    .unwrap();
-                }
+            .child(button("Unmovable", move |cx| {
+                cx.open_window(
+                    WindowOptions {
+                        is_movable: false,
+                        titlebar: None,
+                        window_bounds: Some(window_bounds),
+                        ..Default::default()
+                    },
+                    |cx| {
+                        cx.new_view(|_cx| SubWindow {
+                            custom_titlebar: false,
+                        })
+                    },
+                )
+                .unwrap();
             }))
     }
 }

--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -76,7 +76,7 @@ impl Render for WindowDemo {
             .items_center()
             .gap_2()
             .child(button("Normal", {
-                let window_bounds = window_bounds.clone();
+                let window_bounds = window_bounds;
                 move |cx| {
                     cx.open_window(
                         WindowOptions {
@@ -93,7 +93,7 @@ impl Render for WindowDemo {
                 }
             }))
             .child(button("Popup", {
-                let window_bounds = window_bounds.clone();
+                let window_bounds = window_bounds;
                 move |cx| {
                     cx.open_window(
                         WindowOptions {
@@ -111,7 +111,7 @@ impl Render for WindowDemo {
                 }
             }))
             .child(button("Custom Titlebar", {
-                let window_bounds = window_bounds.clone();
+                let window_bounds = window_bounds;
                 move |cx| {
                     cx.open_window(
                         WindowOptions {
@@ -129,7 +129,7 @@ impl Render for WindowDemo {
                 }
             }))
             .child(button("Invisible", {
-                let window_bounds = window_bounds.clone();
+                let window_bounds = window_bounds;
                 move |cx| {
                     cx.open_window(
                         WindowOptions {
@@ -147,7 +147,7 @@ impl Render for WindowDemo {
                 }
             }))
             .child(button("Unmovable", {
-                let window_bounds = window_bounds.clone();
+                let window_bounds = window_bounds;
                 move |cx| {
                     cx.open_window(
                         WindowOptions {

--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -61,104 +61,11 @@ impl Render for SubWindow {
 
 struct WindowDemo {}
 
-impl WindowDemo {
-    fn window_bounds(cx: &mut AppContext) -> WindowBounds {
-        WindowBounds::Windowed(Bounds::centered(None, size(px(300.0), px(300.0)), cx))
-    }
-
-    fn new_normal_window(cx: &mut AppContext) {
-        let window_bounds = Self::window_bounds(cx);
-
-        cx.open_window(
-            WindowOptions {
-                window_bounds: Some(window_bounds),
-                ..Default::default()
-            },
-            |cx| {
-                cx.new_view(|_cx| SubWindow {
-                    custom_titlebar: false,
-                })
-            },
-        )
-        .unwrap();
-    }
-
-    fn new_popup_window(cx: &mut AppContext) {
-        let window_bounds = Self::window_bounds(cx);
-
-        cx.open_window(
-            WindowOptions {
-                window_bounds: Some(window_bounds),
-                kind: WindowKind::PopUp,
-                ..Default::default()
-            },
-            |cx| {
-                cx.new_view(|_cx| SubWindow {
-                    custom_titlebar: false,
-                })
-            },
-        )
-        .unwrap();
-    }
-
-    fn new_custom_titlebar_window(cx: &mut AppContext) {
-        let window_bounds = Self::window_bounds(cx);
-
-        cx.open_window(
-            WindowOptions {
-                titlebar: None,
-                window_bounds: Some(window_bounds),
-                ..Default::default()
-            },
-            |cx| {
-                cx.new_view(|_cx| SubWindow {
-                    custom_titlebar: true,
-                })
-            },
-        )
-        .unwrap();
-    }
-
-    fn new_hide_window(cx: &mut AppContext) {
-        let window_bounds = Self::window_bounds(cx);
-
-        cx.open_window(
-            WindowOptions {
-                show: false,
-                window_bounds: Some(window_bounds),
-                ..Default::default()
-            },
-            |cx| {
-                cx.new_view(|_cx| SubWindow {
-                    custom_titlebar: false,
-                })
-            },
-        )
-        .unwrap();
-    }
-
-    fn new_unmovable_window(cx: &mut AppContext) {
-        let window_bounds = Self::window_bounds(cx);
-
-        cx.open_window(
-            WindowOptions {
-                is_movable: false,
-                titlebar: None,
-                window_bounds: Some(window_bounds),
-                ..Default::default()
-            },
-            |cx| {
-                cx.new_view(|_cx| SubWindow {
-                    custom_titlebar: false,
-                })
-            },
-        )
-        .unwrap();
-    }
-}
-
 impl Render for WindowDemo {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let window_bounds =
+            WindowBounds::Windowed(Bounds::centered(None, size(px(300.0), px(300.0)), cx));
+
         div()
             .p_4()
             .flex()
@@ -168,20 +75,95 @@ impl Render for WindowDemo {
             .justify_center()
             .items_center()
             .gap_2()
-            .child(button("Normal", |cx| {
-                Self::new_normal_window(cx);
+            .child(button("Normal", {
+                let window_bounds = window_bounds.clone();
+                move |cx| {
+                    cx.open_window(
+                        WindowOptions {
+                            window_bounds: Some(window_bounds),
+                            ..Default::default()
+                        },
+                        |cx| {
+                            cx.new_view(|_cx| SubWindow {
+                                custom_titlebar: false,
+                            })
+                        },
+                    )
+                    .unwrap();
+                }
             }))
-            .child(button("Popup", |cx| {
-                Self::new_popup_window(cx);
+            .child(button("Popup", {
+                let window_bounds = window_bounds.clone();
+                move |cx| {
+                    cx.open_window(
+                        WindowOptions {
+                            window_bounds: Some(window_bounds),
+                            kind: WindowKind::PopUp,
+                            ..Default::default()
+                        },
+                        |cx| {
+                            cx.new_view(|_cx| SubWindow {
+                                custom_titlebar: false,
+                            })
+                        },
+                    )
+                    .unwrap();
+                }
             }))
-            .child(button("Custom Titlebar", |cx| {
-                Self::new_custom_titlebar_window(cx);
+            .child(button("Custom Titlebar", {
+                let window_bounds = window_bounds.clone();
+                move |cx| {
+                    cx.open_window(
+                        WindowOptions {
+                            titlebar: None,
+                            window_bounds: Some(window_bounds),
+                            ..Default::default()
+                        },
+                        |cx| {
+                            cx.new_view(|_cx| SubWindow {
+                                custom_titlebar: true,
+                            })
+                        },
+                    )
+                    .unwrap();
+                }
             }))
-            .child(button("Invisable", |cx| {
-                Self::new_hide_window(cx);
+            .child(button("Invisible", {
+                let window_bounds = window_bounds.clone();
+                move |cx| {
+                    cx.open_window(
+                        WindowOptions {
+                            show: false,
+                            window_bounds: Some(window_bounds),
+                            ..Default::default()
+                        },
+                        |cx| {
+                            cx.new_view(|_cx| SubWindow {
+                                custom_titlebar: false,
+                            })
+                        },
+                    )
+                    .unwrap();
+                }
             }))
-            .child(button("Unmovable", |cx| {
-                Self::new_unmovable_window(cx);
+            .child(button("Unmovable", {
+                let window_bounds = window_bounds.clone();
+                move |cx| {
+                    cx.open_window(
+                        WindowOptions {
+                            is_movable: false,
+                            titlebar: None,
+                            window_bounds: Some(window_bounds),
+                            ..Default::default()
+                        },
+                        |cx| {
+                            cx.new_view(|_cx| SubWindow {
+                                custom_titlebar: false,
+                            })
+                        },
+                    )
+                    .unwrap();
+                }
             }))
     }
 }

--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -1,0 +1,201 @@
+use gpui::*;
+use prelude::FluentBuilder as _;
+
+struct SubWindow {
+    custom_titlebar: bool,
+}
+
+fn button(text: &str, on_click: impl Fn(&mut WindowContext) + 'static) -> impl IntoElement {
+    div()
+        .id(SharedString::from(text.to_string()))
+        .flex_none()
+        .px_2()
+        .bg(rgb(0xf7f7f7))
+        .active(|this| this.opacity(0.85))
+        .border_1()
+        .border_color(rgb(0xe0e0e0))
+        .rounded_md()
+        .cursor_pointer()
+        .child(text.to_string())
+        .on_click(move |_, cx| on_click(cx))
+}
+
+impl Render for SubWindow {
+    fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .bg(rgb(0xffffff))
+            .size_full()
+            .gap_2()
+            .when(self.custom_titlebar, |cx| {
+                cx.child(
+                    div()
+                        .flex()
+                        .h(px(32.))
+                        .px_4()
+                        .bg(gpui::blue())
+                        .text_color(gpui::white())
+                        .w_full()
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .size_full()
+                                .child("Custom Titlebar"),
+                        ),
+                )
+            })
+            .child(
+                div()
+                    .p_8()
+                    .gap_2()
+                    .child("SubWindow")
+                    .child(button("Close", |cx| {
+                        cx.remove_window();
+                    })),
+            )
+    }
+}
+
+struct WindowDemo {}
+
+impl WindowDemo {
+    fn window_bounds(cx: &mut AppContext) -> WindowBounds {
+        WindowBounds::Windowed(Bounds::centered(None, size(px(300.0), px(300.0)), cx))
+    }
+
+    fn new_normal_window(cx: &mut AppContext) {
+        let window_bounds = Self::window_bounds(cx);
+
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(window_bounds),
+                ..Default::default()
+            },
+            |cx| {
+                cx.new_view(|_cx| SubWindow {
+                    custom_titlebar: false,
+                })
+            },
+        )
+        .unwrap();
+    }
+
+    fn new_popup_window(cx: &mut AppContext) {
+        let window_bounds = Self::window_bounds(cx);
+
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(window_bounds),
+                kind: WindowKind::PopUp,
+                ..Default::default()
+            },
+            |cx| {
+                cx.new_view(|_cx| SubWindow {
+                    custom_titlebar: false,
+                })
+            },
+        )
+        .unwrap();
+    }
+
+    fn new_custom_titlebar_window(cx: &mut AppContext) {
+        let window_bounds = Self::window_bounds(cx);
+
+        cx.open_window(
+            WindowOptions {
+                titlebar: None,
+                window_bounds: Some(window_bounds),
+                ..Default::default()
+            },
+            |cx| {
+                cx.new_view(|_cx| SubWindow {
+                    custom_titlebar: true,
+                })
+            },
+        )
+        .unwrap();
+    }
+
+    fn new_hide_window(cx: &mut AppContext) {
+        let window_bounds = Self::window_bounds(cx);
+
+        cx.open_window(
+            WindowOptions {
+                show: false,
+                window_bounds: Some(window_bounds),
+                ..Default::default()
+            },
+            |cx| {
+                cx.new_view(|_cx| SubWindow {
+                    custom_titlebar: false,
+                })
+            },
+        )
+        .unwrap();
+    }
+
+    fn new_unmovable_window(cx: &mut AppContext) {
+        let window_bounds = Self::window_bounds(cx);
+
+        cx.open_window(
+            WindowOptions {
+                is_movable: false,
+                titlebar: None,
+                window_bounds: Some(window_bounds),
+                ..Default::default()
+            },
+            |cx| {
+                cx.new_view(|_cx| SubWindow {
+                    custom_titlebar: false,
+                })
+            },
+        )
+        .unwrap();
+    }
+}
+
+impl Render for WindowDemo {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        div()
+            .p_4()
+            .flex()
+            .flex_wrap()
+            .bg(rgb(0xffffff))
+            .size_full()
+            .justify_center()
+            .items_center()
+            .gap_2()
+            .child(button("Normal", |cx| {
+                Self::new_normal_window(cx);
+            }))
+            .child(button("Popup", |cx| {
+                Self::new_popup_window(cx);
+            }))
+            .child(button("Custom Titlebar", |cx| {
+                Self::new_custom_titlebar_window(cx);
+            }))
+            .child(button("Invisable", |cx| {
+                Self::new_hide_window(cx);
+            }))
+            .child(button("Unmovable", |cx| {
+                Self::new_unmovable_window(cx);
+            }))
+    }
+}
+
+fn main() {
+    App::new().run(|cx: &mut AppContext| {
+        let bounds = Bounds::centered(None, size(px(800.0), px(600.0)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |cx| cx.new_view(|_cx| WindowDemo {}),
+        )
+        .unwrap();
+    });
+}

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -706,7 +706,7 @@ impl MacWindow {
                 }
             }
 
-            if focus {
+            if focus && show {
                 native_window.makeKeyAndOrderFront_(nil);
             } else if show {
                 native_window.orderFront_(nil);


### PR DESCRIPTION
Release Notes:

- N/A
- 
The `show` of WindowOptions is valid on macOS but not on Windows, this changes to fix it to support create an invisible window.

```bash
cargo run -p gpui --example window
```

## Before


https://github.com/user-attachments/assets/4157bdaa-39a7-44df-bbdc-30b00e9c61e9


## After


https://github.com/user-attachments/assets/d48fa524-0caa-4f87-932d-01d7a468c488

https://github.com/user-attachments/assets/dd052f15-c8db-4a2a-a6af-a7c0ffecca84


