### PR TITLE
Simplify line normalization

### DIFF
--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -43,9 +43,8 @@ use undo_map::UndoMap;
 #[cfg(any(test, feature = "test-support"))]
 use util::RandomCharIter;
 
-static LINE_SEPARATORS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\r\n|\r|\u{2028}|\u{2029}").expect("Failed to create LINE_SEPARATORS_REGEX")
-});
+static LINE_SEPARATORS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\r\n|\r").expect("Failed to create LINE_SEPARATORS_REGEX"));
 
 pub type TransactionId = clock::Lamport;
 


### PR DESCRIPTION
Release Notes:

- Added \u2028 and \u2029 to invisible characters. Previously these were treated as \n.