### PR TITLE
c: Add runnable for main function

### DIFF
--- a/crates/languages/src/c/runnables.scm
+++ b/crates/languages/src/c/runnables.scm
@@ -1,0 +1,10 @@
+; Tag the main function
+(
+  (function_definition
+    declarator: (function_declarator
+      declarator: (identifier) @run
+    )
+  ) @c-main
+  (#eq? @run "main")
+  (#set! tag c-main)
+)


### PR DESCRIPTION
Release Notes:

- Added Runnable for C main function

This tags can then be used in tasks, for example:

```json
[
  {
    "label": "Run ${ZED_STEM}",
    "command": "gcc",
    "args": [
      "$ZED_FILE",
      "-o",
      "${ZED_DIRNAME}/${ZED_STEM}.out",
      "&&",
      "${ZED_DIRNAME}/${ZED_STEM}.out"
    ],
    "tags": ["c-main"]
  }
]

```
