### PR TITLE
Add support for GitLab self-hosted instances

### DIFF
--- a/crates/git/src/hosting_provider.rs
+++ b/crates/git/src/hosting_provider.rs
@@ -33,9 +33,6 @@ pub trait GitHostingProvider {
     /// Returns the name of the provider.
     fn name(&self) -> String;
 
-    /// Returns the base URL of the provider.
-    fn base_url(&self) -> Url;
-
     /// Returns a permalink to a Git commit on this hosting provider.
     fn build_commit_permalink(
         &self,
@@ -155,6 +152,7 @@ impl GitHostingProviderRegistry {
 
 #[derive(Debug)]
 pub struct ParsedGitRemote<'a> {
+    pub base_url: Url,
     pub owner: &'a str,
     pub repo: &'a str,
 }

--- a/crates/git_hosting_providers/src/git_hosting_providers.rs
+++ b/crates/git_hosting_providers/src/git_hosting_providers.rs
@@ -23,4 +23,5 @@ pub fn init(cx: &mut AppContext) {
     provider_registry.register_hosting_provider(Arc::new(Bitbucket));
     provider_registry.register_hosting_provider(Arc::new(Sourcehut));
     provider_registry.register_hosting_provider(Arc::new(Codeberg));
+    provider_registry.register_hosting_provider(Arc::new(GitlabSelfHosted));
 }

--- a/crates/git_hosting_providers/src/providers.rs
+++ b/crates/git_hosting_providers/src/providers.rs
@@ -3,6 +3,7 @@ mod codeberg;
 mod gitee;
 mod github;
 mod gitlab;
+mod gitlab_self_hosted;
 mod sourcehut;
 
 pub use bitbucket::*;
@@ -10,4 +11,5 @@ pub use codeberg::*;
 pub use gitee::*;
 pub use github::*;
 pub use gitlab::*;
+pub use gitlab_self_hosted::*;
 pub use sourcehut::*;

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -4,13 +4,12 @@ use git::{BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, 
 
 pub struct Gitee;
 
+static BASE_URL: std::sync::LazyLock<Url> =
+    std::sync::LazyLock::new(|| Url::parse("https://gitee.com").unwrap());
+
 impl GitHostingProvider for Gitee {
     fn name(&self) -> String {
         "Gitee".to_string()
-    }
-
-    fn base_url(&self) -> Url {
-        Url::parse("https://gitee.com").unwrap()
     }
 
     fn supports_avatars(&self) -> bool {
@@ -34,7 +33,11 @@ impl GitHostingProvider for Gitee {
 
             let (owner, repo) = repo_with_owner.split_once('/')?;
 
-            return Some(ParsedGitRemote { owner, repo });
+            return Some(ParsedGitRemote {
+                base_url: BASE_URL.clone(),
+                owner,
+                repo,
+            });
         }
 
         None
@@ -46,23 +49,30 @@ impl GitHostingProvider for Gitee {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("{owner}/{repo}/commit/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
             .unwrap();
         permalink.set_fragment(
@@ -81,6 +91,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_ssh_url() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -100,6 +111,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_ssh_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -119,6 +131,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_ssh_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -138,6 +151,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_https_url() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -157,6 +171,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_https_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -176,6 +191,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_https_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "libkitten",
             repo: "zed",
         };

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -85,14 +85,12 @@ impl Github {
     }
 }
 
+static BASE_URL: std::sync::LazyLock<Url> =
+    std::sync::LazyLock::new(|| Url::parse("https://github.com").unwrap());
 #[async_trait]
 impl GitHostingProvider for Github {
     fn name(&self) -> String {
         "GitHub".to_string()
-    }
-
-    fn base_url(&self) -> Url {
-        Url::parse("https://github.com").unwrap()
     }
 
     fn supports_avatars(&self) -> bool {
@@ -116,7 +114,11 @@ impl GitHostingProvider for Github {
 
             let (owner, repo) = repo_with_owner.split_once('/')?;
 
-            return Some(ParsedGitRemote { owner, repo });
+            return Some(ParsedGitRemote {
+                base_url: BASE_URL.clone(),
+                owner,
+                repo,
+            });
         }
 
         None
@@ -128,23 +130,30 @@ impl GitHostingProvider for Github {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("{owner}/{repo}/commit/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
             .unwrap();
         if path.ends_with(".md") {
@@ -163,7 +172,7 @@ impl GitHostingProvider for Github {
         let capture = pull_request_number_regex().captures(line)?;
         let number = capture.get(1)?.as_str().parse::<u32>().ok()?;
 
-        let mut url = self.base_url();
+        let mut url: Url = remote.base_url.clone();
         let path = format!("/{}/{}/pull/{}", remote.owner, remote.repo, number);
         url.set_path(&path);
 
@@ -201,6 +210,7 @@ mod tests {
     #[test]
     fn test_build_github_permalink_from_ssh_url() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "zed-industries",
             repo: "zed",
         };
@@ -220,6 +230,7 @@ mod tests {
     #[test]
     fn test_build_github_permalink_from_ssh_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "zed-industries",
             repo: "zed",
         };
@@ -239,6 +250,7 @@ mod tests {
     #[test]
     fn test_build_github_permalink_from_ssh_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "zed-industries",
             repo: "zed",
         };
@@ -258,6 +270,7 @@ mod tests {
     #[test]
     fn test_build_github_permalink_from_https_url() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "zed-industries",
             repo: "zed",
         };
@@ -277,6 +290,7 @@ mod tests {
     #[test]
     fn test_build_github_permalink_from_https_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "zed-industries",
             repo: "zed",
         };
@@ -296,6 +310,7 @@ mod tests {
     #[test]
     fn test_build_github_permalink_from_https_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "zed-industries",
             repo: "zed",
         };
@@ -315,6 +330,7 @@ mod tests {
     #[test]
     fn test_github_pull_requests() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "zed-industries",
             repo: "zed",
         };

--- a/crates/git_hosting_providers/src/providers/sourcehut.rs
+++ b/crates/git_hosting_providers/src/providers/sourcehut.rs
@@ -4,13 +4,11 @@ use git::{BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, 
 
 pub struct Sourcehut;
 
+static BASE_URL: std::sync::LazyLock<Url> =
+    std::sync::LazyLock::new(|| Url::parse("https://git.sr.ht").unwrap());
 impl GitHostingProvider for Sourcehut {
     fn name(&self) -> String {
         "Gitee".to_string()
-    }
-
-    fn base_url(&self) -> Url {
-        Url::parse("https://git.sr.ht").unwrap()
     }
 
     fn supports_avatars(&self) -> bool {
@@ -36,7 +34,11 @@ impl GitHostingProvider for Sourcehut {
 
             let (owner, repo) = repo_with_owner.split_once('/')?;
 
-            return Some(ParsedGitRemote { owner, repo });
+            return Some(ParsedGitRemote {
+                base_url: BASE_URL.clone(),
+                owner,
+                repo,
+            });
         }
 
         None
@@ -48,23 +50,30 @@ impl GitHostingProvider for Sourcehut {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("~{owner}/{repo}/commit/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("~{owner}/{repo}/tree/{sha}/item/{path}"))
             .unwrap();
         permalink.set_fragment(
@@ -83,6 +92,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -102,6 +112,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url_with_git_prefix() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "rajveermalviya",
             repo: "zed.git",
         };
@@ -121,6 +132,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -140,6 +152,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -159,6 +172,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_https_url() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -178,6 +192,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_https_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -197,6 +212,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_https_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: BASE_URL.clone(),
             owner: "rajveermalviya",
             repo: "zed",
         };


### PR DESCRIPTION
Closes #18012

Release Notes:

- Added support for gitlab self hosted instances

[test.webm](https://github.com/user-attachments/assets/57f2028f-8161-445c-bc7b-e25c9d55da3a)
