### PR TITLE
multi_buffer: Fix `max_buffer_row` calculate error for multi_buffer

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2464,13 +2464,7 @@ impl MultiBufferSnapshot {
         if self.singleton {
             self.excerpts.summary().max_buffer_row
         } else {
-            // TODO
-            let mut row = 0;
-            let excerpts = self.excerpts.items(&());
-            for excerpt in excerpts.iter() {
-                row += excerpt.text_summary.longest_row;
-            }
-            MultiBufferRow(row)
+            MultiBufferRow(self.max_point().row)
         }
     }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2461,7 +2461,17 @@ impl MultiBufferSnapshot {
     }
 
     pub fn max_buffer_row(&self) -> MultiBufferRow {
-        self.excerpts.summary().max_buffer_row
+        if self.singleton {
+            self.excerpts.summary().max_buffer_row
+        } else {
+            // TODO
+            let mut row = 0;
+            let excerpts = self.excerpts.items(&());
+            for excerpt in excerpts.iter() {
+                row += excerpt.text_summary.longest_row;
+            }
+            MultiBufferRow(row)
+        }
     }
 
     pub fn clip_offset(&self, offset: usize, bias: Bias) -> usize {


### PR DESCRIPTION
with #19054, I found the function `max_buffer_row` is wrong for multi_buffer, and some relate function using `max_buffer_row` might also is not expected.

Closes #19054 

Release Notes:

- N/A
