### PR TITLE
image viewer: Show path in breadcrumbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5797,6 +5797,7 @@ dependencies = [
  "gpui",
  "project",
  "settings",
+ "theme",
  "ui",
  "workspace",
 ]

--- a/crates/image_viewer/Cargo.toml
+++ b/crates/image_viewer/Cargo.toml
@@ -15,9 +15,10 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 db.workspace = true
-gpui.workspace = true
 file_icons.workspace = true
-ui.workspace = true
-settings.workspace = true
-workspace.workspace = true
+gpui.workspace = true
 project.workspace = true
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+workspace.workspace = true


### PR DESCRIPTION
Closes #10057

<img width="354" alt="image" src="https://github.com/user-attachments/assets/47afe8fd-c8ac-45af-be9a-9ca8c5e066f6">

Release Notes:

- Show path in breadcrumbs/toolbar when opening an image
