### PR TITLE
vim: Copy comment to new lines with o/O

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -223,6 +223,7 @@ pub fn render_parsed_markdown(
                 }
             }),
     );
+    // hello
 
     let mut links = Vec::new();
     let mut link_ranges = Vec::new();
@@ -3769,6 +3770,9 @@ impl Editor {
     pub fn newline_below(&mut self, _: &NewlineBelow, cx: &mut ViewContext<Self>) {
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
+        //
+        //
+        //
 
         let mut edits = Vec::new();
         let mut rows = Vec::new();

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -123,6 +123,7 @@ impl EditorLspTestContext {
                     path_suffixes: vec!["rs".to_string()],
                     ..Default::default()
                 },
+                line_comments: vec!["// ".into(), "/// ".into(), "//! ".into()],
                 ..Default::default()
             },
             Some(tree_sitter_rust::LANGUAGE.into()),

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2862,6 +2862,30 @@ impl MultiBufferSnapshot {
         }
     }
 
+    pub fn indent_and_comment_for_line(&self, row: MultiBufferRow, cx: &AppContext) -> String {
+        let mut indent = self.indent_size_for_line(row).chars().collect::<String>();
+
+        if self.settings_at(0, cx).extend_comment_on_newline {
+            if let Some(language_scope) = self.language_scope_at(Point::new(row.0, 0)) {
+                let delimiters = language_scope.line_comment_prefixes();
+                for delimiter in delimiters {
+                    if *self
+                        .chars_at(Point::new(row.0, indent.len() as u32))
+                        .take(delimiter.chars().count())
+                        .collect::<String>()
+                        .as_str()
+                        == **delimiter
+                    {
+                        indent.push_str(&delimiter);
+                        break;
+                    }
+                }
+            }
+        }
+
+        indent
+    }
+
     pub fn prev_non_blank_row(&self, mut row: MultiBufferRow) -> Option<MultiBufferRow> {
         while row.0 > 0 {
             row.0 -= 1;

--- a/crates/vim/test_data/test_o_comment.json
+++ b/crates/vim/test_data/test_o_comment.json
@@ -1,0 +1,8 @@
+{"SetOption":{"value":"filetype=rust"}}
+{"Put":{"state":"// helloˇ\n"}}
+{"Key":"o"}
+{"Get":{"state":"// hello\n// ˇ\n","mode":"Insert"}}
+{"Key":"x"}
+{"Key":"escape"}
+{"Key":"shift-o"}
+{"Get":{"state":"// hello\n// ˇ\n// x\n","mode":"Insert"}}


### PR DESCRIPTION
Co-Authored-By: Kurt Wolf <kurtwolfbuilds@gmail.com>

Closes: #4691

Closes #ISSUE

Release Notes:

- vim: o/O now respect `extend_comment_on_newline`
