### PR TITLE
Tell users they can close a stale issue if they can't repro

### DIFF
--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -14,7 +14,7 @@ jobs:
           stale-issue-message: >
             Hi there! 👋
 
-            We're working to clean up our issue tracker by closing older issues that might not be relevant anymore. Are you able to reproduce this issue in the latest version of Zed? If so, please let us know by commenting on this issue and we will keep it open; otherwise, we'll close it in 7 days. Feel free to open a new issue if you're seeing this message after the issue has been closed.
+            We're working to clean up our issue tracker by closing older issues that might not be relevant anymore. If you are able to reproduce this issue in the latest version of Zed, please let us know by commenting on this issue, and we will keep it open. If you can't reproduce it, feel free to close the issue yourself. Otherwise, we'll close it in 7 days.
 
             Thanks for your help!
           close-issue-message: "This issue was closed due to inactivity. If you're still experiencing this problem, please open a new issue with a link to this issue."


### PR DESCRIPTION
A user commented on this issue to let us know they couldn't reproduce, which would keep it open for another 6 months. Best we can do is tell them what to do if they can't repro, which is to close the issue themselves.

- https://github.com/zed-industries/zed/issues/10671

Release Notes:

- N/A
