### PR TITLE
Fix `use_on_type_format` setting being unused per language

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3442,7 +3442,7 @@ impl Editor {
                 s.select(new_selections)
             });
 
-            if !bracket_inserted && EditorSettings::get_global(cx).use_on_type_format {
+            if !bracket_inserted {
                 if let Some(on_type_format_task) =
                     this.trigger_on_type_formatting(text.to_string(), cx)
                 {
@@ -4190,6 +4190,15 @@ impl Editor {
             .buffer
             .read(cx)
             .text_anchor_for_position(position, cx)?;
+
+        let settings = language_settings::language_settings(
+            buffer.read(cx).language_at(buffer_position).as_ref(),
+            buffer.read(cx).file(),
+            cx,
+        );
+        if !settings.use_on_type_format {
+            return None;
+        }
 
         // OnTypeFormatting returns a list of edits, no need to pass them between Zed instances,
         // hence we do LSP request & edit on host side only — add formats to host's history.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -13,7 +13,6 @@ pub struct EditorSettings {
     pub show_completions_on_input: bool,
     pub show_completion_documentation: bool,
     pub completion_documentation_secondary_query_debounce: u64,
-    pub use_on_type_format: bool,
     pub toolbar: Toolbar,
     pub scrollbar: Scrollbar,
     pub gutter: Gutter,
@@ -209,11 +208,6 @@ pub struct EditorSettingsContent {
     ///
     /// Default: 300 ms
     pub completion_documentation_secondary_query_debounce: Option<u64>,
-    /// Whether to use additional LSP queries to format (and amend) the code after
-    /// every "trigger" symbol input, defined by LSP server capabilities.
-    ///
-    /// Default: true
-    pub use_on_type_format: Option<bool>,
     /// Toolbar related settings
     pub toolbar: Option<ToolbarContent>,
     /// Scrollbar related settings

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -113,6 +113,9 @@ pub struct LanguageSettings {
     pub use_autoclose: bool,
     /// Whether to automatically surround text with brackets.
     pub use_auto_surround: bool,
+    /// Whether to use additional LSP queries to format (and amend) the code after
+    /// every "trigger" symbol input, defined by LSP server capabilities.
+    pub use_on_type_format: bool,
     // Controls how the editor handles the autoclosed characters.
     pub always_treat_brackets_as_autoclosed: bool,
     /// Which code actions to run on save
@@ -333,6 +336,11 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: false
     pub always_treat_brackets_as_autoclosed: Option<bool>,
+    /// Whether to use additional LSP queries to format (and amend) the code after
+    /// every "trigger" symbol input, defined by LSP server capabilities.
+    ///
+    /// Default: true
+    pub use_on_type_format: Option<bool>,
     /// Which code actions to run on save after the formatter.
     /// These are not run if formatting is off.
     ///
@@ -1045,6 +1053,7 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
     merge(&mut settings.soft_wrap, src.soft_wrap);
     merge(&mut settings.use_autoclose, src.use_autoclose);
     merge(&mut settings.use_auto_surround, src.use_auto_surround);
+    merge(&mut settings.use_on_type_format, src.use_on_type_format);
     merge(
         &mut settings.always_treat_brackets_as_autoclosed,
         src.always_treat_brackets_as_autoclosed,


### PR DESCRIPTION
Before this change, `use_on_type_format` would only have an effect when defined on a global level in our settings.

But our default.json settings would also document that it's used in language settings, i.e.:

```json
{
  "languages": {
    "C": {
      "use_on_type_format": false
    },
    "C++": {
      "use_on_type_format": false
    }
  }
}
```

But this did **not** work.

With the change, it now works globally and per-language.

Release Notes:

- Fixed `use_on_type_format` setting not working when defined inside `"languages"` in the settings. This change will now change the default behavior for C, C++, and Markdown, by turning language server's `OnTypeFormatting` completions off by default.