### PR TITLE
Fix clang popovers

### DIFF
--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -7,6 +7,7 @@ use std::ops::Range;
 pub fn parse_markdown(text: &str) -> Vec<(Range<usize>, MarkdownEvent)> {
     let mut options = Options::all();
     options.remove(pulldown_cmark::Options::ENABLE_DEFINITION_LIST);
+    options.remove(pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
 
     let mut events = Vec::new();
     let mut within_link = false;


### PR DESCRIPTION
Closes  #15498

Release Notes:

- Fixed info popups from clangd missing information
