### PR TITLE
dart: Bump to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15132,7 +15132,7 @@ dependencies = [
 
 [[package]]
 name = "zed_dart"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/dart/Cargo.toml
+++ b/extensions/dart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_dart"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/dart/extension.toml
+++ b/extensions/dart/extension.toml
@@ -1,7 +1,7 @@
 id = "dart"
 name = "Dart"
 description = "Dart support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Abdullah Alsigar <abdullah.alsigar@gmail.com>", "Flo <flo80@users.noreply.github.com>", "ybbond <hi@ybbond.id>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Dart extension to v0.1.2.

Changes:

- https://github.com/zed-industries/zed/pull/19592

Release Notes:

- N/A
