### PR TITLE
Clean up notebook item creation in project

### DIFF
--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -23,9 +23,6 @@ use super::{Cell, CellPosition, RenderableCell};
 use nbformat::v4::CellId;
 use nbformat::v4::Metadata as NotebookMetadata;
 
-pub(crate) const DEFAULT_NOTEBOOK_FORMAT: i32 = 4;
-pub(crate) const DEFAULT_NOTEBOOK_FORMAT_MINOR: i32 = 0;
-
 actions!(
     notebook,
     [
@@ -524,6 +521,7 @@ impl FocusableView for NotebookEditor {
 pub struct NotebookItem {
     path: PathBuf,
     project_path: ProjectPath,
+    // Raw notebook data
     notebook: nbformat::v4::Notebook,
     // Store our version of the notebook in memory (cell_order, cell_map)
     id: ProjectEntryId,
@@ -589,6 +587,8 @@ impl project::Item for NotebookItem {
         Some(self.project_path.clone())
     }
 }
+
+impl NotebookItem {}
 
 impl EventEmitter<()> for NotebookEditor {}
 

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -87,8 +87,6 @@ impl NotebookEditor {
     ) -> Self {
         let focus_handle = cx.focus_handle();
 
-        let notebook = notebook_item.read(cx).notebook.clone();
-
         let languages = project.read(cx).languages().clone();
         let language_name = notebook_item.read(cx).language_name();
 
@@ -100,7 +98,14 @@ impl NotebookEditor {
         let mut cell_order = vec![]; // Vec<CellId>
         let mut cell_map = HashMap::default(); // HashMap<CellId, Cell>
 
-        for (index, cell) in notebook.cells.iter().enumerate() {
+        for (index, cell) in notebook_item
+            .read(cx)
+            .notebook
+            .clone()
+            .cells
+            .iter()
+            .enumerate()
+        {
             let cell_id = cell.id();
             cell_order.push(cell_id.clone());
             cell_map.insert(

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -520,10 +520,12 @@ impl FocusableView for NotebookEditor {
     }
 }
 
+// Intended to be a NotebookBuffer
 pub struct NotebookItem {
     path: PathBuf,
     project_path: ProjectPath,
     notebook: nbformat::v4::Notebook,
+    // Store our version of the notebook in memory (cell_order, cell_map)
     id: ProjectEntryId,
 }
 
@@ -571,6 +573,8 @@ impl project::Item for NotebookItem {
                 // * Does VS Code _actually_ use this?
                 // * Does Pyright?
                 // * Do we possibly need to create a large buffer
+                //
+                //
 
                 let notebook = nbformat::parse_notebook(&file_content);
 

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -91,9 +91,7 @@ impl NotebookEditor {
         let language_name = notebook_item.read(cx).language_name();
 
         let notebook_language = notebook_item.read(cx).notebook_language();
-        let notebook_language = cx
-            .spawn(|_, _| async move { notebook_language.await })
-            .shared();
+        let notebook_language = cx.spawn(|_, _| notebook_language).shared();
 
         let mut cell_order = vec![]; // Vec<CellId>
         let mut cell_map = HashMap::default(); // HashMap<CellId, Cell>


### PR DESCRIPTION
* Implement `clone_on_split` to allow splitting a notebook into another pane

* Switched to `tab_content` in `impl Item for NotebookEditor` to show both the notebook name and an icon

* Added placeholder methods and TODOs for future work, such as saving, reloading, and search functionality within the notebook editor.

* Started moving more core `Model` bits into `NotebookItem`, including pulling the language of the notebook (which affects every code cell)

* Loaded notebook asynchronously using `fs`

Release Notes:

- N/A
