### PR TITLE
terminal: Do not show multibuffer hint when in centered pane

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1131,6 +1131,10 @@ impl Item for TerminalView {
         false
     }
 
+    fn is_singleton(&self, _cx: &AppContext) -> bool {
+        true
+    }
+
     fn as_searchable(&self, handle: &View<Self>) -> Option<Box<dyn SearchableItemHandle>> {
         Some(Box::new(handle.clone()))
     }


### PR DESCRIPTION
Co-Authored-by: Bennet <bennet@zed.dev>

![image](https://github.com/user-attachments/assets/581f493e-aa9b-4767-8029-6ab83755336b)

Release Notes:

- Fixed an issue where the multibuffer hint was shown when terminal was in centered mode
