### PR TITLE
Standardize confirmation key bindings for opening recent projects

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -51,7 +51,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action(
                     "Open Recent...",
                     recent_projects::OpenRecent {
-                        create_new_window: true,
+                        create_new_window: false,
                     },
                 ),
                 MenuItem::separator(),


### PR DESCRIPTION
This change makes the `projects::OpenRecent` action have the same `create_new_window: false` behavior as the `application_menu`'s OpenRecent.

`File->Open Recent` is also affected since it is the same implementation as `projects::OpenRecent` binding.

Closes #17765

Release Notes:

- Made `File->Open Recent...`, Burger Menu (`Project > Open Recent Projects`), and the `projects: open recent` command have the same key binding for 1) creating a new window or 2) reusing the existing window.
