### PR TITLE
Allow adding advanced options to context menus

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -584,7 +584,17 @@ impl TitleBar {
                             .separator()
                         })
                         .action("Settings", zed_actions::OpenSettings.boxed_clone())
+                        .advanced_action(
+                            "Default Settings",
+                            zed_actions::OpenSettings.boxed_clone(),
+                            Some("Settings".into()),
+                        )
                         .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
+                        .advanced_action(
+                            "Some Advanced",
+                            Box::new(zed_actions::DecreaseUiFontSize),
+                            None,
+                        )
                         .action("Themes…", theme_selector::Toggle::default().boxed_clone())
                         .action("Extensions", extensions_ui::Extensions.boxed_clone())
                         .separator()
@@ -613,7 +623,17 @@ impl TitleBar {
                 .menu(|cx| {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
+                            .advanced_action(
+                                "Default Settings",
+                                zed_actions::OpenSettings.boxed_clone(),
+                                Some("Settings".into()),
+                            )
                             .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
+                            .advanced_action(
+                                "Some Advanced",
+                                Box::new(zed_actions::DecreaseUiFontSize),
+                                None,
+                            )
                             .action("Themes…", theme_selector::Toggle::default().boxed_clone())
                             .action("Extensions", extensions_ui::Extensions.boxed_clone())
                     })

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -461,9 +461,6 @@ impl Render for ContextMenu {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let ui_font_size = ThemeSettings::get_global(cx).ui_font_size;
 
-        println!("show_advanced: {}", self.show_advanced);
-        println!("hidden_items: {:#?}", self.item_visibility);
-
         div().occlude().elevation_2(cx).flex().flex_row().child(
             WithRemSize::new(ui_font_size).flex().child(
                 v_flex()


### PR DESCRIPTION
WIP - Will likely ship a bit more sophisticated of an approach than this.

https://github.com/user-attachments/assets/1c95d246-48c1-47aa-9993-ea8b06d444aa


This PR introduces the ability to add advanced options to context menus.

This feature allows for two main types of advanced entries:

1. Additional Advanced Entries
2. Swappable Advanced Entries

### 1. Additional Advanced Entries

These are menu items that are only visible when the advanced mode is active (`alt` key is pressed). They are added to the menu without affecting other entries.

Example usage:
```rust
.advanced_entry(
    "Advanced Option",
    Some(action.boxed_clone()),
    handler,
    None
)
```

### 2. Swappable Advanced Entries

These entries replace an existing entry when advanced mode is active. This allows for a more compact menu while still providing advanced functionality.

Example usage:
```rust
.advanced_entry(
    "Advanced Option",
    Some(action.boxed_clone()),
    handler,
    Some("Regular Option")
)
```

In this case, "Advanced Option" will replace "Regular Option" when advanced mode is active.

---

Swapping items using labels isn't ideal, and needing to keep a second vec of bools also isn't ideal.

Maybe we can use an index map or just keep a vec of ids that are hidden? We'll just need to introduce ids to entries.

See also:
- https://github.com/zed-industries/zed/issues/18833

Release Notes:

- Added support for advanced options in context menus, accessible by holding the `option`/`alt` key