### PR TITLE
Fix macOS App shortcut

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -216,7 +216,8 @@ impl MacPlatform {
 
         for menu_config in menus {
             let menu = NSMenu::new(nil).autorelease();
-            menu.setTitle_(ns_string(&menu_config.name));
+            let menu_title = ns_string(&menu_config.name);
+            menu.setTitle_(menu_title);
             menu.setDelegate_(delegate);
 
             for item_config in menu_config.items {
@@ -229,6 +230,7 @@ impl MacPlatform {
             }
 
             let menu_item = NSMenuItem::new(nil).autorelease();
+            menu_item.setTitle_(menu_title);
             menu_item.setSubmenu_(menu);
             application_menu.addItem_(menu_item);
 


### PR DESCRIPTION
The App Shortcuts in macOS System Settings does not work for Zed since the menu titles were not set.

See https://github.com/kovidgoyal/kitty/issues/5132 for the symptom in another App and https://github.com/henryhchchc/kitty/commit/1978cc5b55374a470515b7be6410386c748f48e7 for a similar fix.

Currently you can set a shortcut for `Zoom` but not `Window->Zoom` like you can with Finder and other MacOS apps.

Release Notes:

- Fixed support for macOS Keyboard Shortcuts for specific menu items like 'Window->Zoom'
