### PR TITLE
Add .editorconfig matching the rules set in .zed/settings.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.js]
+indent_size = 2
+
+[*.css]
+indent_size = 2


### PR DESCRIPTION
Add .editorconfig matching the rules set in .zed/settings.json

This will help those editing the zed code with other editors keeping a consistent space format. Plus zed just merged in support for .editorconfig files.

Release Notes:

- N/A
