### PR TITLE
Fix wrong default value of `ui_font_features`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -60,7 +60,7 @@
   // The OpenType features to enable for text in the UI
   "ui_font_features": {
     // Disable ligatures:
-    "calt": false
+    // "calt": false
   },
   // The weight of the UI font in standard CSS units from 100 to 900.
   "ui_font_weight": 400,


### PR DESCRIPTION
I'm not sure, but I think it makes sense to have the same default as the buffer font. If I'm wrong, please let me know.

Release Notes:

- N/A
