### PR TITLE
windows: Fix extension uninstall

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -846,26 +846,18 @@ impl ExtensionStore {
             )
             .await?;
 
-            // TODO:
+            // todo(windows)
             // Stop the server here.
+            this.update(cx, |this, cx| this.reload(None, cx))?.await;
 
-            this.update(&mut cx, |this, cx| this.reload(None, cx))?
-                .await;
-
-            let ret1 = fs
-                .remove_dir(
-                    &work_dir,
-                    RemoveOptions {
-                        recursive: true,
-                        ignore_if_not_exists: true,
-                    },
-                )
-                .await;
-            println!("=> 1: {:?}", ret1);
-            println!("=> 1: work dir: {:?}", work_dir.display());
-            ret1?;
-            this.update(&mut cx, |this, cx| this.reload(None, cx))?
-                .await;
+            fs.remove_dir(
+                &work_dir,
+                RemoveOptions {
+                    recursive: true,
+                    ignore_if_not_exists: true,
+                },
+            )
+            .await?;
 
             anyhow::Ok(())
         })

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -846,6 +846,11 @@ impl ExtensionStore {
                     },
                 )
                 .await;
+            println!(
+                "-> Deleting: {}<->{}",
+                work_dir.display(),
+                extension_dir.display()
+            );
             println!("=> 1: {:?}", ret1);
             println!("=> 1: work dir: {:?}", work_dir.display());
             ret1?;

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -837,24 +837,18 @@ impl ExtensionStore {
                 }
             });
 
-            println!(
-                "-> Deleting: {}<->{}",
-                work_dir.display(),
-                extension_dir.display()
-            );
+            fs.remove_dir(
+                &extension_dir,
+                RemoveOptions {
+                    recursive: true,
+                    ignore_if_not_exists: true,
+                },
+            )
+            .await?;
 
-            let ret2 = fs
-                .remove_dir(
-                    &extension_dir,
-                    RemoveOptions {
-                        recursive: true,
-                        ignore_if_not_exists: true,
-                    },
-                )
-                .await;
-            println!("=> 2: {:?}", ret2);
-            println!("=> 2: ext dir: {:?}", extension_dir.display());
-            ret2?;
+            // TODO:
+            // Stop the server here.
+
             this.update(&mut cx, |this, cx| this.reload(None, cx))?
                 .await;
 
@@ -870,7 +864,8 @@ impl ExtensionStore {
             println!("=> 1: {:?}", ret1);
             println!("=> 1: work dir: {:?}", work_dir.display());
             ret1?;
-            this.update(cx, |this, cx| this.reload(None, cx))?.await;
+            this.update(&mut cx, |this, cx| this.reload(None, cx))?
+                .await;
 
             anyhow::Ok(())
         })

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -837,23 +837,31 @@ impl ExtensionStore {
                 }
             });
 
-            fs.remove_dir(
-                &work_dir,
-                RemoveOptions {
-                    recursive: true,
-                    ignore_if_not_exists: true,
-                },
-            )
-            .await?;
+            let ret1 = fs
+                .remove_dir(
+                    &work_dir,
+                    RemoveOptions {
+                        recursive: true,
+                        ignore_if_not_exists: true,
+                    },
+                )
+                .await;
+            println!("=> 1: {:?}", ret1);
+            println!("=> 1: work dir: {:?}", work_dir.display());
+            ret1?;
 
-            fs.remove_dir(
-                &extension_dir,
-                RemoveOptions {
-                    recursive: true,
-                    ignore_if_not_exists: true,
-                },
-            )
-            .await?;
+            let ret2 = fs
+                .remove_dir(
+                    &extension_dir,
+                    RemoveOptions {
+                        recursive: true,
+                        ignore_if_not_exists: true,
+                    },
+                )
+                .await;
+            println!("=> 2: {:?}", ret2);
+            println!("=> 2: ext dir: {:?}", extension_dir.display());
+            ret2?;
 
             this.update(cx, |this, cx| this.reload(None, cx))?.await;
             anyhow::Ok(())

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -837,23 +837,11 @@ impl ExtensionStore {
                 }
             });
 
-            let ret1 = fs
-                .remove_dir(
-                    &work_dir,
-                    RemoveOptions {
-                        recursive: true,
-                        ignore_if_not_exists: true,
-                    },
-                )
-                .await;
             println!(
                 "-> Deleting: {}<->{}",
                 work_dir.display(),
                 extension_dir.display()
             );
-            println!("=> 1: {:?}", ret1);
-            println!("=> 1: work dir: {:?}", work_dir.display());
-            ret1?;
 
             let ret2 = fs
                 .remove_dir(
@@ -867,8 +855,23 @@ impl ExtensionStore {
             println!("=> 2: {:?}", ret2);
             println!("=> 2: ext dir: {:?}", extension_dir.display());
             ret2?;
+            this.update(&mut cx, |this, cx| this.reload(None, cx))?
+                .await;
 
+            let ret1 = fs
+                .remove_dir(
+                    &work_dir,
+                    RemoveOptions {
+                        recursive: true,
+                        ignore_if_not_exists: true,
+                    },
+                )
+                .await;
+            println!("=> 1: {:?}", ret1);
+            println!("=> 1: work dir: {:?}", work_dir.display());
+            ret1?;
             this.update(cx, |this, cx| this.reload(None, cx))?.await;
+
             anyhow::Ok(())
         })
         .detach_and_log_err(cx)


### PR DESCRIPTION
Closes #18153


When calling `uninstall_extension`, the `work_dir` associated with this `extension` doesn't have its corresponding `FileHandle` properly closed, preventing the deletion of the `work_dir`. As seen in the image below, after installing the `toml` extension, `zed.exe` holds two `Handle`s for the folder `C:\Users\36477\AppData\Local\Zed\extensions\work\toml`.

![Screenshot 2024-09-27 171149](https://github.com/user-attachments/assets/f75f3f6f-9a62-43b5-9450-73ee1ed8e7f9)


Therefore, after deleting `extension_dir` and then calling `this.update(...)`, `zed.exe` releases these two `Handles`, and only then can the folder `C:\Users\36477\AppData\Local\Zed\extensions\work\toml` be deleted. See the corresponding file handles are closed after calling `this.update(...)`:

![Screenshot 2024-09-28 132823](https://github.com/user-attachments/assets/476e0494-850a-4af5-b351-899e60ae98f7)

However, if there is a running server of the extension, the error will persist. At this point, I haven’t found a direct way to terminate all running servers of the extension. Since this feature might affect the `LspStore` structure, I paused my work here.


See when `toml` extension is running, we can not delete `C:\Users\36477\AppData\Local\Zed\extensions\work\toml` since `C:\Users\36477\AppData\Local\Zed\extensions\work\toml\taplo.exe` is still running:

![Screenshot 2024-09-28 134709](https://github.com/user-attachments/assets/6801d6e2-2a44-4103-8570-467c507e6e20)



cc @ConradIrwin You're the expert in this area—what are your thoughts?



Release Notes:

- N/A
