### PR TITLE
Fix mouse clicks on remote-open-folder UI

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -4707,7 +4707,7 @@ impl Render for ConfigurationView {
 
         let mut element = v_flex()
             .id("assistant-configuration-view")
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .bg(cx.theme().colors().editor_background)
             .size_full()
             .overflow_y_scroll()

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -931,7 +931,7 @@ impl Render for ChatPanel {
 
         v_flex()
             .key_context("ChatPanel")
-            .track_focus(&self.focus_handle(cx))
+            .track_focus(&self.focus_handle)
             .size_full()
             .on_action(cx.listener(Self::send))
             .child(

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -931,7 +931,7 @@ impl Render for ChatPanel {
 
         v_flex()
             .key_context("ChatPanel")
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .size_full()
             .on_action(cx.listener(Self::send))
             .child(

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2726,7 +2726,7 @@ impl Render for CollabPanel {
             .on_action(cx.listener(CollabPanel::collapse_selected_channel))
             .on_action(cx.listener(CollabPanel::expand_selected_channel))
             .on_action(cx.listener(CollabPanel::start_move_selected_channel))
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .size_full()
             .child(if self.user_store.read(cx).current_user().is_none() {
                 self.render_signed_out(cx)

--- a/crates/copilot/src/sign_in.rs
+++ b/crates/copilot/src/sign_in.rs
@@ -185,7 +185,7 @@ impl Render for CopilotCodeVerification {
 
         v_flex()
             .id("copilot code verification")
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .elevation_3(cx)
             .w_96()
             .items_center()

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -101,7 +101,7 @@ impl Render for ProjectDiagnosticsEditor {
         };
 
         div()
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .when(self.path_states.is_empty(), |el| {
                 el.key_context("EmptyPane")
             })

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -485,7 +485,7 @@ impl Render for TextInput {
         div()
             .flex()
             .key_context("TextInput")
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .cursor(CursorStyle::IBeam)
             .on_action(cx.listener(Self::backspace))
             .on_action(cx.listener(Self::delete))
@@ -549,7 +549,7 @@ impl Render for InputExample {
         let num_keystrokes = self.recent_keystrokes.len();
         div()
             .bg(rgb(0xaaaaaa))
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .flex()
             .flex_col()
             .size_full()

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -16,7 +16,7 @@
 /// impl Render for Editor {
 ///   fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
 ///     div()
-///       .track_focus(&self.focus_handle)
+///       .track_focus(&self.focus_handle(cx))
 ///       .keymap_context("Editor")
 ///       .on_action(cx.listener(Editor::undo))
 ///       .on_action(cx.listener(Editor::redo))

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -271,7 +271,7 @@ impl Render for ImageView {
             .left_0();
 
         div()
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .size_full()
             .child(checkered_background)
             .child(

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -479,7 +479,7 @@ impl Render for MarkdownPreviewView {
         v_flex()
             .id("MarkdownPreview")
             .key_context("MarkdownPreview")
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -3787,7 +3787,7 @@ impl Render for OutlinePanel {
                     }
                 }),
             )
-            .track_focus(&self.focus_handle);
+            .track_focus(&self.focus_handle(cx));
 
         if self.cached_entries.is_empty() {
             let header = if self.updating_fs_entries {

--- a/crates/picker/src/head.rs
+++ b/crates/picker/src/head.rs
@@ -53,7 +53,7 @@ impl EmptyHead {
 
 impl Render for EmptyHead {
     fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
-        div().track_focus(&self.focus_handle)
+        div().track_focus(&self.focus_handle(cx))
     }
 }
 

--- a/crates/picker/src/head.rs
+++ b/crates/picker/src/head.rs
@@ -52,7 +52,7 @@ impl EmptyHead {
 }
 
 impl Render for EmptyHead {
-    fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         div().track_focus(&self.focus_handle(cx))
     }
 }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3136,7 +3136,7 @@ impl Render for ProjectPanel {
                         }
                     }),
                 )
-                .track_focus(&self.focus_handle)
+                .track_focus(&self.focus_handle(cx))
                 .child(
                     uniform_list(cx.view().clone(), "entries", item_count, {
                         |this, range, cx| {
@@ -3268,7 +3268,7 @@ impl Render for ProjectPanel {
                 .id("empty-project_panel")
                 .size_full()
                 .p_4()
-                .track_focus(&self.focus_handle)
+                .track_focus(&self.focus_handle(cx))
                 .child(
                     Button::new("open_project", "Open a project")
                         .full_width()

--- a/crates/recent_projects/src/disconnected_overlay.rs
+++ b/crates/recent_projects/src/disconnected_overlay.rs
@@ -149,7 +149,7 @@ impl Render for DisconnectedOverlay {
         };
 
         div()
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .elevation_3(cx)
             .on_action(cx.listener(Self::cancel))
             .occlude()

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1266,7 +1266,7 @@ impl Render for RemoteServerProjects {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         self.selectable_items.reset();
         div()
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .elevation_3(cx)
             .w(rems(34.))
             .key_context("RemoteServerModal")

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -327,7 +327,7 @@ impl Render for ProjectSearchView {
             div()
                 .flex_1()
                 .size_full()
-                .track_focus(&self.focus_handle)
+                .track_focus(&self.focus_handle(cx))
                 .child(self.results_editor.clone())
         } else {
             let model = self.model.read(cx);
@@ -365,7 +365,7 @@ impl Render for ProjectSearchView {
                 .size_full()
                 .justify_center()
                 .bg(cx.theme().colors().editor_background)
-                .track_focus(&self.focus_handle)
+                .track_focus(&self.focus_handle(cx))
                 .child(
                     h_flex()
                         .size_full()

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -975,7 +975,7 @@ impl Render for TerminalView {
         div()
             .size_full()
             .relative()
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .key_context(self.dispatch_context(cx))
             .on_action(cx.listener(TerminalView::send_text))
             .on_action(cx.listener(TerminalView::send_keystroke))

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -348,7 +348,7 @@ impl Render for ContextMenu {
                     .min_w(px(200.))
                     .max_h(vh(0.75, cx))
                     .overflow_y_scroll()
-                    .track_focus(&self.focus_handle)
+                    .track_focus(&self.focus_handle(cx))
                     .on_mouse_down_out(cx.listener(|this, _, cx| this.cancel(&menu::Cancel, cx)))
                     .key_context("menu")
                     .on_action(cx.listener(ContextMenu::select_first))

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -72,7 +72,7 @@ impl Render for WelcomePage {
         h_flex()
             .size_full()
             .bg(cx.theme().colors().editor_background)
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .child(
                 v_flex()
                     .w_80()

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -658,7 +658,7 @@ impl Render for Dock {
 
             div()
                 .key_context(dispatch_context)
-                .track_focus(&self.focus_handle)
+                .track_focus(&self.focus_handle(cx))
                 .flex()
                 .bg(cx.theme().colors().panel_background)
                 .border_color(cx.theme().colors().border)
@@ -689,7 +689,7 @@ impl Render for Dock {
         } else {
             div()
                 .key_context(dispatch_context)
-                .track_focus(&self.focus_handle)
+                .track_focus(&self.focus_handle(cx))
         }
     }
 }
@@ -826,8 +826,8 @@ pub mod test {
     }
 
     impl Render for TestPanel {
-        fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
-            div().id("test").track_focus(&self.focus_handle)
+        fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+            div().id("test").track_focus(&self.focus_handle(cx))
         }
     }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1173,8 +1173,8 @@ pub mod test {
     }
 
     impl Render for TestItem {
-        fn render(&mut self, _: &mut ViewContext<Self>) -> impl IntoElement {
-            gpui::div().track_focus(&self.focus_handle)
+        fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+            gpui::div().track_focus(&self.focus_handle(cx))
         }
     }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2574,7 +2574,7 @@ impl Render for Pane {
 
         v_flex()
             .key_context(key_context)
-            .track_focus(&self.focus_handle)
+            .track_focus(&self.focus_handle(cx))
             .size_full()
             .flex_none()
             .overflow_hidden()


### PR DESCRIPTION
Also change Zed's standard style to use `.track_focus(&self.focus_handle(cx))`, instead of `.track_focus(&self.focus_handle)`, to catch these kinds of errors more easily in the future.

Release Notes:

- N/A
