### PR TITLE
vim: Fix `d shift-g` not deleting until EOD if soft-wrap is on

### DIFF
--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -731,6 +731,24 @@ async fn test_wrapped_motions(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_wrapped_delete_end_document(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    cx.set_shared_wrap(12).await;
+
+    cx.set_shared_state(indoc! {"
+                aaˇaaaaaaaaaaaaaaaaaa
+                bbbbbbbbbbbbbbbbbbbb
+                cccccccccccccccccccc"
+    })
+    .await;
+    cx.simulate_shared_keystrokes("d shift-g i z z z").await;
+    cx.shared_state().await.assert_eq(indoc! {"
+                zzzˇ"
+    });
+}
+
+#[gpui::test]
 async fn test_paragraphs_dont_wrap(cx: &mut gpui::TestAppContext) {
     let mut cx = NeovimBackedTestContext::new(cx).await;
 

--- a/crates/vim/test_data/test_wrapped_delete_end_document.json
+++ b/crates/vim/test_data/test_wrapped_delete_end_document.json
@@ -1,0 +1,10 @@
+{"SetOption":{"value":"wrap"}}
+{"SetOption":{"value":"columns=12"}}
+{"Put":{"state":"aaˇaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbbb\ncccccccccccccccccccc"}}
+{"Key":"d"}
+{"Key":"shift-g"}
+{"Key":"i"}
+{"Key":"z"}
+{"Key":"z"}
+{"Key":"z"}
+{"Get":{"state":"zzzˇ","mode":"Insert"}}


### PR DESCRIPTION
This previously didn't work: `d G` would delete to the end of the "first of the soft-wrapped lines" of the last line.

To fix it, we special case the delete behavior for `shift-g`, which is what Neovim also seems to do.


Release Notes:

- Fixed `d G` in Vim mode not deleting until the actual end of the document if soft-wrap is turned on.