### PR TITLE
Add tooltip for code actions icon button

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5368,6 +5368,19 @@ impl Editor {
                     .icon_size(IconSize::XSmall)
                     .icon_color(Color::Muted)
                     .selected(is_active)
+                    .tooltip({
+                        let focus_handle = self.focus_handle.clone();
+                        move |cx| {
+                            Tooltip::for_action_in(
+                                "Toggle Code Actions",
+                                &ToggleCodeActions {
+                                    deployed_from_indicator: None,
+                                },
+                                &focus_handle,
+                                cx,
+                            )
+                        }
+                    })
                     .on_click(cx.listener(move |editor, _e, cx| {
                         editor.focus(cx);
                         editor.toggle_code_actions(


### PR DESCRIPTION
I have just recently discovered this keybinding myself out of talking to folks, ha. The tooltip here might ease the discovery for other folks in the future.

<img width="700" alt="Screenshot 2024-09-27 at 11 04 28 PM" src="https://github.com/user-attachments/assets/844d3b55-15af-47f7-a8db-5c8832ceba29">

---

Release Notes:

- N/A
