### PR TITLE
editor: Support opening files in splits from the FileFinder

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -622,7 +622,11 @@
   },
   {
     "context": "FileFinder",
-    "bindings": { "ctrl-shift-p": "file_finder::SelectPrev" }
+    "bindings": {
+      "ctrl-shift-p": "file_finder::SelectPrev",
+      "ctrl-shift-r": "pane::SplitRight",
+      "ctrl-shift-b": "pane::SplitDown"
+    }
   },
   {
     "context": "TabSwitcher",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -623,7 +623,11 @@
   },
   {
     "context": "FileFinder",
-    "bindings": { "cmd-shift-p": "file_finder::SelectPrev" }
+    "bindings": {
+      "cmd-shift-p": "file_finder::SelectPrev",
+      "cmd-shift-r": "pane::SplitRight",
+      "cmd-shift-b": "pane::SplitDown"
+    }
   },
   {
     "context": "TabSwitcher",

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -29,9 +29,12 @@ use std::{
     },
 };
 use text::Point;
-use ui::{prelude::*, HighlightedLabel, ListItem, ListItemSpacing};
+use ui::{prelude::*, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing};
 use util::{paths::PathWithPosition, post_inc, ResultExt};
-use workspace::{item::PreviewTabsSettings, notifications::NotifyResultExt, ModalView, Workspace};
+use workspace::{
+    item::PreviewTabsSettings, notifications::NotifyResultExt, pane, ModalView, SplitDirection,
+    Workspace,
+};
 
 actions!(file_finder, [SelectPrev]);
 
@@ -137,6 +140,53 @@ impl FileFinder {
         self.init_modifiers = Some(cx.modifiers());
         cx.dispatch_action(Box::new(menu::SelectPrev));
     }
+
+    fn go_to_file_split_left(&mut self, _: &pane::SplitLeft, cx: &mut ViewContext<Self>) {
+        self.go_to_file_split_inner(SplitDirection::Left, cx)
+    }
+
+    fn go_to_file_split_right(&mut self, _: &pane::SplitRight, cx: &mut ViewContext<Self>) {
+        self.go_to_file_split_inner(SplitDirection::Right, cx)
+    }
+
+    fn go_to_file_split_up(&mut self, _: &pane::SplitUp, cx: &mut ViewContext<Self>) {
+        self.go_to_file_split_inner(SplitDirection::Up, cx)
+    }
+
+    fn go_to_file_split_down(&mut self, _: &pane::SplitDown, cx: &mut ViewContext<Self>) {
+        self.go_to_file_split_inner(SplitDirection::Down, cx)
+    }
+
+    fn go_to_file_split_inner(
+        &mut self,
+        split_direction: SplitDirection,
+        cx: &mut ViewContext<Self>,
+    ) {
+        self.picker.update(cx, |picker, cx| {
+            let delegate = &mut picker.delegate;
+            if let Some(workspace) = delegate.workspace.upgrade() {
+                if let Some(m) = delegate.matches.get(delegate.selected_index()) {
+                    let path = match &m {
+                        Match::History { path, .. } => {
+                            let worktree_id = path.project.worktree_id;
+                            ProjectPath {
+                                worktree_id,
+                                path: Arc::clone(&path.project.path),
+                            }
+                        }
+                        Match::Search(m) => ProjectPath {
+                            worktree_id: WorktreeId::from_usize(m.0.worktree_id),
+                            path: m.0.path.clone(),
+                        },
+                    };
+                    let open_task = workspace.update(cx, move |workspace, cx| {
+                        workspace.split_path_preview(path, false, Some(split_direction), cx)
+                    });
+                    open_task.detach_and_log_err(cx);
+                }
+            }
+        })
+    }
 }
 
 impl EventEmitter<DismissEvent> for FileFinder {}
