### PR TITLE
csharp: Add support for triple-slash doc comments

### DIFF
--- a/extensions/csharp/languages/csharp/config.toml
+++ b/extensions/csharp/languages/csharp/config.toml
@@ -2,7 +2,7 @@ name = "CSharp"
 code_fence_block_name = "csharp"
 grammar = "c_sharp"
 path_suffixes = ["cs"]
-line_comments = ["// "]
+line_comments = ["// ", "/// "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
This PR adds support for triple-slash (`///`) doc comments in C#.

As requested by https://github.com/zed-industries/zed/issues/18766.

Release Notes:

- N/A
