### PR TITLE
docs: Update msys2 section in development/windows

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -63,16 +63,16 @@ cargo test --workspace
 
 ## Installing from msys2
 
-[MSYS2](https://msys2.org/) distribution provides Zed as a package [mingw-w64-zed](https://packages.msys2.org/base/mingw-w64-zed). To download the prebuilt binary, run
+[MSYS2](https://msys2.org/) distribution provides Zed as a package [mingw-w64-zed](https://packages.msys2.org/base/mingw-w64-zed). The package is available for UCRT64 and CLANG64. To download it, run
 
 ```sh
 pacman -Syu
-pacman -S mingw-w64-ucrt-x86_64-zed
+pacman -S $MINGW_PACKAGE_PREFIX-zed
 ```
 
-then you can run `zed` in a UCRT64 shell.
+then you can run `zed` in a shell.
 
-You can see the [build script](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-zed/PKGBUILD) for more details.
+You can see the [build script](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-zed/PKGBUILD) for more details on build process.
 
 > Please, report any issue in [msys2/MINGW-packages/issues](https://github.com/msys2/MINGW-packages/issues?q=is%3Aissue+is%3Aopen+zed) first.
 


### PR DESCRIPTION
Release Notes:

- N/A

merge after https://packages.msys2.org/packages/mingw-w64-clang-x86_64-zed is available. alternatively you can check the [queue](https://packages.msys2.org/queue) for build status

Zed now compiles and runs under msys2/CLANG64 environment, so change the docs to give the users a choice of their environment