@@ -154,6 +204,10 @@ impl Render for FileFinder {
             .w(rems(34.))
             .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
             .on_action(cx.listener(Self::handle_select_prev))
+            .on_action(cx.listener(Self::go_to_file_split_left))
+            .on_action(cx.listener(Self::go_to_file_split_right))
+            .on_action(cx.listener(Self::go_to_file_split_up))
+            .on_action(cx.listener(Self::go_to_file_split_down))
             .child(self.picker.clone())
     }
 }
@@ -930,7 +984,7 @@ impl PickerDelegate for FileFinderDelegate {
                             let allow_preview =
                                 PreviewTabsSettings::get_global(cx).enable_preview_from_file_finder;
                             if secondary {
-                                workspace.split_path_preview(project_path, allow_preview, cx)
+                                workspace.split_path_preview(project_path, allow_preview, None, cx)
                             } else {
                                 workspace.open_path_preview(
                                     project_path,
@@ -1093,6 +1147,44 @@ impl PickerDelegate for FileFinderDelegate {
                                 .color(Color::Muted),
                         ),
                 ),
+        )
+    }
+
+    fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<AnyElement> {
+        let action_source = self
+            .workspace
+            .update(cx, |workspace, cx| workspace.active_pane().focus_handle(cx))
+            .ok()?;
+        Some(
+            h_flex()
+                .w_full()
+                .border_t_1()
+                .py_2()
+                .pr_2()
+                .border_color(cx.theme().colors().border)
+                .justify_end()
+                .gap_4()
+                .child(
+                    Button::new("split_right", "Split right")
+                        .label_size(LabelSize::Small)
+                        .key_binding(KeyBinding::for_action_in(
+                            &pane::SplitRight,
+                            &action_source,
+                            cx,
+                        ))
+                        .on_click(|_, cx| cx.dispatch_action(pane::SplitRight.boxed_clone())),
+                )
+                .child(
+                    Button::new("split_down", "Split down")
+                        .label_size(LabelSize::Small)
+                        .key_binding(KeyBinding::for_action_in(
+                            &pane::SplitDown,
+                            &action_source,
+                            cx,
+                        ))
+                        .on_click(|_, cx| cx.dispatch_action(pane::SplitDown.boxed_clone())),
+                )
+                .into_any(),
         )
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2606,13 +2606,14 @@ impl Workspace {
         path: impl Into<ProjectPath>,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<Box<dyn ItemHandle>, anyhow::Error>> {
-        self.split_path_preview(path, false, cx)
+        self.split_path_preview(path, false, None, cx)
     }
 
     pub fn split_path_preview(
         &mut self,
         path: impl Into<ProjectPath>,
         allow_preview: bool,
+        split_direction: Option<SplitDirection>,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<Box<dyn ItemHandle>, anyhow::Error>> {
         let pane = self.last_active_center_pane.clone().unwrap_or_else(|| {
@@ -2633,7 +2634,8 @@ impl Workspace {
             let (project_entry_id, build_item) = task.await?;
             this.update(&mut cx, move |this, cx| -> Option<_> {
                 let pane = pane.upgrade()?;
-                let new_pane = this.split_pane(pane, SplitDirection::Right, cx);
+                let new_pane =
+                    this.split_pane(pane, split_direction.unwrap_or(SplitDirection::Right), cx);
                 new_pane.update(cx, |new_pane, cx| {
                     Some(new_pane.open_item(project_entry_id, true, allow_preview, cx, build_item))
                 })


### PR DESCRIPTION
Add action handlers to the FileFinder to support splitting in all directions. Additionally, push some default keymaps to support splitting right (vertically) and down (horizontally) in both MacOS and Linux.

These actions are also exposed via buttons in the FileFinder footer.

**I don't think this is yet mergable given the behavior I'm seeing around the displayed keybindings**

In the file finder we don't have a focus handle that can be used to query the keybindings for a shortcut. At the Zed hack day in Montreal, @SomeoneToIgnore and I landed upon querying the active pane and using that, but it doesn't quite fit as the intent here is to allow users to set a different keybinding for opening files within splits within the finder.

Release Notes:

- Add action handlers to the FileFinder to support splitting in all directions, and expose split actions in the FileFinder footer.
