### PR TITLE
Rename proto language to Proto

### DIFF
--- a/crates/languages/src/proto/config.toml
+++ b/crates/languages/src/proto/config.toml
@@ -1,4 +1,4 @@
-name = "proto"
+name = "Proto"
 grammar = "proto"
 path_suffixes = ["proto"]
 line_comments = ["// "]


### PR DESCRIPTION
All the other languages are capitalized. So should Proto be.

Release Notes:

- Protocol Buffers language support: Renamed "proto" language to "Proto". This is a breaking change and requires users adjust their settings accordingly from `proto` to `Proto` under `file_types` and `languages`.