### PR TITLE
Remove deprecated copilot event

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -429,8 +429,6 @@ pub async fn post_events(
                 country_code.clone(),
                 checksum_matched,
             )),
-            // Needed for clients sending old copilot_event types
-            Event::Copilot(_) => {}
             Event::InlineCompletion(event) => {
                 to_upload
                     .inline_completion_events

--- a/crates/telemetry_events/src/telemetry_events.rs
+++ b/crates/telemetry_events/src/telemetry_events.rs
@@ -91,7 +91,6 @@ impl Display for AssistantPhase {
 #[serde(tag = "type")]
 pub enum Event {
     Editor(EditorEvent),
-    Copilot(CopilotEvent), // Needed for clients sending old copilot_event types
     InlineCompletion(InlineCompletionEvent),
     Call(CallEvent),
     Assistant(AssistantEvent),
@@ -119,15 +118,6 @@ pub struct EditorEvent {
     pub copilot_enabled_for_language: bool,
     /// Whether the client is editing a local file or a remote file via SSH
     pub is_via_ssh: bool,
-}
-
-/// Deprecated since Zed v0.137.0 (2024-05-29). Replaced by InlineCompletionEvent.
-// Needed for clients sending old copilot_event types
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct CopilotEvent {
-    pub suggestion_id: Option<String>,
-    pub suggestion_accepted: bool,
-    pub file_extension: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
`CopilotEvent` was succeeded by `InlineCompletionEvent` 5 months ago.

Release Notes:

- N/A
