### PR TITLE
ci: Add script/determine-release-channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,29 +192,12 @@ jobs:
       - name: Determine version and release channel
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          set -eu
+          # This exports RELEASE_CHANNEL into env (GITHUB_ENV)
+          script/determine-release-channel
 
-          version=$(script/get-crate-version zed)
-          channel=$(cat crates/zed/RELEASE_CHANNEL)
-          echo "Publishing version: ${version} on release channel ${channel}"
-          echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
-
-          expected_tag_name=""
-          case ${channel} in
-            stable)
-              expected_tag_name="v${version}";;
-            preview)
-              expected_tag_name="v${version}-pre";;
-            nightly)
-              expected_tag_name="v${version}-nightly";;
-            *)
-              echo "can't publish a release on channel ${channel}"
-              exit 1;;
-          esac
-          if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
-            echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
-            exit 1
-          fi
+      - name: Draft release notes
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
           mkdir -p target/
           # Ignore any errors that occur while drafting release notes to not fail the build.
           script/draft-release-notes "$version" "$channel" > target/release-notes.md || true
@@ -289,29 +272,8 @@ jobs:
       - name: Determine version and release channel
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          set -eu
-
-          version=$(script/get-crate-version zed)
-          channel=$(cat crates/zed/RELEASE_CHANNEL)
-          echo "Publishing version: ${version} on release channel ${channel}"
-          echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
-
-          expected_tag_name=""
-          case ${channel} in
-            stable)
-              expected_tag_name="v${version}";;
-            preview)
-              expected_tag_name="v${version}-pre";;
-            nightly)
-              expected_tag_name="v${version}-nightly";;
-            *)
-              echo "can't publish a release on channel ${channel}"
-              exit 1;;
-          esac
-          if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
-            echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
-            exit 1
-          fi
+          # This exports RELEASE_CHANNEL into env (GITHUB_ENV)
+          script/determine-release-channel
 
       - name: Create Linux .tar.gz bundle
         run: script/bundle-linux
@@ -357,29 +319,8 @@ jobs:
       - name: Determine version and release channel
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          set -eu
-
-          version=$(script/get-crate-version zed)
-          channel=$(cat crates/zed/RELEASE_CHANNEL)
-          echo "Publishing version: ${version} on release channel ${channel}"
-          echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
-
-          expected_tag_name=""
-          case ${channel} in
-            stable)
-              expected_tag_name="v${version}";;
-            preview)
-              expected_tag_name="v${version}-pre";;
-            nightly)
-              expected_tag_name="v${version}-nightly";;
-            *)
-              echo "can't publish a release on channel ${channel}"
-              exit 1;;
-          esac
-          if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
-            echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
-            exit 1
-          fi
+          # This exports RELEASE_CHANNEL into env (GITHUB_ENV)
+          script/determine-release-channel
 
       - name: Create and upload Linux .tar.gz bundle
         run: script/bundle-linux

--- a/script/bump-zed-patch-version
+++ b/script/bump-zed-patch-version
@@ -9,11 +9,8 @@ case $channel in
   preview)
     tag_suffix="-pre"
     ;;
-  nightly)
-    tag_suffix="-nightly"
-    ;;
   *)
-    echo "this must be run on either of stable|preview|nightly release branches" >&2
+    echo "this must be run on either of stable|preview release branches" >&2
     exit 1
     ;;
 esac

--- a/script/determine-release-channel
+++ b/script/determine-release-channel
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ -z "${GITHUB_ACTIONS-}" ]; then
+    echo "Error: This script must be run in a GitHub Actions environment"
+    exit 1
+elif [ -z "${GITHUB_REF-}" ]; then
+    # This should be the release tag 'v0.x.x'
+    echo "Error: GITHUB_REF is not set"
+    exit 1
+fi
+
+version=$(script/get-crate-version zed)
+channel=$(cat crates/zed/RELEASE_CHANNEL)
+echo "Publishing version: ${version} on release channel ${channel}"
+echo "RELEASE_CHANNEL=${channel}" >> $GITHUB_ENV
+
+expected_tag_name=""
+case ${channel} in
+stable)
+    expected_tag_name="v${version}";;
+preview)
+    expected_tag_name="v${version}-pre";;
+nightly)
+    expected_tag_name="v${version}-nightly";;
+*)
+    echo "can't publish a release on channel ${channel}"
+    exit 1;;
+esac
+if [[ $GITHUB_REF_NAME != $expected_tag_name ]]; then
+    echo "invalid release tag ${GITHUB_REF_NAME}. expected ${expected_tag_name}"
+    exit 1
+fi

--- a/script/determine-release-channel
+++ b/script/determine-release-channel
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 if [ -z "${GITHUB_ACTIONS-}" ]; then
     echo "Error: This script must be run in a GitHub Actions environment"

--- a/script/determine-release-channel
+++ b/script/determine-release-channel
@@ -22,8 +22,6 @@ stable)
     expected_tag_name="v${version}";;
 preview)
     expected_tag_name="v${version}-pre";;
-nightly)
-    expected_tag_name="v${version}-nightly";;
 *)
     echo "can't publish a release on channel ${channel}"
     exit 1;;


### PR DESCRIPTION
- Refactor duplicated inline script from ci.yml to `script/determine-release-channel`
- Remove references to non-existent '-nightly' release tags

Release Notes:

- N/A