### PR TITLE
editor: Use predefined `rounding` value for color swatches

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1230,7 +1230,7 @@ impl CompletionsMenu {
 
                         let color_swatch = completion
                             .color()
-                            .map(|color| div().size_4().bg(color).rounded(px(2.)));
+                            .map(|color| div().size_4().bg(color).rounded_sm());
 
                         div().min_w(px(220.)).max_w(px(540.)).child(
                             ListItem::new(mat.candidate_id)


### PR DESCRIPTION
This PR updates the color swatches added in #18665 to use a predefined `rounding` value instead of a literal value.

The underlying values are the same, but we don't want to diverge from our design system.

Release Notes:

- N/A
