### PR TITLE
vue: Bump to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14901,7 +14901,7 @@ dependencies = [
 
 [[package]]
 name = "zed_vue"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "zed_extension_api 0.1.0",

--- a/extensions/vue/Cargo.toml
+++ b/extensions/vue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_vue"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/vue/extension.toml
+++ b/extensions/vue/extension.toml
@@ -1,7 +1,7 @@
 id = "vue"
 name = "Vue"
 description = "Vue support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Vue extension to v0.1.1.

Changes:

- https://github.com/zed-industries/zed/pull/19419

Release Notes:

- N/A
