### PR TITLE
Add a setting to sync the sizes of panels in a dock

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -84,9 +84,9 @@
     // workspace when the centered layout is used.
     "right_padding": 0.2
   },
-  // Whether to sync the sizes of panels a dock. This setting takes in a list of dock positions.
+  // Whether to sync the sizes of panels within a dock. This setting takes in a list of dock positions.
   // Note that this setting cannot sync size between docks.
-  "sync_dock_size": [],
+  "sync_panel_size_within_dock": [],
   // The key to use for adding multiple cursors
   // Currently "alt" or "cmd_or_ctrl"  (also aliased as
   // "cmd" and "ctrl") are supported.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -84,6 +84,9 @@
     // workspace when the centered layout is used.
     "right_padding": 0.2
   },
+  // Whether to sync the sizes of panels a dock. This setting takes in a list of dock positions.
+  // Note that this setting cannot sync size between docks.
+  "sync_dock_size": [],
   // The key to use for adding multiple cursors
   // Currently "alt" or "cmd_or_ctrl"  (also aliased as
   // "cmd" and "ctrl") are supported.

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -579,6 +579,14 @@ impl Dock {
         }
     }
 
+    pub fn resize_all_panels(&mut self, size: Option<Pixels>, cx: &mut ViewContext<Self>) {
+        for entry in self.panel_entries.iter_mut() {
+            let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE).round());
+            entry.panel.set_size(size, cx);
+        }
+        cx.notify();
+    }
+
     pub fn toggle_action(&self) -> Box<dyn Action> {
         match self.position {
             DockPosition::Left => crate::ToggleLeftDock.boxed_clone(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4743,10 +4743,20 @@ impl Render for Workspace {
                                                     workspace.left_dock.update(
                                                         cx,
                                                         |left_dock, cx| {
-                                                            left_dock.resize_active_panel(
-                                                                Some(size),
-                                                                cx,
-                                                            );
+                                                            if WorkspaceSettings::get_global(cx)
+                                                                .sync_dock_size
+                                                                .contains(&DockPosition::Left)
+                                                            {
+                                                                left_dock.resize_all_panels(
+                                                                    Some(size),
+                                                                    cx,
+                                                                );
+                                                            } else {
+                                                                left_dock.resize_active_panel(
+                                                                    Some(size),
+                                                                    cx,
+                                                                );
+                                                            }
                                                         },
                                                     );
                                                 }
@@ -4756,10 +4766,20 @@ impl Render for Workspace {
                                                     workspace.right_dock.update(
                                                         cx,
                                                         |right_dock, cx| {
-                                                            right_dock.resize_active_panel(
-                                                                Some(size),
-                                                                cx,
-                                                            );
+                                                            if WorkspaceSettings::get_global(cx)
+                                                                .sync_dock_size
+                                                                .contains(&DockPosition::Right)
+                                                            {
+                                                                right_dock.resize_all_panels(
+                                                                    Some(size),
+                                                                    cx,
+                                                                );
+                                                            } else {
+                                                                right_dock.resize_active_panel(
+                                                                    Some(size),
+                                                                    cx,
+                                                                );
+                                                            }
                                                         },
                                                     );
                                                 }
@@ -4769,10 +4789,20 @@ impl Render for Workspace {
                                                     workspace.bottom_dock.update(
                                                         cx,
                                                         |bottom_dock, cx| {
-                                                            bottom_dock.resize_active_panel(
-                                                                Some(size),
-                                                                cx,
-                                                            );
+                                                            if WorkspaceSettings::get_global(cx)
+                                                                .sync_dock_size
+                                                                .contains(&DockPosition::Bottom)
+                                                            {
+                                                                bottom_dock.resize_all_panels(
+                                                                    Some(size),
+                                                                    cx,
+                                                                );
+                                                            } else {
+                                                                bottom_dock.resize_active_panel(
+                                                                    Some(size),
+                                                                    cx,
+                                                                );
+                                                            }
                                                         },
                                                     );
                                                 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4744,7 +4744,7 @@ impl Render for Workspace {
                                                         cx,
                                                         |left_dock, cx| {
                                                             if WorkspaceSettings::get_global(cx)
-                                                                .sync_dock_size
+                                                                .sync_panel_size_within_dock
                                                                 .contains(&DockPosition::Left)
                                                             {
                                                                 left_dock.resize_all_panels(
@@ -4767,7 +4767,7 @@ impl Render for Workspace {
                                                         cx,
                                                         |right_dock, cx| {
                                                             if WorkspaceSettings::get_global(cx)
-                                                                .sync_dock_size
+                                                                .sync_panel_size_within_dock
                                                                 .contains(&DockPosition::Right)
                                                             {
                                                                 right_dock.resize_all_panels(
@@ -4790,7 +4790,7 @@ impl Render for Workspace {
                                                         cx,
                                                         |bottom_dock, cx| {
                                                             if WorkspaceSettings::get_global(cx)
-                                                                .sync_dock_size
+                                                                .sync_panel_size_within_dock
                                                                 .contains(&DockPosition::Bottom)
                                                             {
                                                                 bottom_dock.resize_all_panels(

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -21,7 +21,7 @@ pub struct WorkspaceSettings {
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub use_system_path_prompts: bool,
     pub command_aliases: HashMap<String, String>,
-    pub sync_dock_size: Vec<DockPosition>,
+    pub sync_panel_size_within_dock: Vec<DockPosition>,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -114,8 +114,8 @@ pub struct WorkspaceSettingsContent {
     /// Whether to sync the sizes of panels in a dock.
     /// When a dock position is on the list, resizing one panel will resize all panels in that dock.
     ///
-    /// Default: none
-    pub sync_dock_size: Option<Vec<DockPosition>>,
+    /// Default: []
+    pub sync_panel_size_within_dock: Option<Vec<DockPosition>>,
 }
 
 #[derive(Deserialize)]

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -5,6 +5,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
 
+use crate::dock::DockPosition;
+
 #[derive(Deserialize)]
 pub struct WorkspaceSettings {
     pub active_pane_magnification: f32,
@@ -19,6 +21,7 @@ pub struct WorkspaceSettings {
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub use_system_path_prompts: bool,
     pub command_aliases: HashMap<String, String>,
+    pub sync_dock_size: Vec<DockPosition>,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -108,6 +111,11 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: true
     pub command_aliases: Option<HashMap<String, String>>,
+    /// Whether to sync the sizes of panels in a dock.
+    /// When a dock position is on the list, resizing one panel will resize all panels in that dock.
+    ///
+    /// Default: none
+    pub sync_dock_size: Option<Vec<DockPosition>>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Closes #12667

Release Notes:

- Added an option to sync the sizes of panels in a dock

https://github.com/user-attachments/assets/f8860a86-746a-4845-9f73-a3624fbd2e33


