### PR TITLE
Upgrade nbformat and runtimelib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5585,7 +5585,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -6157,9 +6157,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-serde"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a444fb3f87ee6885eb316028cc998c7d84811663ef95d78c419419423d5a054"
+checksum = "77b96de099fc23d5c21e05de32cc087c8326983895b7f6c242562af01f7d4c81"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6492,7 +6492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7157,9 +7157,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146074ad45cab20f5d98ccded164826158471f21d04f96e40b9872529e10979d"
+checksum = "84f8a9ab08b34237c2c1d0504b794c2ff01c08dfc46a060d160f004a7f479c31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9970,9 +9970,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263588fe9593333c4bfde258c9021fc64e766ea434e070c6b67c7100536d6499"
+checksum = "bc7fe3c17675445fe89de68d130be00b7115104924fbcf53a9b0a84b0283fc81"
 dependencies = [
  "anyhow",
  "async-dispatcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,7 +370,7 @@ linkify = "0.10.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
 markup5ever_rcdom = "0.3.0"
 nanoid = "0.4"
-nbformat = "0.3.1"
+nbformat = "0.3.2"
 nix = "0.29"
 num-format = "0.4.4"
 once_cell = "1.19.0"
@@ -403,7 +403,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "fd110f
     "stream",
 ] }
 rsa = "0.9.6"
-runtimelib = { version = "0.16.0", default-features = false, features = [
+runtimelib = { version = "0.16.1", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }
 rustc-demangle = "0.1.23"


### PR DESCRIPTION
Fixes an issue on load of notebooks that have `text/*` output in `Vec<String>` rather than `String`. This ensures that Markdown output will render correctly.

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/0bcc7dc8-527f-4067-a916-3ae569ea197d">


Release Notes:

- N/A
