### PR TITLE
ci: Give names to all github actions

### DIFF
--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -1,3 +1,5 @@
+name: Release Actions
+
 on:
   release:
     types: [published]

--- a/.github/workflows/update_all_top_ranking_issues.yml
+++ b/.github/workflows/update_all_top_ranking_issues.yml
@@ -1,3 +1,5 @@
+name: Update All Top Ranking Issues
+
 on:
   schedule:
     - cron: "0 */12 * * *"

--- a/.github/workflows/update_weekly_top_ranking_issues.yml
+++ b/.github/workflows/update_weekly_top_ranking_issues.yml
@@ -1,3 +1,5 @@
+name: Update Weekly Top Ranking Issues
+
 on:
   schedule:
     - cron: "0 15 * * *"


### PR DESCRIPTION
ci: Give names to all github actions

Looking at https://github.com/zed-industries/zed/actions - most workflows have names, but three just have the filename (Which is displayed as ".github/workflows/" and then the rest is truncated)

(`bump_patch_version` also feels like it should have a titlecase name, but I'm not sure if that one was named weird intentionally...)

Release Notes:

- N/A
