### PR TITLE
remote server: Fix language servers not starting

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -288,6 +288,15 @@ fn load_config(name: &str) -> LanguageConfig {
         .with_context(|| format!("failed to load config.toml for language {name:?}"))
         .unwrap();
 
+    #[cfg(not(feature = "load-grammars"))]
+    {
+        config = LanguageConfig {
+            name: config.name,
+            matcher: config.matcher,
+            ..Default::default()
+        }
+    }
+
     config
 }
 


### PR DESCRIPTION
PR #19653 change the code in this diff, which lead to the remote_server binary trying to load language grammars, which in turn failed, and stopped languages from being loaded correctly.

That then lead to language servers not starting up.

This change reintroduces what #19653 removed, so that we don't load the grammar on the remote_server, by ignoring the grammar name from the config. The tests still all work.


Release Notes:

- N/A
