### PR TITLE
Add vim::MoveTo{Next,Prev} flags for regex and case sensitive search

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -276,12 +276,6 @@ impl Vim {
                     drop(search_bar.search("", None, cx));
                     return None;
                 };
-                if search_bar.should_use_smartcase_search(cx) {
-                    options.set(
-                        SearchOptions::CASE_SENSITIVE,
-                        search_bar.is_contains_uppercase(&query),
-                    );
-                }
                 let mut query = regex::escape(&query);
                 if whole_word {
                     query = format!(r"\<{}\>", query);

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -276,6 +276,12 @@ impl Vim {
                     drop(search_bar.search("", None, cx));
                     return None;
                 };
+                if search_bar.should_use_smartcase_search(cx) {
+                    options.set(
+                        SearchOptions::CASE_SENSITIVE,
+                        search_bar.is_contains_uppercase(&query),
+                    );
+                }
                 let mut query = regex::escape(&query);
                 if whole_word {
                     query = format!(r"\<{}\>", query);


### PR DESCRIPTION
This makes the hard-coded regex and case-sensitive search flags in `vim::MoveToNext` and `vim::MoveToPrev` commands configurable in key bindings.

Example:

```json
{
  "context": "VimControl && !menu",
  "bindings": {
    "*": ["vim::MoveToNext", { "regex": false, "caseSensitive": false }],
    "#": ["vim::MoveToPrev", { "regex": false, "caseSensitive": false }]
  }
}
```

Closes #15837.

Release Notes:

- Added `regex` and `caseSensitive` arguments to `vim::MoveToNext` and `vim ::MoveToPrev` commands, for toggling regex and case sensitive search.