### PR TITLE
Make the divider rule color more muted

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -525,7 +525,7 @@ async fn parse_blocks(
                     font_family: Some(buffer_font_family),
                     ..Default::default()
                 },
-                rule_color: Color::Muted.color(cx),
+                rule_color: cx.theme().colors().border,
                 block_quote_border_color: Color::Muted.color(cx),
                 block_quote: TextStyleRefinement {
                     color: Some(Color::Muted.color(cx)),


### PR DESCRIPTION
I've been a bit annoyed by the hover divider rule being extremely bright compared to other divider rules in the UI. This PR updates their color to use the regular border color from the current theme instead of the muted (but still pretty bright) text color.

Apologies for the unsolicited PR (and please feel free to close if it goes against some other plans / designs you already have in place :).

#### Example screenshot before:
<img width="302" alt="Screenshot 2024-10-15 at 23 29 18" src="https://github.com/user-attachments/assets/7ea22808-8135-4a46-9457-e670225aebaa">

#### Example screenshot after:
<img width="312" alt="Screenshot 2024-10-15 at 23 28 16" src="https://github.com/user-attachments/assets/63ac0d02-ae6d-4962-84a2-1fdb95519b15">

***

Release Notes:

- Make the divider rule in LSP hovers more muted
