### PR TITLE
Fix option-t and option-shift-t in terminal

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -440,7 +440,12 @@
       "cmd-k shift-right": ["workspace::SwapPaneInDirection", "Right"],
       "cmd-k shift-up": ["workspace::SwapPaneInDirection", "Up"],
       "cmd-k shift-down": ["workspace::SwapPaneInDirection", "Down"],
-      "cmd-shift-x": "zed::Extensions",
+      "cmd-shift-x": "zed::Extensions"
+    }
+  },
+  {
+    "context": "Editor && !Terminal",
+    "bindings": {
       "alt-t": "task::Rerun",
       "alt-shift-t": "task::Spawn"
     }


### PR DESCRIPTION
- Closes https://github.com/zed-industries/zed/issues/18711

Release Notes:

- Fixed `option-t` and `option-shift-t` in terminal on MacOS