### PR TITLE
Fix file descriptors leak in evals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10498,6 +10498,7 @@ dependencies = [
  "futures 0.3.30",
  "gpui",
  "parking_lot",
+ "paths",
  "serde",
  "serde_json",
  "snippet",

--- a/crates/gpui/src/platform/mac/attributed_string.rs
+++ b/crates/gpui/src/platform/mac/attributed_string.rs
@@ -70,9 +70,7 @@ mod tests {
 
         unsafe {
             let image: id = msg_send![class!(NSImage), alloc];
-            image.initWithContentsOfFile_(
-                NSString::alloc(nil).init_str("/Users/rtfeldman/Downloads/test.jpeg"),
-            );
+            image.initWithContentsOfFile_(NSString::alloc(nil).init_str("test.jpeg"));
             let _size = image.size();
 
             let string = NSString::alloc(nil).init_str("Test String");

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -587,10 +587,7 @@ impl Project {
             cx.spawn(move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx))
                 .detach();
             let tasks = Inventory::new(cx);
-            let global_snippets_dir = paths::config_dir().join("snippets");
-            let snippets =
-                SnippetProvider::new(fs.clone(), BTreeSet::from_iter([global_snippets_dir]), cx);
-
+            let snippets = SnippetProvider::new(fs.clone(), BTreeSet::from_iter([]), cx);
             let worktree_store = cx.new_model(|_| WorktreeStore::local(false, fs.clone()));
             cx.subscribe(&worktree_store, Self::on_worktree_store_event)
                 .detach();
@@ -875,9 +872,8 @@ impl Project {
         let this = cx.new_model(|cx| {
             let replica_id = response.payload.replica_id as ReplicaId;
             let tasks = Inventory::new(cx);
-            let global_snippets_dir = paths::config_dir().join("snippets");
-            let snippets =
-                SnippetProvider::new(fs.clone(), BTreeSet::from_iter([global_snippets_dir]), cx);
+
+            let snippets = SnippetProvider::new(fs.clone(), BTreeSet::from_iter([]), cx);
 
             let mut worktrees = Vec::new();
             for worktree in response.payload.worktrees {

--- a/crates/snippet_provider/Cargo.toml
+++ b/crates/snippet_provider/Cargo.toml
@@ -15,6 +15,7 @@ fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 parking_lot.workspace = true
+paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snippet.workspace = true


### PR DESCRIPTION
Fixes an issue where evals were hitting "too many open files" errors because we were adding (and detaching) new directory watches for each project. Now we add those watches globally/at the worktree level, and we store the tasks so they stop watching on drop.

Release Notes:

- N/A
