### PR TITLE
editor: Qualify `RangeExt::overlaps` call to prevent phantom diagnostics

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10792,7 +10792,7 @@ impl Editor {
             .selections
             .all::<Point>(cx)
             .iter()
-            .any(|selection| selection.range().overlaps(&intersection_range));
+            .any(|selection| RangeExt::overlaps(&selection.range(), &intersection_range));
 
         self.unfold_ranges(std::iter::once(intersection_range), true, autoscroll, cx)
     }


### PR DESCRIPTION
This PR qualifies a call to `RangeExt::overlaps` to avoid some confusion in rust-analyzer not being able to distinguish between `RangeExt::overlaps` and `AnchorRangeExt::overlaps` and producing phantom diagnostics.

We may also want to consider renaming the method on `AnchorRangeExt` to disambiguate them.

Release Notes:

- N/A
