### PR TITLE
Add a rather-conservative stale issue action in dry-run mode

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,0 +1,33 @@
+name: "Close Stale Issues"
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            Hi there! 👋
+
+            We're tidying up our issue tracker. Is this still a problem in the latest version?
+
+            If we don't hear back in a week, we'll close this for housekeeping. No worries though - just respond to keep it open, or feel free to open a new issue later if needed.
+
+            Thanks for your help.
+          close-issue-message: "This issue was closed due to inactivity; feel free to open a new issue if you're still experiencing this problem!"
+          days-before-stale: 365
+          days-before-close: 7
+          only-labels: "defect,panic / crash"
+          only-issues: true
+          operations-per-run: 100
+          ascending: true
+          enable-statistics: true
+          debug-only: true
+          ignore-updates: true
+          ignore-issue-updates: true
+          stale-issue-label: "stale"

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -14,11 +14,9 @@ jobs:
           stale-issue-message: >
             Hi there! 👋
 
-            We're tidying up our issue tracker. Is this still a problem in the latest version?
+            We're working to clean up our issue tracker by closing older issues that might not be relevant anymore. Are you able to reproduce this issue in the latest version of Zed? If so, please let us know by commenting on this issue and we will keep it open; otherwise, we'll close it in a week. Feel free to open a new issue if you're seeing this message after the issue has been closed.
 
-            If we don't hear back in a week, we'll close this for housekeeping. No worries though - just respond to keep it open, or feel free to open a new issue later if needed.
-
-            Thanks for your help.
+            Thanks for your help!
           close-issue-message: "This issue was closed due to inactivity; feel free to open a new issue if you're still experiencing this problem!"
           days-before-stale: 365
           days-before-close: 7

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -23,11 +23,8 @@ jobs:
           days-before-stale: 365
           days-before-close: 7
           only-labels: "defect,panic / crash"
-          only-issues: true
           operations-per-run: 100
           ascending: true
           enable-statistics: true
           debug-only: true
-          ignore-updates: true
-          ignore-issue-updates: true
           stale-issue-label: "stale"

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -22,7 +22,7 @@ jobs:
           close-issue-message: "This issue was closed due to inactivity; feel free to open a new issue if you're still experiencing this problem!"
           days-before-stale: 365
           days-before-close: 7
-          only-labels: "defect,panic / crash"
+          only-issue-labels: "defect,panic / crash"
           operations-per-run: 100
           ascending: true
           enable-statistics: true


### PR DESCRIPTION
Zed is becoming more popular and our issue tracker is only growing larger and larger. I realize that a stale issue action can be controversial, but the way we currently manage issues hasn't scaled well and it will only get worse. We need some crowd-sourced system. Let's ask those who have opened issues if their issues are still valid. This is rather conservative and only targets bugs and crashes. I'll run it in debug mode, report the results, and enable it if it feels right. We can always turn this off if users end up really not liking it.

My original rules were:

```txt
If an issue is old enough (12 months or older)
AND if there are no recent comments from the team (last dev comment is older than 6 months)
AND it has less than X upvotes (5)
AND it does not have an open PR linked to it
AND is a "defect" or "panic / crash"
AND does not have a "ignore top-ranking issues" label
AND was not opened by a org member
AND is open
AND is issue (not a pull request)

THEN close the issue with a kind message.
```

But only some of these were actually supported in the configuration.

Release Notes:

- N/A
