### PR TITLE
go: Add `go-generate` runnables and tasks

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -498,7 +498,6 @@ impl ContextProvider for GoContextProvider {
                 label: "go test ./...".into(),
                 command: "go".into(),
                 args: vec!["test".into(), "./...".into()],
-                cwd: package_cwd.clone(),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
@@ -547,6 +546,20 @@ impl ContextProvider for GoContextProvider {
                 args: vec!["run".into(), ".".into()],
                 cwd: package_cwd.clone(),
                 tags: vec!["go-main".to_owned()],
+                ..TaskTemplate::default()
+            },
+            TaskTemplate {
+                label: format!("go generate {}", GO_PACKAGE_TASK_VARIABLE.template_value()),
+                command: "go".into(),
+                args: vec!["generate".into()],
+                cwd: package_cwd.clone(),
+                tags: vec!["go-generate".to_owned()],
+                ..TaskTemplate::default()
+            },
+            TaskTemplate {
+                label: format!("go generate ./..."),
+                command: "go".into(),
+                args: vec!["generate".into(), "./...".into()],
                 ..TaskTemplate::default()
             },
         ]))

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -498,6 +498,7 @@ impl ContextProvider for GoContextProvider {
                 label: "go test ./...".into(),
                 command: "go".into(),
                 args: vec!["test".into(), "./...".into()],
+                cwd: package_cwd.clone(),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
@@ -557,9 +558,10 @@ impl ContextProvider for GoContextProvider {
                 ..TaskTemplate::default()
             },
             TaskTemplate {
-                label: format!("go generate ./..."),
+                label: "go generate ./...".into(),
                 command: "go".into(),
                 args: vec!["generate".into(), "./...".into()],
+                cwd: package_cwd.clone(),
                 ..TaskTemplate::default()
             },
         ]))

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -7,6 +7,13 @@
   (#set! tag go-test)
 )
 
+; `go:generate` comments
+(
+    ((comment) @_comment @run
+    (#match? @_comment "^//go:generate"))
+    (#set! tag go-generate)
+)
+
 ; `t.Run`
 (
   (


### PR DESCRIPTION
I was missing the `go generate` runnable from other editors so I figured I'd implement one here! Now, comments of the form `//go:generate` can prompt for the `go generate <package>` task. Meanwhile, I've also added a global `go generate ./...` task.

~When making the global task, I noticed that the existing `go test ./...` task runs tests in subdirectories of the CWD of the active editor, whereas I would really expect it to run all tests across my project. I have changed to use the latter behavior (run relative to project root) for both `go generate ./...` and `go test ./...`. Please let me know if the prior behavior was intended, and I can revert.~

Release Notes:

- Added runnable and tasks for `go generate` commands