### PR TITLE
Force astro-language-server to be the primary one for Astro

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -824,6 +824,7 @@
   // Different settings for specific languages.
   "languages": {
     "Astro": {
+      "language_servers": ["astro-language-server", "..."],
       "prettier": {
         "allowed": true,
         "plugins": ["prettier-plugin-astro"]


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/19239

Overall, this hardcoding approach has to stop and Zed better show some notification/modal that proposes to select a primary language server, when launching with the language that has no such settings.

Release Notes:

- Fixed Astro LSP interactions
