### PR TITLE
remote server: Fix error log about inability to open buffer

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -790,9 +790,9 @@ impl FileFinderDelegate {
             let mut path_matches = Vec::new();
 
             let abs_file_exists = if let Ok(task) = project.update(&mut cx, |this, cx| {
-                this.abs_file_path_exists(query.path_query(), cx)
+                this.resolve_abs_file_path(query.path_query(), cx)
             }) {
-                task.await
+                task.await.is_some()
             } else {
                 false
             };

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -259,9 +259,6 @@ message Envelope {
         CloseBuffer close_buffer = 245;
         UpdateUserSettings update_user_settings = 246;
 
-        CheckFileExists check_file_exists = 255;
-        CheckFileExistsResponse check_file_exists_response = 256;
-
         ShutdownRemoteServer shutdown_remote_server = 257;
 
         RemoveWorktree remove_worktree = 258;
@@ -284,13 +281,16 @@ message Envelope {
         GitBranchesResponse git_branches_response = 271;
 
         UpdateGitBranch update_git_branch = 272;
+
         ListToolchains list_toolchains = 273;
         ListToolchainsResponse list_toolchains_response = 274;
         ActivateToolchain activate_toolchain = 275;
         ActiveToolchain active_toolchain = 276;
-        ActiveToolchainResponse active_toolchain_response = 277; // current max
-    }
+        ActiveToolchainResponse active_toolchain_response = 277;
 
+        GetPathMetadata get_path_metadata = 278;
+        GetPathMetadataResponse get_path_metadata_response = 279; // current max
+    }
 
     reserved 87 to 88;
     reserved 158 to 161;
@@ -305,6 +305,7 @@ message Envelope {
     reserved 221;
     reserved 224 to 229;
     reserved 247 to 254;
+    reserved 255 to 256;
 }
 
 // Messages
@@ -2357,14 +2358,15 @@ message UpdateUserSettings {
     }
 }
 
