### PR TITLE
Fix horizontal scroll caused by diagnostic block width error

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -14188,7 +14188,7 @@ pub fn diagnostic_block_renderer(
             .relative()
             .size_full()
             .pl(cx.gutter_dimensions.width)
-            .w(cx.max_width + cx.gutter_dimensions.width)
+            .w(cx.max_width - cx.gutter_dimensions.full_width())
             .child(
                 div()
                     .flex()


### PR DESCRIPTION
Previously, when scrolling the diagnostics view with the mouse, we'd get a spurious horizontal scroll (even if the content was not overflowing horizontally) due to an error in the widths of the diagnostic blocks.

Release Notes:

- Fixed an issue where the project diagnostics view spuriously allowed horizontal scrolling by a small amount.
