### PR TITLE
storybook: Load GPUI with default features

### DIFF
--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -20,7 +20,7 @@ ctrlc = "3.4"
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 editor.workspace = true
 fuzzy.workspace = true
-gpui.workspace = true
+gpui = { workspace = true, default-features = true }
 indoc.workspace = true
 language.workspace = true
 log.workspace = true


### PR DESCRIPTION
This PR makes it so the Storybook loads GPUI with the default features enabled.

This fixes a panic that would occur when trying to run any of the stories.

Release Notes:

- N/A
