### PR TITLE
ssh: Fix abs paths in file history & repeated go-to-def

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -758,11 +758,8 @@ impl FileFinderDelegate {
         cx: &mut ViewContext<'_, Picker<Self>>,
     ) -> Task<()> {
         cx.spawn(|picker, mut cx| async move {
-            let Some((project, fs)) = picker
-                .update(&mut cx, |picker, cx| {
-                    let fs = Arc::clone(&picker.delegate.project.read(cx).fs());
-                    (picker.delegate.project.clone(), fs)
-                })
+            let Some(project) = picker
+                .update(&mut cx, |picker, _| picker.delegate.project.clone())
                 .log_err()
             else {
                 return;

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2242,6 +2242,15 @@ impl Project {
             return;
         }
 
+        if let Some(ssh) = &self.ssh_client {
+            ssh.read(cx)
+                .to_proto_client()
+                .send(proto::RemoveWorktree {
+                    worktree_id: id_to_remove.to_proto(),
+                })
+                .log_err();
+        }
+
         cx.notify();
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3079,7 +3079,7 @@ impl Project {
         }
     }
 
-    // Returns the resolved version of `path`, that was found in `buffer`, if it exists.
+    /// Returns the resolved version of `path`, that was found in `buffer`, if it exists.
     pub fn resolve_existing_file_path(
         &self,
         path: &str,
@@ -3088,38 +3088,53 @@ impl Project {
     ) -> Task<Option<ResolvedPath>> {
         let path_buf = PathBuf::from(path);
         if path_buf.is_absolute() || path.starts_with("~") {
-            if self.is_local() {
-                let expanded = PathBuf::from(shellexpand::tilde(&path).into_owned());
-
-                let fs = self.fs.clone();
-                cx.background_executor().spawn(async move {
-                    let path = expanded.as_path();
-                    let exists = fs.is_file(path).await;
-
-                    exists.then(|| ResolvedPath::AbsPath(expanded))
-                })
-            } else if let Some(ssh_client) = self.ssh_client.as_ref() {
-                let request =
-                    ssh_client
-                        .read(cx)
-                        .to_proto_client()
-                        .request(proto::CheckFileExists {
-                            project_id: SSH_PROJECT_ID,
-                            path: path.to_string(),
-                        });
-                cx.background_executor().spawn(async move {
-                    let response = request.await.log_err()?;
-                    if response.exists {
-                        Some(ResolvedPath::AbsPath(PathBuf::from(response.path)))
-                    } else {
-                        None
-                    }
-                })
-            } else {
-                return Task::ready(None);
-            }
+            self.resolve_abs_file_path(path, cx)
         } else {
             self.resolve_path_in_worktrees(path_buf, buffer, cx)
+        }
+    }
+
+    pub fn abs_file_path_exists(&self, path: &str, cx: &mut ModelContext<Self>) -> Task<bool> {
+        let resolve_task = self.resolve_abs_file_path(path, cx);
+        cx.background_executor().spawn(async move {
+            let resolved_path = resolve_task.await;
+            resolved_path.is_some()
+        })
+    }
+
+    fn resolve_abs_file_path(
+        &self,
+        path: &str,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Option<ResolvedPath>> {
+        if self.is_local() {
+            let expanded = PathBuf::from(shellexpand::tilde(&path).into_owned());
+
+            let fs = self.fs.clone();
+            cx.background_executor().spawn(async move {
+                let path = expanded.as_path();
+                let exists = fs.is_file(path).await;
+
+                exists.then(|| ResolvedPath::AbsPath(expanded))
+            })
+        } else if let Some(ssh_client) = self.ssh_client.as_ref() {
+            let request = ssh_client
+                .read(cx)
+                .to_proto_client()
+                .request(proto::CheckFileExists {
+                    project_id: SSH_PROJECT_ID,
+                    path: path.to_string(),
+                });
+            cx.background_executor().spawn(async move {
+                let response = request.await.log_err()?;
+                if response.exists {
+                    Some(ResolvedPath::AbsPath(PathBuf::from(response.path)))
+                } else {
+                    None
+                }
+            })
+        } else {
+            return Task::ready(None);
         }
     }
 

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::RefCell,
+    future::Future,
     path::{Path, PathBuf},
     sync::{atomic::AtomicUsize, Arc},
 };
@@ -237,19 +238,20 @@ impl WorktreeStore {
             .to_string_lossy()
             .to_string();
         cx.spawn(|this, mut cx| async move {
-            this.update(&mut cx, |this, _| {
-                this.retain_worktrees = true;
-            })?;
-            let response = client
-                .request(proto::AddWorktree {
-                    project_id: SSH_PROJECT_ID,
-                    path: abs_path.clone(),
-                    visible,
-                })
-                .await?;
-            this.update(&mut cx, |this, _| {
-                this.retain_worktrees = false;
-            })?;
+            let this = this.upgrade().context("Dropped worktree store")?;
+
+            let add_worktree = client.request(proto::AddWorktree {
+                project_id: SSH_PROJECT_ID,
+                path: abs_path.clone(),
+                visible,
+            });
+
+            // If we receive a `ProjectUpdate` message in between sending
+            // `AddWorktree` to the ssh remote and waiting for the response, we
+            // need to ensure that we do not drop a worktree that is still being
+            // created. This can happen because invisible worktrees are stored
+            // as weak references.
+            let response = retain_worktrees(&this, &mut cx, add_worktree).await??;
 
             if let Some(existing_worktree) = this.read_with(&cx, |this, cx| {
                 this.worktree_for_id(WorktreeId::from_proto(response.worktree_id), cx)
@@ -971,4 +973,22 @@ impl WorktreeHandle {
             WorktreeHandle::Weak(handle) => handle.upgrade(),
         }
     }
+}
+
+/// Ensures that no worktrees can be dropped while waiting for the future to complete (invisible worktrees are weak references).
+async fn retain_worktrees<T>(
+    this: &Model<WorktreeStore>,
+    cx: &mut AsyncAppContext,
+    future: impl Future<Output = T>,
+) -> Result<T> {
+    let prev_value = this.update(cx, |this, _| {
+        let prev_value = this.retain_worktrees;
+        this.retain_worktrees = true;
+        prev_value
+    })?;
+    let value = future.await;
+    this.update(cx, |this, _| {
+        this.retain_worktrees = prev_value;
+    })?;
+    Ok(value)
 }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -282,7 +282,9 @@ message Envelope {
         CheckFileExists check_file_exists = 255;
         CheckFileExistsResponse check_file_exists_response = 256;
 
-        ShutdownRemoteServer shutdown_remote_server = 257; // current max
+        ShutdownRemoteServer shutdown_remote_server = 257;
+
+        RemoveWorktree remove_worktree = 258; // current max
     }
 
     reserved 87 to 88;
@@ -2432,6 +2434,7 @@ message GetLlmTokenResponse {
 message AddWorktree {
     uint64 project_id = 2;
     string path = 1;
+    bool visible = 3;
 }
 
 message AddWorktreeResponse {
@@ -2460,3 +2463,7 @@ message CheckFileExistsResponse {
 }
 
 message ShutdownRemoteServer {}
+
+message RemoveWorktree {
+    uint64 worktree_id = 1;
+}

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -364,6 +364,7 @@ messages!(
     (CheckFileExists, Background),
     (CheckFileExistsResponse, Background),
     (ShutdownRemoteServer, Foreground),
+    (RemoveWorktree, Foreground),
 );
 
 request_messages!(
@@ -486,7 +487,8 @@ request_messages!(
     (LspExtSwitchSourceHeader, LspExtSwitchSourceHeaderResponse),
     (AddWorktree, AddWorktreeResponse),
     (CheckFileExists, CheckFileExistsResponse),
-    (ShutdownRemoteServer, Ack)
+    (ShutdownRemoteServer, Ack),
+    (RemoveWorktree, Ack)
 );
 
 entity_messages!(

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -248,7 +248,7 @@ impl HeadlessProject {
             })?
             .await?;
 
-        let response = this.update(&mut cx, |this, cx| {
+        let response = this.update(&mut cx, |_, cx| {
             worktree.update(cx, |worktree, _| proto::AddWorktreeResponse {
                 worktree_id: worktree.id().to_proto(),
             })


### PR DESCRIPTION
This fixes two things:

- Go-to-def to absolute paths (i.e. opening stdlib files) multiple times (opening, dropping, and re-opening worktrees)
- Re-opening abs paths from the file picker history that were added there by go-to-def


Release Notes:

- N/A
