### PR TITLE
Improve `fold_at_level` performance

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10756,12 +10756,10 @@ impl Editor {
                         let nested_start_row = foldable_range.0.start.row + 1;
                         let nested_end_row = foldable_range.0.end.row;
 
-                        if current_level == fold_at_level {
-                            fold_ranges.push(foldable_range);
-                        }
-
-                        if current_level <= fold_at_level {
+                        if current_level < fold_at_level {
                             stack.push((nested_start_row, nested_end_row, current_level + 1));
+                        } else if current_level == fold_at_level {
+                            fold_ranges.push(foldable_range);
                         }
 
                         start_row = nested_end_row + 1;


### PR DESCRIPTION
Just spotted a tiny error that was causing us to continue looking for nested folds 1 layer deeper than any fold already found at the target level. We shouldn't continue to seek for a deeper fold after the fold at the target level is found.

Tested on a debug build and used `editor.rs` as the source material:

```
Old

Level 1 fold:
[crates/editor/src/editor.rs:10777:9] counter = 2806
[crates/editor/src/editor.rs:10778:9] time_elapsed = 320.570792ms

Level 2 fold:
[crates/editor/src/editor.rs:10777:9] counter = 5615
[crates/editor/src/editor.rs:10778:9] time_elapsed = 497.4305ms

Level 3 fold:
[crates/editor/src/editor.rs:10777:9] counter = 7528
[crates/editor/src/editor.rs:10778:9] time_elapsed = 619.818334ms

New

Level 1 fold:
[crates/editor/src/editor.rs:10776:9] counter = 543
[crates/editor/src/editor.rs:10777:9] time_elapsed = 139.115625ms

Level 2 fold:
[crates/editor/src/editor.rs:10776:9] counter = 2806
[crates/editor/src/editor.rs:10777:9] time_elapsed = 312.560416ms

Level 3 fold:
[crates/editor/src/editor.rs:10776:9] counter = 5615
[crates/editor/src/editor.rs:10777:9] time_elapsed = 498.873292ms
```

Release Notes:

- N/A
