### PR TITLE
assistant: Add implementation for `/delta` argument completion

### DIFF
--- a/crates/assistant/src/slash_command/delta_command.rs
+++ b/crates/assistant/src/slash_command/delta_command.rs
@@ -1,5 +1,5 @@
 use crate::slash_command::file_command::{FileCommandMetadata, FileSlashCommand};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use assistant_slash_command::{
     ArgumentCompletion, SlashCommand, SlashCommandOutput, SlashCommandOutputSection,
     SlashCommandResult,
@@ -38,7 +38,7 @@ impl SlashCommand for DeltaSlashCommand {
         _workspace: Option<WeakView<Workspace>>,
         _cx: &mut WindowContext,
     ) -> Task<Result<Vec<ArgumentCompletion>>> {
-        unimplemented!()
+        Task::ready(Err(anyhow!("this command does not require argument")))
     }
 
     fn run(


### PR DESCRIPTION
This PR fixes a panic that could occur when trying to complete arguments for the `/delta` slash command.

We were using `unimplemented!()` instead of providing a default no-op implementation like we do for other slash commands that do not support completing arguments.

Closes https://github.com/zed-industries/zed/issues/19686.

Release Notes:

- Fixed a panic that could occur when trying to complete arguments with the `/delta` command.
