### PR TITLE
macOS: Drop input handler to avoid editor/project not being dropped

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -768,6 +768,7 @@ impl Drop for MacWindow {
         unsafe {
             this.native_window.setDelegate_(nil);
         }
+        this.input_handler.take();
         this.executor
             .spawn(async move {
                 unsafe {


### PR DESCRIPTION
This fixes the problem of a `Project` sometimes not being dropped when closing the single, last window of Zed.

Turns out, it wasn't get dropped for the following reason:

1. `editor::Editor` held a reference to project
2. The macOS `input_handler` on the `Window` held a reference to that `Editor`
3. The AppKit window (and its input handler) get dropped asynchronously (in the code in this diff), after the window is closed.
4. After the window is closed and no `cx.update()` calls are made anymore, `flush_effects` is not called anymore.
5. But `flush_effects` is where we dropped entities that don't have any more references.

In short: we dropped `Editor`, which held a reference to `Project`, out of band, `flush_effects` wasn't called anymore, and thus the `Project` wasn't dropped.

cc @ConradIrwin @bennetbo since we talked about this.

Release Notes:

- N/A
