### PR TITLE
terminal: Fix blinking settings & blinking with custom shape

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -215,7 +215,6 @@ impl Project {
             spawn_task,
             shell,
             env,
-            Some(settings.blinking),
             settings.cursor_shape.unwrap_or_default(),
             settings.alternate_scroll,
             settings.max_scroll_history_lines,


### PR DESCRIPTION
This is a follow-up to #18530 thanks to this comment here: https://github.com/zed-industries/zed/pull/18530#issuecomment-2382870564

In short: it fixes the `blinking` setting and the `cursor_shape` setting as it relates to blinking.

Turns out our `blinking` setting was always the wrong value when using `terminal_controlled` and the terminal _would_ control the blinking.

Example script to test with:

```bash
echo -e "0 normal \x1b[\x30 q"; sleep 2
echo -e "1 blink block \x1b[\x31 q"; sleep 2
echo -e "2 solid block \x1b[\x32 q"; sleep 2
echo -e "3 blink under \x1b[\x33 q"; sleep 2
echo -e "4 solid under \x1b[\x34 q"; sleep 2
echo -e "5 blink vert \x1b[\x35 q"; sleep 2
echo -e "6 solid vert \x1b[\x36 q"; sleep 2
echo -e "0 normal \x1b[\x30 q"; sleep 2

echo -e "color \x1b]12;#00ff00\x1b\\"; sleep 2
echo -e "reset \x1b]112\x1b\\ \x1b[\x30 q"
```

Before the changes in here, this script would set the cursor shape and the blinking, but the blinking boolean would always be wrong.

This change here makes sure that it works consistently:

- `terminal.cursor_shape` only controls the *default* shape of the terminal, not the blinking.
- `terminal.blinking = on` means that it's *always* blinking, regardless of what terminal programs want
- `terminal.blinking = off` means that it's *never* blinking, regardless of what terminal programs want
- `terminal.blinking = terminal_controlled (default)` means that it's blinking depending on what terminal programs want. when a terminal program resets the cursor to default, it sets it back to `terminal.cursor_shape` if that is set.

Release Notes:

- Fixed the behavior of `{"terminal": {"blinking": "[on|off|terminal_controlled]"}` to work correctly and to work correctly when custom `cursor_shape` is set.
  - `terminal.cursor_shape` only controls the *default* shape of the terminal, not the blinking.
  - `terminal.blinking = on` means that it's *always* blinking, regardless of what terminal programs want
  - `terminal.blinking = off` means that it's *never* blinking, regardless of what terminal programs want
  - `terminal.blinking = terminal_controlled (default)` means that it's blinking depending on what terminal programs want. when a terminal program resets the cursor to default, it sets it back to `terminal.cursor_shape` if that is set.

Demo:

https://github.com/user-attachments/assets/b3fbeafd-ad58-41c8-9c07-1f03bc31771f


