### PR TITLE
SSH Remoting: Fix reconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9119,6 +9119,7 @@ name = "remote"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "collections",
  "fs",
  "futures 0.3.30",

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -26,7 +26,7 @@ async fn test_sharing_an_ssh_remote_project(
         .await;
 
     // Set up project on remote FS
-    let (client_ssh, server_ssh) = SshRemoteClient::fake(cx_a, server_cx);
+    let (forwarder, server_ssh) = SshRemoteClient::fake_server(server_cx);
     let remote_fs = FakeFs::new(server_cx.executor());
     remote_fs
         .insert_tree(
@@ -67,6 +67,7 @@ async fn test_sharing_an_ssh_remote_project(
         )
     });
 
+    let client_ssh = SshRemoteClient::fake_client(forwarder, cx_a).await;
     let (project_a, worktree_id) = client_a
         .build_ssh_project("/code/project1", client_ssh, cx_a)
         .await;

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -26,7 +26,7 @@ async fn test_sharing_an_ssh_remote_project(
         .await;
 
     // Set up project on remote FS
-    let (forwarder, server_ssh) = SshRemoteClient::fake_server(server_cx);
+    let (port, server_ssh) = SshRemoteClient::fake_server(cx_a, server_cx);
     let remote_fs = FakeFs::new(server_cx.executor());
     remote_fs
         .insert_tree(
@@ -67,7 +67,7 @@ async fn test_sharing_an_ssh_remote_project(
         )
     });
 
-    let client_ssh = SshRemoteClient::fake_client(forwarder, cx_a).await;
+    let client_ssh = SshRemoteClient::fake_client(port, cx_a).await;
     let (project_a, worktree_id) = client_a
         .build_ssh_project("/code/project1", client_ssh, cx_a)
         .await;

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1243,6 +1243,10 @@ impl Project {
         self.client.clone()
     }
 
