### PR TITLE
git: Add support for opening git worktrees

### DIFF
--- a/crates/fs/src/linux_watcher.rs
+++ b/crates/fs/src/linux_watcher.rs
@@ -1,0 +1,134 @@
+use std::sync::Arc;
+
+use notify::EventKind;
+use parking_lot::Mutex;
+
+use crate::{PathEvent, PathEventKind, Watcher};
+
+pub struct LinuxWatcher {
+    tx: smol::channel::Sender<()>,
+    pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
+}
+
+impl LinuxWatcher {
+    pub(crate) fn new(
+        tx: smol::channel::Sender<()>,
+        pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
+    ) -> Self {
+        Self {
+            tx,
+            pending_path_events,
+        }
+    }
+}
+
+impl Watcher for LinuxWatcher {
+    fn add(&self, path: &std::path::Path) -> gpui::Result<()> {
+        let root_path = path.to_path_buf();
+
+        let tx = self.tx.clone();
+        let pending_paths = self.pending_path_events.clone();
+
+        use notify::Watcher;
+
+        watcher::global({
+            |g| {
+                g.add(move |event: &notify::Event| {
+                    let kind = match event.kind {
+                        EventKind::Create(_) => Some(PathEventKind::Created),
+                        EventKind::Modify(_) => Some(PathEventKind::Changed),
+                        EventKind::Remove(_) => Some(PathEventKind::Removed),
+                        _ => None,
+                    };
+                    let mut path_events = event
+                        .paths
+                        .iter()
+                        .filter_map(|event_path| {
+                            if event_path.starts_with(&root_path) {
+                                Some(PathEvent {
+                                    path: event_path.clone(),
+                                    kind,
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    if !path_events.is_empty() {
+                        path_events.sort();
+                        let mut pending_paths = pending_paths.lock();
+                        if pending_paths.is_empty() {
+                            tx.try_send(()).ok();
+                        }
+                        util::extend_sorted(
+                            &mut *pending_paths,
+                            path_events,
+                            usize::MAX,
+                            |a, b| a.path.cmp(&b.path),
+                        );
+                    }
+                })
+            }
+        })?;
+
+        watcher::global(|g| {
+            g.inotify
+                .lock()
+                .watch(path, notify::RecursiveMode::NonRecursive)
+        })??;
+
+        Ok(())
+    }
+
+    fn remove(&self, path: &std::path::Path) -> gpui::Result<()> {
+        use notify::Watcher;
+        Ok(watcher::global(|w| w.inotify.lock().unwatch(path))??)
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub mod watcher {
+    use std::sync::OnceLock;
+
+    use parking_lot::Mutex;
+    use util::ResultExt;
+
+    pub struct GlobalWatcher {
+        // two mutexes because calling inotify.add triggers an inotify.event, which needs watchers.
+        pub(super) inotify: Mutex<notify::INotifyWatcher>,
+        pub(super) watchers: Mutex<Vec<Box<dyn Fn(&notify::Event) + Send + Sync>>>,
+    }
+
+    impl GlobalWatcher {
+        pub(super) fn add(&self, cb: impl Fn(&notify::Event) + Send + Sync + 'static) {
+            self.watchers.lock().push(Box::new(cb))
+        }
+    }
+
+    static INOTIFY_INSTANCE: OnceLock<anyhow::Result<GlobalWatcher, notify::Error>> =
+        OnceLock::new();
+
+    fn handle_event(event: Result<notify::Event, notify::Error>) {
+        let Some(event) = event.log_err() else { return };
+        global::<()>(move |watcher| {
+            for f in watcher.watchers.lock().iter() {
+                f(&event)
+            }
+        })
+        .log_err();
+    }
+
+    pub fn global<T>(f: impl FnOnce(&GlobalWatcher) -> T) -> anyhow::Result<T> {
+        let result = INOTIFY_INSTANCE.get_or_init(|| {
+            notify::recommended_watcher(handle_event).map(|file_watcher| GlobalWatcher {
+                inotify: Mutex::new(file_watcher),
+                watchers: Default::default(),
+            })
+        });
+        match result {
+            Ok(g) => Ok(f(g)),
+            Err(e) => Err(anyhow::anyhow!("{}", e)),
+        }
+    }
+}

--- a/crates/fs/src/linux_watcher.rs
+++ b/crates/fs/src/linux_watcher.rs
@@ -11,7 +11,7 @@ pub struct LinuxWatcher {
 }
 
 impl LinuxWatcher {
-    pub(crate) fn new(
+    pub fn new(
         tx: smol::channel::Sender<()>,
         pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
     ) -> Self {
@@ -44,14 +44,10 @@ impl Watcher for LinuxWatcher {
                         .paths
                         .iter()
                         .filter_map(|event_path| {
-                            if event_path.starts_with(&root_path) {
-                                Some(PathEvent {
-                                    path: event_path.clone(),
-                                    kind,
-                                })
-                            } else {
-                                None
-                            }
+                            event_path.starts_with(&root_path).then(|| PathEvent {
+                                path: event_path.clone(),
+                                kind,
+                            })
                         })
                         .collect::<Vec<_>>();
 

--- a/crates/fs/src/mac_watcher.rs
+++ b/crates/fs/src/mac_watcher.rs
@@ -1,0 +1,70 @@
+use crate::Watcher;
+use anyhow::{Context as _, Result};
+use collections::{BTreeMap, Bound};
+use fsevent::EventStream;
+use parking_lot::Mutex;
+use std::{
+    path::{Path, PathBuf},
+    sync::Weak,
+    time::Duration,
+};
+
+pub struct MacWatcher {
+    events_tx: smol::channel::Sender<Vec<fsevent::Event>>,
+    handles: Weak<Mutex<BTreeMap<PathBuf, fsevent::Handle>>>,
+    latency: Duration,
+}
+
+impl MacWatcher {
+    pub fn new(
+        events_tx: smol::channel::Sender<Vec<fsevent::Event>>,
+        handles: Weak<Mutex<BTreeMap<PathBuf, fsevent::Handle>>>,
+        latency: Duration,
+    ) -> Self {
+        Self {
+            events_tx,
+            handles,
+            latency,
+        }
+    }
+}
+
+impl Watcher for MacWatcher {
+    fn add(&self, path: &Path) -> Result<()> {
+        let handles = self
+            .handles
+            .upgrade()
+            .context("unable to watch path, receiver dropped")?;
+        let mut handles = handles.lock();
+
+        // Return early if an ancestor of this path was already being watched.
+        if let Some((watched_path, _)) = handles
+            .range::<Path, _>((Bound::Unbounded, Bound::Included(path)))
+            .next_back()
+        {
+            if path.starts_with(watched_path) {
+                return Ok(());
+            }
+        }
+
+        let (stream, handle) = EventStream::new(&[path], self.latency);
+        let tx = self.events_tx.clone();
+        std::thread::spawn(move || {
+            stream.run(move |events| smol::block_on(tx.send(events)).is_ok());
+        });
+        handles.insert(path.into(), handle);
+
+        Ok(())
+    }
+
+    fn remove(&self, path: &Path) -> gpui::Result<()> {
+        let handles = self
+            .handles
+            .upgrade()
+            .context("unable to remove path, receiver dropped")?;
+
+        let mut handles = handles.lock();
+        handles.remove(path);
+        Ok(())
+    }
+}

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -45,6 +45,8 @@ pub trait GitRepository: Send + Sync {
     fn branch_exits(&self, _: &str) -> Result<bool>;
 
     fn blame(&self, path: &Path, content: Rope) -> Result<crate::blame::Blame>;
+
+    fn path(&self) -> Option<PathBuf>;
 }
 
 impl std::fmt::Debug for dyn GitRepository {
@@ -81,6 +83,11 @@ impl GitRepository for RealGitRepository {
         if let Ok(mut index) = self.repository.lock().index() {
             _ = index.read(false);
         }
+    }
+
+    fn path(&self) -> Option<PathBuf> {
+        let repo = self.repository.lock();
+        Some(repo.path().into())
     }
 
     fn load_index_text(&self, relative_file_path: &Path) -> Option<String> {
@@ -273,6 +280,10 @@ impl GitRepository for FakeGitRepository {
     }
 
     fn head_sha(&self) -> Option<String> {
+        None
+    }
+
+    fn path(&self) -> Option<PathBuf> {
         None
     }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -46,7 +46,7 @@ pub trait GitRepository: Send + Sync {
 
     fn blame(&self, path: &Path, content: Rope) -> Result<crate::blame::Blame>;
 
-    fn path(&self) -> Option<PathBuf>;
+    fn path(&self) -> PathBuf;
 }
 
 impl std::fmt::Debug for dyn GitRepository {
@@ -85,9 +85,9 @@ impl GitRepository for RealGitRepository {
         }
     }
 
-    fn path(&self) -> Option<PathBuf> {
+    fn path(&self) -> PathBuf {
         let repo = self.repository.lock();
-        Some(repo.path().into())
+        repo.path().into()
     }
 
     fn load_index_text(&self, relative_file_path: &Path) -> Option<String> {
@@ -283,8 +283,9 @@ impl GitRepository for FakeGitRepository {
         None
     }
 
-    fn path(&self) -> Option<PathBuf> {
-        None
+    fn path(&self) -> PathBuf {
+        let state = self.state.lock();
+        state.path.clone()
     }
 
     fn status(&self, path_prefixes: &[PathBuf]) -> Result<GitStatus> {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2024,6 +2024,7 @@ pub fn perform_project_search(
     text: impl Into<std::sync::Arc<str>>,
     cx: &mut gpui::VisualTestContext,
 ) {
+    cx.run_until_parked();
     search_view.update(cx, |search_view, cx| {
         search_view
             .query_editor

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4506,7 +4506,6 @@ impl BackgroundScanner {
         let mut repo_updates = Vec::new();
         {
             let mut state = self.state.lock();
-
             let scan_id = state.snapshot.scan_id;
             for dot_git_dir in dot_git_paths {
                 let existing_repository_entry =
@@ -4640,7 +4639,6 @@ impl BackgroundScanner {
         let Some(statuses) = job.repository.status(&[PathBuf::from("")]).log_err() else {
             return;
         };
-
         log::trace!(
             "computed git statuses for repo {:?} in {:?}",
             job.work_directory.0,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2953,14 +2953,15 @@ impl BackgroundScannerState {
 
         let t0 = Instant::now();
         let repository = fs.open_repo(&dot_git_abs_path)?;
-        let actual_dot_git_dir_abs_path = Arc::from(
-            repository
-                .path()
+
+        let actual_repo_path = repository.path();
+        let actual_dot_git_dir_abs_path: Arc<Path> = Arc::from(
+            actual_repo_path
                 .ancestors()
                 .find(|ancestor| ancestor.file_name() == Some(&*DOT_GIT))?,
         );
 
-        watcher.add(&actual_dot_git_dir_abs_path).log_err()?;
+        watcher.add(&actual_repo_path).log_err()?;
 
         let dot_git_worktree_abs_path = if actual_dot_git_dir_abs_path.as_ref() == dot_git_abs_path
         {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2952,7 +2952,7 @@ impl BackgroundScannerState {
         let repository = fs.open_repo(&dot_git_abs_path)?;
         let git_dir_path = Arc::from(
             repository
-                .path()?
+                .path()
                 .ancestors()
                 .find(|ancestor| ancestor.file_name() == Some(&*DOT_GIT))?,
         );
@@ -2975,7 +2975,7 @@ impl BackgroundScannerState {
         }
 
         self.snapshot.repository_entries.insert(
-            work_directory.clone(), // ""
+            work_directory.clone(),
             RepositoryEntry {
                 work_directory: work_dir_id.into(),
                 branch: repository.branch_name().map(Into::into),

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -843,7 +843,7 @@ async fn test_write_file(cx: &mut TestAppContext) {
     .unwrap();
 
     #[cfg(target_os = "linux")]
-    fs::linux_watcher::watcher::global(|_| {}).unwrap();
+    fs::linux_watcher::global(|_| {}).unwrap();
 
     cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
         .await;

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -843,7 +843,7 @@ async fn test_write_file(cx: &mut TestAppContext) {
     .unwrap();
 
     #[cfg(target_os = "linux")]
-    fs::watcher::global(|_| {}).unwrap();
+    fs::linux_watcher::watcher::global(|_| {}).unwrap();
 
     cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
         .await;

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -720,7 +720,7 @@ async fn test_rescan_with_gitignore(cx: &mut TestAppContext) {
     cx.read(|cx| {
         let tree = tree.read(cx);
         assert_entry_git_state(tree, "tracked-dir/tracked-file1", None, false);
-        assert_entry_git_state(tree, "tracked-dir/ancestor-ignored-file1", None, true);
+        assert_entry_git_state(tree, "tracked-dir/ancestor-ignored-file1", None, false);
         assert_entry_git_state(tree, "ignored-dir/ignored-file1", None, true);
     });
 
@@ -757,7 +757,7 @@ async fn test_rescan_with_gitignore(cx: &mut TestAppContext) {
             Some(GitFileStatus::Added),
             false,
         );
-        assert_entry_git_state(tree, "tracked-dir/ancestor-ignored-file2", None, true);
+        assert_entry_git_state(tree, "tracked-dir/ancestor-ignored-file2", None, false);
         assert_entry_git_state(tree, "ignored-dir/ignored-file2", None, true);
         assert!(tree.entry_for_path(".git").unwrap().is_ignored);
     });
@@ -2635,6 +2635,12 @@ fn assert_entry_git_state(
     is_ignored: bool,
 ) {
     let entry = tree.entry_for_path(path).expect("entry {path} not found");
-    assert_eq!(entry.git_status, git_status);
-    assert_eq!(entry.is_ignored, is_ignored);
+    assert_eq!(
+        entry.git_status, git_status,
+        "expected {path} to have git status: {git_status:?}"
+    );
+    assert_eq!(
+        entry.is_ignored, is_ignored,
+        "expected {path} to have is_ignored: {is_ignored}"
+    );
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -154,7 +154,7 @@ pub fn initialize_workspace(
         .detach();
 
         #[cfg(target_os = "linux")]
-        if let Err(e) = fs::watcher::global(|_| {}) {
+        if let Err(e) = fs::linux_watcher::watcher::global(|_| {}) {
             let message = format!(db::indoc!{r#"
                 inotify_init returned {}
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -154,7 +154,7 @@ pub fn initialize_workspace(
         .detach();
 
         #[cfg(target_os = "linux")]
-        if let Err(e) = fs::linux_watcher::watcher::global(|_| {}) {
+        if let Err(e) = fs::linux_watcher::global(|_| {}) {
             let message = format!(db::indoc!{r#"
                 inotify_init returned {}
 


### PR DESCRIPTION
This adds support for [git worktrees](https://matklad.github.io/2024/07/25/git-worktrees.html). It fixes the errors that show up (git blame not working) and actually adds support for detecting git changes in a `.git` folder that's outside of our path (and not even in the ancestor chain of our root path).

(While working on this we discovered that our `.gitignore` handling is not 100% correct. For example: we do stop processing `.gitignore` files once we found a `.git` repository and don't go further up the ancestors, which is correct, but then we also don't take into account the `excludesFile` that a user might have configured, see: https://git-scm.com/docs/gitignore)


Closes https://github.com/zed-industries/zed/issues/19842
Closes https://github.com/zed-industries/zed/issues/4670

Release Notes:

- Added support for git worktrees. Zed can now open git worktrees and the git status in them is correctly handled.