### PR TITLE
lsp: Handle unregistration "textDocument/rename" from a server

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6057,6 +6057,16 @@ impl LspStore {
                                         );
                                     })?;
                                 }
+                                "textDocument/rename" => {
+                                    this.update(&mut cx, |this, _| {
+                                        if let Some(server) = this.language_server_for_id(server_id)
+                                        {
+                                            server.update_capabilities(|capabilities| {
+                                                capabilities.rename_provider = None
+                                            })
+                                        }
+                                    })?;
+                                }
                                 "textDocument/rangeFormatting" => {
                                     this.update(&mut cx, |this, _| {
                                         if let Some(server) = this.language_server_for_id(server_id)


### PR DESCRIPTION
Hi. While working on https://github.com/zed-industries/zed/pull/19230 I noticed that some servers send a request to unregistered the `textDocument/rename` capability. I thought it would be good to handle that message in Zed:

```plaintext
[2024-10-18T21:25:07+02:00 WARN  project::lsp_store] unhandled capability unregistration: Unregistration { id: "biome_rename", method: "textDocument/rename" }
```

So this pull request implements that. Thanks.

Release Notes:

- N/A
