### PR TITLE
Tweak assistant prompt to only fix diagnostic issues when requested to do so

### DIFF
--- a/assets/prompts/content_prompt.hbs
+++ b/assets/prompts/content_prompt.hbs
@@ -50,6 +50,9 @@ And here's the section to rewrite based on that prompt again for reference:
 
 {{#if diagnostic_errors}}
 {{#each diagnostic_errors}}
+
+Below are the diagnostic errors visible to the user.  If the user requests problems to be fixed, use this information, but do not try to fix these errors if the user hasn't asked you to.
+
 <diagnostic_error>
     <line_number>{{line_number}}</line_number>
     <error_message>{{error_message}}</error_message>


### PR DESCRIPTION
Release Notes:

- Assistant: Make the model less likely to incorporate diagnostic information when not requested to fix any issues.
 
![CleanShot 2024-10-01 at 13 44 08](https://github.com/user-attachments/assets/f0e9a132-6cac-4dc6-889f-467e59ec8bbc)
