### PR TITLE
Future-proof indent guides settings for panels

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -346,8 +346,6 @@
     "git_status": true,
     // Amount of indentation for nested items.
     "indent_size": 20,
-    // Whether to show indent guides in the project panel.
-    "indent_guides": true,
     // Whether to reveal it in the project panel automatically,
     // when a corresponding project entry becomes active.
     // Gitignored entries are never auto revealed.
@@ -371,6 +369,17 @@
       /// 5. Never show the scrollbar:
       ///    "never"
       "show": null
+    },
+    // Settings related to indent guides in the project panel.
+    "indent_guides": {
+      // When to show indent guides in the project panel.
+      // This setting can take two values:
+      //
+      // 1. Always show indent guides:
+      //    "always"
+      // 2. Never show indent guides:
+      //    "never"
+      "show": "always"
     }
   },
   "outline_panel": {
@@ -388,15 +397,24 @@
     "git_status": true,
     // Amount of indentation for nested items.
     "indent_size": 20,
-    // Whether to show indent guides in the outline panel.
-    "indent_guides": true,
     // Whether to reveal it in the outline panel automatically,
     // when a corresponding outline entry becomes active.
     // Gitignored entries are never auto revealed.
     "auto_reveal_entries": true,
     /// Whether to fold directories automatically
     /// when a directory has only one directory inside.
-    "auto_fold_dirs": true
+    "auto_fold_dirs": true,
+    // Settings related to indent guides in the outline panel.
+    "indent_guides": {
+      // When to show indent guides in the outline panel.
+      // This setting can take two values:
+      //
+      // 1. Always show indent guides:
+      //    "always"
+      // 2. Never show indent guides:
+      //    "never"
+      "show": "always"
+    }
   },
   "collaboration_panel": {
     // Whether to show the collaboration panel button in the status bar.

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -35,7 +35,7 @@ use itertools::Itertools;
 use language::{BufferId, BufferSnapshot, OffsetRangeExt, OutlineItem};
 use menu::{Cancel, SelectFirst, SelectLast, SelectNext, SelectPrev};
 
-use outline_panel_settings::{OutlinePanelDockPosition, OutlinePanelSettings};
+use outline_panel_settings::{OutlinePanelDockPosition, OutlinePanelSettings, ShowIndentGuides};
 use project::{File, Fs, Item, Project};
 use search::{BufferSearchBar, ProjectSearchView};
 use serde::{Deserialize, Serialize};
@@ -3748,7 +3748,7 @@ impl Render for OutlinePanel {
         let pinned = self.pinned;
         let settings = OutlinePanelSettings::get_global(cx);
         let indent_size = settings.indent_size;
-        let show_indent_guides = settings.indent_guides;
+        let show_indent_guides = settings.indent_guides.show == ShowIndentGuides::Always;
 
         let outline_panel = v_flex()
             .id("outline-panel")

--- a/crates/outline_panel/src/outline_panel_settings.rs
+++ b/crates/outline_panel/src/outline_panel_settings.rs
@@ -10,6 +10,13 @@ pub enum OutlinePanelDockPosition {
     Right,
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ShowIndentGuides {
+    Always,
+    Never,
+}
+
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct OutlinePanelSettings {
     pub button: bool,
@@ -19,9 +26,20 @@ pub struct OutlinePanelSettings {
     pub folder_icons: bool,
     pub git_status: bool,
     pub indent_size: f32,
-    pub indent_guides: bool,
+    pub indent_guides: IndentGuidesSettings,
     pub auto_reveal_entries: bool,
     pub auto_fold_dirs: bool,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct IndentGuidesSettings {
+    pub show: ShowIndentGuides,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct IndentGuidesSettingsContent {
+    /// When to show the scrollbar in the project panel.
+    pub show: Option<ShowIndentGuides>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -54,10 +72,6 @@ pub struct OutlinePanelSettingsContent {
     ///
     /// Default: 20
     pub indent_size: Option<f32>,
-    /// Whether to show indent guides in the outline panel.
-    ///
-    /// Default: true
-    pub indent_guides: Option<bool>,
     /// Whether to reveal it in the outline panel automatically,
     /// when a corresponding project entry becomes active.
     /// Gitignored entries are never auto revealed.
@@ -69,6 +83,8 @@ pub struct OutlinePanelSettingsContent {
     ///
     /// Default: true
     pub auto_fold_dirs: Option<bool>,
+    /// Settings related to indent guides in the project panel.
+    pub indent_guides: Option<IndentGuidesSettingsContent>,
 }
 
 impl Settings for OutlinePanelSettings {

--- a/crates/outline_panel/src/outline_panel_settings.rs
+++ b/crates/outline_panel/src/outline_panel_settings.rs
@@ -38,7 +38,7 @@ pub struct IndentGuidesSettings {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct IndentGuidesSettingsContent {
-    /// When to show the scrollbar in the project panel.
+    /// When to show the scrollbar in the outline panel.
     pub show: Option<ShowIndentGuides>,
 }
 
@@ -83,7 +83,7 @@ pub struct OutlinePanelSettingsContent {
     ///
     /// Default: true
     pub auto_fold_dirs: Option<bool>,
-    /// Settings related to indent guides in the project panel.
+    /// Settings related to indent guides in the outline panel.
     pub indent_guides: Option<IndentGuidesSettingsContent>,
 }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -30,7 +30,7 @@ use project::{
     relativize_path, Entry, EntryKind, Fs, Project, ProjectEntryId, ProjectPath, Worktree,
     WorktreeId,
 };
-use project_panel_settings::{ProjectPanelDockPosition, ProjectPanelSettings};
+use project_panel_settings::{ProjectPanelDockPosition, ProjectPanelSettings, ShowIndentGuides};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::{
@@ -3043,7 +3043,8 @@ impl Render for ProjectPanel {
         let has_worktree = !self.visible_entries.is_empty();
         let project = self.project.read(cx);
         let indent_size = ProjectPanelSettings::get_global(cx).indent_size;
-        let indent_guides = ProjectPanelSettings::get_global(cx).indent_guides;
+        let show_indent_guides =
+            ProjectPanelSettings::get_global(cx).indent_guides.show == ShowIndentGuides::Always;
         let is_local = project.is_local();
 
         if has_worktree {
@@ -3147,7 +3148,7 @@ impl Render for ProjectPanel {
                             items
                         }
                     })
-                    .when(indent_guides, |list| {
+                    .when(show_indent_guides, |list| {
                         list.with_decoration(
                             ui::indent_guides(
                                 cx.view().clone(),

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -11,6 +11,13 @@ pub enum ProjectPanelDockPosition {
     Right,
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ShowIndentGuides {
+    Always,
+    Never,
+}
+
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct ProjectPanelSettings {
     pub button: bool,
@@ -20,10 +27,21 @@ pub struct ProjectPanelSettings {
     pub folder_icons: bool,
     pub git_status: bool,
     pub indent_size: f32,
-    pub indent_guides: bool,
+    pub indent_guides: IndentGuidesSettings,
     pub auto_reveal_entries: bool,
     pub auto_fold_dirs: bool,
     pub scrollbar: ScrollbarSettings,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct IndentGuidesSettings {
+    pub show: ShowIndentGuides,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct IndentGuidesSettingsContent {
+    /// When to show the scrollbar in the project panel.
+    pub show: Option<ShowIndentGuides>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -72,10 +90,6 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: 20
     pub indent_size: Option<f32>,
-    /// Whether to show indent guides in the project panel.
-    ///
-    /// Default: true
-    pub indent_guides: Option<bool>,
     /// Whether to reveal it in the project panel automatically,
     /// when a corresponding project entry becomes active.
     /// Gitignored entries are never auto revealed.
@@ -89,6 +103,8 @@ pub struct ProjectPanelSettingsContent {
     pub auto_fold_dirs: Option<bool>,
     /// Scrollbar-related settings
     pub scrollbar: Option<ScrollbarSettingsContent>,
+    /// Settings related to indent guides in the project panel.
+    pub indent_guides: Option<IndentGuidesSettingsContent>,
 }
 
 impl Settings for ProjectPanelSettings {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2047,6 +2047,9 @@ Run the `theme selector: toggle` action in the command palette to see a current 
     "auto_fold_dirs": true,
     "scrollbar": {
       "show": null
+    },
+    "indent_guides": {
+      "show": "always",
     }
   }
 }
@@ -2164,27 +2167,54 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 - Setting: `indent_size`
 - Default: `20`
 
-### Indent Guides
+### Indent Guides: Show
 
-- Description: Whether to show indent guides in the project panel.
+- Description: Whether to show indent guides in the project panel. Possible values: "always", "never".
 - Setting: `indent_guides`
-- Default: `true`
-
-### Scrollbar
-
-- Description: Scrollbar related settings. Possible values: null, "auto", "system", "always", "never". Inherits editor settings when absent, see its description for more details.
-- Setting: `scrollbar`
-- Default:
 
 ```json
-"scrollbar": {
-    "show": null
+"indent_guides": {
+  "show": "always"
 }
 ```
 
 **Options**
 
-1. Show scrollbar in project panel
+1. Show indent guides in the project panel
+
+```json
+{
+  "indent_guides": {
+    "show": "always"
+  }
+}
+```
+
+2. Hide indent guides in the project panel
+
+```json
+{
+  "indent_guides": {
+    "show": "never"
+  }
+}
+```
+
+### Scrollbar: Show
+
+- Description: Whether to show a scrollbar in the project panel. Possible values: null, "auto", "system", "always", "never". Inherits editor settings when absent, see its description for more details.
+- Setting: `scrollbar`
+- Default:
+
+```json
+"scrollbar": {
+  "show": null
+}
+```
+
+**Options**
+
+1. Show scrollbar in the project panel
 
 ```json
 {
@@ -2194,7 +2224,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 }
 ```
 
-2. Hide scrollbar in project panel
+2. Hide scrollbar in the project panel
 
 ```json
 {
@@ -2237,9 +2267,11 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   "folder_icons": true,
   "git_status": true,
   "indent_size": 20,
-  "indent_guides": true,
   "auto_reveal_entries": true,
   "auto_fold_dirs": true,
+  "indent_guides": {
+    "show": "always"
+  }
 }
 ```
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2049,7 +2049,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
       "show": null
     },
     "indent_guides": {
-      "show": "always",
+      "show": "always"
     }
   }
 }


### PR DESCRIPTION
This PR ensures that we do not have to break the indent guides settings for the project/outline panel. In the future we might want to have a more granular way to control when to show indent guides, or control other indent guide properties, like its width.

Release Notes:

- N/A
