### PR TITLE
Restore horizontal scrollbar checks

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2821,6 +2821,17 @@ impl ProjectPanel {
             return None;
         }
 
+        let scroll_handle = self.scroll_handle.0.borrow();
+        let longest_item_width = scroll_handle
+            .last_item_size
+            .filter(|size| size.contents.width > size.item.width)?
+            .contents
+            .width
+            .0 as f64;
+        if longest_item_width < scroll_handle.base_handle.bounds().size.width.0 as f64 {
+            return None;
+        }
+
         Some(
             div()
                 .occlude()


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/19637

Follow-up of https://github.com/zed-industries/zed/pull/18927 , restores the condition that removed the horizontal scrollbar when panel's items are not long enough.

Release Notes:

- Fixed horizontal scrollbar not being hidden ([#19637](https://github.com/zed-industries/zed/issues/19637))
