### PR TITLE
dart: Improve indentation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -162,7 +162,14 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
+  "private_files": [
+    "**/.env*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.cert",
+    "**/*.crt",
+    "**/secrets.yml"
+  ],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,
@@ -839,6 +846,9 @@
       "prettier": {
         "allowed": true
       }
+    },
+    "Dart": {
+      "tab_size": 2
     },
     "Elixir": {
       "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -162,14 +162,7 @@
   // The default number of lines to expand excerpts in the multibuffer by.
   "expand_excerpt_lines": 3,
   // Globs to match against file paths to determine if a file is private.
-  "private_files": [
-    "**/.env*",
-    "**/*.pem",
-    "**/*.key",
-    "**/*.cert",
-    "**/*.crt",
-    "**/secrets.yml"
-  ],
+  "private_files": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"],
   // Whether to use additional LSP queries to format (and amend) the code after
   // every "trigger" symbol input, defined by LSP server capabilities.
   "use_on_type_format": true,

--- a/extensions/dart/languages/dart/indents.scm
+++ b/extensions/dart/languages/dart/indents.scm
@@ -1,18 +1,3 @@
-(class_definition
-    "class" @context
-    name: (_) @name) @item
-
-(function_signature
-    name: (_) @name) @item
-
-(getter_signature
-    "get" @context
-    name: (_) @name) @item
-
-(setter_signature
-    "set" @context
-    name: (_) @name) @item
-
-(enum_declaration
-    "enum" @context
-    name: (_) @name) @item
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent


### PR DESCRIPTION
- Closes https://github.com/zed-industries/zed/issues/18758

Validated by [@CalebQ42](https://github.com/zed-industries/zed/issues/18758#issuecomment-2398820118).

Steps to test:
1. Add the following to your zed settings:
```
  "languages":
    "Dart": {
      "tab_size": 2
    },
  }
```

2. Clone the zed repo and checkout this branch (no need to build zed, we just need the source for extensions)
```
cd ~/code
git clone https://github.com/zed-industries/zed
cd zed
git checkout dart_indent
```
3. Open Zed and Uninstall the current Dart zed extension.
4. Go to the zed extensions (cmd-shift-x / ctrl-shift-x) and click "install dev extension"
5. Select `zed/extensions/dart`

Test!

Release Notes:

- N/A
