### PR TITLE
Add vim::Search command option for non-regex search

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -41,6 +41,8 @@ pub(crate) struct MoveToPrev {
 pub(crate) struct Search {
     #[serde(default)]
     backwards: bool,
+    #[serde(default = "default_true")]
+    regex: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -130,7 +132,11 @@ impl Vim {
                     cx.focus_self();
 
                     search_bar.set_replacement(None, cx);
-                    search_bar.set_search_options(SearchOptions::NONE | SearchOptions::REGEX, cx);
+                    let mut options = SearchOptions::NONE;
+                    if action.regex {
+                        options |= SearchOptions::REGEX;
+                    }
+                    search_bar.set_search_options(options, cx);
 
                     self.search = SearchState {
                         direction,


### PR DESCRIPTION
Similar to e2647025ac833856961a1234ed2bd0202f9c4746, this adds a `regex` option to `vim::Search` command to allow disabling regex search.

Release Notes:

- Added `regex` option to `vim::Search` command to allow disabling regex search by default in the keymap. Example usage:
  ```yaml
  {
    "context": "VimControl && !menu",
    "bindings": {
      "/": ["vim::Search", { "regex": false }],
    }
  }
  ```