### PR TITLE
dart: Add support for documentation comments

### DIFF
--- a/extensions/dart/languages/dart/config.toml
+++ b/extensions/dart/languages/dart/config.toml
@@ -1,7 +1,7 @@
 name = "Dart"
 grammar = "dart"
 path_suffixes = ["dart"]
-line_comments = ["//", "// ", "///", "/// "]
+line_comments = ["// ", "/// "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/extensions/dart/languages/dart/config.toml
+++ b/extensions/dart/languages/dart/config.toml
@@ -1,7 +1,7 @@
 name = "Dart"
 grammar = "dart"
 path_suffixes = ["dart"]
-line_comments = ["// "]
+line_comments = ["//", "// ", "///", "/// "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
Closes #19590

Release Notes:

- N/A
---

I'm unable to test this because rebuilding Zed with the changes does not seem to use the changes. If maintainers could let me know how to test these changes I'd like to verify that this really fixes #19590.