### PR TITLE
remote_server: Fix add folder to project from project panel not working as expected

### DIFF
--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -376,6 +376,7 @@ impl WorktreeStore {
 
     pub fn set_worktrees_from_proto(
         &mut self,
+        project_id: u64,
         worktrees: Vec<proto::WorktreeMetadata>,
         replica_id: ReplicaId,
         cx: &mut ModelContext<Self>,
@@ -408,7 +409,7 @@ impl WorktreeStore {
                 self.worktrees.push(handle);
             } else {
                 self.add(
-                    &Worktree::remote(self.remote_id, replica_id, worktree, client.clone(), cx),
+                    &Worktree::remote(project_id, replica_id, worktree, client.clone(), cx),
                     cx,
                 );
             }


### PR DESCRIPTION
Before we can add folder to project from project_panel, but cannot open the entry.

If I understant, project_id should also need to set_worktree_from_proto.

I tested local, that work. 

Release Notes:

- N/A
