### PR TITLE
Port of `Align cursor` extension from vscode

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -208,6 +208,7 @@ gpui::actions!(
         AcceptPartialInlineCompletion,
         AddSelectionAbove,
         AddSelectionBelow,
+        AlignCursor,
         ApplyAllDiffHunks,
         ApplyDiffHunk,
         Backspace,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6414,8 +6414,8 @@ impl Editor {
 
                     b.push(Vec::new());
                     for j in 0..a[i].len() {
-                        if a.get(i+1).is_some_and(|row| row.get(j).is_some()) {
-                            a[i+1][j] += max - a[i][j];
+                        if a.get(i + 1).is_some_and(|row| row.get(j).is_some()) {
+                            a[i + 1][j] += max - a[i][j];
                         }
                         b[i].push(max - a[i][j]);
                         a[i][j] = max;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13488,39 +13488,85 @@ async fn test_align_cursor(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;
 
-    cx.set_state(
-        &r#"
-        let zero ˇ= 0;
-        let one ˇ= 1;
-        let two ˇ= 2;
-        let three ˇ= 3;
-        let four ˇ= 4;
-        let five ˇ= 5;
-        let six ˇ= 6;
-        let seven ˇ= 7;
-        let eight ˇ= 8;
-        let nine ˇ= 9;
-        "#
-        .unindent(),
-    );
+    {
+        cx.set_state(
+            &r#"
+                let zero ˇ= 0;
+                let one ˇ= 1;
+                let two ˇ= 2;
+                let three ˇ= 3;
+                let four ˇ= 4;
+                let five ˇ= 5;
+                let six ˇ= 6;
+                let seven ˇ= 7;
+                let eight ˇ= 8;
+                let nine ˇ= 9;
+            "#,
+        );
 
-    cx.update_editor(|editor, cx| editor.align_cursor(&AlignCursor, cx));
+        cx.update_editor(|editor, cx| editor.align_cursor(&AlignCursor, cx));
 
-    cx.assert_editor_state(
-        &r#"
-        let zero  ˇ= 0;
-        let one   ˇ= 1;
-        let two   ˇ= 2;
-        let three ˇ= 3;
-        let four  ˇ= 4;
-        let five  ˇ= 5;
-        let six   ˇ= 6;
-        let seven ˇ= 7;
-        let eight ˇ= 8;
-        let nine  ˇ= 9;
-        "#
-        .unindent(),
-    );
+        cx.assert_editor_state(
+            &r#"
+                let zero  ˇ= 0;
+                let one   ˇ= 1;
+                let two   ˇ= 2;
+                let three ˇ= 3;
+                let four  ˇ= 4;
+                let five  ˇ= 5;
+                let six   ˇ= 6;
+                let seven ˇ= 7;
+                let eight ˇ= 8;
+                let nine  ˇ= 9;
+            "#,
+        );
+    }
+
+    {
+        cx.set_state(
+            &r#"
+                let zero ˇ= 0; let one ˇ= 1;
+                let two ˇ= 2; let three ˇ= 3;
+                let four ˇ= 4; let five ˇ= 5;
+                let six ˇ= 6; let seven ˇ= 7;
+                let eight ˇ= 8; let nine ˇ= 9;
+            "#,
+        );
+
+        cx.update_editor(|editor, cx| editor.align_cursor(&AlignCursor, cx));
+
+        cx.assert_editor_state(
+            &r#"
+                let zero  ˇ= 0; let one   ˇ= 1;
+                let two   ˇ= 2; let three ˇ= 3;
+                let four  ˇ= 4; let five  ˇ= 5;
+                let six   ˇ= 6; let seven ˇ= 7;
+                let eight ˇ= 8; let nine  ˇ= 9;
+            "#,
+        );
+    }
+
+    {
+        cx.set_state(
+            &r#"
+                let zero ˇ= 0; let one ˇ= 1; let two ˇ= 2; let three ˇ= 3;
+                let four ˇ= 4; let five ˇ= 5; let six ˇ= 6;
+                let seven ˇ= 7; let eight ˇ= 8;
+                let nine ˇ= 9;
+            "#,
+        );
+
+        cx.update_editor(|editor, cx| editor.align_cursor(&AlignCursor, cx));
+
+        cx.assert_editor_state(
+            &r#"
+                let zero  ˇ= 0; let one   ˇ= 1; let two ˇ= 2; let three ˇ= 3;
+                let four  ˇ= 4; let five  ˇ= 5; let six ˇ= 6;
+                let seven ˇ= 7; let eight ˇ= 8;
+                let nine  ˇ= 9;
+            "#,
+        );
+    }
 }
 
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13483,6 +13483,46 @@ async fn test_find_enclosing_node_with_task(cx: &mut gpui::TestAppContext) {
     });
 }
 
+#[gpui::test]
+async fn test_align_cursor(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(
+        &r#"
+        let zero ˇ= 0;
+        let one ˇ= 1;
+        let two ˇ= 2;
+        let three ˇ= 3;
+        let four ˇ= 4;
+        let five ˇ= 5;
+        let six ˇ= 6;
+        let seven ˇ= 7;
+        let eight ˇ= 8;
+        let nine ˇ= 9;
+        "#
+        .unindent(),
+    );
+
+    cx.update_editor(|editor, cx| editor.align_cursor(&AlignCursor, cx));
+
+    cx.assert_editor_state(
+        &r#"
+        let zero  ˇ= 0;
+        let one   ˇ= 1;
+        let two   ˇ= 2;
+        let three ˇ= 3;
+        let four  ˇ= 4;
+        let five  ˇ= 5;
+        let six   ˇ= 6;
+        let seven ˇ= 7;
+        let eight ˇ= 8;
+        let nine  ˇ= 9;
+        "#
+        .unindent(),
+    );
+}
+
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {
     let point = DisplayPoint::new(DisplayRow(row as u32), column as u32);
     point..point

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -451,6 +451,7 @@ impl EditorElement {
         register_action(view, cx, Editor::open_active_item_in_terminal);
         register_action(view, cx, Editor::reload_file);
         register_action(view, cx, Editor::spawn_nearest_task);
+        register_action(view, cx, Editor::align_cursor);
     }
 
     fn register_key_listeners(&self, cx: &mut WindowContext, layout: &EditorLayout) {


### PR DESCRIPTION
Inspired by: [align cursor](https://marketplace.visualstudio.com/items?itemName=yo1dog.cursor-align)

Ideally, I would have wanted to implement it as an actual extensions, instead of committing it into the core but have not figured how to do it yet. I'd be glad if you'd provide an example of how to interact with editor through the extension API.

> Nothing exists on that front, alas.

Progress:
- [x] Support multiple cursors in the same line
- [ ] Add tests for backwards selection
- [ ] Add the ability to align with tabs

Release Notes:

- Added `align cursor` action to `command pallete`