### PR TITLE
Do not alter soft wrap based on .editorconfig contents

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use collections::{HashMap, HashSet};
 use core::slice;
 use ec4rs::{
-    property::{FinalNewline, IndentSize, IndentStyle, MaxLineLen, TabWidth, TrimTrailingWs},
+    property::{FinalNewline, IndentSize, IndentStyle, TabWidth, TrimTrailingWs},
     Properties as EditorconfigProperties,
 };
 use globset::{Glob, GlobMatcher, GlobSet, GlobSetBuilder};
@@ -876,10 +876,6 @@ impl AllLanguageSettings {
 }
 
 fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigProperties) {
-    let max_line_length = cfg.get::<MaxLineLen>().ok().and_then(|v| match v {
-        MaxLineLen::Value(u) => Some(u as u32),
-        MaxLineLen::Off => None,
-    });
     let tab_size = cfg.get::<IndentSize>().ok().and_then(|v| match v {
         IndentSize::Value(u) => NonZeroU32::new(u as u32),
         IndentSize::UseTabWidth => cfg.get::<TabWidth>().ok().and_then(|w| match w {
@@ -902,13 +898,6 @@ fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigPr
             TrimTrailingWs::Value(b) => b,
         })
         .ok();
-    let preferred_line_length = max_line_length;
-    let soft_wrap = if max_line_length.is_some() {
-        Some(SoftWrap::PreferredLineLength)
-    } else {
-        None
-    };
-
     fn merge<T>(target: &mut T, value: Option<T>) {
         if let Some(value) = value {
             *target = value;
@@ -924,8 +913,6 @@ fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigPr
         &mut settings.ensure_final_newline_on_save,
         ensure_final_newline_on_save,
     );
-    merge(&mut settings.preferred_line_length, preferred_line_length);
-    merge(&mut settings.soft_wrap, soft_wrap);
 }
 
 /// The kind of an inlay hint.

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -4,9 +4,7 @@ use futures::{future, StreamExt};
 use gpui::{AppContext, SemanticVersion, UpdateGlobal};
 use http_client::Url;
 use language::{
-    language_settings::{
-        language_settings, AllLanguageSettings, LanguageSettingsContent, SoftWrap,
-    },
+    language_settings::{language_settings, AllLanguageSettings, LanguageSettingsContent},
     tree_sitter_rust, tree_sitter_typescript, Diagnostic, DiagnosticSet, FakeLspAdapter,
     LanguageConfig, LanguageMatcher, LanguageName, LineEnding, OffsetRangeExt, Point, ToPoint,
 };
@@ -106,7 +104,6 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
             end_of_line = lf
             insert_final_newline = true
             trim_trailing_whitespace = true
-            max_line_length = 80
         [*.js]
             tab_width = 10
         "#,
@@ -116,7 +113,6 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
                 "hard_tabs": false,
                 "ensure_final_newline_on_save": false,
                 "remove_trailing_whitespace_on_save": false,
-                "preferred_line_length": 64,
                 "soft_wrap": "editor_width"
             }"#,
         },
@@ -125,7 +121,6 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
             ".editorconfig": r#"
             [*.rs]
                 indent_size = 2
-                max_line_length = off
             "#,
             "b.rs": "fn b() {\n    B\n}",
         },
@@ -174,20 +169,12 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
         assert_eq!(settings_a.hard_tabs, true);
         assert_eq!(settings_a.ensure_final_newline_on_save, true);
         assert_eq!(settings_a.remove_trailing_whitespace_on_save, true);
-        assert_eq!(settings_a.preferred_line_length, 80);
-
-        // "max_line_length" also sets "soft_wrap"
-        assert_eq!(settings_a.soft_wrap, SoftWrap::PreferredLineLength);
 
         // .editorconfig in b/ overrides .editorconfig in root
         assert_eq!(Some(settings_b.tab_size), NonZeroU32::new(2));
 
         // "indent_size" is not set, so "tab_width" is used
         assert_eq!(Some(settings_c.tab_size), NonZeroU32::new(10));
-
-        // When max_line_length is "off", default to .zed/settings.json
-        assert_eq!(settings_b.preferred_line_length, 64);
-        assert_eq!(settings_b.soft_wrap, SoftWrap::EditorWidth);
 
         // README.md should not be affected by .editorconfig's globe "*.rs"
         assert_eq!(Some(settings_readme.tab_size), NonZeroU32::new(8));


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20194

Release Notes:

- Fixed Zed incorrectly changing soft wrap based on .editorconfig contents ([#20194](https://github.com/zed-industries/zed/issues/20194))
