### PR TITLE
terminal: Fix Alacritty TERM handling

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -334,7 +334,7 @@ impl TerminalBuilder {
         );
 
         // setup_env modifies the current process's environment, which we are
-        // ignoring in favour of the env variable here. Instead, we copy over
+        // ignoring in favor of the env variable here. Instead, we copy over
         // the relevant variables from the current environment after
         // modification so that we don't have to re-implement the logic here.
         alacritty_terminal::tty::setup_env();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -333,6 +333,16 @@ impl TerminalBuilder {
             release_channel::AppVersion::global(cx).to_string(),
         );
 
+        // setup_env modifies the current process's environment, which we are
+        // ignoring in favour of the env variable here. Instead, we copy over
+        // the relevant variables from the current environment after
+        // modification so that we don't have to re-implement the logic here.
+        alacritty_terminal::tty::setup_env();
+        env.insert("TERM".to_string(), std::env::var("TERM").unwrap());
+        env.insert("COLORTERM".to_string(),  std::env::var("COLORTERM").unwrap());
+        env.remove("DESKTOP_STARTUP_ID");
+        env.remove("XDG_ACTIVATION_TOKEN");
+
         let pty_options = {
             let alac_shell = match shell.clone() {
                 Shell::System => None,
@@ -351,9 +361,6 @@ impl TerminalBuilder {
                 env: env.into_iter().collect(),
             }
         };
-
-        // Setup Alacritty's env, which modifies the current process's environment
-        alacritty_terminal::tty::setup_env();
 
         let default_cursor_style = AlacCursorStyle::from(cursor_shape);
         let scrolling_history = if task.is_some() {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -339,7 +339,7 @@ impl TerminalBuilder {
         // modification so that we don't have to re-implement the logic here.
         alacritty_terminal::tty::setup_env();
         env.insert("TERM".to_string(), std::env::var("TERM").unwrap());
-        env.insert("COLORTERM".to_string(),  std::env::var("COLORTERM").unwrap());
+        env.insert("COLORTERM".to_string(), std::env::var("COLORTERM").unwrap());
         env.remove("DESKTOP_STARTUP_ID");
         env.remove("XDG_ACTIVATION_TOKEN");
 


### PR DESCRIPTION
- Closes #17991

setup_env modifies the current process's environment, which we are ignoring in favour of the env variable. Instead, we copy over the relevant variables from the current environment after modification so that we don't have to re-implement the logic.

Release Notes:

- N/A
