### PR TITLE
collab: Include `checkout_complete` query parameter after checking out

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -252,7 +252,10 @@ async fn create_billing_subscription(
 
     let default_model = llm_db.model(rpc::LanguageModelProvider::Anthropic, "claude-3-5-sonnet")?;
     let stripe_model = stripe_billing.register_model(default_model).await?;
-    let success_url = format!("{}/account", app.config.zed_dot_dev_url());
+    let success_url = format!(
+        "{}/account?checkout_complete=1",
+        app.config.zed_dot_dev_url()
+    );
     let checkout_session_url = stripe_billing
         .checkout(customer_id, &user.github_login, &stripe_model, &success_url)
         .await?;


### PR DESCRIPTION
This PR updates the checkout flow to include the `?checkout_complete=1` query parameter after successfully checking out.

We'll use this on the account page to adapt the UI accordingly.

Release Notes:

- N/A
