### PR TITLE
gpui: Add drop_image

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -581,6 +581,7 @@ impl<T> AtlasTextureList<T> {
         self.textures.drain(..)
     }
 
+    #[allow(dead_code)]
     fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut T> {
         self.textures.iter_mut().flatten()
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -43,6 +43,7 @@ use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
+use std::ops;
 use std::time::{Duration, Instant};
 use std::{
     fmt::{self, Debug},
@@ -549,6 +550,40 @@ pub(crate) trait PlatformAtlas: Send + Sync {
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
     ) -> Result<Option<AtlasTile>>;
     fn remove(&self, key: &AtlasKey);
+}
+
+struct AtlasTextureList<T> {
+    textures: Vec<Option<T>>,
+    free_list: Vec<usize>,
+}
+
+impl<T> Default for AtlasTextureList<T> {
+    fn default() -> Self {
+        Self {
+            textures: Vec::default(),
+            free_list: Vec::default(),
+        }
+    }
+}
+
+impl<T> ops::Index<usize> for AtlasTextureList<T> {
+    type Output = Option<T>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.textures[index]
+    }
+}
+
+impl<T> AtlasTextureList<T> {
+    #[allow(unused)]
+    fn drain(&mut self) -> std::vec::Drain<Option<T>> {
+        self.free_list.clear();
+        self.textures.drain(..)
+    }
+
+    fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut T> {
+        self.textures.iter_mut().flatten()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -548,7 +548,7 @@ pub(crate) trait PlatformAtlas: Send + Sync {
         key: &AtlasKey,
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
     ) -> Result<Option<AtlasTile>>;
-    fn remove(&self, key: &AtlasKey) -> Result<bool>;
+    fn remove(&self, key: &AtlasKey);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -548,6 +548,7 @@ pub(crate) trait PlatformAtlas: Send + Sync {
         key: &AtlasKey,
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
     ) -> Result<Option<AtlasTile>>;
+    fn remove(&self, key: &AtlasKey) -> Result<bool>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -140,11 +140,7 @@ impl PlatformAtlas for BladeAtlas {
             return;
         };
 
-        let Some(texture_slot) = lock
-            .storage
-            .get(id.kind)
-            .and_then(|storage| storage.get_mut(id.index as usize))
-        else {
+        let Some(texture_slot) = lock.storage[id.kind].get_mut(id.index as usize) else {
             return;
         };
 
@@ -352,7 +348,7 @@ struct BladeAtlasTexture {
     raw: gpu::Texture,
     raw_view: gpu::TextureView,
     format: gpu::TextureFormat,
-    allocations: u32,
+    live_atlas_keys: u32,
 }
 
 impl BladeAtlasTexture {
@@ -371,7 +367,7 @@ impl BladeAtlasTexture {
                 size,
             },
         };
-        self.allocations += 1;
+        self.live_atlas_keys += 1;
         Some(tile)
     }
 
@@ -385,11 +381,11 @@ impl BladeAtlasTexture {
     }
 
     fn decrement_ref_count(&mut self) {
-        self.allocations -= 1;
+        self.live_atlas_keys -= 1;
     }
 
     fn is_unreferenced(&mut self) -> bool {
-        self.allocations == 0
+        self.live_atlas_keys == 0
     }
 }
 

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -67,10 +67,8 @@ impl BladeAtlas {
     pub(crate) fn clear_textures(&self, texture_kind: AtlasTextureKind) {
         let mut lock = self.0.lock();
         let textures = &mut lock.storage[texture_kind];
-        for texture in textures {
-            if let Some(texture) = texture {
-                texture.clear();
-            }
+        for texture in textures.iter_mut().flatten() {
+            texture.clear();
         }
     }
 
@@ -324,20 +322,14 @@ impl ops::Index<AtlasTextureId> for BladeAtlasStorage {
 
 impl BladeAtlasStorage {
     fn destroy(&mut self, gpu: &gpu::Context) {
-        for mut texture in self.monochrome_textures.drain(..) {
-            if let Some(mut texture) = texture {
-                texture.destroy(gpu);
-            }
+        for mut texture in self.monochrome_textures.drain(..).flatten() {
+            texture.destroy(gpu);
         }
-        for mut texture in self.polychrome_textures.drain(..) {
-            if let Some(mut texture) = texture {
-                texture.destroy(gpu);
-            }
+        for mut texture in self.polychrome_textures.drain(..).flatten() {
+            texture.destroy(gpu);
         }
-        for mut texture in self.path_textures.drain(..) {
-            if let Some(mut texture) = texture {
-                texture.destroy(gpu);
-            }
+        for mut texture in self.path_textures.drain(..).flatten() {
+            texture.destroy(gpu);
         }
     }
 }

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -340,12 +340,8 @@ impl PlatformAtlas for TestAtlas {
         Ok(Some(state.tiles[key].clone()))
     }
 
-    fn remove(&self, key: &AtlasKey) -> anyhow::Result<bool> {
+    fn remove(&self, key: &AtlasKey) {
         let mut state = self.0.lock();
-        if state.tiles.remove(key).is_some() {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        state.tiles.remove(key);
     }
 }

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -339,4 +339,13 @@ impl PlatformAtlas for TestAtlas {
 
         Ok(Some(state.tiles[key].clone()))
     }
+
+    fn remove(&self, key: &AtlasKey) -> anyhow::Result<bool> {
+        let mut state = self.0.lock();
+        if state.tiles.remove(key).is_some() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2697,7 +2697,7 @@ impl<'a> WindowContext<'a> {
                 frame_index,
             };
 
-            self.window.sprite_atlas.remove(&params.clone().into())?;
+            self.window.sprite_atlas.remove(&params.clone().into());
         }
 
         Ok(())

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2689,6 +2689,20 @@ impl<'a> WindowContext<'a> {
         });
     }
 
+    /// Removes an image from the sprite atlas.
+    pub fn drop_image(&mut self, data: Arc<RenderImage>) -> Result<()> {
+        for frame_index in 0..data.frame_count() {
+            let params = RenderImageParams {
+                image_id: data.id,
+                frame_index,
+            };
+
+            self.window.sprite_atlas.remove(&params.clone().into())?;
+        }
+
+        Ok(())
+    }
+
     #[must_use]
     /// Add a node to the layout tree for the current frame. Takes the `Style` of the element for which
     /// layout is being requested, along with the layout ids of any children. This method is called during


### PR DESCRIPTION
This PR adds a function, WindowContext::drop_image, to manually remove a RenderImage from the sprite atlas. In addition, PlatformAtlas::remove was added to support this behavior. Previously, there was no way to request a RenderImage to be removed from the sprite atlas, and since they are not removed automatically the sprite would remain in video memory once added until the window was closed. This PR allows a developer to request the image be dropped from memory manually, however it does not add automatic removal.

Release Notes:

- N/A
