### PR TITLE
remote: Store remote server in ~/.local/libexec with architecture

### DIFF
--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -351,9 +351,18 @@ impl remote::SshClientDelegate for SshClientDelegate {
         rx
     }
 
-    fn remote_server_binary_path(&self, cx: &mut AsyncAppContext) -> Result<PathBuf> {
+    fn remote_server_binary_path(
+        &self,
+        platform: SshPlatform,
+        cx: &mut AsyncAppContext,
+    ) -> Result<PathBuf> {
         let release_channel = cx.update(|cx| ReleaseChannel::global(cx))?;
-        Ok(format!(".local/zed-remote-server-{}", release_channel.dev_name()).into())
+        Ok(format!(
+            ".local/libexec/zed-remote-server-{}-{}",
+            release_channel.dev_name(),
+            platform.arch,
+        )
+        .into())
     }
 }
 

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -138,7 +138,11 @@ pub trait SshClientDelegate: Send + Sync {
         prompt: String,
         cx: &mut AsyncAppContext,
     ) -> oneshot::Receiver<Result<String>>;
-    fn remote_server_binary_path(&self, cx: &mut AsyncAppContext) -> Result<PathBuf>;
+    fn remote_server_binary_path(
+        &self,
+        platform: SshPlatform,
+        cx: &mut AsyncAppContext,
+    ) -> Result<PathBuf>;
     fn get_server_binary(
         &self,
         platform: SshPlatform,
@@ -938,7 +942,7 @@ impl SshRemoteClient {
 
         let platform = ssh_connection.query_platform().await?;
         let (local_binary_path, version) = delegate.get_server_binary(platform, cx).await??;
-        let remote_binary_path = delegate.remote_server_binary_path(cx)?;
+        let remote_binary_path = delegate.remote_server_binary_path(platform, cx)?;
         ssh_connection
             .ensure_server_binary(
                 &delegate,


### PR DESCRIPTION
remote: store remote server in ~/.local/libexec with architecture

Keeping zed's internal binaries in one place, because it feels weird to have them spread out (From the install docs: "You will need to build crates/zed and put it at $PATH/to/cli/../../libexec/zed-editor. For example, if you are going to put the cli at ~/.local/bin/zed put zed at ~/.local/libexec/zed-editor")

Also adding the architecture into the filename, so that I can sync my home directory between laptop, dev server, and raspberry pi and not have things break in mysterious ways :)

Release Notes:

- N/A
