### PR TITLE
proto: Bump to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14866,7 +14866,7 @@ dependencies = [
 
 [[package]]
 name = "zed_proto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/proto/Cargo.toml
+++ b/extensions/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_proto"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/proto/extension.toml
+++ b/extensions/proto/extension.toml
@@ -1,7 +1,7 @@
 id = "proto"
 name = "Proto"
 description = "Protocol Buffers support."
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Zed Industries <support@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Protobuf extension to v0.2.0.

Changes:

- https://github.com/zed-industries/zed/pull/18763

Release Notes:

- N/A
