### PR TITLE
zig: Account for doctests in outline

### DIFF
--- a/extensions/zig/languages/zig/outline.scm
+++ b/extensions/zig/languages/zig/outline.scm
@@ -19,6 +19,9 @@
 (
     TestDecl (
         "test" @context
-        (STRINGLITERALSINGLE)? @name
+        [
+         (STRINGLITERALSINGLE)
+         (IDENTIFIER)
+        ]? @name
     )
 ) @item


### PR DESCRIPTION
zig has a feature called [doctests](https://ziglang.org/documentation/master/#Doctests) where instead of providing a string as the name of a test you use an identifier so that the test is "tied" to it and can be used in documentation. this wasnt accounted for so any tests using this were unnamed in the outline

Release Notes:

- N/A
