### PR TITLE
remote server on macOS: Sign with entitlements

### DIFF
--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -83,7 +83,10 @@ if [ "$local_arch" = true ]; then
     cargo build ${build_flag} --package zed --package cli --package remote_server
 else
     echo "Compiling zed binaries"
-    cargo build ${build_flag} --package zed --package cli --package remote_server --target aarch64-apple-darwin --target x86_64-apple-darwin
+    cargo build ${build_flag} --package zed --package cli --target aarch64-apple-darwin --target x86_64-apple-darwin
+    # Build remote_server in separate invocation to prevent feature unification from other crates
+    # from influencing dynamic libraries required by it.
+    cargo build ${build_flag} --package remote_server     --target aarch64-apple-darwin --target x86_64-apple-darwin
 fi
 
 echo "Creating application bundle"
@@ -358,7 +361,7 @@ function sign_binary() {
 
     if [[ $can_code_sign = true ]]; then
         echo "Code signing executable $binary_path"
-        /usr/bin/codesign --deep --force --timestamp --options runtime --sign "$IDENTITY" "${binary_path}" -v
+        /usr/bin/codesign --deep --force --timestamp --options runtime --entitlements crates/zed/resources/zed.entitlements --sign "$IDENTITY" "${binary_path}" -v
     fi
 }
 


### PR DESCRIPTION
This does two things:

- Prevent feature unification
- Sign the remote-server binary with the same entitlements we use for Zed because we saw this in crash report:

      Crashed Thread:        4  Dispatch queue: com.apple.root.user-initiated-qos

      Exception Type:        EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))
      Exception Codes:       UNKNOWN_0x32 at 0x0000000103636644
      Exception Codes:       0x0000000000000032, 0x0000000103636644

      Termination Reason:    Namespace CODESIGNING, Code 2 Invalid Page

      VM Region Info: 0x103636644 is in 0x103634000-0x103638000;  bytes after start: 9796  bytes before end: 6587
            REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
            VM_ALLOCATE                 103630000-103634000    [   16K] r--/rwx SM=ZER
      --->  VM_ALLOCATE                 103634000-103638000    [   16K] r-x/rwx SM=COW
            VM_ALLOCATE                 103638000-103640000    [   32K] r--/rwx SM=ZER

  Which sounds a lot like codesigning/jit/entitlements stuff.


Release Notes:

- N/A
