### PR TITLE
Compare migrations formatted uniformly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10710,6 +10710,7 @@ dependencies = [
  "libsqlite3-sys",
  "parking_lot",
  "smol",
+ "sqlformat",
  "thread_local",
  "util",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,6 +419,7 @@ similar = "1.3"
 simplelog = "0.12.2"
 smallvec = { version = "1.6", features = ["union"] }
 smol = "1.2"
+sqlformat = "0.2"
 strsim = "0.11"
 strum = { version = "0.25.0", features = ["derive"] }
 subtle = "2.5.0"

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -16,6 +16,7 @@ indoc.workspace = true
 libsqlite3-sys = { version = "0.28", features = ["bundled"] }
 parking_lot.workspace = true
 smol.workspace = true
+sqlformat.workspace = true
 thread_local = "1.1.4"
 util.workspace = true
 uuid.workspace = true

--- a/crates/sqlez/src/migrations.rs
+++ b/crates/sqlez/src/migrations.rs
@@ -55,7 +55,16 @@ impl Connection {
                 .exec_bound("INSERT INTO migrations (domain, step, migration) VALUES (?, ?, ?)")?;
 
             for (index, migration) in migrations.iter().enumerate() {
+                let migration =
+                    sqlformat::format(migration, &sqlformat::QueryParams::None, Default::default());
                 if let Some((_, _, completed_migration)) = completed_migrations.get(index) {
+                    // Reformat completed migrations with the current `sqlformat` version, so that past migrations stored
+                    // conform to the new formatting rules.
+                    let completed_migration = sqlformat::format(
+                        completed_migration,
+                        &sqlformat::QueryParams::None,
+                        Default::default(),
+                    );
                     if completed_migration == migration {
                         // Migration already run. Continue
                         continue;
@@ -71,8 +80,8 @@ impl Connection {
                     }
                 }
 
-                self.eager_exec(migration)?;
-                store_completed_migration((domain, index, *migration))?;
+                self.eager_exec(&migration)?;
+                store_completed_migration((domain, index, migration))?;
             }
 
             Ok(())
@@ -108,11 +117,7 @@ mod test {
                 .select::<String>("SELECT (migration) FROM migrations")
                 .unwrap()()
             .unwrap()[..],
-            &[indoc! {"
-                CREATE TABLE test1 (
-                    a TEXT,
-                    b TEXT
-                )"}],
+            &[indoc! {"CREATE TABLE test1 (a TEXT, b TEXT)"}],
         );
 
         // Add another step to the migration and run it again
@@ -141,16 +146,8 @@ mod test {
                 .unwrap()()
             .unwrap()[..],
             &[
-                indoc! {"
-                    CREATE TABLE test1 (
-                        a TEXT,
-                        b TEXT
-                    )"},
-                indoc! {"
-                    CREATE TABLE test2 (
-                        c TEXT,
-                        d TEXT
-                    )"},
+                indoc! {"CREATE TABLE test1 (a TEXT, b TEXT)"},
+                indoc! {"CREATE TABLE test2 (c TEXT, d TEXT)"},
             ],
         );
     }

--- a/crates/sqlez_macros/Cargo.toml
+++ b/crates/sqlez_macros/Cargo.toml
@@ -15,5 +15,5 @@ doctest = false
 
 [dependencies]
 sqlez.workspace = true
-sqlformat = "0.2"
+sqlformat.workspace = true
 syn = "1.0"


### PR DESCRIPTION
Otherwise old migrations may be formatted differently than new migrations, causing comparison errors.

Follow-up of https://github.com/zed-industries/zed/pull/18676

Release Notes:

- N/A
