### PR TITLE
Use correct context path for focused element in WindowContext::bindings_for_action

### DIFF
--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -68,7 +68,7 @@ pub(crate) struct DispatchNodeId(usize);
 
 pub(crate) struct DispatchTree {
     node_stack: Vec<DispatchNodeId>,
-    pub(crate) context_stack: Vec<KeyContext>,
+    context_stack: Vec<KeyContext>,
     view_stack: Vec<EntityId>,
     nodes: Vec<DispatchNode>,
     focusable_node_ids: FxHashMap<FocusId, DispatchNodeId>,
@@ -396,13 +396,15 @@ impl DispatchTree {
     pub fn bindings_for_action(
         &self,
         action: &dyn Action,
-        context_stack: &[KeyContext],
+        context_path: &[KeyContext],
     ) -> Vec<KeyBinding> {
         let keymap = self.keymap.borrow();
         keymap
             .bindings_for_action(action)
             .filter(|binding| {
-                let (bindings, _) = keymap.bindings_for_input(&binding.keystrokes, context_stack);
+                dbg!(&binding);
+                let (bindings, _) =
+                    keymap.bindings_for_input(&binding.keystrokes, dbg!(context_path));
                 bindings
                     .iter()
                     .next()
@@ -517,6 +519,13 @@ impl DispatchTree {
         }
         dispatch_path.reverse(); // Reverse the path so it goes from the root to the focused node.
         dispatch_path
+    }
+
+    pub fn context_path(&self, node_id: DispatchNodeId) -> SmallVec<[KeyContext; 32]> {
+        self.dispatch_path(node_id)
+            .into_iter()
+            .filter_map(|node_id| self.node(node_id).context.clone())
+            .collect()
     }
 
     pub fn focus_path(&self, focus_id: FocusId) -> SmallVec<[FocusId; 8]> {

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -402,9 +402,9 @@ impl DispatchTree {
         keymap
             .bindings_for_action(action)
             .filter(|binding| {
-                dbg!(&binding);
+                &binding;
                 let (bindings, _) =
-                    keymap.bindings_for_input(&binding.keystrokes, dbg!(context_path));
+                    keymap.bindings_for_input(&binding.keystrokes, context_path);
                 bindings
                     .iter()
                     .next()

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -402,9 +402,7 @@ impl DispatchTree {
         keymap
             .bindings_for_action(action)
             .filter(|binding| {
-                &binding;
-                let (bindings, _) =
-                    keymap.bindings_for_input(&binding.keystrokes, context_path);
+                let (bindings, _) = keymap.bindings_for_input(&binding.keystrokes, context_path);
                 bindings
                     .iter()
                     .next()

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -94,7 +94,7 @@ impl Keymap {
     pub fn bindings_for_input(
         &self,
         input: &[Keystroke],
-        context_stack: &[KeyContext],
+        context_path: &[KeyContext],
     ) -> (SmallVec<[KeyBinding; 1]>, bool) {
         let possibilities = self.bindings().rev().filter_map(|binding| {
             binding
@@ -106,8 +106,8 @@ impl Keymap {
         let mut is_pending = None;
 
         'outer: for (binding, pending) in possibilities {
-            for depth in (0..=context_stack.len()).rev() {
-                if self.binding_enabled(binding, &context_stack[0..depth]) {
+            for depth in (0..=context_path.len()).rev() {
+                if self.binding_enabled(binding, &context_path[0..depth]) {
                     if is_pending.is_none() {
                         is_pending = Some(pending);
                     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3697,15 +3697,11 @@ impl<'a> WindowContext<'a> {
     ) -> Vec<KeyBinding> {
         let dispatch_tree = &self.window.rendered_frame.dispatch_tree;
 
-        let Some(node_id) = dispatch_tree.focusable_node_id(focus_handle.id) else {
-            return vec![];
-        };
-        let context_stack: Vec<_> = dispatch_tree
-            .dispatch_path(node_id)
-            .into_iter()
-            .filter_map(|node_id| dispatch_tree.node(node_id).context.clone())
-            .collect();
-        dispatch_tree.bindings_for_action(action, &context_stack)
+        if let Some(node_id) = dispatch_tree.focusable_node_id(focus_handle.id) {
+            dispatch_tree.bindings_for_action(action, &dispatch_tree.context_path(node_id))
+        } else {
+            vec![]
+        }
     }
 
     fn focused_node_id(&self) -> DispatchNodeId {


### PR DESCRIPTION
Previously, we were reaching in and using the context_stack on the dispatch tree, which was incorrect.

/cc @as-cii 
/cc @ConradIrwin

Release Notes:

- N/A
