### PR TITLE
gpui: Fix uniform list horizon offset for non-horizontal scrollable lists

### DIFF
--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -297,7 +297,11 @@ impl Element for UniformList {
                         for (mut item, ix) in items.into_iter().zip(visible_range) {
                             let item_origin = padded_bounds.origin
                                 + point(
-                                    scroll_offset.x + padding.left,
+                                    if can_scroll_horizontally {
+                                        scroll_offset.x + padding.left
+                                    } else {
+                                        scroll_offset.x
+                                    },
                                     item_height * ix + scroll_offset.y + padding.top,
                                 );
                             let available_width = if can_scroll_horizontally {


### PR DESCRIPTION
Closes #18739

/cc @osiewicz 
/cc @maxdeviant 

I'm not sure why the `+ padding.left` was added, but this was the cause of the issue. I also tested removing the extra left padding but didn't seem to see a difference inside the project panel. So we can maybe even remove it?

**Before:**
![Screenshot 2024-10-04 at 21 43 34](https://github.com/user-attachments/assets/b5d67cd9-f92b-4301-880c-d351fe156c98)

**After:**
<img width="294" alt="Screenshot 2024-10-04 at 21 49 05" src="https://github.com/user-attachments/assets/8cc84170-a86b-46b8-91c9-39def64f0bd0">

Release Notes:

- Fix code action list not horizontal aligned correctly
