### PR TITLE
Include commit summary in inline Git blame

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -1978,6 +1978,7 @@ async fn test_git_blame_is_forwarded(cx_a: &mut TestAppContext, cx_b: &mut TestA
         enabled: false,
         delay_ms: None,
         min_column: None,
+        show_commit_message: false,
     });
     cx_a.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -1978,7 +1978,7 @@ async fn test_git_blame_is_forwarded(cx_a: &mut TestAppContext, cx_b: &mut TestA
         enabled: false,
         delay_ms: None,
         min_column: None,
-        show_commit_message: false,
+        show_commit_summary: false,
     });
     cx_a.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4153,7 +4153,20 @@ fn render_inline_blame_entry(
     let relative_timestamp = blame_entry_relative_timestamp(&blame_entry);
 
     let author = blame_entry.author.as_deref().unwrap_or_default();
-    let text = format!("{}, {}", author, relative_timestamp);
+    let summary_enabled = ProjectSettings::get_global(cx)
+        .git
+        .show_inline_commit_summary();
+
+    let text = if summary_enabled && blame_entry.summary.is_some() {
+        format!(
+            "{}, {} - {}",
+            author,
+            relative_timestamp,
+            blame_entry.summary.as_ref().unwrap()
+        )
+    } else {
+        format!("{}, {}", author, relative_timestamp)
+    };
 
     let details = blame.read(cx).details_for_entry(&blame_entry);
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4157,15 +4157,11 @@ fn render_inline_blame_entry(
         .git
         .show_inline_commit_summary();
 
-    let text = if summary_enabled && blame_entry.summary.is_some() {
-        format!(
-            "{}, {} - {}",
-            author,
-            relative_timestamp,
-            blame_entry.summary.as_ref().unwrap()
-        )
-    } else {
-        format!("{}, {}", author, relative_timestamp)
+    let text = match blame_entry.summary.as_ref() {
+        Some(summary) if summary_enabled => {
+            format!("{}, {} - {}", author, relative_timestamp, summary)
+        }
+        _ => format!("{}, {}", author, relative_timestamp),
     };
 
     let details = blame.read(cx).details_for_entry(&blame_entry);

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -111,6 +111,16 @@ impl GitSettings {
             _ => None,
         }
     }
+
+    pub fn show_inline_commit_summary(&self) -> bool {
+        match self.inline_blame {
+            Some(InlineBlameSettings {
+                show_commit_summary,
+                ..
+            }) => show_commit_summary,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -141,9 +151,17 @@ pub struct InlineBlameSettings {
     ///
     /// Default: 0
     pub min_column: Option<u32>,
+    /// Whether to show commit summary as part of the inline blame.
+    ///
+    /// Default: false
+    #[serde(default = "false_value")]
+    pub show_commit_summary: bool,
 }
 
 const fn true_value() -> bool {
+    true
+}
+const fn false_value() -> bool {
     true
 }
 


### PR DESCRIPTION
Closes #19758

Release Notes:

- Added feature to show commit summary as part of the inline Git blame
