### PR TITLE
Revert "lsp: Do not notify all language servers on file save"

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2899,27 +2899,11 @@ impl LspStore {
         let file = File::from_dyn(buffer.read(cx).file())?;
         let worktree_id = file.worktree_id(cx);
         let abs_path = file.as_local()?.abs_path(cx);
-        let worktree_path = file.as_local()?.path();
         let text_document = lsp::TextDocumentIdentifier {
             uri: lsp::Url::from_file_path(abs_path).log_err()?,
         };
 
-        let watched_paths_for_server = &self.as_local()?.language_server_watched_paths;
         for server in self.language_servers_for_worktree(worktree_id) {
-            let should_notify = maybe!({
-                Some(
-                    watched_paths_for_server
-                        .get(&server.server_id())?
-                        .read(cx)
-                        .worktree_paths
-                        .get(&worktree_id)?
-                        .is_match(worktree_path),
-                )
-            })
-            .unwrap_or_default();
-            if !should_notify {
-                continue;
-            }
             if let Some(include_text) = include_text(server.as_ref()) {
                 let text = if include_text {
                     Some(buffer.read(cx).text())


### PR DESCRIPTION
Reverts zed-industries/zed#17756. According to the existing implementations of the LSP specification, namely [Helix](https://github.com/helix-editor/helix/blob/a7651f5bf027ec98645d571ab05a685d97e1b772/helix-view/src/document.rs#L1038) and, if I'm not wrong, [VSCode](https://github.com/microsoft/vscode-languageserver-node/blob/main/client/src/common/textSynchronization.ts#L580), `textDocument/didSave` has nothing to do with the watched files and should be sent to the language servers connected to the buffers even if the files are not watched by those. As the LSP spec doesn't say anything about `didSave` being related to the watched files, and the reference implementation in VSCode seemingly does not filter the notifications according to those, it seems like this is an incorrect interpretation of the specification

This also causes issues with language servers. See [Metals issue](https://github.com/scalameta/metals-zed/issues/28#issuecomment-2410393150) for example

Closes #18636

Release Notes:

- N/A