### PR TITLE
Add option to hide Sign In in title bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11904,6 +11904,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "title_bar"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "auto_update",
  "call",
  "client",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -770,7 +770,7 @@
     // Existing terminals will not pick up this change until they are recreated.
     // "max_scroll_history_lines": 10000,
   },
-  "titlebar_signin": false,
+  "titlebar_signin": true,
   "code_actions_on_format": {},
   /// Settings related to running tasks.
   "tasks": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -770,6 +770,7 @@
     // Existing terminals will not pick up this change until they are recreated.
     // "max_scroll_history_lines": 10000,
   },
+  "titlebar_signin": false,
   "code_actions_on_format": {},
   /// Settings related to running tasks.
   "tasks": {

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -29,6 +29,7 @@ test-support = [
 ]
 
 [dependencies]
+anyhow.workspace = true
 auto_update.workspace = true
 call.workspace = true
 client.workspace = true


### PR DESCRIPTION
Closes #12325

Trivial modification of title_bar to include a setting that does not render the Sign In button.