### PR TITLE
Switch to Anthropic -latest tags

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -29,13 +29,13 @@ pub struct AnthropicModelCacheConfiguration {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
     #[default]
-    #[serde(rename = "claude-3-5-sonnet", alias = "claude-3-5-sonnet-20240620")]
+    #[serde(rename = "claude-3-5-sonnet", alias = "claude-3-5-sonnet-latest")]
     Claude3_5Sonnet,
-    #[serde(rename = "claude-3-opus", alias = "claude-3-opus-20240229")]
+    #[serde(rename = "claude-3-opus", alias = "claude-3-opus-latest")]
     Claude3Opus,
-    #[serde(rename = "claude-3-sonnet", alias = "claude-3-sonnet-20240229")]
+    #[serde(rename = "claude-3-sonnet", alias = "claude-3-sonnet-latest")]
     Claude3Sonnet,
-    #[serde(rename = "claude-3-haiku", alias = "claude-3-haiku-20240307")]
+    #[serde(rename = "claude-3-haiku", alias = "claude-3-haiku-latest")]
     Claude3Haiku,
     #[serde(rename = "custom")]
     Custom {
@@ -69,10 +69,10 @@ impl Model {
 
     pub fn id(&self) -> &str {
         match self {
-            Model::Claude3_5Sonnet => "claude-3-5-sonnet-20240620",
-            Model::Claude3Opus => "claude-3-opus-20240229",
-            Model::Claude3Sonnet => "claude-3-sonnet-20240229",
-            Model::Claude3Haiku => "claude-3-haiku-20240307",
+            Model::Claude3_5Sonnet => "claude-3-5-sonnet-latest",
+            Model::Claude3Opus => "claude-3-opus-latest",
+            Model::Claude3Sonnet => "claude-3-sonnet-latest",
+            Model::Claude3Haiku => "claude-3-haiku-latest",
             Self::Custom { name, .. } => name,
         }
     }

--- a/crates/language_model/src/provider/anthropic.rs
+++ b/crates/language_model/src/provider/anthropic.rs
@@ -40,7 +40,7 @@ pub struct AnthropicSettings {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct AvailableModel {
-    /// The model's name in the Anthropic API. e.g. claude-3-5-sonnet-20240620
+    /// The model's name in the Anthropic API. e.g. claude-3-5-sonnet-latest, claude-3-opus-20240229, etc
     pub name: String,
     /// The model's name in Zed's UI, such as in the model selector dropdown menu in the assistant panel.
     pub display_name: Option<String>,

--- a/docs/src/assistant/configuration.md
+++ b/docs/src/assistant/configuration.md
@@ -49,8 +49,8 @@ You can add custom models to the Anthropic provider by adding the following to y
     "anthropic": {
       "available_models": [
         {
-          "name": "some-model",
-          "display_name": "some-model",
+          "name": "claude-3-5-sonnet-20240620",
+          "display_name": "Sonnet 2024-June",
           "max_tokens": 128000,
           "max_output_tokens": 2560,
           "cache_configuration": {


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/19609

Switches us to using `-latest` tags with Anthropic models instead of pinning to a specific date version.
See: [Anthropic Model Docs](https://docs.anthropic.com/en/docs/about-claude/models)

This is a no-op for:
- Claude 3 Opus (`claude-3-opus-20240229`)
- Claude 3 Sonnet (`claude-3-sonnet-20240229`)
- Claude 3 Haiku (`claude-3-haiku-20240307`)

For Claude 3.5 Sonnet this will update us from `claude-3-5-sonnet-20240620` to `claude-3-5-sonnet-20241022`.  We will also pickup any subsequent model updates automatically when Anthropic updates the `latest` tag.

This matches the behavior for OpenAI where use `gpt-4o` as the model_name and not `gpt-4o-2024-08-06`.

Release Notes:

- N/A