### PR TITLE
docs: Add missing link to jsonnet.md in the summary

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -85,6 +85,7 @@
 - [JavaScript](./languages/javascript.md)
 - [Julia](./languages/julia.md)
 - [JSON](./languages/json.md)
+- [Jsonnet](./languages/jsonnet.md)
 - [Kotlin](./languages/kotlin.md)
 - [Lua](./languages/lua.md)
 - [Luau](./languages/luau.md)


### PR DESCRIPTION
This is a fixup for #19410.

Apparently, `mdbook` requires a reference to the document from the `SUMMARY.md`. This fixes the 404 (https://zed.dev/docs/languages/jsonnet.html) and also adds the Jsonnet to the docs' navigation.

Release Notes:

- N/A
