### PR TITLE
gpui: Bump crates resvg and usvg to 0.44.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4443,7 +4443,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7"
 dependencies = [
- "roxmltree 0.20.0",
+ "roxmltree",
 ]
 
 [[package]]
@@ -5782,9 +5782,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgref"
@@ -9756,9 +9756,9 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2327ced609dadeed3e9702fec3e6b2ddd208758a9268d13e06566c6101ba533"
+checksum = "4a325d5e8d1cebddd070b13f44cec8071594ab67d1012797c121f27a669b7958"
 dependencies = [
  "log",
  "pico-args",
@@ -9910,12 +9910,6 @@ dependencies = [
  "unicode-segmentation",
  "util",
 ]
-
-[[package]]
-name = "roxmltree"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "roxmltree"
@@ -13174,9 +13168,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c704361d822337cfc00387672c7b59eaa72a1f0744f62b2a68aa228a0c6927d"
+checksum = "7447e703d7223b067607655e625e0dbca80822880248937da65966194c4864e6"
 dependencies = [
  "base64 0.22.1",
  "data-url",
@@ -13185,7 +13179,7 @@ dependencies = [
  "kurbo",
  "log",
  "pico-args",
- "roxmltree 0.19.0",
+ "roxmltree",
  "simplecss",
  "siphasher 1.0.1",
  "strict-num",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -90,8 +90,8 @@ profiling.workspace = true
 rand = { optional = true, workspace = true }
 raw-window-handle = "0.6"
 refineable.workspace = true
-resvg = { version = "0.41.0", default-features = false }
-usvg = { version = "0.41.0", default-features = false }
+resvg = { version = "0.44.0", default-features = false }
+usvg = { version = "0.44.0", default-features = false }
 schemars.workspace = true
 seahash = "4.1"
 semantic_version.workspace = true

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -60,10 +60,8 @@ impl SvgRenderer {
         let mut pixmap = resvg::tiny_skia::Pixmap::new(size.width.into(), size.height.into())
             .ok_or(usvg::Error::InvalidSize)?;
 
-        let transform = tree.view_box().to_transform(
-            resvg::tiny_skia::Size::from_wh(size.width.0 as f32, size.height.0 as f32)
-                .ok_or(usvg::Error::InvalidSize)?,
-        );
+        let scale = size.width.0 as f32 / tree.size().width();
+        let transform = resvg::tiny_skia::Transform::from_scale(scale, scale);
 
         resvg::render(&tree, transform, &mut pixmap.as_mut());
 


### PR DESCRIPTION
Closes #17388

Release Notes:

- N/A

We are using gpui to build a project, and we want to render SVGs with the `<text>` tag. We use `resvg` and `usvg` with the same version as gpui, like `0.41.0`. However, when we enable the feature `text`, we get an error from `usvg`.

```shell
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
  --> /Users/madcodelife/.cargo/git/checkouts/zed-23e65a6dff445450/e681a4b/crates/gpui/src/svg_renderer.rs:49:20
   |
49 |         let tree = usvg::Tree::from_data(bytes, &usvg::Options::default())?;
   |                    ^^^^^^^^^^^^^^^^^^^^^---------------------------------- argument #3 of type `&Database` is missing
   |
```

This error occurs because when the `text` feature is enabled, the `form_data` function needs an extra argument, `fontdb`. 
[The code is here](https://github.com/linebender/resvg/blob/fb7e28513f561ed847acbf4a6fb8b743474837a0/crates/usvg/src/parser/mod.rs#L98).

They changed the API in version [`0.42.0`](https://github.com/linebender/resvg/blob/b1d06e9463a3b089fbd70e7c38aebbfc811311ff/crates/usvg/src/parser/mod.rs#L98).

So, I updated the versions to the latest (0.44.0).

This is our demo:

## Before:
<img width="620" alt="image" src="https://github.com/user-attachments/assets/7c71f8b1-e5fe-4e60-8f21-bb3bd9924e03">

## After:
<img width="620" alt="image" src="https://github.com/user-attachments/assets/4b0a0602-928f-4017-b5df-859eeb5f6b4a">
