### PR TITLE
Improve increment/decrement with leading zeros in vim mode

### DIFF
--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -218,8 +218,6 @@ fn find_number(
                 begin = Some(offset);
             }
             num.push(ch);
-            // println!("pushing {}", ch); // why do we println here ?
-            // println!();
         } else if begin.is_some() {
             end = Some(offset);
             break;
@@ -313,6 +311,44 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_increment_with_leading_zeros_and_zero(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state(indoc! {"
+            01ˇ1
+            "})
+            .await;
+
+        cx.simulate_shared_keystrokes("ctrl-a").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            01ˇ2
+            "});
+        cx.simulate_shared_keystrokes("1 2 ctrl-x").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            00ˇ0
+            "});
+    }
+
+    #[gpui::test]
+    async fn test_increment_with_changing_leading_zeros(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state(indoc! {"
+            099ˇ9
+            "})
+            .await;
+
+        cx.simulate_shared_keystrokes("ctrl-a").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            100ˇ0
+            "});
+        cx.simulate_shared_keystrokes("2 ctrl-x").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            99ˇ8
+            "});
+    }
+
+    #[gpui::test]
     async fn test_increment_with_two_dots(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
 
@@ -352,9 +388,13 @@ mod test {
     async fn test_increment_sign_change_with_leading_zeros(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
         cx.set_shared_state(indoc! {"
-                00ˇ0
+                00ˇ1
                 "})
             .await;
+        cx.simulate_shared_keystrokes("ctrl-x").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+                00ˇ0
+                "});
         cx.simulate_shared_keystrokes("ctrl-x").await;
         cx.shared_state().await.assert_eq(indoc! {"
                 -00ˇ1

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -218,8 +218,8 @@ fn find_number(
                 begin = Some(offset);
             }
             num.push(ch);
-            println!("pushing {}", ch);
-            println!();
+            // println!("pushing {}", ch); // why do we println here ?
+            // println!();
         } else if begin.is_some() {
             end = Some(offset);
             break;

--- a/crates/vim/test_data/test_increment_sign_change_with_leading_zeros.json
+++ b/crates/vim/test_data/test_increment_sign_change_with_leading_zeros.json
@@ -1,4 +1,6 @@
-{"Put":{"state":"00ˇ0\n"}}
+{"Put":{"state":"00ˇ1\n"}}
+{"Key":"ctrl-x"}
+{"Get":{"state":"00ˇ0\n","mode":"Normal"}}
 {"Key":"ctrl-x"}
 {"Get":{"state":"-00ˇ1\n","mode":"Normal"}}
 {"Key":"2"}

--- a/crates/vim/test_data/test_increment_sign_change_with_leading_zeros.json
+++ b/crates/vim/test_data/test_increment_sign_change_with_leading_zeros.json
@@ -1,0 +1,6 @@
+{"Put":{"state":"00ˇ0\n"}}
+{"Key":"ctrl-x"}
+{"Get":{"state":"-00ˇ1\n","mode":"Normal"}}
+{"Key":"2"}
+{"Key":"ctrl-a"}
+{"Get":{"state":"00ˇ1\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_with_changing_leading_zeros.json
+++ b/crates/vim/test_data/test_increment_with_changing_leading_zeros.json
@@ -1,0 +1,6 @@
+{"Put":{"state":"099ˇ9\n"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"100ˇ0\n","mode":"Normal"}}
+{"Key":"2"}
+{"Key":"ctrl-x"}
+{"Get":{"state":"99ˇ8\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_with_leading_zeros.json
+++ b/crates/vim/test_data/test_increment_with_leading_zeros.json
@@ -1,0 +1,6 @@
+{"Put":{"state":"000ˇ9\n"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"001ˇ0\n","mode":"Normal"}}
+{"Key":"2"}
+{"Key":"ctrl-x"}
+{"Get":{"state":"000ˇ8\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_with_leading_zeros_and_zero.json
+++ b/crates/vim/test_data/test_increment_with_leading_zeros_and_zero.json
@@ -1,0 +1,7 @@
+{"Put":{"state":"01ˇ1\n"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"01ˇ2\n","mode":"Normal"}}
+{"Key":"1"}
+{"Key":"2"}
+{"Key":"ctrl-x"}
+{"Get":{"state":"00ˇ0\n","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_zero_leading_zeros.json
+++ b/crates/vim/test_data/test_increment_zero_leading_zeros.json
@@ -1,0 +1,4 @@
+{"Put":{"state":"001ˇ0\n"}}
+{"Key":"10"}
+{"Key":"ctrl-x"}
+{"Get":{"state":"000ˇ9\n","mode":"Normal"}}


### PR DESCRIPTION
- Closes: #18360

Release Notes:

- Added support for incrementing and decrementing numbers with leading zeros 