### PR TITLE
chore: Fix some violations of 'needless_pass_by_ref_mut' lint

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 allow-private-module-inception = true
+avoid-breaking-exported-api = false

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -549,7 +549,7 @@ impl Context {
         cx: &mut ModelContext<Self>,
     ) -> Self {
         let buffer = cx.new_model(|_cx| {
-            let mut buffer = Buffer::remote(
+            let buffer = Buffer::remote(
                 language::BufferId::new(1).unwrap(),
                 replica_id,
                 capability,

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -394,7 +394,7 @@ pub struct PendingEntitySubscription<T: 'static> {
 }
 
 impl<T: 'static> PendingEntitySubscription<T> {
-    pub fn set_model(mut self, model: &Model<T>, cx: &mut AsyncAppContext) -> Subscription {
+    pub fn set_model(mut self, model: &Model<T>, cx: &AsyncAppContext) -> Subscription {
         self.consumed = true;
         let mut handlers = self.client.handler_set.lock();
         let id = (TypeId::of::<T>(), self.remote_id);

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -288,7 +288,7 @@ impl Telemetry {
         system_id: Option<String>,
         installation_id: Option<String>,
         session_id: String,
-        cx: &mut AppContext,
+        cx: &AppContext,
     ) {
         let mut state = self.state.lock();
         state.system_id = system_id.map(|id| id.into());

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -188,7 +188,7 @@ macro_rules! define_connection {
     };
 }
 
-pub fn write_and_log<F>(cx: &mut AppContext, db_write: impl FnOnce() -> F + Send + 'static)
+pub fn write_and_log<F>(cx: &AppContext, db_write: impl FnOnce() -> F + Send + 'static)
 where
     F: Future<Output = anyhow::Result<()>> + Send,
 {

--- a/crates/git_hosting_providers/src/git_hosting_providers.rs
+++ b/crates/git_hosting_providers/src/git_hosting_providers.rs
@@ -8,7 +8,7 @@ use gpui::AppContext;
 pub use crate::providers::*;
 
 /// Initializes the Git hosting providers.
-pub fn init(cx: &mut AppContext) {
+pub fn init(cx: &AppContext) {
     let provider_registry = GitHostingProviderRegistry::global(cx);
 
     // The providers are stored in a `BTreeMap`, so insertion order matters.

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -348,7 +348,7 @@ impl AppContext {
     }
 
     /// Gracefully quit the application via the platform's standard routine.
-    pub fn quit(&mut self) {
+    pub fn quit(&self) {
         self.platform.quit();
     }
 
@@ -1004,11 +1004,7 @@ impl AppContext {
         self.globals_by_type.insert(global_type, lease.global);
     }
 
-    pub(crate) fn new_view_observer(
-        &mut self,
-        key: TypeId,
-        value: NewViewListener,
-    ) -> Subscription {
+    pub(crate) fn new_view_observer(&self, key: TypeId, value: NewViewListener) -> Subscription {
         let (subscription, activate) = self.new_view_observers.insert(key, value);
         activate();
         subscription
@@ -1016,7 +1012,7 @@ impl AppContext {
     /// Arrange for the given function to be invoked whenever a view of the specified type is created.
     /// The function will be passed a mutable reference to the view along with an appropriate context.
     pub fn observe_new_views<V: 'static>(
-        &mut self,
+        &self,
         on_new: impl 'static + Fn(&mut V, &mut ViewContext<V>),
     ) -> Subscription {
         self.new_view_observer(
@@ -1035,7 +1031,7 @@ impl AppContext {
     /// Observe the release of a model or view. The callback is invoked after the model or view
     /// has no more strong references but before it has been dropped.
     pub fn observe_release<E, T>(
-        &mut self,
+        &self,
         handle: &E,
         on_release: impl FnOnce(&mut T, &mut AppContext) + 'static,
     ) -> Subscription
@@ -1062,7 +1058,7 @@ impl AppContext {
         mut f: impl FnMut(&KeystrokeEvent, &mut WindowContext) + 'static,
     ) -> Subscription {
         fn inner(
-            keystroke_observers: &mut SubscriberSet<(), KeystrokeObserver>,
+            keystroke_observers: &SubscriberSet<(), KeystrokeObserver>,
             handler: KeystrokeObserver,
         ) -> Subscription {
             let (subscription, activate) = keystroke_observers.insert((), handler);
@@ -1140,7 +1136,7 @@ impl AppContext {
     /// Register a callback to be invoked when the application is about to quit.
     /// It is not possible to cancel the quit event at this point.
     pub fn on_app_quit<Fut>(
-        &mut self,
+        &self,
         mut on_quit: impl FnMut(&mut AppContext) -> Fut + 'static,
     ) -> Subscription
     where
@@ -1186,7 +1182,7 @@ impl AppContext {
     }
 
     /// Sets the menu bar for this application. This will replace any existing menu bar.
-    pub fn set_menus(&mut self, menus: Vec<Menu>) {
+    pub fn set_menus(&self, menus: Vec<Menu>) {
         self.platform.set_menus(menus, &self.keymap.borrow());
     }
 
@@ -1196,7 +1192,7 @@ impl AppContext {
     }
 
     /// Sets the right click menu for the app icon in the dock
-    pub fn set_dock_menu(&mut self, menus: Vec<MenuItem>) {
+    pub fn set_dock_menu(&self, menus: Vec<MenuItem>) {
         self.platform.set_dock_menu(menus, &self.keymap.borrow());
     }
 
@@ -1204,7 +1200,7 @@ impl AppContext {
     /// The list is usually shown on the application icon's context menu in the dock,
     /// and allows to open the recent files via that context menu.
     /// If the path is already in the list, it will be moved to the bottom of the list.
-    pub fn add_recent_document(&mut self, path: &Path) {
+    pub fn add_recent_document(&self, path: &Path) {
         self.platform.add_recent_document(path);
     }
 

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -107,7 +107,7 @@ impl Context for AsyncAppContext {
 
 impl AsyncAppContext {
     /// Schedules all windows in the application to be redrawn.
-    pub fn refresh(&mut self) -> Result<()> {
+    pub fn refresh(&self) -> Result<()> {
         let app = self
             .app
             .upgrade()
@@ -205,7 +205,7 @@ impl AsyncAppContext {
     /// A convenience method for [AppContext::update_global]
     /// for updating the global state of the specified type.
     pub fn update_global<G: Global, R>(
-        &mut self,
+        &self,
         update: impl FnOnce(&mut G, &mut AppContext) -> R,
     ) -> Result<R> {
         let app = self

--- a/crates/gpui/src/app/model_context.rs
+++ b/crates/gpui/src/app/model_context.rs
@@ -91,7 +91,7 @@ impl<'a, T: 'static> ModelContext<'a, T> {
 
     /// Register a callback to be invoked when GPUI releases this model.
     pub fn on_release(
-        &mut self,
+        &self,
         on_release: impl FnOnce(&mut T, &mut AppContext) + 'static,
     ) -> Subscription
     where
@@ -110,7 +110,7 @@ impl<'a, T: 'static> ModelContext<'a, T> {
 
     /// Register a callback to be run on the release of another model or view
     pub fn observe_release<T2, E>(
-        &mut self,
+        &self,
         entity: &E,
         on_release: impl FnOnce(&mut T, &mut T2, &mut ModelContext<'_, T>) + 'static,
     ) -> Subscription
@@ -154,7 +154,7 @@ impl<'a, T: 'static> ModelContext<'a, T> {
     /// Arrange for the given function to be invoked whenever the application is quit.
     /// The future returned from this callback will be polled for up to [crate::SHUTDOWN_TIMEOUT] until the app fully quits.
     pub fn on_app_quit<Fut>(
-        &mut self,
+        &self,
         mut on_quit: impl FnMut(&mut T, &mut ModelContext<T>) -> Fut + 'static,
     ) -> Subscription
     where

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1418,7 +1418,7 @@ impl Interactivity {
     }
 
     fn clamp_scroll_position(
-        &mut self,
+        &self,
         bounds: Bounds<Pixels>,
         style: &Style,
         cx: &mut WindowContext,
@@ -1547,7 +1547,7 @@ impl Interactivity {
 
     #[cfg(debug_assertions)]
     fn paint_debug_info(
-        &mut self,
+        &self,
         global_id: Option<&GlobalElementId>,
         hitbox: &Hitbox,
         style: &Style,

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -252,7 +252,7 @@ impl TextLayout {
     }
 
     fn layout(
-        &mut self,
+        &self,
         text: SharedString,
         runs: Option<Vec<TextRun>>,
         cx: &mut WindowContext,
@@ -350,7 +350,7 @@ impl TextLayout {
         layout_id
     }
 
-    fn prepaint(&mut self, bounds: Bounds<Pixels>, text: &str) {
+    fn prepaint(&self, bounds: Bounds<Pixels>, text: &str) {
         let mut element_state = self.lock();
         let element_state = element_state
             .as_mut()
@@ -359,7 +359,7 @@ impl TextLayout {
         element_state.bounds = Some(bounds);
     }
 
-    fn paint(&mut self, text: &str, cx: &mut WindowContext) {
+    fn paint(&self, text: &str, cx: &mut WindowContext) {
         let element_state = self.lock();
         let element_state = element_state
             .as_ref()

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -115,7 +115,7 @@ impl UniformListScrollHandle {
     }
 
     /// Scroll the list to the given item index.
-    pub fn scroll_to_item(&mut self, ix: usize) {
+    pub fn scroll_to_item(&self, ix: usize) {
         self.0.borrow_mut().deferred_scroll_to_item = Some(ix);
     }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -706,11 +706,7 @@ pub struct Bounds<T: Clone + Default + Debug> {
 
 impl Bounds<Pixels> {
     /// Generate a centered bounds for the given display or primary display if none is provided
-    pub fn centered(
-        display_id: Option<DisplayId>,
-        size: Size<Pixels>,
-        cx: &mut AppContext,
-    ) -> Self {
+    pub fn centered(display_id: Option<DisplayId>, size: Size<Pixels>, cx: &AppContext) -> Self {
         let display = display_id
             .and_then(|id| cx.find_display(id))
             .or_else(|| cx.primary_display());
@@ -730,7 +726,7 @@ impl Bounds<Pixels> {
     }
 
     /// Generate maximized bounds for the given display or primary display if none is provided
-    pub fn maximized(display_id: Option<DisplayId>, cx: &mut AppContext) -> Self {
+    pub fn maximized(display_id: Option<DisplayId>, cx: &AppContext) -> Self {
         let display = display_id
             .and_then(|id| cx.find_display(id))
             .or_else(|| cx.primary_display());

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -219,7 +219,7 @@ impl DispatchTree {
         self.focusable_node_ids.insert(focus_id, node_id);
     }
 
-    pub fn parent_view_id(&mut self) -> Option<EntityId> {
+    pub fn parent_view_id(&self) -> Option<EntityId> {
         self.view_stack.last().copied()
     }
 
@@ -484,7 +484,7 @@ impl DispatchTree {
 
     /// Converts the longest prefix of input to a replay event and returns the rest.
     fn replay_prefix(
-        &mut self,
+        &self,
         mut input: SmallVec<[Keystroke; 1]>,
         dispatch_path: &SmallVec<[DispatchNodeId; 32]>,
     ) -> (SmallVec<[Keystroke; 1]>, SmallVec<[Replay; 1]>) {

--- a/crates/gpui/src/platform/app_menu.rs
+++ b/crates/gpui/src/platform/app_menu.rs
@@ -171,7 +171,7 @@ pub enum OsAction {
     Redo,
 }
 
-pub(crate) fn init_app_menus(platform: &dyn Platform, cx: &mut AppContext) {
+pub(crate) fn init_app_menus(platform: &dyn Platform, cx: &AppContext) {
     platform.on_will_open_app_menu(Box::new({
         let cx = cx.to_async();
         move || {

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -284,11 +284,11 @@ impl MetalRenderer {
         }
     }
 
-    pub fn update_transparency(&mut self, _transparent: bool) {
+    pub fn update_transparency(&self, _transparent: bool) {
         // todo(mac)?
     }
 
-    pub fn destroy(&mut self) {
+    pub fn destroy(&self) {
         // nothing to do
     }
 
@@ -486,7 +486,7 @@ impl MetalRenderer {
     }
 
     fn rasterize_paths(
-        &mut self,
+        &self,
         paths: &[Path<ScaledPixels>],
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
@@ -576,7 +576,7 @@ impl MetalRenderer {
     }
 
     fn draw_shadows(
-        &mut self,
+        &self,
         shadows: &[Shadow],
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
@@ -639,7 +639,7 @@ impl MetalRenderer {
     }
 
     fn draw_quads(
-        &mut self,
+        &self,
         quads: &[Quad],
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
@@ -698,7 +698,7 @@ impl MetalRenderer {
     }
 
     fn draw_paths(
-        &mut self,
+        &self,
         paths: &[Path<ScaledPixels>],
         tiles_by_path_id: &HashMap<PathId, AtlasTile>,
         instance_buffer: &mut InstanceBuffer,
@@ -808,7 +808,7 @@ impl MetalRenderer {
     }
 
     fn draw_underlines(
-        &mut self,
+        &self,
         underlines: &[Underline],
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
@@ -871,7 +871,7 @@ impl MetalRenderer {
     }
 
     fn draw_monochrome_sprites(
-        &mut self,
+        &self,
         texture_id: AtlasTextureId,
         sprites: &[MonochromeSprite],
         instance_buffer: &mut InstanceBuffer,
@@ -945,7 +945,7 @@ impl MetalRenderer {
     }
 
     fn draw_polychrome_sprites(
-        &mut self,
+        &self,
         texture_id: AtlasTextureId,
         sprites: &[PolychromeSprite],
         instance_buffer: &mut InstanceBuffer,

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -1432,7 +1432,7 @@ impl UTType {
         self.0
     }
 
-    fn inner_mut(&mut self) -> *mut Object {
+    fn inner_mut(&self) -> *mut Object {
         self.0 as *mut _
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -835,10 +835,7 @@ impl Window {
             prompt: None,
         })
     }
-    fn new_focus_listener(
-        &mut self,
-        value: AnyWindowFocusListener,
-    ) -> (Subscription, impl FnOnce()) {
+    fn new_focus_listener(&self, value: AnyWindowFocusListener) -> (Subscription, impl FnOnce()) {
         self.focus_listeners.insert((), value)
     }
 }
@@ -929,7 +926,7 @@ impl<'a> WindowContext<'a> {
 
     /// Obtain a new [`FocusHandle`], which allows you to track and manipulate the keyboard focus
     /// for elements rendered within this window.
-    pub fn focus_handle(&mut self) -> FocusHandle {
+    pub fn focus_handle(&self) -> FocusHandle {
         FocusHandle::new(&self.window.focus_handles)
     }
 
@@ -1127,7 +1124,7 @@ impl<'a> WindowContext<'a> {
 
     /// Register a callback to be invoked when the given Model or View is released.
     pub fn observe_release<E, T>(
-        &mut self,
+        &self,
         entity: &E,
         mut on_release: impl FnOnce(&mut T, &mut WindowContext) + 'static,
     ) -> Subscription
@@ -1155,7 +1152,7 @@ impl<'a> WindowContext<'a> {
     }
 
     /// Schedule the given closure to be run directly after the current frame is rendered.
-    pub fn on_next_frame(&mut self, callback: impl FnOnce(&mut WindowContext) + 'static) {
+    pub fn on_next_frame(&self, callback: impl FnOnce(&mut WindowContext) + 'static) {
         RefCell::borrow_mut(&self.window.next_frame_callbacks).push(Box::new(callback));
     }
 
@@ -1165,7 +1162,7 @@ impl<'a> WindowContext<'a> {
     /// It will cause the window to redraw on the next frame, even if no other changes have occurred.
     ///
     /// If called from within a view, it will notify that view on the next frame. Otherwise, it will refresh the entire window.
-    pub fn request_animation_frame(&mut self) {
+    pub fn request_animation_frame(&self) {
         let parent_id = self.parent_view_id();
         self.on_next_frame(move |cx| {
             if let Some(parent_id) = parent_id {
@@ -1179,7 +1176,7 @@ impl<'a> WindowContext<'a> {
     /// Spawn the future returned by the given closure on the application thread pool.
     /// The closure is provided a handle to the current window and an `AsyncWindowContext` for
     /// use within your future.
-    pub fn spawn<Fut, R>(&mut self, f: impl FnOnce(AsyncWindowContext) -> Fut) -> Task<R>
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncWindowContext) -> Fut) -> Task<R>
     where
         R: 'static,
         Fut: Future<Output = R> + 'static,
@@ -2865,7 +2862,7 @@ impl<'a> WindowContext<'a> {
     }
 
     /// Get the last view id for the current element
-    pub fn parent_view_id(&mut self) -> Option<EntityId> {
+    pub fn parent_view_id(&self) -> Option<EntityId> {
         self.window.next_frame.dispatch_tree.parent_view_id()
     }
 
@@ -3606,7 +3603,7 @@ impl<'a> WindowContext<'a> {
     }
 
     /// Updates the IME panel position suggestions for languages like japanese, chinese.
-    pub fn invalidate_character_coordinates(&mut self) {
+    pub fn invalidate_character_coordinates(&self) {
         self.on_next_frame(|cx| {
             if let Some(mut input_handler) = cx.window.platform_window.take_input_handler() {
                 if let Some(bounds) = input_handler.selected_bounds(cx) {
@@ -3752,7 +3749,7 @@ impl<'a> WindowContext<'a> {
 
     /// Register a callback that can interrupt the closing of the current window based the returned boolean.
     /// If the callback returns false, the window won't be closed.
-    pub fn on_window_should_close(&mut self, f: impl Fn(&mut WindowContext) -> bool + 'static) {
+    pub fn on_window_should_close(&self, f: impl Fn(&mut WindowContext) -> bool + 'static) {
         let mut this = self.to_async();
         self.window
             .platform_window
@@ -4070,7 +4067,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
     }
 
     /// Sets a given callback to be run on the next frame.
-    pub fn on_next_frame(&mut self, f: impl FnOnce(&mut V, &mut ViewContext<V>) + 'static)
+    pub fn on_next_frame(&self, f: impl FnOnce(&mut V, &mut ViewContext<V>) + 'static)
     where
         V: 'static,
     {
@@ -4162,7 +4159,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
     /// The callback receives a handle to the view's window. This handle may be
     /// invalid, if the window was closed before the view was released.
     pub fn on_release(
-        &mut self,
+        &self,
         on_release: impl FnOnce(&mut V, AnyWindowHandle, &mut AppContext) + 'static,
     ) -> Subscription {
         let window_handle = self.window.handle;
@@ -4179,7 +4176,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
 
     /// Register a callback to be invoked when the given Model or View is released.
     pub fn observe_release<V2, E>(
-        &mut self,
+        &self,
         entity: &E,
         mut on_release: impl FnMut(&mut V, &mut V2, &mut ViewContext<'_, V>) + 'static,
     ) -> Subscription
@@ -4212,7 +4209,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
 
     /// Register a callback to be invoked when the window is resized.
     pub fn observe_window_bounds(
-        &mut self,
+        &self,
         mut callback: impl FnMut(&mut V, &mut ViewContext<V>) + 'static,
     ) -> Subscription {
         let view = self.view.downgrade();
@@ -4226,7 +4223,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
 
     /// Register a callback to be invoked when the window is activated or deactivated.
     pub fn observe_window_activation(
-        &mut self,
+        &self,
         mut callback: impl FnMut(&mut V, &mut ViewContext<V>) + 'static,
     ) -> Subscription {
         let view = self.view.downgrade();
@@ -4240,7 +4237,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
 
     /// Registers a callback to be invoked when the window appearance changes.
     pub fn observe_window_appearance(
-        &mut self,
+        &self,
         mut callback: impl FnMut(&mut V, &mut ViewContext<V>) + 'static,
     ) -> Subscription {
         let view = self.view.downgrade();
@@ -4260,7 +4257,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
         mut f: impl FnMut(&mut V, &KeystrokeEvent, &mut ViewContext<V>) + 'static,
     ) -> Subscription {
         fn inner(
-            keystroke_observers: &mut SubscriberSet<(), KeystrokeObserver>,
+            keystroke_observers: &SubscriberSet<(), KeystrokeObserver>,
             handler: KeystrokeObserver,
         ) -> Subscription {
             let (subscription, activate) = keystroke_observers.insert((), handler);
@@ -4284,7 +4281,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
 
     /// Register a callback to be invoked when the window's pending input changes.
     pub fn observe_pending_input(
-        &mut self,
+        &self,
         mut callback: impl FnMut(&mut V, &mut ViewContext<V>) + 'static,
     ) -> Subscription {
         let view = self.view.downgrade();
@@ -4372,7 +4369,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
     /// and this callback lets you chose a default place to restore the users focus.
     /// Returns a subscription and persists until the subscription is dropped.
     pub fn on_focus_lost(
-        &mut self,
+        &self,
         mut listener: impl FnMut(&mut V, &mut ViewContext<V>) + 'static,
     ) -> Subscription {
         let view = self.view.downgrade();
@@ -4418,10 +4415,7 @@ impl<'a, V: 'static> ViewContext<'a, V> {
     /// The given callback is invoked with a [`WeakView<V>`] to avoid leaking the view for a long-running process.
     /// It's also given an [`AsyncWindowContext`], which can be used to access the state of the view across await points.
     /// The returned future will be polled on the main thread.
-    pub fn spawn<Fut, R>(
-        &mut self,
-        f: impl FnOnce(WeakView<V>, AsyncWindowContext) -> Fut,
-    ) -> Task<R>
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(WeakView<V>, AsyncWindowContext) -> Fut) -> Task<R>
     where
         R: 'static,
         Fut: Future<Output = R> + 'static,

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -71,7 +71,7 @@ impl Markdown {
         source: String,
         style: MarkdownStyle,
         language_registry: Option<Arc<LanguageRegistry>>,
-        cx: &mut ViewContext<Self>,
+        cx: &ViewContext<Self>,
         fallback_code_block_language: Option<String>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
@@ -97,7 +97,7 @@ impl Markdown {
         source: String,
         style: MarkdownStyle,
         language_registry: Option<Arc<LanguageRegistry>>,
-        cx: &mut ViewContext<Self>,
+        cx: &ViewContext<Self>,
         fallback_code_block_language: Option<String>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
@@ -119,12 +119,12 @@ impl Markdown {
         this
     }
 
-    pub fn append(&mut self, text: &str, cx: &mut ViewContext<Self>) {
+    pub fn append(&mut self, text: &str, cx: &ViewContext<Self>) {
         self.source.push_str(text);
         self.parse(cx);
     }
 
-    pub fn reset(&mut self, source: String, cx: &mut ViewContext<Self>) {
+    pub fn reset(&mut self, source: String, cx: &ViewContext<Self>) {
         if source == self.source() {
             return;
         }
@@ -145,7 +145,7 @@ impl Markdown {
         &self.parsed_markdown
     }
 
-    fn copy(&self, text: &RenderedText, cx: &mut ViewContext<Self>) {
+    fn copy(&self, text: &RenderedText, cx: &ViewContext<Self>) {
         if self.selection.end <= self.selection.start {
             return;
         }
@@ -153,7 +153,7 @@ impl Markdown {
         cx.write_to_clipboard(ClipboardItem::new_string(text));
     }
 
-    fn parse(&mut self, cx: &mut ViewContext<Self>) {
+    fn parse(&mut self, cx: &ViewContext<Self>) {
         if self.source.is_empty() {
             return;
         }
@@ -319,7 +319,7 @@ impl MarkdownElement {
     }
 
     fn paint_selection(
-        &mut self,
+        &self,
         bounds: Bounds<Pixels>,
         rendered_text: &RenderedText,
         cx: &mut WindowContext,
@@ -382,7 +382,7 @@ impl MarkdownElement {
     }
 
     fn paint_mouse_listeners(
-        &mut self,
+        &self,
         hitbox: &Hitbox,
         rendered_text: &RenderedText,
         cx: &mut WindowContext,
@@ -487,7 +487,7 @@ impl MarkdownElement {
         });
     }
 
-    fn autoscroll(&mut self, rendered_text: &RenderedText, cx: &mut WindowContext) -> Option<()> {
+    fn autoscroll(&self, rendered_text: &RenderedText, cx: &mut WindowContext) -> Option<()> {
         let autoscroll_index = self
             .markdown
             .update(cx, |markdown, _| markdown.autoscroll_request.take())?;

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -515,7 +515,7 @@ impl MultiBuffer {
     }
 
     pub fn edit<I, S, T>(
-        &mut self,
+        &self,
         edits: I,
         mut autoindent_mode: Option<AutoindentMode>,
         cx: &mut ModelContext<Self>,
@@ -664,7 +664,7 @@ impl MultiBuffer {
         drop(snapshot);
         // Non-generic part of edit, hoisted out to avoid blowing up LLVM IR.
         fn tail(
-            this: &mut MultiBuffer,
+            this: &MultiBuffer,
             buffer_edits: HashMap<BufferId, Vec<BufferEdit>>,
             autoindent_mode: Option<AutoindentMode>,
             edited_excerpt_ids: Vec<ExcerptId>,
@@ -928,7 +928,7 @@ impl MultiBuffer {
         }
     }
 
-    pub fn push_transaction<'a, T>(&mut self, buffer_transactions: T, cx: &mut ModelContext<Self>)
+    pub fn push_transaction<'a, T>(&mut self, buffer_transactions: T, cx: &ModelContext<Self>)
     where
         T: IntoIterator<Item = (&'a Model<Buffer>, &'a language::Transaction)>,
     {
@@ -952,7 +952,7 @@ impl MultiBuffer {
     }
 
     pub fn set_active_selections(
-        &mut self,
+        &self,
         selections: &[Selection<Anchor>],
         line_mode: bool,
         cursor_shape: CursorShape,
@@ -1028,7 +1028,7 @@ impl MultiBuffer {
         }
     }
 
-    pub fn remove_active_selections(&mut self, cx: &mut ModelContext<Self>) {
+    pub fn remove_active_selections(&self, cx: &mut ModelContext<Self>) {
         for buffer in self.buffers.borrow().values() {
             buffer
                 .buffer
@@ -1180,7 +1180,7 @@ impl MultiBuffer {
     }
 
     pub fn push_multiple_excerpts_with_context_lines(
-        &mut self,
+        &self,
         buffers_with_ranges: Vec<(Model<Buffer>, Vec<Range<text::Anchor>>)>,
         context_line_count: u32,
         cx: &mut ModelContext<Self>,
@@ -4208,7 +4208,7 @@ impl History {
         &mut self,
         buffer_transactions: T,
         now: Instant,
-        cx: &mut ModelContext<MultiBuffer>,
+        cx: &ModelContext<MultiBuffer>,
     ) where
         T: IntoIterator<Item = (&'a Model<Buffer>, &'a language::Transaction)>,
     {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -321,7 +321,7 @@ impl SettingsObserver {
     pub async fn handle_update_user_settings(
         _: Model<Self>,
         envelope: TypedEnvelope<proto::UpdateUserSettings>,
-        mut cx: AsyncAppContext,
+        cx: AsyncAppContext,
     ) -> anyhow::Result<()> {
         cx.update_global(move |settings_store: &mut SettingsStore, cx| {
             settings_store.set_user_settings(&envelope.payload.content, cx)

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -188,7 +188,7 @@ impl ChannelForwarder {
     fn new(
         mut incoming_tx: UnboundedSender<Envelope>,
         mut outgoing_rx: UnboundedReceiver<Envelope>,
-        cx: &mut AsyncAppContext,
+        cx: &AsyncAppContext,
     ) -> (Self, UnboundedSender<Envelope>, UnboundedReceiver<Envelope>) {
         let (quit_tx, mut quit_rx) = mpsc::unbounded::<()>();
 
@@ -298,7 +298,7 @@ impl SshRemoteClient {
         Ok(this)
     }
 
-    fn reconnect(this: Arc<Self>, cx: &mut AsyncAppContext) -> Result<()> {
+    fn reconnect(this: Arc<Self>, cx: &AsyncAppContext) -> Result<()> {
         let Some(state) = this.inner_state.lock().take() else {
             return Err(anyhow!("reconnect is already in progress"));
         };
@@ -355,7 +355,7 @@ impl SshRemoteClient {
         mut ssh_process: Child,
         incoming_tx: UnboundedSender<Envelope>,
         mut outgoing_rx: UnboundedReceiver<Envelope>,
-        cx: &mut AsyncAppContext,
+        cx: &AsyncAppContext,
     ) -> Task<Result<()>> {
         let mut child_stderr = ssh_process.stderr.take().unwrap();
         let mut child_stdout = ssh_process.stdout.take().unwrap();

--- a/crates/session/src/session.rs
+++ b/crates/session/src/session.rs
@@ -64,7 +64,7 @@ pub struct AppSession {
 }
 
 impl AppSession {
-    pub fn new(session: Session, cx: &mut ModelContext<Self>) -> Self {
+    pub fn new(session: Session, cx: &ModelContext<Self>) -> Self {
         let _subscriptions = vec![cx.on_app_quit(Self::app_will_quit)];
 
         let _serialization_task = Some(cx.spawn(|_, cx| async move {

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -77,7 +77,7 @@ pub fn handle_settings_file_changes(
             .set_user_settings(&user_settings_content, cx)
             .log_err();
     });
-    cx.spawn(move |mut cx| async move {
+    cx.spawn(move |cx| async move {
         while let Some(user_settings_content) = user_settings_file_rx.next().await {
             let result = cx.update_global(|store: &mut SettingsStore, cx| {
                 let result = store.set_user_settings(&user_settings_content, cx);

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -179,7 +179,7 @@ impl SnippetProvider {
     }
 
     /// Add directory to be watched for content changes
-    fn watch_directory(&mut self, path: &Path, cx: &mut ModelContext<Self>) {
+    fn watch_directory(&mut self, path: &Path, cx: &ModelContext<Self>) {
         let path: Arc<Path> = Arc::from(path);
 
         self.watch_tasks.push(cx.spawn(|this, mut cx| async move {

--- a/crates/task/src/static_source.rs
+++ b/crates/task/src/static_source.rs
@@ -27,7 +27,7 @@ impl<T: PartialEq + 'static + Sync> TrackedFile<T> {
     pub fn new(
         mut tracker: UnboundedReceiver<String>,
         notification_outlet: UnboundedSender<()>,
-        cx: &mut AppContext,
+        cx: &AppContext,
     ) -> Self
     where
         T: for<'a> Deserialize<'a> + Default + Send,
@@ -69,7 +69,7 @@ impl<T: PartialEq + 'static + Sync> TrackedFile<T> {
     pub fn new_convertible<U: for<'a> Deserialize<'a> + TryInto<T, Error = anyhow::Error>>(
         mut tracker: UnboundedReceiver<String>,
         notification_outlet: UnboundedSender<()>,
-        cx: &mut AppContext,
+        cx: &AppContext,
     ) -> Self
     where
         T: Default + Send,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -320,7 +320,7 @@ impl TerminalBuilder {
         max_scroll_history_lines: Option<usize>,
         window: AnyWindowHandle,
         completion_tx: Sender<()>,
-        cx: &mut AppContext,
+        cx: &AppContext,
     ) -> Result<TerminalBuilder> {
         // TODO: Properly set the current locale,
         env.entry("LC_ALL".to_string())
@@ -455,7 +455,7 @@ impl TerminalBuilder {
         })
     }
 
-    pub fn subscribe(mut self, cx: &mut ModelContext<Terminal>) -> Terminal {
+    pub fn subscribe(mut self, cx: &ModelContext<Terminal>) -> Terminal {
         //Event loop
         cx.spawn(|terminal, mut cx| async move {
             while let Some(event) = self.events_rx.next().await {
@@ -1280,7 +1280,7 @@ impl Terminal {
         }
     }
 
-    fn drag_line_delta(&mut self, e: &MouseMoveEvent, region: Bounds<Pixels>) -> Option<Pixels> {
+    fn drag_line_delta(&self, e: &MouseMoveEvent, region: Bounds<Pixels>) -> Option<Pixels> {
         //TODO: Why do these need to be doubled? Probably the same problem that the IME has
         let top = region.origin.y + (self.last_content.size.line_height * 2.);
         let bottom = region.lower_left().y - (self.last_content.size.line_height * 2.);
@@ -1351,12 +1351,7 @@ impl Terminal {
         }
     }
 
-    pub fn mouse_up(
-        &mut self,
-        e: &MouseUpEvent,
-        origin: Point<Pixels>,
-        cx: &mut ModelContext<Self>,
-    ) {
+    pub fn mouse_up(&mut self, e: &MouseUpEvent, origin: Point<Pixels>, cx: &ModelContext<Self>) {
         let setting = TerminalSettings::get_global(cx);
 
         let position = e.position - origin;
@@ -1458,9 +1453,9 @@ impl Terminal {
     }
 
     pub fn find_matches(
-        &mut self,
+        &self,
         mut searcher: RegexSearch,
-        cx: &mut ModelContext<Self>,
+        cx: &ModelContext<Self>,
     ) -> Task<Vec<RangeInclusive<AlacPoint>>> {
         let term = self.term.clone();
         cx.background_executor().spawn(async move {
@@ -1530,7 +1525,7 @@ impl Terminal {
         self.task.as_ref()
     }
 
-    pub fn wait_for_completed_task(&self, cx: &mut AppContext) -> Task<()> {
+    pub fn wait_for_completed_task(&self, cx: &AppContext) -> Task<()> {
         if let Some(task) = self.task() {
             if task.status == TaskStatus::Running {
                 let mut completion_receiver = task.completion_rx.clone();

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -189,7 +189,7 @@ impl ThemeRegistry {
     }
 
     /// Removes all themes from the registry.
-    pub fn clear(&mut self) {
+    pub fn clear(&self) {
         self.state.write().themes.clear();
     }
 

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -498,7 +498,7 @@ pub fn observe_buffer_font_size_adjustment<V: 'static>(
 }
 
 /// Sets the adjusted buffer font size.
-pub fn adjusted_font_size(size: Pixels, cx: &mut AppContext) -> Pixels {
+pub fn adjusted_font_size(size: Pixels, cx: &AppContext) -> Pixels {
     if let Some(AdjustedBufferFontSize(adjusted_size)) = cx.try_global::<AdjustedBufferFontSize>() {
         let buffer_font_size = ThemeSettings::get_global(cx).buffer_font_size;
         let delta = *adjusted_size - buffer_font_size;
@@ -530,7 +530,7 @@ pub fn adjust_buffer_font_size(cx: &mut AppContext, f: fn(&mut Pixels)) {
 }
 
 /// Returns whether the buffer font size has been adjusted.
-pub fn has_adjusted_buffer_font_size(cx: &mut AppContext) -> bool {
+pub fn has_adjusted_buffer_font_size(cx: &AppContext) -> bool {
     cx.has_global::<AdjustedBufferFontSize>()
 }
 
@@ -576,7 +576,7 @@ pub fn adjust_ui_font_size(cx: &mut AppContext, f: fn(&mut Pixels)) {
 }
 
 /// Returns whether the UI font size has been adjusted.
-pub fn has_adjusted_ui_font_size(cx: &mut AppContext) -> bool {
+pub fn has_adjusted_ui_font_size(cx: &AppContext) -> bool {
     cx.has_global::<AdjustedUiFontSize>()
 }
 

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -347,7 +347,7 @@ pub fn monitor_main_thread_hangs(
 fn upload_panics_and_crashes(
     http: Arc<HttpClientWithUrl>,
     installation_id: Option<String>,
-    cx: &mut AppContext,
+    cx: &AppContext,
 ) {
     let telemetry_settings = *client::TelemetrySettings::get_global(cx);
     cx.background_executor()

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -573,7 +573,7 @@ fn feature_gate_zed_pro_actions(cx: &mut AppContext) {
     .detach();
 }
 
-fn initialize_pane(workspace: &mut Workspace, pane: &View<Pane>, cx: &mut ViewContext<Workspace>) {
+fn initialize_pane(workspace: &Workspace, pane: &View<Pane>, cx: &mut ViewContext<Workspace>) {
     pane.update(cx, |pane, cx| {
         pane.toolbar().update(cx, |toolbar, cx| {
             let multibuffer_hint = cx.new_view(|_| MultibufferHint::new());
@@ -981,7 +981,7 @@ fn open_telemetry_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Works
 }
 
 fn open_bundled_file(
-    workspace: &mut Workspace,
+    workspace: &Workspace,
     text: Cow<'static, str>,
     title: &'static str,
     language: &'static str,

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -64,7 +64,7 @@ pub fn init(telemetry: Arc<Telemetry>, cx: &mut AppContext) {
     .detach();
 }
 
-fn register_backward_compatible_actions(editor: &mut Editor, cx: &mut ViewContext<Editor>) {
+fn register_backward_compatible_actions(editor: &mut Editor, cx: &ViewContext<Editor>) {
     // We renamed some of these actions to not be copilot-specific, but that
     // would have not been backwards-compatible. So here we are re-registering
     // the actions with the old names to not break people's keymaps.

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -661,7 +661,7 @@ mod tests {
         path: &str,
         open_new_workspace: Option<bool>,
         app_state: Arc<AppState>,
-        cx: &mut TestAppContext,
+        cx: &TestAppContext,
     ) {
         let (response_tx, _) = ipc::channel::<CliResponse>().unwrap();
 


### PR DESCRIPTION
While this lint is allow-by-default, it seems pretty useful to get rid of mutable borrows when they're not needed.

Closes #ISSUE

Release Notes:

- N/A
