### PR TITLE
Add missing full-size styles for panes

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2696,6 +2696,7 @@ impl Render for Pane {
                     .flex_1()
                     .relative()
                     .group("")
+                    .overflow_hidden()
                     .on_drag_move::<DraggedTab>(cx.listener(Self::handle_drag_move))
                     .on_drag_move::<DraggedSelection>(cx.listener(Self::handle_drag_move))
                     .when(is_local, |div| {
@@ -2704,6 +2705,8 @@ impl Render for Pane {
                     .map(|div| {
                         if let Some(item) = self.active_item() {
                             div.v_flex()
+                                .size_full()
+                                .overflow_hidden()
                                 .child(self.toolbar.clone())
                                 .child(item.to_any())
                         } else {


### PR DESCRIPTION
As we don't use scrolling flex layouts directly in panes that often, the methods that would normally be applied to containers that should fill the space weren't applied here.

Should help un-stuck #19872's layout issue, but I'm merging this change separately in case it creates some other layout issue in panes.

Release Notes:

- N/A
