### PR TITLE
gpui: Fix window display on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -258,10 +258,6 @@ impl WindowsWindowStatePtr {
             placement.rcNormalPosition = calculate_window_rect(bounds, lock.border_offset);
             drop(lock);
             SetWindowPlacement(self.hwnd, &placement).log_err();
-            UpdateWindow(self.hwnd)
-                .ok()
-                .context("Update window")
-                .log_err();
         });
         Ok(())
     }
@@ -330,9 +326,6 @@ impl WindowsWindow {
                 WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX,
             )
         };
-        if !params.show {
-            dwstyle |= WS_MINIMIZE;
-        }
 
         let hinstance = get_module_handle();
         let display = if let Some(display_id) = params.display_id {
@@ -396,12 +389,6 @@ impl WindowsWindow {
             placement.rcNormalPosition = calculate_window_rect(bounds, lock.border_offset);
             drop(lock);
             SetWindowPlacement(raw_hwnd, &placement)?;
-        }
-
-        if params.show {
-            unsafe { ShowWindow(raw_hwnd, SW_SHOW).ok()? };
-        } else {
-            unsafe { ShowWindow(raw_hwnd, SW_HIDE).ok()? };
         }
 
         Ok(Self(state_ptr))


### PR DESCRIPTION
- Closes #18610


This PR addresses the same issue as PR #18578. After a full day of research and testing, I believe I’ve found the best solution to resolve this issue. With this PR, the window creation behavior on Windows becomes more consistent with macOS:

- When `params.show` is `true`: The window is created and immediately displayed.
- When `params.show` is `false`: The window is created but remains hidden until the first call to `activate_window`.

As I mentioned in #18578, `winit` creates hidden windows by setting the window's `exstyle` to `WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW`, which is different from the method used in this PR. Here, the window is created with normal parameters, but we do not call `ShowWindow` so the window is not shown.

I'm not sure why `winit` doesn't use a smilliar approach like this PR to create hidden windows. My guess is that `winit` is creating this hidden window to function as a "DispatchWindow" — serving a purpose similar to `WindowsPlatform` in `zed`. To ensure the window stays hidden even if `ShowWindow` is called, they use the `exstyle` approach.

With the method used in this PR, my initial tests haven't revealed any issues.



Release Notes:

- N/A
