### PR TITLE
Ensure issues without core labels have triage labels

### DIFF
--- a/script/label_data.json
+++ b/script/label_data.json
@@ -9,5 +9,6 @@
     "support"
   ],
   "additional_labels": ["ai", "linux", "vim", "windows"],
-  "ignored_label": "ignore top-ranking issues"
+  "ignored_label": "ignore top-ranking issues",
+  "new_issue_labels": ["triage", "admin read"]
 }

--- a/script/update_top_ranking_issues/main.py
+++ b/script/update_top_ranking_issues/main.py
@@ -15,29 +15,36 @@ from typer import Typer
 app: Typer = typer.Typer()
 
 DATETIME_FORMAT: str = "%m/%d/%Y %I:%M %p"
+LABEL_DATA_FILE_PATH = pathlib.Path(__file__).parent.parent / "label_data.json"
+ISSUES_PER_LABEL: int = 20
+MISSING_LABEL_ERROR_MESSAGE: str = "missing core label"
 
-label_data_file_path = pathlib.Path(__file__).parent.parent / "label_data.json"
-
-with open(label_data_file_path, "r") as label_data_file:
+with open(LABEL_DATA_FILE_PATH, "r") as label_data_file:
     label_data = json.load(label_data_file)
     CORE_LABELS: set[str] = set(label_data["core_labels"])
     # A set of labels for adding in labels that we want present in the final
     # report, but that we don't want being defined as a core label, since issues
     # with without core labels are flagged as errors.
     ADDITIONAL_LABELS: set[str] = set(label_data["additional_labels"])
+    NEW_ISSSUE_LABELS: set[str] = set(label_data["new_issue_labels"])
     IGNORED_LABEL: str = label_data["ignored_label"]
 
 
-ISSUES_PER_LABEL: int = 20
+class MissingCoreLabelError(Exception):
+    """Raised when an issue is missing a core label."""
+
+    pass
 
 
 class IssueData:
     def __init__(self, issue: Issue) -> None:
+        self.title = issue.title
         self.url: str = issue.html_url
         self.like_count: int = issue._rawData["reactions"]["+1"]  # type: ignore [attr-defined]
         self.creation_datetime: str = issue.created_at.strftime(DATETIME_FORMAT)
         # TODO: Change script to support storing labels here, rather than directly in the script
         self.labels: set[str] = {label["name"] for label in issue._rawData["labels"]}  # type: ignore [attr-defined]
+        self._issue = issue
 
 
 @app.command()
