### PR TITLE
git_hosting_providers: Clean up tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,11 +4909,11 @@ dependencies = [
  "git",
  "gpui",
  "http_client",
+ "indoc",
  "pretty_assertions",
  "regex",
  "serde",
  "serde_json",
- "unindent",
  "url",
  "util",
 ]

--- a/crates/git_hosting_providers/Cargo.toml
+++ b/crates/git_hosting_providers/Cargo.toml
@@ -25,6 +25,6 @@ url.workspace = true
 util.workspace = true
 
 [dev-dependencies]
-unindent.workspace = true
+indoc.workspace = true
 serde_json.workspace = true
 pretty_assertions.workspace = true

--- a/crates/git_hosting_providers/src/providers/bitbucket.rs
+++ b/crates/git_hosting_providers/src/providers/bitbucket.rs
@@ -87,6 +87,7 @@ mod tests {
     use std::sync::Arc;
 
     use git::{parse_git_remote_url, GitHostingProviderRegistry};
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/crates/git_hosting_providers/src/providers/bitbucket.rs
+++ b/crates/git_hosting_providers/src/providers/bitbucket.rs
@@ -84,54 +84,62 @@ impl GitHostingProvider for Bitbucket {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use git::{parse_git_remote_url, GitHostingProviderRegistry};
     use pretty_assertions::assert_eq;
 
     use super::*;
 
     #[test]
-    fn test_parse_git_remote_url_bitbucket_https_with_username() {
-        let provider_registry = Arc::new(GitHostingProviderRegistry::new());
-        provider_registry.register_hosting_provider(Arc::new(Bitbucket));
-        let url = "https://thorstenballzed@bitbucket.org/thorstenzed/testingrepo.git";
-        let (provider, parsed) = parse_git_remote_url(provider_registry, url).unwrap();
-        assert_eq!(provider.name(), "Bitbucket");
-        assert_eq!(parsed.owner.as_ref(), "thorstenzed");
-        assert_eq!(parsed.repo.as_ref(), "testingrepo");
+    fn test_parse_remote_url_given_ssh_url() {
+        let parsed_remote = Bitbucket
+            .parse_remote_url("git@bitbucket.org:zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
     }
 
     #[test]
-    fn test_parse_git_remote_url_bitbucket_https_without_username() {
-        let provider_registry = Arc::new(GitHostingProviderRegistry::new());
-        provider_registry.register_hosting_provider(Arc::new(Bitbucket));
-        let url = "https://bitbucket.org/thorstenzed/testingrepo.git";
-        let (provider, parsed) = parse_git_remote_url(provider_registry, url).unwrap();
-        assert_eq!(provider.name(), "Bitbucket");
-        assert_eq!(parsed.owner.as_ref(), "thorstenzed");
-        assert_eq!(parsed.repo.as_ref(), "testingrepo");
+    fn test_parse_remote_url_given_https_url() {
+        let parsed_remote = Bitbucket
+            .parse_remote_url("https://bitbucket.org/zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
     }
 
     #[test]
-    fn test_parse_git_remote_url_bitbucket_git() {
-        let provider_registry = Arc::new(GitHostingProviderRegistry::new());
-        provider_registry.register_hosting_provider(Arc::new(Bitbucket));
-        let url = "git@bitbucket.org:thorstenzed/testingrepo.git";
-        let (provider, parsed) = parse_git_remote_url(provider_registry, url).unwrap();
-        assert_eq!(provider.name(), "Bitbucket");
-        assert_eq!(parsed.owner.as_ref(), "thorstenzed");
-        assert_eq!(parsed.repo.as_ref(), "testingrepo");
+    fn test_parse_remote_url_given_https_url_with_username() {
+        let parsed_remote = Bitbucket
+            .parse_remote_url("https://thorstenballzed@bitbucket.org/zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
     }
 
     #[test]
-    fn test_build_bitbucket_permalink_from_ssh_url() {
-        let remote = ParsedGitRemote {
-            owner: "thorstenzed".into(),
-            repo: "testingrepo".into(),
-        };
+    fn test_build_bitbucket_permalink() {
         let permalink = Bitbucket.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "f00b4r",
                 path: "main.rs",
@@ -139,18 +147,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://bitbucket.org/thorstenzed/testingrepo/src/f00b4r/main.rs";
+        let expected_url = "https://bitbucket.org/zed-industries/zed/src/f00b4r/main.rs";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_bitbucket_permalink_from_ssh_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "thorstenzed".into(),
-            repo: "testingrepo".into(),
-        };
+    fn test_build_bitbucket_permalink_with_single_line_selection() {
         let permalink = Bitbucket.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "f00b4r",
                 path: "main.rs",
@@ -158,19 +165,17 @@ mod tests {
             },
         );
 
-        let expected_url =
-            "https://bitbucket.org/thorstenzed/testingrepo/src/f00b4r/main.rs#lines-7";
+        let expected_url = "https://bitbucket.org/zed-industries/zed/src/f00b4r/main.rs#lines-7";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_bitbucket_permalink_from_ssh_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "thorstenzed".into(),
-            repo: "testingrepo".into(),
-        };
+    fn test_build_bitbucket_permalink_with_multi_line_selection() {
         let permalink = Bitbucket.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "f00b4r",
                 path: "main.rs",
@@ -179,7 +184,7 @@ mod tests {
         );
 
         let expected_url =
-            "https://bitbucket.org/thorstenzed/testingrepo/src/f00b4r/main.rs#lines-24:48";
+            "https://bitbucket.org/zed-industries/zed/src/f00b4r/main.rs#lines-24:48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }

--- a/crates/git_hosting_providers/src/providers/codeberg.rs
+++ b/crates/git_hosting_providers/src/providers/codeberg.rs
@@ -180,13 +180,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_codeberg_permalink_from_ssh_url() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
+    fn test_parse_remote_url_given_ssh_url() {
+        let parsed_remote = Codeberg
+            .parse_remote_url("git@codeberg.org:zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_https_url() {
+        let parsed_remote = Codeberg
+            .parse_remote_url("https://codeberg.org/zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_codeberg_permalink() {
         let permalink = Codeberg.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
                 path: "crates/editor/src/git/permalink.rs",
@@ -194,18 +223,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs";
+        let expected_url = "https://codeberg.org/zed-industries/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_codeberg_permalink_from_ssh_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_codeberg_permalink_with_single_line_selection() {
         let permalink = Codeberg.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
                 path: "crates/editor/src/git/permalink.rs",
@@ -213,18 +241,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs#L7";
+        let expected_url = "https://codeberg.org/zed-industries/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs#L7";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_codeberg_permalink_from_ssh_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_codeberg_permalink_with_multi_line_selection() {
         let permalink = Codeberg.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
                 path: "crates/editor/src/git/permalink.rs",
@@ -232,64 +259,7 @@ mod tests {
             },
         );
 
-        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs#L24-L48";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_codeberg_permalink_from_https_url() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Codeberg.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
-                path: "crates/zed/src/main.rs",
-                selection: None,
-            },
-        );
-
-        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/zed/src/main.rs";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_codeberg_permalink_from_https_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Codeberg.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
-                path: "crates/zed/src/main.rs",
-                selection: Some(6..6),
-            },
-        );
-
-        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/zed/src/main.rs#L7";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_codeberg_permalink_from_https_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Codeberg.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
-                path: "crates/zed/src/main.rs",
-                selection: Some(23..47),
-            },
-        );
-
-        let expected_url = "https://codeberg.org/rajveermalviya/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/zed/src/main.rs#L24-L48";
+        let expected_url = "https://codeberg.org/zed-industries/zed/src/commit/faa6f979be417239b2e070dbbf6392b909224e0b/crates/editor/src/git/permalink.rs#L24-L48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }

--- a/crates/git_hosting_providers/src/providers/codeberg.rs
+++ b/crates/git_hosting_providers/src/providers/codeberg.rs
@@ -175,6 +175,8 @@ impl GitHostingProvider for Codeberg {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -84,6 +84,8 @@ impl GitHostingProvider for Gitee {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -87,13 +87,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_gitee_permalink_from_ssh_url() {
-        let remote = ParsedGitRemote {
-            owner: "libkitten".into(),
-            repo: "zed".into(),
-        };
+    fn test_parse_remote_url_given_ssh_url() {
+        let parsed_remote = Gitee
+            .parse_remote_url("git@gitee.com:zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_https_url() {
+        let parsed_remote = Gitee
+            .parse_remote_url("https://gitee.com/zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_gitee_permalink() {
         let permalink = Gitee.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
                 path: "crates/editor/src/git/permalink.rs",
@@ -101,18 +130,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs";
+        let expected_url = "https://gitee.com/zed-industries/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_gitee_permalink_from_ssh_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "libkitten".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_gitee_permalink_with_single_line_selection() {
         let permalink = Gitee.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
                 path: "crates/editor/src/git/permalink.rs",
@@ -120,18 +148,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L7";
+        let expected_url = "https://gitee.com/zed-industries/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L7";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_gitee_permalink_from_ssh_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "libkitten".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_gitee_permalink_with_multi_line_selection() {
         let permalink = Gitee.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
                 path: "crates/editor/src/git/permalink.rs",
@@ -139,64 +166,7 @@ mod tests {
             },
         );
 
-        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L24-48";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_gitee_permalink_from_https_url() {
-        let remote = ParsedGitRemote {
-            owner: "libkitten".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Gitee.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-                path: "crates/zed/src/main.rs",
-                selection: None,
-            },
-        );
-
-        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_gitee_permalink_from_https_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "libkitten".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Gitee.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-                path: "crates/zed/src/main.rs",
-                selection: Some(6..6),
-            },
-        );
-
-        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs#L7";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_gitee_permalink_from_https_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "libkitten".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Gitee.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "e5fe811d7ad0fc26934edd76f891d20bdc3bb194",
-                path: "crates/zed/src/main.rs",
-                selection: Some(23..47),
-            },
-        );
-
-        let expected_url = "https://gitee.com/libkitten/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/zed/src/main.rs#L24-48";
+        let expected_url = "https://gitee.com/zed-industries/zed/blob/e5fe811d7ad0fc26934edd76f891d20bdc3bb194/crates/editor/src/git/permalink.rs#L24-48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -236,13 +236,30 @@ mod tests {
     }
 
     #[test]
-    fn test_build_github_permalink_from_ssh_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_github_permalink() {
         let permalink = Github.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
+            BuildPermalinkParams {
+                sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
+                path: "crates/zed/src/main.rs",
+                selection: None,
+            },
+        );
+
+        let expected_url = "https://github.com/zed-industries/zed/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs";
+        assert_eq!(permalink.to_string(), expected_url.to_string())
+    }
+
+    #[test]
+    fn test_build_github_permalink_with_single_line_selection() {
+        let permalink = Github.build_permalink(
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
                 path: "crates/editor/src/git/permalink.rs",
@@ -255,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_github_permalink_from_ssh_url_multi_line_selection() {
+    fn test_build_github_permalink_with_multi_line_selection() {
         let remote = ParsedGitRemote {
             owner: "zed-industries".into(),
             repo: "zed".into(),
@@ -270,63 +287,6 @@ mod tests {
         );
 
         let expected_url = "https://github.com/zed-industries/zed/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs#L24-L48";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_github_permalink_from_https_url() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Github.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-                path: "crates/zed/src/main.rs",
-                selection: None,
-            },
-        );
-
-        let expected_url = "https://github.com/zed-industries/zed/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_github_permalink_from_https_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Github.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-                path: "crates/zed/src/main.rs",
-                selection: Some(6..6),
-            },
-        );
-
-        let expected_url = "https://github.com/zed-industries/zed/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L7";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_github_permalink_from_https_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Github.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-                path: "crates/zed/src/main.rs",
-                selection: Some(23..47),
-            },
-        );
-
-        let expected_url = "https://github.com/zed-industries/zed/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L24-L48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -202,6 +202,36 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_parse_remote_url_given_ssh_url() {
+        let parsed_remote = Github
+            .parse_remote_url("git@github.com:zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_https_url() {
+        let parsed_remote = Github
+            .parse_remote_url("https://github.com/zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
     fn test_parse_remote_url_given_https_url_with_username() {
         let parsed_remote = Github
             .parse_remote_url("https://jlannister@github.com/some-org/some-repo.git")
@@ -273,12 +303,11 @@ mod tests {
 
     #[test]
     fn test_build_github_permalink_with_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
         let permalink = Github.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
                 path: "crates/editor/src/git/permalink.rs",

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -198,6 +198,7 @@ impl GitHostingProvider for Github {
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use pretty_assertions::assert_eq;
 
     use super::*;
 

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -197,8 +197,7 @@ impl GitHostingProvider for Github {
 
 #[cfg(test)]
 mod tests {
-    // TODO: Replace with `indoc`.
-    use unindent::Unindent;
+    use indoc::indoc;
 
     use super::*;
 
@@ -342,7 +341,7 @@ mod tests {
         assert!(Github.extract_pull_request(&remote, message).is_none());
 
         // Pull request number at end of first line
-        let message = r#"
+        let message = indoc! {r#"
             project panel: do not expand collapsed worktrees on "collapse all entries" (#10687)
 
             Fixes #10597
@@ -351,7 +350,7 @@ mod tests {
 
             - Fixed "project panel: collapse all entries" expanding collapsed worktrees.
             "#
-        .unindent();
+        };
 
         assert_eq!(
             Github
@@ -363,12 +362,12 @@ mod tests {
         );
 
         // Pull request number in middle of line, which we want to ignore
-        let message = r#"
+        let message = indoc! {r#"
             Follow-up to #10687 to fix problems
 
             See the original PR, this is a fix.
             "#
-        .unindent();
+        };
         assert_eq!(Github.extract_pull_request(&remote, &message), None);
     }
 }

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -131,13 +131,60 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_gitlab_permalink_from_ssh_url() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
+    fn test_parse_remote_url_given_ssh_url() {
+        let parsed_remote = Gitlab::new()
+            .parse_remote_url("git@gitlab.com:zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_https_url() {
+        let parsed_remote = Gitlab::new()
+            .parse_remote_url("https://gitlab.com/zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_self_hosted_ssh_url() {
+        let remote_url = "git@gitlab.my-enterprise.com:zed-industries/zed.git";
+
+        let parsed_remote = Gitlab::from_remote_url(remote_url)
+            .unwrap()
+            .parse_remote_url(remote_url)
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_gitlab_permalink() {
         let permalink = Gitlab::new().build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
                 path: "crates/editor/src/git/permalink.rs",
@@ -150,13 +197,12 @@ mod tests {
     }
 
     #[test]
-    fn test_build_gitlab_permalink_from_ssh_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_gitlab_permalink_with_single_line_selection() {
         let permalink = Gitlab::new().build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
                 path: "crates/editor/src/git/permalink.rs",
@@ -169,13 +215,12 @@ mod tests {
     }
 
     #[test]
-    fn test_build_gitlab_permalink_from_ssh_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_gitlab_permalink_with_multi_line_selection() {
         let permalink = Gitlab::new().build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
                 path: "crates/editor/src/git/permalink.rs",
@@ -184,63 +229,6 @@ mod tests {
         );
 
         let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7/crates/editor/src/git/permalink.rs#L24-48";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_gitlab_permalink_from_https_url() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Gitlab::new().build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-                path: "crates/zed/src/main.rs",
-                selection: None,
-            },
-        );
-
-        let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_gitlab_permalink_from_https_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Gitlab::new().build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-                path: "crates/zed/src/main.rs",
-                selection: Some(6..6),
-            },
-        );
-
-        let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L7";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_gitlab_permalink_from_https_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Gitlab::new().build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
-                path: "crates/zed/src/main.rs",
-                selection: Some(23..47),
-            },
-        );
-
-        let expected_url = "https://gitlab.com/zed-industries/zed/-/blob/b2efec9824c45fcc90c9a7eb107a50d1772a60aa/crates/zed/src/main.rs#L24-48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -234,15 +234,14 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_self_hosted_permalink_from_ssh_url() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
         let gitlab =
             Gitlab::from_remote_url("git@gitlab.some-enterprise.com:zed-industries/zed.git")
                 .unwrap();
         let permalink = gitlab.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "e6ebe7974deb6bb6cc0e2595c8ec31f0c71084b7",
                 path: "crates/editor/src/git/permalink.rs",
@@ -256,15 +255,14 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_self_hosted_permalink_from_https_url() {
-        let remote = ParsedGitRemote {
-            owner: "zed-industries".into(),
-            repo: "zed".into(),
-        };
         let gitlab =
             Gitlab::from_remote_url("https://gitlab-instance.big-co.com/zed-industries/zed.git")
                 .unwrap();
         let permalink = gitlab.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "b2efec9824c45fcc90c9a7eb107a50d1772a60aa",
                 path: "crates/zed/src/main.rs",

--- a/crates/git_hosting_providers/src/providers/sourcehut.rs
+++ b/crates/git_hosting_providers/src/providers/sourcehut.rs
@@ -39,7 +39,7 @@ impl GitHostingProvider for Sourcehut {
         }
 
         let mut path_segments = url.path_segments()?;
-        let owner = path_segments.next()?;
+        let owner = path_segments.next()?.trim_start_matches('~');
         // We don't trim the `.git` suffix here like we do elsewhere, as
         // sourcehut treats a repo with `.git` suffix as a separate repo.
         //
@@ -92,13 +92,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_sourcehut_permalink_from_ssh_url() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
+    fn test_parse_remote_url_given_ssh_url() {
+        let parsed_remote = Sourcehut
+            .parse_remote_url("git@git.sr.ht:~zed-industries/zed")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_ssh_url_with_git_suffix() {
+        let parsed_remote = Sourcehut
+            .parse_remote_url("git@git.sr.ht:~zed-industries/zed.git")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed.git".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_remote_url_given_https_url() {
+        let parsed_remote = Sourcehut
+            .parse_remote_url("https://git.sr.ht/~zed-industries/zed")
+            .unwrap();
+
+        assert_eq!(
+            parsed_remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_sourcehut_permalink() {
         let permalink = Sourcehut.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
                 path: "crates/editor/src/git/permalink.rs",
@@ -106,18 +150,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs";
+        let expected_url = "https://git.sr.ht/~zed-industries/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_sourcehut_permalink_from_ssh_url_with_git_prefix() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed.git".into(),
-        };
+    fn test_build_sourcehut_permalink_with_git_suffix() {
         let permalink = Sourcehut.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed.git".into(),
+            },
             BuildPermalinkParams {
                 sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
                 path: "crates/editor/src/git/permalink.rs",
@@ -125,18 +168,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://git.sr.ht/~rajveermalviya/zed.git/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs";
+        let expected_url = "https://git.sr.ht/~zed-industries/zed.git/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_sourcehut_permalink_from_ssh_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_sourcehut_permalink_with_single_line_selection() {
         let permalink = Sourcehut.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
                 path: "crates/editor/src/git/permalink.rs",
@@ -144,18 +186,17 @@ mod tests {
             },
         );
 
-        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs#L7";
+        let expected_url = "https://git.sr.ht/~zed-industries/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs#L7";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 
     #[test]
-    fn test_build_sourcehut_permalink_from_ssh_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
+    fn test_build_sourcehut_permalink_with_multi_line_selection() {
         let permalink = Sourcehut.build_permalink(
-            remote,
+            ParsedGitRemote {
+                owner: "zed-industries".into(),
+                repo: "zed".into(),
+            },
             BuildPermalinkParams {
                 sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
                 path: "crates/editor/src/git/permalink.rs",
@@ -163,64 +204,7 @@ mod tests {
             },
         );
 
-        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs#L24-48";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_sourcehut_permalink_from_https_url() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Sourcehut.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
-                path: "crates/zed/src/main.rs",
-                selection: None,
-            },
-        );
-
-        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/zed/src/main.rs";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_sourcehut_permalink_from_https_url_single_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Sourcehut.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
-                path: "crates/zed/src/main.rs",
-                selection: Some(6..6),
-            },
-        );
-
-        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/zed/src/main.rs#L7";
-        assert_eq!(permalink.to_string(), expected_url.to_string())
-    }
-
-    #[test]
-    fn test_build_sourcehut_permalink_from_https_url_multi_line_selection() {
-        let remote = ParsedGitRemote {
-            owner: "rajveermalviya".into(),
-            repo: "zed".into(),
-        };
-        let permalink = Sourcehut.build_permalink(
-            remote,
-            BuildPermalinkParams {
-                sha: "faa6f979be417239b2e070dbbf6392b909224e0b",
-                path: "crates/zed/src/main.rs",
-                selection: Some(23..47),
-            },
-        );
-
-        let expected_url = "https://git.sr.ht/~rajveermalviya/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/zed/src/main.rs#L24-48";
+        let expected_url = "https://git.sr.ht/~zed-industries/zed/tree/faa6f979be417239b2e070dbbf6392b909224e0b/item/crates/editor/src/git/permalink.rs#L24-48";
         assert_eq!(permalink.to_string(), expected_url.to_string())
     }
 }

--- a/crates/git_hosting_providers/src/providers/sourcehut.rs
+++ b/crates/git_hosting_providers/src/providers/sourcehut.rs
@@ -89,6 +89,8 @@ impl GitHostingProvider for Sourcehut {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
This PR cleans up the tests for the various Git hosting providers.

These tests had rotted a bit over time, to the point that some of them weren't even testing what they claimed anymore.

Release Notes:

- N/A
