### PR TITLE
Fix unnecessarily-specific struct pattern in rust outline query

### DIFF
--- a/crates/languages/src/rust/outline.scm
+++ b/crates/languages/src/rust/outline.scm
@@ -4,8 +4,7 @@
 (struct_item
     (visibility_modifier)? @context
     "struct" @context
-    name: (_) @name
-    body: (_ "{" @open (_)* "}" @close)) @item
+    name: (_) @name) @item
 
 (enum_item
     (visibility_modifier)? @context


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/18294

Release Notes:

- Fixed a recent regression where tuple and unit structs were omitted from the outline view in Rust (#18294).
