### PR TITLE
assistant: Implement `/selection` slash command

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -44,7 +44,8 @@ use settings::{update_settings_file, Settings, SettingsStore};
 use slash_command::{
     auto_command, cargo_workspace_command, context_server_command, default_command, delta_command,
     diagnostics_command, docs_command, fetch_command, file_command, now_command, project_command,
-    prompt_command, search_command, symbols_command, tab_command, terminal_command,
+    prompt_command, search_command, selection_command, symbols_command, tab_command,
+    terminal_command,
 };
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -436,6 +437,7 @@ fn register_slash_commands(prompt_builder: Option<Arc<PromptBuilder>>, cx: &mut 
     slash_command_registry
         .register_command(cargo_workspace_command::CargoWorkspaceSlashCommand, true);
     slash_command_registry.register_command(prompt_command::PromptSlashCommand, true);
+    slash_command_registry.register_command(selection_command::SelectionCommand, true);
     slash_command_registry.register_command(default_command::DefaultSlashCommand, false);
     slash_command_registry.register_command(terminal_command::TerminalSlashCommand, true);
     slash_command_registry.register_command(now_command::NowSlashCommand, false);

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2973,97 +2973,11 @@ impl ContextEditor {
         let Some(panel) = workspace.panel::<AssistantPanel>(cx) else {
             return;
         };
-        let Some(editor) = workspace
-            .active_item(cx)
-            .and_then(|item| item.act_as::<Editor>(cx))
-        else {
+
+        let Some(creases) = selections_creases(workspace, cx) else {
             return;
         };
 
-        let mut creases = vec![];
-        editor.update(cx, |editor, cx| {
-            let selections = editor.selections.all_adjusted(cx);
-            let buffer = editor.buffer().read(cx).snapshot(cx);
-            for selection in selections {
-                let range = editor::ToOffset::to_offset(&selection.start, &buffer)
-                    ..editor::ToOffset::to_offset(&selection.end, &buffer);
-                let selected_text = buffer.text_for_range(range.clone()).collect::<String>();
-                if selected_text.is_empty() {
-                    continue;
-                }
-                let start_language = buffer.language_at(range.start);
-                let end_language = buffer.language_at(range.end);
-                let language_name = if start_language == end_language {
-                    start_language.map(|language| language.code_fence_block_name())
-                } else {
-                    None
-                };
-                let language_name = language_name.as_deref().unwrap_or("");
-                let filename = buffer
-                    .file_at(selection.start)
-                    .map(|file| file.full_path(cx));
-                let text = if language_name == "markdown" {
-                    selected_text
-                        .lines()
-                        .map(|line| format!("> {}", line))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                } else {
-                    let start_symbols = buffer
-                        .symbols_containing(selection.start, None)
-                        .map(|(_, symbols)| symbols);
-                    let end_symbols = buffer
-                        .symbols_containing(selection.end, None)
-                        .map(|(_, symbols)| symbols);
-
-                    let outline_text = if let Some((start_symbols, end_symbols)) =
-                        start_symbols.zip(end_symbols)
-                    {
-                        Some(
-                            start_symbols
-                                .into_iter()
-                                .zip(end_symbols)
-                                .take_while(|(a, b)| a == b)
-                                .map(|(a, _)| a.text)
-                                .collect::<Vec<_>>()
-                                .join(" > "),
-                        )
-                    } else {
-                        None
-                    };
-
-                    let line_comment_prefix = start_language
-                        .and_then(|l| l.default_scope().line_comment_prefixes().first().cloned());
-
-                    let fence = codeblock_fence_for_path(
-                        filename.as_deref(),
-                        Some(selection.start.row..=selection.end.row),
-                    );
-
-                    if let Some((line_comment_prefix, outline_text)) =
-                        line_comment_prefix.zip(outline_text)
-                    {
-                        let breadcrumb =
-                            format!("{line_comment_prefix}Excerpt from: {outline_text}\n");
-                        format!("{fence}{breadcrumb}{selected_text}\n```")
-                    } else {
-                        format!("{fence}{selected_text}\n```")
-                    }
-                };
-                let crease_title = if let Some(path) = filename {
-                    let start_line = selection.start.row + 1;
-                    let end_line = selection.end.row + 1;
-                    if start_line == end_line {
-                        format!("{}, Line {}", path.display(), start_line)
-                    } else {
-                        format!("{}, Lines {} to {}", path.display(), start_line, end_line)
-                    }
-                } else {
-                    "Quoted selection".to_string()
-                };
-                creases.push((text, crease_title));
-            }
-        });
         if creases.is_empty() {
             return;
         }
@@ -3952,6 +3866,99 @@ fn find_surrounding_code_block(snapshot: &BufferSnapshot, offset: usize) -> Opti
     }
 
     None
+}
+
+pub fn selections_creases(
+    workspace: &mut workspace::Workspace,
+    cx: &mut ViewContext<Workspace>,
+) -> Option<Vec<(String, String)>> {
+    let editor = workspace
+        .active_item(cx)
+        .and_then(|item| item.act_as::<Editor>(cx))?;
+
+    let mut creases = vec![];
+    editor.update(cx, |editor, cx| {
+        let selections = editor.selections.all_adjusted(cx);
+        let buffer = editor.buffer().read(cx).snapshot(cx);
+        for selection in selections {
+            let range = editor::ToOffset::to_offset(&selection.start, &buffer)
+                ..editor::ToOffset::to_offset(&selection.end, &buffer);
+            let selected_text = buffer.text_for_range(range.clone()).collect::<String>();
+            if selected_text.is_empty() {
+                continue;
+            }
+            let start_language = buffer.language_at(range.start);
+            let end_language = buffer.language_at(range.end);
+            let language_name = if start_language == end_language {
+                start_language.map(|language| language.code_fence_block_name())
+            } else {
+                None
+            };
+            let language_name = language_name.as_deref().unwrap_or("");
+            let filename = buffer
+                .file_at(selection.start)
+                .map(|file| file.full_path(cx));
+            let text = if language_name == "markdown" {
+                selected_text
+                    .lines()
+                    .map(|line| format!("> {}", line))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            } else {
+                let start_symbols = buffer
+                    .symbols_containing(selection.start, None)
+                    .map(|(_, symbols)| symbols);
+                let end_symbols = buffer
+                    .symbols_containing(selection.end, None)
+                    .map(|(_, symbols)| symbols);
+
+                let outline_text =
+                    if let Some((start_symbols, end_symbols)) = start_symbols.zip(end_symbols) {
+                        Some(
+                            start_symbols
+                                .into_iter()
+                                .zip(end_symbols)
+                                .take_while(|(a, b)| a == b)
+                                .map(|(a, _)| a.text)
+                                .collect::<Vec<_>>()
+                                .join(" > "),
+                        )
+                    } else {
+                        None
+                    };
+
+                let line_comment_prefix = start_language
+                    .and_then(|l| l.default_scope().line_comment_prefixes().first().cloned());
+
+                let fence = codeblock_fence_for_path(
+                    filename.as_deref(),
+                    Some(selection.start.row..=selection.end.row),
+                );
+
+                if let Some((line_comment_prefix, outline_text)) =
+                    line_comment_prefix.zip(outline_text)
+                {
+                    let breadcrumb = format!("{line_comment_prefix}Excerpt from: {outline_text}\n");
+                    format!("{fence}{breadcrumb}{selected_text}\n```")
+                } else {
+                    format!("{fence}{selected_text}\n```")
+                }
+            };
+            let crease_title = if let Some(path) = filename {
+                let start_line = selection.start.row + 1;
+                let end_line = selection.end.row + 1;
+                if start_line == end_line {
+                    format!("{}, Line {}", path.display(), start_line)
+                } else {
+                    format!("{}, Lines {} to {}", path.display(), start_line, end_line)
+                }
+            } else {
+                "Quoted selection".to_string()
+            };
+            creases.push((text, crease_title));
+        }
+    });
+    Some(creases)
 }
 
 fn render_fold_icon_button(

--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -31,6 +31,7 @@ pub mod now_command;
 pub mod project_command;
 pub mod prompt_command;
 pub mod search_command;
+pub mod selection_command;
 pub mod streaming_example_command;
 pub mod symbols_command;
 pub mod tab_command;

--- a/crates/assistant/src/slash_command/selection_command.rs
+++ b/crates/assistant/src/slash_command/selection_command.rs
@@ -4,8 +4,8 @@ use assistant_slash_command::{SlashCommand, SlashCommandContent, SlashCommandEve
 use futures::stream;
 use gpui::Task;
 use smol::stream::StreamExt;
-use ui::IconName;
 
+use ui::IconName;
 pub(crate) struct SelectionCommand;
 
 impl SlashCommand for SelectionCommand {
@@ -14,11 +14,7 @@ impl SlashCommand for SelectionCommand {
     }
 
     fn description(&self) -> String {
-        "Insert editor selection".into()
-    }
-
-    fn icon(&self) -> IconName {
-        IconName::Quote
+        "Quote your active selection".into()
     }
 
     fn menu_text(&self) -> String {

--- a/crates/assistant/src/slash_command/selection_command.rs
+++ b/crates/assistant/src/slash_command/selection_command.rs
@@ -19,6 +19,10 @@ impl SlashCommand for SelectionCommand {
         "selection".into()
     }
 
+    fn label(&self, _cx: &AppContext) -> CodeLabel {
+        CodeLabel::plain(self.name(), None)
+    }
+
     fn description(&self) -> String {
         "Insert editor selection".into()
     }
@@ -31,6 +35,14 @@ impl SlashCommand for SelectionCommand {
         self.description()
     }
 
+    fn requires_argument(&self) -> bool {
+        false
+    }
+
+    fn accepts_arguments(&self) -> bool {
+        true
+    }
+
     fn complete_argument(
         self: Arc<Self>,
         _arguments: &[String],
@@ -39,10 +51,6 @@ impl SlashCommand for SelectionCommand {
         _cx: &mut WindowContext,
     ) -> Task<Result<Vec<ArgumentCompletion>>> {
         Task::ready(Err(anyhow!("this command does not require argument")))
-    }
-
-    fn requires_argument(&self) -> bool {
-        false
     }
 
     fn run(
@@ -86,13 +94,5 @@ impl SlashCommand for SelectionCommand {
         let result = futures::stream::iter(events).boxed();
 
         Task::ready(Ok(result))
-    }
-
-    fn label(&self, _cx: &AppContext) -> CodeLabel {
-        CodeLabel::plain(self.name(), None)
-    }
-
-    fn accepts_arguments(&self) -> bool {
-        self.requires_argument()
     }
 }

--- a/crates/assistant/src/slash_command/selection_command.rs
+++ b/crates/assistant/src/slash_command/selection_command.rs
@@ -1,0 +1,88 @@
+use super::super::assistant_panel::selections_creases;
+use anyhow::anyhow;
+use assistant_slash_command::{SlashCommand, SlashCommandContent, SlashCommandEvent};
+use futures::stream;
+use gpui::Task;
+use smol::stream::StreamExt;
+
+use ui::IconName;
+pub(crate) struct SelectionCommand;
+
+impl SlashCommand for SelectionCommand {
+    fn name(&self) -> String {
+        "selection".into()
+    }
+
+    fn description(&self) -> String {
+        "Quote your active selection".into()
+    }
+
+    fn menu_text(&self) -> String {
+        self.description()
+    }
+
+    fn complete_argument(
+        self: std::sync::Arc<Self>,
+        _arguments: &[String],
+        _cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        _workspace: Option<gpui::WeakView<workspace::Workspace>>,
+        _cx: &mut ui::WindowContext,
+    ) -> gpui::Task<gpui::Result<Vec<assistant_slash_command::ArgumentCompletion>>> {
+        gpui::Task::ready(Err(anyhow!("this command does not require argument")))
+    }
+
+    fn requires_argument(&self) -> bool {
+        false
+    }
+
+    fn run(
+        self: std::sync::Arc<Self>,
+        _arguments: &[String],
+        _context_slash_command_output_sections: &[assistant_slash_command::SlashCommandOutputSection<language::Anchor>],
+        _context_buffer: language::BufferSnapshot,
+        workspace: gpui::WeakView<workspace::Workspace>,
+        _delegate: Option<std::sync::Arc<dyn language::LspAdapterDelegate>>,
+        cx: &mut ui::WindowContext,
+    ) -> gpui::Task<assistant_slash_command::SlashCommandResult> {
+        let mut events = vec![];
+
+        let Some(creases) = workspace
+            .update(cx, selections_creases)
+            .unwrap_or_else(|e| {
+                events.push(Err(e));
+                None
+            })
+        else {
+            return Task::ready(Err(anyhow!("no active selection")));
+        };
+
+        for (text, b) in creases.iter() {
+            events.push(Ok(SlashCommandEvent::StartSection {
+                icon: IconName::TextSnippet,
+                label: b.clone().into(),
+                metadata: None,
+            }));
+            events.push(Ok(SlashCommandEvent::Content(SlashCommandContent::Text {
+                text: text.into(),
+                run_commands_in_text: false,
+            })));
+            events.push(Ok(SlashCommandEvent::EndSection { metadata: None }));
+            events.push(Ok(SlashCommandEvent::Content(SlashCommandContent::Text {
+                text: "\n".into(),
+                run_commands_in_text: false,
+            })));
+        }
+
+        let result = stream::iter(events).boxed();
+
+        Task::ready(Ok(result))
+    }
+
+    fn label(&self, _cx: &gpui::AppContext) -> language::CodeLabel {
+        language::CodeLabel::plain(self.name(), None)
+    }
+
+    fn accepts_arguments(&self) -> bool {
+        self.requires_argument()
+    }
+}

--- a/crates/assistant/src/slash_command/selection_command.rs
+++ b/crates/assistant/src/slash_command/selection_command.rs
@@ -4,8 +4,8 @@ use assistant_slash_command::{SlashCommand, SlashCommandContent, SlashCommandEve
 use futures::stream;
 use gpui::Task;
 use smol::stream::StreamExt;
-
 use ui::IconName;
+
 pub(crate) struct SelectionCommand;
 
 impl SlashCommand for SelectionCommand {
@@ -14,7 +14,11 @@ impl SlashCommand for SelectionCommand {
     }
 
     fn description(&self) -> String {
-        "Quote your active selection".into()
+        "Insert editor selection".into()
+    }
+
+    fn icon(&self) -> IconName {
+        IconName::Quote
     }
 
     fn menu_text(&self) -> String {

--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -4,10 +4,9 @@ use assistant_slash_command::SlashCommandRegistry;
 
 use gpui::{AnyElement, DismissEvent, SharedString, Task, WeakView};
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
-use ui::{prelude::*, KeyBinding, ListItem, ListItemSpacing, PopoverMenu, PopoverTrigger};
+use ui::{prelude::*, ListItem, ListItemSpacing, PopoverMenu, PopoverTrigger};
 
 use crate::assistant_panel::ContextEditor;
-use crate::QuoteSelection;
 
 #[derive(IntoElement)]
 pub(super) struct SlashCommandSelector<T: PopoverTrigger> {
@@ -32,7 +31,6 @@ enum SlashCommandEntry {
         renderer: fn(&mut WindowContext<'_>) -> AnyElement,
         on_confirm: fn(&mut WindowContext<'_>),
     },
-    QuoteButton,
 }
 
 impl AsRef<str> for SlashCommandEntry {
@@ -40,7 +38,6 @@ impl AsRef<str> for SlashCommandEntry {
         match self {
             SlashCommandEntry::Info(SlashCommandInfo { name, .. })
             | SlashCommandEntry::Advert { name, .. } => name,
-            SlashCommandEntry::QuoteButton => "Quote Selection",
         }
     }
 }
@@ -153,9 +150,6 @@ impl PickerDelegate for SlashCommandDelegate {
                         })
                         .ok();
                 }
-                SlashCommandEntry::QuoteButton => {
-                    cx.dispatch_action(Box::new(QuoteSelection));
-                }
                 SlashCommandEntry::Advert { on_confirm, .. } => {
                     on_confirm(cx);
                 }
@@ -223,40 +217,6 @@ impl PickerDelegate for SlashCommandDelegate {
                             ),
                     ),
             ),
-            SlashCommandEntry::QuoteButton => {
-                let focus = cx.focus_handle();
-                let key_binding = KeyBinding::for_action_in(&QuoteSelection, &focus, cx);
-
-                Some(
-                    ListItem::new(ix)
-                        .inset(true)
-                        .spacing(ListItemSpacing::Dense)
-                        .selected(selected)
-                        .child(
-                            v_flex()
-                                .child(
-                                    h_flex()
-                                        .gap_1p5()
-                                        .child(Icon::new(IconName::Quote).size(IconSize::XSmall))
-                                        .child(
-                                            div().font_buffer(cx).child(
-                                                Label::new("selection").size(LabelSize::Small),
-                                            ),
-                                        ),
-                                )
-                                .child(
-                                    h_flex()
-                                        .gap_1p5()
-                                        .child(
-                                            Label::new("Insert editor selection")
-                                                .color(Color::Muted)
-                                                .size(LabelSize::Small),
-                                        )
-                                        .children(key_binding.map(|kb| kb.render(cx))),
-                                ),
-                        ),
-                )
-            }
             SlashCommandEntry::Advert { renderer, .. } => Some(
                 ListItem::new(ix)
                     .inset(true)
@@ -290,47 +250,44 @@ impl<T: PopoverTrigger> RenderOnce for SlashCommandSelector<T> {
                     icon: command.icon(),
                 }))
             })
-            .chain([
-                SlashCommandEntry::Advert {
-                    name: "create-your-command".into(),
-                    renderer: |cx| {
-                        v_flex()
-                            .w_full()
-                            .child(
-                                h_flex()
-                                    .w_full()
-                                    .font_buffer(cx)
-                                    .items_center()
-                                    .justify_between()
-                                    .child(
-                                        h_flex()
-                                            .items_center()
-                                            .gap_1p5()
-                                            .child(Icon::new(IconName::Plus).size(IconSize::XSmall))
-                                            .child(
-                                                div().font_buffer(cx).child(
-                                                    Label::new("create-your-command")
-                                                        .size(LabelSize::Small),
-                                                ),
+            .chain([SlashCommandEntry::Advert {
+                name: "create-your-command".into(),
+                renderer: |cx| {
+                    v_flex()
+                        .w_full()
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .font_buffer(cx)
+                                .items_center()
+                                .justify_between()
+                                .child(
+                                    h_flex()
+                                        .items_center()
+                                        .gap_1p5()
+                                        .child(Icon::new(IconName::Plus).size(IconSize::XSmall))
+                                        .child(
+                                            div().font_buffer(cx).child(
+                                                Label::new("create-your-command")
+                                                    .size(LabelSize::Small),
                                             ),
-                                    )
-                                    .child(
-                                        Icon::new(IconName::ArrowUpRight)
-                                            .size(IconSize::XSmall)
-                                            .color(Color::Muted),
-                                    ),
-                            )
-                            .child(
-                                Label::new("Create your custom command")
-                                    .size(LabelSize::Small)
-                                    .color(Color::Muted),
-                            )
-                            .into_any_element()
-                    },
-                    on_confirm: |cx| cx.open_url("https://zed.dev/docs/extensions/slash-commands"),
+                                        ),
+                                )
+                                .child(
+                                    Icon::new(IconName::ArrowUpRight)
+                                        .size(IconSize::XSmall)
+                                        .color(Color::Muted),
+                                ),
+                        )
+                        .child(
+                            Label::new("Create your custom command")
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .into_any_element()
                 },
-                SlashCommandEntry::QuoteButton,
-            ])
+                on_confirm: |cx| cx.open_url("https://zed.dev/docs/extensions/slash-commands"),
+            }])
             .collect::<Vec<_>>();
 
         let delegate = SlashCommandDelegate {

--- a/docs/src/assistant/commands.md
+++ b/docs/src/assistant/commands.md
@@ -98,9 +98,9 @@ Usage: `/terminal [<number>]`
 
 ## `/selection`
 
-The `/selection` command inserts the selected text into the context. This is useful for referencing specific parts of your code.
+The `/selection` command inserts the selected text in the editor into the context. This is useful for referencing specific parts of your code.
 
-This is equivalent to the `assistant: quote selection` command ({#kb assistant::QuoteSelection}). (see [Interacting with the Assistant](./assistant-panel.md#interacting-with-the-assistant)))
+This is equivalent to the `assistant: quote selection` command ({#kb assistant::QuoteSelection}). See [Interacting with the Assistant](./assistant-panel.md#interacting-with-the-assistant)).
 
 Usage: `/selection`
 

--- a/docs/src/assistant/commands.md
+++ b/docs/src/assistant/commands.md
@@ -13,6 +13,7 @@ Slash commands enhance the assistant's capabilities. Begin by typing a `/` at th
 - `/symbols`: Inserts the current tab's active symbols into the context
 - `/tab`: Inserts the content of the active tab or all open tabs into the context
 - `/terminal`: Inserts a select number of lines of output from the terminal
+- `/selection`: Inserts the selected text into the context
 
 ### Other Commands:
 
@@ -94,6 +95,14 @@ The `/terminal` command inserts a select number of lines of output from the term
 Usage: `/terminal [<number>]`
 
 - `<number>`: Optional parameter to specify the number of lines to insert (default is a 50).
+
+## `/selection`
+
+The `/selection` command inserts the selected text into the context. This is useful for referencing specific parts of your code.
+
+This is equivalent to the `assistant: quote selection` command ({#kb assistant::QuoteSelection}). (see [Interacting with the Assistant](./assistant-panel.md#interacting-with-the-assistant)))
+
+Usage: `/selection`
 
 ## `/workflow`
 


### PR DESCRIPTION
- Closes #18868

## Summary
This PR introduces a new slash command `/selection` to enhance the usability of the assistant's quote selection feature. 

## Changes Made
1. Extracted a function from the `assistant: quote selection` action to find the selected text and format it as an assistant section.
2.  Created a new slash command `/selection` that utilizes the extracted function to achieve the same effect as the existing `assistant: quote selection` action.
3.  Updated the documentation to include information about the new `/selection` slash command.


Release Notes:

- Moved the text selection action to a slash command (`/selection`) in the assistant panel

