### PR TITLE
Add setting to clear search matches when selection changes

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -300,6 +300,8 @@
     "include_ignored": false,
     "regex": false
   },
+  // Whether to visually clear search matches when cursor is moved or text is edited.
+  "clear_search_matches_on_selection_change": false,
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:
   //

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -31,6 +31,7 @@ pub struct EditorSettings {
     pub search_wrap: bool,
     #[serde(default)]
     pub search: SearchSettings,
+    pub clear_search_matches_on_selection_change: bool,
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub jupyter: Jupyter,
@@ -271,6 +272,11 @@ pub struct EditorSettingsContent {
     ///
     /// Default: nothing is enabled
     pub search: Option<SearchSettings>,
+
+    /// Whether to visually clear search matches when cursor is moved or text is edited.
+    ///
+    /// Default: false
+    pub clear_search_matches_on_selection_change: Option<bool>,
 
     /// Whether to automatically show a signature help pop-up or not.
     ///


### PR DESCRIPTION
I don't like having search match highlights persist because of the visual clutter. I normally hit cmd-f twice to get rid of them. 

This PR adds an option to clear the search highlights when user moves the cursor or edits text.

Release Notes:

- Add `clear_search_matches_on_selection_change` setting. When set to true, this will clear the search match highlights when you move the cursor or make an edit, leaving you with less screen clutter. You can get the search match highlights back by hitting ctrl/cmd-g (select next match) or ctrl/cmd-shift-g (select previous match). Default is false. 
