### PR TITLE
ssh remoting: Fix hang when activity channel gets dropped

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -743,7 +743,11 @@ impl SshRemoteClient {
 
                 loop {
                     select_biased! {
-                        _ = connection_activity_rx.next().fuse() => {
+                        result = connection_activity_rx.next().fuse() => {
+                            if result.is_none() {
+                                log::warn!("ssh heartbeat: connection activity channel has been dropped. stopping.");
+                                return Ok(());
+                            }
                             keepalive_timer.set(cx.background_executor().timer(HEARTBEAT_INTERVAL).fuse());
                         }
                         _ = keepalive_timer => {


### PR DESCRIPTION
When the SSH command dies or the server, the channel gets dropped and the heartbeat method went into an infinite loop causing a hang.

Oversight from yesterday. Fixed now.

Release Notes:

- N/A
