### PR TITLE
cargo: Make mold compatible with GCC < 12.1.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,11 +7,11 @@ xtask = "run --package xtask --"
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+rustflags = ["-C", "link-arg=-Bmold"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+rustflags = ["-C", "link-arg=-Bmold"]
 
 # This cfg will reduce the size of `windows::core::Error` from 16 bytes to 4 bytes
 [target.'cfg(target_os = "windows")']


### PR DESCRIPTION
When zed cross-compiles zed-remote-server(host: MacOS M3 Pro and Docker Desktop, target: aarch64 ubunut 20.04), the GCC version in the auto used image `cross-rs/cross-custom-zed:aarch64-unknown-linux-gnu-8d728` is `9.4.0`, which does not support the `-fuse-ld=mold` parameter but requires [-Bmold](https://github.com/rui314/mold?tab=readme-ov-file#how-to-use) , otherwise it reports an error:

> = note: aarch64-linux-gnu-gcc: error: unrecognized command line option '-fuse-ld=mold'; did you mean '-fuse-ld=gold'?


Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
