### PR TITLE
Always have cmd-o open a local project

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1889,11 +1889,7 @@ impl Workspace {
                 directories: true,
                 multiple: true,
             },
-            if self.project.read(cx).is_via_ssh() {
-                DirectoryLister::Project(self.project.clone())
-            } else {
-                DirectoryLister::Local(self.app_state.fs.clone())
-            },
+            DirectoryLister::Local(self.app_state.fs.clone()),
             cx,
         );
 


### PR DESCRIPTION
Release Notes:

- Fixed `cmd-o` in an SSH project to always open a local project 
