### PR TITLE
Make closing the SSH modal equivalent to cancelling the SSH connection task

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -547,7 +547,7 @@ impl RemoteServerProjects {
                         })
                         .ok();
 
-                    let Some(session) = session else {
+                    let Some(Some(session)) = session else {
                         workspace
                             .update(&mut cx, |workspace, cx| {
                                 let weak = cx.view().downgrade();

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1071,7 +1071,7 @@ impl RemoteServerProjects {
                             );
 
                             cx.spawn(|mut cx| async move {
-                                if confirmation.await.ok() == Some(0) {
+                                if confirmation.await.ok() == Some(1) {
                                     remote_servers
                                         .update(&mut cx, |this, cx| {
                                             this.delete_ssh_server(index, cx);

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -124,6 +124,7 @@ pub struct SshPrompt {
     nickname: Option<SharedString>,
     status_message: Option<SharedString>,
     prompt: Option<(View<Markdown>, oneshot::Sender<Result<String>>)>,
+    cancellation: Option<oneshot::Sender<()>>,
     editor: View<Editor>,
 }
 
@@ -144,8 +145,13 @@ impl SshPrompt {
             nickname,
             editor: cx.new_view(Editor::single_line),
             status_message: None,
+            cancellation: None,
             prompt: None,
         }
+    }
+
+    pub fn set_cancellation_tx(&mut self, tx: oneshot::Sender<()>) {
+        self.cancellation = Some(tx);
     }
 
     pub fn set_prompt(
@@ -270,7 +276,13 @@ impl SshConnectionModal {
     }
 
     fn dismiss(&mut self, _: &menu::Cancel, cx: &mut ViewContext<Self>) {
-        cx.emit(DismissEvent);
+        if let Some(tx) = self
+            .prompt
+            .update(cx, |prompt, _cx| prompt.cancellation.take())
+        {
+            tx.send(()).ok();
+        }
+        self.finished(cx);
     }
 }
 
@@ -322,6 +334,7 @@ impl Render for SshConnectionModal {
             .w(rems(34.))
             .border_1()
             .border_color(theme.colors().border)
+            .key_context("SshConnectionModal")
             .track_focus(&self.focus_handle(cx))
             .on_action(cx.listener(Self::dismiss))
             .on_action(cx.listener(Self::confirm))
@@ -486,7 +499,11 @@ impl SshClientDelegate {
         use smol::process::{Command, Stdio};
 
         async fn run_cmd(command: &mut Command) -> Result<()> {
-            let output = command.stderr(Stdio::inherit()).output().await?;
+            let output = command
+                .kill_on_drop(true)
+                .stderr(Stdio::inherit())
+                .output()
+                .await?;
             if !output.status.success() {
                 Err(anyhow::anyhow!("failed to run command: {:?}", command))?;
             }
@@ -585,13 +602,16 @@ pub fn connect_over_ssh(
     connection_options: SshConnectionOptions,
     ui: View<SshPrompt>,
     cx: &mut WindowContext,
-) -> Task<Result<Model<SshRemoteClient>>> {
+) -> Task<Result<Option<Model<SshRemoteClient>>>> {
     let window = cx.window_handle();
     let known_password = connection_options.password.clone();
+    let (tx, rx) = oneshot::channel();
+    ui.update(cx, |ui, _cx| ui.set_cancellation_tx(tx));
 
     remote::SshRemoteClient::new(
         unique_identifier,
         connection_options,
+        rx,
         Arc::new(SshClientDelegate {
             window,
             ui,
@@ -628,6 +648,7 @@ pub async fn open_ssh_project(
     };
 
     loop {
+        let (cancel_tx, cancel_rx) = oneshot::channel();
         let delegate = window.update(cx, {
             let connection_options = connection_options.clone();
             let nickname = nickname.clone();
@@ -643,6 +664,10 @@ pub async fn open_ssh_project(
                     .prompt
                     .clone();
 
+                ui.update(cx, |ui, _cx| {
+                    ui.set_cancellation_tx(cancel_tx);
+                });
+
                 Arc::new(SshClientDelegate {
                     window: cx.window_handle(),
                     ui,
@@ -656,6 +681,7 @@ pub async fn open_ssh_project(
                 workspace::open_ssh_project(
                     window,
                     connection_options.clone(),
+                    cancel_rx,
                     delegate.clone(),
                     app_state.clone(),
                     paths.clone(),

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -657,9 +657,9 @@ pub async fn open_ssh_project(
                 workspace.toggle_modal(cx, |cx| {
                     SshConnectionModal::new(&connection_options, nickname.clone(), cx)
                 });
+
                 let ui = workspace
-                    .active_modal::<SshConnectionModal>(cx)
-                    .unwrap()
+                    .active_modal::<SshConnectionModal>(cx)?
                     .read(cx)
                     .prompt
                     .clone();
@@ -668,13 +668,15 @@ pub async fn open_ssh_project(
                     ui.set_cancellation_tx(cancel_tx);
                 });
 
-                Arc::new(SshClientDelegate {
+                Some(Arc::new(SshClientDelegate {
                     window: cx.window_handle(),
                     ui,
                     known_password: connection_options.password.clone(),
-                })
+                }))
             }
         })?;
+
+        let Some(delegate) = delegate else { break };
 
         let did_open_ssh_project = cx
             .update(|cx| {

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -142,9 +142,9 @@ impl SshPrompt {
         Self {
             connection_string,
             nickname,
+            editor: cx.new_view(Editor::single_line),
             status_message: None,
             prompt: None,
-            editor: cx.new_view(Editor::single_line),
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4350,9 +4350,7 @@ impl Workspace {
             .on_action(cx.listener(Self::activate_pane_at_index))
             .on_action(cx.listener(|workspace, _: &Unfollow, cx| {
                 let pane = workspace.active_pane().clone();
-                if workspace.unfollow_in_pane(&pane, cx).is_none() {
-                    cx.propagate();
-                }
+                workspace.unfollow_in_pane(&pane, cx);
             }))
             .on_action(cx.listener(|workspace, action: &Save, cx| {
                 workspace
@@ -5536,6 +5534,7 @@ pub fn join_hosted_project(
 pub fn open_ssh_project(
     window: WindowHandle<Workspace>,
     connection_options: SshConnectionOptions,
+    cancel_rx: oneshot::Receiver<()>,
     delegate: Arc<dyn SshClientDelegate>,
     app_state: Arc<AppState>,
     paths: Vec<PathBuf>,
@@ -5557,11 +5556,21 @@ pub fn open_ssh_project(
             workspace_id.0
         );
 
-        let session = cx
+        let session = match cx
             .update(|cx| {
-                remote::SshRemoteClient::new(unique_identifier, connection_options, delegate, cx)
+                remote::SshRemoteClient::new(
+                    unique_identifier,
+                    connection_options,
+                    cancel_rx,
+                    delegate,
+                    cx,
+                )
             })?
-            .await?;
+            .await?
+        {
+            Some(result) => result,
+            None => return Ok(()),
+        };
 
         let project = cx.update(|cx| {
             project::Project::ssh(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4350,7 +4350,9 @@ impl Workspace {
             .on_action(cx.listener(Self::activate_pane_at_index))
             .on_action(cx.listener(|workspace, _: &Unfollow, cx| {
                 let pane = workspace.active_pane().clone();
-                workspace.unfollow_in_pane(&pane, cx);
+                if workspace.unfollow_in_pane(&pane, cx).is_none() {
+                    cx.propagate();
+                }
             }))
             .on_action(cx.listener(|workspace, action: &Save, cx| {
                 workspace

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -274,7 +274,6 @@ pub fn initialize_workspace(
                 workspace.add_panel(channels_panel, cx);
                 workspace.add_panel(chat_panel, cx);
                 workspace.add_panel(notification_panel, cx);
-                cx.focus_self();
             })
         })
         .detach();


### PR DESCRIPTION
TODO: 
- [x] Fix focus not being on the modal initially

Release Notes:

- N/A
