### PR TITLE
Environment loading fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5529,7 +5529,7 @@ name = "http_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes 1.7.1",
+ "bytes 1.7.2",
  "derive_more",
  "futures 0.3.30",
  "http 1.1.0",

--- a/crates/project/src/direnv.rs
+++ b/crates/project/src/direnv.rs
@@ -31,13 +31,17 @@ impl From<DirenvError> for Option<EnvironmentErrorMessage> {
 }
 
 #[cfg(not(any(test, feature = "test-support")))]
-pub async fn load_direnv_environment(dir: &Path) -> Result<HashMap<String, String>, DirenvError> {
+pub async fn load_direnv_environment(
+    env: &HashMap<String, String>,
+    dir: &Path,
+) -> Result<HashMap<String, String>, DirenvError> {
     let Ok(direnv_path) = which::which("direnv") else {
         return Err(DirenvError::NotFound);
     };
 
     let Some(direnv_output) = smol::process::Command::new(direnv_path)
         .args(["export", "json"])
+        .envs(env)
         .env("TERM", "dumb")
         .current_dir(dir)
         .output()

--- a/crates/project/src/direnv.rs
+++ b/crates/project/src/direnv.rs
@@ -1,7 +1,7 @@
 use crate::environment::EnvironmentErrorMessage;
 use std::process::ExitStatus;
 
-#[cfg(not(any(test, feature = "test-support")))]
+#[cfg(not(any(target_os = "windows", test, feature = "test-support")))]
 use {collections::HashMap, std::path::Path, util::ResultExt};
 
 #[derive(Clone)]
@@ -30,7 +30,7 @@ impl From<DirenvError> for Option<EnvironmentErrorMessage> {
     }
 }
 
-#[cfg(not(any(test, feature = "test-support")))]
+#[cfg(not(any(target_os = "windows", test, feature = "test-support")))]
 pub async fn load_direnv_environment(
     env: &HashMap<String, String>,
     dir: &Path,

--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -194,18 +194,6 @@ impl EnvironmentErrorMessage {
     }
 }
 
-#[cfg(all(target_os = "windows", not(any(test, feature = "test-support"))))]
-async fn load_shell_environment(
-    _dir: &Path,
-    _load_direnv: &DirenvSettings,
-) -> (
-    Option<HashMap<String, String>>,
-    Option<EnvironmentErrorMessage>,
-) {
-    // TODO the current code works with Unix $SHELL only, implement environment loading on windows
-    (None, None)
-}
-
 #[cfg(any(test, feature = "test-support"))]
 async fn load_shell_environment(
     _dir: &Path,
@@ -218,6 +206,18 @@ async fn load_shell_environment(
         .into_iter()
         .collect();
     (Some(fake_env), None)
+}
+
+#[cfg(all(target_os = "windows", not(any(test, feature = "test-support"))))]
+async fn load_shell_environment(
+    _dir: &Path,
+    _load_direnv: &DirenvSettings,
+) -> (
+    Option<HashMap<String, String>>,
+    Option<EnvironmentErrorMessage>,
+) {
+    // TODO the current code works with Unix $SHELL only, implement environment loading on windows
+    (None, None)
 }
 
 #[cfg(not(any(target_os = "windows", test, feature = "test-support")))]

--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -202,6 +202,7 @@ async fn load_shell_environment(
     Option<HashMap<String, String>>,
     Option<EnvironmentErrorMessage>,
 ) {
+    // TODO the current code works with Unix $SHELL only, implement environment loading on windows
     (None, None)
 }
 

--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -194,7 +194,7 @@ impl EnvironmentErrorMessage {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", not(any(test, feature = "test-support"))))]
 async fn load_shell_environment(
     _dir: &Path,
     _load_direnv: &DirenvSettings,
@@ -206,7 +206,7 @@ async fn load_shell_environment(
     (None, None)
 }
 
-#[cfg(all(not(target_os = "windows"), any(test, feature = "test-support")))]
+#[cfg(any(test, feature = "test-support"))]
 async fn load_shell_environment(
     _dir: &Path,
     _load_direnv: &DirenvSettings,

--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -194,7 +194,18 @@ impl EnvironmentErrorMessage {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(target_os = "windows")]
+async fn load_shell_environment(
+    _dir: &Path,
+    _load_direnv: &DirenvSettings,
+) -> (
+    Option<HashMap<String, String>>,
+    Option<EnvironmentErrorMessage>,
+) {
+    (None, None)
+}
+
+#[cfg(all(not(target_os = "windows"), any(test, feature = "test-support")))]
 async fn load_shell_environment(
     _dir: &Path,
     _load_direnv: &DirenvSettings,
@@ -208,7 +219,7 @@ async fn load_shell_environment(
     (Some(fake_env), None)
 }
 
-#[cfg(not(any(test, feature = "test-support")))]
+#[cfg(not(any(target_os = "windows", test, feature = "test-support")))]
 async fn load_shell_environment(
     dir: &Path,
     load_direnv: &DirenvSettings,
@@ -224,18 +235,6 @@ async fn load_shell_environment(
         let message = EnvironmentErrorMessage::from_str(with);
         (None, Some(message))
     }
-
-    let (direnv_environment, direnv_error) = match load_direnv {
-        DirenvSettings::ShellHook => (None, None),
-        DirenvSettings::Direct => match load_direnv_environment(dir).await {
-            Ok(env) => (Some(env), None),
-            Err(err) => (
-                None,
-                <Option<EnvironmentErrorMessage> as From<DirenvError>>::from(err),
-            ),
-        },
-    };
-    let direnv_environment = direnv_environment.unwrap_or(HashMap::default());
 
     let marker = "ZED_SHELL_START";
     let Some(shell) = std::env::var("SHELL").log_err() else {
@@ -279,7 +278,6 @@ async fn load_shell_environment(
 
     let Some(output) = smol::process::Command::new(&shell)
         .args(["-l", "-i", "-c", &command])
-        .envs(direnv_environment)
         .output()
         .await
         .log_err()
@@ -304,6 +302,21 @@ async fn load_shell_environment(
     parse_env_output(env_output, |key, value| {
         parsed_env.insert(key, value);
     });
+
+    let (direnv_environment, direnv_error) = match load_direnv {
+        DirenvSettings::ShellHook => (None, None),
+        DirenvSettings::Direct => match load_direnv_environment(&parsed_env, dir).await {
+            Ok(env) => (Some(env), None),
+            Err(err) => (
+                None,
+                <Option<EnvironmentErrorMessage> as From<DirenvError>>::from(err),
+            ),
+        },
+    };
+
+    for (key, value) in direnv_environment.unwrap_or(HashMap::default()) {
+        parsed_env.insert(key, value);
+    }
 
     (Some(parsed_env), direnv_error)
 }


### PR DESCRIPTION
Closes #19040
Addresses the problem with annoying error messages on windows (see comment from SomeoneToIgnore on #18567)

Release Notes:

- Fixed the bug where language servers from PATH would sometimes be prioritised over the ones from `direnv`
- Stopped running environment loading on windows as it didn't work anyways due to `SHELL` not being set 