### PR TITLE
collab: Don't record billing events if billing is not enabled

### DIFF
--- a/crates/collab/src/llm/db/queries/usages.rs
+++ b/crates/collab/src/llm/db/queries/usages.rs
@@ -409,7 +409,8 @@ impl LlmDatabase {
                 monthly_usage.output_tokens as usize,
             );
 
-            if spending_this_month > FREE_TIER_MONTHLY_SPENDING_LIMIT
+            if !is_staff
+                && spending_this_month > FREE_TIER_MONTHLY_SPENDING_LIMIT
                 && has_llm_subscription
                 && spending_this_month <= max_monthly_spend
             {


### PR DESCRIPTION
This PR adjusts the billing logic to not write any records to `billing_events` if:

- The user is staff, as we don't want to bill staff members
- Billing is disabled (we currently enable billing based on the presence of the Stripe API key)

Release Notes:

- N/A
