### PR TITLE
collab: Unconditionally execute billing checks

### DIFF
--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -198,10 +198,6 @@ impl Config {
         }
     }
 
-    pub fn is_llm_billing_enabled(&self) -> bool {
-        self.stripe_api_key.is_some()
-    }
-
     #[cfg(test)]
     pub fn test() -> Self {
         Self {


### PR DESCRIPTION
This PR removes the conditional checks around the billing-related enforcement for LLM completions.

These were just in place to prevent executing any billing code before we had rolled it out. Now that it is rolled out, we don't need this conditional execution anymore.

Release Notes:

- N/A
