### PR TITLE
vim: Add support for insert button

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -252,6 +252,7 @@
       "@": ["vim::PushOperator", "ReplayRegister"],
       "ctrl-pagedown": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
+      "insert": "vim::InsertBefore",
       // tree-sitter related commands
       "[ x": "editor::SelectLargerSyntaxNode",
       "] x": "editor::SelectSmallerSyntaxNode",
@@ -334,7 +335,8 @@
       "ctrl-t": "vim::Indent",
       "ctrl-d": "vim::Outdent",
       "ctrl-k": ["vim::PushOperator", { "Digraph": {} }],
-      "ctrl-r": ["vim::PushOperator", "Register"]
+      "ctrl-r": ["vim::PushOperator", "Register"],
+      "insert": "vim::ToggleReplace"
     }
   },
   {
@@ -353,7 +355,8 @@
       "ctrl-k": ["vim::PushOperator", { "Digraph": {} }],
       "backspace": "vim::UndoReplace",
       "tab": "vim::Tab",
-      "enter": "vim::Enter"
+      "enter": "vim::Enter",
+      "insert": "vim::InsertBefore"
     }
   },
   {


### PR DESCRIPTION
This commit adds support for using the physical insert-button. First click toggles insert mode and subsequent clicks toggle back and forth between replace and insert mode.

Closes #19224

Release Notes:

- Added support for using the insert button for vim_mode.

