### PR TITLE
assistant: Improve role button loading state

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2608,22 +2608,24 @@ impl ContextEditor {
                                 None,
                             ),
                             Role::Assistant => {
-                                let label = Label::new("Assistant").color(Color::Info);
-                                let label = if llm_loading {
-                                    label
+                                let base_label = Label::new("Assistant").color(Color::Info);
+                                let mut spinner = None;
+                                let mut note = None;
+                                let animated_label = if llm_loading {
+                                    base_label
                                         .with_animation(
                                             "pulsating-label",
                                             Animation::new(Duration::from_secs(2))
                                                 .repeat()
-                                                .with_easing(pulsating_between(0.4, 0.8)),
+                                                .with_easing(pulsating_between(0.3, 0.9)),
                                             |label, delta| label.alpha(delta),
                                         )
                                         .into_any_element()
                                 } else {
-                                    label.into_any_element()
+                                    base_label.into_any_element()
                                 };
-                                let spinner = if llm_loading {
-                                    Some(
+                                if llm_loading {
+                                    spinner = Some(
                                         Icon::new(IconName::ArrowCircle)
                                             .size(IconSize::XSmall)
                                             .color(Color::Muted)
@@ -2637,21 +2639,15 @@ impl ContextEditor {
                                                 },
                                             )
                                             .into_any_element(),
-                                    )
-                                } else {
-                                    None
-                                };
-                                let note = if llm_loading {
-                                    Some(
+                                    );
+                                    note = Some(
                                         Label::new("Press 'esc' to cancel")
                                             .color(Color::Muted)
                                             .size(LabelSize::XSmall)
                                             .into_any_element(),
-                                    )
-                                } else {
-                                    None
-                                };
-                                (label, spinner, note)
+                                    );
+                                }
+                                (animated_label, spinner, note)
                             }
                             Role::System => (
                                 Label::new("System")

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2669,7 +2669,7 @@ impl ContextEditor {
                                             .items_center()
                                             .gap_1p5()
                                             .child(label)
-                                            .children(spinner.into_iter()),
+                                            .children(spinner),
                                     )
                                     .tooltip(|cx| {
                                         Tooltip::with_meta(
@@ -2691,7 +2691,7 @@ impl ContextEditor {
                                         }
                                     }),
                             )
-                            .children(note.into_iter());
+                            .children(note);
 
                         h_flex()
                             .id(("message_header", message_id.as_u64()))

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2641,9 +2641,17 @@ impl ContextEditor {
                                             .into_any_element(),
                                     );
                                     note = Some(
-                                        Label::new("Press 'esc' to cancel")
-                                            .color(Color::Muted)
-                                            .size(LabelSize::XSmall)
+                                        div()
+                                            .font(
+                                                theme::ThemeSettings::get_global(cx)
+                                                    .buffer_font
+                                                    .clone(),
+                                            )
+                                            .child(
+                                                Label::new("Press 'esc' to cancel")
+                                                    .color(Color::Muted)
+                                                    .size(LabelSize::XSmall),
+                                            )
                                             .into_any_element(),
                                     );
                                 }


### PR DESCRIPTION
We've received feedback that it wasn't clear how to cancel/interrupt the LLM while it's generating a response. Additionally, I also had folks telling me that the loading state was hard to notice—the pulsating animation is too subtle on its own. This PR attempts to improve both of these things. The end result is:

![llm](https://github.com/user-attachments/assets/57a94f8a-c254-4011-adc0-7c63ed13daa1)

Release Notes:

- N/A
