### PR TITLE
Support uppercase extensions in image preview

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -36,7 +36,9 @@ impl project::Item for ImageItem {
             .path
             .extension()
             .and_then(OsStr::to_str)
+            .map(str::to_lowercase)
             .unwrap_or_default();
+        let ext = ext.as_str();
 
         // Only open the item if it's a binary image (no SVGs, etc.)
         // Since we do not have a way to toggle to an editor


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/19276

Release Notes:

- Add support for detecting images with non-lowercase file extensions