### PR TITLE
settings: Allow `null` as a value for font fallback fields

### DIFF
--- a/crates/settings/src/json_schema.rs
+++ b/crates/settings/src/json_schema.rs
@@ -1,4 +1,6 @@
-use schemars::schema::{ArrayValidation, InstanceType, RootSchema, Schema, SchemaObject};
+use schemars::schema::{
+    ArrayValidation, InstanceType, RootSchema, Schema, SchemaObject, SingleOrVec,
+};
 use serde_json::Value;
 
 pub struct SettingsJsonSchemaParams<'a> {
@@ -20,7 +22,10 @@ impl<'a> SettingsJsonSchemaParams<'a> {
 
     pub fn font_fallback_schema(&self) -> Schema {
         SchemaObject {
-            instance_type: Some(InstanceType::Array.into()),
+            instance_type: Some(SingleOrVec::Vec(vec![
+                InstanceType::Array,
+                InstanceType::Null,
+            ])),
             array: Some(Box::new(ArrayValidation {
                 items: Some(schemars::schema::SingleOrVec::Single(Box::new(
                     self.font_family_schema(),


### PR DESCRIPTION
This PR updates the `buffer_font_fallbacks` and `ui_font_fallbacks` settings to allow `null` as a value instead of showing a warning.

Related to https://github.com/zed-industries/zed/issues/18006.

Release Notes:

- Updated the settings schema to allow `null` as a value for `buffer_font_fallbacks` and `ui_font_fallbacks` instead of showing a warning.
