### PR TITLE
collab: Add Stripe API key to Kubernetes template

### DIFF
--- a/crates/collab/k8s/collab.template.yml
+++ b/crates/collab/k8s/collab.template.yml
@@ -199,6 +199,12 @@ spec:
                 secretKeyRef:
                   name: slack
                   key: panics_webhook
+            - name: STRIPE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: stripe
+                  key: api_key
+                  optional: true
             - name: COMPLETE_WITH_LANGUAGE_MODEL_RATE_LIMIT_PER_HOUR
               value: "1000"
             - name: SUPERMAVEN_ADMIN_API_KEY


### PR DESCRIPTION
This PR adds the Stripe API key to the Kubernetes template.

It's optional right now, so we can set the API key when we're ready.

Release Notes:

- N/A
