### PR TITLE
Add filter options for project search in both global and local setting file

### DIFF
--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -160,7 +160,7 @@ pub enum ScrollBeyondLastLine {
 }
 
 /// Default options for buffer and project search items.
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct SearchSettings {
     #[serde(default)]
     pub whole_word: bool,
@@ -170,6 +170,8 @@ pub struct SearchSettings {
     pub include_ignored: bool,
     #[serde(default)]
     pub regex: bool,
+    pub include: Option<String>,
+    pub exclude: Option<String>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -9,7 +9,7 @@ use editor::{
     items::active_match_index,
     scroll::{Autoscroll, Axis},
     Anchor, Editor, EditorElement, EditorEvent, EditorSettings, EditorStyle, MultiBuffer,
-    MAX_TAB_TITLE_LEN,
+    SearchSettings, MAX_TAB_TITLE_LEN,
 };
 use futures::StreamExt;
 use gpui::{
@@ -21,6 +21,7 @@ use gpui::{
 use language::Buffer;
 use menu::Confirm;
 use project::{
+    project_settings::SearchSettings as LocalSearchSettings,
     search::{SearchInputKind, SearchQuery},
     search_history::SearchHistoryCursor,
     Project, ProjectPath,
@@ -634,6 +635,35 @@ impl ProjectSearchView {
         });
     }
 
+    fn load_searchsettings(
+        cx: &mut ViewContext<Self>,
+    ) -> (SearchOptions, Option<String>, Option<String>, bool) {
+        if let Some(project_search_setting) = LocalSearchSettings::try_global(cx) {
+            let settings = SearchSettings {
+                whole_word: project_search_setting.whole_word,
+                case_sensitive: project_search_setting.case_sensitive,
+                include_ignored: project_search_setting.include_ignored,
+                regex: project_search_setting.regex,
+                include: project_search_setting.include.clone(),
+                exclude: project_search_setting.exclude.clone(),
+            };
+            return (
+                (SearchOptions::from_settings(&settings)),
+                settings.include.clone(),
+                settings.exclude.clone(),
+                settings.include.is_some() || settings.exclude.is_some(),
+            );
+        }
+
+        (
+            (SearchOptions::from_settings(&EditorSettings::get_global(cx).search)),
+            EditorSettings::get_global(cx).search.include.clone(),
+            EditorSettings::get_global(cx).search.exclude.clone(),
+            EditorSettings::get_global(cx).search.include.is_some()
+                || EditorSettings::get_global(cx).search.exclude.is_some(),
+        )
+    }
+
     pub fn new(
         workspace: WeakView<Workspace>,
         model: Model<ProjectSearch>,
@@ -645,16 +675,15 @@ impl ProjectSearchView {
         let mut replacement_text = None;
         let mut query_text = String::new();
         let mut subscriptions = Vec::new();
-
-        // Read in settings if available
-        let (mut options, filters_enabled) = if let Some(settings) = settings {
-            (settings.search_options, settings.filters_enabled)
-        } else {
-            let search_options =
-                SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
-            (search_options, false)
-        };
-
+        // Read in settings from setting.json (project and global)
+        let (mut options, mut include_filters, mut exclude_filters, mut filters_enabled) =
+            Self::load_searchsettings(cx);
+        // Read in settings from history
+        if let Some(settings) = settings {
+            options = settings.search_options;
+            filters_enabled = settings.filters_enabled;
+        }
+        // Read in settings from active query
         {
             let model = model.read(cx);
             project = model.project.clone();
@@ -663,7 +692,24 @@ impl ProjectSearchView {
                 query_text = active_query.as_str().to_string();
                 replacement_text = active_query.replacement().map(ToOwned::to_owned);
                 options = SearchOptions::from_query(active_query);
+                include_filters = Some(
+                    active_query
+                        .as_inner()
+                        .files_to_include()
+                        .sources()
+                        .join(","),
+                );
+                exclude_filters = Some(
+                    active_query
+                        .as_inner()
+                        .files_to_exclude()
+                        .sources()
+                        .join(","),
+                );
             }
+        }
+        if include_filters.is_some() || exclude_filters.is_some() {
+            filters_enabled = true;
         }
         subscriptions.push(cx.observe(&model, |this, _, cx| this.model_changed(cx)));
 
@@ -718,7 +764,9 @@ impl ProjectSearchView {
         let included_files_editor = cx.new_view(|cx| {
             let mut editor = Editor::single_line(cx);
             editor.set_placeholder_text("Include: crates/**/*.toml", cx);
-
+            if let Some(include_filters) = include_filters {
+                editor.set_text(include_filters, cx);
+            }
             editor
         });
         // Subscribe to include_files_editor in order to reraise editor events for workspace item activation purposes
@@ -731,7 +779,9 @@ impl ProjectSearchView {
         let excluded_files_editor = cx.new_view(|cx| {
             let mut editor = Editor::single_line(cx);
             editor.set_placeholder_text("Exclude: vendor/*, *.lock", cx);
-
+            if let Some(exclude_filters) = exclude_filters {
+                editor.set_text(exclude_filters, cx);
+            }
             editor
         });
         // Subscribe to excluded_files_editor in order to reraise editor events for workspace item activation purposes


### PR DESCRIPTION
Closes #19333

Release Notes:

- Added: include filter and exclude filter in search configuration. We can now set zed's config file ( $user_root/.config/zed/settings.json ) like this:

_"search": { 
    "whole_word": false,
    "case_sensitive": false,
    "include_ignored": false,
    "regex": false,
    "include": "*.md",
    "exclude": "public,static,assets"
  },_

- Added: Search setting in project's local setting file ( $project_root/.zed/settings.json ); Search settings in project is priority over global setting.


Project local setting sample.
![settings](https://github.com/user-attachments/assets/d549eab3-caa0-49aa-aac7-5eefa56cebe6)


Project Search UI responses to settings.
![project search](https://github.com/user-attachments/assets/7118a250-30fa-4bc4-9914-b37dbca5d6c7)


Buffer Search UI responses to settings.
![buffer search](https://github.com/user-attachments/assets/5783cd8e-8872-41ed-8888-dd2b8a789a9c)
