### PR TITLE
lua: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14617,7 +14617,7 @@ dependencies = [
 
 [[package]]
 name = "zed_lua"
-version = "0.0.4"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14617,7 +14617,7 @@ dependencies = [
 
 [[package]]
 name = "zed_lua"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/lua/Cargo.toml
+++ b/extensions/lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_lua"
-version = "0.0.4"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/lua/Cargo.toml
+++ b/extensions/lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_lua"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/lua/extension.toml
+++ b/extensions/lua/extension.toml
@@ -1,7 +1,7 @@
 id = "lua"
 name = "Lua"
 description = "Lua support."
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/lua/extension.toml
+++ b/extensions/lua/extension.toml
@@ -1,7 +1,7 @@
 id = "lua"
 name = "Lua"
 description = "Lua support."
-version = "0.0.4"
+version = "0.1.0"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Lua extension to v0.1.0

- https://github.com/zed-industries/zed/pull/18199
- https://github.com/zed-industries/zed/pull/16955

@maxdeviant I haven't bumped an extension before.
Let me know if this isn't the correct process.

Release Notes:

- N/A
