### PR TITLE
editor: Fix cursor shape not restoring when setting removed

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -389,6 +389,7 @@ impl Vim {
             }
             EditorEvent::Edited { .. } => self.push_to_change_list(cx),
             EditorEvent::FocusedIn => self.sync_vim_settings(cx),
+            EditorEvent::CursorShapeChanged => self.cursor_shape_changed(cx),
             _ => {}
         }
     }
@@ -676,6 +677,12 @@ impl Vim {
         self.clear_operator(cx);
         self.update_editor(cx, |_, editor, cx| {
             editor.set_cursor_shape(language::CursorShape::Hollow, cx);
+        });
+    }
+
+    fn cursor_shape_changed(&mut self, cx: &mut ViewContext<Self>) {
+        self.update_editor(cx, |vim, editor, cx| {
+            editor.set_cursor_shape(vim.cursor_shape(), cx);
         });
     }
 


### PR DESCRIPTION
Closes #18119

Release Notes:

- Fixed the cursor shape in the editor not changing back to default when `{"cursor_shape": "..."}` setting is removed. (Does not apply to Vim mode.)
