### PR TITLE
Automatically indent JSX

### DIFF
--- a/crates/languages/src/javascript/indents.scm
+++ b/crates/languages/src/javascript/indents.scm
@@ -13,3 +13,9 @@
 (_ "<" ">" @end) @indent
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
+
+(jsx_opening_element ">" @end) @indent
+
+(jsx_element
+  (jsx_opening_element) @start
+  (jsx_closing_element)? @end) @indent

--- a/crates/languages/src/tsx/indents.scm
+++ b/crates/languages/src/tsx/indents.scm
@@ -13,3 +13,9 @@
 (_ "<" ">" @end) @indent
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
+
+(jsx_opening_element ">" @end) @indent
+
+(jsx_element
+  (jsx_opening_element) @start
+  (jsx_closing_element)? @end) @indent


### PR DESCRIPTION
indents jsx in a way that is [consistent with html](https://github.com/zed-industries/zed/blob/main/extensions/html/languages/html/indents.scm)

before, no automatic indentation would apply and it would even dedent you when you add a line above the cursor (shift-o in vim mode)

https://github.com/user-attachments/assets/470fbdb2-3e31-42c4-b535-bb26ae1706ab


after, it applies automatic indentation when you hit return

https://github.com/user-attachments/assets/e86c739d-370d-490d-8c6f-d0190e65f832



Closes #16127

Release Notes:

- Improved automatic indentation behavior in JSX ([#16127](https://github.com/zed-industries/zed/issues/16127))

