### PR TITLE
ssh remote: Revert #19193 and treat killed proxy as non-zero

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -823,7 +823,10 @@ impl SshRemoteClient {
                                 child_stdin.close().await?;
                                 outgoing_rx.close();
                                 let status = ssh_proxy_process.status().await?;
-                                return Ok(status.code());
+                                // If we don't have a code, we assume process
+                                // has been killed and treat it as non-zero exit
+                                // code
+                                return Ok(status.code().or_else(|| Some(1)));
                             }
                             Ok(len) => {
                                 if len < stdout_buffer.len() {
@@ -1149,14 +1152,7 @@ impl SshRemoteConnection {
             .stderr(Stdio::piped())
             .env("SSH_ASKPASS_REQUIRE", "force")
             .env("SSH_ASKPASS", &askpass_script_path)
-            .args([
-                "-N",
-                "-o",
-                "ControlPersist=no",
-                "-o",
-                "ControlMaster=yes",
-                "-o",
-            ])
+            .args(["-N", "-o", "ControlMaster=yes", "-o"])
             .arg(format!("ControlPath={}", socket_path.display()))
             .arg(&url)
             .spawn()?;


### PR DESCRIPTION
This does two things.

Important one: it reverts #19193, which lead to our whole process handling breaking. When the `proxy` process was killed, it apparently didn't close the stdout/stderr anymore, which meant we would not detect when it died. (Watching its `status()` in the io loop also didn't work!)

We should figure out how to keep our process handling working before we make this change in #19193, which sounds reasonable.

Second, less important thing: I think we should treat the process being killed from a signal as non-zero, as an error.

Release Notes:

- N/A
