### PR TITLE
editor: Ensure proposed changes editor is syntax-highlighted when opened

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -819,6 +819,9 @@ impl Buffer {
                 branch.set_language_registry(language_registry);
             }
 
+            // Reparse the branch buffer so that we get syntax highlighting immediately.
+            branch.reparse(cx);
+
             branch
         })
     }


### PR DESCRIPTION
This PR fixes an issue where the proposed changes editor would not have any syntax highlighting until a modification was made.

When creating the branch buffer we reparse the buffer to rebuild the syntax map.

Release Notes:

- N/A
