### PR TITLE
Make slash command descriptions consistent

### DIFF
--- a/crates/assistant/src/slash_command/auto_command.rs
+++ b/crates/assistant/src/slash_command/auto_command.rs
@@ -25,19 +25,17 @@ impl FeatureFlag for AutoSlashCommandFeatureFlag {
 
 pub(crate) struct AutoCommand;
 
-const COMMAND_DESCRIPTION: &str = "Automatically infer what context to add";
-
 impl SlashCommand for AutoCommand {
     fn name(&self) -> String {
         "auto".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Automatically infer what context to add".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn label(&self, cx: &AppContext) -> CodeLabel {

--- a/crates/assistant/src/slash_command/auto_command.rs
+++ b/crates/assistant/src/slash_command/auto_command.rs
@@ -25,17 +25,19 @@ impl FeatureFlag for AutoSlashCommandFeatureFlag {
 
 pub(crate) struct AutoCommand;
 
+const COMMAND_DESCRIPTION: &str = "Automatically infer what context to add";
+
 impl SlashCommand for AutoCommand {
     fn name(&self) -> String {
         "auto".into()
     }
 
     fn description(&self) -> String {
-        "Automatically infer what context to add, based on your prompt".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Automatically Infer Context".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn label(&self, cx: &AppContext) -> CodeLabel {

--- a/crates/assistant/src/slash_command/delta_command.rs
+++ b/crates/assistant/src/slash_command/delta_command.rs
@@ -13,19 +13,17 @@ use workspace::Workspace;
 
 pub(crate) struct DeltaSlashCommand;
 
-const COMMAND_DESCRIPTION: &str = "Re-insert changed files";
-
 impl SlashCommand for DeltaSlashCommand {
     fn name(&self) -> String {
         "delta".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Re-insert changed files".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/delta_command.rs
+++ b/crates/assistant/src/slash_command/delta_command.rs
@@ -13,17 +13,19 @@ use workspace::Workspace;
 
 pub(crate) struct DeltaSlashCommand;
 
+const COMMAND_DESCRIPTION: &str = "Re-insert changed files";
+
 impl SlashCommand for DeltaSlashCommand {
     fn name(&self) -> String {
         "delta".into()
     }
 
     fn description(&self) -> String {
-        "re-insert changed files".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Re-insert Changed Files".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -81,8 +81,6 @@ impl DiagnosticsSlashCommand {
     }
 }
 
-const COMMAND_DESCRIPTION: &str = "Insert diagnostics";
-
 impl SlashCommand for DiagnosticsSlashCommand {
     fn name(&self) -> String {
         "diagnostics".into()
@@ -93,11 +91,11 @@ impl SlashCommand for DiagnosticsSlashCommand {
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert diagnostics".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/diagnostics_command.rs
+++ b/crates/assistant/src/slash_command/diagnostics_command.rs
@@ -81,6 +81,8 @@ impl DiagnosticsSlashCommand {
     }
 }
 
+const COMMAND_DESCRIPTION: &str = "Insert diagnostics";
+
 impl SlashCommand for DiagnosticsSlashCommand {
     fn name(&self) -> String {
         "diagnostics".into()
@@ -91,11 +93,11 @@ impl SlashCommand for DiagnosticsSlashCommand {
     }
 
     fn description(&self) -> String {
-        "Insert diagnostics".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Diagnostics".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -98,19 +98,17 @@ impl FetchSlashCommand {
     }
 }
 
-const COMMAND_DESCRIPTION: &str = "Insert fecthed URL contents";
-
 impl SlashCommand for FetchSlashCommand {
     fn name(&self) -> String {
         "fetch".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert fetched URL contents".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/fetch_command.rs
+++ b/crates/assistant/src/slash_command/fetch_command.rs
@@ -98,17 +98,19 @@ impl FetchSlashCommand {
     }
 }
 
+const COMMAND_DESCRIPTION: &str = "Insert fecthed URL contents";
+
 impl SlashCommand for FetchSlashCommand {
     fn name(&self) -> String {
         "fetch".into()
     }
 
     fn description(&self) -> String {
-        "insert URL contents".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert fetched URL contents".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -104,19 +104,17 @@ impl FileSlashCommand {
     }
 }
 
-const COMMAND_DESCRIPTION: &str = "Insert file";
-
 impl SlashCommand for FileSlashCommand {
     fn name(&self) -> String {
         "file".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert file".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -104,17 +104,19 @@ impl FileSlashCommand {
     }
 }
 
+const COMMAND_DESCRIPTION: &str = "Insert file";
+
 impl SlashCommand for FileSlashCommand {
     fn name(&self) -> String {
         "file".into()
     }
 
     fn description(&self) -> String {
-        "insert file".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert File".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -13,19 +13,17 @@ use workspace::Workspace;
 
 pub(crate) struct NowSlashCommand;
 
-const COMMAND_DESCRIPTION: &str = "Insert current date and time";
-
 impl SlashCommand for NowSlashCommand {
     fn name(&self) -> String {
         "now".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert current date and time".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/now_command.rs
+++ b/crates/assistant/src/slash_command/now_command.rs
@@ -13,17 +13,19 @@ use workspace::Workspace;
 
 pub(crate) struct NowSlashCommand;
 
+const COMMAND_DESCRIPTION: &str = "Insert current date and time";
+
 impl SlashCommand for NowSlashCommand {
     fn name(&self) -> String {
         "now".into()
     }
 
     fn description(&self) -> String {
-        "insert the current date and time".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Current Date and Time".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -37,8 +37,6 @@ impl ProjectSlashCommand {
     }
 }
 
-const COMMAND_DESCRIPTION: &str = "Generate a semantic search based on context";
-
 impl SlashCommand for ProjectSlashCommand {
     fn name(&self) -> String {
         "project".into()
@@ -49,11 +47,11 @@ impl SlashCommand for ProjectSlashCommand {
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Generate a semantic search based on context".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/project_command.rs
+++ b/crates/assistant/src/slash_command/project_command.rs
@@ -37,6 +37,8 @@ impl ProjectSlashCommand {
     }
 }
 
+const COMMAND_DESCRIPTION: &str = "Generate a semantic search based on context";
+
 impl SlashCommand for ProjectSlashCommand {
     fn name(&self) -> String {
         "project".into()
@@ -47,11 +49,11 @@ impl SlashCommand for ProjectSlashCommand {
     }
 
     fn description(&self) -> String {
-        "Generate semantic searches based on the current context".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Project Context".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -10,17 +10,19 @@ use workspace::Workspace;
 
 pub(crate) struct PromptSlashCommand;
 
+const COMMAND_DESCRIPTION: &str = "Insert prompt from library";
+
 impl SlashCommand for PromptSlashCommand {
     fn name(&self) -> String {
         "prompt".into()
     }
 
     fn description(&self) -> String {
-        "insert prompt from library".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Prompt from Library".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/prompt_command.rs
+++ b/crates/assistant/src/slash_command/prompt_command.rs
@@ -10,19 +10,17 @@ use workspace::Workspace;
 
 pub(crate) struct PromptSlashCommand;
 
-const COMMAND_DESCRIPTION: &str = "Insert prompt from library";
-
 impl SlashCommand for PromptSlashCommand {
     fn name(&self) -> String {
         "prompt".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert prompt from library".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -24,6 +24,8 @@ impl FeatureFlag for SearchSlashCommandFeatureFlag {
 
 pub(crate) struct SearchSlashCommand;
 
+const COMMAND_DESCRIPTION: &str = "Search your project semantically";
+
 impl SlashCommand for SearchSlashCommand {
     fn name(&self) -> String {
         "search".into()
@@ -34,11 +36,11 @@ impl SlashCommand for SearchSlashCommand {
     }
 
     fn description(&self) -> String {
-        "semantic search".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Semantic Search".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/search_command.rs
+++ b/crates/assistant/src/slash_command/search_command.rs
@@ -24,8 +24,6 @@ impl FeatureFlag for SearchSlashCommandFeatureFlag {
 
 pub(crate) struct SearchSlashCommand;
 
-const COMMAND_DESCRIPTION: &str = "Search your project semantically";
-
 impl SlashCommand for SearchSlashCommand {
     fn name(&self) -> String {
         "search".into()
@@ -36,11 +34,11 @@ impl SlashCommand for SearchSlashCommand {
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Search your project semantically".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/symbols_command.rs
+++ b/crates/assistant/src/slash_command/symbols_command.rs
@@ -11,17 +11,19 @@ use workspace::Workspace;
 
 pub(crate) struct OutlineSlashCommand;
 
+const COMMAND_DESCRIPTION: &str = "Insert symbols for active tab";
+
 impl SlashCommand for OutlineSlashCommand {
     fn name(&self) -> String {
         "symbols".into()
     }
 
     fn description(&self) -> String {
-        "insert symbols for active tab".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Symbols for Active Tab".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn complete_argument(

--- a/crates/assistant/src/slash_command/symbols_command.rs
+++ b/crates/assistant/src/slash_command/symbols_command.rs
@@ -11,19 +11,17 @@ use workspace::Workspace;
 
 pub(crate) struct OutlineSlashCommand;
 
-const COMMAND_DESCRIPTION: &str = "Insert symbols for active tab";
-
 impl SlashCommand for OutlineSlashCommand {
     fn name(&self) -> String {
         "symbols".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert symbols for active tab".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn complete_argument(

--- a/crates/assistant/src/slash_command/tab_command.rs
+++ b/crates/assistant/src/slash_command/tab_command.rs
@@ -16,8 +16,6 @@ use workspace::Workspace;
 
 pub(crate) struct TabSlashCommand;
 
-const COMMAND_DESCRIPTION: &str = "Insert open tabs (active tab by default)";
-
 const ALL_TABS_COMPLETION_ITEM: &str = "all";
 
 impl SlashCommand for TabSlashCommand {
@@ -26,11 +24,11 @@ impl SlashCommand for TabSlashCommand {
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.to_owned()
+        "Insert open tabs (active tab by default)".to_owned()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.to_owned()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/tab_command.rs
+++ b/crates/assistant/src/slash_command/tab_command.rs
@@ -16,6 +16,8 @@ use workspace::Workspace;
 
 pub(crate) struct TabSlashCommand;
 
+const COMMAND_DESCRIPTION: &str = "Insert open tabs (active tab by default)";
+
 const ALL_TABS_COMPLETION_ITEM: &str = "all";
 
 impl SlashCommand for TabSlashCommand {
@@ -24,11 +26,11 @@ impl SlashCommand for TabSlashCommand {
     }
 
     fn description(&self) -> String {
-        "insert open tabs (active tab by default)".to_owned()
+        COMMAND_DESCRIPTION.to_owned()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Open Tabs".to_owned()
+        COMMAND_DESCRIPTION.to_owned()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/terminal_command.rs
+++ b/crates/assistant/src/slash_command/terminal_command.rs
@@ -17,6 +17,8 @@ use super::create_label_for_command;
 
 pub(crate) struct TerminalSlashCommand;
 
+const COMMAND_DESCRIPTION: &str = "Insert terminal output";
+
 const LINE_COUNT_ARG: &str = "--line-count";
 
 impl SlashCommand for TerminalSlashCommand {
@@ -29,11 +31,11 @@ impl SlashCommand for TerminalSlashCommand {
     }
 
     fn description(&self) -> String {
-        "insert terminal output".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Terminal Output".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/terminal_command.rs
+++ b/crates/assistant/src/slash_command/terminal_command.rs
@@ -17,8 +17,6 @@ use super::create_label_for_command;
 
 pub(crate) struct TerminalSlashCommand;
 
-const COMMAND_DESCRIPTION: &str = "Insert terminal output";
-
 const LINE_COUNT_ARG: &str = "--line-count";
 
 impl SlashCommand for TerminalSlashCommand {
@@ -31,11 +29,11 @@ impl SlashCommand for TerminalSlashCommand {
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert terminal output".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/workflow_command.rs
+++ b/crates/assistant/src/slash_command/workflow_command.rs
@@ -23,17 +23,19 @@ impl WorkflowSlashCommand {
     }
 }
 
+const COMMAND_DESCRIPTION: &str = "Insert prompt to opt into the edit workflow";
+
 impl SlashCommand for WorkflowSlashCommand {
     fn name(&self) -> String {
         "workflow".into()
     }
 
     fn description(&self) -> String {
-        "insert a prompt that opts into the edit workflow".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Workflow Prompt".into()
+        COMMAND_DESCRIPTION.into()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/workflow_command.rs
+++ b/crates/assistant/src/slash_command/workflow_command.rs
@@ -23,19 +23,17 @@ impl WorkflowSlashCommand {
     }
 }
 
-const COMMAND_DESCRIPTION: &str = "Insert prompt to opt into the edit workflow";
-
 impl SlashCommand for WorkflowSlashCommand {
     fn name(&self) -> String {
         "workflow".into()
     }
 
     fn description(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        "Insert prompt to opt into the edit workflow".into()
     }
 
     fn menu_text(&self) -> String {
-        COMMAND_DESCRIPTION.into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -184,7 +184,7 @@ impl PickerDelegate for SlashCommandDelegate {
                         h_flex()
                             .group(format!("command-entry-label-{ix}"))
                             .w_full()
-                            .min_w(px(220.))
+                            .min_w(px(250.))
                             .child(
                                 v_flex()
                                     .child(
@@ -203,7 +203,9 @@ impl PickerDelegate for SlashCommandDelegate {
                                                     div()
                                                         .font_buffer(cx)
                                                         .child(
-                                                            Label::new(args).size(LabelSize::Small),
+                                                            Label::new(args)
+                                                                .size(LabelSize::Small)
+                                                                .color(Color::Muted),
                                                         )
                                                         .visible_on_hover(format!(
                                                             "command-entry-label-{ix}"


### PR DESCRIPTION
This PR adds a description constant in most of the slash command files so that both the editor _and_ footer pickers use the same string. In terms of copywriting, I did some tweaking to reduce the longer ones a bit. Also standardized them all to use sentence case, as opposed to each instance using a different convention. The editor picker needs more work, though, given the arguments and descriptions are being cut at the moment. This should happen in a follow-up!

<img width="900" alt="Screenshot 2024-10-01 at 7 25 19 PM" src="https://github.com/user-attachments/assets/e8759eff-0de9-4a4d-a026-366d85507b3c">

---

Release Notes:

- N/A
