### PR TITLE
lsp: Show error message in read only buffer

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -101,6 +101,7 @@ impl ActivityIndicator {
                             None,
                             cx,
                         );
+                        buffer.set_capability(language::Capability::ReadOnly, cx);
                     })?;
                     workspace.update(&mut cx, |workspace, cx| {
                         workspace.add_item_to_active_pane(


### PR DESCRIPTION
Clicking on

<img width="361" alt="image" src="https://github.com/user-attachments/assets/b55e2575-b438-4c26-922f-313dc1f41fea">

now opens a read only buffer

<img width="547" alt="image" src="https://github.com/user-attachments/assets/af82e104-1603-4fe4-9351-635a02cfb4f9">

Previously the buffer would show up as a normal untitled buffer and would open a prompt when closing the tab.

Co-Authored-by: Thorsten <thorsten@zed.dev>

Release Notes:

- N/A
