### PR TITLE
ci: Check spelling separately from formatting

### DIFF
--- a/.github/actions/check_style/action.yml
+++ b/.github/actions/check_style/action.yml
@@ -4,11 +4,6 @@ description: "Checks code formatting use cargo fmt"
 runs:
   using: "composite"
   steps:
-    - name: Check for Typos with Typos-CLI
-      uses: crate-ci/typos@v1.24.6
-      with:
-        config: ./typos.toml
-
     - name: cargo fmt
       shell: bash -euxo pipefail {0}
       run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Run style checks
         uses: ./.github/actions/check_style
 
+      - name: Check for typos
+        uses: crate-ci/typos@v1.24.6
+        with:
+          config: ./typos.toml
+
   macos_tests:
     timeout-minutes: 60
     name: (macOS) Run Clippy and tests


### PR DESCRIPTION
This PR moves the spelling check out of the `check_style` action, which we can leave for just checking formatting.

We can't use the `crates-ci-typos` action as-is on the macOS runners due to the absence of `wget`.

Release Notes:

- N/A
