### PR TITLE
editor: Save base buffers when applying changes from their branches

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6260,28 +6260,6 @@ impl Editor {
         }
     }
 
-    fn apply_selected_diff_hunks(&mut self, _: &ApplyDiffHunk, cx: &mut ViewContext<Self>) {
-        let snapshot = self.buffer.read(cx).snapshot(cx);
-        let hunks = hunks_for_selections(&snapshot, &self.selections.disjoint_anchors());
-        let mut ranges_by_buffer = HashMap::default();
-        self.transact(cx, |editor, cx| {
-            for hunk in hunks {
-                if let Some(buffer) = editor.buffer.read(cx).buffer(hunk.buffer_id) {
-                    ranges_by_buffer
-                        .entry(buffer.clone())
-                        .or_insert_with(Vec::new)
-                        .push(hunk.buffer_range.to_offset(buffer.read(cx)));
-                }
-            }
-
-            for (buffer, ranges) in ranges_by_buffer {
-                buffer.update(cx, |buffer, cx| {
-                    buffer.merge_into_base(ranges, cx);
-                });
-            }
-        });
-    }
-
     pub fn open_active_item_in_terminal(&mut self, _: &OpenInTerminal, cx: &mut ViewContext<Self>) {
         if let Some(working_directory) = self.active_excerpt(cx).and_then(|(_, buffer, _)| {
             let project_path = buffer.read(cx).project_path(cx)?;

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -720,6 +720,10 @@ impl Item for Editor {
     ) -> Task<Result<()>> {
         self.report_editor_event("save", None, cx);
         let buffers = self.buffer().clone().read(cx).all_buffers();
+        let buffers = buffers
+            .into_iter()
+            .map(|handle| handle.read(cx).diff_base_buffer().unwrap_or(handle.clone()))
+            .collect::<HashSet<_>>();
         cx.spawn(|this, mut cx| async move {
             if format {
                 this.update(&mut cx, |editor, cx| {

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -323,7 +323,7 @@ impl Render for ProposedChangesEditorToolbar {
             if let Some(editor) = &editor {
                 editor.update(cx, |editor, cx| {
                     editor.editor.update(cx, |editor, cx| {
-                        editor.apply_all_changes(cx);
+                        editor.apply_all_diff_hunks(cx);
                     })
                 });
             }

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -298,6 +298,20 @@ impl Item for ProposedChangesEditor {
             Item::set_nav_history(editor, nav_history, cx)
         });
     }
+
+    fn can_save(&self, cx: &AppContext) -> bool {
+        self.editor.read(cx).can_save(cx)
+    }
+
+    fn save(
+        &mut self,
+        format: bool,
+        project: Model<Project>,
+        cx: &mut ViewContext<Self>,
+    ) -> Task<gpui::Result<()>> {
+        self.editor
+            .update(cx, |editor, cx| Item::save(editor, format, project, cx))
+    }
 }
 
 impl ProposedChangesEditorToolbar {


### PR DESCRIPTION
This PR makes it so that when we apply changes within a branch buffer—currently just the edits buffer—we save the underlying buffer.

This also fixes an issue where new files created via edits were not properly flushed to disk.

Release Notes:

- N/A
