### PR TITLE
Always wait for completion resolve before applying the completion edits

### DIFF
--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -363,10 +363,12 @@ mod tests {
 
             // Confirming a completion inserts it and hides the context menu, without showing
             // the copilot suggestion afterwards.
-            editor
-                .confirm_completion(&Default::default(), cx)
-                .unwrap()
-                .detach();
+            editor.confirm_completion(&Default::default(), cx).unwrap()
+        })
+        .await
+        .unwrap();
+
+        cx.update_editor(|editor, cx| {
             assert!(!editor.context_menu_visible());
             assert!(!editor.has_active_inline_completion(cx));
             assert_eq!(editor.text(cx), "one.completion_a\ntwo\nthree\n");

--- a/crates/editor/src/debounced_delay.rs
+++ b/crates/editor/src/debounced_delay.rs
@@ -42,4 +42,8 @@ impl DebouncedDelay {
             }
         }));
     }
+
+    pub fn take(&mut self) -> Option<Task<()>> {
+        self.task.take()
+    }
 }

--- a/crates/editor/src/debounced_delay.rs
+++ b/crates/editor/src/debounced_delay.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{ops::ControlFlow, time::Duration};
 
 use futures::{channel::oneshot, FutureExt};
 use gpui::{Task, ViewContext};
@@ -7,7 +7,7 @@ use crate::Editor;
 
 pub struct DebouncedDelay {
     task: Option<Task<()>>,
-    cancel_channel: Option<oneshot::Sender<()>>,
+    cancel_channel: Option<oneshot::Sender<ControlFlow<()>>>,
 }
 
 impl DebouncedDelay {
@@ -23,17 +23,22 @@ impl DebouncedDelay {
         F: 'static + Send + FnOnce(&mut Editor, &mut ViewContext<Editor>) -> Task<()>,
     {
         if let Some(channel) = self.cancel_channel.take() {
-            _ = channel.send(());
+            channel.send(ControlFlow::Break(())).ok();
         }
 
-        let (sender, mut receiver) = oneshot::channel::<()>();
+        let (sender, mut receiver) = oneshot::channel::<ControlFlow<()>>();
         self.cancel_channel = Some(sender);
 
         drop(self.task.take());
         self.task = Some(cx.spawn(move |model, mut cx| async move {
             let mut timer = cx.background_executor().timer(delay).fuse();
             futures::select_biased! {
-                _ = receiver => return,
+                interrupt = receiver => {
+                    match interrupt {
+                        Ok(ControlFlow::Break(())) | Err(_) => return,
+                        Ok(ControlFlow::Continue(())) => {},
+                    }
+                }
                 _ = timer => {}
             }
 
@@ -43,7 +48,10 @@ impl DebouncedDelay {
         }));
     }
 
-    pub fn take(&mut self) -> Option<Task<()>> {
+    pub fn start_now(&mut self) -> Option<Task<()>> {
+        if let Some(channel) = self.cancel_channel.take() {
+            channel.send(ControlFlow::Continue(())).ok();
+        }
         self.task.take()
     }
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7996,7 +7996,7 @@ async fn test_completion(cx: &mut gpui::TestAppContext) {
             .unwrap()
     });
     cx.assert_editor_state(indoc! {"
-        one.second_completionˇ
+        one.ˇ
         two
         three
     "});
@@ -8029,9 +8029,9 @@ async fn test_completion(cx: &mut gpui::TestAppContext) {
     cx.assert_editor_state(indoc! {"
         one.second_completionˇ
         two
-        three
-        additional edit
-    "});
+        thoverlapping additional editree
+
+        additional edit"});
 
     cx.set_state(indoc! {"
         one.second_completion
@@ -8091,8 +8091,8 @@ async fn test_completion(cx: &mut gpui::TestAppContext) {
     });
     cx.assert_editor_state(indoc! {"
         one.second_completion
-        two sixth_completionˇ
-        three sixth_completionˇ
+        two siˇ
+        three siˇ
         additional edit
     "});
 
@@ -8133,9 +8133,11 @@ async fn test_completion(cx: &mut gpui::TestAppContext) {
             .confirm_completion(&ConfirmCompletion::default(), cx)
             .unwrap()
     });
-    cx.assert_editor_state("editor.closeˇ");
+    cx.assert_editor_state("editor.cloˇ");
     handle_resolve_completion_request(&mut cx, None).await;
     apply_additional_edits.await.unwrap();
+    cx.assert_editor_state(indoc! {"
+    editor.closeˇ"});
 }
 
 #[gpui::test]
@@ -10140,7 +10142,7 @@ async fn test_completions_with_additional_edits(cx: &mut gpui::TestAppContext) {
             .confirm_completion(&ConfirmCompletion::default(), cx)
             .unwrap()
     });
-    cx.assert_editor_state(indoc! {"fn main() { let a = 2.Some(2)ˇ; }"});
+    cx.assert_editor_state(indoc! {"fn main() { let a = 2.ˇ; }"});
 
     cx.handle_request::<lsp::request::ResolveCompletionItem, _, _>(move |_, _, _| {
         let task_completion_item = completion_item.clone();

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -821,7 +821,7 @@ mod tests {
                 hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
                 completion_provider: Some(lsp::CompletionOptions {
                     trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
-                    resolve_provider: Some(true),
+                    resolve_provider: Some(false),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -913,12 +913,15 @@ mod tests {
         assert_eq!(counter.load(atomic::Ordering::Acquire), 1);
 
         //apply a completion and check it was successfully applied
-        let _apply_additional_edits = cx.update_editor(|editor, cx| {
-            editor.context_menu_next(&Default::default(), cx);
-            editor
-                .confirm_completion(&ConfirmCompletion::default(), cx)
-                .unwrap()
-        });
+        let () = cx
+            .update_editor(|editor, cx| {
+                editor.context_menu_next(&Default::default(), cx);
+                editor
+                    .confirm_completion(&ConfirmCompletion::default(), cx)
+                    .unwrap()
+            })
+            .await
+            .unwrap();
         cx.assert_editor_state(indoc! {"
             one.second_completionˇ
             two

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -13,6 +13,7 @@ use itertools::Itertools;
 use language::{Buffer, BufferSnapshot, LanguageRegistry};
 use multi_buffer::{ExcerptRange, ToPoint};
 use parking_lot::RwLock;
+use pretty_assertions::assert_eq;
 use project::{FakeFs, Project};
 use std::{
     any::TypeId,

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -387,7 +387,7 @@ mod test {
             lsp::ServerCapabilities {
                 completion_provider: Some(lsp::CompletionOptions {
                     trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
-                    resolve_provider: Some(true),
+                    resolve_provider: Some(false),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -432,7 +432,9 @@ mod test {
         request.next().await;
         cx.condition(|editor, _| editor.context_menu_visible())
             .await;
-        cx.simulate_keystrokes("down enter ! escape");
+        cx.simulate_keystrokes("down enter");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("! escape");
 
         cx.assert_state(
             indoc! {"


### PR DESCRIPTION
After https://github.com/rust-lang/rust-analyzer/pull/18167 and certain people who type and complete rapidly, it turned out that we have not waited for `completionItem/resolve` to finish before applying the completion results.

Release Notes:

- Fixed completion items applied improperly on fast typing