-message CheckFileExists {
+message GetPathMetadata {
     uint64 project_id = 1;
     string path = 2;
 }
 
-message CheckFileExistsResponse {
+message GetPathMetadataResponse {
     bool exists = 1;
     string path = 2;
+    bool is_dir = 3;
 }
 
 message ShutdownRemoteServer {}

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -343,8 +343,6 @@ messages!(
     (FindSearchCandidatesResponse, Background),
     (CloseBuffer, Foreground),
     (UpdateUserSettings, Foreground),
-    (CheckFileExists, Background),
-    (CheckFileExistsResponse, Background),
     (ShutdownRemoteServer, Foreground),
     (RemoveWorktree, Foreground),
     (LanguageServerLog, Foreground),
@@ -363,7 +361,9 @@ messages!(
     (ListToolchainsResponse, Foreground),
     (ActivateToolchain, Foreground),
     (ActiveToolchain, Foreground),
-    (ActiveToolchainResponse, Foreground)
+    (ActiveToolchainResponse, Foreground),
+    (GetPathMetadata, Background),
+    (GetPathMetadataResponse, Background)
 );
 
 request_messages!(
@@ -472,7 +472,6 @@ request_messages!(
     (SynchronizeContexts, SynchronizeContextsResponse),
     (LspExtSwitchSourceHeader, LspExtSwitchSourceHeaderResponse),
     (AddWorktree, AddWorktreeResponse),
-    (CheckFileExists, CheckFileExistsResponse),
     (ShutdownRemoteServer, Ack),
     (RemoveWorktree, Ack),
     (OpenServerSettings, OpenBufferResponse),
@@ -483,7 +482,8 @@ request_messages!(
     (UpdateGitBranch, Ack),
     (ListToolchains, ListToolchainsResponse),
     (ActivateToolchain, Ack),
-    (ActiveToolchain, ActiveToolchainResponse)
+    (ActiveToolchain, ActiveToolchainResponse),
+    (GetPathMetadata, GetPathMetadataResponse)
 );
 
 entity_messages!(
@@ -555,7 +555,6 @@ entity_messages!(
     SynchronizeContexts,
     LspExtSwitchSourceHeader,
     UpdateUserSettings,
-    CheckFileExists,
     LanguageServerLog,
     Toast,
     HideToast,
@@ -566,7 +565,8 @@ entity_messages!(
     UpdateGitBranch,
     ListToolchains,
     ActivateToolchain,
-    ActiveToolchain
+    ActiveToolchain,
+    GetPathMetadata
 );
 
 entity_messages!(

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -150,7 +150,7 @@ impl HeadlessProject {
         session.subscribe_to_entity(SSH_PROJECT_ID, &settings_observer);
 
         client.add_request_handler(cx.weak_model(), Self::handle_list_remote_directory);
-        client.add_request_handler(cx.weak_model(), Self::handle_check_file_exists);
+        client.add_request_handler(cx.weak_model(), Self::handle_resolve_fs_metadata);
         client.add_request_handler(cx.weak_model(), Self::handle_shutdown_remote_server);
         client.add_request_handler(cx.weak_model(), Self::handle_ping);
 
@@ -525,18 +525,20 @@ impl HeadlessProject {
         Ok(proto::ListRemoteDirectoryResponse { entries })
     }
 
-    pub async fn handle_check_file_exists(
+    pub async fn handle_resolve_fs_metadata(
         this: Model<Self>,
-        envelope: TypedEnvelope<proto::CheckFileExists>,
+        envelope: TypedEnvelope<proto::GetPathMetadata>,
         cx: AsyncAppContext,
-    ) -> Result<proto::CheckFileExistsResponse> {
+    ) -> Result<proto::GetPathMetadataResponse> {
         let fs = cx.read_model(&this, |this, _| this.fs.clone())?;
         let expanded = shellexpand::tilde(&envelope.payload.path).to_string();
 
-        let exists = fs.is_file(&PathBuf::from(expanded.clone())).await;
+        let metadata = fs.metadata(&PathBuf::from(expanded.clone())).await?;
+        let is_dir = metadata.map(|metadata| metadata.is_dir).unwrap_or(false);
 
-        Ok(proto::CheckFileExistsResponse {
-            exists,
+        Ok(proto::GetPathMetadataResponse {
+            exists: metadata.is_some(),
+            is_dir,
             path: expanded,
         })
     }

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -150,7 +150,7 @@ impl HeadlessProject {
         session.subscribe_to_entity(SSH_PROJECT_ID, &settings_observer);
 
         client.add_request_handler(cx.weak_model(), Self::handle_list_remote_directory);
-        client.add_request_handler(cx.weak_model(), Self::handle_resolve_fs_metadata);
+        client.add_request_handler(cx.weak_model(), Self::handle_get_path_metadata);
         client.add_request_handler(cx.weak_model(), Self::handle_shutdown_remote_server);
         client.add_request_handler(cx.weak_model(), Self::handle_ping);
 
@@ -525,7 +525,7 @@ impl HeadlessProject {
         Ok(proto::ListRemoteDirectoryResponse { entries })
     }
 
-    pub async fn handle_resolve_fs_metadata(
+    pub async fn handle_get_path_metadata(
         this: Model<Self>,
         envelope: TypedEnvelope<proto::GetPathMetadata>,
         cx: AsyncAppContext,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1218,7 +1218,7 @@ impl Workspace {
             notify_if_database_failed(window, &mut cx);
             let opened_items = window
                 .update(&mut cx, |_workspace, cx| {
-                    open_items(serialized_workspace, project_paths, app_state, cx)
+                    open_items(serialized_workspace, project_paths, cx)
                 })?
                 .await
                 .unwrap_or_default();
@@ -2058,8 +2058,10 @@ impl Workspace {
         cx: &mut ViewContext<Self>,
     ) -> Task<anyhow::Result<Box<dyn ItemHandle>>> {
         match path {
-            ResolvedPath::ProjectPath(project_path) => self.open_path(project_path, None, true, cx),
-            ResolvedPath::AbsPath(path) => self.open_abs_path(path, false, cx),
+            ResolvedPath::ProjectPath { project_path, .. } => {
+                self.open_path(project_path, None, true, cx)
+            }
+            ResolvedPath::AbsPath { path, .. } => self.open_abs_path(path, false, cx),
         }
     }
 
@@ -4563,7 +4565,6 @@ fn window_bounds_env_override() -> Option<Bounds<Pixels>> {
 fn open_items(
     serialized_workspace: Option<SerializedWorkspace>,
     mut project_paths_to_open: Vec<(PathBuf, Option<ProjectPath>)>,
-    app_state: Arc<AppState>,
     cx: &mut ViewContext<Workspace>,
 ) -> impl 'static + Future<Output = Result<Vec<Option<Result<Box<dyn ItemHandle>>>>>> {
     let restored_items = serialized_workspace.map(|serialized_workspace| {
@@ -4619,14 +4620,20 @@ fn open_items(
                 .enumerate()
                 .map(|(ix, (abs_path, project_path))| {
                     let workspace = workspace.clone();
-                    cx.spawn(|mut cx| {
-                        let fs = app_state.fs.clone();
-                        async move {
-                            let file_project_path = project_path?;
-                            if fs.is_dir(&abs_path).await {
-                                None
-                            } else {
-                                Some((
+                    cx.spawn(|mut cx| async move {
+                        let file_project_path = project_path?;
+                        let abs_path_task = workspace.update(&mut cx, |workspace, cx| {
+                            workspace.project().update(cx, |project, cx| {
+                                project.resolve_abs_path(abs_path.to_string_lossy().as_ref(), cx)
+                            })
+                        });
+
+                        // We only want to open file paths here. If one of the items
+                        // here is a directory, it was already opened further above
+                        // with a `find_or_create_worktree`.
+                        if let Ok(task) = abs_path_task {
+                            if task.await.map_or(false, |p| p.is_file()) {
+                                return Some((
                                     ix,
                                     workspace
                                         .update(&mut cx, |workspace, cx| {
@@ -4634,9 +4641,10 @@ fn open_items(
                                         })
                                         .log_err()?
                                         .await,
-                                ))
+                                ));
                             }
                         }
+                        None
                     })
                 });
 
@@ -5580,7 +5588,7 @@ pub fn open_ssh_project(
             .update(&mut cx, |_, cx| {
                 cx.activate_window();
 
-                open_items(serialized_workspace, project_paths_to_open, app_state, cx)
+                open_items(serialized_workspace, project_paths_to_open, cx)
             })?
             .await?;
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4632,7 +4632,7 @@ fn open_items(
                         // here is a directory, it was already opened further above
                         // with a `find_or_create_worktree`.
                         if let Ok(task) = abs_path_task {
-                            if task.await.map_or(false, |p| p.is_file()) {
+                            if task.await.map_or(true, |p| p.is_file()) {
                                 return Some((
                                     ix,
                                     workspace


### PR DESCRIPTION
Turns out that we used client-side `fs` to check whether something is a directory or not, which obviously doesn't work with SSH projects.

Release Notes:

- N/A
