### PR TITLE
zig: Fix highlighting of keywords like `orelse`, `or`, `and`

### DIFF
--- a/extensions/zig/languages/zig/highlights.scm
+++ b/extensions/zig/languages/zig/highlights.scm
@@ -103,6 +103,7 @@ field_constant: (IDENTIFIER) @constant
 (BlockLabel (IDENTIFIER) @tag)
 
 [
+  "fn"
   "asm"
   "defer"
   "errdefer"
@@ -112,74 +113,21 @@ field_constant: (IDENTIFIER) @constant
   "enum"
   "opaque"
   "error"
-] @keyword
-
-[
-  "async"
-  "await"
-  "suspend"
-  "nosuspend"
-  "resume"
-] @keyword.coroutine
-
-[
-  "fn"
-] @keyword
-
-[
-  "and"
-  "or"
-  "orelse"
-] @operator
-
-[
-  "return"
-] @keyword.return
-
-[
-  "if"
-  "else"
-  "switch"
-] @keyword.control
-
-[
+  "try"
+  "catch"
   "for"
   "while"
   "break"
   "continue"
-] @keyword
-
-[
-  "usingnamespace"
-] @constant
-
-[
-  "try"
-  "catch"
-] @keyword
-
-[
-  "anytype"
-  "anyframe"
-  (BuildinTypeExpr)
-] @type
-
-[
   "const"
   "var"
   "volatile"
   "allowzero"
   "noalias"
-] @keyword
-
-[
   "addrspace"
   "align"
   "callconv"
   "linksection"
-] @keyword.storage
-
-[
   "comptime"
   "export"
   "extern"
@@ -188,7 +136,29 @@ field_constant: (IDENTIFIER) @constant
   "packed"
   "pub"
   "threadlocal"
+  "async"
+  "await"
+  "suspend"
+  "nosuspend"
+  "resume"
+  "and"
+  "or"
+  "orelse"
+  "return"
+  "if"
+  "else"
+  "switch"
 ] @keyword
+
+[
+  "usingnamespace"
+] @constant
+
+[
+  "anytype"
+  "anyframe"
+  (BuildinTypeExpr)
+] @type
 
 [
   "null"


### PR DESCRIPTION
This changes the Zig highlights.scm to tag all keywords with `@keyword` and not with `@keyword.<subtype>`, so the highlighting works properly.

Closes #9355

Release Notes:

- N/A

Demo:

![screenshot-2024-09-25-09 32 20@2x](https://github.com/user-attachments/assets/567b8817-a522-4741-af7f-dcb1a79ddd40)

