### PR TITLE
Remove Qwen2 model

### DIFF
--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -149,18 +149,6 @@ spec:
                 secretKeyRef:
                   name: google-ai
                   key: api_key
-            - name: RUNPOD_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: runpod
-                  key: api_key
-                  optional: true
-            - name: RUNPOD_API_SUMMARY_URL
-              valueFrom:
-                secretKeyRef:
-                  name: runpod
-                  key: summary
-                  optional: true
             - name: BLOB_STORE_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -170,8 +170,6 @@ pub struct Config {
     pub anthropic_api_key: Option<Arc<str>>,
     pub anthropic_staff_api_key: Option<Arc<str>>,
     pub llm_closed_beta_model_name: Option<Arc<str>>,
-    pub runpod_api_key: Option<Arc<str>>,
-    pub runpod_api_summary_url: Option<Arc<str>>,
     pub zed_client_checksum_seed: Option<String>,
     pub slack_panics_webhook: Option<String>,
     pub auto_join_channel_id: Option<ChannelId>,
@@ -235,8 +233,6 @@ impl Config {
             stripe_api_key: None,
             stripe_price_id: None,
             supermaven_admin_api_key: None,
-            runpod_api_key: None,
-            runpod_api_summary_url: None,
             user_backfiller_github_access_token: None,
         }
     }

--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -400,42 +400,6 @@ async fn perform_completion(
                 })
                 .boxed()
         }
-        LanguageModelProvider::Zed => {
-            let api_key = state
-                .config
-                .runpod_api_key
-                .as_ref()
-                .context("no Qwen2-7B API key configured on the server")?;
-            let api_url = state
-                .config
-                .runpod_api_summary_url
-                .as_ref()
-                .context("no Qwen2-7B URL configured on the server")?;
-            let chunks = open_ai::stream_completion(
-                &state.http_client,
-                api_url,
-                api_key,
-                serde_json::from_str(params.provider_request.get())?,
-                None,
-            )
-            .await?;
-
-            chunks
-                .map(|event| {
-                    event.map(|chunk| {
-                        let input_tokens =
-                            chunk.usage.as_ref().map_or(0, |u| u.prompt_tokens) as usize;
-                        let output_tokens =
-                            chunk.usage.as_ref().map_or(0, |u| u.completion_tokens) as usize;
-                        (
-                            serde_json::to_vec(&chunk).unwrap(),
-                            input_tokens,
-                            output_tokens,
-                        )
-                    })
-                })
-                .boxed()
-        }
     };
 
     Ok(Response::new(Body::wrap_stream(TokenCountingStream {

--- a/crates/collab/src/llm/authorization.rs
+++ b/crates/collab/src/llm/authorization.rs
@@ -77,7 +77,6 @@ fn authorize_access_for_country(
         LanguageModelProvider::Anthropic => anthropic::is_supported_country(country_code),
         LanguageModelProvider::OpenAi => open_ai::is_supported_country(country_code),
         LanguageModelProvider::Google => google_ai::is_supported_country(country_code),
-        LanguageModelProvider::Zed => true,
     };
     if !is_country_supported_by_provider {
         Err(Error::http(
@@ -213,7 +212,6 @@ mod tests {
             (LanguageModelProvider::Anthropic, "T1"), // Tor
             (LanguageModelProvider::OpenAi, "T1"),    // Tor
             (LanguageModelProvider::Google, "T1"),    // Tor
-            (LanguageModelProvider::Zed, "T1"),       // Tor
         ];
 
         for (provider, country_code) in cases {

--- a/crates/collab/src/llm/db/seed.rs
+++ b/crates/collab/src/llm/db/seed.rs
@@ -40,15 +40,6 @@ pub async fn seed_database(_config: &Config, db: &mut LlmDatabase, _force: bool)
             price_per_million_input_tokens: 25,   // $0.25/MTok
             price_per_million_output_tokens: 125, // $1.25/MTok
         },
-        ModelParams {
-            provider: LanguageModelProvider::Zed,
-            name: "Qwen/Qwen2-7B-Instruct".into(),
-            max_requests_per_minute: 5,
-            max_tokens_per_minute: 25_000, // These are arbitrary limits we've set to cap costs; we control this number
-            max_tokens_per_day: 300_000,
-            price_per_million_input_tokens: 25,
-            price_per_million_output_tokens: 125,
-        },
     ])
     .await
 }

--- a/crates/collab/src/llm/db/tests/provider_tests.rs
+++ b/crates/collab/src/llm/db/tests/provider_tests.rs
@@ -26,7 +26,6 @@ async fn test_initialize_providers(db: &mut LlmDatabase) {
             LanguageModelProvider::Anthropic,
             LanguageModelProvider::Google,
             LanguageModelProvider::OpenAi,
-            LanguageModelProvider::Zed
         ]
     )
 }

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -679,8 +679,6 @@ impl TestServer {
                 stripe_api_key: None,
                 stripe_price_id: None,
                 supermaven_admin_api_key: None,
-                runpod_api_key: None,
-                runpod_api_summary_url: None,
                 user_backfiller_github_access_token: None,
             },
         })

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -12,33 +12,12 @@ pub enum CloudModel {
     Anthropic(anthropic::Model),
     OpenAi(open_ai::Model),
     Google(google_ai::Model),
-    Zed(ZedModel),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, EnumIter)]
 pub enum ZedModel {
     #[serde(rename = "Qwen/Qwen2-7B-Instruct")]
     Qwen2_7bInstruct,
-}
-
-impl ZedModel {
-    pub fn id(&self) -> &str {
-        match self {
-            ZedModel::Qwen2_7bInstruct => "Qwen/Qwen2-7B-Instruct",
-        }
-    }
-
-    pub fn display_name(&self) -> &str {
-        match self {
-            ZedModel::Qwen2_7bInstruct => "Qwen2 7B Instruct",
-        }
-    }
-
-    pub fn max_token_count(&self) -> usize {
-        match self {
-            ZedModel::Qwen2_7bInstruct => 28000,
-        }
-    }
 }
 
 impl Default for CloudModel {
@@ -53,7 +32,6 @@ impl CloudModel {
             Self::Anthropic(model) => model.id(),
             Self::OpenAi(model) => model.id(),
             Self::Google(model) => model.id(),
-            Self::Zed(model) => model.id(),
         }
     }
 
@@ -62,7 +40,6 @@ impl CloudModel {
             Self::Anthropic(model) => model.display_name(),
             Self::OpenAi(model) => model.display_name(),
             Self::Google(model) => model.display_name(),
-            Self::Zed(model) => model.display_name(),
         }
     }
 
@@ -78,7 +55,6 @@ impl CloudModel {
             Self::Anthropic(model) => model.max_token_count(),
             Self::OpenAi(model) => model.max_token_count(),
             Self::Google(model) => model.max_token_count(),
-            Self::Zed(model) => model.max_token_count(),
         }
     }
 
@@ -114,9 +90,6 @@ impl CloudModel {
                 | google_ai::Model::Custom { .. } => {
                     LanguageModelAvailability::RequiresPlan(Plan::ZedPro)
                 }
-            },
-            Self::Zed(model) => match model {
-                ZedModel::Qwen2_7bInstruct => LanguageModelAvailability::RequiresPlan(Plan::ZedPro),
             },
         }
     }

--- a/crates/rpc/src/llm.rs
+++ b/crates/rpc/src/llm.rs
@@ -12,7 +12,6 @@ pub enum LanguageModelProvider {
     Anthropic,
     OpenAi,
     Google,
-    Zed,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Removed deprecated Qwen2 7B Instruct model from zed.dev provider (staff only).

Release Notes:

- N/A