### PR TITLE
terminal: Improve default locale handling

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -332,9 +332,14 @@ impl TerminalBuilder {
         completion_tx: Sender<()>,
         cx: &AppContext,
     ) -> Result<TerminalBuilder> {
-        // TODO: Properly set the current locale,
-        env.entry("LC_ALL".to_string())
-            .or_insert_with(|| "en_US.UTF-8".to_string());
+        // If the parent environment doesn't have a locale set
+        // (As is the case when launched from a .app on MacOS),
+        // and the Project doesn't have a locale set, then
+        // set a fallback for our child environment to use.
+        if std::env::var("LANG").is_err() {
+            env.entry("LANG".to_string())
+                .or_insert_with(|| "en_US.UTF-8".to_string());
+        }
 
         env.insert("ZED_TERM".to_string(), "true".to_string());
         env.insert("TERM_PROGRAM".to_string(), "zed".to_string());


### PR DESCRIPTION
terminal: Improve default locale handling

* Use `LANG` instead of `LC_ALL` (`LC_ALL` is the highest priority which will override any other end-user settings; when that isn't set things fall back to separate `LC_*` variables; and when those aren't set things fall back to `LANG`). [0]
* Only set `LANG` for our child if necessary (if it already exists in the parent, then the child will inherit that, no need for us to do anything)

[0] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_02

Tested cases:

- `unset LANG ; cargo run`: locale inside zed's terminal is set to  `en_US.UTF-8`
- `export LANG=en_GB.UTF-8 ; cargo run`: locale inside zed's terminal is set to `en_GB.UTF-8`

Release Notes:

- Use the system locale in the terminal instead of forcing `en_US.UTF-8`
