### PR TITLE
Implement missing low_speed_timeout functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7524,6 +7524,7 @@ dependencies = [
  "anyhow",
  "futures 0.3.30",
  "http_client",
+ "isahc",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/ollama/Cargo.toml
+++ b/crates/ollama/Cargo.toml
@@ -19,6 +19,7 @@ schemars = ["dep:schemars"]
 anyhow.workspace = true
 futures.workspace = true
 http_client.workspace = true
+isahc.workspace = true
 schemars = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Release Notes:

- Fixed usage of low_speed_timeout_in_seconds configuration parameter that was ignored in ollama stream_chat_completion function