### PR TITLE
settings: Include `null` in the type for optional settings

### DIFF
--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -746,7 +746,7 @@ impl SettingsStore {
         };
 
         let settings = SchemaSettings::draft07().with(|settings| {
-            settings.option_add_null_type = false;
+            settings.option_add_null_type = true;
         });
         let mut generator = SchemaGenerator::new(settings);
         let mut combined_schema = RootSchema::default();


### PR DESCRIPTION
This PR updates all settings that are defined as `Option`s to include `null` in their type.

This prevents warnings from being displayed when `null` is used a default value.

Closes https://github.com/zed-industries/zed/issues/18006.

Release Notes:

- Updated the settings schema to allow `null` as a value for optional settings instead of showing a warning.
