### PR TITLE
keymap: Add cmd-o 'Go to symbol' for JetBrains MacOS key bindings

### DIFF
--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -34,7 +34,7 @@
       "cmd-]": "pane::GoForward",
       "alt-f7": "editor::FindAllReferences",
       "cmd-alt-f7": "editor::FindAllReferences",
-      "cmd-b": "editor::GoToDefinition",
+      "cmd-b": "editor::GoToDefinition", // Conflicts with workspace::ToggleLeftDock
       "cmd-alt-b": "editor::GoToDefinitionSplit",
       "cmd-shift-b": "editor::GoToTypeDefinition",
       "cmd-alt-shift-b": "editor::GoToTypeDefinitionSplit",
@@ -64,7 +64,8 @@
       "cmd-shift-o": "file_finder::Toggle",
       "cmd-shift-a": "command_palette::Toggle",
       "shift shift": "command_palette::Toggle",
-      "cmd-alt-o": "project_symbols::Toggle",
+      "cmd-alt-o": "project_symbols::Toggle", // JetBrains: Go to Symbol
+      "cmd-o": "project_symbols::Toggle", // JetBrains: Go to Class
       "cmd-1": "workspace::ToggleLeftDock",
       "cmd-6": "diagnostics::Deploy"
     }


### PR DESCRIPTION
Reported on Discord 

<img width="933" alt="Screenshot 2024-10-18 at 9 49 04" src="https://github.com/user-attachments/assets/4c7a3789-5a1b-4ca8-8c11-1e78774b8766">

<img width="308" alt="Screenshot 2024-10-18 at 9 49 59" src="https://github.com/user-attachments/assets/fecdebe7-6300-425a-ab17-1f1cd8d48d06">

Release Notes:

- N/A
