### PR TITLE
ssh remoting: Daemonize server process properly by forking and closing stdio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9159,6 +9159,7 @@ dependencies = [
  "client",
  "clock",
  "env_logger",
+ "fork",
  "fs",
  "futures 0.3.30",
  "git",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9168,6 +9168,7 @@ dependencies = [
  "http_client",
  "language",
  "languages",
+ "libc",
  "log",
  "lsp",
  "node_runtime",

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -28,6 +28,7 @@ backtrace = "0.3"
 clap.workspace = true
 client.workspace = true
 env_logger.workspace = true
+fork.workspace = true
 fs.workspace = true
 futures.workspace = true
 git.workspace = true

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -28,7 +28,6 @@ backtrace = "0.3"
 clap.workspace = true
 client.workspace = true
 env_logger.workspace = true
-fork.workspace = true
 fs.workspace = true
 futures.workspace = true
 git.workspace = true
@@ -37,7 +36,6 @@ gpui.workspace = true
 http_client.workspace = true
 language.workspace = true
 languages.workspace = true
-libc.workspace = true
 log.workspace = true
 lsp.workspace = true
 node_runtime.workspace = true
@@ -54,6 +52,10 @@ shellexpand.workspace = true
 smol.workspace = true
 util.workspace = true
 worktree.workspace = true
+
+[target.'cfg(not(windows))'.dependencies]
+fork.workspace = true
+libc.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -37,6 +37,7 @@ gpui.workspace = true
 http_client.workspace = true
 language.workspace = true
 languages.workspace = true
+libc.workspace = true
 log.workspace = true
 lsp.workspace = true
 node_runtime.workspace = true

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -310,7 +310,7 @@ pub fn execute_run(
 
     match daemonize()? {
         ControlFlow::Break(_) => return Ok(()),
-        ControlFlow::Continue(_) => {},
+        ControlFlow::Continue(_) => {}
     }
 
     init_panic_hook();
@@ -541,8 +541,13 @@ fn spawn_server(paths: &ServerPaths) -> Result<()> {
         .arg("--stderr-socket")
         .arg(&paths.stderr_socket);
 
-    let status = server_process.status().context("failed to launch server process")?;
-    anyhow::ensure!(status.success(), "failed to launch and detach server process");
+    let status = server_process
+        .status()
+        .context("failed to launch server process")?;
+    anyhow::ensure!(
+        status.success(),
+        "failed to launch and detach server process"
+    );
 
     let mut total_time_waited = std::time::Duration::from_secs(0);
     let wait_duration = std::time::Duration::from_millis(20);
@@ -752,8 +757,8 @@ fn daemonize() -> Result<ControlFlow<()>> {
     match fork::fork().map_err(|e| anyhow::anyhow!("failed to call fork with error code {}", e))? {
         fork::Fork::Parent(_) => {
             return Ok(ControlFlow::Break(()));
-        },
-        fork::Fork::Child => {},
+        }
+        fork::Fork::Child => {}
     }
 
     // Once we've detached from the parent, we want to close stdout/stderr/stdin
@@ -769,7 +774,10 @@ unsafe fn redirect_standard_streams() -> Result<()> {
 
     let process_stdio = |name, fd| {
         let reopened_fd = libc::dup2(devnull_fd, fd);
-        anyhow::ensure!(reopened_fd != -1, format!("failed to redirect {} to /dev/null", name));
+        anyhow::ensure!(
+            reopened_fd != -1,
+            format!("failed to redirect {} to /dev/null", name)
+        );
         Ok(())
     };
 
@@ -777,7 +785,10 @@ unsafe fn redirect_standard_streams() -> Result<()> {
     process_stdio("stdout", libc::STDOUT_FILENO)?;
     process_stdio("stderr", libc::STDERR_FILENO)?;
 
-    anyhow::ensure!(libc::close(devnull_fd) != -1, "failed to close /dev/null fd after redirecting");
+    anyhow::ensure!(
+        libc::close(devnull_fd) != -1,
+        "failed to close /dev/null fd after redirecting"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This fixes the `ssh` proxy process not being notified when the proxy process dies. Turns out that the server would have stdout/stderr/stdin connected to the grand-parent ssh process connected to it and as long as the server kept running (even once it was daemonized into the background) the grand-parent ssh process wouldn't exit.

That in turn meant that the Zed client wasn't notified when the proxy process died.

Release Notes:

- N/A
