### PR TITLE
Context Servers: Protocol fixes and UI improvements

### DIFF
--- a/crates/assistant/src/slash_command/context_server_command.rs
+++ b/crates/assistant/src/slash_command/context_server_command.rs
@@ -36,11 +36,17 @@ impl SlashCommand for ContextServerSlashCommand {
     }
 
     fn description(&self) -> String {
-        format!("Run context server command: {}", self.prompt.name)
+        match &self.prompt.description {
+            Some(desc) => desc.clone(),
+            None => format!("Run '{}' from {}", self.prompt.name, self.server_id),
+        }
     }
 
     fn menu_text(&self) -> String {
-        format!("Run '{}' from {}", self.prompt.name, self.server_id)
+        match &self.prompt.description {
+            Some(desc) => desc.clone(),
+            None => format!("Run '{}' from {}", self.prompt.name, self.server_id),
+        }
     }
 
     fn requires_argument(&self) -> bool {

--- a/crates/assistant/src/slash_command/context_server_command.rs
+++ b/crates/assistant/src/slash_command/context_server_command.rs
@@ -1,3 +1,4 @@
+use super::create_label_for_command;
 use anyhow::{anyhow, Result};
 use assistant_slash_command::{
     AfterCompletion, ArgumentCompletion, SlashCommand, SlashCommandOutput,
@@ -8,7 +9,7 @@ use context_servers::{
     manager::{ContextServer, ContextServerManager},
     types::Prompt,
 };
-use gpui::{Task, WeakView, WindowContext};
+use gpui::{AppContext, Task, WeakView, WindowContext};
 use language::{BufferSnapshot, CodeLabel, LspAdapterDelegate};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -33,6 +34,16 @@ impl ContextServerSlashCommand {
 impl SlashCommand for ContextServerSlashCommand {
     fn name(&self) -> String {
         self.prompt.name.clone()
+    }
+
+    fn label(&self, cx: &AppContext) -> language::CodeLabel {
+        let mut parts = vec![self.prompt.name.as_str()];
+        if let Some(args) = &self.prompt.arguments {
+            if let Some(arg) = args.first() {
+                parts.push(arg.name.as_str());
+            }
+        }
+        create_label_for_command(&parts[0], &parts[1..], cx)
     }
 
     fn description(&self) -> String {

--- a/crates/assistant/src/slash_command/context_server_command.rs
+++ b/crates/assistant/src/slash_command/context_server_command.rs
@@ -6,7 +6,7 @@ use assistant_slash_command::{
 use collections::HashMap;
 use context_servers::{
     manager::{ContextServer, ContextServerManager},
-    protocol::PromptInfo,
+    types::Prompt,
 };
 use gpui::{Task, WeakView, WindowContext};
 use language::{BufferSnapshot, CodeLabel, LspAdapterDelegate};
@@ -18,11 +18,11 @@ use workspace::Workspace;
 
 pub struct ContextServerSlashCommand {
     server_id: String,
-    prompt: PromptInfo,
+    prompt: Prompt,
 }
 
 impl ContextServerSlashCommand {
-    pub fn new(server: &Arc<ContextServer>, prompt: PromptInfo) -> Self {
+    pub fn new(server: &Arc<ContextServer>, prompt: Prompt) -> Self {
         Self {
             server_id: server.id.clone(),
             prompt,
@@ -154,7 +154,7 @@ impl SlashCommand for ContextServerSlashCommand {
     }
 }
 
-fn completion_argument(prompt: &PromptInfo, arguments: &[String]) -> Result<(String, String)> {
+fn completion_argument(prompt: &Prompt, arguments: &[String]) -> Result<(String, String)> {
     if arguments.is_empty() {
         return Err(anyhow!("No arguments given"));
     }
@@ -170,7 +170,7 @@ fn completion_argument(prompt: &PromptInfo, arguments: &[String]) -> Result<(Str
     }
 }
 
-fn prompt_arguments(prompt: &PromptInfo, arguments: &[String]) -> Result<HashMap<String, String>> {
+fn prompt_arguments(prompt: &Prompt, arguments: &[String]) -> Result<HashMap<String, String>> {
     match &prompt.arguments {
         Some(args) if args.len() > 1 => Err(anyhow!(
             "Prompt has more than one argument, which is not supported"
@@ -199,7 +199,7 @@ fn prompt_arguments(prompt: &PromptInfo, arguments: &[String]) -> Result<HashMap
 /// MCP servers can return prompts with multiple arguments. Since we only
 /// support one argument, we ignore all others. This is the necessary predicate
 /// for this.
-pub fn acceptable_prompt(prompt: &PromptInfo) -> bool {
+pub fn acceptable_prompt(prompt: &Prompt) -> bool {
     match &prompt.arguments {
         None => true,
         Some(args) if args.len() <= 1 => true,

--- a/crates/context_servers/src/client.rs
+++ b/crates/context_servers/src/client.rs
@@ -26,7 +26,7 @@ const JSON_RPC_VERSION: &str = "2.0";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 type ResponseHandler = Box<dyn Send + FnOnce(Result<String, Error>)>;
-type NotificationHandler = Box<dyn Send + FnMut(RequestId, Value, AsyncAppContext)>;
+type NotificationHandler = Box<dyn Send + FnMut(Value, AsyncAppContext)>;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -94,7 +94,6 @@ enum CspResult<T> {
 #[derive(Serialize, Deserialize)]
 struct Notification<'a, T> {
     jsonrpc: &'static str,
-    id: RequestId,
     #[serde(borrow)]
     method: &'a str,
     params: T,
@@ -103,7 +102,6 @@ struct Notification<'a, T> {
 #[derive(Debug, Clone, Deserialize)]
 struct AnyNotification<'a> {
     jsonrpc: &'a str,
-    id: RequestId,
     method: String,
     #[serde(default)]
     params: Option<Value>,
@@ -246,11 +244,7 @@ impl Client {
                     if let Some(handler) =
                         notification_handlers.get_mut(notification.method.as_str())
                     {
-                        handler(
-                            notification.id,
-                            notification.params.unwrap_or(Value::Null),
-                            cx.clone(),
-                        );
+                        handler(notification.params.unwrap_or(Value::Null), cx.clone());
                     }
                 }
             }
@@ -378,10 +372,8 @@ impl Client {
     /// Sends a notification to the context server without expecting a response.
     /// This function serializes the notification and sends it through the outbound channel.
     pub fn notify(&self, method: &str, params: impl Serialize) -> Result<()> {
-        let id = self.next_id.fetch_add(1, SeqCst);
         let notification = serde_json::to_string(&Notification {
             jsonrpc: JSON_RPC_VERSION,
-            id: RequestId::Int(id),
             method,
             params,
         })
@@ -396,7 +388,7 @@ impl Client {
     {
         self.notification_handlers
             .lock()
-            .insert(method, Box::new(move |_, params, cx| f(params, cx)));
+            .insert(method, Box::new(move |params, cx| f(params, cx)));
     }
 
     pub fn name(&self) -> &str {

--- a/crates/context_servers/src/client.rs
+++ b/crates/context_servers/src/client.rs
@@ -382,13 +382,13 @@ impl Client {
         Ok(())
     }
 
-    pub fn on_notification<F>(&self, method: &'static str, mut f: F)
+    pub fn on_notification<F>(&self, method: &'static str, f: F)
     where
         F: 'static + Send + FnMut(Value, AsyncAppContext),
     {
         self.notification_handlers
             .lock()
-            .insert(method, Box::new(move |params, cx| f(params, cx)));
+            .insert(method, Box::new(f));
     }
 
     pub fn name(&self) -> &str {

--- a/crates/context_servers/src/manager.rs
+++ b/crates/context_servers/src/manager.rs
@@ -85,7 +85,7 @@ impl ContextServer {
         )?;
 
         let protocol = crate::protocol::ModelContextProtocol::new(client);
-        let client_info = types::EntityInfo {
+        let client_info = types::Implementation {
             name: "Zed".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
         };

--- a/crates/context_servers/src/protocol.rs
+++ b/crates/context_servers/src/protocol.rs
@@ -105,6 +105,18 @@ impl InitializedContextServerProtocol {
         Ok(response.prompts)
     }
 
+    /// List the MCP resources.
+    pub async fn list_resources(&self) -> Result<types::ResourcesListResponse> {
+        self.check_capability(ServerCapability::Resources)?;
+
+        let response: types::ResourcesListResponse = self
+            .inner
+            .request(types::RequestType::ResourcesList.as_str(), ())
+            .await?;
+
+        Ok(response)
+    }
+
     /// Executes a prompt with the given arguments and returns the result.
     pub async fn run_prompt<P: AsRef<str>>(
         &self,

--- a/crates/context_servers/src/protocol.rs
+++ b/crates/context_servers/src/protocol.rs
@@ -11,8 +11,6 @@ use collections::HashMap;
 use crate::client::Client;
 use crate::types;
 
-pub use types::PromptInfo;
-
 const PROTOCOL_VERSION: u32 = 1;
 
 pub struct ModelContextProtocol {
@@ -26,7 +24,7 @@ impl ModelContextProtocol {
 
     pub async fn initialize(
         self,
-        client_info: types::EntityInfo,
+        client_info: types::Implementation,
     ) -> Result<InitializedContextServerProtocol> {
         let params = types::InitializeParams {
             protocol_version: PROTOCOL_VERSION,
@@ -96,7 +94,7 @@ impl InitializedContextServerProtocol {
     }
 
     /// List the MCP prompts.
-    pub async fn list_prompts(&self) -> Result<Vec<types::PromptInfo>> {
+    pub async fn list_prompts(&self) -> Result<Vec<types::Prompt>> {
         self.check_capability(ServerCapability::Prompts)?;
 
         let response: types::PromptsListResponse = self


### PR DESCRIPTION
This PR does two things. It fixes some minor inconsistencies in the protocol. This is mostly about handling JSON RPC notifications correctly and skipping fields when set to None.

Second part is about improving the rendering of context server commands, by passing on the description
of the command to the slash command UI and showing the name of the argument as a CodeLabel.

Release Notes:

- N/A
