### PR TITLE
vim: Add support for temporary normal mode (ctrl-o) within insert mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -299,7 +299,8 @@
       "ctrl-q": ["vim::PushOperator", { "Literal": {} }],
       "ctrl-shift-q": ["vim::PushOperator", { "Literal": {} }],
       "ctrl-r": ["vim::PushOperator", "Register"],
-      "insert": "vim::ToggleReplace"
+      "insert": "vim::ToggleReplace",
+      "ctrl-o": "vim::TemporaryNormal"
     }
   },
   {

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -38,7 +38,7 @@ impl Vim {
     }
 
     fn temporary_normal(&mut self, _: &TemporaryNormal, cx: &mut ViewContext<Self>) {
-        self.switch_mode(Mode::Normal, false, cx);
+        self.switch_mode(Mode::Normal, true, cx);
         self.temp_mode = true;
     }
 }

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -3,10 +3,11 @@ use editor::{scroll::Autoscroll, Bias, Editor};
 use gpui::{actions, Action, ViewContext};
 use language::SelectionGoal;
 
-actions!(vim, [NormalBefore]);
+actions!(vim, [NormalBefore, TemporaryNormal]);
 
 pub fn register(editor: &mut Editor, cx: &mut ViewContext<Vim>) {
     Vim::action(editor, cx, Vim::normal_before);
+    Vim::action(editor, cx, Vim::temporary_normal);
 }
 
 impl Vim {
@@ -34,6 +35,11 @@ impl Vim {
         }
 
         self.repeat(true, cx)
+    }
+
+    fn temporary_normal(&mut self, _: &TemporaryNormal, cx: &mut ViewContext<Self>) {
+        self.switch_mode(Mode::Normal, false, cx);
+        self.temp_mode = true;
     }
 }
 

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -88,12 +88,19 @@ impl Render for ModeIndicator {
             return div().into_any();
         };
 
+        let vim_readable = vim.read(cx);
+        let mode = if vim_readable.temp_mode {
+            format!("(insert) {}", vim_readable.mode)
+        } else {
+            vim_readable.mode.to_string()
+        };
+
         let current_operators_description = self.current_operators_description(vim.clone(), cx);
         let pending = self
             .pending_keys
             .as_ref()
             .unwrap_or(&current_operators_description);
-        Label::new(format!("{} -- {} --", pending, vim.read(cx).mode))
+        Label::new(format!("{} -- {} --", pending, mode))
             .size(LabelSize::Small)
             .line_height_style(LineHeightStyle::UiLabel)
             .into_any_element()

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -260,7 +260,7 @@ impl Vim {
         });
     }
 
-    pub fn insert_after(&mut self, _: &InsertAfter, cx: &mut ViewContext<Self>) {
+    fn insert_after(&mut self, _: &InsertAfter, cx: &mut ViewContext<Self>) {
         self.start_recording(cx);
         self.switch_mode(Mode::Insert, false, cx);
         self.update_editor(cx, |_, editor, cx| {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -185,6 +185,8 @@ impl Vim {
                 error!("Unexpected normal mode motion operator: {:?}", operator)
             }
         }
+        // Exit temporary normal mode (if active).
+        self.exit_temporary_normal(cx);
     }
 
     pub fn normal_object(&mut self, object: Object, cx: &mut ViewContext<Self>) {
@@ -484,6 +486,12 @@ impl Vim {
                 }
             });
         });
+    }
+
+    fn exit_temporary_normal(&mut self, cx: &mut ViewContext<Self>) {
+        if self.temp_mode {
+            self.switch_mode(Mode::Insert, true, cx);
+        }
     }
 }
 #[cfg(test)]

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -260,7 +260,7 @@ impl Vim {
         });
     }
 
