### PR TITLE
Use LanguageServerName in more places

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -19,7 +19,10 @@ use workspace::{item::ItemHandle, StatusItemView, Workspace};
 actions!(activity_indicator, [ShowErrorMessage]);
 
 pub enum Event {
-    ShowError { lsp_name: Arc<str>, error: String },
+    ShowError {
+        lsp_name: LanguageServerName,
+        error: String,
+    },
 }
 
 pub struct ActivityIndicator {
@@ -123,7 +126,7 @@ impl ActivityIndicator {
         self.statuses.retain(|status| {
             if let LanguageServerBinaryStatus::Failed { error } = &status.status {
                 cx.emit(Event::ShowError {
-                    lsp_name: status.name.0.clone(),
+                    lsp_name: status.name.clone(),
                     error: error.clone(),
                 });
                 false

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -102,7 +102,7 @@ async fn test_sharing_an_ssh_remote_project(
             all_language_settings(file, cx)
                 .language(Some(&("Rust".into())))
                 .language_servers,
-            ["override-rust-analyzer".into()]
+            ["override-rust-analyzer".to_string()]
         )
     });
 

--- a/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
@@ -9,10 +9,10 @@ use futures::{io::BufReader, FutureExt as _};
 use futures::{lock::Mutex, AsyncReadExt};
 use indexed_docs::IndexedDocsDatabase;
 use isahc::config::{Configurable, RedirectPolicy};
-use language::LanguageName;
 use language::{
     language_settings::AllLanguageSettings, LanguageServerBinaryStatus, LspAdapterDelegate,
 };
+use language::{LanguageName, LanguageServerName};
 use project::project_settings::ProjectSettings;
 use semantic_version::SemanticVersion;
 use std::{
@@ -366,7 +366,7 @@ impl ExtensionImports for WasmState {
                             .and_then(|key| {
                                 ProjectSettings::get(location, cx)
                                     .lsp
-                                    .get(&Arc::<str>::from(key))
+                                    .get(&LanguageServerName(key.into()))
                             })
                             .cloned()
                             .unwrap_or_default();

--- a/crates/extension/src/wasm_host/wit/since_v0_2_0.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_2_0.rs
@@ -9,10 +9,10 @@ use futures::{io::BufReader, FutureExt as _};
 use futures::{lock::Mutex, AsyncReadExt};
 use indexed_docs::IndexedDocsDatabase;
 use isahc::config::{Configurable, RedirectPolicy};
-use language::LanguageName;
 use language::{
     language_settings::AllLanguageSettings, LanguageServerBinaryStatus, LspAdapterDelegate,
 };
+use language::{LanguageName, LanguageServerName};
 use project::project_settings::ProjectSettings;
 use semantic_version::SemanticVersion;
 use std::{
@@ -412,7 +412,7 @@ impl ExtensionImports for WasmState {
                             .and_then(|key| {
                                 ProjectSettings::get(location, cx)
                                     .lsp
-                                    .get(&Arc::<str>::from(key))
+                                    .get(&LanguageServerName::from_proto(key))
                             })
                             .cloned()
                             .unwrap_or_default();

--- a/crates/gpui/src/shared_string.rs
+++ b/crates/gpui/src/shared_string.rs
@@ -9,6 +9,13 @@ use util::arc_cow::ArcCow;
 #[derive(Deref, DerefMut, Eq, PartialEq, PartialOrd, Ord, Hash, Clone)]
 pub struct SharedString(ArcCow<'static, str>);
 
+impl SharedString {
+    /// creates a static SharedString
+    pub const fn new_static(s: &'static str) -> Self {
+        Self(ArcCow::Borrowed(s))
+    }
+}
+
 impl Default for SharedString {
     fn default() -> Self {
         Self(ArcCow::Owned(Arc::default()))

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -236,7 +236,7 @@ impl LogStore {
                             ));
                         this.add_language_server(
                             LanguageServerKind::Global {
-                                name: LanguageServerName(Arc::from("copilot")),
+                                name: LanguageServerName::new_static("copilot"),
                             },
                             server.server_id(),
                             Some(server.clone()),

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -13,13 +13,13 @@ use util::{fs::remove_matching, maybe, ResultExt};
 pub struct CLspAdapter;
 
 impl CLspAdapter {
-    const SERVER_NAME: &'static str = "clangd";
+    const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("clangd");
 }
 
 #[async_trait(?Send)]
 impl super::LspAdapter for CLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(Self::SERVER_NAME.into())
+        Self::SERVER_NAME.clone()
     }
 
     async fn check_if_user_installed(
@@ -28,7 +28,8 @@ impl super::LspAdapter for CLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            language_server_settings(delegate, Self::SERVER_NAME, cx).and_then(|s| s.binary.clone())
+            language_server_settings(delegate, &Self::SERVER_NAME, cx)
+                .and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -33,7 +33,7 @@ fn server_binary_arguments() -> Vec<OsString> {
 pub struct GoLspAdapter;
 
 impl GoLspAdapter {
-    const SERVER_NAME: &'static str = "gopls";
+    const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("gopls");
 }
 
 static GOPLS_VERSION_REGEX: LazyLock<Regex> =
@@ -46,7 +46,7 @@ static GO_ESCAPE_SUBTEST_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 #[async_trait(?Send)]
 impl super::LspAdapter for GoLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(Self::SERVER_NAME.into())
+        Self::SERVER_NAME.clone()
     }
 
     async fn fetch_latest_server_version(
@@ -71,7 +71,8 @@ impl super::LspAdapter for GoLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            language_server_settings(delegate, Self::SERVER_NAME, cx).and_then(|s| s.binary.clone())
+            language_server_settings(delegate, &Self::SERVER_NAME, cx)
+                .and_then(|s| s.binary.clone())
         });
 
         match configured_binary {

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -25,13 +25,13 @@ use util::{fs::remove_matching, maybe, ResultExt};
 pub struct RustLspAdapter;
 
 impl RustLspAdapter {
-    const SERVER_NAME: &'static str = "rust-analyzer";
+    const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("rust-analyzer");
 }
 
 #[async_trait(?Send)]
 impl LspAdapter for RustLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(Self::SERVER_NAME.into())
+        Self::SERVER_NAME.clone()
     }
 
     async fn check_if_user_installed(
@@ -41,7 +41,7 @@ impl LspAdapter for RustLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx
             .update(|cx| {
-                language_server_settings(delegate, Self::SERVER_NAME, cx)
+                language_server_settings(delegate, &Self::SERVER_NAME, cx)
                     .and_then(|s| s.binary.clone())
             })
             .ok()?;
@@ -60,7 +60,7 @@ impl LspAdapter for RustLspAdapter {
                 path_lookup: None,
                 ..
             }) => {
-                let path = delegate.which(Self::SERVER_NAME.as_ref()).await;
+                let path = delegate.which("rust-analyzer".as_ref()).await;
                 let env = delegate.shell_env().await;
 
                 if let Some(path) = path {

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -32,7 +32,8 @@ pub struct TailwindLspAdapter {
 }
 
 impl TailwindLspAdapter {
-    const SERVER_NAME: &'static str = "tailwindcss-language-server";
+    const SERVER_NAME: LanguageServerName =
+        LanguageServerName::new_static("tailwindcss-language-server");
 
     pub fn new(node: Arc<dyn NodeRuntime>) -> Self {
         TailwindLspAdapter { node }
@@ -42,7 +43,7 @@ impl TailwindLspAdapter {
 #[async_trait(?Send)]
 impl LspAdapter for TailwindLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(Self::SERVER_NAME.into())
+        Self::SERVER_NAME.clone()
     }
 
     async fn check_if_user_installed(
@@ -52,7 +53,7 @@ impl LspAdapter for TailwindLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx
             .update(|cx| {
-                language_server_settings(delegate, Self::SERVER_NAME, cx)
+                language_server_settings(delegate, &Self::SERVER_NAME, cx)
                     .and_then(|s| s.binary.clone())
             })
             .ok()??;
@@ -152,7 +153,7 @@ impl LspAdapter for TailwindLspAdapter {
         cx: &mut AsyncAppContext,
     ) -> Result<Value> {
         let tailwind_user_settings = cx.update(|cx| {
-            language_server_settings(delegate.as_ref(), Self::SERVER_NAME, cx)
+            language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
                 .and_then(|s| s.settings.clone())
                 .unwrap_or_default()
         })?;

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -71,7 +71,8 @@ pub struct TypeScriptLspAdapter {
 impl TypeScriptLspAdapter {
     const OLD_SERVER_PATH: &'static str = "node_modules/typescript-language-server/lib/cli.js";
     const NEW_SERVER_PATH: &'static str = "node_modules/typescript-language-server/lib/cli.mjs";
-    const SERVER_NAME: &'static str = "typescript-language-server";
+    const SERVER_NAME: LanguageServerName =
+        LanguageServerName::new_static("typescript-language-server");
     pub fn new(node: Arc<dyn NodeRuntime>) -> Self {
         TypeScriptLspAdapter { node }
     }
@@ -97,7 +98,7 @@ struct TypeScriptVersions {
 #[async_trait(?Send)]
 impl LspAdapter for TypeScriptLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(Self::SERVER_NAME.into())
+        Self::SERVER_NAME.clone()
     }
 
     async fn fetch_latest_server_version(
@@ -239,7 +240,7 @@ impl LspAdapter for TypeScriptLspAdapter {
         cx: &mut AsyncAppContext,
     ) -> Result<Value> {
         let override_options = cx.update(|cx| {
-            language_server_settings(delegate.as_ref(), Self::SERVER_NAME, cx)
+            language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
                 .and_then(|s| s.settings.clone())
         })?;
         if let Some(options) = override_options {
@@ -304,7 +305,7 @@ impl EsLintLspAdapter {
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::Zip;
 
     const SERVER_PATH: &'static str = "vscode-eslint/server/out/eslintServer.js";
-    const SERVER_NAME: &'static str = "eslint";
+    const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("eslint");
 
     const FLAT_CONFIG_FILE_NAMES: &'static [&'static str] =
         &["eslint.config.js", "eslint.config.mjs", "eslint.config.cjs"];
@@ -331,7 +332,7 @@ impl LspAdapter for EsLintLspAdapter {
         let workspace_root = delegate.worktree_root_path();
 
         let eslint_user_settings = cx.update(|cx| {
-            language_server_settings(delegate.as_ref(), Self::SERVER_NAME, cx)
+            language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
                 .and_then(|s| s.settings.clone())
                 .unwrap_or_default()
         })?;
@@ -403,7 +404,7 @@ impl LspAdapter for EsLintLspAdapter {
     }
 
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(Self::SERVER_NAME.into())
+        Self::SERVER_NAME.clone()
     }
 
     async fn fetch_latest_server_version(

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -48,11 +48,11 @@ struct TypeScriptVersions {
     server_version: String,
 }
 
-const SERVER_NAME: &str = "vtsls";
+const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("vtsls");
 #[async_trait(?Send)]
 impl LspAdapter for VtslsLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(SERVER_NAME.into())
+        SERVER_NAME.clone()
     }
 
     async fn fetch_latest_server_version(
@@ -74,7 +74,7 @@ impl LspAdapter for VtslsLspAdapter {
         cx: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx.update(|cx| {
-            language_server_settings(delegate, SERVER_NAME, cx).and_then(|s| s.binary.clone())
+            language_server_settings(delegate, &SERVER_NAME, cx).and_then(|s| s.binary.clone())
         });
 
         match configured_binary {
@@ -267,7 +267,7 @@ impl LspAdapter for VtslsLspAdapter {
         cx: &mut AsyncAppContext,
     ) -> Result<Value> {
         let override_options = cx.update(|cx| {
-            language_server_settings(delegate.as_ref(), SERVER_NAME, cx)
+            language_server_settings(delegate.as_ref(), &SERVER_NAME, cx)
                 .and_then(|s| s.settings.clone())
         })?;
 

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -30,7 +30,7 @@ pub struct YamlLspAdapter {
 }
 
 impl YamlLspAdapter {
-    const SERVER_NAME: &'static str = "yaml-language-server";
+    const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("yaml-language-server");
     pub fn new(node: Arc<dyn NodeRuntime>) -> Self {
         YamlLspAdapter { node }
     }
@@ -39,7 +39,7 @@ impl YamlLspAdapter {
 #[async_trait(?Send)]
 impl LspAdapter for YamlLspAdapter {
     fn name(&self) -> LanguageServerName {
-        LanguageServerName(Self::SERVER_NAME.into())
+        Self::SERVER_NAME.clone()
     }
 
     async fn check_if_user_installed(
@@ -49,7 +49,7 @@ impl LspAdapter for YamlLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let configured_binary = cx
             .update(|cx| {
-                language_server_settings(delegate, Self::SERVER_NAME, cx)
+                language_server_settings(delegate, &Self::SERVER_NAME, cx)
                     .and_then(|s| s.binary.clone())
             })
             .ok()??;
@@ -145,7 +145,7 @@ impl LspAdapter for YamlLspAdapter {
         let mut options = serde_json::json!({"[yaml]": {"editor.tabSize": tab_size}});
 
         let project_options = cx.update(|cx| {
-            language_server_settings(delegate.as_ref(), Self::SERVER_NAME, cx)
+            language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
                 .and_then(|s| s.settings.clone())
         })?;
         if let Some(override_options) = project_options {

--- a/crates/project/src/prettier_store.rs
+++ b/crates/project/src/prettier_store.rs
@@ -338,7 +338,7 @@ impl PrettierStore {
             prettier_store
                 .update(cx, |prettier_store, cx| {
                     let name = if is_default {
-                        LanguageServerName(Arc::from("prettier (default)"))
+                        LanguageServerName("prettier (default)".to_string().into())
                     } else {
                         let worktree_path = worktree_id
                             .and_then(|id| {
@@ -366,7 +366,7 @@ impl PrettierStore {
                             }
                             None => format!("prettier ({})", prettier_dir.display()),
                         };
-                        LanguageServerName(Arc::from(name))
+                        LanguageServerName(name.into())
                     };
                     cx.emit(PrettierStoreEvent::LanguageServerAdded {
                         new_server_id,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1,6 +1,7 @@
 use collections::HashMap;
 use fs::Fs;
 use gpui::{AppContext, AsyncAppContext, BorrowAppContext, EventEmitter, Model, ModelContext};
+use language::LanguageServerName;
 use paths::local_settings_file_relative_path;
 use rpc::{proto, AnyProtoClient, TypedEnvelope};
 use schemars::JsonSchema;
@@ -27,7 +28,7 @@ pub struct ProjectSettings {
     /// name to the lsp value.
     /// Default: null
     #[serde(default)]
-    pub lsp: HashMap<Arc<str>, LspSettings>,
+    pub lsp: HashMap<LanguageServerName, LspSettings>,
 
     /// Configuration for Git-related features
     #[serde(default)]

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -205,7 +205,7 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
             AllLanguageSettings::get_global(cx)
                 .language(Some(&"Rust".into()))
                 .language_servers,
-            ["custom-rust-analyzer".into()]
+            ["custom-rust-analyzer".to_string()]
         )
     });
 
@@ -264,7 +264,7 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
             )
             .language(Some(&"Rust".into()))
             .language_servers,
-            ["override-rust-analyzer".into()]
+            ["override-rust-analyzer".to_string()]
         )
     });
 
@@ -274,7 +274,7 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
             all_language_settings(file, cx)
                 .language(Some(&"Rust".into()))
                 .language_servers,
-            ["override-rust-analyzer".into()]
+            ["override-rust-analyzer".to_string()]
         )
     });
 }
@@ -357,7 +357,7 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
             all_language_settings(file, cx)
                 .language(Some(&"Rust".into()))
                 .language_servers,
-            ["rust-analyzer".into()]
+            ["rust-analyzer".to_string()]
         )
     });
 


### PR DESCRIPTION
This pushes the new LanguageServerName type to more places.

As both languages and language servers were identified by Arc<str>, it was
sometimes hard to tell which was intended.

Release Notes:

- N/A
