### PR TITLE
vue: Support `lang` attribute for `style` tag injections

### DIFF
--- a/extensions/vue/languages/vue/injections.scm
+++ b/extensions/vue/languages/vue/injections.scm
@@ -54,7 +54,28 @@
     (attribute_value) @content
     (#set! "language" "typescript")))
 
-; TODO: support less/sass/scss
+; Vue <style lang="css"> injections
 (style_element
-  (raw_text) @content
-  (#set! "language" "css"))
+    (start_tag
+        (attribute
+            (attribute_name) @_attr_name
+            (#eq? @_attr_name "lang")
+            (quoted_attribute_value
+                (attribute_value) @language
+            )
+        )
+    )
+    (raw_text) @content
+)
+
+; Vue <style> css injections (no lang attribute)
+(style_element
+    (start_tag
+        (attribute
+            (attribute_name) @_attr_name
+        )*
+    )
+    (raw_text) @content
+    (#not-any-of? @_attr_name "lang")
+    (#set! language "css")
+)


### PR DESCRIPTION
This PR adds support for injecting languages into `<style>` tags using `<style lang="...">` in Vue.

Extracted from https://github.com/zed-industries/zed/pull/18052.

Release Notes:

- N/A
