### PR TITLE
remote: Polish for connection progress & error dialogs

### DIFF
--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -175,7 +175,7 @@ impl Render for SshPrompt {
             .child(
                 h_flex()
                     .p_2()
-                    .flex_wrap()
+                    .flex()
                     .child(if self.error_message.is_some() {
                         Icon::new(IconName::XCircle)
                             .size(IconSize::Medium)
@@ -195,6 +195,7 @@ impl Render for SshPrompt {
                     })
                     .child(
                         div()
+                            .ml_1()
                             .text_ellipsis()
                             .overflow_x_hidden()
                             .when_some(self.error_message.as_ref(), |el, error| {
@@ -205,7 +206,7 @@ impl Render for SshPrompt {
                                 |el| {
                                     el.child(
                                         Label::new(format!(
-                                            "－{}…",
+                                            "{}…",
                                             self.status_message.clone().unwrap()
                                         ))
                                         .size(LabelSize::Small),

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1321,7 +1321,10 @@ impl SshRemoteConnection {
             let mut stderr = master_process.stderr.take().unwrap();
             stderr.read_to_end(&mut output).await?;
 
-            let error_message = format!("failed to connect: {}", String::from_utf8_lossy(&output));
+            let error_message = format!(
+                "failed to connect: {}",
+                String::from_utf8_lossy(&output).trim()
+            );
             delegate.set_error(error_message.clone(), cx);
             Err(anyhow!(error_message))?;
         }
@@ -1382,14 +1385,14 @@ impl SshRemoteConnection {
         let server_mode = 0o755;
 
         let t0 = Instant::now();
-        delegate.set_status(Some("uploading remote development server"), cx);
+        delegate.set_status(Some("Uploading remote development server"), cx);
         log::info!("uploading remote development server ({}kb)", size / 1024);
         self.upload_file(&src_path, &dst_path_gz)
             .await
             .context("failed to upload server binary")?;
         log::info!("uploaded remote development server in {:?}", t0.elapsed());
 
-        delegate.set_status(Some("extracting remote development server"), cx);
+        delegate.set_status(Some("Extracting remote development server"), cx);
         run_cmd(
             self.socket
                 .ssh_command("gunzip")
@@ -1398,7 +1401,7 @@ impl SshRemoteConnection {
         )
         .await?;
 
-        delegate.set_status(Some("unzipping remote development server"), cx);
+        delegate.set_status(Some("Marking remote development server executable"), cx);
         run_cmd(
             self.socket
                 .ssh_command("chmod")


### PR DESCRIPTION
Before/after:
![err1-before](https://github.com/user-attachments/assets/43d959b3-c9d9-45dd-938e-42d34ec1cfc5)
![err1-after](https://github.com/user-attachments/assets/311d53e0-752c-4eb8-9816-64b1970c228d)

Before/after (I feel like text-wrapping would be more useful than text-ellipsis here, but I don't see any wrap function):
![err2-before](https://github.com/user-attachments/assets/1626cda9-bf06-43fe-9b7d-3ec64f4db08a)
![err2-after](https://github.com/user-attachments/assets/749a6950-1409-4e75-808e-a1a96dbfc87e)

Before/after:
![prog-before](https://github.com/user-attachments/assets/f5f5a171-db42-4797-bab0-ad71c750bb20)
![prog-after](https://github.com/user-attachments/assets/b52a7694-36f6-4f7a-8a90-ceb223f12ec1)

Release Notes:

- N/A
