### PR TITLE
svelte: Bump to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14866,7 +14866,7 @@ dependencies = [
 
 [[package]]
 name = "zed_svelte"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/svelte/Cargo.toml
+++ b/extensions/svelte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_svelte"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/svelte/extension.toml
+++ b/extensions/svelte/extension.toml
@@ -1,7 +1,7 @@
 id = "svelte"
 name = "Svelte"
 description = "Svelte support"
-version = "0.2.0"
+version = "0.2.1"
 schema_version = 1
 authors = []
 repository = "https://github.com/zed-extensions/svelte"


### PR DESCRIPTION
This PR bumps the Svelte extension to v0.2.1.

Changes:

- https://github.com/zed-industries/zed/pull/19418

Release Notes:

- N/A
