### PR TITLE
Do not resolve more completion fields 

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -627,14 +627,6 @@ impl LanguageServer {
                                     "additionalTextEdits".to_string(),
                                     "command".to_string(),
                                     "documentation".to_string(),
-                                    "filterText".to_string(),
-                                    "labelDetails".to_string(),
-                                    "tags".to_string(),
-                                    // Details are rendered as rich text (markdown) inside the completion menu,
-                                    // and if not taken from there, regular text labels are used.
-                                    // If we start to resolve those, Zed's menu will flicker, as first it will show unresolved completions,
-                                    // and then the resolved ones will bring the colored labels, causing a flicker.
-                                    // "detail".to_string(),
                                     // NB: Do not have this resolved, otherwise Zed becomes slow to complete things
                                     // "textEdit".to_string(),
                                 ],

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -626,11 +626,15 @@ impl LanguageServer {
                                 properties: vec![
                                     "additionalTextEdits".to_string(),
                                     "command".to_string(),
-                                    "detail".to_string(),
                                     "documentation".to_string(),
                                     "filterText".to_string(),
                                     "labelDetails".to_string(),
                                     "tags".to_string(),
+                                    // Details are rendered as rich text (markdown) inside the completion menu,
+                                    // and if not taken from there, regular text labels are used.
+                                    // If we start to resolve those, Zed's menu will flicker, as first it will show unresolved completions,
+                                    // and then the resolved ones will bring the colored labels, causing a flicker.
+                                    // "detail".to_string(),
                                     // NB: Do not have this resolved, otherwise Zed becomes slow to complete things
                                     // "textEdit".to_string(),
                                 ],


### PR DESCRIPTION
As Zed instantly shows completion items in the completion menu, and the resolve will cause the details to appear, flickering.
We can safely resolve the `documentation`, `additionalTextEdits` and `command` fields, the rest should be resolved eagerly for now.

Release Notes:

- Fixed completion menu rendering
