### PR TITLE
Make direct direnv loading default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -599,13 +599,11 @@
     }
   },
   // Configuration for how direnv configuration should be loaded. May take 2 values:
-  // 1. Load direnv configuration through the shell hook, works for POSIX shells and fish.
-  //      "load_direnv": "shell_hook"
-  // 2. Load direnv configuration using `direnv export json` directly.
-  //    This can help with some shells that otherwise would not detect
-  //    the direnv environment, such as nushell or elvish.
+  // 1. Load direnv configuration using `direnv export json` directly.
   //      "load_direnv": "direct"
-  "load_direnv": "shell_hook",
+  // 2. Load direnv configuration through the shell hook, works for POSIX shells and fish.
+  //      "load_direnv": "shell_hook"
+  "load_direnv": "direct",
   "inline_completions": {
     // A list of globs representing files that inline completions should be disabled for.
     "disabled_globs": [".env"]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -62,12 +62,9 @@ pub struct NodeBinarySettings {
 #[serde(rename_all = "snake_case")]
 pub enum DirenvSettings {
     /// Load direnv configuration through a shell hook
-    #[default]
     ShellHook,
     /// Load direnv configuration directly using `direnv export json`
-    ///
-    /// Warning: This option is experimental and might cause some inconsistent behavior compared to using the shell hook.
-    /// If it does, please report it to GitHub
+    #[default]
     Direct,
 }
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -267,12 +267,14 @@ left and right padding of the central pane from the workspace when the centered 
 
 ## Direnv Integration
 
-- Description: Settings for [direnv](https://direnv.net/) integration. Requires `direnv` to be installed. `direnv` integration currently only means that the environment variables set by a `direnv` configuration can be used to detect some language servers in `$PATH` instead of installing them.
+- Description: Settings for [direnv](https://direnv.net/) integration. Requires `direnv` to be installed.
+  `direnv` integration make it possible to use the environment variables set by a `direnv` configuration to detect some language servers in `$PATH` instead of installing them.
+  It also allows for those environment variables to be used in tasks.
 - Setting: `load_direnv`
 - Default:
 
 ```json
-"load_direnv": "shell_hook"
+"load_direnv": "direct"
 ```
 
 **Options**


### PR DESCRIPTION
I've been running with direct direnv loading for a while now and haven't experienced any significant issues other than #18473. Making it default would make direnv integration more reliable and consistent. I've also updated the docs a bit to ensure that they represent current status of direnv integration

Release Notes:

- Made direnv integration use direct (`direnv export json`) mode by default instead of relying on a shell hook, improving consistency and reliability of direnv detection