### PR TITLE
Fix script/linux on RHEL/Fedora

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -89,7 +89,7 @@ if [[ -n $dnf ]] || [[ -n $yum ]]; then
       perl-File-Copy
       mold
     )
-  elif grep grep -qP '^ID="(rhel|rocky|alma|centos|ol)' /etc/os-release; then
+  elif grep -qP '^ID="(rhel|rocky|alma|centos|ol)' /etc/os-release; then
     deps+=( perl-interpreter )
   fi
 

--- a/script/linux
+++ b/script/linux
@@ -102,7 +102,7 @@ if [[ -n $dnf ]] || [[ -n $yum ]]; then
   fi
 
   # libxkbcommon-x11-devel is in a non-default repo on RHEL 8.x/9.x (except on AmazonLinux)
-  if grep -qP '^VERSION_ID="(8|9)' && grep -qP '^ID="(rhel|rocky|centos|alma|ol)' /etc/os-release; then
+  if grep -qP '^VERSION_ID="(8|9)' /etc/os-release && grep -qP '^ID="(rhel|rocky|centos|alma|ol)' /etc/os-release; then
     $maysudo dnf install -y 'dnf-command(config-manager)'
     if grep -qP '^PRETTY_NAME="(AlmaLinux 8|Rocky Linux 8)' /etc/os-release; then
       $maysudo dnf config-manager --set-enabled powertools


### PR DESCRIPTION
in one of the grep instructions to find the Linux distribution, the script was getting hung for some reason. On closer inspection, I saw the grep operation was apparently waiting for input, rather than hung. This is what is leading me now to add what I believe to be the right file, given the surrounding context.

Edit: I'm running on Fedora 40.

Release Notes:

- N/A