### PR TITLE
Fine-tune hunk controls block

### DIFF
--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -381,7 +381,7 @@ impl Editor {
                         )
                         .child(
                             h_flex()
-                                .pl_1p5()
+                                .pl_2()
                                 .pr_6()
                                 .size_full()
                                 .justify_between()

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -513,7 +513,7 @@ impl Editor {
                                                 }),
                                         )
                                         .child(
-                                            IconButton::new("discard", IconName::RotateCcw)
+                                            IconButton::new("discard", IconName::Undo)
                                                 .shape(IconButtonShape::Square)
                                                 .icon_size(IconSize::Small)
                                                 .tooltip({

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -360,8 +360,11 @@ impl Editor {
 
                     h_flex()
                         .id(cx.block_id)
-                        .w_full()
                         .h(cx.line_height())
+                        .w_full()
+                        .border_t_1()
+                        .border_color(border_color)
+                        .bg(cx.theme().colors().editor_background)
                         .child(
                             div()
                                 .id("gutter-strip")
@@ -385,8 +388,6 @@ impl Editor {
                                 .pr_6()
                                 .size_full()
                                 .justify_between()
-                                .border_t_1()
-                                .border_color(border_color)
                                 .child(
                                     h_flex()
                                         .gap_1()


### PR DESCRIPTION
This PR changes the undo icon and adds a background color so that indent lines don't bleed through the control block.

<img width="900" alt="Screenshot 2024-09-30 at 5 38 44 PM" src="https://github.com/user-attachments/assets/4955f0f6-50ce-432f-85b9-1da0172d5e51">

Release Notes:

- N/A
