### PR TITLE
Cap the size of the Supermaven states buffer

### DIFF
--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -147,6 +147,14 @@ impl Supermaven {
                     updates_tx,
                 },
             );
+            // ensure the states map is max 1000 elements
+            if agent.states.len() > 1000 {
+                // state id is monotonic so it's sufficient to remove the first element
+                agent
+                    .states
+                    .remove(&agent.states.keys().next().unwrap().clone());
+            }
+
             let _ = agent
                 .outgoing_tx
                 .unbounded_send(OutboundMessage::StateUpdate(StateUpdateMessage {


### PR DESCRIPTION
Caps the size of the Supermaven states buffer to 1000 elements. Previously, the buffer would grow unbounded so for long sessions the number of states that the Supermaven autocomplete provider maintains can be quite large. In practice, states that are sufficiently old are so unlikely to be visited again that we can regenerate the completion. Thus, we can cap the buffer to 1000 elements.

Release Notes:

- N/A
