### PR TITLE
Implement grapheme support for supermaven completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11006,6 +11006,7 @@ dependencies = [
  "text",
  "theme",
  "ui",
+ "unicode-segmentation",
  "util",
  "windows 0.58.0",
 ]

--- a/crates/supermaven/Cargo.toml
+++ b/crates/supermaven/Cargo.toml
@@ -29,6 +29,7 @@ supermaven_api.workspace = true
 smol.workspace = true
 text.workspace = true
 ui.workspace = true
+unicode-segmentation.workspace = true
 util.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
Closes [#18278](https://github.com/zed-industries/zed/issues/18278)

Release Notes:

- Fixed a panic when graphemes are included in supermaven completions
