### PR TITLE
Remove non-wrapping settings from the language configuration

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -535,17 +535,16 @@
   // How to soft-wrap long lines of text.
   // Possible values:
   //
-  // 1. Do not soft wrap.
-  //      "soft_wrap": "none",
   // 2. Prefer a single line generally, unless an overly long line is encountered.
-  //      "soft_wrap": "prefer_line",
+  //      "soft_wrap": "none",
+  //      "soft_wrap": "prefer_line", // (deprecated, same as "none")
   // 3. Soft wrap lines that overflow the editor.
   //      "soft_wrap": "editor_width",
   // 4. Soft wrap lines at the preferred line length.
   //      "soft_wrap": "preferred_line_length",
   // 5. Soft wrap lines at the preferred line length or the editor width (whichever is smaller).
   //      "soft_wrap": "bounded",
-  "soft_wrap": "prefer_line",
+  "soft_wrap": "none",
   // The column at which to soft-wrap lines, for buffers where soft-wrap
   // is enabled.
   "preferred_line_length": 80,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4994,10 +4994,8 @@ impl Element for EditorElement {
                             snapshot
                         } else {
                             let wrap_width = match editor.soft_wrap_mode(cx) {
-                                SoftWrap::None => None,
-                                SoftWrap::PreferLine => {
-                                    Some((MAX_LINE_LEN / 2) as f32 * em_advance)
-                                }
+                                SoftWrap::GitDiff => None,
+                                SoftWrap::None => Some((MAX_LINE_LEN / 2) as f32 * em_advance),
                                 SoftWrap::EditorWidth => Some(editor_width),
                                 SoftWrap::Column(column) => Some(column as f32 * em_advance),
                                 SoftWrap::Bounded(column) => {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -379,15 +379,16 @@ pub struct FeaturesContent {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SoftWrap {
-    /// Do not soft wrap.
+    /// Prefer a single line generally, unless an overly long line is encountered.
     None,
+    /// Deprecated: use None instead. Left to avoid breakin existing users' configs.
     /// Prefer a single line generally, unless an overly long line is encountered.
     PreferLine,
-    /// Soft wrap lines that exceed the editor width
+    /// Soft wrap lines that exceed the editor width.
     EditorWidth,
-    /// Soft wrap lines at the preferred line length
+    /// Soft wrap lines at the preferred line length.
     PreferredLineLength,
-    /// Soft wrap line at the preferred line length or the editor width (whichever is smaller)
+    /// Soft wrap line at the preferred line length or the editor width (whichever is smaller).
     Bounded,
 }
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1357,12 +1357,12 @@ Or to set a `socks5` proxy:
 
 - Description: Whether or not to automatically wrap lines of text to fit editor / preferred width.
 - Setting: `soft_wrap`
-- Default: `prefer_line`
+- Default: `none`
 
 **Options**
 
-1. `none` to stop the soft-wrapping
-2. `prefer_line` to avoid wrapping generally, unless the line is too long
+1. `none` to avoid wrapping generally, unless the line is too long
+2. `prefer_line` (deprecated, same as `none`)
 3. `editor_width` to wrap lines that overflow the editor width
 4. `preferred_line_length` to wrap lines that overflow `preferred_line_length` config value
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/17736

Those are limited with 1024 symbols before wrapping still, and were introduced for git diff deleted hunks display.
Instead of confusing people with actually wrapping, restores behavior that was before https://github.com/zed-industries/zed/pull/11080

Release Notes:

- Removed confusing soft wrap option behavior ([#17736]https://github.com/zed-industries/zed/issues/17736) 