### PR TITLE
remote servers: Fix title from alpha to beta

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1204,7 +1204,7 @@ impl RemoteServerProjects {
         Modal::new("remote-projects", Some(self.scroll_handle.clone()))
             .header(
                 ModalHeader::new()
-                    .child(Headline::new("Remote Projects (alpha)").size(HeadlineSize::XSmall)),
+                    .child(Headline::new("Remote Projects (beta)").size(HeadlineSize::XSmall)),
             )
             .section(
                 Section::new().padded(false).child(


### PR DESCRIPTION
Discussed this in Slack yesterday. We use `beta` because that's what we use in the docs as well.

Release Notes:

- N/A