### PR TITLE
ssh remoting: Show error message if project path does not exist

### DIFF
--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -18,7 +18,7 @@ use gpui::{
 use postage::oneshot;
 use rpc::{
     proto::{self, SSH_PROJECT_ID},
-    AnyProtoClient, TypedEnvelope,
+    AnyProtoClient, ErrorExt, TypedEnvelope,
 };
 use smol::{
     channel::{Receiver, Sender},
@@ -207,7 +207,7 @@ impl WorktreeStore {
         cx.background_executor().spawn(async move {
             match task.await {
                 Ok(worktree) => Ok(worktree),
-                Err(err) => Err(anyhow!("{}", err)),
+                Err(err) => Err((*err).cloned()),
             }
         })
     }

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -22,6 +22,7 @@ test-support = ["fs/test-support"]
 
 [dependencies]
 anyhow.workspace = true
+client.workspace = true
 env_logger.workspace = true
 fs.workspace = true
 futures.workspace = true


### PR DESCRIPTION
This now shows an error message if you try open a project over SSH that doesn't exist. If it's a possible file-path though, it acts like Zed's `cli` and opens the file so that it can be created.

- Works: `cargo run ssh://127.0.0.1/~/folder-exists/file-does-not-exist` — this will open `file-does-not-exist`
- Shows error: `cargo run ssh://127.0.0.1/~/folder-does-not-exist/file-does-not-exist` — this will show an error

Release Notes:

- N/A
