### PR TITLE
Declare RUSTFLAGS env var for all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   migration_checks:
@@ -116,13 +117,13 @@ jobs:
         uses: ./.github/actions/run_tests
 
       - name: Build collab
-        run: RUSTFLAGS="-D warnings" cargo build -p collab
+        run: cargo build -p collab
 
       - name: Build other binaries and features
         run: |
-          RUSTFLAGS="-D warnings" cargo build --workspace --bins --all-features
+          cargo build --workspace --bins --all-features
           cargo check -p gpui --features "macos-blade"
-          RUSTFLAGS="-D warnings" cargo build -p remote_server
+          cargo build -p remote_server
 
   linux_tests:
     timeout-minutes: 60
@@ -155,7 +156,7 @@ jobs:
         uses: ./.github/actions/run_tests
 
       - name: Build Zed
-        run: RUSTFLAGS="-D warnings" cargo build -p zed
+        run: cargo build -p zed
 
   build_remote_server:
     timeout-minutes: 60
@@ -182,7 +183,7 @@ jobs:
         run: ./script/remote-server && ./script/install-mold 2.34.0
 
       - name: Build Remote Server
-        run: RUSTFLAGS="-D warnings" cargo build -p remote_server
+        run: cargo build -p remote_server
 
   # todo(windows): Actually run the tests
   windows_tests:
@@ -207,7 +208,7 @@ jobs:
         run: cargo xtask clippy
 
       - name: Build Zed
-        run: $env:RUSTFLAGS="-D warnings"; cargo build
+        run: cargo build
 
   bundle-mac:
     timeout-minutes: 60


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/19149 

Makes RUSTFLAGS propagation uniform, to ensure all `cargo ...` jobs get the same RUSTFLAGS env set.

Release Notes:

- N/A
