### PR TITLE
Fix `Proxy` is not set for `NodeRuntime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5561,7 +5561,6 @@ name = "http_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "derive_more",
  "futures 0.3.30",
  "http 0.2.12",
  "log",

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -531,7 +531,6 @@ impl Client {
         let http = Arc::new(HttpClientWithUrl::new_uri(
             cx.http_client(),
             &ClientSettings::get_global(cx).server_url,
-            cx.http_client().proxy().cloned(),
         ));
         Self::new(clock, http, cx)
     }

--- a/crates/evals/src/eval.rs
+++ b/crates/evals/src/eval.rs
@@ -283,7 +283,6 @@ async fn run_evaluation(
                 Arc::new(http_client::HttpClientWithUrl::new(
                     http_client.clone(),
                     "https://zed.dev",
-                    None,
                 )),
                 cx,
             )

--- a/crates/http_client/Cargo.toml
+++ b/crates/http_client/Cargo.toml
@@ -18,7 +18,7 @@ doctest = true
 [dependencies]
 http = "0.2"
 anyhow.workspace = true
-derive_more.workspace = true
+# derive_more.workspace = true
 futures.workspace = true
 log.workspace = true
 serde.workspace = true

--- a/crates/isahc_http_client/src/isahc_http_client.rs
+++ b/crates/isahc_http_client/src/isahc_http_client.rs
@@ -30,14 +30,14 @@ impl IsahcHttpClient {
     }
 }
 
-impl From<isahc::HttpClient> for IsahcHttpClient {
-    fn from(client: isahc::HttpClient) -> Self {
-        Self {
-            client,
-            proxy: None,
-        }
-    }
-}
+// impl From<isahc::HttpClient> for IsahcHttpClient {
+//     fn from(client: isahc::HttpClient) -> Self {
+//         Self {
+//             client,
+//             proxy: None,
+//         }
+//     }
+// }
 
 impl HttpClient for IsahcHttpClient {
     fn proxy(&self) -> Option<&Uri> {

--- a/crates/isahc_http_client/src/isahc_http_client.rs
+++ b/crates/isahc_http_client/src/isahc_http_client.rs
@@ -30,14 +30,14 @@ impl IsahcHttpClient {
     }
 }
 
-// impl From<isahc::HttpClient> for IsahcHttpClient {
-//     fn from(client: isahc::HttpClient) -> Self {
-//         Self {
-//             client,
-//             proxy: None,
-//         }
-//     }
-// }
+impl From<isahc::HttpClient> for IsahcHttpClient {
+    fn from(client: isahc::HttpClient) -> Self {
+        Self {
+            client,
+            proxy: None,
+        }
+    }
+}
 
 impl HttpClient for IsahcHttpClient {
     fn proxy(&self) -> Option<&Uri> {

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -110,6 +110,7 @@ impl NodeRuntime {
         args: &[&str],
     ) -> Result<Output> {
         let http = self.0.lock().await.http.clone();
+        println!("==> {:#?}", http.proxy());
         self.instance()
             .await?
             .run_npm_subcommand(Some(directory), http.proxy(), subcommand, args)

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -110,7 +110,6 @@ impl NodeRuntime {
         args: &[&str],
     ) -> Result<Output> {
         let http = self.0.lock().await.http.clone();
-        println!("==> {:#?}", http.proxy());
         self.instance()
             .await?
             .run_npm_subcommand(Some(directory), http.proxy(), subcommand, args)

--- a/crates/semantic_index/examples/index.rs
+++ b/crates/semantic_index/examples/index.rs
@@ -31,7 +31,6 @@ fn main() {
         let http = Arc::new(HttpClientWithUrl::new(
             IsahcHttpClient::new(None, None),
             "http://localhost:11434",
-            None,
         ));
         let client = client::Client::new(clock, http.clone(), cx);
         Client::set_global(client.clone(), cx);


### PR DESCRIPTION
Currently, on the `main` branch, the `proxy` in `NodeRuntime` is always set to `None`. This issue was unintentionally introduced in PR #15446.

Additionally, I noticed that under the changes in this PR, `HttpClientWithProxy` and `IsahcHttpClient` share the same member variables. Therefore, I have removed `HttpClientWithProxy` to avoid redundancy.

cc @osiewicz 

Release Notes:

- N/A
