### PR TITLE
keymaps: Fix how single line editor handles new lines in BufferSearch

### DIFF
--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -59,6 +59,12 @@
     }
   },
   {
+    "context": "BufferSearchBar > Editor",
+    "bindings": {
+      "shift-enter": "search::SelectPrevMatch"
+    }
+  },
+  {
     "context": "Workspace",
     "bindings": {
       "cmd-shift-o": "file_finder::Toggle",


### PR DESCRIPTION
This PR updates the JetBrains keymaps preset to handle the `shift-enter` combination as the `SelectPrevMatch` action.

That is, it seems that, with the current defaults, pressing the Shift+Enter inside the search editor (`single_line` mode Editor inside the `BufferSearchBar`) triggers the "Editor::newline". With the updated defaults, it works as I expect it.

~~Also, the PR adds the `alt-enter` in the context of the editor inside the `BufferSearchBar` to trigger the newline. This matches with how it works in other editors on macOS, e.g. in Xcode.~~

Release Notes:

- N/A

