### PR TITLE
tasks: Add spawn option for tag filter

### DIFF
--- a/assets/settings/initial_tasks.json
+++ b/assets/settings/initial_tasks.json
@@ -38,6 +38,8 @@
     //           "args": ["--login"]
     //         }
     //     }
-    "shell": "system"
+    "shell": "system",
+    // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
+    "tags": []
   }
 ]

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -51,7 +51,7 @@ pub struct TaskTemplate {
     /// * `on_success` — hide the terminal tab on task success only, otherwise behaves similar to `always`.
     #[serde(default)]
     pub hide: HideStrategy,
-    /// Represents the tags which this template attaches to. Adding this removes this task from other UI.
+    /// Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
     #[serde(default)]
     pub tags: Vec<String>,
     /// Which shell to use when spawning the task.

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -26,14 +26,21 @@ use serde::Deserialize;
 pub struct Spawn {
     #[serde(default)]
     /// Name of the task to spawn.
-    /// If it is not set, a modal with a list of available tasks is opened instead.
+    /// If neither task_name nor task_tag is set, a modal with a list of available tasks is opened instead.
     /// Defaults to None.
     pub task_name: Option<String>,
+    /// Name of the tag to spawn all related tasks.
+    /// If neither task_name nor task_tag is set, a modal with a list of available tasks is opened instead.
+    /// Defaults to None.
+    pub task_tag: Option<String>,
 }
 
 impl Spawn {
     pub fn modal() -> Self {
-        Self { task_name: None }
+        Self {
+            task_name: None,
+            task_tag: None,
+        }
     }
 }
 
@@ -721,6 +728,7 @@ mod tests {
 
         cx.dispatch_action(Spawn {
             task_name: Some("example task".to_string()),
+            task_tag: None,
         });
         let tasks_picker = workspace.update(cx, |workspace, cx| {
             workspace

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -40,7 +40,9 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     //           "args": ["--login"]
     //         }
     //     }
-    "shell": "system"
+    "shell": "system",
+    // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
+    "tags": []
   }
 ]
 ```
@@ -103,13 +105,17 @@ The intended use of ephemeral tasks is to stay in the flow with continuous `task
 
 ## Custom keybindings for tasks
 
-You can define your own keybindings for your tasks via additional argument to `task::Spawn`. If you wanted to bind the aforementioned `echo current file's path` task to `alt-g`, you would add the following snippet in your [`keymap.json`](./key-bindings.md) file:
+You can define your own keybindings for your tasks via additional argument to `task::Spawn`. You can filter the task(s) to spawn either with `task_name` (spawn a single task) or `task_tag` (spawn all tasks with a tag).
+A snippet in your [`keymap.json`](./key-bindings.md) file might look like this:
 
 ```json
 {
   "context": "Workspace",
   "bindings": {
-    "alt-g": ["task::Spawn", { "task_name": "echo current file's path" }]
+    // run the "echo current file's path" task on `alt-s e`
+    "alt-s e": ["task::Spawn", { "task_name": "echo current file's path" }],
+    // spawn all tasks with a "keybind:startup" tag on `alt-s s`
+    "alt-s s": ["task::Spawn", { "task_tag": "keybind:startup" }]
   }
 }
 ```


### PR DESCRIPTION
Relates to #19497

This adds the minimal feature demand. Optimally, the tags should be enlisted in the UI as well (maybe, only if a tag starts with something like `ui:`).

I tried to write some tests as well, but as a rust (and project) newbie, I was blocked as I didn't know how to assert any task to have been run.

Since this is my first contribution, let me say thanks for a great project at this point as well :tada: 

Release Notes:

- Tasks: Added `task::Spawn` option `"task_tag": "my-tag"` to enable spawning multiple tasks at once
