### PR TITLE
Icon for zig

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -356,6 +356,9 @@
     },
     "vue": {
       "icon": "icons/file_icons/vue.svg"
+    },
+    "zig": {
+      "icon": "icons/file_icons/zig.svg"
     }
   }
 }

--- a/assets/icons/file_icons/zig.svg
+++ b/assets/icons/file_icons/zig.svg
@@ -1,0 +1,21 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <g fill="#121212" transform="matrix(0.10457500070333481, 0, 0, 0.11428599804639815, 0, 0)">
+    <g>
+      <polygon points="46,22 28,44 19,30"/>
+      <polygon points="46,22 33,33 28,44 22,44 22,95 31,95 20,100 12,117 0,117 0,22" shape-rendering="crispEdges"/>
+      <polygon points="31,95 12,117 4,106"/>
+    </g>
+    <g>
+      <polygon points="56,22 62,36 37,44"/>
+      <polygon points="56,22 111,22 111,44 37,44 56,32" shape-rendering="crispEdges"/>
+      <polygon points="116,95 97,117 90,104"/>
+      <polygon points="116,95 100,104 97,117 42,117 42,95" shape-rendering="crispEdges"/>
+      <polygon points="150,0 52,117 3,140 101,22"/>
+    </g>
+    <g>
+      <polygon points="141,22 140,40 122,45"/>
+      <polygon points="153,22 153,117 106,117 120,105 125,95 131,95 131,45 122,45 132,36 141,22" shape-rendering="crispEdges"/>
+      <polygon points="125,95 130,110 106,117"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Release Notes:

- Added zig icon instead of the generic "file.svg"

![zig](https://github.com/user-attachments/assets/c0964244-bba0-4250-93f8-db5afeede9c4)

Icon is based on this: https://github.com/ziglang/logo/blob/master/zig-mark-neg-black.svg and scaled to 16x16.

I'm not sure if there's anything to do regarding the license. From the ziglang repo, it's ["CC BY-SA 4.0"](https://creativecommons.org/licenses/by-sa/4.0/deed.en).

I didn't see any other SVGs containing a license, so I don't know where/how I should add credit or attribution.