### PR TITLE
Make terminal.option_as_meta=false in default settings

### DIFF
--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -151,7 +151,7 @@ pub struct TerminalSettingsContent {
     pub alternate_scroll: Option<AlternateScroll>,
     /// Sets whether the option key behaves as the meta key.
     ///
-    /// Default: true
+    /// Default: false
     pub option_as_meta: Option<bool>,
     /// Whether or not selecting text in the terminal will automatically
     /// copy to the system clipboard.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1498,13 +1498,13 @@ List of `integer` column numbers
         "directories": [".env", "env", ".venv", "venv"],
         "activate_script": "default"
       }
-    }
+    },
     "env": {},
     "font_family": null,
     "font_features": null,
     "font_size": null,
     "line_height": "comfortable",
-    "option_as_meta": true,
+    "option_as_meta": false,
     "button": false,
     "shell": {},
     "toolbar": {


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/17057
- Closes: https://github.com/zed-industries/zed/issues/16730
- Closes: https://github.com/zed-industries/zed/issues/15964
- Closes: https://github.com/zed-industries/zed/issues/19201

This reverts the change I made in https://github.com/zed-industries/zed/pull/15535 which set `option_as_meta` to `true` in the default settings.

`true` is a reasonable default for US Keyboards, but is terrible for many others which rely on `alt+<key>` for totally normal keystroke combinations.

Our intention is to support individual mapping of left_alt / right_alt actions (e.g. meta / alt) as part of the work discussed here:
- https://github.com/zed-industries/zed/discussions/17031 

Release Notes:

- Settings: Change `terminal.option_as_meta` default from `true` to `false` for better out-of-the-box experience on non-US keyboards. Terminal Emacs users will want to set this to `true`. 
