### PR TITLE
dart: Bump to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14750,7 +14750,7 @@ dependencies = [
 
 [[package]]
 name = "zed_dart"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/dart/Cargo.toml
+++ b/extensions/dart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_dart"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/dart/extension.toml
+++ b/extensions/dart/extension.toml
@@ -1,7 +1,7 @@
 id = "dart"
 name = "Dart"
 description = "Dart support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Abdullah Alsigar <abdullah.alsigar@gmail.com>", "Flo <flo80@users.noreply.github.com>", "ybbond <hi@ybbond.id>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Includes:
- https://github.com/zed-industries/zed/pull/18845

Release Notes:

- N/A
