### PR TITLE
ssh remoting: Fix opening settings file

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1093,17 +1093,27 @@ fn open_settings_file(
     cx: &mut ViewContext<Workspace>,
 ) {
     cx.spawn(|workspace, mut cx| async move {
-        let (worktree_creation_task, settings_open_task) =
-            workspace.update(&mut cx, |workspace, cx| {
-                let worktree_creation_task = workspace.project().update(cx, |project, cx| {
-                    // Set up a dedicated worktree for settings, since otherwise we're dropping and re-starting LSP servers for each file inside on every settings file close/open
-                    // TODO: Do note that all other external files (e.g. drag and drop from OS) still have their worktrees released on file close, causing LSP servers' restarts.
-                    project.find_or_create_worktree(paths::config_dir().as_path(), false, cx)
-                });
-                let settings_open_task = create_and_open_local_file(abs_path, cx, default_content);
-                (worktree_creation_task, settings_open_task)
-            })?;
+        let (worktree_creation_task, settings_open_task) = workspace
+            .update(&mut cx, |workspace, cx| {
+                workspace.with_local_workspace(cx, move |workspace, cx| {
+                    let worktree_creation_task = workspace.project().update(cx, |project, cx| {
+                        // Set up a dedicated worktree for settings, since
+                        // otherwise we're dropping and re-starting LSP servers
+                        // for each file inside on every settings file
+                        // close/open
 
+                        // TODO: Do note that all other external files (e.g.
+                        // drag and drop from OS) still have their worktrees
+                        // released on file close, causing LSP servers'
+                        // restarts.
+                        project.find_or_create_worktree(paths::config_dir().as_path(), false, cx)
+                    });
+                    let settings_open_task =
+                        create_and_open_local_file(abs_path, cx, default_content);
+                    (worktree_creation_task, settings_open_task)
+                })
+            })?
+            .await?;
         let _ = worktree_creation_task.await?;
         let _ = settings_open_task.await?;
         anyhow::Ok(())


### PR DESCRIPTION
We have to do `workspace.with_local_workspace`, otherwise we'll try to open the settings on the remote host.


Release Notes:

- N/A