### PR TITLE
gpui: Fix keystroke to keep valid IME commit on Linux

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -132,6 +132,22 @@ impl Keystroke {
                 || self.modifiers.alt)
     }
 
+    /// Returns true if this keystroke is valid as an ime commit.
+    /// And filter out keys that are simulated
+    pub fn is_valid_ime_commit(&self) -> bool {
+        if self.ime_key.is_some() {
+            match self.key.as_str() {
+                "space" => self.ime_key != Some(" ".into()),
+                "enter" => self.ime_key != Some("\n".into()),
+                "shift_l" => true,
+                "shift_r" => true,
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+
     /// Returns a new keystroke with the ime_key filled.
     /// This is used for dispatch_keystroke where we want users to
     /// be able to simulate typing "space", etc.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3273,6 +3273,15 @@ impl<'a> WindowContext<'a> {
             return;
         };
 
+        #[cfg(target_os = "linux")]
+        {
+            if keystroke.is_valid_ime_commit() {
+                self.propagate_event = true;
+                self.finish_dispatch_key_event(event, dispatch_path);
+                return;
+            }
+        }
+
         let mut currently_pending = self.window.pending_input.take().unwrap_or_default();
         if currently_pending.focus.is_some() && currently_pending.focus != self.window.focus {
             currently_pending = PendingInput::default();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1244,6 +1244,13 @@ impl Terminal {
     }
 
     pub fn try_keystroke(&mut self, keystroke: &Keystroke, alt_is_meta: bool) -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            if keystroke.is_valid_ime_commit() {
+                return false;
+            }
+        }
+
         if self.vi_mode_enabled {
             self.vi_motion(keystroke);
             return true;


### PR DESCRIPTION
When typing Chinese characters using an IME and pressing the Enter key to confirm the input, the entire event is recognized as an Enter key press by the keybinding. The IME's commit is discarded, therefore, an additional check needs to be made for this situation before handling the keybinding.

Release Notes:

- N/A

before:

https://github.com/user-attachments/assets/a4108373-59ad-4a97-a148-1302ebe9c64f

after:

https://github.com/user-attachments/assets/9969ee78-7fae-4fe9-a875-53c48ff04ce2

