### PR TITLE
typescript: Improve installation checks for `vtsls`

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -161,6 +161,10 @@ impl NodeRuntime {
         directory: &Path,
         packages: &[(&str, &str)],
     ) -> Result<()> {
+        if packages.is_empty() {
+            return Ok(());
+        }
+
         let packages: Vec<_> = packages
             .iter()
             .map(|(name, version)| format!("{name}@{version}"))


### PR DESCRIPTION
This PR improves the installation checks for `vtsls`.

Previously we were checking the installed version of TypeScript against the latest available version to determine whether we needed to installed the `vtsls` language server or not.

However, these are two independent concerns, so we should be checking individually whether `typescript` or `@vtsls/language-server` need to be installed/updated.

Closes https://github.com/zed-industries/zed/issues/18349.

Release Notes:

- typescript: Fixed an issue where `@vtsls/language-server` may not have been updated to the latest version.
