### PR TITLE
Optional telemetry logging to persistent file

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -257,7 +257,7 @@ impl Telemetry {
                                 .log_err()
                         } else {
                             NamedTempFile::new_in(paths::logs_dir().as_path())
-                                .map(|temp_file| TelemetryFile::Temporary(temp_file))
+                                .map(TelemetryFile::Temporary)
                                 .log_err()
                         };
 

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -35,11 +35,13 @@ pub struct Telemetry {
     state: Arc<Mutex<TelemetryState>>,
 }
 
+#[cfg(not(debug_assertions))]
 enum TelemetryFile {
     Permanent(File, PathBuf),
     Temporary(NamedTempFile),
 }
 
+#[cfg(not(debug_assertions))]
 impl TelemetryFile {
     fn as_file_mut(&mut self) -> &mut File {
         match self {

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -35,13 +35,12 @@ pub struct Telemetry {
     state: Arc<Mutex<TelemetryState>>,
 }
 
-#[cfg(not(debug_assertions))]
+#[allow(dead_code)]
 enum TelemetryFile {
     Permanent(File, PathBuf),
     Temporary(NamedTempFile),
 }
 
-#[cfg(not(debug_assertions))]
 impl TelemetryFile {
     fn as_file_mut(&mut self) -> &mut File {
         match self {


### PR DESCRIPTION
Release Notes:

- Added option to write telemetry to file given by os environment variable `$ZED_TELEMETRY_FILE`