### PR TITLE
Fix condition for re-using highlights when seeking buffer chunks iterator

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4035,7 +4035,7 @@ impl<'a> BufferChunks<'a> {
         let old_range = std::mem::replace(&mut self.range, range.clone());
         self.chunks.set_range(self.range.clone());
         if let Some(highlights) = self.highlights.as_mut() {
-            if old_range.start >= self.range.start && old_range.end <= self.range.end {
+            if old_range.start <= self.range.start && old_range.end >= self.range.end {
                 // Reuse existing highlights stack, as the new range is a subrange of the old one.
                 highlights
                     .stack


### PR DESCRIPTION
Fixes a syntax highlighting regression introduced in https://github.com/zed-industries/zed/pull/19531, which caused syntax highlighting to be missing after any block.

Release Notes:

- N/A
