### PR TITLE
settings: Add max tabs option

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -552,6 +552,8 @@
   // 4. Save when idle for a certain amount of time:
   //     "autosave": { "after_delay": {"milliseconds": 500} },
   "autosave": "off",
+  // Maximum number of tabs per pane. Unset for unlimited.
+  "max_tabs": null,
   // Settings related to the editor's tab bar.
   "tab_bar": {
     // Whether or not to show the tab bar in the editor

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use anyhow::Result;
 use collections::HashMap;
 use gpui::AppContext;
@@ -20,6 +22,7 @@ pub struct WorkspaceSettings {
     pub use_system_path_prompts: bool,
     pub command_aliases: HashMap<String, String>,
     pub show_user_picture: bool,
+    pub max_tabs: Option<NonZeroUsize>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -133,6 +136,11 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: true
     pub show_user_picture: Option<bool>,
+    // Maximum open tabs in a pane. Will not close an unsaved
+    // tab. Set to `None` for unlimited tabs.
+    //
+    // Default: none
+    pub max_tabs: Option<NonZeroUsize>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Add a `max_tabs` option to the settings that ensure no more than this amount of tabs are open in a pane. If set to `null`, there is no limit.

Closes #4784

Release Notes:

- Added a `max_tabs` option to cap the maximum number of open tabs.