### PR TITLE
vim: Reset search options whenever `/` is used

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -129,14 +129,13 @@ impl Vim {
                     search_bar.select_query(cx);
                     cx.focus_self();
 
-                    if query.is_empty() {
-                        search_bar.set_replacement(None, cx);
-                        search_bar.set_search_options(SearchOptions::REGEX, cx);
-                    }
+                    search_bar.set_replacement(None, cx);
+                    search_bar.set_search_options(SearchOptions::NONE | SearchOptions::REGEX, cx);
+
                     self.search = SearchState {
                         direction,
                         count,
-                        initial_query: query.clone(),
+                        initial_query: query,
                         prior_selections,
                         prior_operator: self.operator_stack.last().cloned(),
                         prior_mode: self.mode,


### PR DESCRIPTION
This is a bit of a personal thing, but it's been bugging me for a while now that the search options are sticky whenever I use `/` in Vim mode.

This change makes it so that the options are reset with each new `/`.

That means you can, for example, use `v` to create a visual selection, then hit `*` to search for that (which activates a bunch of search options), but then continue with `/` to get a normal search.

Release Notes:

- Changed `/` in Vim mode to always reset the search options in the search bar back to regex-only. That means using `*` (in normal or visual mode) still works with its options, but the next `/` will reset the search options. That makes it much closer to how `/` behaves in Vim.
