### PR TITLE
Add support for Doxygen doc comments in C++

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,7 +1,7 @@
 name = "C++"
 grammar = "cpp"
 path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "cu", "cuh"]
-line_comments = ["// "]
+line_comments = ["// ", "/// ", "//! "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
This PR adds support for Doxygen-style doc comments in C++.

<img width="962" alt="Screenshot 2024-10-28 at 5 38 34 PM" src="https://github.com/user-attachments/assets/57d0fa4b-07c1-4b71-899a-fba78e822e8f">

https://www.doxygen.nl/manual/docblocks.html

Closes https://github.com/zed-industries/zed/issues/18361.

Release Notes:

- C++: Added support for Doxygen-style doc comments starting with `/// ` or `//! `.
