### PR TITLE
ssh: Remove server count from modal header

### DIFF
--- a/crates/recent_projects/src/dev_servers.rs
+++ b/crates/recent_projects/src/dev_servers.rs
@@ -1160,17 +1160,10 @@ impl DevServerProjects {
             )
             .into_any_element();
 
-        let server_count = format!("Servers: {}", ssh_connections.len());
-
         Modal::new("remote-projects", Some(self.scroll_handle.clone()))
             .header(
-                ModalHeader::new().child(
-                    h_flex()
-                        .items_center()
-                        .justify_between()
-                        .child(Headline::new("Remote Projects (alpha)").size(HeadlineSize::XSmall))
-                        .child(Label::new(server_count).size(LabelSize::Small)),
-                ),
+                ModalHeader::new()
+                    .child(Headline::new("Remote Projects (alpha)").size(HeadlineSize::XSmall)),
             )
             .section(
                 Section::new().padded(false).child(


### PR DESCRIPTION
The server count was something that existed since the remote development implementation and we just kept it there without a lot of critical thinking. However, it doesn't feel like it's particularly useful yet, which means that, at least for now, we could clean it up more and wait for further feedback to add it back, if ever requested. 

Release Notes:

- N/A
