### PR TITLE
Remove duplicate `load_system_fonts`call 

### DIFF
--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -36,10 +36,8 @@ struct CosmicTextSystemState {
 
 impl CosmicTextSystem {
     pub(crate) fn new() -> Self {
-        let mut font_system = FontSystem::new();
-
         // todo(linux) make font loading non-blocking
-        font_system.db_mut().load_system_fonts();
+        let mut font_system = FontSystem::new();
 
         Self(RwLock::new(CosmicTextSystemState {
             font_system,


### PR DESCRIPTION
Related comment on issue https://github.com/zed-industries/zed/issues/14222#issuecomment-2418375056

On `crates/gpui/src/platform/linux/text_system.rs` on method `CosmicTextSystem::new` `load_system_fonts` is being called twice: 
```rust
    pub(crate) fn new() -> Self {
        let mut font_system = FontSystem::new();

        // todo(linux) make font loading non-blocking
        font_system.db_mut().load_system_fonts();

        Self(RwLock::new(CosmicTextSystemState {
            font_system,
            swash_cache: SwashCache::new(),
            scratch: ShapeBuffer::default(),
            loaded_fonts_store: Vec::new(),
            font_ids_by_family_cache: HashMap::default(),
            postscript_names: HashMap::default(),
        }))
    }
```

First one on `FontSystem::new()` and second one is explicit on `font_system.db_mut().load_system_fonts()`. The first call `FontSystem::new()` is defined as: 
```
    pub fn new() -> Self {
        Self::new_with_fonts(core::iter::empty())
    }
```
And `new_with_fonts`: 
```rust
    /// Create a new [`FontSystem`] with a pre-specified set of fonts.
    pub fn new_with_fonts(fonts: impl IntoIterator<Item = fontdb::Source>) -> Self {
        let locale = Self::get_locale();
        log::debug!("Locale: {}", locale);

        let mut db = fontdb::Database::new();

        //TODO: configurable default fonts
        db.set_monospace_family("Fira Mono");
        db.set_sans_serif_family("Fira Sans");
        db.set_serif_family("DejaVu Serif");

        Self::load_fonts(&mut db, fonts.into_iter());

        Self::new_with_locale_and_db(locale, db)
    }
```
Finally `Self::load_fonts(&mut db, fonts.into_iter())` calls `load_system_fonts`: 
```rust
    #[cfg(feature = "std")]
    fn load_fonts(db: &mut fontdb::Database, fonts: impl Iterator<Item = fontdb::Source>) {
        #[cfg(not(target_arch = "wasm32"))]
        let now = std::time::Instant::now();

        db.load_system_fonts();

        for source in fonts {
            db.load_font_source(source);
        }
        ...
```

Release Notes:

- Remove duplicate font loading on Linux
