### PR TITLE
vue: Use latest available @vue/language-server package

### DIFF
--- a/extensions/vue/extension.toml
+++ b/extensions/vue/extension.toml
@@ -1,7 +1,7 @@
 id = "vue"
 name = "Vue"
 description = "Vue support."
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/vue/src/vue.rs
+++ b/extensions/vue/src/vue.rs
@@ -48,8 +48,7 @@ impl VueExtension {
             language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-        // We hardcode the version to 1.8 since we do not support @vue/language-server 2.0 yet.
-        let version = "1.8".to_string();
+        let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
 
         if !server_exists
             || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)


### PR DESCRIPTION
This PR relates to https://github.com/zed-industries/zed/pull/9846 which pinned the [@vue/language-server package ](https://www.npmjs.com/package/@vue/language-server) to a version approximately 12 months old. This PR brings behaviour inline with how other JS language extensions works by pulling the latest available package.

I have tested on Zed 0.155.2 and it now seems to be behaving.

Release Notes:

- N/A

