### PR TITLE
lsp: Remove reinstall, update config

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -782,7 +782,7 @@
   /// or to ensure Zed always downloads and installs an isolated version of node:
   /// {
   ///   "node": {
-  ///     "disable_path_lookup": true
+  ///     "ignore_system_version": true,
   ///   }
   /// NOTE: changing this setting currently requires restarting Zed.
   "node": {},

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -299,7 +299,7 @@ impl ActivityIndicator {
                         .into_any_element(),
                 ),
                 message: format!(
-                    "Failed to download {}. Click to show error.",
+                    "Failed to run {}. Click to show error.",
                     failed
                         .iter()
                         .map(|name| name.0.as_ref())

--- a/crates/extension/src/extension_lsp_adapter.rs
+++ b/crates/extension/src/extension_lsp_adapter.rs
@@ -10,16 +10,11 @@ use gpui::AsyncAppContext;
 use language::{
     CodeLabel, HighlightId, Language, LanguageServerName, LspAdapter, LspAdapterDelegate,
 };
-use lsp::{CodeActionKind, LanguageServerBinary};
+use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerBinaryOptions};
 use serde::Serialize;
 use serde_json::Value;
 use std::ops::Range;
-use std::{
-    any::Any,
-    path::{Path, PathBuf},
-    pin::Pin,
-    sync::Arc,
-};
+use std::{any::Any, path::PathBuf, pin::Pin, sync::Arc};
 use util::{maybe, ResultExt};
 use wasmtime_wasi::WasiView as _;
 
@@ -38,8 +33,8 @@ impl LspAdapter for ExtensionLspAdapter {
 
     fn get_language_server_command<'a>(
         self: Arc<Self>,
-        _: Option<Arc<Path>>,
         delegate: Arc<dyn LspAdapterDelegate>,
+        _: LanguageServerBinaryOptions,
         _: futures::lock::MutexGuard<'a, Option<LanguageServerBinary>>,
         _: &'a mut AsyncAppContext,
     ) -> Pin<Box<dyn 'a + Future<Output = Result<LanguageServerBinary>>>> {

--- a/crates/extension/src/extension_lsp_adapter.rs
+++ b/crates/extension/src/extension_lsp_adapter.rs
@@ -124,10 +124,6 @@ impl LspAdapter for ExtensionLspAdapter {
         unreachable!("get_language_server_command is overridden")
     }
 
-    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
-        None
-    }
-
     fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
         let code_action_kinds = self
             .extension

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -260,17 +260,6 @@ impl CachedLspAdapter {
             .await
     }
 
-    pub fn can_be_reinstalled(&self) -> bool {
-        self.adapter.can_be_reinstalled()
-    }
-
-    pub async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        self.adapter.installation_test_binary(container_dir).await
-    }
-
     pub fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
         self.adapter.code_action_kinds()
     }
@@ -441,21 +430,6 @@ pub trait LspAdapter: 'static + Send + Sync {
         &self,
         container_dir: PathBuf,
         delegate: &dyn LspAdapterDelegate,
-    ) -> Option<LanguageServerBinary>;
-
-    /// Returns `true` if a language server can be reinstalled.
-    ///
-    /// If language server initialization fails, a reinstallation will be attempted unless the value returned from this method is `false`.
-    ///
-    /// Implementations that rely on software already installed on user's system
-    /// should have [`can_be_reinstalled`](Self::can_be_reinstalled) return `false`.
-    fn can_be_reinstalled(&self) -> bool {
-        true
-    }
-
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
     ) -> Option<LanguageServerBinary>;
 
     fn process_diagnostics(&self, _: &mut lsp::PublishDiagnosticsParams) {}
