### PR TITLE
ui: Fix avatar indicators getting cut off

### DIFF
--- a/crates/ui/src/components/avatar/avatar.rs
+++ b/crates/ui/src/components/avatar/avatar.rs
@@ -84,7 +84,7 @@ impl RenderOnce for Avatar {
         div()
             .size(container_size)
             .rounded_full()
-            .overflow_hidden()
+            // .overflow_hidden()
             .when_some(self.border_color, |this, color| {
                 this.border(border_width).border_color(color)
             })

--- a/crates/ui/src/components/avatar/avatar.rs
+++ b/crates/ui/src/components/avatar/avatar.rs
@@ -84,7 +84,6 @@ impl RenderOnce for Avatar {
         div()
             .size(container_size)
             .rounded_full()
-            // .overflow_hidden()
             .when_some(self.border_color, |this, color| {
                 this.border(border_width).border_color(color)
             })


### PR DESCRIPTION
This PR fixes an issue introduced in #18810 that was causing the avatar indicators to get cut off.

Release Notes:

- N/A
