### PR TITLE
assistant: Fix safety settings for google_ai

### DIFF
--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -294,7 +294,10 @@ impl LanguageModelRequest {
                 top_p: None,
                 top_k: None,
             }),
-            safety_settings: None,
+            safety_settings: Some(vec![google_ai::SafetySetting {
+                category: google_ai::HarmCategory::DangerousContent,
+                threshold: google_ai::HarmBlockThreshold::BlockNone,
+            }]),
         }
     }
 


### PR DESCRIPTION
Sometimes Gemini API's safety filter blocks code, considering it dangerous content. This happens quite often. The bug has been described in some comments under #18561. Here is an example prompt for Gemini Flash.
In Zed:
<img width="432" alt="error_prompt_zed" src="https://github.com/user-attachments/assets/6ba49c08-4065-4b73-916d-eff43f4434e9">
In Google AI Studio:
<img width="490" alt="error_prompt_google" src="https://github.com/user-attachments/assets/8408c995-4e2c-41f9-8cd3-72b19fc38c5a">

Disabling the `DangerousContent` category for the filter solves the problem

Release Notes:

- N/A

