### PR TITLE
languages: Enable grammar loading when compiling with test feature

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -325,7 +325,7 @@ fn load_config(name: &str) -> LanguageConfig {
         .with_context(|| format!("failed to load config.toml for language {name:?}"))
         .unwrap();
 
-    #[cfg(not(feature = "load-grammars"))]
+    #[cfg(not(any(feature = "load-grammars", test)))]
     {
         config = LanguageConfig {
             name: config.name,


### PR DESCRIPTION
This ensures that `cargo tests -p languages` will not fail with a confusing error message.

Follow up to #19821

We opted to check the `test` feature flag instead of defining a runtime flag, because we only want to include the `tree-sitter-*` dependencies in some cases, which is not possible with a runtime flag.

Co-Authored-by: Thorsten <thorsten@zed.dev>

Release Notes:

- N/A
