### PR TITLE
Fix Ollama timeouts broken on Preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7523,6 +7523,7 @@ dependencies = [
  "anyhow",
  "futures 0.3.30",
  "http_client",
+ "isahc",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/ollama/Cargo.toml
+++ b/crates/ollama/Cargo.toml
@@ -19,6 +19,7 @@ schemars = ["dep:schemars"]
 anyhow.workspace = true
 futures.workspace = true
 http_client.workspace = true
+isahc.workspace = true
 schemars = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Supersedes: https://github.com/zed-industries/zed/pull/18310
See also: https://github.com/zed-industries/zed/issues/18304

This PR targets v0.155.x and is a hotfix for Preview.

Release Notes:

- Fixed Ollama timeouts (Preview Only)