### PR TITLE
collab: Drop mistakenly-added columns from the `usages` table

### DIFF
--- a/crates/collab/migrations_llm/20241007220716_drop_incorrect_usages_columns.sql
+++ b/crates/collab/migrations_llm/20241007220716_drop_incorrect_usages_columns.sql
@@ -1,0 +1,3 @@
+alter table usages
+    drop column cache_creation_input_tokens_this_month,
+    drop column cache_read_input_tokens_this_month;


### PR DESCRIPTION
This PR drops the `cache_creation_input_tokens_this_month ` and `cache_read_input_tokens_this_month ` columns from the `usages` table in the LLM database.

We mistakenly added these in #18834, but these aren't necessary due to the structure of the `usages` table. We weren't actually using these columns anywhere.

Release Notes:

- N/A
