### PR TITLE
remote project: Fix project reference leak when waiting for prompt reply

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3603,6 +3603,13 @@ impl Project {
             anyhow::Ok(())
         })??;
 
+        // We drop `this` to avoid holding a reference in this future for too
+        // long.
+        // If we keep the reference, we might not drop the `Project` early
+        // enough when closing a window and it will only get releases on the
+        // next `flush_effects()` call.
+        drop(this);
+
         let answer = rx.next().await;
 
         Ok(LanguageServerPromptResponse {


### PR DESCRIPTION
When the language server gave us a prompt and we'd close the window, we wouldn't release the `project` until the next `flush_effects` call that came in when opening a window.

With this change, we no longer hold a strong reference to the project in the future. Fixes the leak and makes sure we clean up the SSH connection when closing a window.

Release Notes:

- N/A
