### PR TITLE
editor: Use background color variants for Git gutter

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3196,7 +3196,7 @@ impl EditorElement {
                         );
                         Some((
                             hunk_bounds,
-                            cx.theme().status().modified,
+                            cx.theme().status().modified_background,
                             Corners::all(px(0.)),
                         ))
                     }
@@ -3204,12 +3204,12 @@ impl EditorElement {
                         hitbox.as_ref().map(|hunk_hitbox| match status {
                             DiffHunkStatus::Added => (
                                 hunk_hitbox.bounds,
-                                cx.theme().status().created,
+                                cx.theme().status().created_background,
                                 Corners::all(px(0.)),
                             ),
                             DiffHunkStatus::Modified => (
                                 hunk_hitbox.bounds,
-                                cx.theme().status().modified,
+                                cx.theme().status().modified_background,
                                 Corners::all(px(0.)),
                             ),
                             DiffHunkStatus::Removed => (
@@ -3220,7 +3220,7 @@ impl EditorElement {
                                     ),
                                     size(hunk_hitbox.size.width * px(2.), hunk_hitbox.size.height),
                                 ),
-                                cx.theme().status().deleted,
+                                cx.theme().status().deleted_background,
                                 Corners::all(1. * line_height),
                             ),
                         })


### PR DESCRIPTION
Closes #12275

This PR updates the editor to use the "background" colours to render the git gutter. As I outlined in #12275, the default colour variants for "created", "modified", "deleted" statuses are used to colour the text, e.g. the name of a modified file in the project explorer. These colours need to be more vibrant than the one that marks a background in the gutter.

Here is how the changes look in [my configuration](https://gist.github.com/narqo/e947f9b5bfa57974f3914816be76d319):

*Before*
<img width="1470" alt="Screenshot 2024-10-26 at 00 11 27" src="https://github.com/user-attachments/assets/ad09ecdc-97c8-4a0b-9959-1f2fa6ec40bb">

*After*
<img width="1470" alt="Screenshot 2024-10-26 at 00 09 44" src="https://github.com/user-attachments/assets/3f7b87ca-a196-4c32-bee9-f5953d94cbbd">


Release Notes:

- N/A
