### PR TITLE
linux/x11: Give title bar inactive bg on mouse down

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -76,7 +76,7 @@ impl Render for TitleBar {
         let supported_controls = cx.window_controls();
         let decorations = cx.window_decorations();
         let titlebar_color = if cfg!(target_os = "linux") {
-            if cx.is_window_active() {
+            if cx.is_window_active() && !self.should_move {
                 cx.theme().colors().title_bar_background
             } else {
                 cx.theme().colors().title_bar_inactive_background


### PR DESCRIPTION
This fixes something that I felt was off for a while. Previously, when you'd click on the titlebar to move the window, the titlebar would only change its background once the moving starts, but not on mouse-down.

That felt really off, since the moving is down with mouse-down and move, so I think giving the user feedback about the mouse-down event makes more sense.

I know there's a subjectivity to this change, so I'm ready to hear other opinions, but for now I want to go with this.

Release Notes:

- N/A
