### PR TITLE
client: Remove unused `fs` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,7 +2409,6 @@ dependencies = [
  "cocoa 0.26.0",
  "collections",
  "feature_flags",
- "fs",
  "futures 0.3.30",
  "gpui",
  "http_client",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -23,7 +23,6 @@ chrono = { workspace = true, features = ["serde"] }
 clock.workspace = true
 collections.workspace = true
 feature_flags.workspace = true
-fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 http_client.workspace = true


### PR DESCRIPTION
CI bot notified me about that in https://github.com/zed-industries/zed/pull/18323


Release Notes:

- N/A
