### PR TITLE
Prefer users to open new issues if closed stale issue is valid

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -17,7 +17,7 @@ jobs:
             We're working to clean up our issue tracker by closing older issues that might not be relevant anymore. Are you able to reproduce this issue in the latest version of Zed? If so, please let us know by commenting on this issue and we will keep it open; otherwise, we'll close it in 7 days. Feel free to open a new issue if you're seeing this message after the issue has been closed.
 
             Thanks for your help!
-          close-issue-message: "This issue was closed due to inactivity. If you're still experiencing this problem, feel free to ping a Zed team member to reopen this issue or open a new one."
+            close-issue-message: "This issue was closed due to inactivity. If you're still experiencing this problem, please open a new issue with a link to this issue."
           # We will increase `days-before-stale` to 365 on or after Jan 24th,
           # 2024. This date marks one year since migrating issues from
           # 'community' to 'zed' repository. The migration added activity to all


### PR DESCRIPTION
I no longer want to have to keep my ears and eyes open for GitHub notifications that relate to someone requesting a closed stale issue be reopened. As a community maintainer, I can get hundreds or even thousands of notifications a week, and a lot of those are about activity on closed issues. If everyone following an issue did not react fast enough (7 days) to keep an issue flagged as `stale` open, let's instruct them to open new issues, so we are forced to see it during next triage.

Release Notes:

- N/A
