### PR TITLE
Use zstd without dynamic linking due to musl usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14709,7 +14709,6 @@ dependencies = [
  "winresource",
  "workspace",
  "zed_actions",
- "zstd",
 ]
 
 [[package]]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -125,8 +125,6 @@ winresource = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd.workspace = true
-# We don't use zstd in the zed crate, but we want to add this feature when compiling a desktop build of Zed
-zstd = { workspace = true, features = [ "pkg-config" ] }
 
 [dev-dependencies]
 call = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
Due to leaning towards `musl` builds, unit features for `zstd` and link it statically too for Zed.

https://github.com/gyscos/zstd-rs/blob/bfe1e34f593c2427e9dc35f1b98d06788174711f/zstd-safe/zstd-sys/build.rs#L260 shows that `ZSTD_SYS_USE_PKG_CONFIG` env var can be used to return this behavior.

Release Notes:

- N/A
