### PR TITLE
assistant: Fix Gemini 1.5 Pro throwing "missing field 'index' at line N column M"

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -136,7 +136,7 @@ pub struct GenerateContentResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GenerateContentCandidate {
-    pub index: usize,
+    pub index: Option<usize>,
     pub content: Content,
     pub finish_reason: Option<String>,
     pub finish_message: Option<String>,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20033

Release Notes:

- Assistant: Fixed deserialization error with Gemini 1.5 Pro

<img width="1113" alt="zed_pre" src="https://github.com/user-attachments/assets/7b34d280-0965-4b54-be2d-38a03b7d9303">

<img width="1117" alt="zed_post" src="https://github.com/user-attachments/assets/bc89ef7c-e393-4d84-90f6-fc2d810a1df6">
