### PR TITLE
Do less work when revealing entries in the outline panel

### DIFF
--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -239,7 +239,7 @@ impl SelectionsCollection {
 
     pub fn newest<D: TextDimension + Ord + Sub<D, Output = D>>(
         &self,
-        cx: &mut AppContext,
+        cx: &AppContext,
     ) -> Selection<D> {
         let buffer = self.buffer(cx);
         self.newest_anchor().map(|p| p.summary::<D>(&buffer))

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -239,7 +239,7 @@ impl SelectionsCollection {
 
     pub fn newest<D: TextDimension + Ord + Sub<D, Output = D>>(
         &self,
-        cx: &AppContext,
+        cx: &mut AppContext,
     ) -> Selection<D> {
         let buffer = self.buffer(cx);
         self.newest_anchor().map(|p| p.summary::<D>(&buffer))

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4479,7 +4479,13 @@ mod tests {
         cx.executor()
             .advance_clock(UPDATE_DEBOUNCE + Duration::from_millis(100));
         cx.run_until_parked();
-        outline_panel.update(cx, |outline_panel, _| {
+        outline_panel.update(cx, |outline_panel, cx| {
+            // Project search re-adds items to the buffer, removing the caret from it.
+            // Select the first entry and move 4 elements down.
+            for _ in 0..6 {
+                outline_panel.select_next(&SelectNext, cx);
+            }
+
             assert_eq!(
                 display_entries(
                     &outline_panel.cached_entries,
@@ -4795,7 +4801,7 @@ mod tests {
                 r#"/
   public/lottie/
     syntax-tree.json
-      search: { "something": "static" }  <==== selected
+      search: { "something": "static" }
   src/
     app/(site)/
       (about)/jobs/[slug]/
@@ -4811,8 +4817,11 @@ mod tests {
         });
 
         outline_panel.update(cx, |outline_panel, cx| {
-            outline_panel.select_next(&SelectNext, cx);
-            outline_panel.select_next(&SelectNext, cx);
+            // After the search is done, we have updated the outline panel contents and caret is not in any excerot, so there are no selections.
+            // Move to 5th element in the list (0th action will selection the first element)
+            for _ in 0..6 {
+                outline_panel.select_next(&SelectNext, cx);
+            }
             outline_panel.collapse_selected_entry(&CollapseSelectedEntry, cx);
         });
         cx.run_until_parked();


### PR DESCRIPTION
Before this change, we were trying to determine current element before debouncing, causing a lot of extra work on caret movement. Now, we only do this for the task that managed to wait the entire debounce period.

Closes https://github.com/zed-industries/zed/issues/19817
Closes https://github.com/zed-industries/zed/issues/14235

Release Notes:

- Fixed outline panel-related performance issues when selections change in the large document  ([#19817](https://github.com/zed-industries/zed/issues/19817)), ([#14235](https://github.com/zed-industries/zed/issues/14235))
