### PR TITLE
Use multi-line regex for '\s'

### DIFF
--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -125,7 +125,7 @@ impl SearchQuery {
             query = word_query
         }
 
-        let multiline = query.contains('\n') || query.contains("\\n");
+        let multiline = query.contains('\n') || query.contains("\\n") || query.contains("\\s");
         let regex = RegexBuilder::new(&query)
             .case_insensitive(!case_sensitive)
             .multi_line(multiline)


### PR DESCRIPTION
- Closes https://github.com/zed-industries/zed/issues/19184

Release Notes:

- Fixed `\s` in regex search not behaving correctly.