### PR TITLE
Use WHOLE_WORD search option in vim mode's whole-word search

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -269,6 +269,9 @@ impl Vim {
                 if regex {
                     options |= SearchOptions::REGEX;
                 }
+                if whole_word {
+                    options |= SearchOptions::WHOLE_WORD;
+                }
                 if !search_bar.show(cx) {
                     return None;
                 }
@@ -276,10 +279,7 @@ impl Vim {
                     drop(search_bar.search("", None, cx));
                     return None;
                 };
-                let mut query = regex::escape(&query);
-                if whole_word {
-                    query = format!(r"\<{}\>", query);
-                }
+                let query = regex::escape(&query);
                 Some(search_bar.search(&query, Some(options), cx))
             });
 


### PR DESCRIPTION
Instead of wrapping the search term with `\<...\>`, enable the `WHOLE_WORD` search option.

The advantage of the search option is that it can be toggled with one click/key press (alt+w by default), and it doesn't require regex mode.

Release Notes:

- Vim mode's whole word search now uses the search bar's "Match whole words" option, instead of wrapping the search term with `\<...\>`. This allows easier toggling of whole-word search, and it also works without enabling the regex mode.