### PR TITLE
Continue to redirect to GitHub commits for nightly and dev release notes

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -264,6 +264,12 @@ pub fn view_release_notes(_: &ViewReleaseNotes, cx: &mut AppContext) -> Option<(
 
 fn view_release_notes_locally(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
     let release_channel = ReleaseChannel::global(cx);
+
+    if matches!(release_channel, ReleaseChannel::Nightly) {
+        cx.open_url("https://github.com/zed-industries/zed/commits/nightly/");
+        return;
+    }
+
     let version = AppVersion::global(cx).to_string();
 
     let client = client::Client::global(cx).http_client();

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -265,8 +265,14 @@ pub fn view_release_notes(_: &ViewReleaseNotes, cx: &mut AppContext) -> Option<(
 fn view_release_notes_locally(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
     let release_channel = ReleaseChannel::global(cx);
 
-    if matches!(release_channel, ReleaseChannel::Nightly) {
-        cx.open_url("https://github.com/zed-industries/zed/commits/nightly/");
+    let url = match release_channel {
+        ReleaseChannel::Nightly => Some("https://github.com/zed-industries/zed/commits/nightly/"),
+        ReleaseChannel::Dev => Some("https://github.com/zed-industries/zed/commits/main/"),
+        _ => None,
+    };
+
+    if let Some(url) = url {
+        cx.open_url(url);
         return;
     }
 


### PR DESCRIPTION
We are now using the `view release notes locally` action when clicking on the update toast - the endpoint for this action does not currently return anything for valid for these channels, as we don't have support yet for diffing between these builds, so for now, [continue to do what the `view release notes` action did and just send the user to the commit view on GitHub](https://github.com/zed-industries/zed/blob/caffb2733f8e859637050e3708dbd10b6e409762/crates/auto_update/src/auto_update.rs#L255-L260). It is a bit counterintuitive to send the user to the browser when using the "local" action, but this is just a patch in the interim.

If we make adjustments to our channels to keep the nightly tag stable and add some sort of unique suffix, like a timestamp, we can then adjust things to return these in the request body and show them in the editor.

Release Notes:

- N/A
