### PR TITLE
Hide squiggly underlines in the editor

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -142,6 +142,8 @@
   // Whether to display inline and alongside documentation for items in the
   // completions menu
   "show_completion_documentation": true,
+  // Whether to show squiggle underlines for diagnostics in the editor
+  "show_squiggly_underlines": true,
   // The debounce delay before re-querying the language server for completion
   // documentation when not included in original completion list.
   "completion_documentation_secondary_query_debounce": 300,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -695,7 +695,9 @@ impl DisplaySnapshot {
 
             if let Some(severity) = chunk.diagnostic_severity {
                 // Omit underlines for HINT/INFO diagnostics on 'unnecessary' code.
-                if severity <= DiagnosticSeverity::WARNING || !chunk.is_unnecessary {
+                if editor_style.show_squiggly_underlines
+                    && (severity <= DiagnosticSeverity::WARNING || !chunk.is_unnecessary)
+                {
                     let diagnostic_color = super::diagnostic_style(severity, &editor_style.status);
                     diagnostic_highlight.underline = Some(UnderlineStyle {
                         color: Some(diagnostic_color),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -405,6 +405,7 @@ pub struct EditorStyle {
     pub inlay_hints_style: HighlightStyle,
     pub suggestions_style: HighlightStyle,
     pub unnecessary_code_fade: f32,
+    pub show_squiggly_underlines: bool,
 }
 
 impl Default for EditorStyle {
@@ -422,6 +423,7 @@ impl Default for EditorStyle {
             inlay_hints_style: HighlightStyle::default(),
             suggestions_style: HighlightStyle::default(),
             unnecessary_code_fade: Default::default(),
+            show_squiggly_underlines: Default::default(),
         }
     }
 }
@@ -13719,6 +13721,7 @@ impl Render for Editor {
                     ..HighlightStyle::default()
                 },
                 unnecessary_code_fade: ThemeSettings::get_global(cx).unnecessary_code_fade,
+                show_squiggly_underlines: EditorSettings::get_global(cx).show_squiggly_underlines,
             },
         )
     }

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -34,6 +34,7 @@ pub struct EditorSettings {
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub jupyter: Jupyter,
+    pub show_squiggly_underlines: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -284,6 +285,9 @@ pub struct EditorSettingsContent {
 
     /// Jupyter REPL settings.
     pub jupyter: Option<JupyterContent>,
+
+    /// Whether to show squiggle underlines for diagnostics in the editor.
+    pub show_squiggly_underlines: Option<bool>,
 }
 
 // Toolbar related settings


### PR DESCRIPTION
Release Notes:

- Added a setting to show or hide squiggly underlines in the editor
