### PR TITLE
docs: Formatter arguments, document `{buffer_path}` usage

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -739,7 +739,18 @@ While other options may be changed at a runtime and should be placed under `sett
 }
 ```
 
-3. Or to use code actions provided by the connected language servers, use `"code_actions"`:
+3. External formatters may optionally include a `{buffer_path}` placeholder which at runtime will include the path of the buffer being formatted. Formatters operate by receiving file content via standard input, reformatting it and then outputting it to standard output and so normally don't know the filename of what they are formatting. Tools like prettier support receiving the file path via a command line argument which can then used to impact formatting decisions.
+
+```json
+  "formatter": {
+    "external": {
+      "command": "prettier",
+      "arguments": ["--stdin-filepath", "{buffer_path}"]
+    }
+  }
+```
+
+4. Or to use code actions provided by the connected language servers, use `"code_actions"`:
 
 ```json
 {
@@ -754,7 +765,7 @@ While other options may be changed at a runtime and should be placed under `sett
 }
 ```
 
-4. Or to use multiple formatters consecutively, use an array of formatters:
+5. Or to use multiple formatters consecutively, use an array of formatters:
 
 ```json
 {


### PR DESCRIPTION
- Closes https://github.com/zed-industries/zed/issues/19016

Release Notes:

- N/A
