### PR TITLE
ssh: Fix text wrapping in loading text

### DIFF
--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -173,6 +173,8 @@ impl Render for SshPrompt {
                     )
                     .child(
                         div()
+                            .text_ellipsis()
+                            .overflow_x_hidden()
                             .when_some(self.error_message.as_ref(), |el, error| {
                                 el.child(Label::new(format!("－{}", error)).size(LabelSize::Small))
                             })

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -146,9 +146,9 @@ impl Render for SshPrompt {
             .justify_center()
             .child(
                 h_flex()
-                    .py_2()
-                    .px_4()
+                    .p_2()
                     .justify_center()
+                    .flex_wrap()
                     .child(if self.error_message.is_some() {
                         Icon::new(IconName::XCircle)
                             .size(IconSize::Medium)


### PR DESCRIPTION
This PR adds `flex_wrap` to the loading text container to prevent the loading modal layout to break.

Release Notes:

- N/A
