### PR TITLE
Remove another false-positive Danger message

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -8,7 +8,7 @@ prHygiene({
   },
 });
 
-const RELEASE_NOTES_PATTERN = new RegExp("Release Notes:\\r?\\n\\s+-", "gm");
+const RELEASE_NOTES_PATTERN = /Release Notes:\r?\n\s+-/gm;
 const body = danger.github.pr.body;
 
 const hasReleaseNotes = RELEASE_NOTES_PATTERN.test(body);
@@ -36,28 +36,22 @@ if (!hasReleaseNotes) {
   );
 }
 
-const ISSUE_LINK_PATTERN = new RegExp(
-  "(?<!(?:Close[sd]?|Fixe[sd]|Resolve[sd]|Implement[sed])\\s+)https://github\\.com/[\\w-]+/[\\w-]+/issues/\\d+",
-  "gi"
-);
+const ISSUE_LINK_PATTERN =
+  /(?<!(?:Close[sd]?|Fixe[sd]|Resolve[sd]|Implement[sed]|Follow-up of|Part of)\s+)https:\/\/github\.com\/[\w-]+\/[\w-]+\/issues\/\d+/gi;
 
-
-const includesIssueUrl = ISSUE_LINK_PATTERN.test(body);
+const bodyWithoutReleaseNotes = hasReleaseNotes ? body.split(/Release Notes:/)[0] : body;
+const includesIssueUrl = ISSUE_LINK_PATTERN.test(bodyWithoutReleaseNotes);
 
 if (includesIssueUrl) {
-  const matches = body.match(ISSUE_LINK_PATTERN) ?? [];
+  const matches = bodyWithoutReleaseNotes.match(ISSUE_LINK_PATTERN) ?? [];
   const issues = matches
-    .map((match) =>
-      match
-        .replace(/^#/, "")
-        .replace(/https:\/\/github\.com\/zed-industries\/zed\/issues\//, ""),
-    )
+    .map((match) => match.replace(/^#/, "").replace(/https:\/\/github\.com\/zed-industries\/zed\/issues\//, ""))
     .filter((issue, index, self) => self.indexOf(issue) === index);
 
+  const issuesToReport = issues.map((issue) => `#${issue}`).join(", ");
   message(
     [
-      "This PR includes links to the following GitHub Issues: " +
-        issues.map((issue) => `#${issue}`).join(", "),
+      `This PR includes links to the following GitHub Issues: ${issuesToReport}`,
       "If this PR aims to close an issue, please include a `Closes #ISSUE` line at the top of the PR body.",
     ].join("\n"),
   );


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/19151

Ignores any URLs aftrer `Release Notes:` (if present) and after `Follow-up of` and `Part of` words.


Release Notes:

- N/A