### PR TITLE
windows: Fix sometimes log error messages don't show the crate name

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -381,10 +381,7 @@ where
     #[cfg(not(target_os = "windows"))]
     let file = caller.file();
     #[cfg(target_os = "windows")]
-    let file = caller
-        .file()
-        .trim_start_matches("\\\\?\\")
-        .replace('\\', "/");
+    let file = caller.file().replace('\\', "/");
     // In this codebase, the first segment of the file path is
     // the 'crates' folder, followed by the crate name.
     let target = file.split('/').nth(1);

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -378,9 +378,16 @@ fn log_error_with_caller<E>(caller: core::panic::Location<'_>, error: E, level: 
 where
     E: std::fmt::Debug,
 {
+    #[cfg(not(target_os = "windows"))]
+    let file = caller.file();
+    #[cfg(target_os = "windows")]
+    let file = caller
+        .file()
+        .trim_start_matches("\\\\?\\")
+        .replace('\\', "/");
     // In this codebase, the first segment of the file path is
     // the 'crates' folder, followed by the crate name.
-    let target = caller.file().split('/').nth(1);
+    let target = file.split('/').nth(1);
 
     log::logger().log(
         &log::Record::builder()


### PR DESCRIPTION
On windows, path could be something like `C:\path\to\the\crate`. Hence, `split('/')` would refuse to work in this case.

### Before

![Screenshot 2024-10-04 023652](https://github.com/user-attachments/assets/9c14fb24-5ee0-4b56-8fbd-313abb28f134)

### After

![Screenshot 2024-10-04 024115](https://github.com/user-attachments/assets/217e175c-b0e1-4589-9c3d-98670882b185)


Release Notes:

- N/A