+    pub fn ssh_client(&self) -> Option<Model<SshRemoteClient>> {
+        self.ssh_client.clone()
+    }
+
     pub fn user_store(&self) -> Model<UserStore> {
         self.user_store.clone()
     }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -12,6 +12,7 @@ message Envelope {
     uint32 id = 1;
     optional uint32 responding_to = 2;
     optional PeerId original_sender_id = 3;
+    optional uint32 ack_id = 266;
 
     oneof payload {
         Hello hello = 4;
@@ -295,7 +296,9 @@ message Envelope {
         OpenServerSettings open_server_settings = 263;
 
         GetPermalinkToLine get_permalink_to_line = 264;
-        GetPermalinkToLineResponse get_permalink_to_line_response = 265;  // current max
+        GetPermalinkToLineResponse get_permalink_to_line_response = 265;
+
+        FlushBufferedMessages flush_buffered_messages = 267;
     }
 
     reserved 87 to 88;
@@ -2522,3 +2525,6 @@ message GetPermalinkToLine {
 message GetPermalinkToLineResponse {
     string permalink = 1;
 }
+
+message FlushBufferedMessages {}
+message FlushBufferedMessagesResponse {}

--- a/crates/proto/src/macros.rs
+++ b/crates/proto/src/macros.rs
@@ -32,6 +32,7 @@ macro_rules! messages {
                         responding_to,
                         original_sender_id,
                         payload: Some(envelope::Payload::$name(self)),
+                        ack_id: None,
                     }
                 }
 

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -372,6 +372,7 @@ messages!(
     (OpenServerSettings, Foreground),
     (GetPermalinkToLine, Foreground),
     (GetPermalinkToLineResponse, Foreground),
+    (FlushBufferedMessages, Foreground),
 );
 
 request_messages!(
@@ -498,6 +499,7 @@ request_messages!(
     (RemoveWorktree, Ack),
     (OpenServerSettings, OpenBufferResponse),
     (GetPermalinkToLine, GetPermalinkToLineResponse),
+    (FlushBufferedMessages, Ack),
 );
 
 entity_messages!(

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -19,6 +19,7 @@ test-support = ["fs/test-support"]
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 collections.workspace = true
 fs.workspace = true
 futures.workspace = true

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -14,7 +14,7 @@ use futures::{
         oneshot,
     },
     future::BoxFuture,
-    select_biased, AsyncReadExt as _, Future, FutureExt as _, SinkExt, StreamExt as _,
+    select_biased, AsyncReadExt as _, Future, FutureExt as _, StreamExt as _,
 };
 use gpui::{
     AppContext, AsyncAppContext, Context, EventEmitter, Model, ModelContext, SemanticVersion, Task,
@@ -22,9 +22,7 @@ use gpui::{
 };
 use parking_lot::Mutex;
 use rpc::{
-    proto::{
-        self, build_typed_envelope, Envelope, EnvelopedMessage, PeerId, RequestMessage, SSH_PEER_ID,
-    },
+    proto::{self, build_typed_envelope, Envelope, EnvelopedMessage, PeerId, RequestMessage},
     AnyProtoClient, EntityMessageSubscriber, ProtoClient, ProtoMessageHandlerSet, RpcError,
 };
 use smol::{
@@ -40,7 +38,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU32, Ordering::SeqCst},
-        Arc,
+        Arc, Weak,
     },
     time::{Duration, Instant},
 };
@@ -279,72 +277,6 @@ async fn run_cmd(command: &mut process::Command) -> Result<String> {
     }
 }
 
-pub struct ChannelForwarder {
-    quit_tx: UnboundedSender<()>,
-    forwarding_task: Task<(UnboundedSender<Envelope>, UnboundedReceiver<Envelope>)>,
-}
-
-impl ChannelForwarder {
-    fn new(
-        mut incoming_tx: UnboundedSender<Envelope>,
-        mut outgoing_rx: UnboundedReceiver<Envelope>,
-        cx: &AsyncAppContext,
-    ) -> (Self, UnboundedSender<Envelope>, UnboundedReceiver<Envelope>) {
-        let (quit_tx, mut quit_rx) = mpsc::unbounded::<()>();
-
-        let (proxy_incoming_tx, mut proxy_incoming_rx) = mpsc::unbounded::<Envelope>();
-        let (mut proxy_outgoing_tx, proxy_outgoing_rx) = mpsc::unbounded::<Envelope>();
-
-        let forwarding_task = cx.background_executor().spawn(async move {
-            loop {
-                select_biased! {
-                    _ = quit_rx.next().fuse() => {
-                        println!("quit");
-                        break;
-                    },
-                    incoming_envelope = proxy_incoming_rx.next().fuse() => {
-                        if let Some(envelope) = incoming_envelope {
-                            println!("incoming {}", envelope.id);
-                            if incoming_tx.send(envelope).await.is_err() {
-                                break;
-                            }
-
-                        } else {
-                            break;
-                        }
-                    }
-                    outgoing_envelope = outgoing_rx.next().fuse() => {
-                        if let Some(envelope) = outgoing_envelope {
-                            println!("outgoing {}", envelope.id);
-                            if proxy_outgoing_tx.send(envelope).await.is_err() {
-                                break;
-                            }
-                        } else {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            (incoming_tx, outgoing_rx)
-        });
-
-        (
-            Self {
-                forwarding_task,
-                quit_tx,
-            },
-            proxy_incoming_tx,
-            proxy_outgoing_rx,
-        )
-    }
-
-    async fn into_channels(mut self) -> (UnboundedSender<Envelope>, UnboundedReceiver<Envelope>) {
-        let _ = self.quit_tx.send(()).await;
-        self.forwarding_task.await
-    }
-}
-
 const MAX_MISSED_HEARTBEATS: usize = 5;
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -356,7 +288,6 @@ enum State {
     Connected {
         ssh_connection: Box<dyn SshRemoteProcess>,
         delegate: Arc<dyn SshClientDelegate>,
-        forwarder: ChannelForwarder,
 
         multiplex_task: Task<Result<()>>,
         heartbeat_task: Task<Result<()>>,
@@ -366,7 +297,6 @@ enum State {
 
         ssh_connection: Box<dyn SshRemoteProcess>,
         delegate: Arc<dyn SshClientDelegate>,
-        forwarder: ChannelForwarder,
 
         multiplex_task: Task<Result<()>>,
         heartbeat_task: Task<Result<()>>,
@@ -375,7 +305,6 @@ enum State {
     ReconnectFailed {
         ssh_connection: Box<dyn SshRemoteProcess>,
         delegate: Arc<dyn SshClientDelegate>,
-        forwarder: ChannelForwarder,
 
         error: anyhow::Error,
         attempts: usize,
@@ -437,14 +366,12 @@ impl State {
             Self::HeartbeatMissed {
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
                 ..
             } => Self::Connected {
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
             },
@@ -457,14 +384,12 @@ impl State {
             Self::Connected {
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
             } => Self::HeartbeatMissed {
                 missed_heartbeats: 1,
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
             },
@@ -472,14 +397,12 @@ impl State {
                 missed_heartbeats,
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
             } => Self::HeartbeatMissed {
                 missed_heartbeats: missed_heartbeats + 1,
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
             },
@@ -546,15 +469,12 @@ impl SshRemoteClient {
                 state: Arc::new(Mutex::new(Some(State::Connecting))),
             })?;
 
-            let (proxy, proxy_incoming_tx, proxy_outgoing_rx) =
-                ChannelForwarder::new(incoming_tx, outgoing_rx, &mut cx);
-
             let (ssh_connection, io_task) = Self::establish_connection(
                 unique_identifier,
                 false,
                 connection_options,
-                proxy_incoming_tx,
-                proxy_outgoing_rx,
+                incoming_tx,
+                outgoing_rx,
                 connection_activity_tx,
                 delegate.clone(),
                 &mut cx,
@@ -575,7 +495,6 @@ impl SshRemoteClient {
                 *this.state.lock() = Some(State::Connected {
                     ssh_connection,
                     delegate,
-                    forwarder: proxy,
                     multiplex_task,
                     heartbeat_task,
                 });
@@ -597,7 +516,6 @@ impl SshRemoteClient {
             heartbeat_task,
             ssh_connection,
             delegate,
-            forwarder,
         } = state
         else {
             return None;
@@ -621,7 +539,6 @@ impl SshRemoteClient {
             drop(heartbeat_task);
             drop(ssh_connection);
             drop(delegate);
-            drop(forwarder);
         })
     }
 
@@ -643,33 +560,30 @@ impl SshRemoteClient {
         }
 
         let state = lock.take().unwrap();
-        let (attempts, mut ssh_connection, delegate, forwarder) = match state {
+        let (attempts, mut ssh_connection, delegate) = match state {
             State::Connected {
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
             }
             | State::HeartbeatMissed {
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task,
                 ..
             } => {
                 drop(multiplex_task);
                 drop(heartbeat_task);
-                (0, ssh_connection, delegate, forwarder)
+                (0, ssh_connection, delegate)
             }
             State::ReconnectFailed {
                 attempts,
                 ssh_connection,
                 delegate,
-                forwarder,
                 ..
-            } => (attempts, ssh_connection, delegate, forwarder),
+            } => (attempts, ssh_connection, delegate),
             State::Connecting
             | State::Reconnecting
             | State::ReconnectExhausted
@@ -696,37 +610,36 @@ impl SshRemoteClient {
         let client = self.client.clone();
         let reconnect_task = cx.spawn(|this, mut cx| async move {
             macro_rules! failed {
-                ($error:expr, $attempts:expr, $ssh_connection:expr, $delegate:expr, $forwarder:expr) => {
+                ($error:expr, $attempts:expr, $ssh_connection:expr, $delegate:expr) => {
                     return State::ReconnectFailed {
                         error: anyhow!($error),
                         attempts: $attempts,
                         ssh_connection: $ssh_connection,
                         delegate: $delegate,
-                        forwarder: $forwarder,
                     };
                 };
             }
 
-            if let Err(error) = ssh_connection.kill().await.context("Failed to kill ssh process") {
-                failed!(error, attempts, ssh_connection, delegate, forwarder);
+            if let Err(error) = ssh_connection
+                .kill()
+                .await
+                .context("Failed to kill ssh process")
+            {
+                failed!(error, attempts, ssh_connection, delegate);
             };
 
             let connection_options = ssh_connection.connection_options();
 
-            let (incoming_tx, mut outgoing_rx) = forwarder.into_channels().await;
-            while let Ok(Some(msg)) = outgoing_rx.try_next() {
-                dbg!("flushing msg {}", msg.id);
-            }
-            let (forwarder, proxy_incoming_tx, proxy_outgoing_rx) =
-                ChannelForwarder::new(incoming_tx, outgoing_rx, &mut cx);
+            let (outgoing_tx, outgoing_rx) = mpsc::unbounded::<Envelope>();
+            let (incoming_tx, incoming_rx) = mpsc::unbounded::<Envelope>();
             let (connection_activity_tx, connection_activity_rx) = mpsc::channel::<()>(1);
 
             let (ssh_connection, io_task) = match Self::establish_connection(
                 identifier,
                 true,
                 connection_options,
-                proxy_incoming_tx,
-                proxy_outgoing_rx,
+                incoming_tx,
+                outgoing_rx,
                 connection_activity_tx,
                 delegate.clone(),
                 &mut cx,
@@ -735,20 +648,20 @@ impl SshRemoteClient {
             {
                 Ok((ssh_connection, ssh_process)) => (ssh_connection, ssh_process),
                 Err(error) => {
-                    failed!(error, attempts, ssh_connection, delegate, forwarder);
+                    failed!(error, attempts, ssh_connection, delegate);
                 }
             };
 
             let multiplex_task = Self::monitor(this.clone(), io_task, &cx);
+            client.reconnect(incoming_rx, outgoing_tx, &cx);
 
             if let Err(error) = client.resync(HEARTBEAT_TIMEOUT).await {
-                failed!(error, attempts, ssh_connection, delegate, forwarder);
+                failed!(error, attempts, ssh_connection, delegate);
             };
 
             State::Connected {
                 ssh_connection,
                 delegate,
-                forwarder,
                 multiplex_task,
                 heartbeat_task: Self::heartbeat(this.clone(), connection_activity_rx, &mut cx),
             }
@@ -982,7 +895,7 @@ impl SshRemoteClient {
             }
         });
 
-        cx.spawn(|cx| async move {
+        cx.spawn(|_| async move {
             let result = futures::select! {
                 result = stdin_task.fuse() => {
                     result.context("stdin")
@@ -1070,23 +983,18 @@ impl SshRemoteClient {
         unique_identifier: String,
         reconnect: bool,
         connection_options: SshConnectionOptions,
-        proxy_incoming_tx: UnboundedSender<Envelope>,
-        mut proxy_outgoing_rx: UnboundedReceiver<Envelope>,
+        incoming_tx: UnboundedSender<Envelope>,
+        outgoing_rx: UnboundedReceiver<Envelope>,
         connection_activity_tx: Sender<()>,
         delegate: Arc<dyn SshClientDelegate>,
         cx: &mut AsyncAppContext,
     ) -> Result<(Box<dyn SshRemoteProcess>, Task<Result<i32>>)> {
-        if reconnect {
-            while let Ok(Some(msg)) = proxy_outgoing_rx.try_next() {
-                println!("dropping {}", msg.id);
-            }
-        }
         #[cfg(any(test, feature = "test-support"))]
         if let Some(fake) = fake::SshRemoteConnection::new(&connection_options) {
             let io_task = fake::SshRemoteConnection::multiplex(
                 fake.connection_options(),
-                proxy_incoming_tx,
-                proxy_outgoing_rx,
+                incoming_tx,
+                outgoing_rx,
                 connection_activity_tx,
                 cx,
             )
@@ -1130,8 +1038,8 @@ impl SshRemoteClient {
 
         let io_task = Self::multiplex(
             ssh_proxy_process,
-            proxy_incoming_tx,
-            proxy_outgoing_rx,
+            incoming_tx,
+            outgoing_rx,
             connection_activity_tx,
             &cx,
         );
@@ -1176,53 +1084,41 @@ impl SshRemoteClient {
     }
 
     #[cfg(any(test, feature = "test-support"))]
-    pub fn simulate_disconnect(&self, cx: &mut AppContext) -> Task<()> {
-        use gpui::BorrowAppContext;
-
+    pub fn simulate_disconnect(&self, client_cx: &mut AppContext) -> Task<()> {
         let port = self.connection_options().port.unwrap();
+        client_cx.spawn(|cx| async move {
+            let (channel, server_cx) = cx
+                .update_global(|c: &mut fake::ServerConnections, _| c.get(port))
+                .unwrap();
 
-        println!("disconnecting...");
-        let disconnect =
-            cx.update_global(|c: &mut fake::GlobalConnections, _cx| c.take(port).into_channels());
-        cx.spawn(|mut cx| async move {
-            let (input_tx, output_rx) = disconnect.await;
-            println!("disconnected...");
-            let (forwarder, _, _) = ChannelForwarder::new(input_tx, output_rx, &mut cx);
-            cx.update_global(|c: &mut fake::GlobalConnections, _cx| c.replace(port, forwarder))
-                .unwrap()
+            let (outgoing_tx, _) = mpsc::unbounded::<Envelope>();
+            let (_, incoming_rx) = mpsc::unbounded::<Envelope>();
+            channel.reconnect(incoming_rx, outgoing_tx, &server_cx);
         })
     }
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn fake_server(
+        client_cx: &mut gpui::TestAppContext,
         server_cx: &mut gpui::TestAppContext,
-    ) -> (ChannelForwarder, Arc<ChannelClient>) {
-        server_cx.update(|cx| {
-            let (outgoing_tx, outgoing_rx) = mpsc::unbounded::<Envelope>();
-            let (incoming_tx, incoming_rx) = mpsc::unbounded::<Envelope>();
-
-            // We use the forwarder on the server side (in production we only use one on the client side)
-            // the idea is that we can simulate a disconnect/reconnect by just messing with the forwarder.
-            let (forwarder, _, _) =
-                ChannelForwarder::new(incoming_tx, outgoing_rx, &mut cx.to_async());
-
-            let client = ChannelClient::new(incoming_rx, outgoing_tx, cx, "fake-server");
-            (forwarder, client)
-        })
+    ) -> (u16, Arc<ChannelClient>) {
+        use gpui::BorrowAppContext;
+        let (outgoing_tx, _) = mpsc::unbounded::<Envelope>();
+        let (_, incoming_rx) = mpsc::unbounded::<Envelope>();
+        let server_client =
+            server_cx.update(|cx| ChannelClient::new(incoming_rx, outgoing_tx, cx, "fake-server"));
+        let port = client_cx.update(|cx| {
+            cx.update_default_global(|c: &mut fake::ServerConnections, _| {
+                c.push(server_client.clone(), server_cx.to_async())
+            })
+        });
+        (port, server_client)
     }
 
     #[cfg(any(test, feature = "test-support"))]
-    pub async fn fake_client(
-        forwarder: ChannelForwarder,
-        client_cx: &mut gpui::TestAppContext,
-    ) -> Model<Self> {
-        use gpui::BorrowAppContext;
+    pub async fn fake_client(port: u16, client_cx: &mut gpui::TestAppContext) -> Model<Self> {
         client_cx
             .update(|cx| {
-                let port = cx.update_default_global(|c: &mut fake::GlobalConnections, _cx| {
-                    c.push(forwarder)
-                });
-
                 Self::new(
                     "fake".to_string(),
                     SshConnectionOptions {
@@ -1567,11 +1463,13 @@ type ResponseChannels = Mutex<HashMap<MessageId, oneshot::Sender<(Envelope, ones
 
 pub struct ChannelClient {
     next_message_id: AtomicU32,
-    outgoing_tx: mpsc::UnboundedSender<Envelope>,
+    outgoing_tx: Mutex<mpsc::UnboundedSender<Envelope>>,
     buffer: Mutex<VecDeque<Envelope>>,
     response_channels: ResponseChannels,
     message_handlers: Mutex<ProtoMessageHandlerSet>,
     max_received: AtomicU32,
+    name: &'static str,
+    task: Mutex<Task<Result<()>>>,
 }
 
 impl ChannelClient {
@@ -1581,33 +1479,31 @@ impl ChannelClient {
         cx: &AppContext,
         name: &'static str,
     ) -> Arc<Self> {
-        let this = Arc::new(Self {
-            outgoing_tx,
+        Arc::new_cyclic(|this| Self {
+            outgoing_tx: Mutex::new(outgoing_tx),
             next_message_id: AtomicU32::new(0),
             max_received: AtomicU32::new(0),
             response_channels: ResponseChannels::default(),
             message_handlers: Default::default(),
             buffer: Mutex::new(VecDeque::new()),
-        });
-
-        Self::start_handling_messages(this.clone(), incoming_rx, cx, name);
-
-        this
+            name,
+            task: Mutex::new(Self::start_handling_messages(
+                this.clone(),
+                incoming_rx,
+                &cx.to_async(),
+            )),
+        })
     }
 
     fn start_handling_messages(
-        this: Arc<Self>,
+        this: Weak<Self>,
         mut incoming_rx: mpsc::UnboundedReceiver<Envelope>,
-        cx: &AppContext,
-        name: &'static str,
-    ) {
+        cx: &AsyncAppContext,
+    ) -> Task<Result<()>> {
         cx.spawn(|cx| {
-            let this = Arc::downgrade(&this);
             async move {
                 let peer_id = PeerId { owner_id: 0, id: 0 };
                 while let Some(incoming) = incoming_rx.next().await {
-                    let type_name =build_typed_envelope(peer_id, Instant::now(), incoming.clone()).map(|e| e.payload_type_name()).unwrap_or("Error");
-                    println!("{} received  type={} id={}, ack_id={:?}", name, type_name, incoming.id, incoming.ack_id);
                     let Some(this) = this.upgrade() else {
                         return anyhow::Ok(());
                     };
@@ -1620,20 +1516,16 @@ impl ChannelClient {
                     if let Some(proto::envelope::Payload::FlushBufferedMessages(_)) =
                         &incoming.payload
                     {
-                        log::debug!("{name}:ssh message received. name:FlushBufferedMessages");
+                        log::debug!("{}:ssh message received. name:FlushBufferedMessages", this.name);
                         {
                             let buffer = this.buffer.lock();
                             for envelope in buffer.iter() {
-                                let type_name = build_typed_envelope(peer_id, Instant::now(), envelope.clone()).map(|e| e.payload_type_name()).unwrap_or("Error");
-                                println!("{} sent(resync) type={} id={:?} ack_id={:?}", name, type_name, envelope.id, envelope.ack_id);
-                                this.outgoing_tx.unbounded_send(envelope.clone()).ok();
+                                this.outgoing_tx.lock().unbounded_send(envelope.clone()).ok();
                             }
                         }
                         let mut envelope = proto::Ack{}.into_envelope(0, Some(incoming.id), None);
                         envelope.id = this.next_message_id.fetch_add(1, SeqCst);
-                        let type_name = build_typed_envelope(peer_id, Instant::now(), envelope.clone()).map(|e| e.payload_type_name()).unwrap_or("Error");
-                        println!("{} sent(resync) type={} id={:?} ack_id={:?}", name, type_name, envelope.id, envelope.ack_id);
-                        this.outgoing_tx.unbounded_send(envelope).ok();
+                        this.outgoing_tx.lock().unbounded_send(envelope).ok();
                         continue;
                     }
 
@@ -1659,28 +1551,37 @@ impl ChannelClient {
                             this.clone().into(),
                             cx.clone(),
                         ) {
-                            log::debug!("{name}:ssh message received. name:{type_name}");
-                            // cx.foreground_executor().spawn(async move {
+                            log::debug!("{}:ssh message received. name:{type_name}", this.name);
+                            cx.foreground_executor().spawn(async move {
                                 match future.await {
                                     Ok(_) => {
-                                        log::debug!("{name}:ssh message handled. name:{type_name}");
+                                        log::debug!("{}:ssh message handled. name:{type_name}", this.name);
                                     }
                                     Err(error) => {
                                         log::error!(
-                                            "{name}:error handling message. type:{type_name}, error:{error}",
+                                            "{}:error handling message. type:{type_name}, error:{error}", this.name,
                                         );
                                     }
                                 }
-                            // }).detach()
+                            }).detach()
                         } else {
-                            log::error!("{name}:unhandled ssh message name:{type_name}");
+                            log::error!("{}:unhandled ssh message name:{type_name}", this.name);
                         }
                     }
                 }
                 anyhow::Ok(())
             }
         })
-        .detach();
+    }
+
+    pub fn reconnect(
+        self: &Arc<Self>,
+        incoming_rx: UnboundedReceiver<Envelope>,
+        outgoing_tx: UnboundedSender<Envelope>,
+        cx: &AsyncAppContext,
+    ) {
+        *self.outgoing_tx.lock() = outgoing_tx;
+        *self.task.lock() = Self::start_handling_messages(Arc::downgrade(self), incoming_rx, cx);
     }
 
     pub fn subscribe_to_entity<E: 'static>(&self, remote_id: u64, entity: &Model<E>) {
@@ -1721,15 +1622,10 @@ impl ChannelClient {
             async {
                 self.request(proto::FlushBufferedMessages {}).await?;
                 for envelope in self.buffer.lock().iter() {
-                    let type_name =
-                        build_typed_envelope(SSH_PEER_ID, Instant::now(), envelope.clone())
-                            .map(|e| e.payload_type_name())
-                            .unwrap_or("Error");
-                    println!(
-                        "client sent(resync) type={} id={:?} ack_id={:?}",
-                        type_name, envelope.id, envelope.ack_id
-                    );
-                    self.outgoing_tx.unbounded_send(envelope.clone()).ok();
+                    self.outgoing_tx
+                        .lock()
+                        .unbounded_send(envelope.clone())
+                        .ok();
                 }
                 Ok(())
             },
@@ -1794,14 +1690,9 @@ impl ChannelClient {
     pub fn send_buffered(&self, mut envelope: proto::Envelope) -> Result<()> {
         envelope.ack_id = Some(self.max_received.load(SeqCst));
         self.buffer.lock().push_back(envelope.clone());
-        let type_name = build_typed_envelope(SSH_PEER_ID, Instant::now(), envelope.clone())
-            .map(|e| e.payload_type_name())
-            .unwrap_or("Error");
-        println!(
-            "sent(buffered) type={} id={:?} ack_id={:?}",
-            type_name, envelope.id, envelope.ack_id
-        );
-        self.outgoing_tx.unbounded_send(envelope)?;
+        // ignore errors on send (happen while we're reconnecting)
+        // assume that the global "disconnected" overlay is sufficient.
+        self.outgoing_tx.lock().unbounded_send(envelope).ok();
         Ok(())
     }
 }
@@ -1834,7 +1725,7 @@ impl ProtoClient for ChannelClient {
 
 #[cfg(any(test, feature = "test-support"))]
 mod fake {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, sync::Arc};
 
     use anyhow::Result;
     use async_trait::async_trait;
@@ -1849,7 +1740,7 @@ mod fake {
     use rpc::proto::Envelope;
 
     use super::{
-        ChannelForwarder, SshClientDelegate, SshConnectionOptions, SshPlatform, SshRemoteProcess,
+        ChannelClient, SshClientDelegate, SshConnectionOptions, SshPlatform, SshRemoteProcess,
     };
 
     pub(super) struct SshRemoteConnection {
@@ -1869,47 +1760,41 @@ mod fake {
         }
         pub(super) async fn multiplex(
             connection_options: SshConnectionOptions,
-            mut client_tx: mpsc::UnboundedSender<Envelope>,
-            mut client_rx: mpsc::UnboundedReceiver<Envelope>,
+            mut client_incoming_tx: mpsc::UnboundedSender<Envelope>,
+            mut client_outgoing_rx: mpsc::UnboundedReceiver<Envelope>,
             mut connection_activity_tx: Sender<()>,
             cx: &mut AsyncAppContext,
         ) -> Task<Result<i32>> {
-            let (server_tx, server_rx) = cx
+            let (mut server_incoming_tx, server_incoming_rx) = mpsc::unbounded::<Envelope>();
+            let (server_outgoing_tx, mut server_outgoing_rx) = mpsc::unbounded::<Envelope>();
+
+            let (channel, server_cx) = cx
                 .update(|cx| {
-                    cx.update_global(|conns: &mut GlobalConnections, _| {
-                        conns.take(connection_options.port.unwrap())
+                    cx.update_global(|conns: &mut ServerConnections, _| {
+                        conns.get(connection_options.port.unwrap())
                     })
                 })
-                .unwrap()
-                .into_channels()
-                .await;
+                .unwrap();
+            channel.reconnect(server_incoming_rx, server_outgoing_tx, &server_cx);
 
-            let (forwarder, mut proxy_tx, mut proxy_rx) =
-                ChannelForwarder::new(server_tx, server_rx, cx);
-
-            cx.update(|cx| {
-                cx.update_global(|conns: &mut GlobalConnections, _| {
-                    conns.replace(connection_options.port.unwrap(), forwarder)
-                })
-            })
-            .unwrap();
+            // send to proxy_tx to get to the server.
+            // receive from
 
             cx.background_executor().spawn(async move {
                 loop {
                     select_biased! {
-                        server_to_client = proxy_rx.next().fuse() => {
+                        server_to_client = server_outgoing_rx.next().fuse() => {
                             let Some(server_to_client) = server_to_client else {
                                 return Ok(1)
                             };
                             connection_activity_tx.try_send(()).ok();
-                            client_tx.send(server_to_client).await.ok();
+                            client_incoming_tx.send(server_to_client).await.ok();
                         }
-                        client_to_server = client_rx.next().fuse() => {
+                        client_to_server = client_outgoing_rx.next().fuse() => {
                             let Some(client_to_server) = client_to_server else {
                                 return Ok(1)
                             };
-                            proxy_tx.send(client_to_server).await.ok();
-
+                            server_incoming_tx.send(client_to_server).await.ok();
                         }
                     }
                 }
@@ -1933,31 +1818,20 @@ mod fake {
     }
 
     #[derive(Default)]
-    pub(super) struct GlobalConnections(Vec<Option<ChannelForwarder>>);
-    impl Global for GlobalConnections {}
+    pub(super) struct ServerConnections(Vec<(Arc<ChannelClient>, AsyncAppContext)>);
+    impl Global for ServerConnections {}
 
-    impl GlobalConnections {
-        pub(super) fn push(&mut self, forwarder: ChannelForwarder) -> u16 {
-            self.0.push(Some(forwarder));
+    impl ServerConnections {
+        pub(super) fn push(&mut self, server: Arc<ChannelClient>, cx: AsyncAppContext) -> u16 {
+            self.0.push((server.clone(), cx));
             self.0.len() as u16 - 1
         }
 
-        pub(super) fn take(&mut self, port: u16) -> ChannelForwarder {
+        pub(super) fn get(&mut self, port: u16) -> (Arc<ChannelClient>, AsyncAppContext) {
             self.0
-                .get_mut(port as usize)
+                .get(port as usize)
                 .expect("no fake server for port")
-                .take()
-                .expect("fake server is already borrowed")
-        }
-        pub(super) fn replace(&mut self, port: u16, forwarder: ChannelForwarder) {
-            let ret = self
-                .0
-                .get_mut(port as usize)
-                .expect("no fake server for port")
-                .replace(forwarder);
-            if ret.is_some() {
-                panic!("fake server is already replaced");
-            }
+                .clone()
         }
     }
 

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -17,8 +17,8 @@ use futures::{
     select_biased, AsyncReadExt as _, Future, FutureExt as _, SinkExt, StreamExt as _,
 };
 use gpui::{
-    AppContext, AsyncAppContext, BorrowAppContext, Context, EventEmitter, Global, Model,
-    ModelContext, SemanticVersion, Task, WeakModel,
+    AppContext, AsyncAppContext, Context, EventEmitter, Model, ModelContext, SemanticVersion, Task,
+    WeakModel,
 };
 use parking_lot::Mutex;
 use rpc::{
@@ -1055,6 +1055,7 @@ impl SshRemoteClient {
         cx.notify();
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn establish_connection(
         unique_identifier: String,
         reconnect: bool,
@@ -1066,8 +1067,8 @@ impl SshRemoteClient {
         cx: &mut AsyncAppContext,
     ) -> Result<(Box<dyn SshRemoteProcess>, Task<Result<i32>>)> {
         #[cfg(any(test, feature = "test-support"))]
-        if let Some(fake) = FakeSshRemoteConnection::new(&connection_options) {
-            let io_task = FakeSshRemoteConnection::multiplex(
+        if let Some(fake) = fake::SshRemoteConnection::new(&connection_options) {
+            let io_task = fake::SshRemoteConnection::multiplex(
                 fake.connection_options(),
                 proxy_incoming_tx,
                 proxy_outgoing_rx,
@@ -1147,7 +1148,6 @@ impl SshRemoteClient {
         self.connection_options.clone()
     }
 
-    #[cfg(not(any(test, feature = "test-support")))]
     pub fn connection_state(&self) -> ConnectionState {
         self.state
             .lock()
@@ -1156,25 +1156,22 @@ impl SshRemoteClient {
             .unwrap_or(ConnectionState::Disconnected)
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn connection_state(&self) -> ConnectionState {
-        ConnectionState::Connected
-    }
-
     pub fn is_disconnected(&self) -> bool {
         self.connection_state() == ConnectionState::Disconnected
     }
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn simulate_disconnect(&self, cx: &mut AppContext) -> Task<()> {
+        use gpui::BorrowAppContext;
+
         let port = self.connection_options().port.unwrap();
 
         let disconnect =
-            cx.update_global(|c: &mut FakeConnections, _cx| c.take(port).into_channels());
+            cx.update_global(|c: &mut fake::GlobalConnections, _cx| c.take(port).into_channels());
         cx.spawn(|mut cx| async move {
             let (input_rx, output_tx) = disconnect.await;
             let (forwarder, _, _) = ChannelForwarder::new(input_rx, output_tx, &mut cx);
-            cx.update_global(|c: &mut FakeConnections, _cx| c.replace(port, forwarder))
+            cx.update_global(|c: &mut fake::GlobalConnections, _cx| c.replace(port, forwarder))
                 .unwrap()
         })
     }
@@ -1205,9 +1202,8 @@ impl SshRemoteClient {
         use gpui::BorrowAppContext;
         client_cx
             .update(|cx| {
-                let port = cx.update_default_global(|c: &mut FakeConnections, _cx| {
-                    c.0.push(Some(forwarder));
-                    c.0.len() as u16 - 1
+                let port = cx.update_default_global(|c: &mut fake::GlobalConnections, _cx| {
+                    c.push(forwarder)
                 });
 
                 Self::new(
@@ -1217,73 +1213,12 @@ impl SshRemoteClient {
                         port: Some(port),
                         ..Default::default()
                     },
-                    Arc::new(FakeDelegate),
+                    Arc::new(fake::Delegate),
                     cx,
                 )
             })
             .await
             .unwrap()
-    }
-}
-
-#[cfg(any(test, feature = "test-support"))]
-#[derive(Default)]
-struct FakeConnections(Vec<Option<ChannelForwarder>>);
-#[cfg(any(test, feature = "test-support"))]
-impl Global for FakeConnections {}
-
-#[cfg(any(test, feature = "test-support"))]
-impl FakeConnections {
-    fn take(&mut self, port: u16) -> ChannelForwarder {
-        self.0
-            .get_mut(port as usize)
-            .expect("no fake server for port")
-            .take()
-            .expect("fake server is already borrowed")
-    }
-    fn replace(&mut self, port: u16, forwarder: ChannelForwarder) {
-        let ret = self
-            .0
-            .get_mut(port as usize)
-            .expect("no fake server for port")
-            .replace(forwarder);
-        if !ret.is_none() {
-            panic!("fake server is already replaced");
-        }
-    }
-}
-
-#[cfg(any(test, feature = "test-support"))]
-struct FakeDelegate;
-
-#[cfg(any(test, feature = "test-support"))]
-impl SshClientDelegate for FakeDelegate {
-    fn ask_password(
-        &self,
-        _: String,
-        _: &mut AsyncAppContext,
-    ) -> oneshot::Receiver<Result<String>> {
-        unreachable!()
-    }
-    fn remote_server_binary_path(
-        &self,
-        _: SshPlatform,
-        _: &mut AsyncAppContext,
-    ) -> Result<PathBuf> {
-        unreachable!()
-    }
-    fn get_server_binary(
-        &self,
-        _: SshPlatform,
-        _: &mut AsyncAppContext,
-    ) -> oneshot::Receiver<Result<(PathBuf, SemanticVersion)>> {
-        unreachable!()
-    }
-    fn set_status(&self, _: Option<&str>, _: &mut AsyncAppContext) {
-        unreachable!()
-    }
-    fn set_error(&self, _: String, _: &mut AsyncAppContext) {
-        unreachable!()
     }
 }
 
@@ -1611,87 +1546,6 @@ impl SshRemoteConnection {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
-struct FakeSshRemoteConnection {
-    connection_options: SshConnectionOptions,
-}
-
-#[cfg(any(test, feature = "test-support"))]
-impl FakeSshRemoteConnection {
-    fn new(connection_options: &SshConnectionOptions) -> Option<Box<dyn SshRemoteProcess>> {
-        if connection_options.host == "<fake>" {
-            return Some(Box::new(Self {
-                connection_options: connection_options.clone(),
-            }));
-        }
-        return None;
-    }
-    async fn multiplex(
-        connection_options: SshConnectionOptions,
-        mut client_tx: mpsc::UnboundedSender<Envelope>,
-        mut client_rx: mpsc::UnboundedReceiver<Envelope>,
-        mut connection_activity_tx: Sender<()>,
-        cx: &mut AsyncAppContext,
-    ) -> Task<Result<i32>> {
-        let (server_tx, server_rx) = cx
-            .update(|cx| {
-                cx.update_global(|conns: &mut FakeConnections, _| {
-                    conns.take(connection_options.port.unwrap())
-                })
-            })
-            .unwrap()
-            .into_channels()
-            .await;
-
-        let (forwarder, mut proxy_tx, mut proxy_rx) =
-            ChannelForwarder::new(server_tx, server_rx, cx);
-
-        cx.update(|cx| {
-            cx.update_global(|conns: &mut FakeConnections, _| {
-                conns.replace(connection_options.port.unwrap(), forwarder)
-            })
-        })
-        .unwrap();
-
-        cx.background_executor().spawn(async move {
-            loop {
-                select_biased! {
-                    server_to_client = proxy_rx.next().fuse() => {
-                        let Some(server_to_client) = server_to_client else {
-                            return Ok(1)
-                        };
-                        connection_activity_tx.try_send(()).ok();
-                        client_tx.send(server_to_client).await.ok();
-                    }
-                    client_to_server = client_rx.next().fuse() => {
-                        let Some(client_to_server) = client_to_server else {
-                            return Ok(1)
-                        };
-                        proxy_tx.send(client_to_server).await.ok();
-
-                    }
-                }
-            }
-        })
-    }
-}
-
-#[cfg(any(test, feature = "test-support"))]
-#[async_trait]
-impl SshRemoteProcess for FakeSshRemoteConnection {
-    async fn kill(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    fn ssh_args(&self) -> Vec<String> {
-        Vec::new()
-    }
-
-    fn connection_options(&self) -> SshConnectionOptions {
-        self.connection_options.clone()
-    }
-}
-
 type ResponseChannels = Mutex<HashMap<MessageId, oneshot::Sender<(Envelope, oneshot::Sender<()>)>>>;
 
 pub struct ChannelClient {
@@ -1738,8 +1592,9 @@ impl ChannelClient {
                     };
                     if let Some(ack_id) = incoming.ack_id {
                         let mut buffer = this.buffer.lock();
+                        dbg!(ack_id);
                         while buffer.front().is_some_and(|msg| msg.id <= ack_id) {
-                            buffer.pop_front();
+                            dbg!(buffer.pop_front());
                         }
                     }
                     if let Some(proto::envelope::Payload::FlushBufferedMessages(_)) =
@@ -1837,6 +1692,7 @@ impl ChannelClient {
         smol::future::or(
             async {
                 self.request(proto::FlushBufferedMessages {}).await?;
+                dbg!("replaying.....", &self.buffer);
                 for envelope in self.buffer.lock().iter() {
                     self.outgoing_tx.unbounded_send(envelope.clone()).ok();
                 }
@@ -1902,6 +1758,7 @@ impl ChannelClient {
 
     pub fn send_buffered(&self, mut envelope: proto::Envelope) -> Result<()> {
         envelope.ack_id = Some(self.max_received.load(SeqCst));
+        dbg!(&envelope);
         self.buffer.lock().push_back(envelope.clone());
         self.outgoing_tx.unbounded_send(envelope)?;
         Ok(())
@@ -1931,5 +1788,167 @@ impl ProtoClient for ChannelClient {
 
     fn is_via_collab(&self) -> bool {
         false
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+mod fake {
+    use std::path::PathBuf;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use futures::{
+        channel::{
+            mpsc::{self, Sender},
+            oneshot,
+        },
+        select_biased, FutureExt, SinkExt, StreamExt,
+    };
+    use gpui::{AsyncAppContext, BorrowAppContext, Global, SemanticVersion, Task};
+    use rpc::proto::Envelope;
+
+    use super::{
+        ChannelForwarder, SshClientDelegate, SshConnectionOptions, SshPlatform, SshRemoteProcess,
+    };
+
+    pub(super) struct SshRemoteConnection {
+        connection_options: SshConnectionOptions,
+    }
+
+    impl SshRemoteConnection {
+        pub(super) fn new(
+            connection_options: &SshConnectionOptions,
+        ) -> Option<Box<dyn SshRemoteProcess>> {
+            if connection_options.host == "<fake>" {
+                return Some(Box::new(Self {
+                    connection_options: connection_options.clone(),
+                }));
+            }
+            return None;
+        }
+        pub(super) async fn multiplex(
+            connection_options: SshConnectionOptions,
+            mut client_tx: mpsc::UnboundedSender<Envelope>,
+            mut client_rx: mpsc::UnboundedReceiver<Envelope>,
+            mut connection_activity_tx: Sender<()>,
+            cx: &mut AsyncAppContext,
+        ) -> Task<Result<i32>> {
+            let (server_tx, server_rx) = cx
+                .update(|cx| {
+                    cx.update_global(|conns: &mut GlobalConnections, _| {
+                        conns.take(connection_options.port.unwrap())
+                    })
+                })
+                .unwrap()
+                .into_channels()
+                .await;
+
+            let (forwarder, mut proxy_tx, mut proxy_rx) =
+                ChannelForwarder::new(server_tx, server_rx, cx);
+
+            cx.update(|cx| {
+                cx.update_global(|conns: &mut GlobalConnections, _| {
+                    conns.replace(connection_options.port.unwrap(), forwarder)
+                })
+            })
+            .unwrap();
+
+            cx.background_executor().spawn(async move {
+                loop {
+                    select_biased! {
+                        server_to_client = proxy_rx.next().fuse() => {
+                            let Some(server_to_client) = server_to_client else {
+                                return Ok(1)
+                            };
+                            connection_activity_tx.try_send(()).ok();
+                            client_tx.send(server_to_client).await.ok();
+                        }
+                        client_to_server = client_rx.next().fuse() => {
+                            let Some(client_to_server) = client_to_server else {
+                                return Ok(1)
+                            };
+                            proxy_tx.send(client_to_server).await.ok();
+
+                        }
+                    }
+                }
+            })
+        }
+    }
+
+    #[async_trait]
+    impl SshRemoteProcess for SshRemoteConnection {
+        async fn kill(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn ssh_args(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn connection_options(&self) -> SshConnectionOptions {
+            self.connection_options.clone()
+        }
+    }
+
+    #[derive(Default)]
+    pub(super) struct GlobalConnections(Vec<Option<ChannelForwarder>>);
+    impl Global for GlobalConnections {}
+
+    impl GlobalConnections {
+        pub(super) fn push(&mut self, forwarder: ChannelForwarder) -> u16 {
+            self.0.push(Some(forwarder));
+            self.0.len() as u16 - 1
+        }
+
+        pub(super) fn take(&mut self, port: u16) -> ChannelForwarder {
+            self.0
+                .get_mut(port as usize)
+                .expect("no fake server for port")
+                .take()
+                .expect("fake server is already borrowed")
+        }
+        pub(super) fn replace(&mut self, port: u16, forwarder: ChannelForwarder) {
+            let ret = self
+                .0
+                .get_mut(port as usize)
+                .expect("no fake server for port")
+                .replace(forwarder);
+            if ret.is_some() {
+                panic!("fake server is already replaced");
+            }
+        }
+    }
+
+    pub(super) struct Delegate;
+
+    impl SshClientDelegate for Delegate {
+        fn ask_password(
+            &self,
+            _: String,
+            _: &mut AsyncAppContext,
+        ) -> oneshot::Receiver<Result<String>> {
+            unreachable!()
+        }
+        fn remote_server_binary_path(
+            &self,
+            _: SshPlatform,
+            _: &mut AsyncAppContext,
+        ) -> Result<PathBuf> {
+            unreachable!()
+        }
+        fn get_server_binary(
+            &self,
+            _: SshPlatform,
+            _: &mut AsyncAppContext,
+        ) -> oneshot::Receiver<Result<(PathBuf, SemanticVersion)>> {
+            unreachable!()
+        }
+        fn set_status(&self, _: Option<&str>, _: &mut AsyncAppContext) {
+            unreachable!()
+        }
+        fn set_error(&self, _: String, _: &mut AsyncAppContext) {
+            unreachable!()
+        }
     }
 }

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -31,6 +31,7 @@ use smol::{
 };
 use std::{
     any::TypeId,
+    collections::VecDeque,
     ffi::OsStr,
     fmt,
     ops::ControlFlow,
@@ -730,7 +731,7 @@ impl SshRemoteClient {
 
             let multiplex_task = Self::monitor(this.clone(), io_task, &cx);
 
-            if let Err(error) = client.ping(HEARTBEAT_TIMEOUT).await {
+            if let Err(error) = client.resync(HEARTBEAT_TIMEOUT).await {
                 failed!(error, attempts, ssh_connection, delegate, forwarder);
             };
 
@@ -1163,7 +1164,7 @@ impl SshRemoteClient {
     }
 
     #[cfg(any(test, feature = "test-support"))]
-    pub fn simulate_disconnect(&self, cx: &mut AppContext) {
+    pub fn simulate_disconnect(&self, cx: &mut AppContext) -> Task<()> {
         let port = self.connection_options().port.unwrap();
 
         let disconnect =
@@ -1174,7 +1175,6 @@ impl SshRemoteClient {
             cx.update_global(|c: &mut FakeConnections, _cx| c.replace(port, forwarder))
                 .unwrap()
         })
-        .detach()
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -1254,6 +1254,7 @@ impl FakeConnections {
 #[cfg(any(test, feature = "test-support"))]
 struct FakeDelegate;
 
+#[cfg(any(test, feature = "test-support"))]
 impl SshClientDelegate for FakeDelegate {
     fn ask_password(
         &self,
@@ -1694,8 +1695,10 @@ type ResponseChannels = Mutex<HashMap<MessageId, oneshot::Sender<(Envelope, ones
 pub struct ChannelClient {
     next_message_id: AtomicU32,
     outgoing_tx: mpsc::UnboundedSender<Envelope>,
-    response_channels: ResponseChannels,             // Lock
-    message_handlers: Mutex<ProtoMessageHandlerSet>, // Lock
+    buffer: Mutex<VecDeque<Envelope>>,
+    response_channels: ResponseChannels,
+    message_handlers: Mutex<ProtoMessageHandlerSet>,
+    max_received: AtomicU32,
 }
 
 impl ChannelClient {
@@ -1707,8 +1710,10 @@ impl ChannelClient {
         let this = Arc::new(Self {
             outgoing_tx,
             next_message_id: AtomicU32::new(0),
+            max_received: AtomicU32::new(0),
             response_channels: ResponseChannels::default(),
             message_handlers: Default::default(),
+            buffer: Mutex::new(VecDeque::new()),
         });
 
         Self::start_handling_messages(this.clone(), incoming_rx, cx);
@@ -1729,6 +1734,27 @@ impl ChannelClient {
                     let Some(this) = this.upgrade() else {
                         return anyhow::Ok(());
                     };
+                    if let Some(ack_id) = incoming.ack_id {
+                        let mut buffer = this.buffer.lock();
+                        while buffer.front().is_some_and(|msg| msg.id <= ack_id) {
+                            buffer.pop_front();
+                        }
+                    }
+                    if let Some(proto::envelope::Payload::FlushBufferedMessages(_)) =
+                        &incoming.payload
+                    {
+                        {
+                            let buffer = this.buffer.lock();
+                            for envelope in buffer.iter() {
+                                this.outgoing_tx.unbounded_send(envelope.clone()).ok();
+                            }
+                        }
+                        let response = proto::Ack {}.into_envelope(0, Some(incoming.id), None);
+                        this.send_dynamic(response).ok();
+                        continue;
+                    }
+
+                    this.max_received.store(incoming.id, SeqCst);
 
                     if let Some(request_id) = incoming.responding_to {
                         let request_id = MessageId(request_id);
@@ -1805,6 +1831,23 @@ impl ChannelClient {
         }
     }
 
+    pub async fn resync(&self, timeout: Duration) -> Result<()> {
+        smol::future::or(
+            async {
+                self.request(proto::FlushBufferedMessages {}).await?;
+                for envelope in self.buffer.lock().iter() {
+                    self.outgoing_tx.unbounded_send(envelope.clone()).ok();
+                }
+                Ok(())
+            },
+            async {
+                smol::Timer::after(timeout).await;
+                Err(anyhow!("Timeout detected"))
+            },
+        )
+        .await
+    }
+
     pub async fn ping(&self, timeout: Duration) -> Result<()> {
         smol::future::or(
             async {
@@ -1834,7 +1877,8 @@ impl ChannelClient {
         let mut response_channels_lock = self.response_channels.lock();
         response_channels_lock.insert(MessageId(envelope.id), tx);
         drop(response_channels_lock);
-        let result = self.outgoing_tx.unbounded_send(envelope);
+
+        let result = self.send_buffered(envelope);
         async move {
             if let Err(error) = &result {
                 log::error!("failed to send message: {}", error);
@@ -1851,6 +1895,12 @@ impl ChannelClient {
 
     pub fn send_dynamic(&self, mut envelope: proto::Envelope) -> Result<()> {
         envelope.id = self.next_message_id.fetch_add(1, SeqCst);
+        self.send_buffered(envelope)
+    }
+
+    pub fn send_buffered(&self, mut envelope: proto::Envelope) -> Result<()> {
+        envelope.ack_id = Some(self.max_received.load(SeqCst));
+        self.buffer.lock().push_back(envelope.clone());
         self.outgoing_tx.unbounded_send(envelope)?;
         Ok(())
     }

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1083,9 +1083,11 @@ impl SshRemoteClient {
 
         let platform = ssh_connection.query_platform().await?;
         let remote_binary_path = delegate.remote_server_binary_path(platform, cx)?;
-        ssh_connection
-            .ensure_server_binary(&delegate, &remote_binary_path, platform, cx)
-            .await?;
+        if !reconnect {
+            ssh_connection
+                .ensure_server_binary(&delegate, &remote_binary_path, platform, cx)
+                .await?;
+        }
 
         let socket = ssh_connection.socket.clone();
         run_cmd(socket.ssh_command(&remote_binary_path).arg("version")).await?;

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -6,6 +6,7 @@ use crate::{
     proxy::ProxyLaunchError,
 };
 use anyhow::{anyhow, Context as _, Result};
+use async_trait::async_trait;
 use collections::HashMap;
 use futures::{
     channel::{
@@ -346,7 +347,7 @@ const MAX_RECONNECT_ATTEMPTS: usize = 3;
 enum State {
     Connecting,
     Connected {
-        ssh_connection: SshRemoteConnection,
+        ssh_connection: Box<dyn SshRemoteProcess>,
         delegate: Arc<dyn SshClientDelegate>,
         forwarder: ChannelForwarder,
 
@@ -356,7 +357,7 @@ enum State {
     HeartbeatMissed {
         missed_heartbeats: usize,
 
-        ssh_connection: SshRemoteConnection,
+        ssh_connection: Box<dyn SshRemoteProcess>,
         delegate: Arc<dyn SshClientDelegate>,
         forwarder: ChannelForwarder,
 
@@ -365,7 +366,7 @@ enum State {
     },
     Reconnecting,
     ReconnectFailed {
-        ssh_connection: SshRemoteConnection,
+        ssh_connection: Box<dyn SshRemoteProcess>,
         delegate: Arc<dyn SshClientDelegate>,
         forwarder: ChannelForwarder,
 
@@ -391,11 +392,11 @@ impl fmt::Display for State {
 }
 
 impl State {
-    fn ssh_connection(&self) -> Option<&SshRemoteConnection> {
+    fn ssh_connection(&self) -> Option<&dyn SshRemoteProcess> {
         match self {
-            Self::Connected { ssh_connection, .. } => Some(ssh_connection),
-            Self::HeartbeatMissed { ssh_connection, .. } => Some(ssh_connection),
-            Self::ReconnectFailed { ssh_connection, .. } => Some(ssh_connection),
+            Self::Connected { ssh_connection, .. } => Some(ssh_connection.as_ref()),
+            Self::HeartbeatMissed { ssh_connection, .. } => Some(ssh_connection.as_ref()),
+            Self::ReconnectFailed { ssh_connection, .. } => Some(ssh_connection.as_ref()),
             _ => None,
         }
     }
@@ -540,23 +541,19 @@ impl SshRemoteClient {
             let (proxy, proxy_incoming_tx, proxy_outgoing_rx) =
                 ChannelForwarder::new(incoming_tx, outgoing_rx, &mut cx);
 
-            let (ssh_connection, ssh_proxy_process) = Self::establish_connection(
+            let (ssh_connection, io_task) = Self::establish_connection(
                 unique_identifier,
                 false,
                 connection_options,
+                proxy_incoming_tx,
+                proxy_outgoing_rx,
+                connection_activity_tx,
                 delegate.clone(),
                 &mut cx,
             )
             .await?;
 
-            let multiplex_task = Self::multiplex(
-                this.downgrade(),
-                ssh_proxy_process,
-                proxy_incoming_tx,
-                proxy_outgoing_rx,
-                connection_activity_tx,
-                &mut cx,
-            );
+            let multiplex_task = Self::monitor(this.downgrade(), io_task, &cx);
 
             if let Err(error) = client.ping(HEARTBEAT_TIMEOUT).await {
                 log::error!("failed to establish connection: {}", error);
@@ -702,30 +699,24 @@ impl SshRemoteClient {
                 };
             }
 
-            if let Err(error) = ssh_connection.master_process.kill() {
+            if let Err(error) = ssh_connection.kill().await.context("Failed to kill ssh process") {
                 failed!(error, attempts, ssh_connection, delegate, forwarder);
             };
 
-            if let Err(error) = ssh_connection
-                .master_process
-                .status()
-                .await
-                .context("Failed to kill ssh process")
-            {
-                failed!(error, attempts, ssh_connection, delegate, forwarder);
-            }
-
-            let connection_options = ssh_connection.socket.connection_options.clone();
+            let connection_options = ssh_connection.connection_options();
 
             let (incoming_tx, outgoing_rx) = forwarder.into_channels().await;
             let (forwarder, proxy_incoming_tx, proxy_outgoing_rx) =
                 ChannelForwarder::new(incoming_tx, outgoing_rx, &mut cx);
             let (connection_activity_tx, connection_activity_rx) = mpsc::channel::<()>(1);
 
-            let (ssh_connection, ssh_process) = match Self::establish_connection(
+            let (ssh_connection, io_task) = match Self::establish_connection(
                 identifier,
                 true,
                 connection_options,
+                proxy_incoming_tx,
+                proxy_outgoing_rx,
+                connection_activity_tx,
                 delegate.clone(),
                 &mut cx,
             )
@@ -737,14 +728,7 @@ impl SshRemoteClient {
                 }
             };
 
-            let multiplex_task = Self::multiplex(
-                this.clone(),
-                ssh_process,
-                proxy_incoming_tx,
-                proxy_outgoing_rx,
-                connection_activity_tx,
-                &mut cx,
-            );
+            let multiplex_task = Self::monitor(this.clone(), io_task, &cx);
 
             if let Err(error) = client.ping(HEARTBEAT_TIMEOUT).await {
                 failed!(error, attempts, ssh_connection, delegate, forwarder);
@@ -910,13 +894,12 @@ impl SshRemoteClient {
     }
 
     fn multiplex(
-        this: WeakModel<Self>,
         mut ssh_proxy_process: Child,
         incoming_tx: UnboundedSender<Envelope>,
         mut outgoing_rx: UnboundedReceiver<Envelope>,
         mut connection_activity_tx: Sender<()>,
         cx: &AsyncAppContext,
-    ) -> Task<Result<()>> {
+    ) -> Task<Result<i32>> {
         let mut child_stderr = ssh_proxy_process.stderr.take().unwrap();
         let mut child_stdout = ssh_proxy_process.stdout.take().unwrap();
         let mut child_stdin = ssh_proxy_process.stdin.take().unwrap();
@@ -1002,9 +985,22 @@ impl SshRemoteClient {
             };
 
             match result {
-                Ok(_) => {
-                    let exit_code = ssh_proxy_process.status().await?.code().unwrap_or(1);
+                Ok(_) => Ok(ssh_proxy_process.status().await?.code().unwrap_or(1)),
+                Err(error) => Err(error),
+            }
+        })
+    }
 
+    fn monitor(
+        this: WeakModel<Self>,
+        io_task: Task<Result<i32>>,
+        cx: &AsyncAppContext,
+    ) -> Task<Result<()>> {
+        cx.spawn(|mut cx| async move {
+            let result = io_task.await;
+
+            match result {
+                Ok(exit_code) => {
                     if let Some(error) = ProxyLaunchError::from_exit_code(exit_code) {
                         match error {
                             ProxyLaunchError::ServerNotRunning => {
@@ -1062,9 +1058,17 @@ impl SshRemoteClient {
         unique_identifier: String,
         reconnect: bool,
         connection_options: SshConnectionOptions,
+        proxy_incoming_tx: UnboundedSender<Envelope>,
+        proxy_outgoing_rx: UnboundedReceiver<Envelope>,
+        connection_activity_tx: Sender<()>,
         delegate: Arc<dyn SshClientDelegate>,
         cx: &mut AsyncAppContext,
-    ) -> Result<(SshRemoteConnection, Child)> {
+    ) -> Result<(Box<dyn SshRemoteProcess>, Task<Result<i32>>)> {
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(fake) = FakeSshRemoteConnection::new(&connection_options, cx) {
+            return Ok(fake);
+        }
+
         let ssh_connection =
             SshRemoteConnection::new(connection_options, delegate.clone(), cx).await?;
 
@@ -1097,7 +1101,15 @@ impl SshRemoteClient {
             .spawn()
             .context("failed to spawn remote server")?;
 
-        Ok((ssh_connection, ssh_proxy_process))
+        let io_task = Self::multiplex(
+            ssh_proxy_process,
+            proxy_incoming_tx,
+            proxy_outgoing_rx,
+            connection_activity_tx,
+            &cx,
+        );
+
+        Ok((Box::new(ssh_connection), io_task))
     }
 
     pub fn subscribe_to_entity<E: 'static>(&self, remote_id: u64, entity: &Model<E>) {
@@ -1109,7 +1121,7 @@ impl SshRemoteClient {
             .lock()
             .as_ref()
             .and_then(|state| state.ssh_connection())
-            .map(|ssh_connection| ssh_connection.socket.ssh_args())
+            .map(|ssh_connection| ssh_connection.ssh_args())
     }
 
     pub fn proto_client(&self) -> AnyProtoClient {
@@ -1173,6 +1185,13 @@ impl From<SshRemoteClient> for AnyProtoClient {
     }
 }
 
+#[async_trait]
+trait SshRemoteProcess: Send + Sync {
+    async fn kill(&mut self) -> Result<()>;
+    fn ssh_args(&self) -> Vec<String>;
+    fn connection_options(&self) -> SshConnectionOptions;
+}
+
 struct SshRemoteConnection {
     socket: SshSocket,
     master_process: process::Child,
@@ -1184,6 +1203,25 @@ impl Drop for SshRemoteConnection {
         if let Err(error) = self.master_process.kill() {
             log::error!("failed to kill SSH master process: {}", error);
         }
+    }
+}
+
+#[async_trait]
+impl SshRemoteProcess for SshRemoteConnection {
+    async fn kill(&mut self) -> Result<()> {
+        self.master_process.kill()?;
+
+        self.master_process.status().await?;
+
+        Ok(())
+    }
+
+    fn ssh_args(&self) -> Vec<String> {
+        self.socket.ssh_args()
+    }
+
+    fn connection_options(&self) -> SshConnectionOptions {
+        self.socket.connection_options.clone()
     }
 }
 
@@ -1462,6 +1500,34 @@ impl SshRemoteConnection {
                 String::from_utf8_lossy(&output.stderr)
             ))
         }
+    }
+}
+
+struct FakeSshRemoteConnection {
+    connection_options: SshConnectionOptions,
+}
+
+impl FakeSshRemoteConnection {
+    fn new(
+        _connection_options: &SshConnectionOptions,
+        _cx: &mut AsyncAppContext,
+    ) -> Option<(Box<dyn SshRemoteProcess>, Task<Result<Option<i32>>>)> {
+        return None;
+    }
+}
+
+#[async_trait]
+impl SshRemoteProcess for FakeSshRemoteConnection {
+    async fn kill(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn ssh_args(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn connection_options(&self) -> SshConnectionOptions {
+        self.connection_options.clone()
     }
 }
 

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -675,6 +675,7 @@ async fn test_reconnect(cx: &mut TestAppContext, server_cx: &mut TestAppContext)
         .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
         .await
         .unwrap();
+
     assert_eq!(
         fs.load("/code/project1/src/lib.rs".as_ref()).await.unwrap(),
         "fn one() -> usize { 100 }"

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -694,7 +694,7 @@ async fn init_test(
 ) -> (Model<Project>, Model<HeadlessProject>, Arc<FakeFs>) {
     init_logger();
 
-    let (forwarder, ssh_server_client) = SshRemoteClient::fake_server(server_cx);
+    let (forwarder, ssh_server_client) = SshRemoteClient::fake_server(cx, server_cx);
     let fs = FakeFs::new(server_cx.executor());
     fs.insert_tree(
         "/code",

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -665,12 +665,11 @@ async fn test_reconnect(cx: &mut TestAppContext, server_cx: &mut TestAppContext)
         let ix = buffer.text().find('1').unwrap();
         buffer.edit([(ix..ix + 1, "100")], None, cx);
     });
-    cx.run_until_parked();
 
     let client = cx.read(|cx| project.read(cx).ssh_client().unwrap());
-    client.update(cx, |client, cx| client.simulate_disconnect(cx));
-
-    cx.run_until_parked();
+    client
+        .update(cx, |client, cx| client.simulate_disconnect(cx))
+        .detach();
 
     project
         .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
@@ -680,8 +679,6 @@ async fn test_reconnect(cx: &mut TestAppContext, server_cx: &mut TestAppContext)
         fs.load("/code/project1/src/lib.rs".as_ref()).await.unwrap(),
         "fn one() -> usize { 100 }"
     );
-
-    cx.run_until_parked();
 }
 
 fn init_logger() {

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -641,7 +641,7 @@ async fn test_open_server_settings(cx: &mut TestAppContext, server_cx: &mut Test
     })
 }
 
-#[gpui::test(iterations = 10)]
+#[gpui::test(iterations = 20)]
 async fn test_reconnect(cx: &mut TestAppContext, server_cx: &mut TestAppContext) {
     let (project, _headless, fs) = init_test(cx, server_cx).await;
 

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -279,7 +279,7 @@ fn start_server(
     })
     .detach();
 
-    ChannelClient::new(incoming_rx, outgoing_tx, cx)
+    ChannelClient::new(incoming_rx, outgoing_tx, cx, "server")
 }
 
 fn init_paths() -> anyhow::Result<()> {


### PR DESCRIPTION
Before this change messages could be lost on reconnect, now they will not be.

Release Notes:

- SSH Remoting: make reconnects smoother
