### PR TITLE
zig: Switch to official Zig grammar

### DIFF
--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -11,5 +11,5 @@ name = "zls"
 language = "Zig"
 
 [grammars.zig]
-repository = "https://github.com/maxxnino/tree-sitter-zig"
-commit = "0d08703e4c3f426ec61695d7617415fff97029bd"
+repository = "https://github.com/tree-sitter-grammars/tree-sitter-zig"
+commit = "eb7d58c2dc4fbeea4745019dee8df013034ae66b"

--- a/extensions/zig/languages/zig/config.toml
+++ b/extensions/zig/languages/zig/config.toml
@@ -1,7 +1,7 @@
 name = "Zig"
 grammar = "zig"
 path_suffixes = ["zig", "zon"]
-line_comments = ["// "]
+line_comments = ["// ", "/// ", "//! "]
 autoclose_before = ";:.,=}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/extensions/zig/languages/zig/highlights.scm
+++ b/extensions/zig/languages/zig/highlights.scm
@@ -1,126 +1,175 @@
-[
-  (container_doc_comment)
-  (doc_comment)
+; Variables
 
-] @comment.doc
+(identifier) @variable
 
-[
-    (line_comment)
-] @comment
+; Parameters
 
-[
-  variable: (IDENTIFIER)
-  variable_type_function: (IDENTIFIER)
-] @variable
+(parameter
+  name: (identifier) @variable.parameter)
 
-;; func parameter
-parameter: (IDENTIFIER) @property
+; Types
 
-[
-  field_member: (IDENTIFIER)
-  field_access: (IDENTIFIER)
-] @property
+(parameter
+  type: (identifier) @type)
 
