### PR TITLE
assistant: Fix copy/cut not working when selection is empty

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -961,7 +961,8 @@ impl AssistantPanel {
     }
 
     fn new_context(&mut self, cx: &mut ViewContext<Self>) -> Option<View<ContextEditor>> {
-        if self.project.read(cx).is_via_collab() {
+        let project = self.project.read(cx);
+        if project.is_via_collab() && project.dev_server_project_id().is_none() {
             let task = self
                 .context_store
                 .update(cx, |store, cx| store.create_remote_context(cx));


### PR DESCRIPTION
Release Notes:

- Fixed copy/cut/paste not working in the assistant panel when selection was empty
