### PR TITLE
Update all occurrences of `option_as_meta` to new default value

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -712,10 +712,10 @@
     // May take 2 values:
     //  1. Rely on default platform handling of option key, on macOS
     //     this means generating certain unicode characters
-    //         "option_to_meta": false,
+    //         "option_as_meta": false,
     //  2. Make the option keys behave as a 'meta' key, e.g. for emacs
-    //         "option_to_meta": true,
-    "option_as_meta": true,
+    //         "option_as_meta": true,
+    "option_as_meta": false,
     // Whether or not selecting text in the terminal will automatically
     // copy to the system clipboard.
     "copy_on_select": false,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1732,7 +1732,7 @@ See Buffer Font Features
 
 - Description: Re-interprets the option keys to act like a 'meta' key, like in Emacs.
 - Setting: `option_as_meta`
-- Default: `true`
+- Default: `false`
 
 **Options**
 


### PR DESCRIPTION
This PR is a quick follow-up to #19364 which updates some left-out occurrences of `option_as_meta` to the new default value (`false`). 

CC @notpeter 

Release Notes:

- N/A
