### PR TITLE
Associate `uv.lock` files with TOML

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -769,7 +769,8 @@
       "**/Zed/**/*.json",
       "tsconfig.json",
       "pyrightconfig.json"
-    ]
+    ],
+    "TOML": ["uv.lock"]
   },
   /// By default use a recent system version of node, or install our own.
   /// You can override this to use a version of node that is not in $PATH with:


### PR DESCRIPTION
The `uv` python package manager uses the TOML for it's `uv.lock` file, see https://docs.astral.sh/uv/guides/projects/#uvlock.

Ref #7808

Release Notes:

- associate `uv.lock` files with the TOML language
