### PR TITLE
gpui: Fix blur region on Plasma/Wayland

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -1046,8 +1046,8 @@ fn update_window(mut state: RefMut<WaylandWindowState>) {
         && state.decorations == WindowDecorations::Server
     {
         // Promise the compositor that this region of the window surface
-        // contains no transparent pixels. This allows the compositor to
-        // do skip whatever is behind the surface for better performance.
+        // contains no transparent pixels. This allows the compositor to skip
+        // updating whatever is behind the surface for better performance.
         state.surface.set_opaque_region(Some(&region));
     } else {
         state.surface.set_opaque_region(None);
@@ -1057,7 +1057,6 @@ fn update_window(mut state: RefMut<WaylandWindowState>) {
         if state.background_appearance == WindowBackgroundAppearance::Blurred {
             if state.blur.is_none() {
                 let blur = blur_manager.create(&state.surface, &state.globals.qh, ());
-                blur.set_region(Some(&region));
                 state.blur = Some(blur);
             }
             state.blur.as_ref().unwrap().commit();


### PR DESCRIPTION
Once again aping after what winit does - since we always want to have the whole window blurred there is apparently no need to specify a blur region at all. Rounded corners would be the exception, but that is not possible with the current protocol (it is planned for the vendor-neutral version though!)

This eliminates the problem where only a fixed region of the window would get blurred if the window was resized to be larger than at launch. Also a drive-by comment grammar fix :wink: 

Release Notes:

- Fixed blur region on Plasma/Wayland
