### PR TITLE
Add Diff language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6373,6 +6373,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-diff",
  "tree-sitter-go",
  "tree-sitter-gomod",
  "tree-sitter-gowork",
@@ -12302,6 +12303,15 @@ name = "tree-sitter-css"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d0018d6b1692a806f9cddaa1e5616951fd58840c39a0b21401b55ab3df12292"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-diff"
+version = "0.2.3"
+source = "git+https://github.com/zed-industries/tree-sitter-diff?rev=0a619794b044b6ac36a37e31fb0f5a5126ea8064#0a619794b044b6ac36a37e31fb0f5a5126ea8064"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12310,8 +12310,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-diff"
-version = "0.2.3"
-source = "git+https://github.com/zed-industries/tree-sitter-diff?rev=0a619794b044b6ac36a37e31fb0f5a5126ea8064#0a619794b044b6ac36a37e31fb0f5a5126ea8064"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe1e5ca280a65dfe5ba4205c1bcc84edf486464fed315db53dee6da9a335889"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ tree-sitter-go = "0.23"
 tree-sitter-go-mod = { git = "https://github.com/zed-industries/tree-sitter-go-mod", rev = "a9aea5e358cde4d0f8ff20b7bc4fa311e359c7ca", package = "tree-sitter-gomod" }
 tree-sitter-gowork = { git = "https://github.com/zed-industries/tree-sitter-go-work", rev = "acb0617bf7f4fda02c6217676cc64acb89536dc7" }
 tree-sitter-heex = { git = "https://github.com/zed-industries/tree-sitter-heex", rev = "1dd45142fbb05562e35b2040c6129c9bca346592" }
-tree-sitter-diff = { git = "https://github.com/zed-industries/tree-sitter-diff", rev = "0a619794b044b6ac36a37e31fb0f5a5126ea8064" }
+tree-sitter-diff = "0.1.0"
 tree-sitter-html = "0.20"
 tree-sitter-jsdoc = "0.23"
 tree-sitter-json = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,6 +449,7 @@ tree-sitter-go = "0.23"
 tree-sitter-go-mod = { git = "https://github.com/zed-industries/tree-sitter-go-mod", rev = "a9aea5e358cde4d0f8ff20b7bc4fa311e359c7ca", package = "tree-sitter-gomod" }
 tree-sitter-gowork = { git = "https://github.com/zed-industries/tree-sitter-go-work", rev = "acb0617bf7f4fda02c6217676cc64acb89536dc7" }
 tree-sitter-heex = { git = "https://github.com/zed-industries/tree-sitter-heex", rev = "1dd45142fbb05562e35b2040c6129c9bca346592" }
+tree-sitter-diff = { git = "https://github.com/zed-industries/tree-sitter-diff", rev = "0a619794b044b6ac36a37e31fb0f5a5126ea8064" }
 tree-sitter-html = "0.20"
 tree-sitter-jsdoc = "0.23"
 tree-sitter-json = "0.23"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -843,6 +843,10 @@
     "Dart": {
       "tab_size": 2
     },
