### PR TITLE
Use `const` over `static` for string literals

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1752,7 +1752,7 @@ impl CredentialsProvider for KeychainCredentialsProvider {
 }
 
 /// prefix for the zed:// url scheme
-pub static ZED_URL_SCHEME: &str = "zed";
+pub const ZED_URL_SCHEME: &str = "zed";
 
 /// Parses the given link into a Zed link.
 ///

--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -23,7 +23,7 @@ use telemetry_events::{
 };
 use uuid::Uuid;
 
-static CRASH_REPORTS_BUCKET: &str = "zed-crash-reports";
+const CRASH_REPORTS_BUCKET: &str = "zed-crash-reports";
 
 pub fn router() -> Router {
     Router::new()

--- a/crates/editor/src/clangd_ext.rs
+++ b/crates/editor/src/clangd_ext.rs
@@ -9,7 +9,7 @@ use crate::lsp_ext::find_specific_language_server_in_selection;
 
 use crate::{element::register_action, Editor, SwitchSourceHeader};
 
-static CLANGD_SERVER_NAME: &str = "clangd";
+const CLANGD_SERVER_NAME: &str = "clangd";
 
 fn is_c_language(language: &Language) -> bool {
     return language.name() == "C++".into() || language.name() == "C".into();

--- a/crates/editor/src/rust_analyzer_ext.rs
+++ b/crates/editor/src/rust_analyzer_ext.rs
@@ -10,7 +10,7 @@ use crate::{
     ExpandMacroRecursively,
 };
 
-static RUST_ANALYZER_NAME: &str = "rust-analyzer";
+const RUST_ANALYZER_NAME: &str = "rust-analyzer";
 
 fn is_rust_language(language: &Language) -> bool {
     language.name() == "Rust".into()

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -24,7 +24,7 @@ pub struct TaffyLayoutEngine {
     nodes_to_measure: FxHashMap<LayoutId, NodeMeasureFn>,
 }
 
-static EXPECT_MESSAGE: &str = "we should avoid taffy layout errors by construction if possible";
+const EXPECT_MESSAGE: &str = "we should avoid taffy layout errors by construction if possible";
 
 impl TaffyLayoutEngine {
     pub fn new() -> Self {

--- a/crates/task/src/vscode_format.rs
+++ b/crates/task/src/vscode_format.rs
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn can_deserialize_ts_tasks() {
-        static TYPESCRIPT_TASKS: &str = include_str!("../test_data/typescript.json");
+        const TYPESCRIPT_TASKS: &str = include_str!("../test_data/typescript.json");
         let vscode_definitions: VsCodeTaskFile =
             serde_json_lenient::from_str(TYPESCRIPT_TASKS).unwrap();
 
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn can_deserialize_rust_analyzer_tasks() {
-        static RUST_ANALYZER_TASKS: &str = include_str!("../test_data/rust-analyzer.json");
+        const RUST_ANALYZER_TASKS: &str = include_str!("../test_data/rust-analyzer.json");
         let vscode_definitions: VsCodeTaskFile =
             serde_json_lenient::from_str(RUST_ANALYZER_TASKS).unwrap();
         let expected = vec![

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -351,7 +351,7 @@ pub enum Event {
     DeletedEntry(ProjectEntryId),
 }
 
-static EMPTY_PATH: &str = "";
+const EMPTY_PATH: &str = "";
 
 impl EventEmitter<Event> for Worktree {}
 

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -441,7 +441,7 @@ async fn upload_previous_panics(
     Ok::<_, anyhow::Error>(most_recent_panic)
 }
 
-static LAST_CRASH_UPLOADED: &str = "LAST_CRASH_UPLOADED";
+const LAST_CRASH_UPLOADED: &str = "LAST_CRASH_UPLOADED";
 
 /// upload crashes from apple's diagnostic reports to our server.
 /// (only if telemetry is enabled)


### PR DESCRIPTION
I noticed a few places where we were storing `&'static str`s in `static`s instead of `const`s.

This PR updates them to use `const`.

Release Notes:

- N/A
