### PR TITLE
vim: Add vif/vaf (for Rust)

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -404,7 +404,8 @@
       "shift-b": "vim::CurlyBrackets",
       "<": "vim::AngleBrackets",
       ">": "vim::AngleBrackets",
-      "a": "vim::Argument"
+      "a": "vim::Argument",
+      "f": "vim::OutlineObject"
     }
   },
   {

--- a/crates/languages/src/rust/outline.scm
+++ b/crates/languages/src/rust/outline.scm
@@ -31,7 +31,8 @@
     (visibility_modifier)? @context
     (function_modifiers)? @context
     "fn" @context
-    name: (_) @name) @item
+    name: (_) @name
+    body: (_ "{" @open (_)* "}" @close)) @item
 
 (function_signature_item
     (visibility_modifier)? @context


### PR DESCRIPTION
TODO: 

Currently this reuses our outline queries, but it would be better to have something more specific.
Perhaps we could import treesitter-nvim's, or build our own for every language..


Release Notes:

- vim: Add support for `vaf`/`vif`
