### PR TITLE
indexed_docs: Turn `IndexedDocsDatabase` into a trait

### DIFF
--- a/crates/extension/src/extension_indexed_docs_provider.rs
+++ b/crates/extension/src/extension_indexed_docs_provider.rs
@@ -52,7 +52,11 @@ impl IndexedDocsProvider for ExtensionIndexedDocsProvider {
             .await
     }
 
-    async fn index(&self, package: PackageName, database: Arc<IndexedDocsDatabase>) -> Result<()> {
+    async fn index(
+        &self,
+        package: PackageName,
+        database: Arc<dyn IndexedDocsDatabase>,
+    ) -> Result<()> {
         self.extension
             .call({
                 let id = self.id.clone();

--- a/crates/extension/src/wasm_host/wit.rs
+++ b/crates/extension/src/wasm_host/wit.rs
@@ -376,7 +376,7 @@ impl Extension {
         store: &mut Store<WasmState>,
         provider: &str,
         package_name: &str,
-        database: Resource<Arc<IndexedDocsDatabase>>,
+        database: Resource<Arc<dyn IndexedDocsDatabase>>,
     ) -> Result<Result<(), String>> {
         match self {
             Extension::V020(ext) => {

--- a/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_1_0.rs
@@ -49,7 +49,7 @@ mod settings {
 }
 
 pub type ExtensionWorktree = Arc<dyn LspAdapterDelegate>;
-pub type ExtensionKeyValueStore = Arc<IndexedDocsDatabase>;
+pub type ExtensionKeyValueStore = Arc<dyn IndexedDocsDatabase>;
 pub type ExtensionHttpResponseStream = Arc<Mutex<::http_client::Response<AsyncBody>>>;
 
 pub fn linker() -> &'static Linker<WasmState> {

--- a/crates/extension/src/wasm_host/wit/since_v0_2_0.rs
+++ b/crates/extension/src/wasm_host/wit/since_v0_2_0.rs
@@ -43,7 +43,7 @@ mod settings {
 }
 
 pub type ExtensionWorktree = Arc<dyn LspAdapterDelegate>;
-pub type ExtensionKeyValueStore = Arc<IndexedDocsDatabase>;
+pub type ExtensionKeyValueStore = Arc<dyn IndexedDocsDatabase>;
 pub type ExtensionHttpResponseStream = Arc<Mutex<::http_client::Response<AsyncBody>>>;
 
 pub fn linker() -> &'static Linker<WasmState> {

--- a/crates/indexed_docs/src/providers/rustdoc.rs
+++ b/crates/indexed_docs/src/providers/rustdoc.rs
@@ -82,7 +82,11 @@ impl IndexedDocsProvider for LocalRustdocProvider {
         Ok(workspace_crates.iter().cloned().collect())
     }
 
-    async fn index(&self, package: PackageName, database: Arc<IndexedDocsDatabase>) -> Result<()> {
+    async fn index(
+        &self,
+        package: PackageName,
+        database: Arc<dyn IndexedDocsDatabase>,
+    ) -> Result<()> {
         index_rustdoc(package, database, {
             move |crate_name, item| {
                 let fs = self.fs.clone();
@@ -159,7 +163,11 @@ impl IndexedDocsProvider for DocsDotRsProvider {
         Ok(POPULAR_CRATES.clone())
     }
 
-    async fn index(&self, package: PackageName, database: Arc<IndexedDocsDatabase>) -> Result<()> {
+    async fn index(
+        &self,
+        package: PackageName,
+        database: Arc<dyn IndexedDocsDatabase>,
+    ) -> Result<()> {
         index_rustdoc(package, database, {
             move |crate_name, item| {
                 let http_client = self.http_client.clone();
@@ -208,7 +216,7 @@ impl IndexedDocsProvider for DocsDotRsProvider {
 
 async fn index_rustdoc(
     package: PackageName,
-    database: Arc<IndexedDocsDatabase>,
+    database: Arc<dyn IndexedDocsDatabase>,
     fetch_page: impl Fn(&PackageName, Option<&RustdocItem>) -> BoxFuture<'static, Result<Option<String>>>
         + Send
         + Sync,

--- a/crates/indexed_docs/src/store.rs
+++ b/crates/indexed_docs/src/store.rs
@@ -359,3 +359,12 @@ impl IndexedDocsDatabase for RealIndexedDocsDatabase {
         })
     }
 }
+
+/// An [`IndexedDocsDatabase`] that doesn't have any behavior.
+pub struct VoidIndexedDocsDatabase;
+
+impl IndexedDocsDatabase for VoidIndexedDocsDatabase {
+    fn insert(&self, _key: String, _docs: String) -> Task<Result<()>> {
+        Task::ready(Ok(()))
+    }
+}


### PR DESCRIPTION
This PR converts the `IndexedDocsDatabase` type into a trait instead of a concrete implementation.

This allows for the extension store to depend on an abstraction rather than the concrete implementation.

We currently have two `IndexedDocsDatabase` implementations:

- `RealIndexedDocsDatabase` — this was previously the `IndexedDocsDatabase` and contains the real implementation of the database.
- `VoidIndexedDocsDatabase` — a null object that doesn't have any behavior.

Release Notes:

- N/A
