### PR TITLE
docs: Remove `default_dock_anchor` in `configuring-zed.md`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -381,12 +381,6 @@ List of `string` values
 "cursor_shape": "hollow"
 ```
 
-## Default Dock Anchor
-
-- Description: The default anchor for new docks.
-- Setting: `default_dock_anchor`
-- Default: `bottom`
-
 **Options**
 
 1. Position the dock attached to the bottom of the workspace: `bottom`


### PR DESCRIPTION
Removed the deprecated option `default_dock_anchor` in `configuring-zed.md`

Note: https://zed.dev/blog/new-panel-system

Release Notes:

- N/A