### PR TITLE
Use fenix toolchain in nix shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1725409566,
-        "narHash": "sha256-PrtLmqhM6UtJP7v7IGyzjBFhbG4eOAHT6LPYOFmYfbk=",
+        "lastModified": 1727060013,
+        "narHash": "sha256-/fC5YlJy4IoAW9GhkJiwyzk0K/gQd9Qi4rRcoweyG9E=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7e4586bad4e3f8f97a9271def747cf58c4b68f3c",
+        "rev": "6b40cc876c929bfe1e3a24bf538ce3b5622646ba",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1726813972,
-        "narHash": "sha256-t6turZgoSAVgj7hn5mxzNlLOeVeZvymFo8+ymB52q34=",
+        "lastModified": 1727073227,
+        "narHash": "sha256-1kmkEQmFfGVuPBasqSZrNThqyMDV1SzTalQdRZxtDRs=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "251caeafc75b710282ee7e375800f75f4c8c5727",
+        "rev": "88cc292eb3c689073c784d6aecc0edbd47e12881",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726642912,
-        "narHash": "sha256-wiZzKGHRAhItEuoE599Wm3ic+Lg/NykuBvhb+awf7N8=",
+        "lastModified": 1726937504,
+        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "395c52d142ec1df377acd67db6d4a22950b02a98",
+        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,27 +17,34 @@
     fenix,
     ...
   }: let
-    forAllSystems = function:
-      nixpkgs.lib.genAttrs [
-        "x86_64-linux"
-        "aarch64-linux"
-      ] (system:
-        function (import nixpkgs {
-          inherit system;
-          overlays = [fenix.overlays.default];
-        }));
+    systems = ["x86_64-linux" "aarch64-linux"];
+
+    overlays = {
+      fenix = fenix.overlays.default;
+      rust-toolchain = final: prev: {
+        rustToolchain = final.fenix.stable.toolchain;
+      };
+      zed-editor = final: prev: {
+        zed-editor = final.callPackage ./nix/build.nix {
+          craneLib = (crane.mkLib final).overrideToolchain final.rustToolchain;
+          rustPlatform = final.makeRustPlatform {
+            inherit (final.rustToolchain) cargo rustc;
+          };
+        };
+      };
+    };
+
+    mkPkgs = system:
+      import nixpkgs {
+        inherit system;
+        overlays = builtins.attrValues overlays;
+      };
+
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f (mkPkgs system));
   in {
-    packages = forAllSystems (pkgs: let
-      craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.fenix.stable.toolchain);
-      rustPlatform = pkgs.makeRustPlatform {
-        inherit (pkgs.fenix.stable.toolchain) cargo rustc;
-      };
-      nightlyBuild = pkgs.callPackage ./nix/build.nix {
-        inherit craneLib rustPlatform;
-      };
-    in {
-      zed-editor = nightlyBuild;
-      default = nightlyBuild;
+    packages = forAllSystems (pkgs: {
+      zed-editor = pkgs.zed-editor;
+      default = pkgs.zed-editor;
     });
 
     devShells = forAllSystems (pkgs: {
@@ -46,13 +53,10 @@
 
     formatter = forAllSystems (pkgs: pkgs.alejandra);
 
-    overlays.default = final: prev: {
-      zed-editor = final.callPackage ./nix/build.nix {
-        craneLib = (crane.mkLib final).overrideToolchain (p: p.fenix.stable.toolchain);
-        rustPlatform = final.makeRustPlatform {
-          inherit (final.fenix.stable.toolchain) cargo rustc;
-        };
+    overlays =
+      overlays
+      // {
+        default = nixpkgs.lib.composeManyExtensions (builtins.attrValues overlays);
       };
-    };
   };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -20,8 +20,7 @@ in
       wayland
       xorg.libxcb
       vulkan-loader
-      rustc
-      cargo
+      rustToolchain
     ];
   in
     pkgs.mkShell.override {inherit stdenv;} {


### PR DESCRIPTION
In #17974 we explicitly depend on rustc/cargo for the nix devShell, however the fenix overlay that contains the latest stable versions was not being applied to that shell. This led to the shell inheriting whatever rustc/cargo was on nixos-unstable from nixpkgs, which sometimes lags behind. This change fixes that, and also restructures the flake to ensure that all outputs rely on the overlaid `pkgs`.

Release Notes:

- N/A
