### PR TITLE
ruby: Add HAML template language support

### DIFF
--- a/extensions/ruby/extension.toml
+++ b/extensions/ruby/extension.toml
@@ -29,3 +29,7 @@ commit = "91fc5ae1140d5c9d922312431f7d251a48d7b8ce"
 [grammars.rbs]
 repository = "https://github.com/joker1007/tree-sitter-rbs"
 commit = "8d8e65ac3f77fbc9e15b1cdb9f980a3e0ac3ab99"
+
+[grammars.haml]
+repository = "https://github.com/vitallium/tree-sitter-haml"
+commit = "945b4806e11d969fc0b0edcdee068400971f3bf3"

--- a/extensions/ruby/languages/haml/config.toml
+++ b/extensions/ruby/languages/haml/config.toml
@@ -1,0 +1,11 @@
+name = "HAML"
+grammar = "haml"
+path_suffixes = ["haml"]
+line_comments = ["-#"]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]
+tab_size = 2
+scope_opt_in_language_servers = ["tailwindcss-language-server"]

--- a/extensions/ruby/languages/haml/highlights.scm
+++ b/extensions/ruby/languages/haml/highlights.scm
@@ -1,0 +1,15 @@
+[
+  "="
+  "-"
+] @operator
+
+(attribute_name) @attribute
+(tag) @tag
+(class) @type
+(comment) @comment
+
+[
+  (quoted_attribute_value)
+] @string
+
+(text_content) @string

--- a/extensions/ruby/languages/haml/injections.scm
+++ b/extensions/ruby/languages/haml/injections.scm
@@ -1,0 +1,15 @@
+(
+  (ruby_block_output
+    (ruby_code) @content)
+  (#set! "language" "ruby")
+)
+
+(
+  (ruby_block_run
+    (ruby_code) @content)
+  (#set! "language" "ruby")
+)
+
+(filter
+  (filter_name) @language
+  (filter_body) @content)


### PR DESCRIPTION
- Closes [#179](https://github.com/zed-industries/extensions/issues/179)

Hi, this pull request adds basic support for [the HAML template language](https://haml.info/) to the Ruby extension. Unfortunately, there is no tree-sitter grammar support for HAML, so I've had to write it from scratch (https://github.com/vitallium/tree-sitter-haml). As a starting point, I tried to cover the basic aspects of the HAML template language, and I think adding the created grammar to the Ruby extension is a good step to collect feedback, issues, and possible improvements. Let me know if that's fine. Thanks!

Here are some screenshots:

![CleanShot 2024-10-06 at 18 41 18@2x](https://github.com/user-attachments/assets/872f01c3-749c-4614-bf1f-c74cae4da737)
![CleanShot 2024-10-06 at 18 41 28@2x](https://github.com/user-attachments/assets/a7079a88-dca7-4625-874f-6cba3274fbed)


Release Notes:

- N/A
