### PR TITLE
Trim whitespace from base64 encoded image data before decoding it

### DIFF
--- a/crates/repl/src/outputs/image.rs
+++ b/crates/repl/src/outputs/image.rs
@@ -16,7 +16,7 @@ pub struct ImageView {
 
 impl ImageView {
     pub fn from(base64_encoded_data: &str) -> Result<Self> {
-        let bytes = BASE64_STANDARD.decode(base64_encoded_data)?;
+        let bytes = BASE64_STANDARD.decode(base64_encoded_data.trim())?;
 
         let format = image::guess_format(&bytes)?;
         let mut data = image::load_from_memory_with_format(&bytes, format)?.into_rgba8();


### PR DESCRIPTION
Closes #17956
Closes #16330

This fix is for both REPL (released) and notebook (unreleased)

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/bd046f0f-3ad1-4c25-b3cb-114e008c2a69">

Release Notes:

- Fixed image support in REPL for certain versions of matplotlib that included preceding and/or trailing whitespace in the base64 image data