### PR TITLE
Temporarily prevent deploying collab to production

### DIFF
--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -3,7 +3,8 @@ name: Publish Collab Server Image
 on:
   push:
     tags:
-      - collab-production
+      # Pause production deploys while we investigate an issue.
+      # - collab-production
       - collab-staging
 
 env:


### PR DESCRIPTION
This PR adds a temporary measure to prevent deploying collab to production, while we investigate some issues stemming from the HTTP client change.

Release Notes:

- N/A
