### PR TITLE
Add support for self-hosted GitLab instances for Git permalinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,6 +4915,7 @@ dependencies = [
  "serde_json",
  "unindent",
  "url",
+ "util",
 ]
 
 [[package]]
@@ -14730,6 +14731,7 @@ dependencies = [
  "fuzzy",
  "git",
  "git2",
+ "git_hosting_providers",
  "gpui",
  "http_client",
  "ignore",

--- a/crates/git/src/hosting_provider.rs
+++ b/crates/git/src/hosting_provider.rs
@@ -111,6 +111,12 @@ impl GitHostingProviderRegistry {
         cx.global::<GlobalGitHostingProviderRegistry>().0.clone()
     }
 
+    /// Returns the global [`GitHostingProviderRegistry`], if one is set.
+    pub fn try_global(cx: &AppContext) -> Option<Arc<Self>> {
+        cx.try_global::<GlobalGitHostingProviderRegistry>()
+            .map(|registry| registry.0.clone())
+    }
+
     /// Returns the global [`GitHostingProviderRegistry`].
     ///
     /// Inserts a default [`GitHostingProviderRegistry`] if one does not yet exist.

--- a/crates/git_hosting_providers/Cargo.toml
+++ b/crates/git_hosting_providers/Cargo.toml
@@ -22,6 +22,7 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 url.workspace = true
+util.workspace = true
 
 [dev-dependencies]
 unindent.workspace = true

--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -29,6 +29,7 @@ fs.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 git.workspace = true
+git_hosting_providers.workspace = true
 gpui.workspace = true
 ignore.workspace = true
 language.workspace = true

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -19,6 +19,7 @@ use futures::{
     FutureExt as _, Stream, StreamExt,
 };
 use fuzzy::CharBag;
+use git::GitHostingProviderRegistry;
 use git::{
     repository::{GitFileStatus, GitRepository, RepoPath},
     status::GitStatus,
@@ -299,6 +300,7 @@ struct BackgroundScannerState {
     removed_entries: HashMap<u64, Entry>,
     changed_paths: Vec<Arc<Path>>,
     prev_snapshot: Snapshot,
+    git_hosting_provider_registry: Arc<GitHostingProviderRegistry>,
 }
 
 #[derive(Debug, Clone)]
@@ -1004,6 +1006,7 @@ impl LocalWorktree {
         let share_private_files = self.share_private_files;
         let next_entry_id = self.next_entry_id.clone();
         let fs = self.fs.clone();
+        let git_hosting_provider_registry = GitHostingProviderRegistry::global(cx);
         let settings = self.settings.clone();
         let (scan_states_tx, mut scan_states_rx) = mpsc::unbounded();
         let background_scanner = cx.background_executor().spawn({
@@ -1039,6 +1042,7 @@ impl LocalWorktree {
                         paths_to_scan: Default::default(),
                         removed_entries: Default::default(),
                         changed_paths: Default::default(),
+                        git_hosting_provider_registry,
                     }),
                     phase: BackgroundScannerPhase::InitialScan,
                     share_private_files,
@@ -2947,6 +2951,11 @@ impl BackgroundScannerState {
         let repository = fs.open_repo(&abs_path)?;
         log::trace!("constructed libgit2 repo in {:?}", t0.elapsed());
         let work_directory = RepositoryWorkDirectory(work_dir_path.clone());
+
+        git_hosting_providers::register_additional_providers(
+            self.git_hosting_provider_registry.clone(),
+            repository.clone(),
+        );
 
         self.snapshot.repository_entries.insert(
             work_directory.clone(),


### PR DESCRIPTION
This PR adds support for self-hosted GitLab instances when generating Git permalinks.

If the `origin` Git remote contains `gitlab` in the URL hostname we will then attempt to register it as a self-hosted GitLab instance.

A note on this: I don't think relying on specific keywords is going to be a suitable long-term solution to detection. In reality the self-hosted instance could be hosted anywhere (e.g., `vcs.my-company.com`), so we will ultimately need a way to have the user indicate which Git provider they are using (perhaps via a setting).

Closes https://github.com/zed-industries/zed/issues/18012.

Release Notes:

- Added support for self-hosted GitLab instances when generating Git permalinks.
  - The instance URL must have `gitlab` somewhere in the host in order to be recognized.
