### PR TITLE
Fix incorrect checkbox placement in Markdown preview

### DIFF
--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -484,7 +484,10 @@ impl<'a> MarkdownParser<'a> {
         let (_, list_source_range) = self.previous().unwrap();
 
         let mut items = Vec::new();
-        let mut items_stack = vec![MarkdownListItem { content: Vec::new(), item_type: None }];
+        let mut items_stack = vec![MarkdownListItem {
+            content: Vec::new(),
+            item_type: None,
+        }];
         let mut depth = 1;
         let mut order = order;
         let mut order_stack = Vec::new();
@@ -525,7 +528,10 @@ impl<'a> MarkdownParser<'a> {
                     start_item_range = source_range.clone();
 
                     self.cursor += 1;
-                    items_stack.push(MarkdownListItem { content: Vec::new(), item_type: None });
+                    items_stack.push(MarkdownListItem {
+                        content: Vec::new(),
+                        item_type: None,
+                    });
 
                     let mut is_task_list = None;
                     // Check for task list marker (`- [ ]` or `- [x]`)
@@ -536,7 +542,8 @@ impl<'a> MarkdownParser<'a> {
                         }
 
                         if let Some((Event::TaskListMarker(checked), range)) = self.current() {
-                            is_task_list = Some(ParsedMarkdownListItemType::Task(*checked, range.clone()));
+                            is_task_list =
+                                Some(ParsedMarkdownListItemType::Task(*checked, range.clone()));
                             self.cursor += 1;
                         }
                     }
@@ -553,7 +560,8 @@ impl<'a> MarkdownParser<'a> {
                                     content.item_type = Some(task_list)
                                 } else if let Some(order) = order {
                                     content.content.push(block);
-                                    content.item_type = Some(ParsedMarkdownListItemType::Ordered(order))
+                                    content.item_type =
+                                        Some(ParsedMarkdownListItemType::Ordered(order))
                                 } else {
                                     content.content.push(block);
                                     content.item_type = Some(ParsedMarkdownListItemType::Unordered);
@@ -733,7 +741,6 @@ mod tests {
     use gpui::BackgroundExecutor;
     use language::{tree_sitter_rust, HighlightId, Language, LanguageConfig, LanguageMatcher};
     use pretty_assertions::assert_eq;
-    use gpui::KeyBindingContextPredicate::Or;
     use ParsedMarkdownListItemType::*;
 
     async fn parse(input: &str) -> ParsedMarkdown {
@@ -979,7 +986,7 @@ Some other content
 1. Number A
 ",
         )
-            .await;
+        .await;
 
         assert_eq!(
             parsed.children,


### PR DESCRIPTION
- Closes #12515

Before fix:
<img width="1506" alt="Screenshot 2024-10-17 at 09 50 19" src="https://github.com/user-attachments/assets/250f50cb-0119-4b96-bc9b-7258aa83247c">

After fix:
<img width="1027" alt="Screenshot 2024-10-17 at 09 52 36" src="https://github.com/user-attachments/assets/c2eb7e4a-3c03-466c-b215-7fcc22eed024">

Testing:
- Manual testing 
- Added unit test

Test results, these tests fail on the main branch for my setup as well, I have docker running but still had some failures:
```
failures:
    tests::integration_tests::test_context_collaboration_with_reconnect
    tests::integration_tests::test_formatting_buffer
    tests::integration_tests::test_fs_operations
    tests::integration_tests::test_git_branch_name
    tests::integration_tests::test_git_diff_base_change
    tests::integration_tests::test_git_status_sync
    tests::integration_tests::test_join_after_restart
    tests::integration_tests::test_join_call_after_screen_was_shared
    tests::integration_tests::test_joining_channels_and_calling_multiple_users_simultaneously
    tests::integration_tests::test_leaving_project
    tests::integration_tests::test_leaving_worktree_while_opening_buffer
    tests::integration_tests::test_local_settings
    tests::integration_tests::test_lsp_hover
    tests::integration_tests::test_mute_deafen
    tests::integration_tests::test_open_buffer_while_getting_definition_pointing_to_it
    tests::integration_tests::test_pane_split_left
    tests::integration_tests::test_prettier_formatting_buffer
    tests::integration_tests::test_preview_tabs
    tests::integration_tests::test_project_reconnect
    tests::integration_tests::test_project_search
    tests::integration_tests::test_project_symbols
    tests::integration_tests::test_propagate_saves_and_fs_changes
    tests::integration_tests::test_references
    tests::integration_tests::test_reloading_buffer_manually
    tests::integration_tests::test_right_click_menu_behind_collab_panel
    tests::integration_tests::test_room_location
    tests::integration_tests::test_room_uniqueness
    tests::integration_tests::test_server_restarts
    tests::integration_tests::test_unshare_project
    tests::notification_tests::test_notifications
    tests::random_project_collaboration_tests::test_random_project_collaboration
    tests::remote_editing_collaboration_tests::test_sharing_an_ssh_remote_project

test result: FAILED. 156 passed; 32 failed; 0 ignored; 0 measured; 0 filtered out; finished in 100.98s
```
Comments:
I do not have a ton of rust knowledge, so very open to feedback. TYSM

Release Notes:

- Fix Incorrect checkbox placement in Markdown preview