### PR TITLE
Treat `.postcss` files as CSS

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -128,6 +128,7 @@
     "php": "php",
     "plist": "template",
     "png": "image",
+    "postcss": "css",
     "ppt": "document",
     "pptx": "document",
     "prettierignore": "prettier",

--- a/crates/languages/src/css/config.toml
+++ b/crates/languages/src/css/config.toml
@@ -1,6 +1,6 @@
 name = "CSS"
 grammar = "css"
-path_suffixes = ["css"]
+path_suffixes = ["css", "postcss"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
This PR makes it so `.postcss` files are recognized as CSS.

The `tree-sitter-css` grammar has basic support for PostCSS: https://github.com/tree-sitter/tree-sitter-css/issues/17#issuecomment-1830349808.

Closes #18051.

Release Notes:

- `.postcss` files are now recognized as CSS.
