### PR TITLE
ssh remoting: Fix ssh process not being cleaned up when connection is closed

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -673,8 +673,6 @@ impl Project {
         cx: &mut AppContext,
     ) -> Model<Self> {
         cx.new_model(|cx: &mut ModelContext<Self>| {
-            cx.on_release(|_, _| println!("Project released")).detach();
-
             let (tx, rx) = mpsc::unbounded();
             cx.spawn(move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx))
                 .detach();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -673,6 +673,8 @@ impl Project {
         cx: &mut AppContext,
     ) -> Model<Self> {
         cx.new_model(|cx: &mut ModelContext<Self>| {
+            cx.on_release(|_, _| println!("Project released")).detach();
+
             let (tx, rx) = mpsc::unbounded();
             cx.spawn(move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx))
                 .detach();


### PR DESCRIPTION
We introduced a memory leak in #18572, which meant that `Drop` was never called on `SshRemoteConnection`, meaning that the ssh process kept running

Co-Authored-by: Thorsten <thorsten@zed.dev>

Release Notes:

- N/A
