### PR TITLE
editor: Include proposed changes editor in navigation history

### DIFF
--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -167,8 +167,7 @@ impl Item for ProposedChangesEditor {
     }
 
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
-        self.editor
-            .update(cx, |editor, cx| Item::deactivated(editor, cx));
+        self.editor.update(cx, Item::deactivated);
     }
 
     fn navigate(&mut self, data: Box<dyn std::any::Any>, cx: &mut ViewContext<Self>) -> bool {

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -161,8 +161,29 @@ impl Item for ProposedChangesEditor {
     }
 
     fn added_to_workspace(&mut self, workspace: &mut Workspace, cx: &mut ViewContext<Self>) {
+        self.editor.update(cx, |editor, cx| {
+            Item::added_to_workspace(editor, workspace, cx)
+        });
+    }
+
+    fn deactivated(&mut self, cx: &mut ViewContext<Self>) {
         self.editor
-            .update(cx, |editor, cx| editor.added_to_workspace(workspace, cx));
+            .update(cx, |editor, cx| Item::deactivated(editor, cx));
+    }
+
+    fn navigate(&mut self, data: Box<dyn std::any::Any>, cx: &mut ViewContext<Self>) -> bool {
+        self.editor
+            .update(cx, |editor, cx| Item::navigate(editor, data, cx))
+    }
+
+    fn set_nav_history(
+        &mut self,
+        nav_history: workspace::ItemNavHistory,
+        cx: &mut ViewContext<Self>,
+    ) {
+        self.editor.update(cx, |editor, cx| {
+            Item::set_nav_history(editor, nav_history, cx)
+        });
     }
 }
 


### PR DESCRIPTION
This PR makes it so the proposed changes editor works with the workspace navigation history.

This allows for easily navigating back to the proposed changes editor after opening one of the excerpts into the base buffer.

Release Notes:

- N/A
