### PR TITLE
Make `danger` to output less false-positives

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -37,9 +37,10 @@ if (!hasReleaseNotes) {
 }
 
 const ISSUE_LINK_PATTERN = new RegExp(
-  "https://github\\.com/[\\w-]+/[\\w-]+/issues/\\d+",
-  "g",
+  "(?<!(?:Close[sd]?|Fixe[sd]|Resolve[sd]|Implement[sed])\\s+)https://github\\.com/[\\w-]+/[\\w-]+/issues/\\d+",
+  "gi"
 );
+
 
 const includesIssueUrl = ISSUE_LINK_PATTERN.test(body);
 

--- a/typos.toml
+++ b/typos.toml
@@ -7,7 +7,7 @@ extend-exclude = [
     # Contributor names aren't typos.
     ".mailmap",
 
-    # File suffixes aren't typos
+    # File suffixes aren't typos.
     "assets/icons/file_icons/file_types.json",
     "crates/extensions_ui/src/extension_suggest.rs",
 
@@ -21,26 +21,28 @@ extend-exclude = [
 
     # Stripe IDs are flagged as typos.
     "crates/collab/src/db/tests/processed_stripe_event_tests.rs",
-    # Not our typos
+    # Not our typos.
     "crates/live_kit_server/",
-    # Vim makes heavy use of partial typing tables
+    # Vim makes heavy use of partial typing tables.
     "crates/vim/",
-    # Editor and file finder rely on partial typing and custom in-string syntax
+    # Editor and file finder rely on partial typing and custom in-string syntax.
     "crates/file_finder/src/file_finder_tests.rs",
     "crates/editor/src/editor_tests.rs",
-    # Clojure uses .edn filename extension, which is not a misspelling of "end"
+    # Clojure uses .edn filename extension, which is not a misspelling of "end".
     "extensions/clojure/languages/clojure/config.toml",
     # There are some names in the test data that are incorrectly flagged as typos.
     "crates/git/test_data/blame_incremental_complex",
     "crates/git/test_data/golden/blame_incremental_complex.json",
     # We have some base64-encoded data that is incorrectly being flagged.
     "crates/rpc/src/auth.rs",
-    # glsl isn't recognized by this tool
+    # glsl isn't recognized by this tool.
     "extensions/glsl/languages/glsl/",
-    # Windows likes its abbreviations
+    # Windows likes its abbreviations.
     "crates/gpui/src/platform/windows/",
     # Some typos in the base mdBook CSS.
-    "docs/theme/css/"
+    "docs/theme/css/",
+    # Spellcheck triggers on `|Fixe[sd]|` regex part.
+    "script/danger/dangerfile.ts",
 ]
 
 [default]


### PR DESCRIPTION
Adjust the script to ignore issue links that start with Fixed/Fixes/Closes/etc.
Avoids false-positives like https://github.com/zed-industries/zed/pull/19150#issuecomment-2408938498

Release Notes:

- N/A
