### PR TITLE
svelte: Adjust block keyword highlighting

### DIFF
--- a/extensions/svelte/languages/svelte/highlights.scm
+++ b/extensions/svelte/languages/svelte/highlights.scm
@@ -20,6 +20,7 @@
     )
 )
 
+; Style self-closing component attributes as @tag.property
 (self_closing_tag
     (
         (tag_name) @_tag_name
@@ -77,19 +78,19 @@
 ; Treating (if, each, ...) as a keyword inside of blocks
 ; like {#if ...} or {#each ...}
 (block_start_tag
-    tag: _ @tag.keyword
+    tag: _ @keyword
 )
 
 (block_tag
-    tag: _ @tag.keyword
+    tag: _ @keyword
 )
 
 (block_end_tag
-    tag: _ @tag.keyword
+    tag: _ @keyword
 )
 
 (expression_tag
-    tag: _ @tag.keyword
+    tag: _ @keyword
 )
 
 ; Style quoted string attribute values

--- a/extensions/svelte/languages/svelte/injections.scm
+++ b/extensions/svelte/languages/svelte/injections.scm
@@ -55,7 +55,7 @@
     (#set! "language" "ts")
 )
 
-; Match style tags with a lang attribute
+; Match <style lang="language"> as the specified language
 (style_element
     (start_tag
         (attribute
@@ -69,7 +69,7 @@
     (raw_text) @content
 )
 
-; Match style tags without a lang attribute
+; Match <style> tags without a lang attribute as CSS
 (style_element
     (start_tag
         (attribute
@@ -81,6 +81,4 @@
     (#set! language "css")
 )
 
-
-; Downstream TODO: Style highlighting for `style:background="red"` and `style="background: red"` strings
-; Downstream TODO: Style component comments as markdown
+; Downstream TODO: Style @component comments as markdown


### PR DESCRIPTION
This PR adjusts the highlights for `{#each ...}` and `{#if ...}` expression blocks to use keyword highlighting.

Extracted from https://github.com/zed-industries/zed/pull/18052.

Release Notes:

- N/A
