### PR TITLE
Remove `historical_event` column in editor events

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -670,7 +670,6 @@ pub struct EditorEventRow {
     time: i64,
     copilot_enabled: bool,
     copilot_enabled_for_language: bool,
-    historical_event: bool,
     architecture: String,
     is_staff: Option<bool>,
     major: Option<i32>,
@@ -718,7 +717,6 @@ impl EditorEventRow {
             country_code: country_code.unwrap_or("XX".to_string()),
             region_code: "".to_string(),
             city: "".to_string(),
-            historical_event: false,
             is_via_ssh: event.is_via_ssh,
         }
     }


### PR DESCRIPTION
We have a lot of data in Clickhouse. This column was used when migrating the events dataset between analytics databases and has no purpose today. 

Naive maths: 257,170,993 editor event rows * 1 byte per boolean = 257,170,993 bytes, or ~0.24 GB

I'll drop the column after deploying a new collab.

Going forward, I'd like to remove more data that we never touch, to try to keep things more focused. We should discuss some TTL at some point.

Release Notes:

- N/A
