### PR TITLE
Speed up point translation in the Rope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9456,6 +9456,7 @@ dependencies = [
  "gpui",
  "log",
  "rand 0.8.5",
+ "rayon",
  "smallvec",
  "sum_tree",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,6 +384,7 @@ prost-build = "0.9"
 prost-types = "0.9"
 pulldown-cmark = { version = "0.12.0", default-features = false }
 rand = "0.8.5"
+rayon = "1.8"
 regex = "1.5"
 repair_json = "0.1.0"
 reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "fd110f6998da16bbca97b6dddda9be7827c50e29", default-features = false, features = [

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/rope.rs"
 [dependencies]
 arrayvec = "0.7.1"
 log.workspace = true
+rayon.workspace = true
 smallvec.workspace = true
 sum_tree.workspace = true
 unicode-segmentation.workspace = true

--- a/crates/rope/benches/rope_benchmark.rs
+++ b/crates/rope/benches/rope_benchmark.rs
@@ -171,6 +171,25 @@ fn rope_benchmarks(c: &mut Criterion) {
         });
     }
     group.finish();
+
+    let mut group = c.benchmark_group("point_to_offset");
+    for size in sizes.iter() {
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            let rope = generate_random_rope(rng.clone(), *size);
+
+            b.iter_batched(
+                || generate_random_rope_points(rng.clone(), &rope),
+                |offsets| {
+                    for offset in offsets.iter() {
+                        black_box(rope.point_to_offset(*offset));
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(benches, rope_benchmarks);

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -499,7 +499,7 @@ impl<'a> ChunkSlice<'a> {
     #[inline(always)]
     fn offset_range_for_row(&self, row: u32) -> Range<usize> {
         let row_start = if row > 0 {
-            (nth_set_bit(self.newlines, row as usize) + 1) as usize
+            nth_set_bit(self.newlines, row as usize) + 1
         } else {
             0
         };
@@ -536,10 +536,10 @@ fn nth_set_bit_u64(v: u64, mut n: u64) -> u64 {
     let mut t: u64;
 
     // Parallel bit count intermediates
-    let a = v - ((v >> 1) & u64::MAX / 3);
-    let b = (a & u64::MAX / 5) + ((a >> 2) & u64::MAX / 5);
-    let c = (b + (b >> 4)) & u64::MAX / 0x11;
-    let d = (c + (c >> 8)) & u64::MAX / 0x101;
+    let a = v - ((v >> 1) & (u64::MAX / 3));
+    let b = (a & u64::MAX / 5) + ((a >> 2) & (u64::MAX / 5));
+    let c = (b + (b >> 4)) & (u64::MAX / 0x11);
+    let d = (c + (c >> 8)) & (u64::MAX / 0x101);
     t = (d >> 32) + (d >> 48);
 
     // Branchless select

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -12,7 +12,6 @@ pub(crate) const MAX_BASE: usize = MIN_BASE * 2;
 pub struct Chunk {
     chars: u128,
     chars_utf16: u128,
-    tabs: u128,
     newlines: u128,
     pub text: ArrayString<MAX_BASE>,
 }
@@ -32,7 +31,6 @@ impl Chunk {
             self.chars |= 1 << ix;
             self.chars_utf16 |= 1 << ix;
             self.chars_utf16 |= (c.len_utf16() as u128) << ix;
-            self.tabs |= ((c == '\t') as u128) << ix;
             self.newlines |= ((c == '\n') as u128) << ix;
         }
         self.text.push_str(text);
@@ -47,7 +45,6 @@ impl Chunk {
         let base_ix = self.text.len();
         self.chars |= slice.chars << base_ix;
         self.chars_utf16 |= slice.chars_utf16 << base_ix;
-        self.tabs |= slice.tabs << base_ix;
         self.newlines |= slice.newlines << base_ix;
         self.text.push_str(&slice.text);
     }
@@ -57,7 +54,6 @@ impl Chunk {
         ChunkSlice {
             chars: self.chars,
             chars_utf16: self.chars_utf16,
-            tabs: self.tabs,
             newlines: self.newlines,
             text: &self.text,
         }
@@ -73,7 +69,6 @@ impl Chunk {
 pub struct ChunkSlice<'a> {
     chars: u128,
     chars_utf16: u128,
-    tabs: u128,
     newlines: u128,
     text: &'a str,
 }
@@ -83,7 +78,6 @@ impl<'a> Into<Chunk> for ChunkSlice<'a> {
         Chunk {
             chars: self.chars,
             chars_utf16: self.chars_utf16,
-            tabs: self.tabs,
             newlines: self.newlines,
             text: self.text.try_into().unwrap(),
         }
@@ -108,7 +102,6 @@ impl<'a> ChunkSlice<'a> {
             let right = ChunkSlice {
                 chars: 0,
                 chars_utf16: 0,
-                tabs: 0,
                 newlines: 0,
                 text: "",
             };
@@ -123,14 +116,12 @@ impl<'a> ChunkSlice<'a> {
             let left = ChunkSlice {
                 chars: self.chars & mask,
                 chars_utf16: self.chars_utf16 & mask,
-                tabs: self.tabs & mask,
                 newlines: self.newlines & mask,
                 text: left_text,
             };
             let right = ChunkSlice {
                 chars: self.chars >> mid,
                 chars_utf16: self.chars_utf16 >> mid,
-                tabs: self.tabs >> mid,
                 newlines: self.newlines >> mid,
                 text: right_text,
             };
@@ -149,7 +140,6 @@ impl<'a> ChunkSlice<'a> {
             Self {
                 chars: 0,
                 chars_utf16: 0,
-                tabs: 0,
                 newlines: 0,
                 text: "",
             }
@@ -157,7 +147,6 @@ impl<'a> ChunkSlice<'a> {
             Self {
                 chars: (self.chars & mask) >> range.start,
                 chars_utf16: (self.chars_utf16 & mask) >> range.start,
-                tabs: (self.tabs & mask) >> range.start,
                 newlines: (self.newlines & mask) >> range.start,
                 text: &self.text[range],
             }

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -254,15 +254,6 @@ impl<'a> ChunkSlice<'a> {
 
     #[inline(always)]
     pub fn offset_to_point(&self, offset: usize) -> Point {
-        if !self.text.is_char_boundary(offset) {
-            debug_panic!(
-                "offset {:?} is not a char boundary for string {:?}",
-                offset,
-                self.text
-            );
-            return Point::zero();
-        }
-
         let mask = if offset == MAX_BASE {
             u128::MAX
         } else {

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -526,7 +526,7 @@ fn nth_set_bit_u64(v: u64, mut n: u64) -> u64 {
 
     // Parallel bit count intermediates
     let a = v - ((v >> 1) & (u64::MAX / 3));
-    let b = (a & u64::MAX / 5) + ((a >> 2) & (u64::MAX / 5));
+    let b = (a & (u64::MAX / 5)) + ((a >> 2) & (u64::MAX / 5));
     let c = (b + (b >> 4)) & (u64::MAX / 0x11);
     let d = (c + (c >> 8)) & (u64::MAX / 0x101);
     t = (d >> 32) + (d >> 48);

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -1,0 +1,727 @@
+use crate::{OffsetUtf16, Point, PointUtf16, TextSummary, Unclipped};
+use arrayvec::ArrayString;
+use std::{cmp, ops::Range};
+use sum_tree::Bias;
+use unicode_segmentation::GraphemeCursor;
+use util::debug_panic;
+
+#[derive(Clone, Debug, Default)]
+pub struct Chunk<const CAPACITY: usize> {
+    chars: usize,
+    chars_utf16: usize,
+    tabs: usize,
+    newlines: usize,
+    pub text: ArrayString<CAPACITY>,
+}
+
+impl<const CAPACITY: usize> Chunk<CAPACITY> {
+    #[inline(always)]
+    pub fn new(text: &str) -> Self {
+        let mut this = Chunk::default();
+        this.push_str(text);
+        this
+    }
+
+    #[inline(always)]
+    pub fn push_str(&mut self, text: &str) {
+        for (char_ix, c) in text.char_indices() {
+            let ix = self.text.len() + char_ix;
+            self.chars |= 1 << ix;
+            self.chars_utf16 |= 1 << ix;
+            self.chars_utf16 |= c.len_utf16() << ix;
+            self.tabs |= ((c == '\t') as usize) << ix;
+            self.newlines |= ((c == '\n') as usize) << ix;
+        }
+        self.text.push_str(text);
+    }
+
+    #[inline(always)]
+    pub fn as_slice(&self) -> ChunkRef {
+        ChunkRef {
+            chars: self.chars,
+            chars_utf16: self.chars_utf16,
+            tabs: self.tabs,
+            newlines: self.newlines,
+            text: &self.text,
+        }
+    }
+
+    #[inline(always)]
+    pub fn slice(&self, range: Range<usize>) -> ChunkRef {
+        self.as_slice().slice(range)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ChunkRef<'a> {
+    chars: usize,
+    chars_utf16: usize,
+    tabs: usize,
+    newlines: usize,
+    text: &'a str,
+}
+
+impl<'a> ChunkRef<'a> {
+    #[inline(always)]
+    pub fn slice(self, range: Range<usize>) -> Self {
+        let mask = (1 << range.end) - 1;
+        Self {
+            chars: (self.chars & mask) >> range.start,
+            chars_utf16: (self.chars_utf16 & mask) >> range.start,
+            tabs: (self.tabs & mask) >> range.start,
+            newlines: (self.newlines & mask) >> range.start,
+            text: &self.text[range],
+        }
+    }
+
+    #[inline(always)]
+    pub fn text_summary(&self) -> TextSummary {
+        let (longest_row, longest_row_chars) = self.longest_row();
+        TextSummary {
+            len: self.len(),
+            len_utf16: self.len_utf16(),
+            lines: self.lines(),
+            first_line_chars: self.first_line_chars(),
+            last_line_chars: self.last_line_chars(),
+            last_line_len_utf16: self.last_line_len_utf16(),
+            longest_row,
+            longest_row_chars,
+        }
+    }
+
+    /// Get length in bytes
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.text.len()
+    }
+
+    /// Get length in UTF-16 code units
+    #[inline(always)]
+    pub fn len_utf16(&self) -> OffsetUtf16 {
+        OffsetUtf16(self.chars_utf16.count_ones() as usize)
+    }
+
+    /// Get point representing number of lines and length of last line
+    #[inline(always)]
+    pub fn lines(&self) -> Point {
+        let row = self.newlines.count_ones();
+        let column = self.newlines.leading_zeros() - (usize::BITS - self.text.len() as u32);
+        Point::new(row, column)
+    }
+
+    /// Get number of chars in first line
+    #[inline(always)]
+    pub fn first_line_chars(&self) -> u32 {
+        if self.newlines == 0 {
+            self.chars.count_ones()
+        } else {
+            let mask = (1 << self.newlines.trailing_zeros() as usize) - 1;
+            (self.chars & mask).count_ones()
+        }
+    }
+
+    /// Get number of chars in last line
+    #[inline(always)]
+    pub fn last_line_chars(&self) -> u32 {
+        if self.newlines == 0 {
+            self.chars.count_ones()
+        } else {
+            let mask = !(usize::MAX >> self.newlines.leading_zeros());
+            (self.chars & mask).count_ones()
+        }
+    }
+
+    /// Get number of UTF-16 code units in last line
+    #[inline(always)]
+    pub fn last_line_len_utf16(&self) -> u32 {
+        if self.newlines == 0 {
+            self.chars_utf16.count_ones()
+        } else {
+            let mask = !(usize::MAX >> self.newlines.leading_zeros());
+            (self.chars_utf16 & mask).count_ones()
+        }
+    }
+
+    /// Get the longest row in the chunk and its length in characters.
+    #[inline(always)]
+    pub fn longest_row(&self) -> (u32, u32) {
+        let mut chars = self.chars;
+        let mut newlines = self.newlines;
+        let mut row = 0;
+        let mut longest_row = 0;
+        let mut longest_row_chars = 0;
+        while newlines > 0 {
+            let newline_ix = newlines.trailing_zeros();
+            let row_chars = (chars & ((1 << newline_ix) - 1)).count_ones() as u8;
+            if row_chars > longest_row_chars {
+                longest_row = row;
+                longest_row_chars = row_chars;
+            }
+
+            newlines >>= newline_ix + 1;
+            chars >>= newline_ix + 1;
+            row += 1;
+        }
+
+        let row_chars = chars.count_ones() as u8;
+        if row_chars > longest_row_chars {
+            (row, row_chars as u32)
+        } else {
+            (longest_row, longest_row_chars as u32)
+        }
+    }
+
+    #[inline(always)]
+    pub fn offset_to_point(&self, offset: usize) -> Point {
+        if !self.text.is_char_boundary(offset) {
+            debug_panic!(
+                "offset {:?} is not a char boundary for string {:?}",
+                offset,
+                self.text
+            );
+            return Point::zero();
+        }
+
+        let mask = (1 << offset) - 1;
+        let row = (self.newlines & mask).count_ones();
+        let newline_ix = usize::BITS - (self.newlines & mask).leading_zeros();
+        let column = (offset - newline_ix as usize) as u32;
+        Point::new(row, column)
+    }
+
+    #[inline(always)]
+    pub fn point_to_offset(&self, point: Point) -> usize {
+        if point.row > self.newlines.count_ones() {
+            debug_panic!(
+                "point {:?} extends beyond rows for string {:?}",
+                point,
+                self.text
+            );
+            return 0;
+        }
+
+        let row_start_offset = if point.row > 0 {
+            (nth_set_bit(self.newlines, point.row as usize) + 1) as usize
+        } else {
+            0
+        };
+
+        let newlines = self.newlines >> row_start_offset;
+        let row_len = cmp::min(newlines.trailing_zeros(), self.text.len() as u32);
+        if point.column > row_len {
+            debug_panic!(
+                "point {:?} extends beyond row for string {:?}",
+                point,
+                self.text
+            );
+            return row_start_offset + row_len as usize;
+        }
+
+        row_start_offset + point.column as usize
+    }
+
+    #[inline(always)]
+    pub fn offset_to_offset_utf16(&self, offset: usize) -> OffsetUtf16 {
+        let mask = (1 << offset) - 1;
+        OffsetUtf16((self.chars_utf16 & mask).count_ones() as usize)
+    }
+
+    #[inline(always)]
+    pub fn offset_utf16_to_offset(&self, target: OffsetUtf16) -> usize {
+        if target.0 == 0 {
+            0
+        } else {
+            let ix = nth_set_bit(self.chars_utf16, target.0) + 1;
+            let utf8_additional_len = cmp::min(
+                (self.chars_utf16 >> ix).trailing_zeros() as usize,
+                self.text.len() - ix,
+            );
+            ix + utf8_additional_len
+        }
+    }
+
+    #[inline(always)]
+    pub fn offset_to_point_utf16(&self, offset: usize) -> PointUtf16 {
+        let mask = (1 << offset) - 1;
+        let row = (self.newlines & mask).count_ones();
+        let newline_ix = usize::BITS - (self.newlines & mask).leading_zeros();
+        let column = ((self.chars_utf16 & mask) >> newline_ix).count_ones();
+        PointUtf16::new(row, column)
+    }
+
+    #[inline(always)]
+    pub fn point_to_point_utf16(&self, point: Point) -> PointUtf16 {
+        self.offset_to_point_utf16(self.point_to_offset(point))
+    }
+
+    #[inline(always)]
+    pub fn point_utf16_to_offset(&self, point: PointUtf16, clip: bool) -> usize {
+        let lines = self.lines();
+        if point.row > lines.row {
+            if !clip {
+                debug_panic!(
+                    "point {:?} is beyond this chunk's extent {:?}",
+                    point,
+                    self.text
+                );
+            }
+            return self.len();
+        }
+
+        let row_start_offset = if point.row > 0 {
+            (nth_set_bit(self.newlines, point.row as usize) + 1) as usize
+        } else {
+            0
+        };
+
+        let row_len_utf8 = cmp::min(
+            (self.newlines >> row_start_offset).trailing_zeros(),
+            self.text.len() as u32,
+        );
+        let mask = (1 << row_len_utf8) - 1;
+        let row_chars_utf16 = (self.chars_utf16 >> row_start_offset) & mask;
+        if point.column > row_chars_utf16.count_ones() {
+            if !clip {
+                debug_panic!(
+                    "point {:?} is beyond the end of the line in chunk {:?}",
+                    point,
+                    self.text
+                );
+            }
+
+            return row_start_offset + row_len_utf8 as usize;
+        }
+
+        let mut offset = row_start_offset;
+        if point.column > 0 {
+            offset += nth_set_bit(row_chars_utf16, point.column as usize) + 1;
+            offset += cmp::min(
+                (self.chars_utf16 >> offset).trailing_zeros() as usize,
+                self.text.len() - offset,
+            );
+
+            if !self.text.is_char_boundary(offset) {
+                offset -= 1;
+                while !self.text.is_char_boundary(offset) {
+                    offset -= 1;
+                }
+                if !clip {
+                    debug_panic!(
+                        "point {:?} is within character in chunk {:?}",
+                        point,
+                        self.text,
+                    );
+                }
+            }
+        }
+        offset
+    }
+
+    pub fn unclipped_point_utf16_to_point(&self, target: Unclipped<PointUtf16>) -> Point {
+        let mut point = Point::zero();
+        let mut point_utf16 = PointUtf16::zero();
+
+        for ch in self.text.chars() {
+            if point_utf16 == target.0 {
+                break;
+            }
+
+            if point_utf16 > target.0 {
+                // If the point is past the end of a line or inside of a code point,
+                // return the last valid point before the target.
+                return point;
+            }
+
+            if ch == '\n' {
+                point_utf16 += PointUtf16::new(1, 0);
+                point += Point::new(1, 0);
+            } else {
+                point_utf16 += PointUtf16::new(0, ch.len_utf16() as u32);
+                point += Point::new(0, ch.len_utf8() as u32);
+            }
+        }
+
+        point
+    }
+
+    // todo!("use bitsets")
+    pub fn clip_point(&self, target: Point, bias: Bias) -> Point {
+        for (row, line) in self.text.split('\n').enumerate() {
+            if row == target.row as usize {
+                let bytes = line.as_bytes();
+                let mut column = target.column.min(bytes.len() as u32) as usize;
+                if column == 0
+                    || column == bytes.len()
+                    || (bytes[column - 1] < 128 && bytes[column] < 128)
+                {
+                    return Point::new(row as u32, column as u32);
+                }
+
+                let mut grapheme_cursor = GraphemeCursor::new(column, bytes.len(), true);
+                loop {
+                    if line.is_char_boundary(column)
+                        && grapheme_cursor.is_boundary(line, 0).unwrap_or(false)
+                    {
+                        break;
+                    }
+
+                    match bias {
+                        Bias::Left => column -= 1,
+                        Bias::Right => column += 1,
+                    }
+                    grapheme_cursor.set_cursor(column);
+                }
+                return Point::new(row as u32, column as u32);
+            }
+        }
+        unreachable!()
+    }
+
+    // todo!("use bitsets")
+    pub fn clip_point_utf16(&self, target: Unclipped<PointUtf16>, bias: Bias) -> PointUtf16 {
+        for (row, line) in self.text.split('\n').enumerate() {
+            if row == target.0.row as usize {
+                let mut code_units = line.encode_utf16();
+                let mut column = code_units.by_ref().take(target.0.column as usize).count();
+                if char::decode_utf16(code_units).next().transpose().is_err() {
+                    match bias {
+                        Bias::Left => column -= 1,
+                        Bias::Right => column += 1,
+                    }
+                }
+                return PointUtf16::new(row as u32, column as u32);
+            }
+        }
+        unreachable!()
+    }
+
+    // todo!("use bitsets")
+    pub fn clip_offset_utf16(&self, target: OffsetUtf16, bias: Bias) -> OffsetUtf16 {
+        let mut code_units = self.text.encode_utf16();
+        let mut offset = code_units.by_ref().take(target.0).count();
+        if char::decode_utf16(code_units).next().transpose().is_err() {
+            match bias {
+                Bias::Left => offset -= 1,
+                Bias::Right => offset += 1,
+            }
+        }
+        OffsetUtf16(offset)
+    }
+}
+
+/// Finds the n-th bit that is set to 1.
+#[inline(always)]
+fn nth_set_bit(v: usize, mut n: usize) -> usize {
+    let v = v.reverse_bits();
+    let mut s: usize = 64;
+    let mut t: usize;
+
+    // Parallel bit count intermediates
+    let a = v - ((v >> 1) & usize::MAX / 3);
+    let b = (a & usize::MAX / 5) + ((a >> 2) & usize::MAX / 5);
+    let c = (b + (b >> 4)) & usize::MAX / 0x11;
+    let d = (c + (c >> 8)) & usize::MAX / 0x101;
+    t = (d >> 32) + (d >> 48);
+
+    // Branchless select
+    s -= ((t.wrapping_sub(n)) & 256) >> 3;
+    n -= t & ((t.wrapping_sub(n)) >> 8);
+
+    t = (d >> (s - 16)) & 0xff;
+    s -= ((t.wrapping_sub(n)) & 256) >> 4;
+    n -= t & ((t.wrapping_sub(n)) >> 8);
+
+    t = (c >> (s - 8)) & 0xf;
+    s -= ((t.wrapping_sub(n)) & 256) >> 5;
+    n -= t & ((t.wrapping_sub(n)) >> 8);
+
+    t = (b >> (s - 4)) & 0x7;
+    s -= ((t.wrapping_sub(n)) & 256) >> 6;
+    n -= t & ((t.wrapping_sub(n)) >> 8);
+
+    t = (a >> (s - 2)) & 0x3;
+    s -= ((t.wrapping_sub(n)) & 256) >> 7;
+    n -= t & ((t.wrapping_sub(n)) >> 8);
+
+    t = (v >> (s - 1)) & 0x1;
+    s -= ((t.wrapping_sub(n)) & 256) >> 8;
+
+    65 - s - 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::prelude::*;
+    use util::RandomCharIter;
+
+    #[gpui::test(iterations = 100)]
+    fn test_random_chunks(mut rng: StdRng) {
+        let max_len = std::env::var("CHUNK_MAX_LEN")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(64);
+        let chunk_len = rng.gen_range(0..max_len);
+        let text = RandomCharIter::new(&mut rng)
+            .take(chunk_len)
+            .collect::<String>();
+        let mut ix = chunk_len;
+        while !text.is_char_boundary(ix) {
+            ix -= 1;
+        }
+        let text = &text[..ix];
+
+        log::info!("Chunk: {:?}", text);
+        let chunk = Chunk::<64>::new(&text);
+        verify_chunk(chunk.as_slice(), text);
+
+        for _ in 0..10 {
+            let mut start = rng.gen_range(0..=chunk.text.len());
+            let mut end = rng.gen_range(start..=chunk.text.len());
+            while !chunk.text.is_char_boundary(start) {
+                start -= 1;
+            }
+            while !chunk.text.is_char_boundary(end) {
+                end -= 1;
+            }
+            let range = start..end;
+            log::info!("Range: {:?}", range);
+            let text_slice = &text[range.clone()];
+            let chunk_slice = chunk.slice(range);
+            verify_chunk(chunk_slice, text_slice);
+        }
+    }
+
+    #[test]
+    fn test_nth_set_bit() {
+        assert_eq!(
+            nth_set_bit(
+                0b1000000000000000000000000000000000000000000000000000000000000000,
+                1
+            ),
+            63
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b1100000000000000000000000000000000000000000000000000000000000000,
+                1
+            ),
+            62
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b1100000000000000000000000000000000000000000000000000000000000000,
+                2
+            ),
+            63
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b0000000000000000000000000000000000000000000000000000000000000001,
+                1
+            ),
+            0
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b0000000000000000000000000000000000000000000000000000000000000011,
+                2
+            ),
+            1
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b0101010101010101010101010101010101010101010101010101010101010101,
+                1
+            ),
+            0
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b0101010101010101010101010101010101010101010101010101010101010101,
+                32
+            ),
+            62
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b1111111111111111111111111111111111111111111111111111111111111111,
+                64
+            ),
+            63
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b1111111111111111111111111111111111111111111111111111111111111111,
+                1
+            ),
+            0
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b1010101010101010101010101010101010101010101010101010101010101010,
+                1
+            ),
+            1
+        );
+        assert_eq!(
+            nth_set_bit(
+                0b1111000011110000111100001111000011110000111100001111000011110000,
+                8
+            ),
+            15
+        );
+    }
+
+    fn verify_chunk(chunk: ChunkRef<'_>, text: &str) {
+        let mut offset = 0;
+        let mut offset_utf16 = OffsetUtf16(0);
+        let mut point = Point::zero();
+        let mut point_utf16 = PointUtf16::zero();
+
+        log::info!("Verifying chunk {:?}", text);
+        assert_eq!(chunk.offset_to_point(0), Point::zero());
+
+        for c in text.chars() {
+            let expected_point = chunk.offset_to_point(offset);
+            assert_eq!(point, expected_point, "mismatch at offset {}", offset);
+            assert_eq!(
+                chunk.point_to_offset(point),
+                offset,
+                "mismatch at point {:?}",
+                point
+            );
+            assert_eq!(
+                chunk.offset_to_offset_utf16(offset),
+                offset_utf16,
+                "mismatch at offset {}",
+                offset
+            );
+            assert_eq!(
+                chunk.offset_utf16_to_offset(offset_utf16),
+                offset,
+                "mismatch at offset_utf16 {:?}",
+                offset_utf16
+            );
+            assert_eq!(
+                chunk.point_to_point_utf16(point),
+                point_utf16,
+                "mismatch at point {:?}",
+                point
+            );
+            assert_eq!(
+                chunk.point_utf16_to_offset(point_utf16, false),
+                offset,
+                "mismatch at point_utf16 {:?}",
+                point_utf16
+            );
+
+            if c == '\n' {
+                point.row += 1;
+                point.column = 0;
+                point_utf16.row += 1;
+                point_utf16.column = 0;
+            } else {
+                point.column += c.len_utf8() as u32;
+                point_utf16.column += c.len_utf16() as u32;
+            }
+
+            offset += c.len_utf8();
+            offset_utf16.0 += c.len_utf16();
+        }
+
+        let final_point = chunk.offset_to_point(offset);
+        assert_eq!(point, final_point, "mismatch at final offset {}", offset);
+        assert_eq!(
+            chunk.point_to_offset(point),
+            offset,
+            "mismatch at point {:?}",
+            point
+        );
+        assert_eq!(
+            chunk.offset_to_offset_utf16(offset),
+            offset_utf16,
+            "mismatch at offset {}",
+            offset
+        );
+        assert_eq!(
+            chunk.offset_utf16_to_offset(offset_utf16),
+            offset,
+            "mismatch at offset_utf16 {:?}",
+            offset_utf16
+        );
+        assert_eq!(
+            chunk.point_to_point_utf16(point),
+            point_utf16,
+            "mismatch at final point {:?}",
+            point
+        );
+        assert_eq!(
+            chunk.point_utf16_to_offset(point_utf16, false),
+            offset,
+            "mismatch at final point_utf16 {:?}",
+            point_utf16
+        );
+
+        // Verify length methods
+        assert_eq!(chunk.len(), text.len());
+        assert_eq!(
+            chunk.len_utf16().0,
+            text.chars().map(|c| c.len_utf16()).sum::<usize>()
+        );
+
+        // Verify line counting
+        let lines = chunk.lines();
+        let mut newline_count = 0;
+        let mut last_line_len = 0;
+        for c in text.chars() {
+            if c == '\n' {
+                newline_count += 1;
+                last_line_len = 0;
+            } else {
+                last_line_len += c.len_utf8() as u32;
+            }
+        }
+        assert_eq!(lines, Point::new(newline_count, last_line_len));
+
+        // Verify first/last line chars
+        if !text.is_empty() {
+            let first_line = text.split('\n').next().unwrap();
+            assert_eq!(chunk.first_line_chars(), first_line.chars().count() as u32);
+
+            let last_line = text.split('\n').last().unwrap();
+            assert_eq!(chunk.last_line_chars(), last_line.chars().count() as u32);
+            assert_eq!(
+                chunk.last_line_len_utf16(),
+                last_line.chars().map(|c| c.len_utf16() as u32).sum::<u32>()
+            );
+        }
+
+        // Verify longest row
+        let (longest_row, longest_chars) = chunk.longest_row();
+        let mut max_chars = 0;
+        let mut current_row = 0;
+        let mut current_chars = 0;
+        let mut max_row = 0;
+
+        for c in text.chars() {
+            if c == '\n' {
+                if current_chars > max_chars {
+                    max_chars = current_chars;
+                    max_row = current_row;
+                }
+                current_row += 1;
+                current_chars = 0;
+            } else {
+                current_chars += 1;
+            }
+        }
+
+        if current_chars > max_chars {
+            max_chars = current_chars;
+            max_row = current_row;
+        }
+
+        assert_eq!((max_row, max_chars as u32), (longest_row, longest_chars));
+    }
+}

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -5,16 +5,24 @@ use sum_tree::Bias;
 use unicode_segmentation::GraphemeCursor;
 use util::debug_panic;
 
+#[cfg(test)]
+pub(crate) const MIN_BASE: usize = 32;
+
+#[cfg(not(test))]
+pub(crate) const MIN_BASE: usize = 32;
+
+pub(crate) const MAX_BASE: usize = MIN_BASE * 2;
+
 #[derive(Clone, Debug, Default)]
-pub struct Chunk<const CAPACITY: usize> {
+pub struct Chunk {
     chars: usize,
     chars_utf16: usize,
     tabs: usize,
     newlines: usize,
-    pub text: ArrayString<CAPACITY>,
+    pub text: ArrayString<MAX_BASE>,
 }
 
-impl<const CAPACITY: usize> Chunk<CAPACITY> {
+impl Chunk {
     #[inline(always)]
     pub fn new(text: &str) -> Self {
         let mut this = Chunk::default();
@@ -36,8 +44,22 @@ impl<const CAPACITY: usize> Chunk<CAPACITY> {
     }
 
     #[inline(always)]
-    pub fn as_slice(&self) -> ChunkRef {
-        ChunkRef {
+    pub fn append(&mut self, slice: ChunkSlice) {
+        if slice.is_empty() {
+            return;
+        };
+
+        let base_ix = self.text.len();
+        self.chars |= slice.chars << base_ix;
+        self.chars_utf16 |= slice.chars_utf16 << base_ix;
+        self.tabs |= slice.tabs << base_ix;
+        self.newlines |= slice.newlines << base_ix;
+        self.text.push_str(&slice.text);
+    }
+
+    #[inline(always)]
+    pub fn as_slice(&self) -> ChunkSlice {
+        ChunkSlice {
             chars: self.chars,
             chars_utf16: self.chars_utf16,
             tabs: self.tabs,
@@ -47,13 +69,13 @@ impl<const CAPACITY: usize> Chunk<CAPACITY> {
     }
 
     #[inline(always)]
-    pub fn slice(&self, range: Range<usize>) -> ChunkRef {
+    pub fn slice(&self, range: Range<usize>) -> ChunkSlice {
         self.as_slice().slice(range)
     }
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct ChunkRef<'a> {
+pub struct ChunkSlice<'a> {
     chars: usize,
     chars_utf16: usize,
     tabs: usize,
@@ -61,7 +83,62 @@ pub struct ChunkRef<'a> {
     text: &'a str,
 }
 
-impl<'a> ChunkRef<'a> {
+impl<'a> Into<Chunk> for ChunkSlice<'a> {
+    fn into(self) -> Chunk {
+        Chunk {
+            chars: self.chars,
+            chars_utf16: self.chars_utf16,
+            tabs: self.tabs,
+            newlines: self.newlines,
+            text: self.text.try_into().unwrap(),
+        }
+    }
+}
+
+impl<'a> ChunkSlice<'a> {
+    #[inline(always)]
+    pub fn is_empty(self) -> bool {
+        self.text.is_empty()
+    }
+
+    #[inline(always)]
+    pub fn is_char_boundary(self, offset: usize) -> bool {
+        self.text.is_char_boundary(offset)
+    }
+
+    #[inline(always)]
+    pub fn split_at(self, mid: usize) -> (ChunkSlice<'a>, ChunkSlice<'a>) {
+        if mid == 64 {
+            let left = self;
+            let right = ChunkSlice {
+                chars: 0,
+                chars_utf16: 0,
+                tabs: 0,
+                newlines: 0,
+                text: "",
+            };
+            (left, right)
+        } else {
+            let mask = ((1u128 << mid) - 1) as usize;
+            let (left_text, right_text) = self.text.split_at(mid);
+            let left = ChunkSlice {
+                chars: self.chars & mask,
+                chars_utf16: self.chars_utf16 & mask,
+                tabs: self.tabs & mask,
+                newlines: self.newlines & mask,
+                text: left_text,
+            };
+            let right = ChunkSlice {
+                chars: self.chars >> mid,
+                chars_utf16: self.chars_utf16 >> mid,
+                tabs: self.tabs >> mid,
+                newlines: self.newlines >> mid,
+                text: right_text,
+            };
+            (left, right)
+        }
+    }
+
     #[inline(always)]
     pub fn slice(self, range: Range<usize>) -> Self {
         let mask = ((1u128 << range.end) - 1) as usize;
@@ -492,11 +569,7 @@ mod tests {
 
     #[gpui::test(iterations = 100)]
     fn test_random_chunks(mut rng: StdRng) {
-        let max_len = std::env::var("CHUNK_MAX_LEN")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(64);
-        let chunk_len = rng.gen_range(0..=max_len);
+        let chunk_len = rng.gen_range(0..=MAX_BASE);
         let text = RandomCharIter::new(&mut rng)
             .take(chunk_len)
             .collect::<String>();
@@ -507,7 +580,7 @@ mod tests {
         let text = &text[..ix];
 
         log::info!("Chunk: {:?}", text);
-        let chunk = Chunk::<64>::new(&text);
+        let chunk = Chunk::new(&text);
         verify_chunk(chunk.as_slice(), text);
 
         for _ in 0..10 {
@@ -608,7 +681,7 @@ mod tests {
         );
     }
 
-    fn verify_chunk(chunk: ChunkRef<'_>, text: &str) {
+    fn verify_chunk(chunk: ChunkSlice<'_>, text: &str) {
         let mut offset = 0;
         let mut offset_utf16 = OffsetUtf16(0);
         let mut point = Point::zero();

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -513,37 +513,36 @@ fn nth_set_bit(v: u128, n: usize) -> usize {
 fn nth_set_bit_u64(v: u64, mut n: u64) -> u64 {
     let v = v.reverse_bits();
     let mut s: u64 = 64;
-    let mut t: u64;
 
     // Parallel bit count intermediates
     let a = v - ((v >> 1) & (u64::MAX / 3));
     let b = (a & (u64::MAX / 5)) + ((a >> 2) & (u64::MAX / 5));
     let c = (b + (b >> 4)) & (u64::MAX / 0x11);
     let d = (c + (c >> 8)) & (u64::MAX / 0x101);
-    t = (d >> 32) + (d >> 48);
 
     // Branchless select
-    s -= ((t.wrapping_sub(n)) & 256) >> 3;
-    n -= t & ((t.wrapping_sub(n)) >> 8);
+    let t = (d >> 32) + (d >> 48);
+    s -= (t.wrapping_sub(n) & 256) >> 3;
+    n -= t & (t.wrapping_sub(n) >> 8);
 
-    t = (d >> (s - 16)) & 0xff;
-    s -= ((t.wrapping_sub(n)) & 256) >> 4;
-    n -= t & ((t.wrapping_sub(n)) >> 8);
+    let t = (d >> (s - 16)) & 0xff;
+    s -= (t.wrapping_sub(n) & 256) >> 4;
+    n -= t & (t.wrapping_sub(n) >> 8);
 
-    t = (c >> (s - 8)) & 0xf;
-    s -= ((t.wrapping_sub(n)) & 256) >> 5;
-    n -= t & ((t.wrapping_sub(n)) >> 8);
+    let t = (c >> (s - 8)) & 0xf;
+    s -= (t.wrapping_sub(n) & 256) >> 5;
+    n -= t & (t.wrapping_sub(n) >> 8);
 
-    t = (b >> (s - 4)) & 0x7;
-    s -= ((t.wrapping_sub(n)) & 256) >> 6;
-    n -= t & ((t.wrapping_sub(n)) >> 8);
+    let t = (b >> (s - 4)) & 0x7;
+    s -= (t.wrapping_sub(n) & 256) >> 6;
+    n -= t & (t.wrapping_sub(n) >> 8);
 
-    t = (a >> (s - 2)) & 0x3;
-    s -= ((t.wrapping_sub(n)) & 256) >> 7;
-    n -= t & ((t.wrapping_sub(n)) >> 8);
+    let t = (a >> (s - 2)) & 0x3;
+    s -= (t.wrapping_sub(n) & 256) >> 7;
+    n -= t & (t.wrapping_sub(n) >> 8);
 
-    t = (v >> (s - 1)) & 0x1;
-    s -= ((t.wrapping_sub(n)) & 256) >> 8;
+    let t = (v >> (s - 1)) & 0x1;
+    s -= (t.wrapping_sub(n) & 256) >> 8;
 
     65 - s - 1
 }
@@ -587,7 +586,7 @@ mod tests {
         }
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 1000)]
     fn test_nth_set_bit_random(mut rng: StdRng) {
         let set_count = rng.gen_range(0..=128);
         let mut set_bits = (0..128).choose_multiple(&mut rng, set_count);

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -38,7 +38,7 @@ impl Rope {
                 .map_or(false, |c| c.text.len() < chunk::MIN_BASE)
                 || chunk.text.len() < chunk::MIN_BASE
             {
-                self.push(&chunk.text);
+                self.push_chunk(chunk.as_slice());
                 chunks.next(&());
             }
         }

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -30,9 +30,7 @@ impl Rope {
     }
 
     pub fn append(&mut self, rope: Rope) {
-        let mut chunks = rope.chunks.cursor::<()>(&());
-        chunks.next(&());
-        if let Some(chunk) = chunks.item() {
+        if let Some(chunk) = rope.chunks.first() {
             if self
                 .chunks
                 .last()
@@ -40,11 +38,17 @@ impl Rope {
                 || chunk.text.len() < chunk::MIN_BASE
             {
                 self.push_chunk(chunk.as_slice());
+
+                let mut chunks = rope.chunks.cursor::<()>(&());
                 chunks.next(&());
+                chunks.next(&());
+                self.chunks.append(chunks.suffix(&()), &());
+                self.check_invariants();
+                return;
             }
         }
 
-        self.chunks.append(chunks.suffix(&()), &());
+        self.chunks.append(rope.chunks.clone(), &());
         self.check_invariants();
     }
 

--- a/crates/rope/src/unclipped.rs
+++ b/crates/rope/src/unclipped.rs
@@ -1,4 +1,4 @@
-use crate::{ChunkSummary, TextDimension, TextSummary};
+use crate::{chunk::ChunkRef, ChunkSummary, TextDimension, TextSummary};
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -25,6 +25,10 @@ impl<'a, T: sum_tree::Dimension<'a, ChunkSummary>> sum_tree::Dimension<'a, Chunk
 impl<T: TextDimension> TextDimension for Unclipped<T> {
     fn from_text_summary(summary: &TextSummary) -> Self {
         Unclipped(T::from_text_summary(summary))
+    }
+
+    fn from_chunk(chunk: ChunkRef) -> Self {
+        Unclipped(T::from_chunk(chunk))
     }
 
     fn add_assign(&mut self, other: &Self) {

--- a/crates/rope/src/unclipped.rs
+++ b/crates/rope/src/unclipped.rs
@@ -1,4 +1,4 @@
-use crate::{chunk::ChunkRef, ChunkSummary, TextDimension, TextSummary};
+use crate::{chunk::ChunkSlice, ChunkSummary, TextDimension, TextSummary};
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -27,7 +27,7 @@ impl<T: TextDimension> TextDimension for Unclipped<T> {
         Unclipped(T::from_text_summary(summary))
     }
 
-    fn from_chunk(chunk: ChunkRef) -> Self {
+    fn from_chunk(chunk: ChunkSlice) -> Self {
         Unclipped(T::from_chunk(chunk))
     }
 

--- a/crates/sum_tree/Cargo.toml
+++ b/crates/sum_tree/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [dependencies]
 arrayvec = "0.7.1"
-rayon = "1.8"
+rayon.workspace = true
 log.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
This pull request introduces an index of Unicode codepoints, newlines and UTF-16 codepoints.

Benchmarks worth a thousand words:

```
push/4096               time:   [467.06 µs 470.07 µs 473.24 µs]
                        thrpt:  [8.2543 MiB/s 8.3100 MiB/s 8.3635 MiB/s]
                 change:
                        time:   [-4.1462% -3.0990% -2.0527%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0957% +3.1981% +4.3255%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
push/65536              time:   [1.4650 ms 1.4796 ms 1.4922 ms]
                        thrpt:  [41.885 MiB/s 42.242 MiB/s 42.664 MiB/s]
                 change:
                        time:   [-3.2871% -2.3489% -1.4555%] (p = 0.00 < 0.05)
                        thrpt:  [+1.4770% +2.4054% +3.3988%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low severe
  3 (3.00%) low mild

append/4096             time:   [729.00 ns 730.57 ns 732.14 ns]
                        thrpt:  [5.2103 GiB/s 5.2215 GiB/s 5.2327 GiB/s]
                 change:
                        time:   [-81.884% -81.836% -81.790%] (p = 0.00 < 0.05)
                        thrpt:  [+449.16% +450.53% +452.01%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe
append/65536            time:   [504.44 ns 505.58 ns 506.77 ns]
                        thrpt:  [120.44 GiB/s 120.72 GiB/s 121.00 GiB/s]
                 change:
                        time:   [-94.833% -94.807% -94.782%] (p = 0.00 < 0.05)
                        thrpt:  [+1816.3% +1825.8% +1835.5%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

slice/4096              time:   [29.661 µs 29.733 µs 29.816 µs]
                        thrpt:  [131.01 MiB/s 131.38 MiB/s 131.70 MiB/s]
                 change:
                        time:   [-48.833% -48.533% -48.230%] (p = 0.00 < 0.05)
                        thrpt:  [+93.161% +94.298% +95.440%]
                        Performance has improved.
slice/65536             time:   [588.00 µs 590.22 µs 592.17 µs]
                        thrpt:  [105.54 MiB/s 105.89 MiB/s 106.29 MiB/s]
                 change:
                        time:   [-45.599% -45.347% -45.099%] (p = 0.00 < 0.05)
                        thrpt:  [+82.147% +82.971% +83.821%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low severe
  1 (1.00%) high mild

bytes_in_range/4096     time:   [3.8630 µs 3.8811 µs 3.8994 µs]
                        thrpt:  [1001.8 MiB/s 1006.5 MiB/s 1011.2 MiB/s]
                 change:
                        time:   [+0.0600% +0.6000% +1.1833%] (p = 0.03 < 0.05)
                        thrpt:  [-1.1695% -0.5964% -0.0600%]
                        Change within noise threshold.
bytes_in_range/65536    time:   [98.178 µs 98.545 µs 98.931 µs]
                        thrpt:  [631.75 MiB/s 634.23 MiB/s 636.60 MiB/s]
                 change:
                        time:   [-0.6513% +0.7537% +2.2265%] (p = 0.30 > 0.05)
                        thrpt:  [-2.1780% -0.7481% +0.6555%]
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

chars/4096              time:   [878.91 ns 879.45 ns 880.06 ns]
                        thrpt:  [4.3346 GiB/s 4.3376 GiB/s 4.3403 GiB/s]
                 change:
                        time:   [+9.1679% +9.4000% +9.6304%] (p = 0.00 < 0.05)
                        thrpt:  [-8.7844% -8.5923% -8.3979%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
chars/65536             time:   [15.615 µs 15.691 µs 15.757 µs]
                        thrpt:  [3.8735 GiB/s 3.8899 GiB/s 3.9087 GiB/s]
                 change:
                        time:   [+5.4902% +5.9345% +6.4044%] (p = 0.00 < 0.05)
                        thrpt:  [-6.0190% -5.6021% -5.2045%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild

clip_point/4096         time:   [29.677 µs 29.835 µs 30.019 µs]
                        thrpt:  [130.13 MiB/s 130.93 MiB/s 131.63 MiB/s]
                 change:
                        time:   [-46.306% -45.866% -45.436%] (p = 0.00 < 0.05)
                        thrpt:  [+83.272% +84.728% +86.240%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
clip_point/65536        time:   [1.5933 ms 1.6116 ms 1.6311 ms]
                        thrpt:  [38.318 MiB/s 38.782 MiB/s 39.226 MiB/s]
                 change:
                        time:   [-30.388% -29.598% -28.717%] (p = 0.00 < 0.05)
                        thrpt:  [+40.286% +42.040% +43.653%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s

point_to_offset/4096    time:   [14.493 µs 14.591 µs 14.707 µs]
                        thrpt:  [265.61 MiB/s 267.72 MiB/s 269.52 MiB/s]
                 change:
                        time:   [-71.990% -71.787% -71.588%] (p = 0.00 < 0.05)
                        thrpt:  [+251.96% +254.45% +257.01%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
point_to_offset/65536   time:   [700.72 µs 713.75 µs 727.26 µs]
                        thrpt:  [85.939 MiB/s 87.566 MiB/s 89.194 MiB/s]
                 change:
                        time:   [-61.778% -61.015% -60.256%] (p = 0.00 < 0.05)
                        thrpt:  [+151.61% +156.51% +161.63%]
                        Performance has improved.
```

Calling `Rope::chars` got slightly slower but I don't think it's a big issue (we don't really call `chars` for an entire `Rope`). 

In a future pull request, I want to use the tab index (which we're not yet using) and the char index to make `TabMap` a lot faster.

Release Notes:

- N/A
