### PR TITLE
zed_extension_api: Add work_dir

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -4,6 +4,7 @@ pub mod http_client;
 pub mod settings;
 
 use core::fmt;
+use std::path::PathBuf;
 
 use wit::*;
 
@@ -146,6 +147,16 @@ pub trait Extension: Send + Sync {
         _database: &KeyValueStore,
     ) -> Result<(), String> {
         Err("`index_docs` not implemented".to_string())
+    }
+
+    /// Extension work dir.
+    fn work_dir() -> Result<PathBuf>
+    where
+        Self: Sized,
+    {
+        std::env::var("PWD")
+            .map(|p| PathBuf::new().join(p))
+            .map_err(|e| e.to_string())
     }
 }
 


### PR DESCRIPTION
Calling std::env::current_dir() in a WASI environment will yield an absolute path in Linux style. This causes some malfunctions on Windows，like: "/C:\Users", For example:  [[Windows] Failed to start language server, generated path seems invalid](https://github.com/zed-industries/zed/issues/17571)
