### PR TITLE
ssh remoting: Fix version check

### DIFF
--- a/crates/remote_server/src/main.rs
+++ b/crates/remote_server/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
             }
         },
         Some(Commands::Version) => {
-            eprintln!("{}", env!("ZED_PKG_VERSION"));
+            println!("{}", env!("ZED_PKG_VERSION"));
             std::process::exit(0);
         }
         None => {


### PR DESCRIPTION
This snuck in when Bennet and I were debugging why our connection to the SSH host would break. We suspected that somewhere something was logging to STDOUT and, I guess, we changed all `println!` to `eprintln!`.

Now, two weeks later, I'm sitting here, wondering why the version check doesn't work anymore. The server always reports a version of `""`.

Turns out we take the command's STDOUT and not STDERR, which is correct.

But it also turns out we started to print the version to STDERR, which breaks the version check.

One-character bug & one-character fix.

Release Notes:

- N/A
