### PR TITLE
Expose allow binary download setting to users

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -619,6 +619,8 @@
   // Automatically update Zed. This setting may be ignored on Linux if
   // installed through a package manager.
   "auto_update": true,
+  // Allows Zed to download binaries like LSPs
+  "allow_binary_download": true,
   // Diagnostics configuration.
   "diagnostics": {
     // Whether to show warnings or not by default.

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5587,7 +5587,13 @@ impl LspStore {
             adapter.name.0
         );
 
-        let binary = self.get_language_server_binary(adapter.clone(), delegate.clone(), true, cx);
+        let allow_binary_download = ProjectSettings::get_global(cx).allow_binary_download;
+        let binary = self.get_language_server_binary(
+            adapter.clone(),
+            delegate.clone(),
+            allow_binary_download,
+            cx,
+        );
 
         let pending_server = cx.spawn({
             let adapter = adapter.clone();

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -56,6 +56,12 @@ pub struct ProjectSettings {
     /// Configuration for session-related features
     #[serde(default)]
     pub session: SessionSettings,
+
+    /// Whether or not to allow Zed to download binaries
+    ///
+    /// Default: true
+    #[serde(default = "true_value")]
+    pub allow_binary_download: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -762,11 +762,11 @@ fn initialize_settings(
     let (tx, rx) = async_watch::channel(None);
     cx.observe_global::<SettingsStore>(move |cx| {
         let settings = &ProjectSettings::get_global(cx).node;
+        let allow_binary_download = ProjectSettings::get_global(cx).allow_binary_download;
         log::info!("Got new node settings: {:?}", settings);
         let options = NodeBinaryOptions {
             allow_path_lookup: !settings.ignore_system_version.unwrap_or_default(),
-            // TODO: Implement this setting
-            allow_binary_download: true,
+            allow_binary_download,
             use_paths: settings.path.as_ref().map(|node_path| {
                 let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                 let npm_path = settings

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -290,10 +290,10 @@ fn main() {
         let (tx, rx) = async_watch::channel(None);
         cx.observe_global::<SettingsStore>(move |cx| {
             let settings = &ProjectSettings::get_global(cx).node;
+            let allow_binary_download = ProjectSettings::get_global(cx).allow_binary_download;
             let options = NodeBinaryOptions {
                 allow_path_lookup: !settings.ignore_system_version.unwrap_or_default(),
-                // TODO: Expose this setting
-                allow_binary_download: true,
+                allow_binary_download,
                 use_paths: settings.path.as_ref().map(|node_path| {
                     let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                     let npm_path = settings

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -128,6 +128,7 @@ Define extensions which should be installed (`true`) or never installed (`false`
 `boolean` values
 
 ## Allow Binary Downloads
+
 - Description: Whether or not to allow Zed to download binarys for internal LSPs
 - Setting: `allow_binary_downloads`
 - Default: `true`

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -127,6 +127,15 @@ Define extensions which should be installed (`true`) or never installed (`false`
 
 `boolean` values
 
+## Allow Binary Downloads
+- Description: Whether or not to allow Zed to download binarys for internal LSPs
+- Setting: `allow_binary_downloads`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## Base Keymap
 
 - Description: Base key bindings scheme. Base keymaps can be overridden with user keymaps.


### PR DESCRIPTION
Closes Todos added in #18172 & #19176. 

Finishes Node Todo from #14034 

Release Notes:
- Exposes `allow_binary_download` setting to user to disable automatically downloading internal LSP adapters

Notes:

This PR exposes `allow_binary_download` settings to users and uses the value from the new setting when downloading language server protocol adapters. I understand that there's more work involved to get this setting to work for copilot and LSP extensions, but I would like to use this in the debugger PR to manage automatically downloading debug adapters. 
