### PR TITLE
file picker: Use muted color for file icons

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1070,7 +1070,9 @@ impl PickerDelegate for FileFinderDelegate {
             self.labels_for_match(path_match, cx, ix);
 
         let file_icon = if settings.file_icons {
-            FileIcons::get_icon(Path::new(&file_name), cx).map(Icon::from_path)
+            FileIcons::get_icon(Path::new(&file_name), cx)
+                .map(Icon::from_path)
+                .map(|icon| icon.color(Color::Muted))
         } else {
             None
         };


### PR DESCRIPTION
I think they were too much in-your-face. Muted looks better.

Before:
![image](https://github.com/user-attachments/assets/73d6171a-6276-4450-acfb-52cd44fdfe59)

After:
![image](https://github.com/user-attachments/assets/1d5f4524-b0b9-4ba6-ab66-5eaf619e58f9)

Release Notes:

- N/A
