### PR TITLE
Update example node settings in default.json to use the correct key for node path

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -803,7 +803,7 @@
   /// You can override this to use a version of node that is not in $PATH with:
   /// {
   ///   "node": {
-  ///     "node_path": "/path/to/node"
+  ///     "path": "/path/to/node"
   ///     "npm_path": "/path/to/npm" (defaults to node_path/../npm)
   ///   }
   /// }


### PR DESCRIPTION
Hey team!

I was investigating the new node settings added in #18172, and when trying to set the node path I noticed that the example settings in `default.json` use the wrong key for the `node_path` - it should be `path` instead.

See [here](https://github.com/zed-industries/zed/blob/19eebcd349d9ea14aa9ec6e0fe178ae26945f52a/crates/zed/src/main.rs#L488) for where the setting is used.

Release Notes:

- N/A