### PR TITLE
ssh remoting: Undo the spawning of message handlers

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1526,19 +1526,16 @@ impl ChannelClient {
                             cx.clone(),
                         ) {
                             log::debug!("ssh message received. name:{type_name}");
-                            cx.foreground_executor().spawn(async move {
-                                match future.await {
-                                    Ok(_) => {
-                                        log::debug!("ssh message handled. name:{type_name}");
-                                    }
-                                    Err(error) => {
-                                        log::error!(
-                                            "error handling message. type:{type_name}, error:{error}",
-                                        );
-                                    }
+                            match future.await {
+                                Ok(_) => {
+                                    log::debug!("ssh message handled. name:{type_name}");
                                 }
-                            }).detach();
-
+                                Err(error) => {
+                                    log::error!(
+                                        "error handling message. type:{type_name}, error:{error}",
+                                    );
+                                }
+                            }
                         } else {
                             log::error!("unhandled ssh message name:{type_name}");
                         }


### PR DESCRIPTION
I suspect that this might have something to do with saving files not being possible after a while.

I want to merge this and bump nightly.

Release Notes:

- N/A
