### PR TITLE
collab: Refresh the user's LLM token when their subscription changes

### DIFF
--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -132,6 +132,8 @@ async fn main() -> Result<()> {
                     let rpc_server = collab::rpc::Server::new(epoch, state.clone());
                     rpc_server.start().await?;
 
+                    poll_stripe_events_periodically(state.clone(), rpc_server.clone());
+
                     app = app
                         .merge(collab::api::routes(rpc_server.clone()))
                         .merge(collab::rpc::routes(rpc_server.clone()));
@@ -140,7 +142,6 @@ async fn main() -> Result<()> {
                 }
 
                 if mode.is_api() {
-                    poll_stripe_events_periodically(state.clone());
                     fetch_extensions_from_blob_store_periodically(state.clone());
                     spawn_user_backfiller(state.clone());
 


### PR DESCRIPTION
This PR makes it so collab will trigger a refresh for a user's LLM token whenever their subscription changes.

This allows us to proactively push down changes to their subscription.

In order to facilitate this, the Stripe event processing has been moved from the `api` service to the `collab` service in order to access the RPC server.

Release Notes:

- N/A
