### PR TITLE
ci: Make docs-only PRs only trigger docs-related tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,13 @@ on:
       - "v[0-9]+.[0-9]+.x"
     tags:
       - "v*"
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches:
       - "**"
+    paths-ignore:
+      - "docs/**"
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,14 @@ jobs:
         with:
           version: 9
 
-      - run: |
+      - name: Prettier Check on /docs
+        working-directory: ./docs
+        run: |
           pnpm dlx prettier . --check || {
             echo "To fix, run from the root of the zed repo:"
             echo "  cd docs && pnpm dlx prettier . --write && cd .."
             false
           }
 
-        working-directory: ./docs
+      - name: Check spelling
+        run: script/check-spelling docs/

--- a/script/check-spelling
+++ b/script/check-spelling
@@ -1,6 +1,9 @@
 #!/bin/sh
 
+set -eu
+
 TYPOS_CLI_VERSION=1.24.6
+TARGET_DIR=${1:-""}
 
 if ! cargo install --list | grep "typos-cli v$TYPOS_CLI_VERSION" > /dev/null; then
     echo "Installing typos-cli@$TYPOS_CLI_VERSION..."
@@ -8,4 +11,4 @@ if ! cargo install --list | grep "typos-cli v$TYPOS_CLI_VERSION" > /dev/null; th
 else
     echo "typos-cli@$TYPOS_CLI_VERSION is already installed."
 fi
-typos
+typos $TARGET_DIR


### PR DESCRIPTION
This should speed up any docs-only PRs so that they don't have to run the full 5 minute battery of tests.

Release Notes:

- N/A
