### PR TITLE
Fix ssh project history

### DIFF
--- a/crates/collab/src/tests/channel_guest_tests.rs
+++ b/crates/collab/src/tests/channel_guest_tests.rs
@@ -95,7 +95,9 @@ async fn test_channel_guest_promotion(cx_a: &mut TestAppContext, cx_b: &mut Test
     let room_b = cx_b
         .read(ActiveCall::global)
         .update(cx_b, |call, _| call.room().unwrap().clone());
-    cx_b.simulate_keystrokes("cmd-p 1 enter");
+    cx_b.simulate_keystrokes("cmd-p");
+    cx_a.run_until_parked();
+    cx_b.simulate_keystrokes("1 enter");
 
     let (project_b, editor_b) = workspace_b.update(cx_b, |workspace, cx| {
         (

--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -1589,8 +1589,9 @@ async fn test_following_stops_on_unshare(cx_a: &mut TestAppContext, cx_b: &mut T
         .await;
     let (workspace_b, cx_b) = client_b.join_workspace(channel_id, cx_b).await;
 
-    cx_a.simulate_keystrokes("cmd-p 2 enter");
+    cx_a.simulate_keystrokes("cmd-p");
     cx_a.run_until_parked();
+    cx_a.simulate_keystrokes("2 enter");
 
     let editor_a = workspace_a.update(cx_a, |workspace, cx| {
         workspace.active_item_as::<Editor>(cx).unwrap()
@@ -2041,7 +2042,9 @@ async fn test_following_to_channel_notes_other_workspace(
     share_workspace(&workspace_a, cx_a).await.unwrap();
 
     // a opens 1.txt
-    cx_a.simulate_keystrokes("cmd-p 1 enter");
+    cx_a.simulate_keystrokes("cmd-p");
+    cx_a.run_until_parked();
+    cx_a.simulate_keystrokes("1 enter");
     cx_a.run_until_parked();
     workspace_a.update(cx_a, |workspace, cx| {
         let editor = workspace.active_item(cx).unwrap();
@@ -2098,7 +2101,9 @@ async fn test_following_while_deactivated(cx_a: &mut TestAppContext, cx_b: &mut 
     share_workspace(&workspace_a, cx_a).await.unwrap();
 
     // a opens 1.txt
-    cx_a.simulate_keystrokes("cmd-p 1 enter");
+    cx_a.simulate_keystrokes("cmd-p");
+    cx_a.run_until_parked();
+    cx_a.simulate_keystrokes("1 enter");
     cx_a.run_until_parked();
     workspace_a.update(cx_a, |workspace, cx| {
         let editor = workspace.active_item(cx).unwrap();
@@ -2118,7 +2123,9 @@ async fn test_following_while_deactivated(cx_a: &mut TestAppContext, cx_b: &mut 
     cx_b.simulate_keystrokes("down");
 
     // a opens a different file while not followed
-    cx_a.simulate_keystrokes("cmd-p 2 enter");
+    cx_a.simulate_keystrokes("cmd-p");
+    cx_a.run_until_parked();
+    cx_a.simulate_keystrokes("2 enter");
 
     workspace_b.update(cx_b, |workspace, cx| {
         let editor = workspace.active_item_as::<Editor>(cx).unwrap();
@@ -2128,7 +2135,9 @@ async fn test_following_while_deactivated(cx_a: &mut TestAppContext, cx_b: &mut 
     // a opens a file in a new window
     let (_, cx_a2) = client_a.build_test_workspace(&mut cx_a2).await;
     cx_a2.update(|cx| cx.activate_window());
-    cx_a2.simulate_keystrokes("cmd-p 3 enter");
+    cx_a2.simulate_keystrokes("cmd-p");
+    cx_a2.run_until_parked();
+    cx_a2.simulate_keystrokes("3 enter");
     cx_a2.run_until_parked();
 
     // b starts following a again

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use editor::Editor;
 use gpui::{Entity, TestAppContext, VisualTestContext};
 use menu::{Confirm, SelectNext, SelectPrev};
-use project::FS_WATCH_LATENCY;
+use project::{RemoveOptions, FS_WATCH_LATENCY};
 use serde_json::json;
 use workspace::{AppState, ToggleFileFinder, Workspace};
 
@@ -1450,6 +1450,15 @@ async fn test_nonexistent_history_items_not_shown(cx: &mut gpui::TestAppContext)
     open_close_queried_buffer("non", 1, "nonexistent.rs", &workspace, cx).await;
     open_close_queried_buffer("thi", 1, "third.rs", &workspace, cx).await;
     open_close_queried_buffer("fir", 1, "first.rs", &workspace, cx).await;
+    app_state
+        .fs
+        .remove_file(
+            Path::new("/src/test/nonexistent.rs"),
+            RemoveOptions::default(),
+        )
+        .await
+        .unwrap();
+    cx.run_until_parked();
 
     let picker = open_file_picker(&workspace, cx);
     cx.simulate_input("rs");

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1875,11 +1875,7 @@ impl Project {
         })
     }
 
-    pub fn get_open_buffer(
-        &mut self,
-        path: &ProjectPath,
-        cx: &mut ModelContext<Self>,
-    ) -> Option<Model<Buffer>> {
+    pub fn get_open_buffer(&self, path: &ProjectPath, cx: &AppContext) -> Option<Model<Buffer>> {
         self.buffer_store.read(cx).get_by_path(path, cx)
     }
 
@@ -3295,17 +3291,10 @@ impl Project {
     }
 
     pub fn absolute_path(&self, project_path: &ProjectPath, cx: &AppContext) -> Option<PathBuf> {
-        let workspace_root = self
-            .worktree_for_id(project_path.worktree_id, cx)?
+        self.worktree_for_id(project_path.worktree_id, cx)?
             .read(cx)
-            .abs_path();
-        let project_path = project_path.path.as_ref();
-
-        Some(if project_path == Path::new("") {
-            workspace_root.to_path_buf()
-        } else {
-            workspace_root.join(project_path)
-        })
+            .absolutize(&project_path.path)
+            .ok()
     }
 
     /// Attempts to find a `ProjectPath` corresponding to the given path. If the path


### PR DESCRIPTION
Use `Fs` instead of `std::fs` and do entry existence checks better:
* first, check the worktree entry existence without any FS checks
* then, only for local cases, use `Fs` to check for abs_path existence of items, in case those came from single-filed worktrees that got closed and removed.

Remote entries do not get file existence checks, so might try opening previously removed buffers for now.

Release Notes:

- N/A
