### PR TITLE
Polish multibuffer UI

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2119,8 +2119,6 @@ impl EditorElement {
                 let icon_offset = gutter_dimensions.width
                     - (gutter_dimensions.left_padding + gutter_dimensions.margin);
 
-                let header_padding = px(6.0);
-
                 let mut result = v_flex().id(block_id).w_full();
 
                 if let Some(prev_excerpt) = prev_excerpt {
@@ -2197,44 +2195,43 @@ impl EditorElement {
 
                         result = result.child(
                             div()
-                                .px(header_padding)
-                                .pt(header_padding)
                                 .w_full()
-                                .h(FILE_HEADER_HEIGHT as f32 * cx.line_height())
+                                .h_auto()
+                                .text_ui_sm(cx)
                                 .child(
                                     h_flex()
                                         .id("path header block")
                                         .size_full()
-                                        .flex_basis(Length::Definite(DefiniteLength::Fraction(
-                                            0.667,
-                                        )))
-                                        .px(gpui::px(12.))
-                                        .rounded_md()
-                                        .shadow_md()
-                                        .border_1()
-                                        .border_color(cx.theme().colors().border)
+                                        .py_2()
+                                        .px_3()
+                                        .mt(px(-1.))
+                                        .border_y_1()
+                                        .border_color(cx.theme().colors().border_variant)
                                         .bg(cx.theme().colors().editor_subheader_background)
-                                        .justify_between()
                                         .hover(|style| style.bg(cx.theme().colors().element_hover))
                                         .child(
-                                            h_flex().gap_3().child(
-                                                h_flex()
-                                                    .gap_2()
-                                                    .child(
-                                                        filename
-                                                            .map(SharedString::from)
-                                                            .unwrap_or_else(|| "untitled".into()),
-                                                    )
-                                                    .when_some(parent_path, |then, path| {
-                                                        then.child(div().child(path).text_color(
-                                                            cx.theme().colors().text_muted,
-                                                        ))
-                                                    }),
-                                            ),
+                                            h_flex()
+                                                .size_full()
+                                                .gap_2()
+                                                .child(
+                                                    svg()
+                                                        .path(IconName::ArrowUpRight.path())
+                                                        .size(IconSize::Indicator.rems())
+                                                        .text_color(cx.theme().colors().editor_line_number)
+                                                )
+                                                .child(
+                                                    filename
+                                                        .map(SharedString::from)
+                                                        .unwrap_or_else(|| "untitled".into())
+                                                )
+                                                .when_some(parent_path, |then, path| {
+                                                    then.child(div().child(path).text_color(
+                                                        cx.theme().colors().text_muted,
+                                                    ))
+                                                })
                                         )
                                         .when_some(jump_data, |el, jump_data| {
-                                            el.child(Icon::new(IconName::ArrowUpRight))
-                                                .cursor_pointer()
+                                            el.child(div()).cursor_pointer()
                                                 .tooltip(|cx| {
                                                     Tooltip::for_action(
                                                         "Jump to File",

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2275,7 +2275,6 @@ impl EditorElement {
                         result = result.child(
                             h_flex()
                                 .id("excerpt header block")
-                                .group("excerpt-jump-action")
                                 .justify_start()
                                 .w_full()
                                 .h(MULTI_BUFFER_EXCERPT_HEADER_HEIGHT as f32 * cx.line_height())
@@ -2287,38 +2286,7 @@ impl EditorElement {
                                         .w_full()
                                         .h_px()
                                         .bg(cx.theme().colors().border_variant)
-                                        .group_hover("excerpt-jump-action", |style| {
-                                            style.bg(cx.theme().colors().border)
-                                        }),
                                 )
-                                .cursor_pointer()
-                                .when_some(jump_data.clone(), |this, jump_data| {
-                                    this.on_click(cx.listener_for(&self.editor, {
-                                        let path = jump_data.path.clone();
-                                        move |editor, _, cx| {
-                                            cx.stop_propagation();
-
-                                            editor.jump(
-                                                path.clone(),
-                                                jump_data.position,
-                                                jump_data.anchor,
-                                                jump_data.line_offset_from_top,
-                                                cx,
-                                            );
-                                        }
-                                    }))
-                                    .tooltip(move |cx| {
-                                        Tooltip::for_action(
-                                            format!(
-                                                "Jump to {}:L{}",
-                                                jump_data.path.path.display(),
-                                                jump_data.position.row + 1
-                                            ),
-                                            &OpenExcerpts,
-                                            cx,
-                                        )
-                                    })
-                                })
                                 .child(
                                     h_flex()
                                         .w(icon_offset)
@@ -2343,14 +2311,6 @@ impl EditorElement {
                                                         .text_color(
                                                             cx.theme().colors().border_variant,
                                                         )
-                                                        .group_hover(
-                                                            "excerpt-jump-action",
-                                                            |style| {
-                                                                style.text_color(
-                                                                    cx.theme().colors().border,
-                                                                )
-                                                            },
-                                                        ),
                                                 )
                                         }),
                                 ),


### PR DESCRIPTION
This branch is mostly intended for polishing small UI details in the multi-buffer view. Specifically, the jump-to-file subheaders are very large and jarring compared to the rest of the UI in the current version. There's also other UI quirks like the fact that the "expand excerpt" (upwards) area is actually clickable and jumps to the file matched – which I find to be an anti-pattern considering the hitbox is completely invisible to the user.

Notes:
- I'd like some feedback on how to keep the subheader text size to match and scale with the rest of the UI, respecting the `ui_font_` settings.

Release Notes:
- N/A

<img width="1134" alt="Screenshot 2024-10-25 at 13 26 56" src="https://github.com/user-attachments/assets/464cea29-4614-48cd-99de-320e46ee8034">