### PR TITLE
Don't highlight Python function arguments as variables

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -1,4 +1,3 @@
-(parameter (identifier) @variable)
 (attribute attribute: (identifier) @property)
 (type (identifier) @type)
 


### PR DESCRIPTION
Works on 
- #14892

Follow up to 
- #17473
- https://github.com/zed-industries/zed/pull/17984#issuecomment-2369815207

Release Notes:

- N/A
