### PR TITLE
collab: Add context to errors syncing billing events to Stripe

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -748,6 +748,7 @@ pub fn sync_llm_usage_with_stripe_periodically(app: Arc<AppState>) {
             loop {
                 sync_with_stripe(&app, &llm_db, &stripe_billing)
                     .await
+                    .context("failed to sync LLM usage to Stripe")
                     .trace_err();
                 executor.sleep(SYNC_LLM_USAGE_WITH_STRIPE_INTERVAL).await;
             }


### PR DESCRIPTION
This PR adds context to errors that occur when trying to sync billing events to Stripe.

Release Notes:

- N/A
