### PR TITLE
docs: Add missing `ui_font_size` option in `configuring-zed.md`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -159,7 +159,7 @@ For example, to use `Nerd Font` as a fallback, add the following to your setting
 
 **Options**
 
-`integer` values
+`integer` values between `6` and `100`
 
 ## Buffer Font Weight
 
@@ -2136,7 +2136,7 @@ Float values between `0.0` and `0.9`, where:
 
 **Options**
 
-`integer` values
+`integer` values between `6` and `100`
 
 ## An example configuration:
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -159,7 +159,7 @@ For example, to use `Nerd Font` as a fallback, add the following to your setting
 
 **Options**
 
-`integer` values between `6` and `100`
+`integer` values from `6` to `100` pixels (inclusive)
 
 ## Buffer Font Weight
 
@@ -2136,7 +2136,7 @@ Float values between `0.0` and `0.9`, where:
 
 **Options**
 
-`integer` values between `6` and `100`
+`integer` values from `6` to `100` pixels (inclusive)
 
 ## An example configuration:
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2128,6 +2128,16 @@ Float values between `0.0` and `0.9`, where:
 }
 ```
 
+## UI Font Size
+
+- Description: The default font size for text in the UI.
+- Setting: `ui_font_size`
+- Default: `16`
+
+**Options**
+
+`integer` values
+
 ## An example configuration:
 
 ```json


### PR DESCRIPTION
Added `ui_font_size`, an option that works in the editor but is missing from the documentation.

Release Notes:

- N/A
