### PR TITLE
Fix merging of an update of a symbol with an insert_before operation before the same symbol

### DIFF
--- a/crates/assistant/src/patch.rs
+++ b/crates/assistant/src/patch.rs
@@ -699,6 +699,57 @@ mod tests {
             .unindent(),
             cx,
         );
+
+        assert_edits(
+            "
+                fn foo() {
+
+                }
+            "
+            .unindent(),
+            vec![
+                AssistantEditKind::InsertBefore {
+                    old_text: "
+                        fn foo() {
+                    "
+                    .unindent(),
+                    new_text: "
+                        fn bar() {
+                            // todo
+                        }
+
+                    "
+                    .unindent(),
+                    description: "implement bar".into(),
+                },
+                AssistantEditKind::Update {
+                    old_text: "
+                        fn foo() {
+
+                        }
+                    "
+                    .unindent(),
+                    new_text: "
+                        fn foo() {
+                            bar();
+                        }
+                    "
+                    .unindent(),
+                    description: "call bar in foo".into(),
+                },
+            ],
+            "
+                fn bar() {
+                    // todo
+                }
+
+                fn foo() {
+                    bar();
+                }
+            "
+            .unindent(),
+            cx,
+        );
     }
 
     #[track_caller]


### PR DESCRIPTION
When we insert before some text and then update that same text, we need to preserve and concatenate the new text associated with both operations.

Release Notes:

- N/A