### PR TITLE
editor: Fix "Reveal in File Manager" not working with multibuffers

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11269,7 +11269,10 @@ impl Editor {
     }
 
     pub fn reveal_in_finder(&mut self, _: &RevealInFileManager, cx: &mut ViewContext<Self>) {
-        maybe!({ Some(cx.reveal_path(&self.reveal_target(cx)?.abs_path(cx))) });
+        maybe!({
+            cx.reveal_path(&self.reveal_target(cx)?.abs_path(cx));
+            Some(())
+        });
     }
 
     pub fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11257,12 +11257,19 @@ impl Editor {
         None
     }
 
+    fn reveal_target<'a>(&self, cx: &'a AppContext) -> Option<&'a dyn language::LocalFile> {
+        let latest_selection = self.selections.newest_anchor().head();
+        self.buffer()
+            .read(cx)
+            .text_anchor_for_position(latest_selection, cx)?
+            .0
+            .read(cx)
+            .file()
+            .and_then(|f| f.as_local())
+    }
+
     pub fn reveal_in_finder(&mut self, _: &RevealInFileManager, cx: &mut ViewContext<Self>) {
-        if let Some(buffer) = self.buffer().read(cx).as_singleton() {
-            if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
-                cx.reveal_path(&file.abs_path(cx));
-            }
-        }
+        maybe!({ Some(cx.reveal_path(&self.reveal_target(cx)?.abs_path(cx))) });
     }
 
     pub fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11258,11 +11258,8 @@ impl Editor {
     }
 
     fn reveal_target<'a>(&self, cx: &'a AppContext) -> Option<&'a dyn language::LocalFile> {
-        let latest_selection = self.selections.newest_anchor().head();
-        self.buffer()
-            .read(cx)
-            .text_anchor_for_position(latest_selection, cx)?
-            .0
+        self.active_excerpt(cx)?
+            .1
             .read(cx)
             .file()
             .and_then(|f| f.as_local())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11257,7 +11257,7 @@ impl Editor {
         None
     }
 
-    fn reveal_target<'a>(&self, cx: &'a AppContext) -> Option<&'a dyn language::LocalFile> {
+    fn target_file<'a>(&self, cx: &'a AppContext) -> Option<&'a dyn language::LocalFile> {
         self.active_excerpt(cx)?
             .1
             .read(cx)
@@ -11266,27 +11266,23 @@ impl Editor {
     }
 
     pub fn reveal_in_finder(&mut self, _: &RevealInFileManager, cx: &mut ViewContext<Self>) {
-        if let Some(target) = self.reveal_target(cx) {
+        if let Some(target) = self.target_file(cx) {
             cx.reveal_path(&target.abs_path(cx));
         }
     }
 
     pub fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {
-        if let Some(buffer) = self.buffer().read(cx).as_singleton() {
-            if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
-                if let Some(path) = file.abs_path(cx).to_str() {
-                    cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
-                }
+        if let Some(file) = self.target_file(cx) {
+            if let Some(path) = file.abs_path(cx).to_str() {
+                cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
             }
         }
     }
 
     pub fn copy_relative_path(&mut self, _: &CopyRelativePath, cx: &mut ViewContext<Self>) {
-        if let Some(buffer) = self.buffer().read(cx).as_singleton() {
-            if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
-                if let Some(path) = file.path().to_str() {
-                    cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
-                }
+        if let Some(file) = self.target_file(cx) {
+            if let Some(path) = file.path().to_str() {
+                cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
             }
         }
     }
@@ -11497,12 +11493,10 @@ impl Editor {
     }
 
     pub fn copy_file_location(&mut self, _: &CopyFileLocation, cx: &mut ViewContext<Self>) {
-        if let Some(buffer) = self.buffer().read(cx).as_singleton() {
-            if let Some(file) = buffer.read(cx).file().and_then(|f| f.as_local()) {
-                if let Some(path) = file.path().to_str() {
-                    let selection = self.selections.newest::<Point>(cx).start.row + 1;
-                    cx.write_to_clipboard(ClipboardItem::new_string(format!("{path}:{selection}")));
-                }
+        if let Some(file) = self.target_file(cx) {
+            if let Some(path) = file.path().to_str() {
+                let selection = self.selections.newest::<Point>(cx).start.row + 1;
+                cx.write_to_clipboard(ClipboardItem::new_string(format!("{path}:{selection}")));
             }
         }
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11269,10 +11269,9 @@ impl Editor {
     }
 
     pub fn reveal_in_finder(&mut self, _: &RevealInFileManager, cx: &mut ViewContext<Self>) {
-        maybe!({
-            cx.reveal_path(&self.reveal_target(cx)?.abs_path(cx));
-            Some(())
-        });
+        if let Some(target) = self.reveal_target(cx) {
+            cx.reveal_path(&target.abs_path(cx));
+        }
     }
 
     pub fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -158,7 +158,7 @@ pub fn deploy_context_menu(
         }
 
         let focus = cx.focused();
-        let has_reveal_target = editor.reveal_target(cx).is_some();
+        let has_reveal_target = editor.target_file(cx).is_some();
         let reveal_in_finder_label = if cfg!(target_os = "macos") {
             "Reveal in Finder"
         } else {

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -158,6 +158,12 @@ pub fn deploy_context_menu(
         }
 
         let focus = cx.focused();
+        let has_reveal_target = editor.reveal_target(cx).is_some();
+        let reveal_in_finder_label = if cfg!(target_os = "macos") {
+            "Reveal in Finder"
+        } else {
+            "Reveal in File Manager"
+        };
         ui::ContextMenu::build(cx, |menu, _cx| {
             let builder = menu
                 .on_blur_subscription(Subscription::new(|| {}))
@@ -180,11 +186,13 @@ pub fn deploy_context_menu(
                 .action("Copy", Box::new(Copy))
                 .action("Paste", Box::new(Paste))
                 .separator()
-                .when(cfg!(target_os = "macos"), |builder| {
-                    builder.action("Reveal in Finder", Box::new(RevealInFileManager))
-                })
-                .when(cfg!(not(target_os = "macos")), |builder| {
-                    builder.action("Reveal in File Manager", Box::new(RevealInFileManager))
+                .map(|builder| {
+                    if has_reveal_target {
+                        builder.action(reveal_in_finder_label, Box::new(RevealInFileManager))
+                    } else {
+                        builder
+                            .disabled_action(reveal_in_finder_label, Box::new(RevealInFileManager))
+                    }
                 })
                 .action("Open in Terminal", Box::new(OpenInTerminal))
                 .action("Copy Permalink", Box::new(CopyPermalinkToLine));


### PR DESCRIPTION
Additionally, mark context menu entry as disabled when the action would fail (untitled buffer, collab sessions).

Supersedes #18584 

Release Notes:

- Fixed "Reveal in Finder/File Manager", "Copy Path", "Copy Relative Path" and "Copy file location" actions not working with multibuffers.
