### PR TITLE
remote servers: Always dismiss modal

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -738,7 +738,8 @@ impl RemoteServerProjects {
                 };
                 let project = project.clone();
                 let server = server.clone();
-                cx.spawn(|remote_server_projects, mut cx| async move {
+                cx.emit(DismissEvent);
+                cx.spawn(|_, mut cx| async move {
                     let result = open_ssh_project(
                         server.into(),
                         project.paths.into_iter().map(PathBuf::from).collect(),
@@ -757,10 +758,6 @@ impl RemoteServerProjects {
                         )
                         .await
                         .ok();
-                    } else {
-                        remote_server_projects
-                            .update(&mut cx, |_, cx| cx.emit(DismissEvent))
-                            .ok();
                     }
                 })
                 .detach();


### PR DESCRIPTION
We display the errors in another window anyway and if the connection takes a while it looks like a bug that the modal stays open.

Release Notes:

- N/A
