### PR TITLE
docs: Add FIPS mode error to Linux troubleshooting

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -147,13 +147,17 @@ It is also possible that you are running out of file descriptors. You can check 
 
 ### FIPS Mode OpenSSL internal error
 
-If your machine is running in FIPS mode (`cat /proc/sys/crypto/fips_enabled` or `sysctl crypto.fips_enabled` are set to `1`) and Zed hangs when starting, check if `zed --foreground` returns the error
+If your machine is running in FIPS mode (`cat /proc/sys/crypto/fips_enabled` or `sysctl crypto.fips_enabled` are set to `1`) Zed may hang when starting and output the following when launched with `zed --foreground`:
+
 ```
 crypto/fips/fips.c:154: OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
 ```
-If so, try removing the `libssl` and `libcrypto` libraries from the `zed.app/lib` directory
+
+As a workaround you can try removing the bundled `libssl` and `libcrypto` libraries from the `zed.app/lib` directory:
+
 ```
-rm zed.app/lib/libssl.so.1.1
-rm zed.app/lib/libcrypto.so.1.1
+rm ~/.local/zed.app/lib/libssl.so.1.1
+rm ~/.local/zed.app/lib/libcrypto.so.1.1
 ```
-so that `zed` will use the FIPS compliant system ssl and crypto libraries instead of the ones bundled with `zed`.
+
+This will force zed to fallback to the system `libssl` and `libcrypto` libraries.

--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -145,15 +145,15 @@ If you are seeing "too many open files" then first try `sysctl fs.inotify`.
 
 It is also possible that you are running out of file descriptors. You can check the limits with `ulimit` and update them by editing `/etc/security/limits.conf`.
 
-### FIPS Mode OpenSSL internal error
+### FIPS Mode OpenSSL internal error {#fips}
 
-If your machine is running in FIPS mode (`cat /proc/sys/crypto/fips_enabled` or `sysctl crypto.fips_enabled` are set to `1`) Zed may hang when starting and output the following when launched with `zed --foreground`:
+If your machine is running in FIPS mode (`cat /proc/sys/crypto/fips_enabled` is set to `1`) Zed may fail to start and output the following when launched with `zed --foreground`:
 
 ```
 crypto/fips/fips.c:154: OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
 ```
 
-As a workaround you can try removing the bundled `libssl` and `libcrypto` libraries from the `zed.app/lib` directory:
+As a workaround, remove the bundled `libssl` and `libcrypto` libraries from the `zed.app/lib` directory:
 
 ```
 rm ~/.local/zed.app/lib/libssl.so.1.1

--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -144,3 +144,16 @@ If you are seeing "too many open files" then first try `sysctl fs.inotify`.
 - You should see that `max_user_watches` is 8000 or higher (you can change the limit with `sudo sysctl fs.inotify.max_user_watches=64000`). Zed needs one watch per directory in all your open projects + one per git repository + a handful more for settings, themes, keymaps, extensions.
 
 It is also possible that you are running out of file descriptors. You can check the limits with `ulimit` and update them by editing `/etc/security/limits.conf`.
+
+### FIPS Mode OpenSSL internal error
+
+If your machine is running in FIPS mode (`cat /proc/sys/crypto/fips_enabled` or `sysctl crypto.fips_enabled` are set to `1`) and Zed hangs when starting, check if `zed --foreground` returns the error
+```
+crypto/fips/fips.c:154: OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
+```
+If so, try removing the `libssl` and `libcrypto` libraries from the `zed.app/lib` directory
+```
+rm zed.app/lib/libssl.so.1.1
+rm zed.app/lib/libcrypto.so.1.1
+```
+so that `zed` will use the FIPS compliant system ssl and crypto libraries instead of the ones bundled with `zed`.


### PR DESCRIPTION
- Closes: #18335
Update linux.md with a workaround for the
```
crypto/fips/fips.c:154: OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
```
error when using bundled libssl and libcrypto.

Release Notes:

- N/A
