### PR TITLE
remote: Disable a race-condition-y safety-check, for now

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1180,6 +1180,11 @@ impl SshRemoteConnection {
 
         drop(askpass_task);
 
+        /*
+         * The master process exiting does not necessarily mean that anything is wrong,
+         * it could just be that SSH has forked into the background despite not being
+         * asked to - see https://bugzilla.mindrot.org/show_bug.cgi?id=3743
+
         if master_process.try_status()?.is_some() {
             output.clear();
             let mut stderr = master_process.stderr.take().unwrap();
@@ -1189,6 +1194,7 @@ impl SshRemoteConnection {
             delegate.set_error(error_message.clone(), cx);
             Err(anyhow!(error_message))?;
         }
+        */
 
         Ok(Self {
             socket: SshSocket {


### PR DESCRIPTION
remote: Disable a race-condition-y safety-check, for now

This safety check would make sense, except that if SSH connects and authenticates _really_ fast, then it will connect and authenticate and fork itself into the background by the time the check runs, and we falsely intepret "ssh forked itself into the background" as "ssh disconnected"

I feel like "ssh forks after authentication even with `-o ForkAfterAuthentication=no`" is an ssh bug, and I have reported it upstream, but so long as this behaviour exists out in the wild I think we need to find a different way to check if the connection is alive :(

Tests:

- Before: Connections to my server result in "Failed to connect: ." (The error message is attempting to show stderr, but stderr is empty)

- After: Connections to my server work reliably

Release Notes:

- N/A