-;; assume TitleCase is a type
-(
+((identifier) @type
+  (#lua-match? @type "^[A-Z_][a-zA-Z0-9_]*"))
+
+(variable_declaration
+  (identifier) @type
+  "="
   [
-    variable_type_function: (IDENTIFIER)
-    field_access: (IDENTIFIER)
-    parameter: (IDENTIFIER)
-  ] @type
-  (#match? @type "^[A-Z]([a-z]+[A-Za-z0-9]*)+$")
-)
-
-;; assume camelCase is a function
-(
-  [
-    variable_type_function: (IDENTIFIER)
-    field_access: (IDENTIFIER)
-    parameter: (IDENTIFIER)
-  ] @function
-  (#match? @function "^[a-z]+([A-Z][a-z0-9]*)+$")
-)
-
-;; assume all CAPS_1 is a constant
-(
-  [
-    variable_type_function: (IDENTIFIER)
-    field_access: (IDENTIFIER)
-  ] @constant
-  (#match? @constant "^[A-Z][A-Z_0-9]+$")
-)
+    (struct_declaration)
+    (enum_declaration)
+    (union_declaration)
+    (opaque_declaration)
+  ])
 
 [
-  function_call: (IDENTIFIER)
-  function: (IDENTIFIER)
-] @function
+  (builtin_type)
+  "anyframe"
+] @type.builtin
 
-exception: "!" @keyword
+; Constants
 
-(
-  (IDENTIFIER) @variable.special
-  (#eq? @variable.special "_")
-)
-
-(PtrTypeStart "c" @variable.special)
-
-(
-  (ContainerDeclType
-    [
-      (ErrorUnionExpr)
-      "enum"
-    ]
-  )
-  (ContainerField (IDENTIFIER) @constant)
-)
-
-field_constant: (IDENTIFIER) @constant
-
-(BUILTINIDENTIFIER) @keyword
-
-((BUILTINIDENTIFIER) @function
-  (#any-of? @function "@import" "@cImport"))
-
-(INTEGER) @number
-
-(FLOAT) @number
+((identifier) @constant
+  (#lua-match? @constant "^[A-Z][A-Z_0-9]+$"))
 
 [
-  "true"
-  "false"
-] @boolean
+  "null"
+  "unreachable"
+  "undefined"
+] @constant.builtin
+
+(field_expression
+  .
+  member: (identifier) @constant)
+
+(enum_declaration
+  (container_field
+    type: (identifier) @constant))
+
+; Labels
+
+(block_label (identifier) @label)
+
+(break_label (identifier) @label)
+
+; Fields
+
+(field_initializer
+  .
+  (identifier) @variable.member)
+
+(field_expression
+  (_)
+  member: (identifier) @variable.member)
+
+(container_field
+  name: (identifier) @variable.member)
+
+(initializer_list
+  (assignment_expression
+      left: (field_expression
+              .
+              member: (identifier) @variable.member)))
+
+; Functions
+
+(builtin_identifier) @function.builtin
+
+(call_expression
+  function: (identifier) @function.call)
+
+(call_expression
+  function: (field_expression
+    member: (identifier) @function.call))
+
+(function_declaration
+  name: (identifier) @function)
+
+; Modules
+
+(variable_declaration
+  (identifier) @module
+  (builtin_function
+    (builtin_identifier) @keyword.import
+    (#any-of? @keyword.import "@import" "@cImport")))
+
+; Builtins
 
 [
-  (LINESTRING)
-  (STRINGLITERALSINGLE)
-] @string
+  "c"
+  "..."
+] @variable.builtin
 
-(CHAR_LITERAL) @string.special.symbol
-(EscapeSequence) @string.escape
-(FormatSequence) @string.special
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "_"))
 
-(BreakLabel (IDENTIFIER) @tag)
-(BlockLabel (IDENTIFIER) @tag)
+(calling_convention
+  (identifier) @variable.builtin)
+
+; Keywords
 
 [
-  "fn"
   "asm"
   "defer"
   "errdefer"
   "test"
+  "error"
+  "const"
+  "var"
+] @keyword
+
+[
   "struct"
   "union"
   "enum"
   "opaque"
-  "error"
-  "try"
-  "catch"
+] @keyword.type
+
+[
+  "async"
+  "await"
+  "suspend"
+  "nosuspend"
+  "resume"
+] @keyword.coroutine
+
+"fn" @keyword.function
+
+[
+  "and"
+  "or"
+  "orelse"
+] @keyword.operator
+
+"return" @keyword.return
+
+[
+  "if"
+  "else"
+  "switch"
+] @keyword.conditional
+
+[
   "for"
   "while"
   "break"
   "continue"
-  "const"
-  "var"
+] @keyword.repeat
+
+[
+  "usingnamespace"
+  "export"
+] @keyword.import
+
+[
+  "try"
+  "catch"
+] @keyword.exception
+
+[
   "volatile"
   "allowzero"
   "noalias"
@@ -128,71 +177,91 @@ field_constant: (IDENTIFIER) @constant
   "align"
   "callconv"
   "linksection"
-  "comptime"
-  "export"
-  "extern"
+  "pub"
   "inline"
   "noinline"
+  "extern"
+  "comptime"
   "packed"
-  "pub"
   "threadlocal"
-  "async"
-  "await"
-  "suspend"
-  "nosuspend"
-  "resume"
-  "and"
-  "or"
-  "orelse"
-  "return"
-  "if"
-  "else"
-  "switch"
-] @keyword
+] @keyword.modifier
+
+; Operator
 
 [
-  "usingnamespace"
-] @constant
-
-[
-  "anytype"
-  "anyframe"
-  (BuildinTypeExpr)
-] @type
-
-[
-  "null"
-  "unreachable"
-  "undefined"
-] @constant
-
-[
-  (CompareOp)
-  (BitwiseOp)
-  (BitShiftOp)
-  (AdditionOp)
-  (AssignOp)
-  (MultiplyOp)
-  (PrefixOp)
+  "="
+  "*="
+  "*%="
+  "*|="
+  "/="
+  "%="
+  "+="
+  "+%="
+  "+|="
+  "-="
+  "-%="
+  "-|="
+  "<<="
+  "<<|="
+  ">>="
+  "&="
+  "^="
+  "|="
+  "!"
+  "~"
+  "-"
+  "-%"
+  "&"
+  "=="
+  "!="
+  ">"
+  ">="
+  "<="
+  "<"
+  "&"
+  "^"
+  "|"
+  "<<"
+  ">>"
+  "<<|"
+  "+"
+  "++"
+  "+%"
+  "-%"
+  "+|"
+  "-|"
   "*"
+  "/"
+  "%"
   "**"
-  "->"
-  ".?"
+  "*%"
+  "*|"
+  "||"
   ".*"
+  ".?"
   "?"
+  ".."
 ] @operator
 
-[
-  ";"
-  "."
-  ","
-  ":"
-] @punctuation.delimiter
+; Literals
 
-[
-  ".."
-  "..."
-] @punctuation.special
+(character) @character
+
+([
+  (string)
+  (multiline_string)
+] @string
+  (#set! "priority" 95))
+
+(integer) @number
+
+(float) @number.float
+
+(boolean) @boolean
+
+(escape_sequence) @string.escape
+
+; Punctuation
 
 [
   "["
@@ -201,10 +270,22 @@ field_constant: (IDENTIFIER) @constant
   ")"
   "{"
   "}"
-  (Payload "|")
-  (PtrPayload "|")
-  (PtrIndexPayload "|")
 ] @punctuation.bracket
 
-; Error
-(ERROR) @error
+[
+  ";"
+  "."
+  ","
+  ":"
+  "=>"
+  "->"
+] @punctuation.delimiter
+
+(payload "|" @punctuation.bracket)
+
+; Comments
+
+(comment) @comment @spell
+
+((comment) @comment.documentation
+  (#lua-match? @comment.documentation "^//!"))

--- a/extensions/zig/languages/zig/highlights.scm
+++ b/extensions/zig/languages/zig/highlights.scm
@@ -13,7 +13,7 @@
   type: (identifier) @type)
 
 ((identifier) @type
-  (#lua-match? @type "^[A-Z_][a-zA-Z0-9_]*"))
+  (#match? @type "^[A-Z_][a-zA-Z0-9_]*"))
 
 (variable_declaration
   (identifier) @type
@@ -33,7 +33,7 @@
 ; Constants
 
 ((identifier) @constant
-  (#lua-match? @constant "^[A-Z][A-Z_0-9]+$"))
+  (#match? @constant "^[A-Z][A-Z_0-9]+$"))
 
 [
   "null"
@@ -63,16 +63,20 @@
 
 (field_expression
   (_)
-  member: (identifier) @variable.member)
+  member: (identifier) @property)
+
+(field_expression
+  (_)
+  member: (identifier) @type (#match? @type "^[A-Z_][a-zA-Z0-9_]*"))
 
 (container_field
-  name: (identifier) @variable.member)
+  name: (identifier) @property)
 
 (initializer_list
   (assignment_expression
       left: (field_expression
               .
-              member: (identifier) @variable.member)))
+              member: (identifier) @property)))
 
 ; Functions
 
@@ -285,7 +289,7 @@
 
 ; Comments
 
-(comment) @comment @spell
+(comment) @comment
 
 ((comment) @comment.documentation
-  (#lua-match? @comment.documentation "^//!"))
+  (#match? @comment.documentation "^//(/|!)"))

--- a/extensions/zig/languages/zig/indents.scm
+++ b/extensions/zig/languages/zig/indents.scm
@@ -1,22 +1,17 @@
 [
-  (AsmExpr)
-  (AssignExpr)
-  (Block)
-  (BlockExpr)
-  (ContainerDecl)
-  (ErrorUnionExpr)
-  (InitList)
-  (SwitchExpr)
-  (TestDecl)
+  (block)
+  (switch_expression)
+  (initializer_list)
 ] @indent.begin
+
+(block
+  "}" @indent.end)
 
 (_ "[" "]" @end) @indent
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
 
 [
-  (line_comment)
-  (container_doc_comment)
-  (doc_comment)
-  (LINESTRING)
+  (comment)
+  (multiline_string)
 ] @indent.ignore

--- a/extensions/zig/languages/zig/injections.scm
+++ b/extensions/zig/languages/zig/injections.scm
@@ -1,5 +1,10 @@
-[
-  (container_doc_comment)
-  (doc_comment)
-  (line_comment)
-] @comment
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+; TODO: add when asm is added
+; (asm_output_item (string) @injection.content
+;   (#set! injection.language "asm"))
+; (asm_input_item (string) @injection.content
+;   (#set! injection.language "asm"))
+; (asm_clobbers (string) @injection.content
+;   (#set! injection.language "asm"))

--- a/extensions/zig/languages/zig/outline.scm
+++ b/extensions/zig/languages/zig/outline.scm
@@ -1,27 +1,26 @@
-(Decl (
-    FnProto(
-        "fn" @context
-        function: (_) @name
-    )
-)
- ) @item
+(test_declaration "test" @context
+  [
+    (string)
+    (identifier)
+  ] @name) @item
 
-(
-    Decl (
-        VarDecl (
-                "const"
-                variable_type_function: (_) @name
-                (ErrorUnionExpr) @context
-            )
-    )
-) @item
 
-(
-    TestDecl (
-        "test" @context
-        [
-         (STRINGLITERALSINGLE)
-         (IDENTIFIER)
-        ]? @name
-    )
-) @item
+(function_declaration 
+  "pub"? @context
+  [
+    "extern"
+    "export"
+    "inline"
+    "noinline"
+  ]? @context
+  "fn" @context
+  name: (_) @name) @item
+
+(variable_declaration
+  "pub"? @context
+  [
+    "extern"
+    "export"
+  ]? @context
+  ["const" "var"] @context
+  (identifier) @name) @item

--- a/extensions/zig/languages/zig/outline.scm
+++ b/extensions/zig/languages/zig/outline.scm
@@ -1,9 +1,9 @@
-(test_declaration "test" @context
+(test_declaration 
+  "test" @context
   [
-    (string)
-    (identifier)
-  ] @name) @item
-
+   (string)
+   (identifier)
+   ] @name) @item
 
 (function_declaration 
   "pub"? @context
@@ -16,11 +16,35 @@
   "fn" @context
   name: (_) @name) @item
 
-(variable_declaration
-  "pub"? @context
-  [
-    "extern"
-    "export"
-  ]? @context
-  ["const" "var"] @context
-  (identifier) @name) @item
+(source_file
+  (variable_declaration
+    "pub"? @context
+    (identifier) @name
+    "=" (_) @context) @item)
+
+(struct_declaration
+  (variable_declaration
+    "pub"? @context
+    (identifier) @name
+    "=" (_) @context) @item)
+
+(union_declaration
+  (variable_declaration
+    "pub"? @context
+    (identifier) @name
+    "=" (_) @context) @item)
+
+(enum_declaration
+  (variable_declaration
+    "pub"? @context
+    (identifier) @name
+    "=" (_) @context) @item)
+
+(opaque_declaration
+  (variable_declaration
+    "pub"? @context
+    (identifier) @name
+    "=" (_) @context) @item)
+
+(container_field
+  . (_) @name) @item


### PR DESCRIPTION
Closes #20001

the old outline was *weird* for many reasons so ill just show it with a hodgepodge of zig declarations
before:
![image](https://github.com/user-attachments/assets/87395623-3e28-491c-9693-c1714da6b29f)
after:
![image](https://github.com/user-attachments/assets/1aa3f3b7-18b0-4d39-b1c6-99740e7bcd6a)

why were values shown? why werent `var`s or modifiers like pub, const, export? it was very odd to me and inconsistent with other languages. i chose to leave out unnamed tests, it just seemed like noise to me since they werent distinct but i can easily revert that
unfortunately there seems to be a bug upstream which causes those `t`/`f` decls to show 2 things https://github.com/tree-sitter-grammars/tree-sitter-zig/issues/3

im very new to treesitter and queries so i really havent looked over the rest of the stuff here, other than outline theyre unmodified please lmk if theres anything wrong

Release Notes:

- Changed upstream treesitter grammar for zig
