### PR TITLE
Fix being unable to open file with colon and brackets

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -57,9 +57,11 @@ struct Args {
     #[arg(long)]
     dev_server_token: Option<String>,
 }
-
-fn parse_path_with_position(argument_str: &str) -> Result<String, std::io::Error> {
-    let path = PathWithPosition::parse_str(argument_str);
+fn parse_path(
+    argument_str: &str,
+    parser: fn(&str) -> PathWithPosition,
+) -> Result<String, std::io::Error> {
+    let path = parser(argument_str);
     let curdir = env::current_dir()?;
 
     let canonicalized = path.map_path(|path| match fs::canonicalize(&path) {
@@ -142,7 +144,7 @@ fn main() -> Result<()> {
             let (file, _) = file.keep()?;
             stdin_tmp_file = Some(file);
         } else {
-            paths.push(parse_path_with_position(path)?)
+            paths.push(parse_path(&path, PathWithPosition::parse_str_without_pos)?)
         }
     }
 

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -751,7 +751,7 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "windows")]
-    fn path_with_position_parse_windows_path() {
+    fn path_without_position_parse_windows_path() {
         assert_eq!(
             PathWithPosition::parse_str_without_pos("crates\\utils\\paths.rs"),
             PathWithPosition {
@@ -773,7 +773,7 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "windows")]
-    fn path_with_position_parse_windows_path_with_suffix() {
+    fn path_without_position_parse_windows_path_with_suffix() {
         assert_eq!(
             PathWithPosition::parse_str_without_pos("crates\\utils\\paths.rs:101"),
             PathWithPosition {

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -57,7 +57,7 @@ impl OpenRequest {
 
     fn parse_file_path(&mut self, file: &str) {
         if let Some(decoded) = urlencoding::decode(file).log_err() {
-            let path_buf = PathWithPosition::parse_str(&decoded);
+            let path_buf = PathWithPosition::parse_str_without_pos(&decoded);
             self.open_paths.push(path_buf)
         }
     }

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -385,7 +385,7 @@ async fn open_workspaces(
         let paths_with_position = paths
             .into_iter()
             .map(|path_with_position_string| {
-                PathWithPosition::parse_str(&path_with_position_string)
+                PathWithPosition::parse_str_without_pos(&path_with_position_string)
             })
             .collect();
         vec![paths_with_position]


### PR DESCRIPTION
- Closes: #18268

the file name like "filename(2)" and "filename:2" will be parsed as filename row 2  by `parse_str`. Because `terminal_view` used this function to locate position , I add a new function called `parse_str_without_pos` to parse file name without the location.

But Windows does not support file names with ":".It may be necessary to add additional parsing restrictions;

Release Notes:

- Fixed unable to open file with  colon and backets
