### PR TITLE
supermaven: Fix crash when editing non-ASCII text

### DIFF
--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -217,11 +217,11 @@ fn find_relevant_completion<'a>(
         };
 
         let current_cursor_offset = cursor_position.to_offset(buffer);
-        let original_cursor_offset = buffer.clip_offset(state.prefix_offset, text::Bias::Left);
-        if current_cursor_offset < original_cursor_offset {
+        if current_cursor_offset < state.prefix_offset {
             continue;
         }
 
+        let original_cursor_offset = buffer.clip_offset(state.prefix_offset, text::Bias::Left);
         let text_inserted_since_completion_request =
             buffer.text_for_range(original_cursor_offset..current_cursor_offset);
         let mut trimmed_completion = state_completion;

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -217,7 +217,7 @@ fn find_relevant_completion<'a>(
         };
 
         let current_cursor_offset = cursor_position.to_offset(buffer);
-        let original_cursor_offset = state.prefix_offset;
+        let original_cursor_offset = buffer.clip_offset(state.prefix_offset, text::Bias::Left);
         if current_cursor_offset < original_cursor_offset {
             continue;
         }


### PR DESCRIPTION
Closes #19051
Closes #19182


#### How to reproduce this crash:
1. Open any file and input some ASCII characters.
2. Replace these characters with `你好`.
3. Press `backspace`.
4. Crash.


https://github.com/user-attachments/assets/ea5c5340-29a5-42c8-98c5-6e60770445a4



The issue lies with the `prefix_offset` introduced in #18858. After the buffer is modified, this value is not always valid and may fall within a `char boundary`, which results in a crash.



Release Notes:

- Fixed Supermaven crashing on deleting non-ASCII text
