### PR TITLE
lsp: Wait for Shutdown response before sending Exit

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7320,6 +7320,8 @@ async fn test_lsp_shutdown(cx: &mut gpui::TestAppContext) {
         cx,
     )
     .await;
+
+    drop(cx);
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7309,6 +7309,20 @@ async fn test_document_format_manual_trigger(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_lsp_shutdown(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            document_formatting_provider: Some(lsp::OneOf::Left(true)),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+}
+
+#[gpui::test]
 async fn test_concurrent_format_requests(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -368,10 +368,12 @@ impl AppContext {
         };
 
         let futures = futures::future::join_all(futures);
-        if background_executor
-            .block_to_shutdown(SHUTDOWN_TIMEOUT, futures)
-            .is_err()
-        {
+        #[cfg(any(test, feature = "test-support"))]
+        let result = background_executor.block_to_shutdown(SHUTDOWN_TIMEOUT, futures);
+        #[cfg(not(any(test, feature = "test-support")))]
+        let result = background_executor.block_with_timeout(SHUTDOWN_TIMEOUT, futures);
+
+        if result.is_err() {
             log::error!("timed out waiting on app_will_quit");
         }
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -369,7 +369,7 @@ impl AppContext {
 
         let futures = futures::future::join_all(futures);
         if background_executor
-            .block_with_timeout_background_and_foreground(SHUTDOWN_TIMEOUT, futures)
+            .block_to_shutdown(SHUTDOWN_TIMEOUT, futures)
             .is_err()
         {
             log::error!("timed out waiting on app_will_quit");

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -106,6 +106,17 @@ impl Context for AsyncAppContext {
 }
 
 impl AsyncAppContext {
+    /// Quit the application gracefully. Handlers registered with [`ModelContext::on_app_quit`]
+    /// will be given 100ms to complete before exiting.
+    pub fn shutdown(&self) -> Result<()> {
+        let app = self
+            .app
+            .upgrade()
+            .ok_or_else(|| anyhow!("app was released"))?;
+        AppContext::shutdown(&app);
+        Ok(())
+    }
+
     /// Schedules all windows in the application to be redrawn.
     pub fn refresh(&self) -> Result<()> {
         let app = self

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -138,7 +138,7 @@ impl TestAppContext {
     /// public so the macro can call it.
     pub fn quit(&self) {
         self.on_quit.borrow_mut().drain(..).for_each(|f| f());
-        self.app.borrow_mut().shutdown();
+        AppContext::shutdown(&self.app);
     }
 
     /// Register cleanup to run when the test ends.

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -299,6 +299,16 @@ impl BackgroundExecutor {
         self.block_internal(true, future, Some(duration))
     }
 
+    /// Block the current thread until the given future resolves
+    /// or `duration` has elapsed.
+    pub fn block_with_timeout_background_and_foreground<R>(
+        &self,
+        duration: Duration,
+        future: impl Future<Output = R>,
+    ) -> Result<R, impl Future<Output = R>> {
+        self.block_internal(false, future, Some(duration))
+    }
+
     /// Scoped lets you start a number of tasks and waits
     /// for all of them to complete before returning.
     pub async fn scoped<'scope, F>(&self, scheduler: F)

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -301,7 +301,7 @@ impl BackgroundExecutor {
 
     /// Block the current thread until the given future resolves
     /// or `duration` has elapsed.
-    pub fn block_with_timeout_background_and_foreground<R>(
+    pub fn block_to_shutdown<R>(
         &self,
         duration: Duration,
         future: impl Future<Output = R>,

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -301,7 +301,7 @@ impl BackgroundExecutor {
 
     /// Block the current thread until the given future resolves
     /// or `duration` has elapsed.
-    pub fn block_to_shutdown<R>(
+    pub(crate) fn block_to_shutdown<R>(
         &self,
         duration: Duration,
         future: impl Future<Output = R>,

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -301,6 +301,7 @@ impl BackgroundExecutor {
 
     /// Block the current thread until the given future resolves
     /// or `duration` has elapsed.
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) fn block_to_shutdown<R>(
         &self,
         duration: Duration,

--- a/crates/gpui/src/platform/test/dispatcher.rs
+++ b/crates/gpui/src/platform/test/dispatcher.rs
@@ -133,7 +133,11 @@ impl TestDispatcher {
                 .map(|runnables| runnables.len())
                 .sum()
         };
+        if !background_only {
+            dbg!(foreground_len);
+        }
         let background_len = state.background.len();
+        dbg!(background_len);
 
         let runnable;
         let main_thread;

--- a/crates/gpui/src/platform/test/dispatcher.rs
+++ b/crates/gpui/src/platform/test/dispatcher.rs
@@ -133,11 +133,7 @@ impl TestDispatcher {
                 .map(|runnables| runnables.len())
                 .sum()
         };
-        if !background_only {
-            dbg!(foreground_len);
-        }
         let background_len = state.background.len();
-        dbg!(background_len);
 
         let runnable;
         let main_thread;

--- a/crates/live_kit_client/examples/test_app.rs
+++ b/crates/live_kit_client/examples/test_app.rs
@@ -161,7 +161,7 @@ fn main() {
                 panic!("unexpected message");
             }
 
-            cx.update(|cx| cx.shutdown()).ok();
+            cx.shutdown().unwrap();
         })
         .detach();
     });

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -749,6 +749,7 @@ impl LanguageServer {
                 &executor,
                 (),
             );
+            println!("--------------------------------------");
 
             let server = self.server.clone();
             let name = self.name.clone();
@@ -1236,6 +1237,8 @@ impl FakeLanguageServer {
                 }
             }
         });
+
+        fake.handle_request::<request::Shutdown, _, _>(|_, _| async move { Ok(()) });
 
         (server, fake)
     }

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -749,7 +749,6 @@ impl LanguageServer {
                 &executor,
                 (),
             );
-            println!("--------------------------------------");
 
             let server = self.server.clone();
             let name = self.name.clone();

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -555,12 +555,10 @@ impl HeadlessProject {
         cx: AsyncAppContext,
     ) -> Result<proto::Ack> {
         cx.spawn(|cx| async move {
-            cx.update(|cx| {
-                // TODO: This is a hack, because in a headless project, shutdown isn't executed
-                // when calling quit, but it should be.
-                cx.shutdown();
-                cx.quit();
-            })
+            // TODO: This is a hack, because in a headless project, shutdown isn't executed
+            // when calling quit, but it should be.
+            AsyncAppContext::shutdown(&cx);
+            cx.update(|cx| cx.quit());
         })
         .detach();
 

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -284,12 +284,10 @@ fn start_server(
                 }
                 _ = futures::FutureExt::fuse(smol::Timer::after(IDLE_TIMEOUT)) => {
                     log::warn!("timed out waiting for new connections after {:?}. exiting.", IDLE_TIMEOUT);
-                    cx.update(|cx| {
-                        // TODO: This is a hack, because in a headless project, shutdown isn't executed
-                        // when calling quit, but it should be.
-                        cx.shutdown();
-                        cx.quit();
-                    })?;
+                    // TODO: This is a hack, because in a headless project, shutdown isn't executed
+                    // when calling quit, but it should be.
+                    cx.shutdown()?;
+                    cx.update(|cx| cx.quit())?;
                     break;
                 }
                 _ = app_quit_rx.next().fuse() => {


### PR DESCRIPTION
This fixes those pesky "[lsp] oneshot canceled" error messages that would show up when closing Zed while an LSP was running.

Bennet and I got so frustrated by them showing up in our logs that we decided to look into it.

Long story short:

1. Spec says: "Clients should also wait with sending the `exit` notification until they have received a response from the `shutdown` request."
2. We didn't do that, we sent `exit` right away.
3. Now we wait for a response to `shutdown` before sending `exit`.

Fixes the error.

Release Notes:

- N/A
