### PR TITLE
Bytes 1.7.2 merge fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5529,7 +5529,7 @@ name = "http_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes 1.7.1",
+ "bytes 1.7.2",
  "derive_more",
  "futures 0.3.30",
  "http 1.1.0",


### PR DESCRIPTION
Cargo.lock here has bytes 1.7.1:
- https://github.com/zed-industries/zed/pull/19136

But in main it was previously upgraded to 1.7.2:
- https://github.com/zed-industries/zed/pull/18656

So if you ran `cargo` on main it would alter Cargo.lock updating it to bytes 1.7.2. 


Release Notes:

- N/A
