### PR TITLE
vsc menu: Fix issue when switching branch while non-visible worktree is open

### DIFF
--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -242,7 +242,7 @@ impl PickerDelegate for BranchListDelegate {
                         BranchEntry::NewBranch { name: branch_name } => branch_name,
                     };
                     let worktree = project
-                        .worktrees(cx)
+                        .visible_worktrees(cx)
                         .next()
                         .context("worktree disappeared")?;
                     let repository = ProjectPath::root_path(worktree.read(cx).id());


### PR DESCRIPTION
Fixes a regression introduced in #19755

<img width="935" alt="Screenshot 2024-10-29 at 12 13 04" src="https://github.com/user-attachments/assets/7699b8da-631d-4932-89a8-bc5d7f2546f1">

Co-Authored-by: Thorsten <thorsten@zed.dev>

Release Notes:

- Fixed an issue where the branch switcher would show an error, when opening a file outside of the project
