### PR TITLE
ssh: Add session state indicator to title bar

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1217,13 +1217,20 @@ impl Project {
         server.ssh_connection_string.is_some()
     }
 
-    pub fn ssh_connection_string(&self, cx: &ModelContext<Self>) -> Option<SharedString> {
+    pub fn ssh_connection_string(&self, cx: &AppContext) -> Option<SharedString> {
+        if let Some(ssh_state) = &self.ssh_client {
+            return Some(ssh_state.connection_string().into());
+        }
         let dev_server_id = self.dev_server_project_id()?;
         dev_server_projects::Store::global(cx)
             .read(cx)
             .dev_server_for_project(dev_server_id)?
             .ssh_connection_string
             .clone()
+    }
+
+    pub fn ssh_is_connected(&self) -> Option<bool> {
+        Some(!self.ssh_client.as_ref()?.is_reconnect_underway())
     }
 
     pub fn replica_id(&self) -> ReplicaId {

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -317,6 +317,7 @@ impl SshClientDelegate {
         if release_channel == ReleaseChannel::Dev
             && platform.arch == std::env::consts::ARCH
             && platform.os == std::env::consts::OS
+            && false
         {
             use smol::process::{Command, Stdio};
 

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -36,6 +36,7 @@ use std::{
     time::Instant,
 };
 use tempfile::TempDir;
+use util::maybe;
 
 #[derive(
     Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, serde::Serialize, serde::Deserialize,
@@ -250,6 +251,7 @@ struct SshRemoteClientState {
 pub struct SshRemoteClient {
     client: Arc<ChannelClient>,
     inner_state: Mutex<Option<SshRemoteClientState>>,
+    connection_options: SshConnectionOptions,
 }
 
 impl SshRemoteClient {
@@ -265,6 +267,7 @@ impl SshRemoteClient {
         let this = Arc::new(Self {
             client,
             inner_state: Mutex::new(None),
+            connection_options: connection_options.clone(),
         });
 
         let inner_state = {
@@ -272,8 +275,7 @@ impl SshRemoteClient {
                 ChannelForwarder::new(incoming_tx, outgoing_rx, cx);
 
             let (ssh_connection, ssh_process) =
-                Self::establish_connection(connection_options.clone(), delegate.clone(), cx)
-                    .await?;
+                Self::establish_connection(connection_options, delegate.clone(), cx).await?;
 
             let multiplex_task = Self::multiplex(
                 Arc::downgrade(&this),
@@ -505,6 +507,13 @@ impl SshRemoteClient {
         self.client.clone().into()
     }
 
+    pub fn connection_string(&self) -> String {
+        self.connection_options.connection_string()
+    }
+
+    pub fn is_reconnect_underway(&self) -> bool {
+        maybe!({ Some(self.inner_state.try_lock()?.is_none()) }).unwrap_or_default()
+    }
     #[cfg(any(test, feature = "test-support"))]
     pub fn fake(
         client_cx: &mut gpui::TestAppContext,

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -49,7 +49,7 @@ pub struct SshSocket {
     socket_path: PathBuf,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct SshConnectionOptions {
     pub host: String,
     pub username: Option<String>,
@@ -528,6 +528,7 @@ impl SshRemoteClient {
                 Arc::new(Self {
                     client,
                     inner_state: Mutex::new(None),
+                    connection_options: SshConnectionOptions::default(),
                 })
             }),
             server_cx.update(|cx| ChannelClient::new(client_to_server_rx, server_to_client_tx, cx)),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0ed6f59c-e0e7-49e6-8db7-f09ec5cdf653)
The indicator turns yellow when ssh client is trying to reconnect. Note that the state tracking is probably not ideal (we'll see how it pans out once we start dog-fooding), but at the very least "green=good" should be a decent mental model for now.

Release Notes:

- N/A
