### PR TITLE
markdown preview: Fix infinite loop in parser when parsing list items

### DIFF
--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -626,6 +626,8 @@ impl<'a> MarkdownParser<'a> {
                         // Otherwise we need to insert the block after all the nested items
                         // that have been parsed so far
                         items.extend(block);
+                    } else {
+                        self.cursor += 1;
                     }
                 }
             }


### PR DESCRIPTION
Release Notes:

- Fixed an issue where HTML tags within list items would break the markdown preview