### PR TITLE
collab: Clarify naming around free tier spending limits

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -703,7 +703,8 @@ async fn update_stripe_subscription(
     let subscription_id = SubscriptionId::from_str(&subscription.stripe_subscription_id)
         .context("failed to parse subscription ID")?;
 
-    let monthly_spending_over_free_tier = monthly_spending.saturating_sub(FREE_TIER_MONTHLY_SPENDING_LIMIT);
+    let monthly_spending_over_free_tier =
+        monthly_spending.saturating_sub(FREE_TIER_MONTHLY_SPENDING_LIMIT);
 
     let new_quantity = (monthly_spending_over_free_tier.0 as f32 / 100.).ceil();
     Subscription::update(

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -29,7 +29,7 @@ use crate::db::{
     UpdateBillingSubscriptionParams,
 };
 use crate::llm::db::LlmDatabase;
-use crate::llm::MONTHLY_SPENDING_LIMIT;
+use crate::llm::FREE_TIER_MONTHLY_SPENDING_LIMIT;
 use crate::rpc::ResultExt as _;
 use crate::{AppState, Error, Result};
 
@@ -703,7 +703,7 @@ async fn update_stripe_subscription(
     let subscription_id = SubscriptionId::from_str(&subscription.stripe_subscription_id)
         .context("failed to parse subscription ID")?;
 
-    let monthly_spending_over_free_tier = monthly_spending.saturating_sub(MONTHLY_SPENDING_LIMIT);
+    let monthly_spending_over_free_tier = monthly_spending.saturating_sub(FREE_TIER_MONTHLY_SPENDING_LIMIT);
 
     let new_quantity = (monthly_spending_over_free_tier.0 as f32 / 100.).ceil();
     Subscription::update(

--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -438,8 +438,9 @@ fn normalize_model_name(known_models: Vec<String>, name: String) -> String {
     }
 }
 
-/// The maximum monthly spending an individual user can reach before they have to pay.
-pub const MONTHLY_SPENDING_LIMIT: Cents = Cents::from_dollars(5);
+/// The maximum monthly spending an individual user can reach on the free tier
+/// before they have to pay.
+pub const FREE_TIER_MONTHLY_SPENDING_LIMIT: Cents = Cents::from_dollars(5);
 
 /// The maximum lifetime spending an individual user can reach before being cut off.
 const LIFETIME_SPENDING_LIMIT: Cents = Cents::from_dollars(1_000);
@@ -462,7 +463,7 @@ async fn check_usage_limit(
         .await?;
 
     if state.config.is_llm_billing_enabled() {
-        if usage.spending_this_month >= MONTHLY_SPENDING_LIMIT {
+        if usage.spending_this_month >= FREE_TIER_MONTHLY_SPENDING_LIMIT {
             if !claims.has_llm_subscription.unwrap_or(false) {
                 return Err(Error::http(
                     StatusCode::PAYMENT_REQUIRED,


### PR DESCRIPTION
This PR renames the `MONTHLY_SPENDING_LIMIT` constant to `FREE_TIER_MONTHLY_SPENDING_LIMIT` to clarify it.

This will help distinguish it from the user's specified limit on their paid monthly spending.

Release Notes:

- N/A
