### PR TITLE
Allow for Gitlab self-hosted instance remote Git urls

### DIFF
--- a/crates/git/src/hosting_provider.rs
+++ b/crates/git/src/hosting_provider.rs
@@ -33,9 +33,6 @@ pub trait GitHostingProvider {
     /// Returns the name of the provider.
     fn name(&self) -> String;
 
-    /// Returns the base URL of the provider.
-    fn base_url(&self) -> Url;
-
     /// Returns a permalink to a Git commit on this hosting provider.
     fn build_commit_permalink(
         &self,
@@ -155,6 +152,7 @@ impl GitHostingProviderRegistry {
 
 #[derive(Debug)]
 pub struct ParsedGitRemote<'a> {
+    pub base_url: Url,
     pub owner: &'a str,
     pub repo: &'a str,
 }

--- a/crates/git_hosting_providers/src/git_hosting_providers.rs
+++ b/crates/git_hosting_providers/src/git_hosting_providers.rs
@@ -15,7 +15,7 @@ pub fn init(cx: &AppContext) {
     // GitHub comes first.
     provider_registry.register_hosting_provider(Arc::new(Github));
 
-    // Then GitLab.
+    // Then GitLab (includes self-hosted instances).
     provider_registry.register_hosting_provider(Arc::new(Gitlab));
 
     // Then the other providers, in the order they were added.

--- a/crates/git_hosting_providers/src/providers/bitbucket.rs
+++ b/crates/git_hosting_providers/src/providers/bitbucket.rs
@@ -9,10 +9,6 @@ impl GitHostingProvider for Bitbucket {
         "Bitbucket".to_string()
     }
 
-    fn base_url(&self) -> Url {
-        Url::parse("https://bitbucket.org").unwrap()
-    }
-
     fn supports_avatars(&self) -> bool {
         false
     }
@@ -33,7 +29,11 @@ impl GitHostingProvider for Bitbucket {
                 .trim_start_matches(':')
                 .split_once('/')?;
 
-            return Some(ParsedGitRemote { owner, repo });
+            return Some(ParsedGitRemote {
+                base_url: Url::parse("https://bitbucket.org").unwrap(),
+                owner,
+                repo,
+            });
         }
 
         None
@@ -45,23 +45,30 @@ impl GitHostingProvider for Bitbucket {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("{owner}/{repo}/commits/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("{owner}/{repo}/src/{sha}/{path}"))
             .unwrap();
         permalink.set_fragment(
@@ -117,6 +124,7 @@ mod tests {
     #[test]
     fn test_build_bitbucket_permalink_from_ssh_url() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://bitbucket.org").unwrap(),
             owner: "thorstenzed",
             repo: "testingrepo",
         };
@@ -136,6 +144,7 @@ mod tests {
     #[test]
     fn test_build_bitbucket_permalink_from_ssh_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://bitbucket.org").unwrap(),
             owner: "thorstenzed",
             repo: "testingrepo",
         };
@@ -156,6 +165,7 @@ mod tests {
     #[test]
     fn test_build_bitbucket_permalink_from_ssh_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://bitbucket.org").unwrap(),
             owner: "thorstenzed",
             repo: "testingrepo",
         };

--- a/crates/git_hosting_providers/src/providers/codeberg.rs
+++ b/crates/git_hosting_providers/src/providers/codeberg.rs
@@ -87,10 +87,6 @@ impl GitHostingProvider for Codeberg {
         "Codeberg".to_string()
     }
 
-    fn base_url(&self) -> Url {
-        Url::parse("https://codeberg.org").unwrap()
-    }
-
     fn supports_avatars(&self) -> bool {
         true
     }
@@ -112,7 +108,11 @@ impl GitHostingProvider for Codeberg {
 
             let (owner, repo) = repo_with_owner.split_once('/')?;
 
-            return Some(ParsedGitRemote { owner, repo });
+            return Some(ParsedGitRemote {
+                base_url: Url::parse("https://codeberg.org").unwrap(),
+                owner,
+                repo,
+            });
         }
 
         None
@@ -124,23 +124,30 @@ impl GitHostingProvider for Codeberg {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("{owner}/{repo}/commit/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("{owner}/{repo}/src/commit/{sha}/{path}"))
             .unwrap();
         permalink.set_fragment(
@@ -148,6 +155,7 @@ impl GitHostingProvider for Codeberg {
                 .map(|selection| self.line_fragment(&selection))
                 .as_deref(),
         );
+
         permalink
     }
 
@@ -175,6 +183,7 @@ mod tests {
     #[test]
     fn test_build_codeberg_permalink_from_ssh_url() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://codeberg.org").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -194,6 +203,7 @@ mod tests {
     #[test]
     fn test_build_codeberg_permalink_from_ssh_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://codeberg.org").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -213,6 +223,7 @@ mod tests {
     #[test]
     fn test_build_codeberg_permalink_from_ssh_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://codeberg.org").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -232,6 +243,7 @@ mod tests {
     #[test]
     fn test_build_codeberg_permalink_from_https_url() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://codeberg.org").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -251,6 +263,7 @@ mod tests {
     #[test]
     fn test_build_codeberg_permalink_from_https_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://codeberg.org").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -270,6 +283,7 @@ mod tests {
     #[test]
     fn test_build_codeberg_permalink_from_https_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://codeberg.org").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -9,10 +9,6 @@ impl GitHostingProvider for Gitee {
         "Gitee".to_string()
     }
 
-    fn base_url(&self) -> Url {
-        Url::parse("https://gitee.com").unwrap()
-    }
-
     fn supports_avatars(&self) -> bool {
         false
     }
@@ -34,7 +30,11 @@ impl GitHostingProvider for Gitee {
 
             let (owner, repo) = repo_with_owner.split_once('/')?;
 
-            return Some(ParsedGitRemote { owner, repo });
+            return Some(ParsedGitRemote {
+                base_url: Url::parse("https://github.com").unwrap(),
+                owner,
+                repo,
+            });
         }
 
         None
@@ -46,23 +46,30 @@ impl GitHostingProvider for Gitee {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("{owner}/{repo}/commit/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
             .unwrap();
         permalink.set_fragment(
@@ -81,6 +88,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_ssh_url() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://gitee.com").unwrap(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -100,6 +108,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_ssh_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://gitee.com").unwrap(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -119,6 +128,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_ssh_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://gitee.com").unwrap(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -138,6 +148,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_https_url() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://gitee.com").unwrap(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -157,6 +168,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_https_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://gitee.com").unwrap(),
             owner: "libkitten",
             repo: "zed",
         };
@@ -176,6 +188,7 @@ mod tests {
     #[test]
     fn test_build_gitee_permalink_from_https_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://gitee.com").unwrap(),
             owner: "libkitten",
             repo: "zed",
         };

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -4,13 +4,41 @@ use git::{BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, 
 
 pub struct Gitlab;
 
+impl Gitlab {
+    fn is_gitlab_instance(&self, host: &str) -> bool {
+        host == "gitlab.com" || host.contains("gitlab")
+    }
+
+    fn extract_base_url(&self, url: &str) -> Option<Url> {
+        if url.starts_with("git@") {
+            let ssh_url = url.strip_prefix("git@")?;
+            let (host, _) = ssh_url.split_once(':')?;
+
+            if !self.is_gitlab_instance(host) {
+                return None;
+            }
+
+            return Url::parse(&format!("https://{}", host)).ok();
+        }
+
+        if !url.starts_with("https://") {
+            return None;
+        }
+
+        let url_obj = Url::parse(url).ok()?;
+        let host = url_obj.host_str()?;
+
+        if !self.is_gitlab_instance(host) {
+            return None;
+        }
+
+        Some(url_obj.join("/").ok()?)
+    }
+}
+
 impl GitHostingProvider for Gitlab {
     fn name(&self) -> String {
         "GitLab".to_string()
-    }
-
-    fn base_url(&self) -> Url {
-        Url::parse("https://gitlab.com").unwrap()
     }
 
     fn supports_avatars(&self) -> bool {
@@ -26,18 +54,33 @@ impl GitHostingProvider for Gitlab {
     }
 
     fn parse_remote_url<'a>(&self, url: &'a str) -> Option<ParsedGitRemote<'a>> {
-        if url.starts_with("git@gitlab.com:") || url.starts_with("https://gitlab.com/") {
-            let repo_with_owner = url
-                .trim_start_matches("git@gitlab.com:")
-                .trim_start_matches("https://gitlab.com/")
-                .trim_end_matches(".git");
+        let base_url = self.extract_base_url(url)?;
+        let host = base_url.host_str()?;
 
-            let (owner, repo) = repo_with_owner.split_once('/')?;
+        let repo_with_owner = if url.starts_with("git@") {
+            let prefix = format!("git@{}:", host);
+            let without_prefix = url.strip_prefix(&prefix)?;
+            without_prefix
+                .strip_suffix(".git")
+                .unwrap_or(without_prefix)
+        } else {
+            let without_prefix = url.strip_prefix(base_url.as_str())?;
+            let without_leading_slash = without_prefix.trim_start_matches('/');
+            without_leading_slash
+                .strip_suffix(".git")
+                .unwrap_or(without_leading_slash)
+        };
 
-            return Some(ParsedGitRemote { owner, repo });
+        let (owner, repo) = repo_with_owner.split_once('/')?;
+        if owner.is_empty() || repo.is_empty() {
+            return None;
         }
 
-        None
+        Some(ParsedGitRemote {
+            base_url,
+            owner,
+            repo,
+        })
     }
 
     fn build_commit_permalink(
@@ -46,23 +89,30 @@ impl GitHostingProvider for Gitlab {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            owner,
+            repo,
+            base_url,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("{owner}/{repo}/-/commit/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            owner,
+            repo,
+            base_url,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("{owner}/{repo}/-/blob/{sha}/{path}"))
             .unwrap();
         if path.ends_with(".md") {
@@ -83,10 +133,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_ssh_url() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries",
-            repo: "zed",
-        };
+        let remote = Gitlab
+            .parse_remote_url("git@gitlab.com:zed-industries/zed.git")
+            .unwrap();
         let permalink = Gitlab.build_permalink(
             remote,
             BuildPermalinkParams {
@@ -102,10 +151,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_ssh_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries",
-            repo: "zed",
-        };
+        let remote = Gitlab
+            .parse_remote_url("git@gitlab.com:zed-industries/zed.git")
+            .unwrap();
         let permalink = Gitlab.build_permalink(
             remote,
             BuildPermalinkParams {
@@ -121,10 +169,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_ssh_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries",
-            repo: "zed",
-        };
+        let remote = Gitlab
+            .parse_remote_url("git@gitlab.com:zed-industries/zed.git")
+            .unwrap();
         let permalink = Gitlab.build_permalink(
             remote,
             BuildPermalinkParams {
@@ -140,10 +187,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_https_url() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries",
-            repo: "zed",
-        };
+        let remote = Gitlab
+            .parse_remote_url("https://gitlab.com/zed-industries/zed")
+            .unwrap();
         let permalink = Gitlab.build_permalink(
             remote,
             BuildPermalinkParams {
@@ -159,10 +205,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_https_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries",
-            repo: "zed",
-        };
+        let remote = Gitlab
+            .parse_remote_url("https://gitlab.com/zed-industries/zed")
+            .unwrap();
         let permalink = Gitlab.build_permalink(
             remote,
             BuildPermalinkParams {
@@ -178,10 +223,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_permalink_from_https_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries",
-            repo: "zed",
-        };
+        let remote = Gitlab
+            .parse_remote_url("https://gitlab.com/zed-industries/zed")
+            .unwrap();
         let permalink = Gitlab.build_permalink(
             remote,
             BuildPermalinkParams {
@@ -193,5 +237,49 @@ mod tests {
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L24-48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_self_hosted_gitlab_ssh_url() {
+        let parsed = Gitlab
+            .parse_remote_url("git@gitlab.zed.dev:zed-industries/zed.git")
+            .unwrap();
+        assert_eq!(parsed.owner, "zed-industries");
+        assert_eq!(parsed.repo, "zed");
+
+        let permalink = Gitlab.build_permalink(
+            parsed,
+            BuildPermalinkParams {
+                sha: "123456",
+                path: "src/main.rs",
+                selection: None,
+            },
+        );
+        assert_eq!(
+            permalink.to_string(),
+            "https://gitlab.zed.dev/zed-industries/zed/-/blob/123456/src/main.rs"
+        );
+    }
+
+    #[test]
+    fn test_self_hosted_gitlab_https_url() {
+        let parsed = Gitlab
+            .parse_remote_url("https://gitlab.zed.dev/zed-industries/zed")
+            .unwrap();
+        assert_eq!(parsed.owner, "zed-industries");
+        assert_eq!(parsed.repo, "zed");
+
+        let permalink = Gitlab.build_permalink(
+            parsed,
+            BuildPermalinkParams {
+                sha: "123456",
+                path: "src/main.rs",
+                selection: None,
+            },
+        );
+        assert_eq!(
+            permalink.to_string(),
+            "https://gitlab.zed.dev/zed-industries/zed/-/blob/123456/src/main.rs"
+        );
     }
 }

--- a/crates/git_hosting_providers/src/providers/sourcehut.rs
+++ b/crates/git_hosting_providers/src/providers/sourcehut.rs
@@ -9,10 +9,6 @@ impl GitHostingProvider for Sourcehut {
         "Gitee".to_string()
     }
 
-    fn base_url(&self) -> Url {
-        Url::parse("https://git.sr.ht").unwrap()
-    }
-
     fn supports_avatars(&self) -> bool {
         false
     }
@@ -36,7 +32,11 @@ impl GitHostingProvider for Sourcehut {
 
             let (owner, repo) = repo_with_owner.split_once('/')?;
 
-            return Some(ParsedGitRemote { owner, repo });
+            return Some(ParsedGitRemote {
+                base_url: Url::parse("https://git.sr.ht").unwrap(),
+                owner,
+                repo,
+            });
         }
 
         None
@@ -48,23 +48,30 @@ impl GitHostingProvider for Sourcehut {
         params: BuildCommitPermalinkParams,
     ) -> Url {
         let BuildCommitPermalinkParams { sha } = params;
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            owner,
+            repo,
+            base_url,
+        } = remote;
 
-        self.base_url()
+        base_url
             .join(&format!("~{owner}/{repo}/commit/{sha}"))
             .unwrap()
     }
 
     fn build_permalink(&self, remote: ParsedGitRemote, params: BuildPermalinkParams) -> Url {
-        let ParsedGitRemote { owner, repo } = remote;
+        let ParsedGitRemote {
+            owner,
+            repo,
+            base_url,
+        } = remote;
         let BuildPermalinkParams {
             sha,
             path,
             selection,
         } = params;
 
-        let mut permalink = self
-            .base_url()
+        let mut permalink = base_url
             .join(&format!("~{owner}/{repo}/tree/{sha}/item/{path}"))
             .unwrap();
         permalink.set_fragment(
@@ -83,6 +90,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://git.sr.ht").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -102,6 +110,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url_with_git_prefix() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://git.sr.ht").unwrap(),
             owner: "rajveermalviya",
             repo: "zed.git",
         };
@@ -121,6 +130,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://git.sr.ht").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -140,6 +150,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_ssh_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://git.sr.ht").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -159,6 +170,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_https_url() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://git.sr.ht").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -178,6 +190,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_https_url_single_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://git.sr.ht").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };
@@ -197,6 +210,7 @@ mod tests {
     #[test]
     fn test_build_sourcehut_permalink_from_https_url_multi_line_selection() {
         let remote = ParsedGitRemote {
+            base_url: Url::parse("https://git.sr.ht").unwrap(),
             owner: "rajveermalviya",
             repo: "zed",
         };


### PR DESCRIPTION
Closes #19735

Closes #18012 

This PR allows for the specification of self-hosted instances of Gitlab Git servers, which fixes the issue of Git permalink generation erroring.

**Before**

Permalink errors when Gitlab remote is not on official `gitlab.com` server

**After**

Permalink generates successfully when on remotely-hosted gitlab instance



https://github.com/user-attachments/assets/28850997-0f37-424d-a37f-880eb6c368ef



Release Notes:

- Changed `base_url` to no longer be a function on `GitHostingProvider impl` and moved it to be a value on the `ParsedGitRemote struct` (needed as we now need to store info about the host, it's no longer inferred from the `impl` we're using)
- Allowed for domains (not full URLs) containing `gitlab` to be parsed as self-hosted instance if the original `gitlab.com` hosted parsing fails
- Kept all prior functionality