@@ -86,6 +93,14 @@ def main(
         top_ranking_issues_issue.edit(body=issue_text)
     else:
         print(issue_text)
+
+    for error_message, issue_data in error_message_to_erroneous_issue_data.items():
+        if error_message == MISSING_LABEL_ERROR_MESSAGE:
+            for issue in issue_data:
+                # Used as a dry-run flag
+                if issue_reference_number:
+                    issue._issue.add_to_labels(*NEW_ISSSUE_LABELS)
+
 
     remaining_requests_after: int = github.rate_limiting[0]
     print(f"Remaining requests after: {remaining_requests_after}")
@@ -191,7 +206,7 @@ def get_error_message_to_erroneous_issues(
     query: str = f"repo:{repository.full_name} is:open is:issue {filter_labels_text}"
 
     for issue in github.search_issues(query):
-        error_message_to_erroneous_issues["missing core label"].append(issue)
+        error_message_to_erroneous_issues[MISSING_LABEL_ERROR_MESSAGE].append(issue)
 
     return error_message_to_erroneous_issues
 

--- a/script/update_top_ranking_issues/main.py
+++ b/script/update_top_ranking_issues/main.py
@@ -30,12 +30,6 @@ with open(LABEL_DATA_FILE_PATH, "r") as label_data_file:
     IGNORED_LABEL: str = label_data["ignored_label"]
 
 
-class MissingCoreLabelError(Exception):
-    """Raised when an issue is missing a core label."""
-
-    pass
-
-
 class IssueData:
     def __init__(self, issue: Issue) -> None:
         self.title = issue.title

--- a/script/update_top_ranking_issues/main.py
+++ b/script/update_top_ranking_issues/main.py
@@ -101,7 +101,6 @@ def main(
                 if issue_reference_number:
                     issue._issue.add_to_labels(*NEW_ISSSUE_LABELS)
 
-
     remaining_requests_after: int = github.rate_limiting[0]
     print(f"Remaining requests after: {remaining_requests_after}")
     print(f"Requests used: {remaining_requests_before - remaining_requests_after}")

--- a/script/update_top_ranking_issues/pyproject.toml
+++ b/script/update_top_ranking_issues/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "mypy>=1.11.2",
     "pygithub>=2.4.0",
     "pytz>=2024.2",
+    "ruff>=0.6.9",
     "typer>=0.12.5",
     "types-pytz>=2024.2.0.20241003",
 ]

--- a/script/update_top_ranking_issues/uv.lock
+++ b/script/update_top_ranking_issues/uv.lock
@@ -277,6 +277,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.6.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/0d/6148a48dab5662ca1d5a93b7c0d13c03abd3cc7e2f35db08410e47cef15d/ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2", size = 3095355 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/8f/f7a0a0ef1818662efb32ed6df16078c95da7a0a3248d64c2410c1e27799f/ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd", size = 10440526 },
+    { url = "https://files.pythonhosted.org/packages/8b/69/b179a5faf936a9e2ab45bb412a668e4661eded964ccfa19d533f29463ef6/ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec", size = 10034612 },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/fd1b4be979c579d191eeac37b5cfc0ec906de72c8bcd8595e2c81bb700c1/ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c", size = 9706197 },
+    { url = "https://files.pythonhosted.org/packages/29/61/b376d775deb5851cb48d893c568b511a6d3625ef2c129ad5698b64fb523c/ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e", size = 10751855 },
+    { url = "https://files.pythonhosted.org/packages/13/d7/def9e5f446d75b9a9c19b24231a3a658c075d79163b08582e56fa5dcfa38/ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577", size = 10200889 },
+    { url = "https://files.pythonhosted.org/packages/6c/d6/7f34160818bcb6e84ce293a5966cba368d9112ff0289b273fbb689046047/ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829", size = 11038678 },
+    { url = "https://files.pythonhosted.org/packages/13/34/a40ff8ae62fb1b26fb8e6fa7e64bc0e0a834b47317880de22edd6bfb54fb/ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5", size = 11808682 },
+    { url = "https://files.pythonhosted.org/packages/2e/6d/25a4386ae4009fc798bd10ba48c942d1b0b3e459b5403028f1214b6dd161/ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7", size = 11330446 },
+    { url = "https://files.pythonhosted.org/packages/f7/f6/bdf891a9200d692c94ebcd06ae5a2fa5894e522f2c66c2a12dd5d8cb2654/ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f", size = 12483048 },
+    { url = "https://files.pythonhosted.org/packages/a7/86/96f4252f41840e325b3fa6c48297e661abb9f564bd7dcc0572398c8daa42/ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa", size = 10936855 },
+    { url = "https://files.pythonhosted.org/packages/45/87/801a52d26c8dbf73424238e9908b9ceac430d903c8ef35eab1b44fcfa2bd/ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb", size = 10713007 },
+    { url = "https://files.pythonhosted.org/packages/be/27/6f7161d90320a389695e32b6ebdbfbedde28ccbf52451e4b723d7ce744ad/ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0", size = 10274594 },
+    { url = "https://files.pythonhosted.org/packages/00/52/dc311775e7b5f5b19831563cb1572ecce63e62681bccc609867711fae317/ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625", size = 10608024 },
+    { url = "https://files.pythonhosted.org/packages/98/b6/be0a1ddcbac65a30c985cf7224c4fce786ba2c51e7efeb5178fe410ed3cf/ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039", size = 10982085 },
+    { url = "https://files.pythonhosted.org/packages/bb/a4/c84bc13d0b573cf7bb7d17b16d6d29f84267c92d79b2f478d4ce322e8e72/ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d", size = 8522088 },
+    { url = "https://files.pythonhosted.org/packages/74/be/fc352bd8ca40daae8740b54c1c3e905a7efe470d420a268cd62150248c91/ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117", size = 9359275 },
+    { url = "https://files.pythonhosted.org/packages/3e/14/fd026bc74ded05e2351681545a5f626e78ef831f8edce064d61acd2e6ec7/ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93", size = 8679879 },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -326,6 +351,7 @@ dependencies = [
     { name = "mypy" },
     { name = "pygithub" },
     { name = "pytz" },
+    { name = "ruff" },
     { name = "typer" },
     { name = "types-pytz" },
 ]
@@ -335,6 +361,7 @@ requires-dist = [
     { name = "mypy", specifier = ">=1.11.2" },
     { name = "pygithub", specifier = ">=2.4.0" },
     { name = "pytz", specifier = ">=2024.2" },
+    { name = "ruff", specifier = ">=0.6.9" },
     { name = "typer", specifier = ">=0.12.5" },
     { name = "types-pytz", specifier = ">=2024.2.0.20241003" },
 ]


### PR DESCRIPTION
Sometimes, issues are created outside of issue templates (which we don't prefer, but we can't prevent). This updates our top-ranking issues script such that it will add `triage` and `admin read` labels to any issue that is missing a core label, so that we don't miss the issues when doing the next triage.

Release Notes:

- N/A
