### PR TITLE
Use theme families to refine user themes

### DIFF
--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -12,9 +12,9 @@ use refineable::Refineable;
 use util::ResultExt;
 
 use crate::{
-    try_parse_color, AccentColors, Appearance, AppearanceContent, PlayerColors, StatusColors,
-    SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeContent, ThemeFamily, ThemeFamilyContent,
-    ThemeStyles,
+    refine_theme_family, try_parse_color, AccentColors, Appearance, AppearanceContent,
+    PlayerColors, StatusColors, SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeContent,
+    ThemeFamily, ThemeFamilyContent, ThemeStyles,
 };
 
 /// The metadata for a theme.
@@ -97,87 +97,10 @@ impl ThemeRegistry {
     #[allow(unused)]
     fn insert_user_theme_families(&self, families: impl IntoIterator<Item = ThemeFamilyContent>) {
         for family in families.into_iter() {
-            self.insert_user_themes(family.themes);
+            let refined_family = refine_theme_family(family);
+
+            self.insert_themes(refined_family.themes);
         }
-    }
-
-    /// Inserts user themes into the registry.
-    pub fn insert_user_themes(&self, themes: impl IntoIterator<Item = ThemeContent>) {
-        self.insert_themes(themes.into_iter().map(|user_theme| {
-            let mut theme_colors = match user_theme.appearance {
-                AppearanceContent::Light => ThemeColors::light(),
-                AppearanceContent::Dark => ThemeColors::dark(),
-            };
-            theme_colors.refine(&user_theme.style.theme_colors_refinement());
-
-            let mut status_colors = match user_theme.appearance {
-                AppearanceContent::Light => StatusColors::light(),
-                AppearanceContent::Dark => StatusColors::dark(),
-            };
-            status_colors.refine(&user_theme.style.status_colors_refinement());
-
-            let mut player_colors = match user_theme.appearance {
-                AppearanceContent::Light => PlayerColors::light(),
-                AppearanceContent::Dark => PlayerColors::dark(),
-            };
-            player_colors.merge(&user_theme.style.players);
-
-            let mut accent_colors = match user_theme.appearance {
-                AppearanceContent::Light => AccentColors::light(),
-                AppearanceContent::Dark => AccentColors::dark(),
-            };
-            accent_colors.merge(&user_theme.style.accents);
-
-            let syntax_highlights = user_theme
-                .style
-                .syntax
-                .iter()
-                .map(|(syntax_token, highlight)| {
-                    (
-                        syntax_token.clone(),
-                        HighlightStyle {
-                            color: highlight
-                                .color
-                                .as_ref()
-                                .and_then(|color| try_parse_color(color).ok()),
-                            background_color: highlight
-                                .background_color
-                                .as_ref()
-                                .and_then(|color| try_parse_color(color).ok()),
-                            font_style: highlight.font_style.map(Into::into),
-                            font_weight: highlight.font_weight.map(Into::into),
-                            ..Default::default()
-                        },
-                    )
-                })
-                .collect::<Vec<_>>();
-            let syntax_theme =
-                SyntaxTheme::merge(Arc::new(SyntaxTheme::default()), syntax_highlights);
-
-            let window_background_appearance = user_theme
-                .style
-                .window_background_appearance
-                .map(Into::into)
-                .unwrap_or_default();
-
-            Theme {
-                id: uuid::Uuid::new_v4().to_string(),
-                name: user_theme.name.into(),
-                appearance: match user_theme.appearance {
-                    AppearanceContent::Light => Appearance::Light,
-                    AppearanceContent::Dark => Appearance::Dark,
-                },
-                styles: ThemeStyles {
-                    system: SystemColors::default(),
-                    window_background_appearance,
-                    accents: accent_colors,
-                    colors: theme_colors,
-                    status: status_colors,
-                    player: player_colors,
-                    syntax: syntax_theme,
-                },
-            }
-        }));
     }
 
     /// Removes the themes with the given names from the registry.

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -6,16 +6,11 @@ use collections::HashMap;
 use derive_more::{Deref, DerefMut};
 use fs::Fs;
 use futures::StreamExt;
-use gpui::{AppContext, AssetSource, Global, HighlightStyle, SharedString};
+use gpui::{AppContext, AssetSource, Global, SharedString};
 use parking_lot::RwLock;
-use refineable::Refineable;
 use util::ResultExt;
 
-use crate::{
-    refine_theme_family, try_parse_color, AccentColors, Appearance, AppearanceContent,
-    PlayerColors, StatusColors, SyntaxTheme, SystemColors, Theme, ThemeColors, ThemeContent,
-    ThemeFamily, ThemeFamilyContent, ThemeStyles,
-};
+use crate::{refine_theme_family, Appearance, Theme, ThemeFamily, ThemeFamilyContent};
 
 /// The metadata for a theme.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR changes the way we load user themes into the ThemeRegistry. 

Rather than directly pass a theme family's themes to `insert_user_themes`, instead we use the new `refine_theme_family ` and `ThemeFamily::refine_theme`.

This PR should have net zero change to themes today, but sets up enabling theme variables. We need to do it this way so each theme has access to it's family when it is refined.

Release Notes:

- N/A
