### PR TITLE
Support inline HTML/CSS highlighting

### DIFF
--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -58,3 +58,19 @@
   arguments: (arguments (template_string (string_fragment) @content
                               (#set! "language" "graphql")))
 )
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^styled(\\.\\w+)?$")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "css"))
+)
+
+((comment) @_css_comment
+  (#match? @_css_comment "/[*]+\\s*(css|style)\\s*[*]+/")
+  (template_string (string_fragment) @content
+    (#set! "language" "css")))
+
+((comment) @_html_comment
+  (#match? @_html_comment "/[*]+\\s*html\\s*[*]+/")
+  (template_string (string_fragment) @content
+    (#set! "language" "html")))

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -62,3 +62,19 @@
   arguments: (arguments (template_string (string_fragment) @content
                               (#set! "language" "graphql")))
 )
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^styled(\\.\\w+)?$")
+  arguments: (template_string (string_fragment) @content
+                              (#set! "language" "css"))
+)
+
+((comment) @_css_comment
+  (#match? @_css_comment "/[*]+\\s*(css|style)\\s*[*]+/")
+  (template_string (string_fragment) @content
+    (#set! "language" "css")))
+
+((comment) @_html_comment
+  (#match? @_html_comment "/[*]+\\s*html\\s*[*]+/")
+  (template_string (string_fragment) @content
+    (#set! "language" "html")))


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/20109

Release Notes:

- Support inline html/css highlight
- Support styled component highlight


![Screenshot 2024-11-03 at 01 13 48](https://github.com/user-attachments/assets/aa739223-3090-46bd-a2f7-b3035d38e318)
![Screenshot 2024-11-03 at 01 17 54](https://github.com/user-attachments/assets/5ab048d7-c43c-4739-b105-62280c400f00)

