### PR TITLE
ssh: Don't erase the connection input on escape key

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -590,7 +590,13 @@ impl RemoteServerProjects {
         match &self.mode {
             Mode::Default(_) => cx.emit(DismissEvent),
             Mode::CreateRemoteServer(state) if state.ssh_prompt.is_some() => {
-                self.mode = Mode::CreateRemoteServer(CreateRemoteServer::new(cx));
+                let new_state = CreateRemoteServer::new(cx);
+                let old_prompt = state.address_editor.read(cx).text(cx);
+                new_state.address_editor.update(cx, |this, cx| {
+                    this.set_text(old_prompt, cx);
+                });
+
+                self.mode = Mode::CreateRemoteServer(new_state);
                 self.selectable_items.reset_selection();
                 cx.notify();
             }


### PR DESCRIPTION
This PR changes the behavior of pressing the `Esc` key on the connection input. Now, if you hit it, the address inserted into the input won't be erased. Effectively, escape now only cancels the connection process instead of doing both (clearing the input _and_ cancelling the connection).

Release Notes:

- N/A
