### PR TITLE
Add width setting for the file finder

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -581,8 +581,18 @@
   "file_finder": {
     // Whether to show file icons in the file finder.
     "file_icons": true,
-    // Width of the file finder window.
-    "window_width": 34
+    // Width of the file finder window. This setting can
+    // take four values.
+    //
+    // 1. Small width:
+    //   "window_width": "small",
+    // 2. Medium width (default):
+    //   "window_width": "medium",
+    // 3. Large width:
+    //   "window_width": "large",
+    // 4. Extra Large width:
+    //   "window_width": "xlarge"
+    "window_width": "medium"
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -581,20 +581,20 @@
   "file_finder": {
     // Whether to show file icons in the file finder.
     "file_icons": true,
-    // Width of the file finder window. This setting can
+    // Width of the file finder modal. This setting can
     // take four values.
     //
     // 1. Small width:
-    //   "window_width": "small",
+    //   "modal_width": "small",
     // 2. Medium width (default):
-    //   "window_width": "medium",
+    //   "modal_width": "medium",
     // 3. Large width:
-    //   "window_width": "large",
+    //   "modal_width": "large",
     // 4. Extra Large width:
-    //   "window_width": "xlarge"
+    //   "modal_width": "xlarge"
     // 5. Fullscreen width:
-    //   "window_width": "full"
-    "window_width": "medium"
+    //   "modal_width": "full"
+    "modal_width": "medium"
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -592,6 +592,8 @@
     //   "window_width": "large",
     // 4. Extra Large width:
     //   "window_width": "xlarge"
+    // 5. Fullscreen width:
+    //   "window_width": "full"
     "window_width": "medium"
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -580,7 +580,9 @@
   // Settings related to the file finder.
   "file_finder": {
     // Whether to show file icons in the file finder.
-    "file_icons": true
+    "file_icons": true,
+    // Width of the file finder window.
+    "window_width": 34
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -258,7 +258,7 @@ impl Render for FileFinder {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let key_context = self.picker.read(cx).delegate.key_context(cx);
 
-        let window_max_width: Pixels = cx.viewport_size().width.into();
+        let window_max_width: Pixels = cx.viewport_size().width;
         let window_choice = FileFinderSettings::get_global(cx).window_width;
         let width = window_choice.calc_width(window_max_width);
 

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -259,8 +259,8 @@ impl Render for FileFinder {
         let key_context = self.picker.read(cx).delegate.key_context(cx);
 
         let window_max_width: Pixels = cx.viewport_size().width;
-        let window_choice = FileFinderSettings::get_global(cx).window_width;
-        let width = window_choice.calc_width(window_max_width);
+        let modal_choice = FileFinderSettings::get_global(cx).modal_width;
+        let width = modal_choice.calc_width(window_max_width);
 
         v_flex()
             .key_context(key_context)

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -14,7 +14,7 @@ use file_finder_settings::FileFinderSettings;
 use file_icons::FileIcons;
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{
-    actions, rems, Action, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle,
+    actions, Action, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle,
     FocusableView, KeyContext, Model, Modifiers, ModifiersChangedEvent, ParentElement, Render,
     Styled, Task, View, ViewContext, VisualContext, WeakView,
 };
@@ -257,9 +257,14 @@ impl FocusableView for FileFinder {
 impl Render for FileFinder {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let key_context = self.picker.read(cx).delegate.key_context(cx);
+
+        let window_max_width: Pixels = cx.viewport_size().width.into();
+        let window_choice = FileFinderSettings::get_global(cx).window_width;
+        let width = window_choice.calc_width(window_max_width);
+
         v_flex()
             .key_context(key_context)
-            .w(rems(34.))
+            .w(width)
             .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
             .on_action(cx.listener(Self::handle_select_prev))
             .on_action(cx.listener(Self::handle_open_menu))

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -8,7 +8,7 @@ use ui::Pixels;
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct FileFinderSettings {
     pub file_icons: bool,
-    pub window_width: FileFinderWidth,
+    pub modal_width: FileFinderWidth,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -17,10 +17,10 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: true
     pub file_icons: Option<bool>,
-    /// The width of the file finder window in rem.
+    /// The width of the file finder modal.
     ///
     /// Default: "medium"
-    pub window_width: Option<FileFinderWidth>,
+    pub modal_width: Option<FileFinderWidth>,
 }
 
 impl Settings for FileFinderSettings {
@@ -45,7 +45,7 @@ pub enum FileFinderWidth {
 }
 
 impl FileFinderWidth {
-    const MIN_WINDOW_WIDTH_PX: f32 = 384.;
+    const MIN_MODAL_WIDTH_PX: f32 = 384.;
 
     pub fn padding_px(&self) -> Pixels {
         let padding_val = match self {
@@ -64,11 +64,11 @@ impl FileFinderWidth {
             return window_width;
         }
 
-        let min_window_width_px = Pixels(FileFinderWidth::MIN_WINDOW_WIDTH_PX);
+        let min_modal_width_px = Pixels(FileFinderWidth::MIN_MODAL_WIDTH_PX);
 
         let padding_px = self.padding_px();
         let width_val = window_width - padding_px;
-        let finder_width = cmp::max(min_window_width_px, width_val);
+        let finder_width = cmp::max(min_modal_width_px, width_val);
 
         finder_width
     }

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -41,6 +41,7 @@ pub enum FileFinderWidth {
     Medium,
     Large,
     XLarge,
+    Full,
 }
 
 impl FileFinderWidth {
@@ -52,12 +53,17 @@ impl FileFinderWidth {
             FileFinderWidth::Medium => 1024.,
             FileFinderWidth::Large => 768.,
             FileFinderWidth::XLarge => 512.,
+            FileFinderWidth::Full => 0.,
         };
 
         Pixels(padding_val)
     }
 
     pub fn calc_width(&self, window_width: Pixels) -> Pixels {
+        if self == &FileFinderWidth::Full {
+            return window_width;
+        }
+
         let min_window_width_px = Pixels(FileFinderWidth::MIN_WINDOW_WIDTH_PX);
 
         let padding_px = self.padding_px();

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -6,6 +6,7 @@ use settings::{Settings, SettingsSources};
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct FileFinderSettings {
     pub file_icons: bool,
+    pub window_width: f32,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -14,6 +15,10 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: true
     pub file_icons: Option<bool>,
+    /// The width of the file finder window in rem.
+    ///
+    /// Default: 34
+    pub window_width: Option<f32>,
 }
 
 impl Settings for FileFinderSettings {
@@ -22,6 +27,25 @@ impl Settings for FileFinderSettings {
     type FileContent = FileFinderSettingsContent;
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut gpui::AppContext) -> Result<Self> {
-        sources.json_merge()
+        let defaults = sources.default;
+
+        let mut this = Self {
+            file_icons: defaults.file_icons.unwrap().into(),
+            window_width: defaults.window_width.unwrap().into(),
+        };
+
+        for value in sources.user.into_iter().chain(sources.release_channel) {
+            if let Some(value) = value.file_icons {
+                this.file_icons = value.into();
+            }
+
+            if let Some(value) = value.window_width {
+                this.window_width = value.into();
+            }
+
+            this.window_width = this.window_width.clamp(16., 128.);
+        }
+
+        Ok(this)
     }
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1416,6 +1416,14 @@ Or to set a `socks5` proxy:
 
 `boolean` values
 
+## File Finder
+
+### Modal Width
+
+- Description: Width of the file finder modal. Can take one of a few values: `small`, `medium`, `large`, `xlarge`, and `full`.
+- Setting: `modal_width`
+- Default: `medium`
+
 ## Preferred Line Length
 
 - Description: The column at which to soft-wrap lines, for buffers where soft-wrap is enabled.


### PR DESCRIPTION
This PR adds the ability to adjust the width of the file finder popup. I found when searching my projects the default width was not always wide enough and there was no option to change it.

It allows values `small`, `medium` (default), `large`, `xlarge`, and `full`

Release Notes:

- Added a setting to adjust the width of the file finder modal


Example Setting:
```json
  "file_finder": {
    "modal_width": "medium"
  },
```

Screenshots can be found in the comments below.