### PR TITLE
editor: Move hunk controls to the right

### DIFF
--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -418,7 +418,7 @@ impl Editor {
                             h_flex()
                                 .px_6()
                                 .size_full()
-                                .justify_between()
+                                .justify_end()
                                 .child(
                                     h_flex()
                                         .gap_1()


### PR DESCRIPTION
This PR moves the hunk controls over to the right so we can see how they feel over there.

Git:

<img width="1068" alt="Screenshot 2024-10-21 at 10 27 34 AM" src="https://github.com/user-attachments/assets/71556e22-024a-4bdf-8a99-fe28430b9155">

Live diffs:

<img width="1060" alt="Screenshot 2024-10-21 at 10 27 28 AM" src="https://github.com/user-attachments/assets/681ff409-dc55-4b63-87d7-7e39016417d2">


Release Notes:

- Moved hunk controls to the right of the header.
