### PR TITLE
Fix notebook cell-height when soft-wrapping lines

### DIFF
--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -553,9 +553,6 @@ impl RunnableCell for CodeCell {
 
 impl Render for CodeCell {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let lines = self.source.lines().count();
-        let height = lines as f32 * cx.line_height();
-
         v_flex()
             .size_full()
             // TODO: Move base cell render into trait impl so we don't have to repeat this
@@ -582,7 +579,7 @@ impl Render for CodeCell {
                                 .border_1()
                                 .border_color(cx.theme().colors().border)
                                 .bg(cx.theme().colors().editor_background)
-                                .child(div().h(height).w_full().child(self.editor.clone())),
+                                .child(div().w_full().child(self.editor.clone())),
                         ),
                     ),
             )


### PR DESCRIPTION
I was curious and had to briefly checkout the notebook UI from #19756 😇 🎉 

This fixes a minor UI issue when code lines are wrapped by the editor.


`main` | This PR
---|---
<img width="504" alt="Screenshot 2024-10-29 at 23 55 26" src="https://github.com/user-attachments/assets/4e39d49c-ea43-43ba-a0e5-5266076f979c"> | <img width="504" alt="Screenshot 2024-10-29 at 23 56 02" src="https://github.com/user-attachments/assets/7f6421be-bfee-4cc4-868f-75acd8024318">


Release Notes:

- N/A
