### PR TITLE
add: EdgeJS icon file support

### DIFF
--- a/assets/icons/file_icons/edge.svg
+++ b/assets/icons/file_icons/edge.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g id="SVGRepo_iconCarrier" transform="matrix(0.5718650221824646, 0, 0, 0.5759429335594177, 0.9357800483703616, 1.0886839628219604)" style="">
+    <path d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12ZM16 12V13.5C16 14.8807 17.1193 16 18.5 16V16C19.8807 16 21 14.8807 21 13.5V12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21H16" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -35,6 +35,7 @@
     "dll": "storage",
     "doc": "document",
     "docx": "document",
+    "edge": "edge",
     "eex": "elixir",
     "elm": "elm",
     "erl": "erlang",
@@ -227,6 +228,9 @@
     },
     "document": {
       "icon": "icons/file_icons/book.svg"
+    },
+    "edge": {
+      "icon": "icons/file_icons/edge.svg"
     },
     "elixir": {
       "icon": "icons/file_icons/elixir.svg"


### PR DESCRIPTION
Release Notes:

- Added EdgeJS icon file

@Brayan-724 and I are working to support [EdgeJS](https://edgejs.dev/docs/introduction) (By [AdonisJS](https://adonisjs.com/)) in Zed, but we ran into the problem of not being able to add a custom icon to `*.edge` files so we created this PR

Extension (not published because we haven't finished the LSP yet, it only has the syntax highlight for the moment): https://github.com/Wilovy09/zed-edgejs

![image](https://github.com/user-attachments/assets/06f89f96-b7e1-40a2-a24b-bef1bbd6f481)
