### PR TITLE
editor: Allow opening excerpts from proposed changes editor

### DIFF
--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -11,7 +11,7 @@ use text::ToOffset;
 use ui::prelude::*;
 use workspace::{
     searchable::SearchableItemHandle, Item, ItemHandle as _, ToolbarItemEvent, ToolbarItemLocation,
-    ToolbarItemView,
+    ToolbarItemView, Workspace,
 };
 
 pub struct ProposedChangesEditor {
@@ -158,6 +158,11 @@ impl Item for ProposedChangesEditor {
         } else {
             None
         }
+    }
+
+    fn added_to_workspace(&mut self, workspace: &mut Workspace, cx: &mut ViewContext<Self>) {
+        self.editor
+            .update(cx, |editor, cx| editor.added_to_workspace(workspace, cx));
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to open excerpts in the base buffer from the proposed changes editor.

Release Notes:

- N/A
