### PR TITLE
Last commit update tree-sitter-markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12443,7 +12443,7 @@ checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 [[package]]
 name = "tree-sitter-md"
 version = "0.3.2"
-source = "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown?rev=9a23c1a96c0513d8fc6520972beedd419a973539#9a23c1a96c0513d8fc6520972beedd419a973539"
+source = "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown?rev=5cdc549ab8f461aff876c5be9741027189299cec#5cdc549ab8f461aff876c5be9741027189299cec"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -459,7 +459,7 @@ tree-sitter-diff = "0.1.0"
 tree-sitter-html = "0.20"
 tree-sitter-jsdoc = "0.23"
 tree-sitter-json = "0.23"
-tree-sitter-md = { git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown", rev = "9a23c1a96c0513d8fc6520972beedd419a973539" }
+tree-sitter-md = { git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown", rev = "5cdc549ab8f461aff876c5be9741027189299cec" }
 tree-sitter-python = "0.23"
 tree-sitter-regex = "0.23"
 tree-sitter-ruby = "0.23"


### PR DESCRIPTION
This pr updates the Tree-sitter markdown grammar introduced in #19570 to the latest commit in the cargo files.