### PR TITLE
Add '?plain=1' to Permalinks on GitLab/GitHub for md files

### DIFF
--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -145,6 +145,9 @@ impl GitHostingProvider for Github {
             .base_url()
             .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
             .unwrap();
+        if path.ends_with(".md") {
+            permalink.set_query(Some("plain=1"));
+        }
         permalink.set_fragment(
             selection
                 .map(|selection| self.line_fragment(&selection))

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -65,6 +65,9 @@ impl GitHostingProvider for Gitlab {
             .base_url()
             .join(&format!("{owner}/{repo}/-/blob/{sha}/{path}"))
             .unwrap();
+        if path.ends_with(".md") {
+            permalink.set_query(Some("plain=1"));
+        }
         permalink.set_fragment(
             selection
                 .map(|selection| self.line_fragment(&selection))


### PR DESCRIPTION
Improve our Permalinks to markdown files:
<img width="767" alt="Screenshot 2024-09-23 at 14 07 55" src="https://github.com/user-attachments/assets/49ac32ab-b5b5-42a9-a298-f47372136eeb">

Source: [GitHub Docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet)

GitLab supports the same syntax.

Thanks to @Moshyfawn for accidentally finding this in #18228

Release Notes:

- Improved Permalinks to markdown files on GitHub and GitLab