### PR TITLE
Try to build with musl on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,6 @@ jobs:
 
       - name: Upload app bundle to release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        if: ${{ env.RELEASE_CHANNEL == 'preview' || env.RELEASE_CHANNEL == 'stable' }}
         with:
           draft: true
           prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -37,16 +37,18 @@ commit=$(git rev-parse HEAD | cut -c 1-7)
 version_info=$(rustc --version --verbose)
 host_line=$(echo "$version_info" | grep host)
 target_triple=${host_line#*: }
+musl_triple=${target_triple%-gnu}-musl
 
 # Generate the licenses first, so they can be baked into the binaries
 script/generate-licenses
+rustup target add "$musl_triple"
 
 # Build binary in release mode
 export RUSTFLAGS="${RUSTFLAGS:-} -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
 cargo build --release --target "${target_triple}" --package zed --package cli
 # Build remote_server in separate invocation to prevent feature unification from other crates
 # from influencing dynamic libraries required by it.
-cargo build --release --target "${target_triple}" --package remote_server
+cargo build --release --target "${musl_triple}" --package remote_server
 
 # Strip the binary of all debug symbols
 # Later, we probably want to do something like this: https://github.com/GabrielMajeri/separate-symbols

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -54,11 +54,11 @@ cargo build --release --target "${musl_triple}" --package remote_server
 # Later, we probably want to do something like this: https://github.com/GabrielMajeri/separate-symbols
 strip --strip-debug "${target_dir}/${target_triple}/release/zed"
 strip --strip-debug "${target_dir}/${target_triple}/release/cli"
-strip --strip-debug "${target_dir}/${target_triple}/release/remote_server"
+strip --strip-debug "${target_dir}/${musl_triple}/release/remote_server"
 
 
 # Ensure that remote_server does not depend on libssl nor libcrypto, as we got rid of these deps.
-! ldd "${target_dir}/${target_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'
+! ldd "${target_dir}/${musl_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'
 
 suffix=""
 if [ "$channel" != "stable" ]; then
@@ -127,4 +127,4 @@ remove_match="zed(-[a-zA-Z0-9]+)?-linux-$(uname -m)\.tar\.gz"
 ls "${target_dir}/release" | grep -E ${remove_match} | xargs -d "\n" -I {} rm -f "${target_dir}/release/{}" || true
 tar -czvf "${target_dir}/release/$archive" -C ${temp_dir} "zed$suffix.app"
 
-gzip --stdout --best "${target_dir}/${target_triple}/release/remote_server" > "${target_dir}/zed-remote-server-linux-${arch}.gz"
+gzip --stdout --best "${target_dir}/${musl_triple}/release/remote_server" > "${target_dir}/zed-remote-server-linux-${arch}.gz"

--- a/script/linux
+++ b/script/linux
@@ -42,6 +42,8 @@ if [[ -n $apt ]]; then
     gettext-base
     elfutils
     libsqlite3-dev
+    musl-tools
+    musl-dev
   )
   if (grep -qP 'PRETTY_NAME="(Linux Mint 22|.+24\.04)' /etc/os-release); then
     deps+=( mold libstdc++-14-dev )


### PR DESCRIPTION
- Closes #19092 
- Closes #15411

Release Notes:

- SSH Remoting: Build with musl (adds support for machines with old, or no glibc)
