### PR TITLE
docs: Note the need for Rust when developing extensions

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -76,6 +76,8 @@ zed::register_extension!(MyExtension);
 
 ## Developing an Extension Locally
 
+Before starting to develop an extension for Zed, be sure to [install Rust](https://www.rust-lang.org/tools/install).
+
 When developing an extension, you can use it in Zed without needing to publish it by installing it as a _dev extension_.
 
 From the extensions page, click the `Install Dev Extension` button and select the directory containing your extension.


### PR DESCRIPTION
Relates to Issue #16693

Improved documentation for developing extensions locally by noting need for Rust to be installed

This one bit me, too. :) 

Release Notes:

- N/A