### PR TITLE
docs: Update info on JDTLS install for Java

### DIFF
--- a/docs/src/languages/java.md
+++ b/docs/src/languages/java.md
@@ -42,8 +42,8 @@ You can add these customizations to your Zed Settings by launching {#action zed:
   "lsp": {
     "jdtls": {
       "settings": {
-        "version": "1.40.0" // jdtls version to download and use
-        //        "classpath": "/path/to/classes.jar:/path/to/more/classes/"
+        "version": "1.40.0", // jdtls version to download and use
+        "classpath": "/path/to/classes.jar:/path/to/more/classes/"
       },
       "initialization_options": {}
     }

--- a/docs/src/languages/java.md
+++ b/docs/src/languages/java.md
@@ -25,9 +25,9 @@ Or manually download and install [OpenJDK 23](https://jdk.java.net/23/).
 
 ### (Optional) Install JDTLS
 
-If you are using Java with Eclipse JDTLS, you can skip this section as it will automatically download a binary for you.
+Both extensions will automatically download a binary for you.
 
-If you are using Zed Java you need to install your own copy of Eclipse JDT Language Server (`eclipse.jdt.ls`).
+If you would prefer, you can install JDTLS yourself and both extensions will use the version you install instead.
 
 - MacOS: `brew install jdtls`
 - Arch: [`jdtls` from AUR](https://aur.archlinux.org/packages/jdtls)
@@ -36,6 +36,21 @@ Or manually download install:
 
 - [JDTLS Milestone Builds](http://download.eclipse.org/jdtls/milestones/) (updated every two weeks)
 - [JDTLS Snapshot Builds](https://download.eclipse.org/jdtls/snapshots/) (frequent updates)
+
+If you are using Zed Java you can also specify a specific version of JDTLS you would like the extension to download, per-project or globally.
+For example:
+
+```json
+{
+  "lsp": {
+    "jdtls": {
+      "settings": {
+        "version": "1.40.0"
+      }
+    }
+  }
+}
+```
 
 ## Extension Install
 
@@ -88,15 +103,16 @@ If you have issues with either of these plugins, please open issues on their res
 
 ## Example Configs
 
-### Zed Java Classpath
+### Zed Java Settings
 
-You can optionally configure the class path that JDTLS uses with:
+You can optionally configure the version of JDTLS to download (see <#optional-install-jdtls>) or the class path that JDTLS uses with:
 
 ```json
 {
   "lsp": {
     "jdtls": {
       "settings": {
+        "version": "1.40.0", // This is the default value
         "classpath": "/path/to/classes.jar:/path/to/more/classes/"
       }
     }

--- a/docs/src/languages/java.md
+++ b/docs/src/languages/java.md
@@ -43,7 +43,7 @@ You can add these customizations to your Zed Settings by launching {#action zed:
     "jdtls": {
       "settings": {
         "version": "1.40.0" // jdtls version to download and use
-//        "classpath": "/path/to/classes.jar:/path/to/more/classes/"
+        //        "classpath": "/path/to/classes.jar:/path/to/more/classes/"
       },
       "initialization_options": {}
     }

--- a/docs/src/languages/java.md
+++ b/docs/src/languages/java.md
@@ -10,9 +10,7 @@ Both use:
 - Tree Sitter: [tree-sitter/tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java)
 - Language Server: [eclipse-jdtls/eclipse.jdt.ls](https://github.com/eclipse-jdtls/eclipse.jdt.ls)
 
-## Pre-requisites
-
-### Install OpenJDK
+## Install OpenJDK
 
 You will need to install a Java runtime (OpenJDK).
 
@@ -23,45 +21,19 @@ You will need to install a Java runtime (OpenJDK).
 
 Or manually download and install [OpenJDK 23](https://jdk.java.net/23/).
 
-### (Optional) Install JDTLS
-
-Both extensions will automatically download a binary for you.
-
-If you would prefer, you can install JDTLS yourself and both extensions will use the version you install instead.
-
-- MacOS: `brew install jdtls`
-- Arch: [`jdtls` from AUR](https://aur.archlinux.org/packages/jdtls)
-
-Or manually download install:
-
-- [JDTLS Milestone Builds](http://download.eclipse.org/jdtls/milestones/) (updated every two weeks)
-- [JDTLS Snapshot Builds](https://download.eclipse.org/jdtls/snapshots/) (frequent updates)
-
-If you are using Zed Java you can also specify a specific version of JDTLS you would like the extension to download, per-project or globally.
-For example:
-
-```json
-{
-  "lsp": {
-    "jdtls": {
-      "settings": {
-        "version": "1.40.0"
-      }
-    }
-  }
-}
-```
-
 ## Extension Install
 
 You can install either by opening {#action zed::Extensions}({#kb zed::Extensions}) and searching for `java`.
+
 We recommend you install one or the other and not both.
 
 ## Settings / Initialization Options
 
+Both extensions will automatically download the language server, see: [Manual JDTLS Install](#manual-jdts-install) below if you'd prefer to manage that yourself.
+
 For available `initialization_options` please see the [Initialize Request section of the Eclipse.jdt.ls Wiki](https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request).
 
-Add the following to your Zed Settings by launching {#action zed::OpenSettings}({#kb zed::OpenSettings}).
+You can add these customizations to your Zed Settings by launching {#action zed::OpenSettings}({#kb zed::OpenSettings}) or by using a `.zed/setting.json` inside your project.
 
 ### Zed Java Settings
 
@@ -69,7 +41,10 @@ Add the following to your Zed Settings by launching {#action zed::OpenSettings}(
 {
   "lsp": {
     "jdtls": {
-      "settings": {},
+      "settings": {
+        "version": "1.40.0" // jdtls version to download and use
+//        "classpath": "/path/to/classes.jar:/path/to/more/classes/"
+      },
       "initialization_options": {}
     }
   }
@@ -89,36 +64,7 @@ Add the following to your Zed Settings by launching {#action zed::OpenSettings}(
 }
 ```
 
-## See also
-
-- [Zed Java Readme](https://github.com/zed-extensions/java)
-- [Java with Eclipse JDTLS Readme](https://github.com/ABckh/zed-java-eclipse-jdtls)
-
-## Support
-
-If you have issues with either of these plugins, please open issues on their respective repositories:
-
-- [Zed Java Issues](https://github.com/zed-extensions/java/issues)
-- [Java with Eclipse JDTLS Issues](https://github.com/ABckh/zed-java-eclipse-jdtls/issues)
-
 ## Example Configs
-
-### Zed Java Settings
-
-You can optionally configure the version of JDTLS to download (see <#optional-install-jdtls>) or the class path that JDTLS uses with:
-
-```json
-{
-  "lsp": {
-    "jdtls": {
-      "settings": {
-        "version": "1.40.0", // This is the default value
-        "classpath": "/path/to/classes.jar:/path/to/more/classes/"
-      }
-    }
-  }
-}
-```
 
 ### Zed Java Initialization Options
 
@@ -220,3 +166,27 @@ For example, to enable [Lombok Support](https://github.com/redhat-developer/vsco
   }
 }
 ```
+
+## Manual JDTLS Install
+
+If you prefer, you can install JDTLS yourself and both extensions can be configured to use that instead.
+
+- MacOS: `brew install jdtls`
+- Arch: [`jdtls` from AUR](https://aur.archlinux.org/packages/jdtls)
+
+Or manually download install:
+
+- [JDTLS Milestone Builds](http://download.eclipse.org/jdtls/milestones/) (updated every two weeks)
+- [JDTLS Snapshot Builds](https://download.eclipse.org/jdtls/snapshots/) (frequent updates)
+
+## See also
+
+- [Zed Java Readme](https://github.com/zed-extensions/java)
+- [Java with Eclipse JDTLS Readme](https://github.com/ABckh/zed-java-eclipse-jdtls)
+
+## Support
+
+If you have issues with either of these plugins, please open issues on their respective repositories:
+
+- [Zed Java Issues](https://github.com/zed-extensions/java/issues)
+- [Java with Eclipse JDTLS Issues](https://github.com/ABckh/zed-java-eclipse-jdtls/issues)


### PR DESCRIPTION
@notpeter @ABckh @HeavySnowJakarta really sorry to open yet another PR for the Java docs, but the Zed Java extension now auto-downloads JDTLS (surprise!) so the information related to that in the docs is no longer accurate.

Release Notes:

- N/A