### PR TITLE
theme: Remove unused `staff` parameter for listing themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6371,7 +6371,6 @@ dependencies = [
  "async-tar",
  "async-trait",
  "collections",
- "feature_flags",
  "futures 0.3.30",
  "gpui",
  "http_client",
@@ -12127,7 +12126,6 @@ name = "theme_selector"
 version = "0.1.0"
 dependencies = [
  "client",
- "feature_flags",
  "fs",
  "fuzzy",
  "gpui",

--- a/crates/extension/src/extension_store_test.rs
+++ b/crates/extension/src/extension_store_test.rs
@@ -296,7 +296,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
             ["ERB", "Plain Text", "Ruby"]
         );
         assert_eq!(
-            theme_registry.list_names(false),
+            theme_registry.list_names(),
             [
                 "Monokai Dark",
                 "Monokai Light",
@@ -377,7 +377,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
         assert_eq!(index.themes, expected_index.themes);
 
         assert_eq!(
-            theme_registry.list_names(false),
+            theme_registry.list_names(),
             [
                 "Gruvbox",
                 "Monokai Dark",
@@ -424,7 +424,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
             ["embedded_template".into(), "ruby".into()]
         );
         assert_eq!(
-            theme_registry.list_names(false),
+            theme_registry.list_names(),
             [
                 "Gruvbox",
                 "Monokai Dark",

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -38,7 +38,6 @@ async-compression.workspace = true
 async-tar.workspace = true
 async-trait.workspace = true
 collections.workspace = true
-feature_flags.workspace = true
 futures.workspace = true
 gpui.workspace = true
 http_client.workspace = true

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -3,7 +3,6 @@ use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
 use async_trait::async_trait;
 use collections::HashMap;
-use feature_flags::FeatureFlagAppExt;
 use futures::StreamExt;
 use gpui::{AppContext, AsyncAppContext};
 use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
@@ -77,13 +76,11 @@ impl JsonLspAdapter {
 
     fn get_workspace_config(language_names: Vec<String>, cx: &mut AppContext) -> Value {
         let action_names = cx.all_action_names();
-        let staff_mode = cx.is_staff();
 
         let font_names = &cx.text_system().all_font_names();
         let settings_schema = cx.global::<SettingsStore>().json_schema(
             &SettingsJsonSchemaParams {
                 language_names: &language_names,
-                staff_mode,
                 font_names,
             },
             cx,

--- a/crates/settings/src/json_schema.rs
+++ b/crates/settings/src/json_schema.rs
@@ -2,7 +2,6 @@ use schemars::schema::{ArrayValidation, InstanceType, RootSchema, Schema, Schema
 use serde_json::Value;
 
 pub struct SettingsJsonSchemaParams<'a> {
-    pub staff_mode: bool,
     pub language_names: &'a [String],
     pub font_names: &'a [String],
 }

--- a/crates/settings_ui/src/appearance_settings_controls.rs
+++ b/crates/settings_ui/src/appearance_settings_controls.rs
@@ -85,7 +85,7 @@ impl RenderOnce for ThemeControl {
             ContextMenu::build(cx, |mut menu, cx| {
                 let theme_registry = <dyn ThemeRegistry>::global(cx);
 
-                for theme in theme_registry.list_names(false) {
+                for theme in theme_registry.list_names() {
                     menu = menu.custom_entry(
                         {
                             let theme = theme.clone();

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -39,10 +39,10 @@ impl Global for GlobalThemeRegistry {}
 #[async_trait]
 pub trait ThemeRegistry: Send + Sync + 'static {
     /// Returns the names of all themes in the registry.
-    fn list_names(&self, _staff: bool) -> Vec<SharedString>;
+    fn list_names(&self) -> Vec<SharedString>;
 
     /// Returns the metadata of all themes in the registry.
-    fn list(&self, _staff: bool) -> Vec<ThemeMeta>;
+    fn list(&self) -> Vec<ThemeMeta>;
 
     /// Returns the theme with the given name.
     fn get(&self, name: &str) -> Result<Arc<Theme>>;
@@ -171,13 +171,13 @@ impl Default for RealThemeRegistry {
 
 #[async_trait]
 impl ThemeRegistry for RealThemeRegistry {
-    fn list_names(&self, _staff: bool) -> Vec<SharedString> {
+    fn list_names(&self) -> Vec<SharedString> {
         let mut names = self.state.read().themes.keys().cloned().collect::<Vec<_>>();
         names.sort();
         names
     }
 
-    fn list(&self, _staff: bool) -> Vec<ThemeMeta> {
+    fn list(&self) -> Vec<ThemeMeta> {
         self.state
             .read()
             .themes
@@ -238,11 +238,11 @@ pub struct VoidThemeRegistry;
 
 #[async_trait]
 impl ThemeRegistry for VoidThemeRegistry {
-    fn list_names(&self, _staff: bool) -> Vec<SharedString> {
+    fn list_names(&self) -> Vec<SharedString> {
         Vec::new()
     }
 
-    fn list(&self, _staff: bool) -> Vec<ThemeMeta> {
+    fn list(&self) -> Vec<ThemeMeta> {
         Vec::new()
     }
 

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -711,7 +711,7 @@ impl settings::Settings for ThemeSettings {
     ) -> schemars::schema::RootSchema {
         let mut root_schema = generator.root_schema_for::<ThemeSettingsContent>();
         let theme_names = <dyn ThemeRegistry>::global(cx)
-            .list_names(params.staff_mode)
+            .list_names()
             .into_iter()
             .map(|theme_name| Value::String(theme_name.to_string()))
             .collect();

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -14,7 +14,6 @@ doctest = false
 
 [dependencies]
 client.workspace = true
-feature_flags.workspace = true
 fs.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -1,5 +1,4 @@
 use client::telemetry::Telemetry;
-use feature_flags::FeatureFlagAppExt;
 use fs::Fs;
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
@@ -96,10 +95,9 @@ impl ThemeSelectorDelegate {
     ) -> Self {
         let original_theme = cx.theme().clone();
 
-        let staff_mode = cx.is_staff();
         let registry = <dyn ThemeRegistry>::global(cx);
         let mut themes = registry
-            .list(staff_mode)
+            .list()
             .into_iter()
             .filter(|meta| {
                 if let Some(theme_filter) = themes_filter {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3424,7 +3424,7 @@ mod tests {
         theme::init(theme::LoadThemes::JustBase, cx);
 
         let mut has_default_theme = false;
-        for theme_name in themes.list(false).into_iter().map(|meta| meta.name) {
+        for theme_name in themes.list().into_iter().map(|meta| meta.name) {
             let theme = themes.get(&theme_name).unwrap();
             assert_eq!(theme.name, theme_name);
             if theme.name == ThemeSettings::get(None, cx).active_theme.name {


### PR DESCRIPTION
This PR removes the `staff` parameter for listing themes, as it was not used.

Release Notes:

- N/A
