### PR TITLE
Keep all hunks expanded in proposed change editor

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3059,7 +3059,7 @@ impl Editor {
     }
 
     pub fn cancel(&mut self, _: &Cancel, cx: &mut ViewContext<Self>) {
-        if self.clear_clicked_diff_hunks(cx) {
+        if self.clear_expanded_diff_hunks(cx) {
             cx.notify();
             return;
         }

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -63,8 +63,11 @@ impl ProposedChangesEditor {
         let (recalculate_diffs_tx, mut recalculate_diffs_rx) = mpsc::unbounded();
 
         Self {
-            editor: cx
-                .new_view(|cx| Editor::for_multibuffer(multibuffer.clone(), project, true, cx)),
+            editor: cx.new_view(|cx| {
+                let mut editor = Editor::for_multibuffer(multibuffer.clone(), project, true, cx);
+                editor.set_expand_all_diff_hunks();
+                editor
+            }),
             recalculate_diffs_tx,
             _recalculate_diffs_task: cx.spawn(|_, mut cx| async move {
                 let mut buffers_to_diff = HashSet::default();


### PR DESCRIPTION
Also, fix visual bug when pressing escape with a non-empty selection in a deleted text block.

Release Notes:

- N/A
