### PR TITLE
project: Fix content not displaying when selecting a folder in Windows

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3904,7 +3904,7 @@ impl<'a> fuzzy::PathMatchCandidateSet<'a> for PathMatchCandidateSet {
         if self.snapshot.root_entry().map_or(false, |e| e.is_file()) {
             self.snapshot.root_name().into()
         } else if self.include_root_name {
-            format!("{}/", self.snapshot.root_name()).into()
+            format!("{}{}", self.snapshot.root_name(), std::path::MAIN_SEPARATOR).into()
         } else {
             Arc::default()
         }


### PR DESCRIPTION
- Closes #16998

This PR resolves issues with the /file and /diagnostics commands in the assistant panel, which previously failed to display the contents of a directory when searching for a folder instead of using the arrow button.

- Changed the format in `project.rs` (located at `crates/project/src/project.rs`) to use `std::path::MAIN_SEPARATOR` for cross-platform compatibility, which resolves errors encountered on Windows that originally used the format `format!("{}/", ...)`.


Release Notes:

- N/A