### PR TITLE
Revert "Fix blurry cursor on Wayland at a scale other than 100%"

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -477,8 +477,7 @@ impl WaylandClient {
             .as_ref()
             .map(|primary_selection_manager| primary_selection_manager.get_device(&seat, &qh, ()));
 
-        // FIXME: Determine the scaling factor dynamically by the compositor
-        let mut cursor = Cursor::new(&conn, &globals, 24, 2);
+        let mut cursor = Cursor::new(&conn, &globals, 24);
 
         handle
             .insert_source(XDPEventSource::new(&common.background_executor), {


### PR DESCRIPTION
Closes #17771

Reverts zed-industries/zed#17496

This PR turns out to need more work than I thought when I merged it. 

Release Notes:

- Linux: Fix a bug where the cursor would be the wrong size on Wayland
