### PR TITLE
remote: Tidy up ssh connection progress / error display

### DIFF
--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -147,6 +147,11 @@ impl Render for SshPrompt {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let cx = cx.window_context();
         let theme = cx.theme();
+        let message = match (self.error_message.clone(), self.status_message.clone()) {
+            (Some(msg), _) => format!("SSH Error － {}", msg.trim()),
+            (_, Some(msg)) => format!("SSH Connection － {}", msg.trim()),
+            _ => "SSH Connection".to_string(),
+        };
         v_flex()
             .key_context("PasswordPrompt")
             .size_full()
@@ -176,27 +181,9 @@ impl Render for SshPrompt {
                     .child(
                         div()
                             .ml_1()
-                            .child(Label::new("SSH Connection").size(LabelSize::Small)),
-                    )
-                    .child(
-                        div()
                             .text_ellipsis()
                             .overflow_x_hidden()
-                            .when_some(self.error_message.as_ref(), |el, error| {
-                                el.child(Label::new(format!("－{}", error)).size(LabelSize::Small))
-                            })
-                            .when(
-                                self.error_message.is_none() && self.status_message.is_some(),
-                                |el| {
-                                    el.child(
-                                        Label::new(format!(
-                                            "－{}",
-                                            self.status_message.clone().unwrap()
-                                        ))
-                                        .size(LabelSize::Small),
-                                    )
-                                },
-                            ),
+                            .child(Label::new(message).size(LabelSize::Small)),
                     ),
             )
             .child(div().when_some(self.prompt.as_ref(), |el, prompt| {

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1270,14 +1270,14 @@ impl SshRemoteConnection {
         let server_mode = 0o755;
 
         let t0 = Instant::now();
-        delegate.set_status(Some("uploading remote development server"), cx);
+        delegate.set_status(Some("Uploading remote development server"), cx);
         log::info!("uploading remote development server ({}kb)", size / 1024);
         self.upload_file(src_path, &dst_path_gz)
             .await
             .context("failed to upload server binary")?;
         log::info!("uploaded remote development server in {:?}", t0.elapsed());
 
-        delegate.set_status(Some("extracting remote development server"), cx);
+        delegate.set_status(Some("Extracting remote development server"), cx);
         run_cmd(
             self.socket
                 .ssh_command("gunzip")
@@ -1286,7 +1286,7 @@ impl SshRemoteConnection {
         )
         .await?;
 
-        delegate.set_status(Some("unzipping remote development server"), cx);
+        delegate.set_status(Some("Marking remote development server executable"), cx);
         run_cmd(
             self.socket
                 .ssh_command("chmod")


### PR DESCRIPTION
I've spent a lot of time looking at these dialog boxes recently, and the weird text alignment and inconsistent capitalisation was starting to bother me ^^;;


Before:
![ps_20241014225129](https://github.com/user-attachments/assets/27168ebf-1cf6-4750-b300-40490e627475)
After (out of date - current code has a little extra padding between icon and text like the original):
![ps_20241014224714](https://github.com/user-attachments/assets/57801ae6-d391-4528-9c39-1ae714de99a7)

Before:
![ps_20241014222948](https://github.com/user-attachments/assets/3f14067c-4855-4629-a84b-2ca902857d18)
After:
![ps_20241017043200](https://github.com/user-attachments/assets/3a9db8db-afed-4667-8c92-dfc9381e3a45)

Release Notes:

- N/A

