### PR TITLE
Ollama llama3.2 default context size

### DIFF
--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -83,7 +83,7 @@ fn get_max_tokens(name: &str) -> usize {
         "codellama" | "starcoder2" => 16384,
         "mistral" | "codestral" | "mixstral" | "llava" | "qwen2" | "dolphin-mixtral" => 32768,
         "llama3.1" | "phi3" | "phi3.5" | "command-r" | "deepseek-coder-v2" | "yi-coder"
-        | "qwen2.5-coder" => 128000,
+        | "llama3.2" | "qwen2.5-coder" => 128000,
         _ => DEFAULT_TOKENS,
     }
     .clamp(1, MAXIMUM_TOKENS)


### PR DESCRIPTION
Release Notes:

- Ollama: Added llama3.2 support