### PR TITLE
client: Send telemetry events with `Content-Type: application/json`

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -653,7 +653,7 @@ impl Telemetry {
                                 .build_zed_api_url("/telemetry/events", &[])?
                                 .as_ref(),
                         )
-                        .header("Content-Type", "text/plain")
+                        .header("Content-Type", "application/json")
                         .header("x-zed-checksum", checksum)
                         .body(json_bytes.into());
 


### PR DESCRIPTION
This PR updates the telemetry events sent to collab to use `Content-Type: application/json` instead of `Content-Type: text/plain`.

The POST bodies are JSON, so `application/json` is the correct MIME type.

I suspect the `text/plain` is a remnant from when the events were still going through Vercel.

Release Notes:

- N/A
