### PR TITLE
collab: Fix GitHub user retrieval in seed script

### DIFF
--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -298,6 +298,12 @@ impl Database {
         result
     }
 
+    /// Returns all feature flags.
+    pub async fn list_feature_flags(&self) -> Result<Vec<feature_flag::Model>> {
+        self.transaction(|tx| async move { Ok(feature_flag::Entity::find().all(&*tx).await?) })
+            .await
+    }
+
     /// Creates a new feature flag.
     pub async fn create_user_flag(&self, flag: &str, enabled_for_all: bool) -> Result<FlagId> {
         self.transaction(|tx| async move {


### PR DESCRIPTION
This PR fixes the GitHub user retrieval in the database seed script.

The users returned from the [list users](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#list-users) endpoint don't have a `created_at` timestamp, so we need to fetch them individually.

I want to rework this further at a later date, this is just a bandaid to get things working again.

Release Notes:

- N/A
