### PR TITLE
[terminal] Consider "main.cs(20,5)" to be a single clickable word

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11407,6 +11407,7 @@ dependencies = [
  "gpui",
  "libc",
  "rand 0.8.5",
+ "regex",
  "release_channel",
  "schemars",
  "serde",

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -37,3 +37,4 @@ windows.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+regex.workspace = true


### PR DESCRIPTION
[terminal] Consider "main.cs(20,5)" to be a single clickable word

First, adding unit tests for the regexes because I'm not certain how these regexes are _intended_ to work, and unit tests work nicely as demonstrations of intended behaviour.

The comment string, and the regex itself, seem to imply that "main.cs(20,5)" is supposed be a single "word" (for the purposes of being clicked on)... but the regex doesn't actually work like that. This PR makes it work :)

(I don't know _why_ "word with an optional `(\d+,\d+)` on the end" doesn't match the full string, while "word with a required `(\d+,\d+)` on the end" _does_ match the full string - aren't regexes supposed to match as much as possible, so it should take the optional extra whenever the extra exists? Either way, "word with a required (\d+,\d+), or word by itself" has the correct behaviour, as demonstrated by the unit test)

Release Notes:

- N/A
