### PR TITLE
ssh: Expose server address in the title bar

### DIFF
--- a/crates/recent_projects/src/disconnected_overlay.rs
+++ b/crates/recent_projects/src/disconnected_overlay.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use dev_server_projects::DevServer;
 use gpui::{ClickEvent, DismissEvent, EventEmitter, FocusHandle, FocusableView, Render, WeakView};
 use remote::SshConnectionOptions;
+use settings::Settings;
 use ui::{
     div, h_flex, rems, Button, ButtonCommon, ButtonStyle, Clickable, ElevationIndex, FluentBuilder,
     Headline, HeadlineSize, IconName, IconPosition, InteractiveElement, IntoElement, Label, Modal,
@@ -12,7 +13,7 @@ use workspace::{notifications::DetachAndPromptErr, ModalView, OpenOptions, Works
 
 use crate::{
     open_dev_server_project, open_ssh_project, remote_servers::reconnect_to_dev_server_project,
-    RemoteServerProjects,
+    RemoteServerProjects, SshSettings,
 };
 
 enum Host {
@@ -157,6 +158,16 @@ impl DisconnectedOverlay {
         let paths = ssh_project.paths.iter().map(PathBuf::from).collect();
 
         cx.spawn(move |_, mut cx| async move {
+            let nickname = cx
+                .update(|cx| {
+                    SshSettings::get_global(cx).nickname_for(
+                        &connection_options.host,
+                        connection_options.port.clone(),
+                        &connection_options.username,
+                    )
+                })
+                .ok()
+                .flatten();
             open_ssh_project(
                 connection_options,
                 paths,
@@ -165,6 +176,7 @@ impl DisconnectedOverlay {
                     replace_window: Some(window),
                     ..Default::default()
                 },
+                nickname,
                 &mut cx,
             )
             .await?;

--- a/crates/recent_projects/src/disconnected_overlay.rs
+++ b/crates/recent_projects/src/disconnected_overlay.rs
@@ -162,7 +162,7 @@ impl DisconnectedOverlay {
                 .update(|cx| {
                     SshSettings::get_global(cx).nickname_for(
                         &connection_options.host,
-                        connection_options.port.clone(),
+                        connection_options.port,
                         &connection_options.username,
                     )
                 })

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -388,6 +388,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                             };
 
                             let args = SshSettings::get_global(cx).args_for(&ssh_project.host, ssh_project.port, &ssh_project.user);
+                            let nickname = SshSettings::get_global(cx).nickname_for(&ssh_project.host, ssh_project.port, &ssh_project.user);
                             let connection_options = SshConnectionOptions {
                                 host: ssh_project.host.clone(),
                                 username: ssh_project.user.clone(),
@@ -399,7 +400,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                             let paths = ssh_project.paths.iter().map(PathBuf::from).collect();
 
                             cx.spawn(|_, mut cx| async move {
-                                open_ssh_project(connection_options, paths, app_state, open_options, &mut cx).await
+                                open_ssh_project(connection_options, paths, app_state, open_options, nickname, &mut cx).await
                             })
                         }
                     }

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -401,7 +401,7 @@ impl RemoteServerProjects {
                 return;
             }
         };
-        let ssh_prompt = cx.new_view(|cx| SshPrompt::new(&connection_options, cx));
+        let ssh_prompt = cx.new_view(|cx| SshPrompt::new(&connection_options, None, cx));
 
         let connection = connect_over_ssh(
             connection_options.remote_server_identifier(),
@@ -478,10 +478,13 @@ impl RemoteServerProjects {
             return;
         };
 
+        let nickname = ssh_connection.nickname.clone();
         let connection_options = ssh_connection.into();
         workspace.update(cx, |_, cx| {
             cx.defer(move |workspace, cx| {
-                workspace.toggle_modal(cx, |cx| SshConnectionModal::new(&connection_options, cx));
+                workspace.toggle_modal(cx, |cx| {
+                    SshConnectionModal::new(&connection_options, nickname, cx)
+                });
                 let prompt = workspace
                     .active_modal::<SshConnectionModal>(cx)
                     .unwrap()

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -727,11 +727,13 @@ impl RemoteServerProjects {
                 let project = project.clone();
                 let server = server.clone();
                 cx.spawn(|_, mut cx| async move {
+                    let nickname = server.nickname.clone();
                     let result = open_ssh_project(
                         server.into(),
                         project.paths.into_iter().map(PathBuf::from).collect(),
                         app_state,
                         OpenOptions::default(),
+                        nickname,
                         &mut cx,
                     )
                     .await;

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -68,6 +68,7 @@ impl SshSettings {
             })
             .next()
             .flatten()
+    }
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -103,6 +103,7 @@ impl Settings for SshSettings {
 
 pub struct SshPrompt {
     connection_string: SharedString,
+    nickname: Option<SharedString>,
     status_message: Option<SharedString>,
     prompt: Option<(View<Markdown>, oneshot::Sender<Result<String>>)>,
     editor: View<Editor>,
@@ -116,11 +117,13 @@ pub struct SshConnectionModal {
 impl SshPrompt {
     pub(crate) fn new(
         connection_options: &SshConnectionOptions,
+        nickname: Option<SharedString>,
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let connection_string = connection_options.connection_string().into();
         Self {
             connection_string,
+            nickname,
             status_message: None,
             prompt: None,
             editor: cx.new_view(Editor::single_line),
@@ -228,9 +231,13 @@ impl Render for SshPrompt {
 }
 
 impl SshConnectionModal {
-    pub fn new(connection_options: &SshConnectionOptions, cx: &mut ViewContext<Self>) -> Self {
+    pub(crate) fn new(
+        connection_options: &SshConnectionOptions,
+        nickname: Option<SharedString>,
+        cx: &mut ViewContext<Self>,
+    ) -> Self {
         Self {
-            prompt: cx.new_view(|cx| SshPrompt::new(connection_options, cx)),
+            prompt: cx.new_view(|cx| SshPrompt::new(connection_options, nickname, cx)),
             finished: false,
         }
     }
@@ -297,6 +304,7 @@ impl RenderOnce for SshConnectionHeader {
 
 impl Render for SshConnectionModal {
     fn render(&mut self, cx: &mut ui::ViewContext<Self>) -> impl ui::IntoElement {
+        let nickname = self.prompt.read(cx).nickname.clone();
         let connection_string = self.prompt.read(cx).connection_string.clone();
         let theme = cx.theme();
 
@@ -313,7 +321,7 @@ impl Render for SshConnectionModal {
             .child(
                 SshConnectionHeader {
                     connection_string,
-                    nickname: None,
+                    nickname,
                 }
                 .render(cx),
             )
@@ -614,7 +622,9 @@ pub async fn open_ssh_project(
             let connection_options = connection_options.clone();
             move |workspace, cx| {
                 cx.activate_window();
-                workspace.toggle_modal(cx, |cx| SshConnectionModal::new(&connection_options, cx));
+                workspace.toggle_modal(cx, |cx| {
+                    SshConnectionModal::new(&connection_options, None, cx)
+                });
                 let ui = workspace
                     .active_modal::<SshConnectionModal>(cx)
                     .unwrap()

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -44,6 +44,7 @@ recent_projects.workspace = true
 remote.workspace = true
 rpc.workspace = true
 serde.workspace = true
+settings.workspace = true
 smallvec.workspace = true
 story = { workspace = true, optional = true }
 theme.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -713,6 +713,16 @@ fn handle_open_request(
 
     if let Some(connection_info) = request.ssh_connection {
         cx.spawn(|mut cx| async move {
+            let nickname = cx
+                .update(|cx| {
+                    SshSettings::get_global(cx).nickname_for(
+                        &connection_info.host,
+                        connection_info.port.clone(),
+                        &connection_info.username,
+                    )
+                })
+                .ok()
+                .flatten();
             let paths_with_position =
                 derive_paths_with_position(app_state.fs.as_ref(), request.open_paths).await;
             open_ssh_project(
@@ -720,6 +730,7 @@ fn handle_open_request(
                 paths_with_position.into_iter().map(|p| p.path).collect(),
                 app_state,
                 workspace::OpenOptions::default(),
+                nickname,
                 &mut cx,
             )
             .await
@@ -888,6 +899,12 @@ async fn restore_or_create_workspace(
                         })
                         .ok()
                         .flatten();
+                    let nickname = cx
+                        .update(|cx| {
+                            SshSettings::get_global(cx).nickname_for(&ssh.host, ssh.port, &ssh.user)
+                        })
+                        .ok()
+                        .flatten();
                     let connection_options = SshConnectionOptions {
                         args,
                         host: ssh.host.clone(),
@@ -902,6 +919,7 @@ async fn restore_or_create_workspace(
                             ssh.paths.into_iter().map(PathBuf::from).collect(),
                             app_state,
                             workspace::OpenOptions::default(),
+                            nickname,
                             &mut cx,
                         )
                         .await

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -717,7 +717,7 @@ fn handle_open_request(
                 .update(|cx| {
                     SshSettings::get_global(cx).nickname_for(
                         &connection_info.host,
-                        connection_info.port.clone(),
+                        connection_info.port,
                         &connection_info.username,
                     )
                 })

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -437,12 +437,19 @@ async fn open_workspaces(
                         port: ssh.port,
                         password: None,
                     };
+                    let nickname = cx
+                        .update(|cx| {
+                            SshSettings::get_global(cx).nickname_for(&ssh.host, ssh.port, &ssh.user)
+                        })
+                        .ok()
+                        .flatten();
                     cx.spawn(|mut cx| async move {
                         open_ssh_project(
                             connection_options,
                             ssh.paths.into_iter().map(PathBuf::from).collect(),
                             app_state,
                             OpenOptions::default(),
+                            nickname,
                             &mut cx,
                         )
                         .await


### PR DESCRIPTION
This PR exposes the server address (or the nickname, if there is one) on the title bar and in all modals that have the SSH header. The title bar tooltip meta description still shows the original server address (regardless of a nickname existing in this case), though.

<img width="600" alt="Screenshot 2024-10-22 at 10 58 36" src="https://github.com/user-attachments/assets/64a94d9f-798b-44a4-9dee-6056886535bb">

Release Notes:

- N/A
