### PR TITLE
collab: Update billing code for LLM usage billing

### DIFF
--- a/crates/collab/migrations_llm/20241008155620_create_monthly_usages.sql
+++ b/crates/collab/migrations_llm/20241008155620_create_monthly_usages.sql
@@ -5,6 +5,8 @@ create table monthly_usages (
     month integer not null,
     year integer not null,
     input_tokens bigint not null default 0,
+    cache_creation_input_tokens bigint not null default 0,
+    cache_read_input_tokens bigint not null default 0,
     output_tokens bigint not null default 0
 );
 

--- a/crates/collab/migrations_llm/20241008155620_create_monthly_usages.sql
+++ b/crates/collab/migrations_llm/20241008155620_create_monthly_usages.sql
@@ -1,0 +1,11 @@
+create table monthly_usages (
+    id serial primary key,
+    user_id integer not null,
+    model_id integer not null references models (id) on delete cascade,
+    month integer not null,
+    year integer not null,
+    input_tokens bigint not null default 0,
+    output_tokens bigint not null default 0
+);
+
+create unique index uix_monthly_usages_on_user_id_model_id_month_year on monthly_usages (user_id, model_id, month, year);

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -79,7 +79,7 @@ async fn list_billing_subscriptions(
             .into_iter()
             .map(|subscription| BillingSubscriptionJson {
                 id: subscription.id,
-                name: "Zed Pro".to_string(),
+                name: "Zed LLM Usage".to_string(),
                 status: subscription.stripe_subscription_status,
                 cancel_at: subscription.stripe_cancel_at.map(|cancel_at| {
                     cancel_at
@@ -117,7 +117,7 @@ async fn create_billing_subscription(
     let Some((stripe_client, stripe_price_id)) = app
         .stripe_client
         .clone()
-        .zip(app.config.stripe_price_id.clone())
+        .zip(app.config.stripe_llm_usage_price_id.clone())
     else {
         log::error!("failed to retrieve Stripe client or price ID");
         Err(Error::http(
@@ -150,7 +150,7 @@ async fn create_billing_subscription(
         params.client_reference_id = Some(user.github_login.as_str());
         params.line_items = Some(vec![CreateCheckoutSessionLineItems {
             price: Some(stripe_price_id.to_string()),
-            quantity: Some(1),
+            quantity: Some(0),
             ..Default::default()
         }]);
         let success_url = format!("{}/account", app.config.zed_dot_dev_url());

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -22,17 +22,15 @@ use stripe::{
 };
 use util::ResultExt;
 
-use crate::db::billing_subscription;
-use crate::llm::MONTHLY_SPENDING_LIMIT_IN_CENTS;
-use crate::{db::billing_subscription::StripeSubscriptionStatus, rpc::ResultExt as _};
-use crate::{
-    db::{
-        billing_customer, BillingSubscriptionId, CreateBillingCustomerParams,
-        CreateBillingSubscriptionParams, CreateProcessedStripeEventParams,
-        UpdateBillingCustomerParams, UpdateBillingSubscriptionParams,
-    },
-    llm::db::LlmDatabase,
+use crate::db::billing_subscription::{self, StripeSubscriptionStatus};
+use crate::db::{
+    billing_customer, BillingSubscriptionId, CreateBillingCustomerParams,
+    CreateBillingSubscriptionParams, CreateProcessedStripeEventParams, UpdateBillingCustomerParams,
+    UpdateBillingSubscriptionParams,
 };
+use crate::llm::db::LlmDatabase;
+use crate::llm::MONTHLY_SPENDING_LIMIT_IN_CENTS;
+use crate::rpc::ResultExt as _;
 use crate::{AppState, Error, Result};
 
 pub fn router() -> Router {

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -675,11 +675,9 @@ async fn sync_with_stripe(
 ) -> anyhow::Result<()> {
     let user_ids = app.db.user_ids_with_llm_subscription().await?;
 
-    for user_id in user_ids {
+    // for user_id in user_ids {
 
-
-    }
-
+    // }
 
     Ok(())
 }

--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -112,6 +112,23 @@ impl Database {
         .await
     }
 
+    pub async fn get_billing_subscriptions_with_price(
+        &self,
+        price_id: &str,
+    ) -> Result<Vec<billing_subscription::Model>> {
+        self.transaction(|tx| async move {
+            let subscriptions = billing_subscription::Entity::find()
+                .inner_join(billing_customer::Entity)
+                .filter(billing_customer::Column::UserId.eq(user_id))
+                .order_by_asc(billing_subscription::Column::Id)
+                .all(&*tx)
+                .await?;
+
+            Ok(subscriptions)
+        })
+        .await
+    }
+
     /// Returns whether the user has an active billing subscription.
     pub async fn has_active_billing_subscription(&self, user_id: UserId) -> Result<bool> {
         Ok(self.count_active_billing_subscriptions(user_id).await? > 0)

--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -112,7 +112,7 @@ impl Database {
         .await
     }
 
-    pub async fn get_billing_subscriptions_with_price(
+    pub async fn get_active_billing_subscription_with_price(
         &self,
         price_id: &str,
     ) -> Result<Vec<billing_subscription::Model>> {

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -22,6 +22,7 @@ use axum::{
 };
 use db::{ChannelId, Database};
 use executor::Executor;
+use llm::db::LlmDatabase;
 pub use rate_limiter::*;
 use serde::Deserialize;
 use std::{path::PathBuf, sync::Arc};
@@ -191,6 +192,10 @@ impl Config {
             "staging" => "https://staging.zed.dev",
             _ => "https://zed.dev",
         }
+    }
+
+    pub fn is_llm_billing_enabled(&self) -> bool {
+        self.stripe_llm_usage_price_id.is_some()
     }
 
     #[cfg(test)]

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -174,7 +174,7 @@ pub struct Config {
     pub slack_panics_webhook: Option<String>,
     pub auto_join_channel_id: Option<ChannelId>,
     pub stripe_api_key: Option<String>,
-    pub stripe_price_id: Option<Arc<str>>,
+    pub stripe_llm_usage_price_id: Option<Arc<str>>,
     pub supermaven_admin_api_key: Option<Arc<str>>,
     pub user_backfiller_github_access_token: Option<Arc<str>>,
 }
@@ -231,7 +231,7 @@ impl Config {
             migrations_path: None,
             seed_path: None,
             stripe_api_key: None,
-            stripe_price_id: None,
+            stripe_llm_usage_price_id: None,
             supermaven_admin_api_key: None,
             user_backfiller_github_access_token: None,
         }

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -22,7 +22,6 @@ use axum::{
 };
 use db::{ChannelId, Database};
 use executor::Executor;
-use llm::db::LlmDatabase;
 pub use rate_limiter::*;
 use serde::Deserialize;
 use std::{path::PathBuf, sync::Arc};

--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -520,7 +520,6 @@ async fn check_usage_limit(
                 UsageMeasure::RequestsPerMinute => "requests_per_minute",
                 UsageMeasure::TokensPerMinute => "tokens_per_minute",
                 UsageMeasure::TokensPerDay => "tokens_per_day",
-                _ => "",
             };
 
             if let Some(client) = state.clickhouse_client.as_ref() {

--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -436,6 +436,9 @@ fn normalize_model_name(known_models: Vec<String>, name: String) -> String {
     }
 }
 
+/// The maximum monthly spending an individual user can reach before they have to pay.
+pub const MONTHLY_SPENDING_LIMIT_IN_CENTS: usize = 5 * 100;
+
 /// The maximum lifetime spending an individual user can reach before being cut off.
 ///
 /// Represented in cents.
@@ -458,6 +461,18 @@ async fn check_usage_limit(
         )
         .await?;
 
+    if state.config.is_llm_billing_enabled() {
+        if usage.spending_this_month >= MONTHLY_SPENDING_LIMIT_IN_CENTS {
+            if !claims.has_llm_subscription.unwrap_or(false) {
+                return Err(Error::http(
+                    StatusCode::PAYMENT_REQUIRED,
+                    "Maximum spending limit reached for this month.".to_string(),
+                ));
+            }
+        }
+    }
+
+    // TODO: Remove this once we've rolled out monthly spending limits.
     if usage.lifetime_spending >= LIFETIME_SPENDING_LIMIT_IN_CENTS {
         return Err(Error::http(
             StatusCode::FORBIDDEN,

--- a/crates/collab/src/llm/db.rs
+++ b/crates/collab/src/llm/db.rs
@@ -102,7 +102,7 @@ impl LlmDatabase {
             .models
             .values()
             .find(|model| model.id == id)
-            .ok_or_else(|| anyhow!("no model for id {id:?}"))?)
+            .ok_or_else(|| anyhow!("no model for ID {id:?}"))?)
     }
 
     pub fn options(&self) -> &ConnectOptions {

--- a/crates/collab/src/llm/db.rs
+++ b/crates/collab/src/llm/db.rs
@@ -97,6 +97,14 @@ impl LlmDatabase {
             .ok_or_else(|| anyhow!("unknown model {provider:?}:{name}"))?)
     }
 
+    pub fn model_by_id(&self, id: ModelId) -> Result<&model::Model> {
+        Ok(self
+            .models
+            .values()
+            .find(|model| model.id == id)
+            .ok_or_else(|| anyhow!("no model for id {id:?}"))?)
+    }
+
     pub fn options(&self) -> &ConnectOptions {
         &self.options
     }

--- a/crates/collab/src/llm/db/tables.rs
+++ b/crates/collab/src/llm/db/tables.rs
@@ -1,5 +1,6 @@
 pub mod lifetime_usage;
 pub mod model;
+pub mod monthly_usage;
 pub mod provider;
 pub mod revoked_access_token;
 pub mod usage;

--- a/crates/collab/src/llm/db/tables/monthly_usage.rs
+++ b/crates/collab/src/llm/db/tables/monthly_usage.rs
@@ -2,7 +2,7 @@ use crate::{db::UserId, llm::db::ModelId};
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-#[sea_orm(table_name = "lifetime_usages")]
+#[sea_orm(table_name = "monthly_usages")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,

--- a/crates/collab/src/llm/db/tables/monthly_usage.rs
+++ b/crates/collab/src/llm/db/tables/monthly_usage.rs
@@ -1,0 +1,22 @@
+use crate::{db::UserId, llm::db::ModelId};
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "lifetime_usages")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub user_id: UserId,
+    pub model_id: ModelId,
+    pub month: i32,
+    pub year: i32,
+    pub input_tokens: i64,
+    pub cache_creation_input_tokens: i64,
+    pub cache_read_input_tokens: i64,
+    pub output_tokens: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/collab/src/llm/db/tables/usage_measure.rs
+++ b/crates/collab/src/llm/db/tables/usage_measure.rs
@@ -9,10 +9,6 @@ pub enum UsageMeasure {
     RequestsPerMinute,
     TokensPerMinute,
     TokensPerDay,
-    InputTokensPerMonth,
-    CacheCreationInputTokensPerMonth,
-    CacheReadInputTokensPerMonth,
-    OutputTokensPerMonth,
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]

--- a/crates/collab/src/llm/db/tests/usage_tests.rs
+++ b/crates/collab/src/llm/db/tests/usage_tests.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     test_llm_db,
 };
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use pretty_assertions::assert_eq;
 use rpc::LanguageModelProvider;
 
@@ -29,7 +29,10 @@ async fn test_tracking_usage(db: &mut LlmDatabase) {
     .await
     .unwrap();
 
-    let t0 = Utc::now();
+    // We're using a fixed datetime to prevent flakiness based on the clock.
+    let t0 = DateTime::parse_from_rfc3339("2024-08-08T22:46:33Z")
+        .unwrap()
+        .with_timezone(&Utc);
     let user_id = UserId::from_proto(123);
 
     let now = t0;
@@ -134,23 +137,10 @@ async fn test_tracking_usage(db: &mut LlmDatabase) {
         }
     );
 
-    let t2 = t0 + Duration::days(30);
-    let now = t2;
-    let usage = db.get_usage(user_id, provider, model, now).await.unwrap();
-    assert_eq!(
-        usage,
-        Usage {
-            requests_this_minute: 0,
-            tokens_this_minute: 0,
-            tokens_this_day: 0,
-            input_tokens_this_month: 9000,
-            cache_creation_input_tokens_this_month: 0,
-            cache_read_input_tokens_this_month: 0,
-            output_tokens_this_month: 0,
-            spending_this_month: 0,
-            lifetime_spending: 0,
-        }
-    );
+    // We're using a fixed datetime to prevent flakiness based on the clock.
+    let now = DateTime::parse_from_rfc3339("2024-10-08T22:15:58Z")
+        .unwrap()
+        .with_timezone(&Utc);
 
     // Test cache creation input tokens
     db.record_usage(user_id, false, provider, model, 1000, 500, 0, 0, now)
@@ -164,7 +154,7 @@ async fn test_tracking_usage(db: &mut LlmDatabase) {
             requests_this_minute: 1,
             tokens_this_minute: 1500,
             tokens_this_day: 1500,
-            input_tokens_this_month: 10000,
+            input_tokens_this_month: 1000,
             cache_creation_input_tokens_this_month: 500,
             cache_read_input_tokens_this_month: 0,
             output_tokens_this_month: 0,
@@ -185,7 +175,7 @@ async fn test_tracking_usage(db: &mut LlmDatabase) {
             requests_this_minute: 2,
             tokens_this_minute: 2800,
             tokens_this_day: 2800,
-            input_tokens_this_month: 11000,
+            input_tokens_this_month: 2000,
             cache_creation_input_tokens_this_month: 500,
             cache_read_input_tokens_this_month: 300,
             output_tokens_this_month: 0,

--- a/crates/collab/src/llm/token.rs
+++ b/crates/collab/src/llm/token.rs
@@ -22,6 +22,12 @@ pub struct LlmTokenClaims {
     pub is_staff: bool,
     #[serde(default)]
     pub has_llm_closed_beta_feature_flag: bool,
+    // This field is temporarily optional so it can be added
+    // in a backwards-compatible way. We can make it required
+    // once all of the LLM tokens have cycled (~1 hour after
+    // this change has been deployed).
+    #[serde(default)]
+    pub has_llm_subscription: Option<bool>,
     pub plan: rpc::proto::Plan,
 }
 
@@ -33,6 +39,7 @@ impl LlmTokenClaims {
         github_user_login: String,
         is_staff: bool,
         has_llm_closed_beta_feature_flag: bool,
+        has_llm_subscription: bool,
         plan: rpc::proto::Plan,
         config: &Config,
     ) -> Result<String> {
@@ -50,6 +57,7 @@ impl LlmTokenClaims {
             github_user_login: Some(github_user_login),
             is_staff,
             has_llm_closed_beta_feature_flag,
+            has_llm_subscription: Some(has_llm_subscription),
             plan,
         };
 

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -191,16 +191,26 @@ impl Session {
         }
     }
 
-    pub async fn current_plan(&self, db: MutexGuard<'_, DbHandle>) -> anyhow::Result<proto::Plan> {
+    pub async fn has_llm_subscription(
+        &self,
+        db: &MutexGuard<'_, DbHandle>,
+    ) -> anyhow::Result<bool> {
         if self.is_staff() {
-            return Ok(proto::Plan::ZedPro);
+            return Ok(true);
         }
 
         let Some(user_id) = self.user_id() else {
-            return Ok(proto::Plan::Free);
+            return Ok(false);
         };
 
-        if db.has_active_billing_subscription(user_id).await? {
+        Ok(db.has_active_billing_subscription(user_id).await?)
+    }
+
+    pub async fn current_plan(
+        &self,
+        _db: &MutexGuard<'_, DbHandle>,
+    ) -> anyhow::Result<proto::Plan> {
+        if self.is_staff() {
             Ok(proto::Plan::ZedPro)
         } else {
             Ok(proto::Plan::Free)
@@ -3471,7 +3481,7 @@ fn should_auto_subscribe_to_channels(version: ZedVersion) -> bool {
 }
 
 async fn update_user_plan(_user_id: UserId, session: &Session) -> Result<()> {
-    let plan = session.current_plan(session.db().await).await?;
+    let plan = session.current_plan(&session.db().await).await?;
 
     session
         .peer
@@ -4471,7 +4481,7 @@ async fn count_language_model_tokens(
     };
     authorize_access_to_legacy_llm_endpoints(&session).await?;
 
-    let rate_limit: Box<dyn RateLimit> = match session.current_plan(session.db().await).await? {
+    let rate_limit: Box<dyn RateLimit> = match session.current_plan(&session.db().await).await? {
         proto::Plan::ZedPro => Box::new(ZedProCountLanguageModelTokensRateLimit),
         proto::Plan::Free => Box::new(FreeCountLanguageModelTokensRateLimit),
     };
@@ -4592,7 +4602,7 @@ async fn compute_embeddings(
     let api_key = api_key.context("no OpenAI API key configured on the server")?;
     authorize_access_to_legacy_llm_endpoints(&session).await?;
 
-    let rate_limit: Box<dyn RateLimit> = match session.current_plan(session.db().await).await? {
+    let rate_limit: Box<dyn RateLimit> = match session.current_plan(&session.db().await).await? {
         proto::Plan::ZedPro => Box::new(ZedProComputeEmbeddingsRateLimit),
         proto::Plan::Free => Box::new(FreeComputeEmbeddingsRateLimit),
     };
@@ -4915,7 +4925,8 @@ async fn get_llm_api_token(
         user.github_login.clone(),
         session.is_staff(),
         has_llm_closed_beta_feature_flag,
-        session.current_plan(db).await?,
+        session.has_llm_subscription(&db).await?,
+        session.current_plan(&db).await?,
         &session.app_state.config,
     )?;
     response.send(proto::GetLlmTokenResponse { token })?;

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -677,7 +677,7 @@ impl TestServer {
                 migrations_path: None,
                 seed_path: None,
                 stripe_api_key: None,
-                stripe_price_id: None,
+                stripe_llm_usage_price_id: None,
                 supermaven_admin_api_key: None,
                 user_backfiller_github_access_token: None,
             },


### PR DESCRIPTION
This PR reworks our existing billing code in preparation for charging based on LLM usage.

We aren't yet exercising the new billing-related code outside of development.

There are some noteworthy changes for our existing LLM usage tracking:

- A new `monthly_usages` table has been added for tracking usage per-user, per-model, per-month
- The per-month usage measures have been removed, in favor of the `monthly_usages` table
- All of the per-month metrics in the Clickhouse rows have been changed from a rolling 30-day window to a calendar month

Release Notes:

- N/A
