### PR TITLE
assistant: Use a labeled button for the slash command menu

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -4249,11 +4249,11 @@ fn render_inject_context_menu(
     slash_command_picker::SlashCommandSelector::new(
         commands.clone(),
         active_context_editor,
-        IconButton::new("trigger", IconName::SlashSquare)
+        Button::new("trigger", "Add Context")
+            .icon(IconName::Plus)
             .icon_size(IconSize::Small)
-            .tooltip(|cx| {
-                Tooltip::with_meta("Insert Context", None, "Type / to insert via keyboard", cx)
-            }),
+            .icon_position(IconPosition::Start)
+            .tooltip(|cx| Tooltip::text("Type / to insert via keyboard", cx)),
     )
 }
 

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3949,7 +3949,7 @@ impl Render for ContextEditor {
                         .bg(cx.theme().colors().editor_background)
                         .child(
                             h_flex()
-                                .gap_2()
+                                .gap_1()
                                 .child(render_inject_context_menu(cx.view().downgrade(), cx))
                                 .child(
                                     IconButton::new("quote-button", IconName::Quote)

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -224,7 +224,7 @@ impl PickerDelegate for SlashCommandDelegate {
             SlashCommandEntry::Advert { renderer, .. } => Some(
                 ListItem::new(ix)
                     .inset(true)
-                    .spacing(ListItemSpacing::Sparse)
+                    .spacing(ListItemSpacing::Dense)
                     .selected(selected)
                     .child(renderer(cx)),
             ),

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -178,7 +178,7 @@ impl PickerDelegate for SlashCommandDelegate {
             SlashCommandEntry::Info(info) => Some(
                 ListItem::new(ix)
                     .inset(true)
-                    .spacing(ListItemSpacing::Sparse)
+                    .spacing(ListItemSpacing::Dense)
                     .selected(selected)
                     .child(
                         h_flex()


### PR DESCRIPTION
This should help a bit more the discoverability of the slash commands.

Release Notes:

- N/A
