### PR TITLE
ci: Use bigger ARMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
     timeout-minutes: 60
     name: Create arm64 Linux bundle
     runs-on:
-      - buildjet-16vcpu-ubuntu-2204-arm
+      - buildjet-32vcpu-ubuntu-2204-arm
     if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling') }}
     needs: [linux_tests]
     env:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -140,7 +140,7 @@ jobs:
     name: Create a Linux *.tar.gz bundle for ARM
     if: github.repository_owner == 'zed-industries'
     runs-on:
-      - hosted-linux-arm-1
+      - buildjet-32vcpu-ubuntu-2204-arm
     needs: tests
     env:
       DIGITALOCEAN_SPACES_ACCESS_KEY: ${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}


### PR DESCRIPTION
See if we can speed up `--release` build times on our ARM runners.

| Runner | Time | Example |
| - | - | - |
| buildjet-32vcpu-ubuntu-2204-arm | 21mins | [build](https://github.com/zed-industries/zed/actions/runs/11488367045/job/31975471019?pr=19643) womp womp|
| buildjet-16vcpu-ubuntu-2204-arm | 23mins | [build](https://github.com/zed-industries/zed/actions/runs/11469118388/job/31916369746) |
| github-hosted-arm | 21mins | [build](https://github.com/zed-industries/zed/actions/runs/11474782892/job/31931694044) |
| buildjet-16vcpu-ubuntu-2004 | 11mins | [build](https://github.com/zed-industries/zed/actions/runs/11469118388/job/31916369958) |

Update:
Maybe 10% faster with 2x the cores. Skipping for now.

Release Notes:

- N/A