### PR TITLE
recent projects: Fix inconsistent keybinding with which window is replaced or not

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -39,7 +39,7 @@ pub struct OpenRecent {
 }
 
 fn default_create_new_window() -> bool {
-    true
+    false
 }
 
 gpui::impl_actions!(projects, [OpenRecent]);


### PR DESCRIPTION
This removes the inconsistency between these two workflows:
- Clicking on the project name in the upper left shows:
<img width="333" alt="image" src="https://github.com/user-attachments/assets/f54c34b4-67ab-4cbc-85ee-845c41aa4a8c">

- Using `projects: Open recent` shows:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/b1eb244f-ce28-4e6c-8404-b6cd88caef1e">

---

We now use `enter` to re-use the window and `cmd-enter` to open a new window in both cases

Closes #16361

Release Notes:

- Fixed an inconsistency in the recent project picker, where different keybindings would determine whether to reuse the window or not
