### PR TITLE
collab: Set cached token values when initially creating lifetime usage records

### DIFF
--- a/crates/collab/src/llm/db/queries/usages.rs
+++ b/crates/collab/src/llm/db/queries/usages.rs
@@ -382,6 +382,10 @@ impl LlmDatabase {
                         user_id: ActiveValue::set(user_id),
                         model_id: ActiveValue::set(model.id),
                         input_tokens: ActiveValue::set(input_token_count as i64),
+                        cache_creation_input_tokens: ActiveValue::set(
+                            cache_creation_input_tokens as i64,
+                        ),
+                        cache_read_input_tokens: ActiveValue::set(cache_read_input_tokens as i64),
                         output_tokens: ActiveValue::set(output_token_count as i64),
                         ..Default::default()
                     }


### PR DESCRIPTION
This PR fixes an issue where we weren't setting the cached token fields when initially creating a lifetime usage record.

Release Notes:

- N/A
