### PR TITLE
vim: Fix comma insertion for newline in JSON

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -642,6 +642,9 @@ pub struct LanguageConfig {
     /// languages, but should not appear to the user as a distinct language.
     #[serde(default)]
     pub hidden: bool,
+    /// Insert trailing commas within blocks, like { } in JSON/JSONC
+    #[serde(default)]
+    pub insert_trailing_commas: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, JsonSchema)]
@@ -729,6 +732,7 @@ impl Default for LanguageConfig {
             soft_wrap: None,
             prettier_parser_name: None,
             hidden: false,
+            insert_trailing_commas: false,
         }
     }
 }
@@ -1524,6 +1528,10 @@ impl LanguageScope {
         let grammar = self.language.grammar.as_ref()?;
         let override_config = grammar.override_config.as_ref()?;
         override_config.values.get(&id).map(|e| &e.1)
+    }
+
+    pub fn insert_trailing_commas(&self) -> bool {
+        self.language.config.insert_trailing_commas
     }
 }
 

--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -10,3 +10,4 @@ brackets = [
 ]
 tab_size = 2
 prettier_parser_name = "json"
+insert_trailing_commas = true

--- a/crates/languages/src/jsonc/config.toml
+++ b/crates/languages/src/jsonc/config.toml
@@ -10,3 +10,4 @@ brackets = [
 ]
 tab_size = 2
 prettier_parser_name = "jsonc"
+insert_trailing_commas = true

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -394,7 +394,6 @@ impl Vim {
                             .language_scope_at(Point::new(row, 0))
                             .map(|s| s.insert_trailing_commas())
                             .unwrap_or_default();
-                        dbg!(insert_trailing_commas);
                         let should_insert_trailing = !["{", ",", " ", "", "["].contains(&last_char);
                         if should_insert_trailing && inside_brackets && insert_trailing_commas {
                             edit.push(',');


### PR DESCRIPTION
Closes #18509

I tried to create a test case for this but ran into blocks. Neovim doesn't appear to do this (IntelliJ does), so I couldn't use the `NeovimTestCase`. I tried using `VimTestCase`:

```rs
#[gpui::test]
    async fn test_comma_insertion(cx: &mut gpui::TestAppContext) {
        // Neovim doesn't do this, so use a Zed-only test
        let mut cx = VimTestContext::new(cx, true).await;
        let doc = r#"{
  "foo": "bar",
  "baz": "qux"ˇ
}"#;
        // cx.set_state(doc, Mode::Normal);
        cx.update_buffer(|b, cx| {
            b.set_text(doc, cx);
            let mut config = LanguageConfig::default();
            config.insert_trailing_commas = true;
            config.tab_size = Some(2.try_into().unwrap());
            b.set_language(Some(std::sync::Arc::new(Language::new(config, None))), cx);
        });
        // cx.set_neovim_option("filetype=json").await;
        let expected = r#"{
  "foo": "bar",
  "baz": "qux",
  ˇ
}"#;
        // cx.set_state(doc, Mode::Normal);
        cx.simulate_keystroke("o");
        assert_eq!(cx.display_text(), expected);
```

but it doesn't seem to execute the newline action with the `cx.simulate_keystroke("o");` line.

Release Notes:

- Zed will insert commas when creating newlines in Vim for JSON/JSONC documents
