### PR TITLE
scrollbar: Fix horizontal scrollbar display overflow last item

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2701,7 +2701,6 @@ impl ProjectPanel {
                 .cursor_default()
                 .when(self.width.is_some(), |this| {
                     this.children(Scrollbar::horizontal(
-                        //percentage as f32..end_offset as f32,
                         self.horizontal_scrollbar_state.clone(),
                     ))
                 }),
@@ -2918,7 +2917,9 @@ impl Render for ProjectPanel {
                     .track_scroll(self.scroll_handle.clone()),
                 )
                 .children(self.render_vertical_scrollbar(cx))
-                .children(self.render_horizontal_scrollbar(cx))
+                .when_some(self.render_horizontal_scrollbar(cx), |this, scrollbar| {
+                    this.pb_4().child(scrollbar)
+                })
                 .children(self.context_menu.as_ref().map(|(menu, position, _)| {
                     deferred(
                         anchored()


### PR DESCRIPTION
currently, the laste item display is overflow by scrollbar, cause it cannot clickable.
So remain one item height for display horizontal scrollbar,.
![Screenshot 2024-10-18 192352](https://github.com/user-attachments/assets/d686f0e8-93f8-426e-8816-6f00ed17a599)



Release Notes:

- N/A 
