### PR TITLE
Add scrollbars to outline panel

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -414,6 +414,23 @@
       // 2. Never show indent guides:
       //    "never"
       "show": "always"
+    },
+    /// Scrollbar-related settings
+    "scrollbar": {
+      /// When to show the scrollbar in the project panel.
+      /// This setting can take four values:
+      ///
+      /// 1. null (default): Inherit editor settings
+      /// 2. Show the scrollbar if there's important information or
+      ///    follow the system's configured behavior (default):
+      ///   "auto"
+      /// 3. Match the system's configured behavior:
+      ///    "system"
+      /// 4. Always show the scrollbar:
+      ///    "always"
+      /// 5. Never show the scrollbar:
+      ///    "never"
+      "show": null
     }
   },
   "collaboration_panel": {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -3841,6 +3841,7 @@ impl OutlinePanel {
 
             v_flex()
                 .flex_1()
+                .justify_center()
                 .size_full()
                 .child(h_flex().justify_center().child(Label::new(header)))
                 .when_some(query.clone(), |panel, query| {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -27,9 +27,10 @@ use gpui::{
     actions, anchored, deferred, div, impl_actions, point, px, size, uniform_list, Action,
     AnyElement, AppContext, AssetSource, AsyncWindowContext, Bounds, ClipboardItem, DismissEvent,
     Div, ElementId, EventEmitter, FocusHandle, FocusableView, HighlightStyle, InteractiveElement,
-    IntoElement, KeyContext, Model, MouseButton, MouseDownEvent, ParentElement, Pixels, Point,
-    Render, SharedString, Stateful, StatefulInteractiveElement as _, Styled, Subscription, Task,
-    UniformListScrollHandle, View, ViewContext, VisualContext, WeakView, WindowContext,
+    IntoElement, KeyContext, ListHorizontalSizingBehavior, ListSizingBehavior, Model, MouseButton,
+    MouseDownEvent, ParentElement, Pixels, Point, Render, SharedString, Stateful,
+    StatefulInteractiveElement as _, Styled, Subscription, Task, UniformListScrollHandle, View,
+    ViewContext, VisualContext, WeakView, WindowContext,
 };
 use itertools::Itertools;
 use language::{BufferId, BufferSnapshot, OffsetRangeExt, OutlineItem};
@@ -4155,6 +4156,8 @@ impl Render for OutlinePanel {
                         }
                     })
                     .size_full()
+                    .with_sizing_behavior(ListSizingBehavior::Infer)
+                    .with_horizontal_sizing_behavior(ListHorizontalSizingBehavior::Unconstrained)
                     .with_width_from_item(self.max_width_item_index)
                     .track_scroll(self.scroll_handle.clone())
                     .when(show_indent_guides, |list| {
@@ -4229,6 +4232,7 @@ impl Render for OutlinePanel {
         }))
         .child(
             v_flex().child(horizontal_separator(cx)).child(
+                // TODO kb rework, has to be below the panel, to avoid scroll overlaps
                 h_flex().p_2().child(self.filter_editor.clone()).child(
                     div().child(
                         IconButton::new(

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4266,12 +4266,10 @@ impl Render for OutlinePanel {
             .when_some(search_query, |outline_panel, search_state| {
                 outline_panel.child(
                     v_flex()
-                        .w_full()
-                        .flex_none()
-                        .mx_2()
                         .child(
                             Label::new(format!("Searching: '{}'", search_state.query))
-                                .color(Color::Muted),
+                                .color(Color::Muted)
+                                .mx_2(),
                         )
                         .child(horizontal_separator(cx)),
                 )

--- a/crates/outline_panel/src/outline_panel_settings.rs
+++ b/crates/outline_panel/src/outline_panel_settings.rs
@@ -1,3 +1,4 @@
+use editor::ShowScrollbar;
 use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -29,6 +30,23 @@ pub struct OutlinePanelSettings {
     pub indent_guides: IndentGuidesSettings,
     pub auto_reveal_entries: bool,
     pub auto_fold_dirs: bool,
+    pub scrollbar: ScrollbarSettings,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ScrollbarSettings {
+    /// When to show the scrollbar in the project panel.
+    ///
+    /// Default: inherits editor scrollbar settings
+    pub show: Option<ShowScrollbar>,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ScrollbarSettingsContent {
+    /// When to show the scrollbar in the project panel.
+    ///
+    /// Default: inherits editor scrollbar settings
+    pub show: Option<Option<ShowScrollbar>>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -85,6 +103,9 @@ pub struct OutlinePanelSettingsContent {
     pub auto_fold_dirs: Option<bool>,
     /// Settings related to indent guides in the outline panel.
     pub indent_guides: Option<IndentGuidesSettingsContent>,
+    /// Scrollbar-related settings
+    pub scrollbar: Option<ScrollbarSettingsContent>,
+
 }
 
 impl Settings for OutlinePanelSettings {

--- a/crates/outline_panel/src/outline_panel_settings.rs
+++ b/crates/outline_panel/src/outline_panel_settings.rs
@@ -105,7 +105,6 @@ pub struct OutlinePanelSettingsContent {
     pub indent_guides: Option<IndentGuidesSettingsContent>,
     /// Scrollbar-related settings
     pub scrollbar: Option<ScrollbarSettingsContent>,
-
 }
 
 impl Settings for OutlinePanelSettings {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2271,6 +2271,9 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   "auto_fold_dirs": true,
   "indent_guides": {
     "show": "always"
+  },
+  "scrollbar": {
+    "show": null
   }
 }
 ```


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/15324

![image](https://github.com/user-attachments/assets/4f32d585-9bd2-46be-8234-3658a71906ee)

Repeats the approach used in the project panel.

Release Notes:

- Added scrollbars to outline panel
