### PR TITLE
docs: Fix codeblock style bug

### DIFF
--- a/docs/theme/css/chrome.css
+++ b/docs/theme/css/chrome.css
@@ -325,6 +325,8 @@ pre > .playground {
 pre > code {
   display: block;
   padding: 1rem;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 /* FIXME: ACE editors overlap their buttons because ACE does absolute


### PR DESCRIPTION
Fixed a bug where long code would break the codeblock box.

Before: 

![before](https://github.com/user-attachments/assets/56763aa0-5834-4661-b8da-e045b31ea8fc)

After update:

![after](https://github.com/user-attachments/assets/243c72d9-fdc4-4538-87ad-ae7ce387cb4e)



Release Notes:

- N/A
