### PR TITLE
paths: Update doc comment

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -101,10 +101,10 @@ pub fn logs_dir() -> &'static PathBuf {
     })
 }
 
-/// Returns the path to the zed server directory on this ssh host.
+/// Returns the path to the Zed server directory on this SSH host.
 pub fn remote_server_state_dir() -> &'static PathBuf {
     static REMOTE_SERVER_STATE: OnceLock<PathBuf> = OnceLock::new();
-    REMOTE_SERVER_STATE.get_or_init(|| return support_dir().join("server_state"))
+    REMOTE_SERVER_STATE.get_or_init(|| support_dir().join("server_state"))
 }
 
 /// Returns the path to the `Zed.log` file.


### PR DESCRIPTION
This PR updates a doc comment to use proper capitalization.

Also removes an unneeded `return`.

Release Notes:

- N/A
