### PR TITLE
Fix Discord link

### DIFF
--- a/docs/src/windows.md
+++ b/docs/src/windows.md
@@ -10,4 +10,4 @@ Zed Employees are not currently working on the Windows build.
 However, we welcome contributions from the community to improve Windows support.
 
 - [GitHub Issues with 'Windows' label](https://github.com/zed-industries/zed/issues?q=is%3Aissue+is%3Aopen+label%3Awindows)
-- [#windows-port on Zed Community Discord](https://discord.com/channels/869392257814519848/1208481909676576818)
+- [Zed Community Discord](https://discord.gg/zed-community) -> `#windows-port`


### PR DESCRIPTION
We can't seem to generate invite links that dumps a user directly into a specific channel, so just adding a general invite link and then pointing them to the Windows channel name.

Release Notes:

- N/A
