### PR TITLE
Fix file reloading not populating the history

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2214,7 +2214,7 @@ impl Project {
         match event {
             BufferEvent::ReloadNeeded => {
                 if !self.is_via_collab() {
-                    self.reload_buffers([buffer.clone()].into_iter().collect(), false, cx)
+                    self.reload_buffers([buffer.clone()].into_iter().collect(), true, cx)
                         .detach_and_log_err(cx);
                 }
             }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20111
Closes https://github.com/zed-industries/zed/issues/20153

cc @mikayla-maki and @ConradIrwin 

Release Notes:

- Fixed undo stack corruption on external file changes ([#20111](https://github.com/zed-industries/zed/issues/20111)) ([#20153](https://github.com/zed-industries/zed/issues/20153))