@@ -1740,10 +1714,6 @@ impl LspAdapter for FakeLspAdapter {
         _: PathBuf,
         _: &dyn LspAdapterDelegate,
     ) -> Option<LanguageServerBinary> {
-        unreachable!();
-    }
-
-    async fn installation_test_binary(&self, _: PathBuf) -> Option<LanguageServerBinary> {
         unreachable!();
     }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -69,7 +69,7 @@ pub use buffer::*;
 pub use diagnostic_set::DiagnosticEntry;
 pub use language_registry::{
     AvailableLanguage, LanguageNotFound, LanguageQueries, LanguageRegistry,
-    LanguageServerBinaryStatus, PendingLanguageServer, QUERY_FILENAME_PREFIXES,
+    LanguageServerBinaryStatus, QUERY_FILENAME_PREFIXES,
 };
 pub use lsp::LanguageServerId;
 pub use outline::*;

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -117,12 +117,6 @@ pub enum LanguageServerBinaryStatus {
     Failed { error: String },
 }
 
-pub struct PendingLanguageServer {
-    pub server_id: LanguageServerId,
-    pub task: Task<Result<(lsp::LanguageServer, Option<serde_json::Value>)>>,
-    pub container_dir: Option<Arc<Path>>,
-}
-
 #[derive(Clone)]
 pub struct AvailableLanguage {
     id: LanguageId,

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -886,8 +886,15 @@ impl LanguageRegistry {
     }
 
     #[cfg(any(test, feature = "test-support"))]
-    pub fn create_fake_langauge_server(&self, name: &LanguageServerName) -> Option<LanguageServer> {
-        let Some(fake_entry) = self.state.write().fake_server_entries.get_mut(&name) else {
+    pub fn create_fake_language_server(
+        &self,
+        server_id: LanguageServerId,
+        name: &LanguageServerName,
+        binary: lsp::LanguageServerBinary,
+        cx: gpui::AsyncAppContext,
+    ) -> Option<lsp::LanguageServer> {
+        let mut state = self.state.write();
+        let Some(fake_entry) = state.fake_server_entries.get_mut(&name) else {
             return None;
         };
         let (server, mut fake_server) = lsp::FakeLanguageServer::new(

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -141,18 +141,6 @@ impl super::LspAdapter for CLspAdapter {
         get_cached_server_binary(container_dir).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir)
-            .await
-            .map(|mut binary| {
-                binary.arguments = vec!["--help".into()];
-                binary
-            })
-    }
-
     async fn label_for_completion(
         &self,
         completion: &lsp::CompletionItem,

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -5,7 +5,6 @@ use gpui::AsyncAppContext;
 use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 pub use language::*;
 use lsp::LanguageServerBinary;
-use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
 use smol::fs::{self, File};
 use std::{any::Any, env::consts, path::PathBuf, sync::Arc};
 use util::{fs::remove_matching, maybe, ResultExt};
@@ -25,41 +24,14 @@ impl super::LspAdapter for CLspAdapter {
     async fn check_if_user_installed(
         &self,
         delegate: &dyn LspAdapterDelegate,
-        cx: &AsyncAppContext,
+        _: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
-        let configured_binary = cx.update(|cx| {
-            language_server_settings(delegate, &Self::SERVER_NAME, cx)
-                .and_then(|s| s.binary.clone())
-        });
-
-        match configured_binary {
-            Ok(Some(BinarySettings {
-                path: Some(path),
-                arguments,
-                ..
-            })) => Some(LanguageServerBinary {
-                path: path.into(),
-                arguments: arguments
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|arg| arg.into())
-                    .collect(),
-                env: None,
-            }),
-            Ok(Some(BinarySettings {
-                path_lookup: Some(false),
-                ..
-            })) => None,
-            _ => {
-                let env = delegate.shell_env().await;
-                let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
-                Some(LanguageServerBinary {
-                    path,
-                    arguments: vec![],
-                    env: Some(env),
-                })
-            }
-        }
+        let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
+        Some(LanguageServerBinary {
+            path,
+            arguments: vec![],
+            env: None,
+        })
     }
 
     async fn fetch_latest_server_version(

--- a/crates/languages/src/css.rs
+++ b/crates/languages/src/css.rs
@@ -84,13 +84,6 @@ impl LspAdapter for CssLspAdapter {
         get_cached_server_binary(container_dir, &self.node).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir, &self.node).await
-    }
-
     async fn initialization_options(
         self: Arc<Self>,
         _: &Arc<dyn LspAdapterDelegate>,

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -214,18 +214,6 @@ impl super::LspAdapter for GoLspAdapter {
         get_cached_server_binary(container_dir).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir)
-            .await
-            .map(|mut binary| {
-                binary.arguments = vec!["--help".into()];
-                binary
-            })
-    }
-
     async fn initialization_options(
         self: Arc<Self>,
         _: &Arc<dyn LspAdapterDelegate>,

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -6,7 +6,6 @@ use gpui::{AppContext, AsyncAppContext, Task};
 use http_client::github::latest_github_release;
 pub use language::*;
 use lsp::LanguageServerBinary;
-use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
 use regex::Regex;
 use serde_json::json;
 use smol::{fs, process};
@@ -68,41 +67,14 @@ impl super::LspAdapter for GoLspAdapter {
     async fn check_if_user_installed(
         &self,
         delegate: &dyn LspAdapterDelegate,
-        cx: &AsyncAppContext,
+        _: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
-        let configured_binary = cx.update(|cx| {
-            language_server_settings(delegate, &Self::SERVER_NAME, cx)
-                .and_then(|s| s.binary.clone())
-        });
-
-        match configured_binary {
-            Ok(Some(BinarySettings {
-                path: Some(path),
-                arguments,
-                ..
-            })) => Some(LanguageServerBinary {
-                path: path.into(),
-                arguments: arguments
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|arg| arg.into())
-                    .collect(),
-                env: None,
-            }),
-            Ok(Some(BinarySettings {
-                path_lookup: Some(false),
-                ..
-            })) => None,
-            _ => {
-                let env = delegate.shell_env().await;
-                let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
-                Some(LanguageServerBinary {
-                    path,
-                    arguments: server_binary_arguments(),
-                    env: Some(env),
-                })
-            }
-        }
+        let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
+        Some(LanguageServerBinary {
+            path,
+            arguments: server_binary_arguments(),
+            env: None,
+        })
     }
 
     fn will_fetch_server(

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -186,13 +186,6 @@ impl LspAdapter for JsonLspAdapter {
         get_cached_server_binary(container_dir, &self.node).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir, &self.node).await
-    }
-
     async fn initialization_options(
         self: Arc<Self>,
         _: &Arc<dyn LspAdapterDelegate>,
@@ -373,18 +366,6 @@ impl LspAdapter for NodeVersionAdapter {
         _delegate: &dyn LspAdapterDelegate,
     ) -> Option<LanguageServerBinary> {
         get_cached_version_server_binary(container_dir).await
-    }
-
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_version_server_binary(container_dir)
-            .await
-            .map(|mut binary| {
-                binary.arguments = vec!["--version".into()];
-                binary
-            })
     }
 }
 

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -97,13 +97,6 @@ impl LspAdapter for PythonLspAdapter {
         get_cached_server_binary(container_dir, &self.node).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir, &self.node).await
-    }
-
     async fn process_completions(&self, items: &mut [lsp::CompletionItem]) {
         // Pyright assigns each completion item a `sortText` of the form `XX.YYYY.name`.
         // Where `XX` is the sorting category, `YYYY` is based on most recent usage,

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -186,18 +186,6 @@ impl LspAdapter for RustLspAdapter {
         get_cached_server_binary(container_dir).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir)
-            .await
-            .map(|mut binary| {
-                binary.arguments = vec!["--help".into()];
-                binary
-            })
-    }
-
     fn disk_based_diagnostic_sources(&self) -> Vec<String> {
         vec!["rustc".into()]
     }

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -8,7 +8,6 @@ use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 pub use language::*;
 use language_settings::all_language_settings;
 use lsp::LanguageServerBinary;
-use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
 use regex::Regex;
 use smol::fs::{self, File};
 use std::{
@@ -37,77 +36,34 @@ impl LspAdapter for RustLspAdapter {
     async fn check_if_user_installed(
         &self,
         delegate: &dyn LspAdapterDelegate,
-        cx: &AsyncAppContext,
+        _: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
-        let configured_binary = cx
-            .update(|cx| {
-                language_server_settings(delegate, &Self::SERVER_NAME, cx)
-                    .and_then(|s| s.binary.clone())
+        let path = delegate.which("rust-analyzer".as_ref()).await?;
+        let env = delegate.shell_env().await;
+
+        // It is surprisingly common for ~/.cargo/bin/rust-analyzer to be a symlink to
+        // /usr/bin/rust-analyzer that fails when you run it; so we need to test it.
+        log::info!("found rust-analyzer in PATH. trying to run `rust-analyzer --help`");
+        let result = delegate
+            .try_exec(LanguageServerBinary {
+                path: path.clone(),
+                arguments: vec!["--help".into()],
+                env: Some(env.clone()),
             })
-            .ok()?;
+            .await;
+        if let Err(err) = result {
+            log::error!(
+                "failed to run rust-analyzer after detecting it in PATH: binary: {:?}: {}",
+                path,
+                err
+            );
+            return None;
+        }
 
-        let (path, env, arguments) = match configured_binary {
-            // If nothing is configured, or path_lookup explicitly enabled,
-            // we lookup the binary in the path.
-            None
-            | Some(BinarySettings {
-                path: None,
-                path_lookup: Some(true),
-                ..
-            })
-            | Some(BinarySettings {
-                path: None,
-                path_lookup: None,
-                ..
-            }) => {
-                let path = delegate.which("rust-analyzer".as_ref()).await;
-                let env = delegate.shell_env().await;
-
-                if let Some(path) = path {
-                    // It is surprisingly common for ~/.cargo/bin/rust-analyzer to be a symlink to
-                    // /usr/bin/rust-analyzer that fails when you run it; so we need to test it.
-                    log::info!("found rust-analyzer in PATH. trying to run `rust-analyzer --help`");
-                    match delegate
-                        .try_exec(LanguageServerBinary {
-                            path: path.clone(),
-                            arguments: vec!["--help".into()],
-                            env: Some(env.clone()),
-                        })
-                        .await
-                    {
-                        Ok(()) => (Some(path), Some(env), None),
-                        Err(err) => {
-                            log::error!("failed to run rust-analyzer after detecting it in PATH: binary: {:?}: {}", path, err);
-                            (None, None, None)
-                        }
-                    }
-                } else {
-                    (None, None, None)
-                }
-            }
-            // Otherwise, we use the configured binary.
-            Some(BinarySettings {
-                path: Some(path),
-                arguments,
-                path_lookup,
-            }) => {
-                if path_lookup.is_some() {
-                    log::warn!("Both `path` and `path_lookup` are set, ignoring `path_lookup`");
-                }
-                (Some(path.into()), None, arguments)
-            }
-
-            _ => (None, None, None),
-        };
-
-        path.map(|path| LanguageServerBinary {
+        Some(LanguageServerBinary {
             path,
-            env,
-            arguments: arguments
-                .unwrap_or_default()
-                .iter()
-                .map(|arg| arg.into())
-                .collect(),
+            env: Some(env),
+            arguments: vec![],
         })
     }
 

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -125,13 +125,6 @@ impl LspAdapter for TailwindLspAdapter {
         get_cached_server_binary(container_dir, &self.node).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir, &self.node).await
-    }
-
     async fn initialization_options(
         self: Arc<Self>,
         _: &Arc<dyn LspAdapterDelegate>,

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -46,38 +46,6 @@ impl LspAdapter for TailwindLspAdapter {
         Self::SERVER_NAME.clone()
     }
 
-    async fn check_if_user_installed(
-        &self,
-        delegate: &dyn LspAdapterDelegate,
-        cx: &AsyncAppContext,
-    ) -> Option<LanguageServerBinary> {
-        let configured_binary = cx
-            .update(|cx| {
-                language_server_settings(delegate, &Self::SERVER_NAME, cx)
-                    .and_then(|s| s.binary.clone())
-            })
-            .ok()??;
-
-        let path = if let Some(configured_path) = configured_binary.path.map(PathBuf::from) {
-            configured_path
-        } else {
-            self.node.binary_path().await.ok()?
-        };
-
-        let arguments = configured_binary
-            .arguments
-            .unwrap_or_default()
-            .iter()
-            .map(|arg| arg.into())
-            .collect();
-
-        Some(LanguageServerBinary {
-            path,
-            arguments,
-            env: None,
-        })
-    }
-
     async fn fetch_latest_server_version(
         &self,
         _: &dyn LspAdapterDelegate,

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -485,7 +485,7 @@ impl LspAdapter for EsLintLspAdapter {
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
             env: None,
-            arguments: eslint_server_binary_arguments(&server_path.join("oops")),
+            arguments: eslint_server_binary_arguments(&server_path),
         })
     }
 

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -164,13 +164,6 @@ impl LspAdapter for TypeScriptLspAdapter {
         get_cached_ts_server_binary(container_dir, &self.node).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_ts_server_binary(container_dir, &self.node).await
-    }
-
     fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
         Some(vec![
             CodeActionKind::QUICKFIX,
@@ -492,7 +485,7 @@ impl LspAdapter for EsLintLspAdapter {
         Ok(LanguageServerBinary {
             path: self.node.binary_path().await?,
             env: None,
-            arguments: eslint_server_binary_arguments(&server_path),
+            arguments: eslint_server_binary_arguments(&server_path.join("oops")),
         })
     }
 
@@ -500,19 +493,6 @@ impl LspAdapter for EsLintLspAdapter {
         &self,
         container_dir: PathBuf,
         _: &dyn LspAdapterDelegate,
-    ) -> Option<LanguageServerBinary> {
-        let server_path =
-            Self::build_destination_path(&container_dir).join(EsLintLspAdapter::SERVER_PATH);
-        Some(LanguageServerBinary {
-            path: self.node.binary_path().await.ok()?,
-            env: None,
-            arguments: eslint_server_binary_arguments(&server_path),
-        })
-    }
-
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
     ) -> Option<LanguageServerBinary> {
         let server_path =
             Self::build_destination_path(&container_dir).join(EsLintLspAdapter::SERVER_PATH);

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -5,7 +5,7 @@ use gpui::AsyncAppContext;
 use language::{LanguageServerName, LspAdapter, LspAdapterDelegate};
 use lsp::{CodeActionKind, LanguageServerBinary};
 use node_runtime::NodeRuntime;
-use project::{lsp_store::language_server_settings, project_settings::BinarySettings};
+use project::lsp_store::language_server_settings;
 use serde_json::Value;
 use std::{
     any::Any,
@@ -71,40 +71,15 @@ impl LspAdapter for VtslsLspAdapter {
     async fn check_if_user_installed(
         &self,
         delegate: &dyn LspAdapterDelegate,
-        cx: &AsyncAppContext,
+        _: &AsyncAppContext,
     ) -> Option<LanguageServerBinary> {
-        let configured_binary = cx.update(|cx| {
-            language_server_settings(delegate, &SERVER_NAME, cx).and_then(|s| s.binary.clone())
-        });
-
-        match configured_binary {
-            Ok(Some(BinarySettings {
-                path: Some(path),
-                arguments,
-                ..
-            })) => Some(LanguageServerBinary {
-                path: path.into(),
-                arguments: arguments
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|arg| arg.into())
-                    .collect(),
-                env: None,
-            }),
-            Ok(Some(BinarySettings {
-                path_lookup: Some(false),
-                ..
-            })) => None,
-            _ => {
-                let env = delegate.shell_env().await;
-                let path = delegate.which(SERVER_NAME.as_ref()).await?;
-                Some(LanguageServerBinary {
-                    path: path.clone(),
-                    arguments: typescript_server_binary_arguments(&path),
-                    env: Some(env),
-                })
-            }
-        }
+        let env = delegate.shell_env().await;
+        let path = delegate.which(SERVER_NAME.as_ref()).await?;
+        Some(LanguageServerBinary {
+            path: path.clone(),
+            arguments: typescript_server_binary_arguments(&path),
+            env: Some(env),
+        })
     }
 
     async fn fetch_server_binary(

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -157,13 +157,6 @@ impl LspAdapter for VtslsLspAdapter {
         get_cached_ts_server_binary(container_dir, &self.node).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_ts_server_binary(container_dir, &self.node).await
-    }
-
     fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
         Some(vec![
             CodeActionKind::QUICKFIX,

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -120,13 +120,6 @@ impl LspAdapter for YamlLspAdapter {
         get_cached_server_binary(container_dir, &self.node).await
     }
 
-    async fn installation_test_binary(
-        &self,
-        container_dir: PathBuf,
-    ) -> Option<LanguageServerBinary> {
-        get_cached_server_binary(container_dir, &self.node).await
-    }
-
     async fn workspace_configuration(
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -42,37 +42,6 @@ impl LspAdapter for YamlLspAdapter {
         Self::SERVER_NAME.clone()
     }
 
-    async fn check_if_user_installed(
-        &self,
-        delegate: &dyn LspAdapterDelegate,
-        cx: &AsyncAppContext,
-    ) -> Option<LanguageServerBinary> {
-        let configured_binary = cx
-            .update(|cx| {
-                language_server_settings(delegate, &Self::SERVER_NAME, cx)
-                    .and_then(|s| s.binary.clone())
-            })
-            .ok()??;
-
-        let path = if let Some(configured_path) = configured_binary.path.map(PathBuf::from) {
-            configured_path
-        } else {
-            self.node.binary_path().await.ok()?
-        };
-
-        let arguments = configured_binary
-            .arguments
-            .unwrap_or_default()
-            .iter()
-            .map(|arg| arg.into())
-            .collect();
-        Some(LanguageServerBinary {
-            path,
-            arguments,
-            env: None,
-        })
-    }
-
     async fn fetch_latest_server_version(
         &self,
         _: &dyn LspAdapterDelegate,

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -64,6 +64,15 @@ pub struct LanguageServerBinary {
     pub env: Option<HashMap<String, String>>,
 }
 
+/// Configures the search (and installation) of language servers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LanguageServerBinaryOptions {
+    /// Whether the adapter should look at the users system
+    pub allow_path_lookup: bool,
+    /// Whether the adapter should download its own version
+    pub allow_binary_download: bool,
+}
+
 /// A running language server process.
 pub struct LanguageServer {
     server_id: LanguageServerId,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5554,8 +5554,10 @@ impl LspStore {
                     }
                 } else {
                     let lsp_binary_options = LanguageServerBinaryOptions {
-                        allow_path_lookup: binary_options.is_none()
-                            || binary_options.as_ref().unwrap().path_lookup.unwrap_or(true),
+                        allow_path_lookup: !binary_options
+                            .as_ref()
+                            .and_then(|b| b.disable_path_lookup)
+                            .unwrap_or_default(),
                         allow_binary_download: true, // todo
                     };
                     let binary_result = adapter
@@ -7934,7 +7936,7 @@ impl LspAdapterDelegate for SshLspAdapterDelegate {
         Ok(())
     }
 
-    async fn language_server_download_dir(&self, name: &LanguageServerName) -> Option<Arc<Path>> {
+    async fn language_server_download_dir(&self, _: &LanguageServerName) -> Option<Arc<Path>> {
         None
     }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5506,7 +5506,7 @@ impl LspStore {
         let lsp_binary_options = LanguageServerBinaryOptions {
             allow_path_lookup: !settings
                 .as_ref()
-                .and_then(|b| b.disable_path_lookup)
+                .and_then(|b| b.ignore_system_version)
                 .unwrap_or_default(),
             allow_binary_download,
         };

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5594,7 +5594,7 @@ impl LspStore {
 
                 #[cfg(any(test, feature = "test-support"))]
                 if let Some(server) = _lsp_store
-                    .update(&mut cx, |this, cx| {
+                    .update(&mut cx.clone(), |this, cx| {
                         this.languages.create_fake_language_server(
                             server_id,
                             &adapter.name,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3958,14 +3958,6 @@ impl Project {
         self.lsp_store.read(cx).supplementary_language_servers()
     }
 
-    pub fn language_server_adapter_for_id(
-        &self,
-        id: LanguageServerId,
-        cx: &AppContext,
-    ) -> Option<Arc<CachedLspAdapter>> {
-        self.lsp_store.read(cx).language_server_adapter_for_id(id)
-    }
-
     pub fn language_server_for_id(
         &self,
         id: LanguageServerId,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -143,7 +143,7 @@ const fn true_value() -> bool {
 pub struct BinarySettings {
     pub path: Option<String>,
     pub arguments: Option<Vec<String>>,
-    pub path_lookup: Option<bool>,
+    pub disable_path_lookup: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -55,7 +55,7 @@ pub struct NodeBinarySettings {
     pub npm_path: Option<String>,
     /// If disabled, zed will download its own copy of node.
     #[serde(default)]
-    pub disable_path_lookup: Option<bool>,
+    pub ignore_system_version: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -143,7 +143,7 @@ const fn true_value() -> bool {
 pub struct BinarySettings {
     pub path: Option<String>,
     pub arguments: Option<Vec<String>>,
-    pub disable_path_lookup: Option<bool>,
+    pub ignore_system_version: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -481,7 +481,7 @@ fn main() {
         cx.observe_global::<SettingsStore>(move |cx| {
             let settings = &ProjectSettings::get_global(cx).node;
             let options = NodeBinaryOptions {
-                allow_path_lookup: !settings.disable_path_lookup.unwrap_or_default(),
+                allow_path_lookup: !settings.ignore_system_version.unwrap_or_default(),
                 // TODO: Expose this setting
                 allow_binary_download: true,
                 use_paths: settings.path.as_ref().map(|node_path| {

--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -64,14 +64,14 @@ You can configure which `rust-analyzer` binary Zed should use.
 
 By default, Zed will try to find a `rust-analyzer` in your `$PATH` and try to use that. If that binary successfully executes `rust-analyzer --help`, it's used. Otherwise, Zed will fall back to installing its own `rust-analyzer` version and using that.
 
-If you want to disable Zed looking for a `rust-analyzer` binary, you can set `disable_path_lookup` to `true` in your `settings.json`:
+If you want to disable Zed looking for a `rust-analyzer` binary, you can set `ignore_system_version` to `true` in your `settings.json`:
 
 ```json
 {
   "lsp": {
     "rust-analyzer": {
       "binary": {
-        "disable_path_lookup": true
+        "ignore_system_version": true
       }
     }
   }

--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -64,14 +64,14 @@ You can configure which `rust-analyzer` binary Zed should use.
 
 By default, Zed will try to find a `rust-analyzer` in your `$PATH` and try to use that. If that binary successfully executes `rust-analyzer --help`, it's used. Otherwise, Zed will fall back to installing its own `rust-analyzer` version and using that.
 
-If you want to disable Zed looking for a `rust-analyzer` binary, you can set `path_lookup` to `false` in your `settings.json`:
+If you want to disable Zed looking for a `rust-analyzer` binary, you can set `disable_path_lookup` to `true` in your `settings.json`:
 
 ```json
 {
   "lsp": {
     "rust-analyzer": {
       "binary": {
-        "path_lookup": false
+        "disable_path_lookup": true
       }
     }
   }


### PR DESCRIPTION
Release Notes:

- Fixed overriding the path of a language server binary for all language servers. `{"lsp":{"<lsp-name>":{"binary":{"path": "_"}}}}` will now work for all language servers including those defined by extensions.
- (breaking change) To disable finding lsp adapters in your path, you must now specify `{"lsp":{"<lsp-name>":{"binary":{"ignore_system_version": true}}}}`. Previously this was `{"lsp":{"<lsp-name>":{"binary":{"path_lookup": false}}}}`. Note that this setting still does not apply to extensions.
- Removed automatic reinstallation of language servers. (It mostly didn't work)
