### PR TITLE
Fix file watching for symlinked workspace on Linux

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -655,14 +655,6 @@ impl Fs for RealFs {
             watcher.add(parent).log_err();
         }
 
-        // Check if path is a symlink and follow the target parent
-        if let Some(target) = self.read_link(&path).await.ok() {
-            watcher.add(&target).ok();
-            if let Some(parent) = target.parent() {
-                watcher.add(parent).log_err();
-            }
-        }
-
         (
             Box::pin(rx.filter_map({
                 let watcher = watcher.clone();


### PR DESCRIPTION
- Closes #17161

- #17609 only fixed file watching for symlinks inside the workspace, not if the folder itself or one of its parents is a symlink. This PR replaces uses of `read_link` with `canonicalize` that returns the right canonical path in these cases. 

Release Notes:

- Fixed file watching for symlinked workspaces on linux
