### PR TITLE
Fix ~ expansion in ssh projects' terminals

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -362,7 +362,16 @@ pub fn wrap_for_ssh(
     }
 
     let commands = if let Some(path) = path {
-        format!("cd {:?}; {} {}", path, env_changes, to_run)
+        let path_string = path.to_string_lossy().to_string();
+        // shlex will wrap the command in single quotes (''), disabling ~ expansion,
+        // replace ith with something that works
+        let tilde_suffix = "~/";
+        if path.starts_with(tilde_suffix) {
+            let trimmed_path = &path_string[tilde_suffix.len()..];
+            format!("cd \"$HOME/{trimmed_path}\"; {env_changes} {to_run}")
+        } else {
+            format!("cd {path:?}; {env_changes} {to_run}")
+        }
     } else {
         format!("cd; {env_changes} {to_run}")
     };

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -365,9 +365,9 @@ pub fn wrap_for_ssh(
         let path_string = path.to_string_lossy().to_string();
         // shlex will wrap the command in single quotes (''), disabling ~ expansion,
         // replace ith with something that works
-        let tilde_suffix = "~/";
-        if path.starts_with(tilde_suffix) {
-            let trimmed_path = &path_string[tilde_suffix.len()..];
+        let tilde_prefix = "~/";
+        if path.starts_with(tilde_prefix) {
+            let trimmed_path = &path_string[tilde_prefix.len()..];
             format!("cd \"$HOME/{trimmed_path}\"; {env_changes} {to_run}")
         } else {
             format!("cd {path:?}; {env_changes} {to_run}")


### PR DESCRIPTION
When setting a remote ssh project path starting with ~, Zed would fail to cd into such project's directory when opening a new terminal.

Release Notes:

- N/A
