### PR TITLE
Improve syntax highlights

### DIFF
--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -102,7 +102,7 @@
   (rune_literal)
 ] @string
 
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 [
   (int_literal)

--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -54,7 +54,7 @@
 
 (comment) @comment
 (string) @string
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 [
   "("

--- a/crates/languages/src/regex/highlights.scm
+++ b/crates/languages/src/regex/highlights.scm
@@ -22,7 +22,7 @@
   (end_assertion)
   (boundary_assertion)
   (non_boundary_assertion)
-] @escape
+] @string.escape
 
 [
   "*"

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -65,6 +65,7 @@
   ">" @punctuation.bracket)
 
 [
+  "."
   ";"
   ","
   "::"
@@ -121,6 +122,8 @@
   (char_literal)
 ] @string
 
+(escape_sequence) @string.escape
+
 [
   (integer_literal)
   (float_literal)
@@ -147,20 +150,16 @@
   "&&"
   "*"
   "*="
-  "*"
   "+"
   "+="
-  ","
   "-"
   "-="
   "->"
-  "."
   ".."
   "..="
   "..."
   "/="
   ":"
-  ";"
   "<<"
   "<<="
   "<"

--- a/extensions/racket/languages/racket/highlights.scm
+++ b/extensions/racket/languages/racket/highlights.scm
@@ -4,7 +4,7 @@
  (here_string)
  (byte_string)] @string
 (regex) @string.regex
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 [(comment)
  (block_comment)

--- a/extensions/ruby/languages/ruby/highlights.scm
+++ b/extensions/ruby/languages/ruby/highlights.scm
@@ -116,7 +116,7 @@
 ] @string.special.symbol
 
 (regex) @string.regex
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 [
   (integer)

--- a/extensions/scheme/languages/scheme/highlights.scm
+++ b/extensions/scheme/languages/scheme/highlights.scm
@@ -7,7 +7,7 @@
 (symbol) @variable
 (string) @string
 
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 [(comment)
  (block_comment)


### PR DESCRIPTION
Closes #18722

- Replace the `@escape` capture name with `@string.escape` for escape sequences in Go, Python, Regex, Racket, Ruby, and Scheme.
- Rust
  - Add syntax highlighting for escape sequences. Close #18722
  - Fix the issue where `@punctuation.delimiter` is being overwritten by `@operator`.
  - Add the period (".") to `@punctuation.delimiter`.

Release Notes:

- N/A
