### PR TITLE
Make `report_assistant_event` take an `AssistantEvent` struct

### DIFF
--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -46,7 +46,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use telemetry_events::{AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
 use text::BufferSnapshot;
 use util::{post_inc, ResultExt, TryFutureExt};
 use uuid::Uuid;
@@ -2133,14 +2133,14 @@ impl Context {
                     });
 
                     if let Some(telemetry) = this.telemetry.as_ref() {
-                        telemetry.report_assistant_event(
-                            Some(this.id.0.clone()),
-                            AssistantKind::Panel,
-                            AssistantPhase::Response,
-                            model.telemetry_id(),
+                        telemetry.report_assistant_event(AssistantEvent {
+                            conversation_id: Some(this.id.0.clone()),
+                            kind: AssistantKind::Panel,
+                            phase: AssistantPhase::Response,
+                            model: model.telemetry_id(),
                             response_latency,
                             error_message,
-                        );
+                        });
                     }
 
                     if let Ok(stop_reason) = result {

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -50,6 +50,7 @@ use std::{
     task::{self, Poll},
     time::{Duration, Instant},
 };
+use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
 use terminal_view::terminal_panel::TerminalPanel;
 use text::{OffsetRangeExt, ToPoint as _};
 use theme::ThemeSettings;
@@ -211,14 +212,14 @@ impl InlineAssistant {
     ) {
         if let Some(telemetry) = self.telemetry.as_ref() {
             if let Some(model) = LanguageModelRegistry::read_global(cx).active_model() {
-                telemetry.report_assistant_event(
-                    None,
-                    telemetry_events::AssistantKind::Inline,
-                    telemetry_events::AssistantPhase::Invoked,
-                    model.telemetry_id(),
-                    None,
-                    None,
-                );
+                telemetry.report_assistant_event(AssistantEvent {
+                    conversation_id: None,
+                    kind: AssistantKind::Inline,
+                    phase: AssistantPhase::Invoked,
+                    model: model.telemetry_id(),
+                    response_latency: None,
+                    error_message: None,
+                });
             }
         }
         let snapshot = editor.read(cx).buffer().read(cx).snapshot(cx);
@@ -763,18 +764,18 @@ impl InlineAssistant {
     pub fn finish_assist(&mut self, assist_id: InlineAssistId, undo: bool, cx: &mut WindowContext) {
         if let Some(telemetry) = self.telemetry.as_ref() {
             if let Some(model) = LanguageModelRegistry::read_global(cx).active_model() {
-                telemetry.report_assistant_event(
-                    None,
-                    telemetry_events::AssistantKind::Inline,
-                    if undo {
-                        telemetry_events::AssistantPhase::Rejected
+                telemetry.report_assistant_event(AssistantEvent {
+                    conversation_id: None,
+                    kind: AssistantKind::Inline,
+                    phase: if undo {
+                        AssistantPhase::Rejected
                     } else {
-                        telemetry_events::AssistantPhase::Accepted
+                        AssistantPhase::Accepted
                     },
-                    model.telemetry_id(),
-                    None,
-                    None,
-                );
+                    model: model.telemetry_id(),
+                    response_latency: None,
+                    error_message: None,
+                });
             }
         }
         if let Some(assist) = self.assists.get(&assist_id) {
@@ -2920,14 +2921,14 @@ impl CodegenAlternative {
                             let error_message =
                                 result.as_ref().err().map(|error| error.to_string());
                             if let Some(telemetry) = telemetry {
-                                telemetry.report_assistant_event(
-                                    None,
-                                    telemetry_events::AssistantKind::Inline,
-                                    telemetry_events::AssistantPhase::Response,
-                                    model_telemetry_id,
+                                telemetry.report_assistant_event(AssistantEvent {
+                                    conversation_id: None,
+                                    kind: AssistantKind::Inline,
+                                    phase: AssistantPhase::Response,
+                                    model: model_telemetry_id,
                                     response_latency,
                                     error_message,
-                                );
+                                });
                             }
 
                             result?;

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -25,6 +25,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
 use terminal::Terminal;
 use terminal_view::TerminalView;
 use theme::ThemeSettings;
@@ -1063,14 +1064,14 @@ impl Codegen {
 
                     let error_message = result.as_ref().err().map(|error| error.to_string());
                     if let Some(telemetry) = telemetry {
-                        telemetry.report_assistant_event(
-                            None,
-                            telemetry_events::AssistantKind::Inline,
-                            telemetry_events::AssistantPhase::Response,
-                            model_telemetry_id,
+                        telemetry.report_assistant_event(AssistantEvent {
+                            conversation_id: None,
+                            kind: AssistantKind::Inline,
+                            phase: AssistantPhase::Response,
+                            model: model_telemetry_id,
                             response_latency,
                             error_message,
-                        );
+                        });
                     }
 
                     result?;

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -16,9 +16,9 @@ use std::io::Write;
 use std::{env, mem, path::PathBuf, sync::Arc, time::Duration};
 use sysinfo::{CpuRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System};
 use telemetry_events::{
-    ActionEvent, AppEvent, AssistantEvent, AssistantKind, AssistantPhase, CallEvent, CpuEvent,
-    EditEvent, EditorEvent, Event, EventRequestBody, EventWrapper, ExtensionEvent,
-    InlineCompletionEvent, MemoryEvent, ReplEvent, SettingEvent,
+    ActionEvent, AppEvent, AssistantEvent, CallEvent, CpuEvent, EditEvent, EditorEvent, Event,
+    EventRequestBody, EventWrapper, ExtensionEvent, InlineCompletionEvent, MemoryEvent, ReplEvent,
+    SettingEvent,
 };
 use tempfile::NamedTempFile;
 #[cfg(not(debug_assertions))]
@@ -391,25 +391,8 @@ impl Telemetry {
         self.report_event(event)
     }
 
-    pub fn report_assistant_event(
-        self: &Arc<Self>,
-        conversation_id: Option<String>,
-        kind: AssistantKind,
-        phase: AssistantPhase,
-        model: String,
-        response_latency: Option<Duration>,
-        error_message: Option<String>,
-    ) {
-        let event = Event::Assistant(AssistantEvent {
-            conversation_id,
-            kind,
-            phase,
-            model: model.to_string(),
-            response_latency,
-            error_message,
-        });
-
-        self.report_event(event)
+    pub fn report_assistant_event(self: &Arc<Self>, event: AssistantEvent) {
+        self.report_event(Event::Assistant(event));
     }
 
     pub fn report_call_event(


### PR DESCRIPTION
This PR makes the `report_assistant_event` method take an `AssistantEvent` struct instead of all of the struct fields as individual parameters.

Release Notes:

- N/A
