### PR TITLE
Standardize on CursorShape::Underline not Underscore

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -118,8 +118,8 @@
   //     "bar"
   //  2. A block that surrounds the following character
   //     "block"
-  //  3. An underline that runs along the following character
-  //     "underscore"
+  //  3. An underline / underscore that runs along the following character
+  //     "underline"
   //  4. A box drawn around the following character
   //     "hollow"
   //
@@ -684,8 +684,8 @@
     //     "block"
     //  2. A vertical bar
     //     "bar"
-    //  3. An underline that runs along the following character
-    //     "underscore"
+    //  3. An underline / underscore that runs along the following character
+    //     "underline"
     //  4. A box drawn around the following character
     //     "hollow"
     //

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -179,7 +179,7 @@ pub struct EditorSettingsContent {
     /// Default: true
     pub cursor_blink: Option<bool>,
     /// Cursor shape for the default editor.
-    /// Can be "bar", "block", "underscore", or "hollow".
+    /// Can be "bar", "block", "underline", or "hollow".
     ///
     /// Default: None
     pub cursor_shape: Option<CursorShape>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6060,7 +6060,7 @@ impl CursorLayout {
                 origin: self.origin + origin,
                 size: size(self.block_width, self.line_height),
             },
-            CursorShape::Underscore => Bounds {
+            CursorShape::Underline => Bounds {
                 origin: self.origin
                     + origin
                     + gpui::Point::new(Pixels::ZERO, self.line_height - px(2.0)),

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -184,7 +184,7 @@ pub enum CursorShape {
     /// A block that surrounds the following character
     Block,
     /// An underline that runs along the following character
-    Underscore,
+    Underline,
     /// A box drawn around the following character
     Hollow,
 }

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -175,7 +175,7 @@ pub fn serialize_cursor_shape(cursor_shape: &CursorShape) -> proto::CursorShape 
     match cursor_shape {
         CursorShape::Bar => proto::CursorShape::CursorBar,
         CursorShape::Block => proto::CursorShape::CursorBlock,
-        CursorShape::Underscore => proto::CursorShape::CursorUnderscore,
+        CursorShape::Underline => proto::CursorShape::CursorUnderscore,
         CursorShape::Hollow => proto::CursorShape::CursorHollow,
     }
 }
@@ -185,7 +185,7 @@ pub fn deserialize_cursor_shape(cursor_shape: proto::CursorShape) -> CursorShape
     match cursor_shape {
         proto::CursorShape::CursorBar => CursorShape::Bar,
         proto::CursorShape::CursorBlock => CursorShape::Block,
-        proto::CursorShape::CursorUnderscore => CursorShape::Underscore,
+        proto::CursorShape::CursorUnderscore => CursorShape::Underline,
         proto::CursorShape::CursorHollow => CursorShape::Hollow,
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -134,7 +134,7 @@ pub struct TerminalSettingsContent {
     /// Default: {}
     pub env: Option<HashMap<String, String>>,
     /// Default cursor shape for the terminal.
-    /// Can be "bar", "block", "underscore", or "hollow".
+    /// Can be "bar", "block", "underline", or "hollow".
     ///
     /// Default: None
     pub cursor_shape: Option<CursorShape>,

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -793,7 +793,7 @@ impl Element for TerminalElement {
                             let (shape, text) = match cursor.shape {
                                 AlacCursorShape::Block if !focused => (CursorShape::Hollow, None),
                                 AlacCursorShape::Block => (CursorShape::Block, Some(cursor_text)),
-                                AlacCursorShape::Underline => (CursorShape::Underscore, None),
+                                AlacCursorShape::Underline => (CursorShape::Underline, None),
                                 AlacCursorShape::Beam => (CursorShape::Bar, None),
                                 AlacCursorShape::HollowBlock => (CursorShape::Hollow, None),
                                 //This case is handled in the if wrapping the whole cursor layout

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -545,10 +545,10 @@ impl Vim {
                 if self.operator_stack.is_empty() {
                     CursorShape::Block
                 } else {
-                    CursorShape::Underscore
+                    CursorShape::Underline
                 }
             }
-            Mode::Replace => CursorShape::Underscore,
+            Mode::Replace => CursorShape::Underline,
             Mode::Visual | Mode::VisualLine | Mode::VisualBlock => CursorShape::Block,
             Mode::Insert => CursorShape::Bar,
         }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -371,10 +371,10 @@ List of `string` values
 "cursor_shape": "block"
 ```
 
-3. An underscore that runs along the following character:
+3. An underline / underscore that runs along the following character:
 
 ```json
-"cursor_shape": "underscore"
+"cursor_shape": "underline"
 ```
 
 4. An box drawn around the following character:


### PR DESCRIPTION
Currently terminal.cursor_shape uses `underline` and `cursor_shape` uses `underscore`.
This standardizes them so they use the same settings value.

I think `underline` is the more common term and it matches the terminology used by VSCode, Alacritty, iTerm, etc.

Note the protobuf enum `CursorShape::CursorUnderscore` remains unchanged.

See also:
- https://github.com/zed-industries/zed/pull/18530
- https://github.com/zed-industries/zed/pull/17572

Release Notes:

- Settings: rename one `cursor_shape` from `underscore` to `underline` (breaking change).