-    fn insert_after(&mut self, _: &InsertAfter, cx: &mut ViewContext<Self>) {
+    pub fn insert_after(&mut self, _: &InsertAfter, cx: &mut ViewContext<Self>) {
         self.start_recording(cx);
         self.switch_mode(Mode::Insert, false, cx);
         self.update_editor(cx, |_, editor, cx| {

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -176,7 +176,7 @@ impl Vim {
                                     .0;
                                 }
                                 cursor = movement::indented_line_beginning(map, cursor, true);
-                            } else if !is_multiline {
+                            } else if !is_multiline && !vim.temp_mode {
                                 cursor = movement::saturating_left(map, cursor)
                             }
                             cursors.push(cursor);

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use crate::{
     insert::NormalBefore,
     motion::Motion,
+    normal::InsertBefore,
     state::{Mode, Operator, RecordedSelection, ReplayableAction, VimGlobals},
     Vim,
 };
@@ -16,6 +17,9 @@ actions!(vim, [Repeat, EndRepeat, ToggleRecord, ReplayLastRecording]);
 fn should_replay(action: &dyn Action) -> bool {
     // skip so that we don't leave the character palette open
     if editor::actions::ShowCharacterPalette.partial_eq(action) {
+        return false;
+    }
+    if Repeat.partial_eq(action) {
         return false;
     }
     true
@@ -307,6 +311,11 @@ impl Vim {
         }
 
         actions.push(ReplayableAction::Action(EndRepeat.boxed_clone()));
+
+        if self.temp_mode {
+            self.temp_mode = false;
+            actions.push(ReplayableAction::Action(InsertBefore.boxed_clone()));
+        }
 
         let globals = Vim::globals(cx);
         globals.dot_replaying = true;

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -19,9 +19,6 @@ fn should_replay(action: &dyn Action) -> bool {
     if editor::actions::ShowCharacterPalette.partial_eq(action) {
         return false;
     }
-    if Repeat.partial_eq(action) {
-        return false;
-    }
     true
 }
 

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -137,6 +137,11 @@ impl Vim {
                         options |= SearchOptions::REGEX;
                     }
                     search_bar.set_search_options(options, cx);
+                    let prior_mode = if self.temp_mode {
+                        Mode::Insert
+                    } else {
+                        self.mode
+                    };
 
                     self.search = SearchState {
                         direction,
@@ -144,7 +149,7 @@ impl Vim {
                         initial_query: query,
                         prior_selections,
                         prior_operator: self.operator_stack.last().cloned(),
-                        prior_mode: self.mode,
+                        prior_mode,
                     }
                 });
             }

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -42,6 +42,7 @@ impl Vim {
                 });
             });
         });
+        self.exit_temporary_normal(cx);
     }
 
     pub fn yank_object(&mut self, object: Object, around: bool, cx: &mut ViewContext<Self>) {
@@ -65,6 +66,7 @@ impl Vim {
                 });
             });
         });
