### PR TITLE
markdown preview: Refresh preview when file is changed outside of the editor

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -297,7 +297,7 @@ impl MarkdownPreviewView {
 
         let subscription = cx.subscribe(&editor, |this, editor, event: &EditorEvent, cx| {
             match event {
-                EditorEvent::Edited { .. } => {
+                EditorEvent::Edited { .. } | EditorEvent::DirtyChanged => {
                     this.parse_markdown_from_active_editor(true, cx);
                 }
                 EditorEvent::SelectionsChanged { .. } => {


### PR DESCRIPTION
Closes #20091

Release Notes:

- Fixed an issue where the markdown preview would not update when a markdown file was changed outside of the editor