### PR TITLE
remote server: Do not spawn server when proxy reconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9155,6 +9155,7 @@ dependencies = [
  "serde_json",
  "smol",
  "tempfile",
+ "thiserror",
  "util",
 ]
 

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -31,6 +31,7 @@ serde.workspace = true
 serde_json.workspace = true
 smol.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 util.workspace = true
 
 [dev-dependencies]

--- a/crates/remote/src/proxy.rs
+++ b/crates/remote/src/proxy.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ProxyLaunchError {
+    #[error("Attempted reconnect. Server is already running.")]
+    ServerNotRunning,
+}
+
+impl ProxyLaunchError {
+    pub fn to_exit_code(&self) -> i32 {
+        match self {
+            Self::ServerNotRunning => 90,
+        }
+    }
+
+    pub fn from_exit_code(exit_code: i32) -> Option<Self> {
+        match exit_code {
+            90 => Some(Self::ServerNotRunning),
+            _ => None,
+        }
+    }
+}

--- a/crates/remote/src/proxy.rs
+++ b/crates/remote/src/proxy.rs
@@ -2,13 +2,16 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ProxyLaunchError {
-    #[error("Attempted reconnect. Server is already running.")]
+    #[error("Attempted reconnect, but server not running.")]
     ServerNotRunning,
 }
 
 impl ProxyLaunchError {
     pub fn to_exit_code(&self) -> i32 {
         match self {
+            // We're using 90 as the exit code, because 0-78 are often taken
+            // by shells and other conventions and >128 also has certain meanings
+            // in certain contexts.
             Self::ServerNotRunning => 90,
         }
     }

--- a/crates/remote/src/remote.rs
+++ b/crates/remote/src/remote.rs
@@ -1,5 +1,6 @@
 pub mod json_log;
 pub mod protocol;
+pub mod proxy;
 pub mod ssh_session;
 
 pub use ssh_session::{

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -730,7 +730,6 @@ impl SshRemoteClient {
                 missed_heartbeats
             );
 
-            println!("heartbeat starting reconnect");
             self.reconnect(cx)
                 .context("failed to start reconnect process after missing heartbeats")
                 .log_err();
@@ -852,7 +851,6 @@ impl SshRemoteClient {
                 Err(error) => {
                     log::warn!("ssh io task died with error: {:?}. reconnecting...", error);
                     this.update(&mut cx, |this, cx| {
-                        println!("multiplex starting reconnect");
                         this.reconnect(cx).ok();
                     })?;
                 }

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -856,9 +856,7 @@ impl SshRemoteClient {
                         log::error!("proxy process terminated unexpectedly");
                     }
                 }
-                Ok(None) => {
-                    log::debug!("shutting down IO tasks");
-                }
+                Ok(None) => {}
                 Err(error) => {
                     log::warn!("ssh io task died with error: {:?}. reconnecting...", error);
                     this.update(&mut cx, |this, cx| {


### PR DESCRIPTION
This ensures that we only ever reconnect to a running server and not spawn a new server with no state.

This avoids the problem of the server process crashing, `proxy` reconnecting, starting a new server, and the user getting errors like "unknown buffer id: ...".

Release Notes:

- N/A
