### PR TITLE
windows: Fix window not displaying correctly on launch

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -662,15 +662,8 @@ impl PlatformWindow for WindowsWindow {
         unsafe {
             if IsWindowVisible(self.0.hwnd).as_bool() {
                 ShowWindowAsync(self.0.hwnd, SW_MAXIMIZE).ok().log_err();
-            } else {
-                self.0
-                    .state
-                    .borrow_mut()
-                    .initial_placement
-                    .as_mut()
-                    .map(|status| {
-                        status.state = WindowOpenState::Maximized;
-                    });
+            } else if let Some(status) = self.0.state.borrow_mut().initial_placement.as_mut() {
+                status.state = WindowOpenState::Maximized;
             }
         }
     }
@@ -678,15 +671,8 @@ impl PlatformWindow for WindowsWindow {
     fn toggle_fullscreen(&self) {
         if unsafe { IsWindowVisible(self.0.hwnd).as_bool() } {
             self.0.toggle_fullscreen();
-        } else {
-            self.0
-                .state
-                .borrow_mut()
-                .initial_placement
-                .as_mut()
-                .map(|status| {
-                    status.state = WindowOpenState::Fullscreen;
-                });
+        } else if let Some(status) = self.0.state.borrow_mut().initial_placement.as_mut() {
+            status.state = WindowOpenState::Fullscreen;
         }
     }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -58,6 +58,7 @@ pub struct WindowsWindowState {
 
 pub(crate) struct WindowsWindowStatePtr {
     hwnd: HWND,
+    this: Weak<Self>,
     pub(crate) state: RefCell<WindowsWindowState>,
     pub(crate) handle: AnyWindowHandle,
     pub(crate) hide_title_bar: bool,
@@ -222,9 +223,10 @@ impl WindowsWindowStatePtr {
             context.display,
         )?);
 
-        Ok(Rc::new(Self {
-            state,
+        Ok(Rc::new_cyclic(|this| Self {
             hwnd,
+            this: this.clone(),
+            state,
             handle: context.handle,
             hide_title_bar: context.hide_title_bar,
             is_movable: context.is_movable,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -659,7 +659,6 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn zoom(&self) {
-        // unsafe { ShowWindowAsync(self.0.hwnd, SW_MAXIMIZE).ok().log_err() };
         unsafe {
             if IsWindowVisible(self.0.hwnd).as_bool() {
                 ShowWindowAsync(self.0.hwnd, SW_MAXIMIZE).ok().log_err();


### PR DESCRIPTION
Closes #18705 (comment)

This PR fixes the issue where the Zed window was not displaying correctly on launch. Now, when Zed is closed in a maximized state, it will reopen in a maximized state.

On macOS, when a window is created but not yet visible, calling `zoom` or `toggle_fullscreen` will still affect the hidden window. However, this behavior is different on Windows, so special handling is required.

Also, since #18705 hasn't been reviewed yet, I'm not sure if this PR should be merged now or if it should wait until #18705 is reviewed first.


Release Notes:

- N/A
