### PR TITLE
ssh project: Handle multiple paths and worktrees correctly

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -268,7 +268,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 .as_ref()
                                 .map(|port| port.to_string())
                                 .unwrap_or_default(),
-                            ssh_project.path,
+                            ssh_project.paths.join(","),
                             ssh_project
                                 .user
                                 .as_ref()
@@ -403,7 +403,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 password: None,
                             };
 
-                            let paths = vec![PathBuf::from(ssh_project.path.clone())];
+                            let paths = ssh_project.paths.iter().map(|path| PathBuf::from(path)).collect();
 
                             cx.spawn(|_, mut cx| async move {
                                 open_ssh_project(connection_options, paths, app_state, open_options, &mut cx).await
@@ -460,9 +460,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                     .filter_map(|i| paths.paths().get(*i).cloned())
                     .collect(),
             ),
-            SerializedWorkspaceLocation::Ssh(ssh_project) => {
-                Arc::new(vec![PathBuf::from(ssh_project.ssh_url())])
-            }
+            SerializedWorkspaceLocation::Ssh(ssh_project) => Arc::new(ssh_project.ssh_urls()),
             SerializedWorkspaceLocation::DevServer(dev_server_project) => {
                 Arc::new(vec![PathBuf::from(format!(
                     "{}:{}",

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -403,7 +403,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 password: None,
                             };
 
-                            let paths = ssh_project.paths.iter().map(|path| PathBuf::from(path)).collect();
+                            let paths = ssh_project.paths.iter().map(PathBuf::from).collect();
 
                             cx.spawn(|_, mut cx| async move {
                                 open_ssh_project(connection_options, paths, app_state, open_options, &mut cx).await

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5516,14 +5516,14 @@ pub fn open_ssh_project(
     cx: &mut AppContext,
 ) -> Task<Result<()>> {
     cx.spawn(|mut cx| async move {
-        // TODO: Handle multiple paths
-        let path = paths.iter().next().cloned().unwrap_or_default();
-
         let serialized_ssh_project = persistence::DB
             .get_or_create_ssh_project(
                 connection_options.host.clone(),
                 connection_options.port,
-                path.to_string_lossy().to_string(),
+                paths
+                    .iter()
+                    .map(|path| path.to_string_lossy().to_string())
+                    .collect::<Vec<_>>(),
                 connection_options.username.clone(),
             )
             .await?;


### PR DESCRIPTION
This makes SSH projects work with `ssh_connections` that have multiple paths:

```json
{
  "ssh_connections": [
    {
      "host": "127.0.0.1",
      "projects": [
        {
          "paths": [
            "/Users/thorstenball/work/projs/go-proj",
            "/Users/thorstenball/work/projs/rust-proj"
          ]
        }
      ]
    }
  ]
}
```

@ConradIrwin @mikayla-maki since this wasn't really released yet, we didn't create a full-on migration, so old ssh projects that were already serialized need to either be manually deleted from the database, or the whole local DB wiped.

Release Notes:

- N/A
