### PR TITLE
worktree: Depend on `rpc` with `test-support` feature in tests

### DIFF
--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -56,4 +56,5 @@ gpui = { workspace = true, features = ["test-support"] }
 http_client.workspace = true
 pretty_assertions.workspace = true
 rand.workspace = true
+rpc = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
This PR updates the `worktree` crate to depend on `rpc` with the `test-support` feature flag when running tests.

This fixes an issue I was seeing locally when trying to run tests in the `worktree` crate:

```
λ cargo test -p worktree -- test_repository_subfolder_git_status
   Compiling worktree v0.1.0 (/Users/maxdeviant/projects/zed/crates/worktree)
error[E0432]: unresolved import `rpc::AnyProtoClient`
  --> crates/worktree/src/worktree.rs:39:18
   |
39 | use rpc::{proto, AnyProtoClient};
   |                  ^^^^^^^^^^^^^^ no `AnyProtoClient` in the root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `worktree` (lib test) due to 1 previous error
```

Release Notes:

- N/A