+        self.exit_temporary_normal(cx);
     }
 
     pub fn yank_selections_content(

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -153,6 +153,7 @@ pub struct VimGlobals {
     pub stop_recording_after_next_action: bool,
     pub ignore_current_insertion: bool,
     pub recorded_count: Option<usize>,
+    pub recording_actions: Vec<ReplayableAction>,
     pub recorded_actions: Vec<ReplayableAction>,
     pub recorded_selection: RecordedSelection,
 
@@ -339,11 +340,12 @@ impl VimGlobals {
 
     pub fn observe_action(&mut self, action: Box<dyn Action>) {
         if self.dot_recording {
-            self.recorded_actions
+            self.recording_actions
                 .push(ReplayableAction::Action(action.boxed_clone()));
 
             if self.stop_recording_after_next_action {
                 self.dot_recording = false;
+                self.recorded_actions = std::mem::take(&mut self.recording_actions);
                 self.stop_recording_after_next_action = false;
             }
         }
@@ -363,12 +365,13 @@ impl VimGlobals {
             return;
         }
         if self.dot_recording {
-            self.recorded_actions.push(ReplayableAction::Insertion {
+            self.recording_actions.push(ReplayableAction::Insertion {
                 text: text.clone(),
                 utf16_range_to_replace: range_to_replace.clone(),
             });
             if self.stop_recording_after_next_action {
                 self.dot_recording = false;
+                self.recorded_actions = std::mem::take(&mut self.recording_actions);
                 self.stop_recording_after_next_action = false;
             }
         }

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1544,3 +1544,25 @@ async fn test_sentence_forwards(cx: &mut gpui::TestAppContext) {
 
     cx.set_shared_state("helˇlo.\n\n\nworld.").await;
 }
+
+#[gpui::test]
+async fn test_ctrl_o_position(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state("helˇlo world.").await;
+    cx.simulate_shared_keystrokes("i ctrl-o d i w").await;
+    cx.shared_state().await.assert_eq("ˇ world.");
+    cx.simulate_shared_keystrokes("ctrl-o p").await;
+    cx.shared_state().await.assert_eq(" helloˇworld.");
+}
+
+#[gpui::test]
+async fn test_ctrl_o_dot(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state("heˇllo world.").await;
+    cx.simulate_shared_keystrokes("x i ctrl-o .").await;
+    cx.shared_state().await.assert_eq("heˇo world.");
+    cx.simulate_shared_keystrokes("l l escape .").await;
+    cx.shared_state().await.assert_eq("hellˇllo world.");
+}

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1546,6 +1546,17 @@ async fn test_sentence_forwards(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_ctrl_o_visual(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_state("helloˇ world.").await;
+    cx.simulate_shared_keystrokes("i ctrl-o v b r l").await;
+    cx.shared_state().await.assert_eq("ˇllllllworld.");
+    cx.simulate_shared_keystrokes("ctrl-o v f w d").await;
+    cx.shared_state().await.assert_eq("ˇorld.");
+}
+
+#[gpui::test]
 async fn test_ctrl_o_position(cx: &mut gpui::TestAppContext) {
     let mut cx = NeovimBackedTestContext::new(cx).await;
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -437,6 +437,16 @@ impl Vim {
     }
 
     pub fn switch_mode(&mut self, mode: Mode, leave_selections: bool, cx: &mut ViewContext<Self>) {
+        if self.temp_mode && mode == Mode::Normal {
+            self.temp_mode = false;
+            self.insert_after(&normal::InsertAfter, cx);
+            return;
+        } else if self.temp_mode
+            && !matches!(mode, Mode::Visual | Mode::VisualLine | Mode::VisualBlock)
+        {
+            self.temp_mode = false;
+        }
+
         let last_mode = self.mode;
         let prior_mode = self.last_mode;
         let prior_tx = self.current_tx;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -146,6 +146,7 @@ impl editor::Addon for VimAddon {
 pub(crate) struct Vim {
     pub(crate) mode: Mode,
     pub last_mode: Mode,
+    pub temp_mode: bool,
 
     /// pre_count is the number before an operator is specified (3 in 3d2d)
     pre_count: Option<usize>,
@@ -196,6 +197,7 @@ impl Vim {
         cx.new_view(|cx| Vim {
             mode: Mode::Normal,
             last_mode: Mode::Normal,
+            temp_mode: false,
             pre_count: None,
             post_count: None,
             operator_stack: Vec::new(),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -356,7 +356,7 @@ impl Vim {
     fn observe_keystrokes(&mut self, keystroke_event: &KeystrokeEvent, cx: &mut ViewContext<Self>) {
         if self.exit_temporary_mode {
             self.exit_temporary_mode = false;
-            // Don't switch to insert mode if the next action is temporary_normal.
+            // Don't switch to insert mode if the action is temporary_normal.
             if let Some(action) = keystroke_event.action.as_ref() {
                 if action.as_any().downcast_ref::<TemporaryNormal>().is_some() {
                     return;
@@ -827,7 +827,6 @@ impl Vim {
             globals.dot_recording = false;
             globals.stop_recording_after_next_action = false;
         }
-        // ???
         self.exit_temporary_mode = self.temp_mode;
     }
 

--- a/crates/vim/test_data/test_ctrl_o_dot.json
+++ b/crates/vim/test_data/test_ctrl_o_dot.json
@@ -1,0 +1,11 @@
+{"Put":{"state":"heˇllo world."}}
+{"Key":"x"}
+{"Key":"i"}
+{"Key":"ctrl-o"}
+{"Key":"."}
+{"Get":{"state":"heˇo world.","mode":"Insert"}}
+{"Key":"l"}
+{"Key":"l"}
+{"Key":"escape"}
+{"Key":"."}
+{"Get":{"state":"hellˇllo world.","mode":"Normal"}}

--- a/crates/vim/test_data/test_ctrl_o_position.json
+++ b/crates/vim/test_data/test_ctrl_o_position.json
@@ -1,0 +1,10 @@
+{"Put":{"state":"helˇlo world."}}
+{"Key":"i"}
+{"Key":"ctrl-o"}
+{"Key":"d"}
+{"Key":"i"}
+{"Key":"w"}
+{"Get":{"state":"ˇ world.","mode":"Insert"}}
+{"Key":"ctrl-o"}
+{"Key":"p"}
+{"Get":{"state":" helloˇworld.","mode":"Insert"}}

--- a/crates/vim/test_data/test_ctrl_o_visual.json
+++ b/crates/vim/test_data/test_ctrl_o_visual.json
@@ -1,0 +1,14 @@
+{"Put":{"state":"helloˇ world."}}
+{"Key":"i"}
+{"Key":"ctrl-o"}
+{"Key":"v"}
+{"Key":"b"}
+{"Key":"r"}
+{"Key":"l"}
+{"Get":{"state":"ˇllllllworld.","mode":"Insert"}}
+{"Key":"ctrl-o"}
+{"Key":"v"}
+{"Key":"f"}
+{"Key":"w"}
+{"Key":"d"}
+{"Get":{"state":"ˇorld.","mode":"Insert"}}


### PR DESCRIPTION
Support has been added for the ctrl-o command within insert mode. Ctrl-o is used to partially enter normal mode for 1 motion to then return back into insert mode.

Release Notes:

- vim: Added support for `ctrl-o` in insert mode to enter temporary normal mode
