### PR TITLE
Resolve completions properly

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -615,8 +615,14 @@ impl LanguageServer {
                             snippet_support: Some(true),
                             resolve_support: Some(CompletionItemCapabilityResolveSupport {
                                 properties: vec![
-                                    "documentation".to_string(),
                                     "additionalTextEdits".to_string(),
+                                    "command".to_string(),
+                                    "detail".to_string(),
+                                    "documentation".to_string(),
+                                    "filterText".to_string(),
+                                    "labelDetails".to_string(),
+                                    "tags".to_string(),
+                                    "textEdit".to_string(),
                                 ],
                             }),
                             insert_replace_support: Some(true),

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1615,10 +1615,6 @@ impl LspStore {
                     let (server_id, completion) = {
                         let completions_guard = completions.read();
                         let completion = &completions_guard[completion_index];
-                        if completion.documentation.is_some() {
-                            continue;
-                        }
-
                         did_resolve = true;
                         let server_id = completion.server_id;
                         let completion = completion.lsp_completion.clone();
@@ -1643,10 +1639,6 @@ impl LspStore {
                     let (server_id, completion) = {
                         let completions_guard = completions.read();
                         let completion = &completions_guard[completion_index];
-                        if completion.documentation.is_some() {
-                            continue;
-                        }
-
                         let server_id = completion.server_id;
                         let completion = completion.lsp_completion.clone();
 
@@ -1743,6 +1735,10 @@ impl LspStore {
                 completion.lsp_completion.insert_text_format = completion_item.insert_text_format;
             }
         }
+
+        let mut completions = completions.write();
+        let completion = &mut completions[completion_index];
+        completion.lsp_completion = completion_item;
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1763,6 +1759,7 @@ impl LspStore {
             buffer_id: buffer_id.into(),
         };
 
+        // TODO kb this has to return the entire LSP completion instead, not just the docs
         let Some(response) = client
             .request(request)
             .await

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -1219,6 +1219,7 @@ message ResolveCompletionDocumentationResponse {
     Anchor old_start = 3;
     Anchor old_end = 4;
     string new_text = 5;
+    bytes lsp_completion = 6;
 }
 
 message ResolveInlayHint {


### PR DESCRIPTION
Related to https://github.com/rust-lang/rust-analyzer/pull/18167

* Declare more completion item fields in the client completion resolve capabilities
* Do resolve completions even if their docs are present
* Instead, do not resolve completions that could not be resolved when handling the remote client resolve requests
* Do replace the old lsp completion data with the resolved one

Release Notes:

- Improved completion resolve mechanism
