### PR TITLE
docs: Document upstream JSONC Prettier issues

### DIFF
--- a/docs/src/languages/json.md
+++ b/docs/src/languages/json.md
@@ -10,6 +10,26 @@ JSON support is available natively in Zed.
 Zed also supports a super-set of JSON called JSONC, which allows single line comments (`//`) in JSON files.
 While editing these files you can use `cmd-/` (macOS) or `ctrl-/` (Linux) to toggle comments on the current line or selection.
 
+## JSONC Prettier Formatting
+
+If you use files with the `*.jsonc` extension when using `Format Document` or have `format_on_save` enabled, Zed invokes Prettier as the formatter.  Prettier has an [outstanding issue](https://github.com/prettier/prettier/issues/15956) where it will add trailing commas to files with a `jsonc` extension.  JSONC files which have a `.json` extension are unaffected.
+
+To workaround this behavior you can add the following to your `.prettierrc`
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["*.jsonc"],
+      "options": {
+        "parser": "json",
+        "trailingComma": "none"
+      }
+    }
+  ]
+}
+```
+
 <!--
 TBD: JSONC Example for how to use `file_types`
 TBD: Add formatter (prettier) settings (autoformat, tab_size, etc)

--- a/docs/src/languages/json.md
+++ b/docs/src/languages/json.md
@@ -12,7 +12,7 @@ While editing these files you can use `cmd-/` (macOS) or `ctrl-/` (Linux) to tog
 
 ## JSONC Prettier Formatting
 
-If you use files with the `*.jsonc` extension when using `Format Document` or have `format_on_save` enabled, Zed invokes Prettier as the formatter.  Prettier has an [outstanding issue](https://github.com/prettier/prettier/issues/15956) where it will add trailing commas to files with a `jsonc` extension.  JSONC files which have a `.json` extension are unaffected.
+If you use files with the `*.jsonc` extension when using `Format Document` or have `format_on_save` enabled, Zed invokes Prettier as the formatter. Prettier has an [outstanding issue](https://github.com/prettier/prettier/issues/15956) where it will add trailing commas to files with a `jsonc` extension. JSONC files which have a `.json` extension are unaffected.
 
 To workaround this behavior you can add the following to your `.prettierrc`
 


### PR DESCRIPTION
- Closes https://github.com/zed-industries/zed/issues/17487

Release Notes:

- N/A
