### PR TITLE
Add handling of X11 scroll button presses

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -45,7 +45,7 @@ use crate::{
 
 use super::x11::X11Client;
 
-pub(crate) const SCROLL_LINES: f64 = 3.0;
+pub(crate) const SCROLL_LINES: f32 = 3.0;
 
 // Values match the defaults on GTK.
 // Taken from https://github.com/GNOME/gtk/blob/main/gtk/gtksettings.c#L320

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1634,10 +1634,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                 let scroll_delta = state.discrete_scroll_delta.get_or_insert(point(0.0, 0.0));
                 match axis {
                     wl_pointer::Axis::VerticalScroll => {
-                        scroll_delta.y += discrete as f32 * axis_modifier * SCROLL_LINES as f32;
+                        scroll_delta.y += discrete as f32 * axis_modifier * SCROLL_LINES;
                     }
                     wl_pointer::Axis::HorizontalScroll => {
-                        scroll_delta.x += discrete as f32 * axis_modifier * SCROLL_LINES as f32;
+                        scroll_delta.x += discrete as f32 * axis_modifier * SCROLL_LINES;
                     }
                     _ => unreachable!(),
                 }
@@ -1662,10 +1662,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                 let wheel_percent = value120 as f32 / 120.0;
                 match axis {
                     wl_pointer::Axis::VerticalScroll => {
-                        scroll_delta.y += wheel_percent * axis_modifier * SCROLL_LINES as f32;
+                        scroll_delta.y += wheel_percent * axis_modifier * SCROLL_LINES;
                     }
                     wl_pointer::Axis::HorizontalScroll => {
-                        scroll_delta.x += wheel_percent * axis_modifier * SCROLL_LINES as f32;
+                        scroll_delta.x += wheel_percent * axis_modifier * SCROLL_LINES;
                     }
                     _ => unreachable!(),
                 }

--- a/crates/gpui/src/platform/linux/x11/event.rs
+++ b/crates/gpui/src/platform/linux/x11/event.rs
@@ -5,13 +5,29 @@ use x11rb::protocol::{
 
 use crate::{Modifiers, MouseButton, NavigationDirection};
 
-pub(crate) fn button_of_key(detail: xproto::Button) -> Option<MouseButton> {
+pub(crate) enum ButtonOrScroll {
+    Button(MouseButton),
+    Scroll(ScrollDirection),
+}
+
+pub(crate) enum ScrollDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+pub(crate) fn button_or_scroll_from_event_detail(detail: u32) -> Option<ButtonOrScroll> {
     Some(match detail {
-        1 => MouseButton::Left,
-        2 => MouseButton::Middle,
-        3 => MouseButton::Right,
-        8 => MouseButton::Navigate(NavigationDirection::Back),
-        9 => MouseButton::Navigate(NavigationDirection::Forward),
+        1 => ButtonOrScroll::Button(MouseButton::Left),
+        2 => ButtonOrScroll::Button(MouseButton::Middle),
+        3 => ButtonOrScroll::Button(MouseButton::Right),
+        4 => ButtonOrScroll::Scroll(ScrollDirection::Up),
+        5 => ButtonOrScroll::Scroll(ScrollDirection::Down),
+        6 => ButtonOrScroll::Scroll(ScrollDirection::Left),
+        7 => ButtonOrScroll::Scroll(ScrollDirection::Right),
+        8 => ButtonOrScroll::Button(MouseButton::Navigate(NavigationDirection::Back)),
+        9 => ButtonOrScroll::Button(MouseButton::Navigate(NavigationDirection::Forward)),
         _ => return None,
     })
 }


### PR DESCRIPTION
Might address some user reports in #14089, #15970, #17230

Release Notes:

- Fixed scrolling on Linux/X11 for devices that only use button press events