+    "Diff": {
+      "remove_trailing_whitespace_on_save": false,
+      "ensure_final_newline_on_save": false
+    },
     "Elixir": {
       "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -15,6 +15,7 @@ load-grammars = [
     "tree-sitter-c",
     "tree-sitter-cpp",
     "tree-sitter-css",
+    "tree-sitter-diff",
     "tree-sitter-go",
     "tree-sitter-go-mod",
     "tree-sitter-gowork",
@@ -59,6 +60,7 @@ tree-sitter-bash = { workspace = true, optional = true }
 tree-sitter-c = { workspace = true, optional = true }
 tree-sitter-cpp = { workspace = true, optional = true }
 tree-sitter-css = { workspace = true, optional = true }
+tree-sitter-diff = { workspace = true, optional = true }
 tree-sitter-go = { workspace = true, optional = true }
 tree-sitter-go-mod = { workspace = true, optional = true }
 tree-sitter-gowork = { workspace = true, optional = true }

--- a/crates/languages/src/diff/config.toml
+++ b/crates/languages/src/diff/config.toml
@@ -1,0 +1,4 @@
+name = "Diff"
+grammar = "diff"
+path_suffixes = ["diff", "patch"]
+brackets = []

--- a/crates/languages/src/diff/highlights.scm
+++ b/crates/languages/src/diff/highlights.scm
@@ -1,0 +1,15 @@
+[
+  (addition)
+  (new_file)
+] @diff.plus
+
+[
+  (deletion)
+  (old_file)
+] @diff.minus
+
+(commit) @constant
+
+(location) @attribute
+
+(command) @function

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -37,6 +37,7 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: NodeRuntime, cx: &mu
         ("c", tree_sitter_c::LANGUAGE),
         ("cpp", tree_sitter_cpp::LANGUAGE),
         ("css", tree_sitter_css::LANGUAGE),
+        ("diff", tree_sitter_diff::LANGUAGE),
         ("go", tree_sitter_go::LANGUAGE),
         ("gomod", tree_sitter_go_mod::LANGUAGE),
         ("gowork", tree_sitter_gowork::LANGUAGE),
@@ -105,6 +106,7 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: NodeRuntime, cx: &mu
         "css",
         vec![Arc::new(css::CssLspAdapter::new(node_runtime.clone())),]
     );
+    language!("diff");
     language!("go", vec![Arc::new(go::GoLspAdapter)], GoContextProvider);
     language!("gomod", vec![Arc::new(go::GoLspAdapter)], GoContextProvider);
     language!(

--- a/docs/src/languages/diff.md
+++ b/docs/src/languages/diff.md
@@ -8,7 +8,7 @@ Diff support is available natively in Zed.
 
 Zed will not attempt to format diff files and has [`remove_trailing_whitespace_on_save`](https://zed.dev/docs/configuring-zed#remove-trailing-whitespace-on-save) and [`ensure-final-newline-on-save`](https://zed.dev/docs/configuring-zed#ensure-final-newline-on-save) set to false.
 
-Zed will automatically recognize files with `patch` and `diff` extensions as Diff files.  To recognize other extensions, add them to `file_types` in your Zed settings.json:
+Zed will automatically recognize files with `patch` and `diff` extensions as Diff files. To recognize other extensions, add them to `file_types` in your Zed settings.json:
 
 ```json
   "file_types": {

--- a/docs/src/languages/diff.md
+++ b/docs/src/languages/diff.md
@@ -1,0 +1,17 @@
+# Diff
+
+Diff support is available natively in Zed.
+
+- Tree Sitter: [zed-industries/the-mikedavis/tree-sitter-diff](https://github.com/the-mikedavis/tree-sitter-diff)
+
+## Configuration
+
+Zed will not attempt to format diff files and has [`remove_trailing_whitespace_on_save`](https://zed.dev/docs/configuring-zed#remove-trailing-whitespace-on-save) and [`ensure-final-newline-on-save`](https://zed.dev/docs/configuring-zed#ensure-final-newline-on-save) set to false.
+
+Zed will automatically recognize files with `patch` and `diff` extensions as Diff files.  To recognize other extensions, add them to `file_types` in your Zed settings.json:
+
+```json
+  "file_types": {
+    "Diff": ["dif"]
+  },
+```


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/18200

Out of the box Zed will do bad things to diff and patch files.  Specifically it will remove trailing whitespace and add final newlines.  We should never be auto-formatting diff/patch files.  I decided against making this a Zed Extension because I don't think you should have to install an extension to make Zed behave non-destructively.

~~I forked the upstream [the-mikedavis/tree-sitter-diff](https://github.com/the-mikedavis/tree-sitter-diff) to [zed-industries/tree-sitter-diff](https://github.com/zed-industries/tree-sitter-diff).  Ideally I would get upstream to upgrade to tree-sitter 0.23 and publish a crate, but for the moment it's working with a fork.~~

Upstream published a crate with tree-sitter 0.23 as v0.1.0:
- https://github.com/the-mikedavis/tree-sitter-diff/issues/16
- https://crates.io/crates/tree-sitter-diff

Release Notes:

- N/A
