### PR TITLE
Fix register selection in visual mode

### DIFF
--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -63,7 +63,6 @@ impl Vim {
         self.marks.insert("<".to_string(), starts);
         self.marks.insert(">".to_string(), ends);
         self.stored_visual_mode.replace((mode, reversed));
-        self.clear_operator(cx);
     }
 
     pub fn jump(&mut self, text: Arc<str>, line: bool, cx: &mut ViewContext<Self>) {

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -673,6 +673,9 @@ mod test {
         cx.simulate_shared_keystrokes("\" _ d d").await;
         cx.shared_register('_').await.assert_eq("");
 
+        cx.simulate_shared_keystrokes("shift-v \" _ y w").await;
+        cx.shared_register('"').await.assert_eq("jumps");
+
         cx.shared_state().await.assert_eq(indoc! {"
                 The quick brown
                 the ˇlazy dog"});

--- a/crates/vim/test_data/test_special_registers.json
+++ b/crates/vim/test_data/test_special_registers.json
@@ -10,6 +10,13 @@
 {"Key":"d"}
 {"Get":{"state":"The quick brown\nthe ˇlazy dog","mode":"Normal"}}
 {"ReadRegister":{"name":"_","value":""}}
+{"Key":"shift-v"}
+{"Key":"\""}
+{"Key":"_"}
+{"Key":"y"}
+{"Key":"w"}
+{"Get":{"state":"The quick brown\nthe ˇlazy dog","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"jumps"}}
 {"Get":{"state":"The quick brown\nthe ˇlazy dog","mode":"Normal"}}
 {"Key":"\""}
 {"Key":"\""}


### PR DESCRIPTION

Related to #12895

Release Notes:

- vim: Fix register selection in visual yank
