### PR TITLE
Enhanced support for the Claude Sonnet model in the Copilot Chat feature

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -23,6 +23,7 @@ pub enum Role {
     User,
     Assistant,
     System,
+    Tool,
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -35,6 +36,12 @@ pub enum Model {
     Gpt4,
     #[serde(alias = "gpt-3.5-turbo", rename = "gpt-3.5-turbo")]
     Gpt3_5Turbo,
+    #[serde(alias = "o1-preview", rename = "o1-preview-2024-09-12")]
+    O1Preview,
+    #[serde(alias = "o1-mini", rename = "o1-mini-2024-09-12")]
+    O1Mini,
+    #[serde(alias = "claude-3.5-sonnet", rename = "claude-3.5-sonnet")]
+    Claude3_5Sonnet,
 }
 
 impl Model {
@@ -43,6 +50,9 @@ impl Model {
             "gpt-4o" => Ok(Self::Gpt4o),
             "gpt-4" => Ok(Self::Gpt4),
             "gpt-3.5-turbo" => Ok(Self::Gpt3_5Turbo),
+            "o1-preview" => Ok(Self::O1Preview),
+            "o1-mini" => Ok(Self::O1Mini),
+            "claude-3.5-sonnet" => Ok(Self::Claude3_5Sonnet),
             _ => Err(anyhow!("Invalid model id: {}", id)),
         }
     }
@@ -52,6 +62,9 @@ impl Model {
             Self::Gpt3_5Turbo => "gpt-3.5-turbo",
             Self::Gpt4 => "gpt-4",
             Self::Gpt4o => "gpt-4o",
+            Self::O1Preview => "o1-preview-2024-09-12",
+            Self::O1Mini => "o1-mini-2024-09-12",
+            Self::Claude3_5Sonnet => "claude-3.5-sonnet",
         }
     }
 
@@ -60,6 +73,9 @@ impl Model {
             Self::Gpt3_5Turbo => "GPT-3.5",
             Self::Gpt4 => "GPT-4",
             Self::Gpt4o => "GPT-4o",
+            Self::O1Preview => "o1-preview",
+            Self::O1Mini => "o1-mini",
+            Self::Claude3_5Sonnet => "Claude-3.5 Sonnet",
         }
     }
 
@@ -68,6 +84,9 @@ impl Model {
             Self::Gpt4o => 128000,
             Self::Gpt4 => 8192,
             Self::Gpt3_5Turbo => 16385,
+            Self::O1Preview => 128000,
+            Self::O1Mini => 128000,
+            Self::Claude3_5Sonnet => 200000,
         }
     }
 }

--- a/crates/language_model/src/provider/copilot_chat.rs
+++ b/crates/language_model/src/provider/copilot_chat.rs
@@ -183,6 +183,15 @@ impl LanguageModel for CopilotChatLanguageModel {
             CopilotChatModel::Gpt4o => open_ai::Model::FourOmni,
             CopilotChatModel::Gpt4 => open_ai::Model::Four,
             CopilotChatModel::Gpt3_5Turbo => open_ai::Model::ThreePointFiveTurbo,
+            CopilotChatModel::O1Preview => open_ai::Model::O1Preview,
+            CopilotChatModel::O1Mini => open_ai::Model::O1Mini,
+            CopilotChatModel::Claude3_5Sonnet => open_ai::Model::Custom{
+                name: "claude-3.5-sonnet".to_string(),
+                display_name: Some("Claude 3.5 Sonnet".to_string()),
+                max_tokens: 200_000,
+                max_output_tokens: Some(8_192),
+                max_completion_tokens: Some(8_192),
+            },
         };
 
         count_open_ai_tokens(request, model, cx)


### PR DESCRIPTION
This pull request introduces new roles and models to the `copilot_chat` module and updates the `LanguageModel` implementation to support these additions. The most important changes include adding a new role, several new models, and updating the `Model` enum and its associated methods to handle these new models.

### New Roles and Models:

* Added a new role `Tool` to the `Role` enum in `crates/copilot/src/copilot_chat.rs`.

* Added new models `O1Preview`, `O1Mini`, and `Claude3_5Sonnet` to the `Model` enum in `crates/copilot/src/copilot_chat.rs`.

### Updates to Model Enum:

* Updated the `impl Model` block to include the new models in the `from_str` method.
* Updated the `impl Model` block to include the new models in the `to_string` method.
* Updated the `impl Model` block to include the new models in the `display_name` method.
* Updated the `impl Model` block to include the new models in the `max_tokens` method.

### Language Model Implementation:

* Updated the `impl LanguageModel for CopilotChatLanguageModel` block to map the new models to their corresponding `open_ai::Model` variants in `crates/language_model/src/provider/copilot_chat.rs`.