### PR TITLE
ssh remoting: Forward LSP logs to client

### DIFF
--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -838,6 +838,7 @@ impl Database {
                 .map(|language_server| proto::LanguageServer {
                     id: language_server.id as u64,
                     name: language_server.name,
+                    worktree_id: None,
                 })
                 .collect(),
             dev_server_project_id: project.dev_server_project_id,

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -718,6 +718,7 @@ impl Database {
             .map(|language_server| proto::LanguageServer {
                 id: language_server.id as u64,
                 name: language_server.name,
+                worktree_id: None,
             })
             .collect::<Vec<_>>();
 

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -184,7 +184,7 @@ pub fn init(cx: &mut AppContext) {
 
     cx.observe_new_views(move |workspace: &mut Workspace, cx| {
         let project = workspace.project();
-        if project.read(cx).is_local() {
+        if project.read(cx).is_local() || project.read(cx).is_via_ssh() {
             log_store.update(cx, |store, cx| {
                 store.add_project(project, cx);
             });
@@ -193,7 +193,7 @@ pub fn init(cx: &mut AppContext) {
         let log_store = log_store.clone();
         workspace.register_action(move |workspace, _: &OpenLanguageServerLogs, cx| {
             let project = workspace.project().read(cx);
-            if project.is_local() {
+            if project.is_local() || project.is_via_ssh() {
                 workspace.split_item(
                     SplitDirection::Right,
                     Box::new(cx.new_view(|cx| {

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -111,7 +111,7 @@ struct LanguageServerState {
 }
 
 #[derive(PartialEq, Clone)]
-enum LanguageServerKind {
+pub enum LanguageServerKind {
     Local { project: WeakModel<Project> },
     Remote { project: WeakModel<Project> },
     Global,
@@ -196,7 +196,7 @@ pub(crate) struct LogMenuItem {
     pub rpc_trace_enabled: bool,
     pub selected_entry: LogKind,
     pub trace_level: lsp::TraceValue,
-    server_kind: LanguageServerKind,
+    pub server_kind: LanguageServerKind,
 }
 
 actions!(debug, [OpenLanguageServerLogs]);

--- a/crates/language_tools/src/lsp_log_tests.rs
+++ b/crates/language_tools/src/lsp_log_tests.rs
@@ -95,6 +95,9 @@ async fn test_lsp_logs(cx: &mut TestAppContext) {
                 rpc_trace_enabled: false,
                 selected_entry: LogKind::Logs,
                 trace_level: lsp::TraceValue::Off,
+                server_kind: lsp_log::LanguageServerKind::Local {
+                    project: project.downgrade()
+                }
             }]
         );
         assert_eq!(view.editor.read(cx).text(cx), "hello from the server\n");

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3924,7 +3924,7 @@ impl LspStore {
             cx.emit(LspStoreEvent::LanguageServerAdded(
                 server_id,
                 LanguageServerName(server.name.into()),
-                server.worktree_id.map(|id| WorktreeId::from_proto(id)),
+                server.worktree_id.map(WorktreeId::from_proto),
             ));
             cx.notify();
         })?;
@@ -4006,7 +4006,8 @@ impl LspStore {
                         1 => MessageType::ERROR,
                         2 => MessageType::WARNING,
                         3 => MessageType::INFO,
-                        4 | _ => MessageType::LOG,
+                        4 => MessageType::LOG,
+                        _ => MessageType::LOG,
                     })
                 }
                 proto::language_server_log::LogType::LogTrace(trace) => {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -219,7 +219,7 @@ enum ProjectClientState {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Event {
-    LanguageServerAdded(LanguageServerId),
+    LanguageServerAdded(LanguageServerId, LanguageServerName, Option<WorktreeId>),
     LanguageServerRemoved(LanguageServerId),
     LanguageServerLog(LanguageServerId, LanguageServerLogType, String),
     Notification(String),
@@ -2072,9 +2072,9 @@ impl Project {
                 path: path.clone(),
                 language_server_id: *language_server_id,
             }),
-            LspStoreEvent::LanguageServerAdded(language_server_id) => {
-                cx.emit(Event::LanguageServerAdded(*language_server_id))
-            }
+            LspStoreEvent::LanguageServerAdded(language_server_id, name, worktree_id) => cx.emit(
+                Event::LanguageServerAdded(*language_server_id, name.clone(), *worktree_id),
+            ),
             LspStoreEvent::LanguageServerRemoved(language_server_id) => {
                 cx.emit(Event::LanguageServerRemoved(*language_server_id))
             }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1185,7 +1185,11 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
     let fake_server = fake_servers.next().await.unwrap();
     assert_eq!(
         events.next().await.unwrap(),
-        Event::LanguageServerAdded(LanguageServerId(0)),
+        Event::LanguageServerAdded(
+            LanguageServerId(0),
+            fake_server.server.name().into(),
+            Some(worktree_id)
+        ),
     );
 
     fake_server
@@ -1295,6 +1299,8 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
         },
     );
 
+    let worktree_id = project.update(cx, |p, cx| p.worktrees(cx).next().unwrap().read(cx).id());
+
     let buffer = project
         .update(cx, |project, cx| project.open_local_buffer("/dir/a.rs", cx))
         .await
@@ -1314,7 +1320,11 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
     let fake_server = fake_servers.next().await.unwrap();
     assert_eq!(
         events.next().await.unwrap(),
-        Event::LanguageServerAdded(LanguageServerId(1))
+        Event::LanguageServerAdded(
+            LanguageServerId(1),
+            fake_server.server.name().into(),
+            Some(worktree_id)
+        )
     );
     fake_server.start_progress(progress_token).await;
     assert_eq!(

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -1296,6 +1296,7 @@ message LamportTimestamp {
 message LanguageServer {
     uint64 id = 1;
     string name = 2;
+    optional uint64 worktree_id = 3;
 }
 
 message StartLanguageServer {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -269,7 +269,7 @@ message Envelope {
 
         GetLlmToken get_llm_token = 235;
         GetLlmTokenResponse get_llm_token_response = 236;
-        RefreshLlmToken refresh_llm_token = 259; // current max
+        RefreshLlmToken refresh_llm_token = 259;
 
         LspExtSwitchSourceHeader lsp_ext_switch_source_header = 241;
         LspExtSwitchSourceHeaderResponse lsp_ext_switch_source_header_response = 242;
@@ -286,6 +286,8 @@ message Envelope {
         ShutdownRemoteServer shutdown_remote_server = 257;
 
         RemoveWorktree remove_worktree = 258;
+
+        LanguageServerLog language_server_log = 260; // current max
     }
 
     reserved 87 to 88;
@@ -1346,6 +1348,20 @@ message LspWorkEnd {
 message LspDiskBasedDiagnosticsUpdating {}
 
 message LspDiskBasedDiagnosticsUpdated {}
+
+message LanguageServerLog {
+    uint64 project_id = 1;
+    uint64 language_server_id = 2;
+    oneof log_type {
+        uint32 log_message_type = 3;
+        LspLogTrace log_trace = 4;
+    }
+    string message = 5;
+}
+
+message LspLogTrace {
+    optional string message = 1;
+}
 
 message UpdateChannels {
     repeated Channel channels = 1;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -366,6 +366,7 @@ messages!(
     (CheckFileExistsResponse, Background),
     (ShutdownRemoteServer, Foreground),
     (RemoveWorktree, Foreground),
+    (LanguageServerLog, Foreground),
 );
 
 request_messages!(
@@ -562,6 +563,7 @@ entity_messages!(
     LspExtSwitchSourceHeader,
     UpdateUserSettings,
     CheckFileExists,
+    LanguageServerLog,
 );
 
 entity_messages!(

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -33,6 +33,7 @@ gpui.workspace = true
 language.workspace = true
 languages.workspace = true
 log.workspace = true
+lsp.workspace = true
 node_runtime.workspace = true
 project.workspace = true
 remote.workspace = true

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Result};
 use fs::Fs;
 use gpui::{AppContext, AsyncAppContext, Context, Model, ModelContext};
 use language::{proto::serialize_operation, Buffer, BufferEvent, LanguageRegistry};
-use lsp::MessageType;
 use node_runtime::NodeRuntime;
 use project::{
     buffer_store::{BufferStore, BufferStoreEvent},
@@ -205,33 +204,12 @@ impl HeadlessProject {
                     .log_err();
             }
             LspStoreEvent::LanguageServerLog(language_server_id, log_type, message) => {
-                let log_type = match log_type {
-                    project::LanguageServerLogType::Log(log_type) => {
-                        let message_type = match *log_type {
-                            MessageType::ERROR => 1,
-                            MessageType::WARNING => 2,
-                            MessageType::INFO => 3,
-                            MessageType::LOG => 4,
-                            other => {
-                                log::warn!("Unknown lsp log message type: {:?}", other);
-                                4
-                            }
-                        };
-                        proto::language_server_log::LogType::LogMessageType(message_type)
-                    }
-                    project::LanguageServerLogType::Trace(message) => {
-                        proto::language_server_log::LogType::LogTrace(proto::LspLogTrace {
-                            message: message.clone(),
-                        })
-                    }
-                };
-
                 self.session
                     .send(proto::LanguageServerLog {
                         project_id: SSH_PROJECT_ID,
                         language_server_id: language_server_id.to_proto(),
                         message: message.clone(),
-                        log_type: Some(log_type),
+                        log_type: Some(log_type.to_proto()),
                     })
                     .log_err();
             }

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use fs::Fs;
 use gpui::{AppContext, AsyncAppContext, Context, Model, ModelContext};
 use language::{proto::serialize_operation, Buffer, BufferEvent, LanguageRegistry};
+use lsp::MessageType;
 use node_runtime::NodeRuntime;
 use project::{
     buffer_store::{BufferStore, BufferStoreEvent},
@@ -200,6 +201,37 @@ impl HeadlessProject {
                         project_id: SSH_PROJECT_ID,
                         language_server_id: language_server_id.to_proto(),
                         variant: Some(message.clone()),
+                    })
+                    .log_err();
+            }
+            LspStoreEvent::LanguageServerLog(language_server_id, log_type, message) => {
+                let log_type = match log_type {
+                    project::LanguageServerLogType::Log(log_type) => {
+                        let message_type = match *log_type {
+                            MessageType::ERROR => 1,
+                            MessageType::WARNING => 2,
+                            MessageType::INFO => 3,
+                            MessageType::LOG => 4,
+                            other => {
+                                log::warn!("Unknown lsp log message type: {:?}", other);
+                                4
+                            }
+                        };
+                        proto::language_server_log::LogType::LogMessageType(message_type)
+                    }
+                    project::LanguageServerLogType::Trace(message) => {
+                        proto::language_server_log::LogType::LogTrace(proto::LspLogTrace {
+                            message: message.clone(),
+                        })
+                    }
+                };
+
+                self.session
+                    .send(proto::LanguageServerLog {
+                        project_id: SSH_PROJECT_ID,
+                        language_server_id: language_server_id.to_proto(),
+                        message: message.clone(),
+                        log_type: Some(log_type),
                     })
                     .log_err();
             }


### PR DESCRIPTION
This fowards LSP logs to the client. It does **not** forward traces and those are disabled for now.

Release Notes:

- N/A
