### PR TITLE
terraform: Bump to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14687,7 +14687,7 @@ dependencies = [
 
 [[package]]
 name = "zed_terraform"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/terraform/Cargo.toml
+++ b/extensions/terraform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_terraform"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/terraform/extension.toml
+++ b/extensions/terraform/extension.toml
@@ -1,7 +1,7 @@
 id = "terraform"
 name = "Terraform"
 description = "Terraform support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Caius Durling <dev@caius.name>", "Daniel Banck <dbanck@users.noreply.github.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Terraform extension to v0.1.1

- https://github.com/zed-industries/zed/pull/17200

Release Notes:

- N/A
