### PR TITLE
Properly open worktrees when cmd-clicking in terminal or on inlay hints

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3428,7 +3428,7 @@ impl LspStore {
         language_server_name: LanguageServerName,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<Model<Buffer>>> {
-        cx.spawn(move |this, mut cx| async move {
+        cx.spawn(move |lsp_store, mut cx| async move {
             // Escape percent-encoded string.
             let current_scheme = abs_path.scheme().to_owned();
             let _ = abs_path.set_scheme("file");
@@ -3437,9 +3437,9 @@ impl LspStore {
                 .to_file_path()
                 .map_err(|_| anyhow!("can't convert URI to path"))?;
             let p = abs_path.clone();
-            let yarn_worktree = this
-                .update(&mut cx, move |this, cx| {
-                    this.as_local().unwrap().yarn.update(cx, |_, cx| {
+            let yarn_worktree = lsp_store
+                .update(&mut cx, move |lsp_store, cx| match lsp_store.as_local() {
+                    Some(local_lsp_store) => local_lsp_store.yarn.update(cx, |_, cx| {
                         cx.spawn(|this, mut cx| async move {
                             let t = this
                                 .update(&mut cx, |this, cx| {
@@ -3448,7 +3448,8 @@ impl LspStore {
                                 .ok()?;
                             t.await
                         })
-                    })
+                    }),
+                    None => Task::ready(None),
                 })?
                 .await;
             let (worktree_root_target, known_relative_path) =
@@ -3458,8 +3459,8 @@ impl LspStore {
                     (Arc::<Path>::from(abs_path.as_path()), None)
                 };
             let (worktree, relative_path) = if let Some(result) =
-                this.update(&mut cx, |this, cx| {
-                    this.worktree_store.update(cx, |worktree_store, cx| {
+                lsp_store.update(&mut cx, |lsp_store, cx| {
+                    lsp_store.worktree_store.update(cx, |worktree_store, cx| {
                         worktree_store.find_worktree(&worktree_root_target, cx)
                     })
                 })? {
@@ -3467,22 +3468,25 @@ impl LspStore {
                     known_relative_path.unwrap_or_else(|| Arc::<Path>::from(result.1));
                 (result.0, relative_path)
             } else {
-                let worktree = this
-                    .update(&mut cx, |this, cx| {
-                        this.worktree_store.update(cx, |worktree_store, cx| {
+                let worktree = lsp_store
+                    .update(&mut cx, |lsp_store, cx| {
+                        lsp_store.worktree_store.update(cx, |worktree_store, cx| {
                             worktree_store.create_worktree(&worktree_root_target, false, cx)
                         })
                     })?
                     .await?;
-                this.update(&mut cx, |this, cx| {
-                    this.register_language_server(
-                        worktree.read(cx).id(),
-                        language_server_name,
-                        language_server_id,
-                    )
-                })
-                .ok();
-                let worktree_root = worktree.update(&mut cx, |this, _| this.abs_path())?;
+                if worktree.update(&mut cx, |worktree, _| worktree.is_local())? {
+                    lsp_store
+                        .update(&mut cx, |lsp_store, cx| {
+                            lsp_store.register_language_server(
+                                worktree.read(cx).id(),
+                                language_server_name,
+                                language_server_id,
+                            )
+                        })
+                        .ok();
+                }
+                let worktree_root = worktree.update(&mut cx, |worktree, _| worktree.abs_path())?;
                 let relative_path = if let Some(known_path) = known_relative_path {
                     known_path
                 } else {
@@ -3494,12 +3498,13 @@ impl LspStore {
                 worktree_id: worktree.update(&mut cx, |worktree, _| worktree.id())?,
                 path: relative_path,
             };
-            this.update(&mut cx, |this, cx| {
-                this.buffer_store().update(cx, |buffer_store, cx| {
-                    buffer_store.open_buffer(project_path, cx)
-                })
-            })?
-            .await
+            lsp_store
+                .update(&mut cx, |lsp_store, cx| {
+                    lsp_store.buffer_store().update(cx, |buffer_store, cx| {
+                        buffer_store.open_buffer(project_path, cx)
+                    })
+                })?
+                .await
         })
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3978,17 +3978,6 @@ impl Project {
             .read(cx)
             .language_servers_for_buffer(buffer, cx)
     }
-
-    pub fn language_server_for_buffer<'a>(
-        &'a self,
-        buffer: &'a Buffer,
-        server_id: LanguageServerId,
-        cx: &'a AppContext,
-    ) -> Option<(&'a Arc<CachedLspAdapter>, &'a Arc<LanguageServer>)> {
-        self.lsp_store
-            .read(cx)
-            .language_server_for_buffer(buffer, server_id, cx)
-    }
 }
 
 fn deserialize_code_actions(code_actions: &HashMap<String, bool>) -> Vec<lsp::CodeActionKind> {

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -280,7 +280,7 @@ impl WorktreeStore {
                         id: response.worktree_id,
                         root_name,
                         visible,
-                        abs_path,
+                        abs_path: response.canonicalized_path,
                     },
                     client,
                     cx,

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2464,6 +2464,7 @@ message AddWorktree {
 
 message AddWorktreeResponse {
     uint64 worktree_id = 1;
+    string canonicalized_path = 2;
 }
 
 message UpdateUserSettings {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -275,7 +275,7 @@ impl HeadlessProject {
         let worktree = this
             .update(&mut cx.clone(), |this, _| {
                 Worktree::local(
-                    Arc::from(canonicalized),
+                    Arc::from(canonicalized.as_path()),
                     message.payload.visible,
                     this.fs.clone(),
                     this.next_entry_id.clone(),
@@ -287,6 +287,7 @@ impl HeadlessProject {
         let response = this.update(&mut cx, |_, cx| {
             worktree.update(cx, |worktree, _| proto::AddWorktreeResponse {
                 worktree_id: worktree.id().to_proto(),
+                canonicalized_path: canonicalized.to_string_lossy().to_string(),
             })
         })?;
 


### PR DESCRIPTION
* uses the state that's synced, to fetch the language server name
* uses proper, canonicalized path when creating a remote ssh worktree, otherwise `~/foo/something` stays unexpanded

Release Notes:

- N/A
