### PR TITLE
languages: Do not expose unnecessary captures from tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14841,7 +14841,7 @@ dependencies = [
 
 [[package]]
 name = "zed_php"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/crates/languages/src/c/runnables.scm
+++ b/crates/languages/src/c/runnables.scm
@@ -4,7 +4,7 @@
     declarator: (function_declarator
       declarator: (identifier) @run
     )
-  ) @c-main
+  ) @_c-main
   (#eq? @run "main")
   (#set! tag c-main)
 )

--- a/crates/languages/src/javascript/runnables.scm
+++ b/crates/languages/src/javascript/runnables.scm
@@ -9,6 +9,6 @@
                 (string_fragment) @run
             )
         )
-    ) @js-test
+    ) @_js-test
     (#set! tag js-test)
 )

--- a/crates/languages/src/python/runnables.scm
+++ b/crates/languages/src/python/runnables.scm
@@ -7,7 +7,7 @@
             (attribute (identifier) @_superclass)]
         )
         (#eq? @_superclass "TestCase")
-    ) @python-unittest-class
+    ) @_python-unittest-class
     (#set! tag python-unittest-class)
 )
 
@@ -24,7 +24,7 @@
                 (function_definition
                     name: (identifier) @run @_unittest_method_name
                     (#match? @_unittest_method_name "^test.*")
-                ) @python-unittest-method
+                ) @_python-unittest-method
                 (#set! tag python-unittest-method)
             )
         )

--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -3,7 +3,7 @@
     (mod_item
         name: (_) @run
         (#eq? @run "tests")
-    ) @rust-mod-test
+    )
     (#set! tag rust-mod-test)
 )
 
@@ -14,14 +14,14 @@
                 (scoped_identifier (identifier) @_attribute)
                 ])
             (#match? @_attribute "test")
-        ) @start
+        ) @_start
         .
         (attribute_item) *
         .
         (function_item
             name: (_) @run
             body: _
-        ) @end
+        ) @_end
     )
     (#set! tag rust-test)
 )

--- a/crates/languages/src/typescript/runnables.scm
+++ b/crates/languages/src/typescript/runnables.scm
@@ -9,6 +9,6 @@
                 (string_fragment) @run
             )
         )
-    ) @ts-test
+    ) @_ts-test
     (#set! tag ts-test)
 )

--- a/extensions/php/Cargo.toml
+++ b/extensions/php/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_php"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/php/extension.toml
+++ b/extensions/php/extension.toml
@@ -1,7 +1,7 @@
 id = "php"
 name = "PHP"
 description = "PHP support."
-version = "0.2.1"
+version = "0.2.2"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/php/languages/php/runnables.scm
+++ b/extensions/php/languages/php/runnables.scm
@@ -16,7 +16,7 @@
                 (#match? @run "^test.*")
             )
         )
-    ) @phpunit-test
+    ) @_phpunit-test
     (#set! tag phpunit-test)
 )
 
@@ -41,7 +41,7 @@
                 (#not-match? @run "^test.*")
             ))
         )
-    ) @phpunit-test
+    ) @_phpunit-test
     (#set! tag phpunit-test)
 )
 
@@ -69,7 +69,7 @@
                 (#not-match? @run "^test.*")
             )
         )
-    ) @phpunit-test
+    ) @_phpunit-test
     (#set! tag phpunit-test)
 )
 
@@ -81,7 +81,7 @@
         (#not-eq? @_modifier "abstract")
         name: (_) @run
         (#match? @run ".*Test$")
-    ) @phpunit-test
+    ) @_phpunit-test
     (#set! tag phpunit-test)
 )
 
@@ -100,6 +100,6 @@
                 ]
             )
         )
-    ) @pest-test
+    ) @_pest-test
     (#set! tag pest-test)
 )


### PR DESCRIPTION
This tackles an issue with us exposing unnecessary env variables in environment which are not actually needed for tasks themselves (and may have little utility), yet come into the way of ssh remoting.

/cc @ConradIrwin 

Release Notes:

- N/A
