### PR TITLE
Don't suggest assistant code actions if it's disabled

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -3277,6 +3277,11 @@ impl CodeActionProvider for AssistantCodeActionProvider {
         range: Range<text::Anchor>,
         cx: &mut WindowContext,
     ) -> Task<Result<Vec<CodeAction>>> {
+        // Don't suggest assistant code actions if the assistant is disabled in settings.
+        if !AssistantSettings::get_global(cx).enabled {
+            return Task::ready(Ok(Vec::new()));
+        }
+
         let snapshot = buffer.read(cx).snapshot();
         let mut range = range.to_point(&snapshot);
 

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -3277,7 +3277,6 @@ impl CodeActionProvider for AssistantCodeActionProvider {
         range: Range<text::Anchor>,
         cx: &mut WindowContext,
     ) -> Task<Result<Vec<CodeAction>>> {
-        // Don't suggest assistant code actions if the assistant is disabled in settings.
         if !AssistantSettings::get_global(cx).enabled {
             return Task::ready(Ok(Vec::new()));
         }


### PR DESCRIPTION
Closes #19155

Release Notes:

- Fixed code action for "Fix with assistant" appearing when assistant was disabled.
