### PR TITLE
Fix empty keystroke with simulated IME

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -146,7 +146,7 @@ impl Keystroke {
                 "space" => Some(" ".into()),
                 "tab" => Some("\t".into()),
                 "enter" => Some("\n".into()),
-                key if !is_printable_key(key) => None,
+                key if !is_printable_key(key) || key.is_empty() => None,
                 key => {
                     if self.modifiers.shift {
                         Some(key.to_uppercase())


### PR DESCRIPTION
Closes #19181

When the keystroke was empty ("") the `ime_key` was converted from `None` to `Some("")` when `with_simulated_ime` was called. That was leading to not intentional behavior when an empty keystroke was combined with `shift-up` in a keybinding `["workspace::SendKeystrokes",  "shift-up "]`. 

By adding a `key.is_empty()` we make sure the `ime_key` keeps as `None`. 

This was manually tested. 

Release Notes:

- Fixed empty keystroke with simulated ime
