### PR TITLE
Don't write temp files for telemetry logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,7 +2432,6 @@ dependencies = [
  "smol",
  "sysinfo",
  "telemetry_events",
- "tempfile",
  "text",
  "thiserror",
  "time",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -44,7 +44,6 @@ sha2.workspace = true
 smol.workspace = true
 sysinfo.workspace = true
 telemetry_events.workspace = true
-tempfile.workspace = true
 text.workspace = true
 thiserror.workspace = true
 time.workspace = true

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -13,6 +13,7 @@ use parking_lot::Mutex;
 use release_channel::ReleaseChannel;
 use settings::{Settings, SettingsStore};
 use sha2::{Digest, Sha256};
+use std::fs::File;
 use std::io::Write;
 use std::{env, mem, path::PathBuf, sync::Arc, time::Duration};
 use sysinfo::{CpuRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System};
@@ -21,10 +22,9 @@ use telemetry_events::{
     EventRequestBody, EventWrapper, ExtensionEvent, InlineCompletionEvent, MemoryEvent, ReplEvent,
     SettingEvent,
 };
-use tempfile::NamedTempFile;
 #[cfg(not(debug_assertions))]
 use util::ResultExt;
-use util::TryFutureExt;
+use util::{ResultExt, TryFutureExt};
 use worktree::{UpdatedEntriesSet, WorktreeId};
 
 use self::event_coalescer::EventCoalescer;
@@ -46,7 +46,7 @@ struct TelemetryState {
     architecture: &'static str,
     events_queue: Vec<EventWrapper>,
     flush_events_task: Option<Task<()>>,
-    log_file: Option<NamedTempFile>,
+    log_file: Option<File>,
     is_staff: Option<bool>,
     first_event_date_time: Option<DateTime<Utc>>,
     event_coalescer: EventCoalescer,
@@ -223,15 +223,13 @@ impl Telemetry {
             os_name: os_name(),
             app_version: release_channel::AppVersion::global(cx).to_string(),
         }));
+        Self::log_file_path();
 
-        #[cfg(not(debug_assertions))]
         cx.background_executor()
             .spawn({
                 let state = state.clone();
                 async move {
-                    if let Some(tempfile) =
-                        NamedTempFile::new_in(paths::logs_dir().as_path()).log_err()
-                    {
+                    if let Some(tempfile) = File::create(Self::log_file_path()).log_err() {
                         state.lock().log_file = Some(tempfile);
                     }
                 }
@@ -280,8 +278,8 @@ impl Telemetry {
         Task::ready(())
     }
 
-    pub fn log_file_path(&self) -> Option<PathBuf> {
-        Some(self.state.lock().log_file.as_ref()?.path().to_path_buf())
+    pub fn log_file_path() -> PathBuf {
+        paths::logs_dir().join("telemetry.log")
     }
 
     pub fn start(
@@ -645,7 +643,6 @@ impl Telemetry {
                     let mut json_bytes = Vec::new();
 
                     if let Some(file) = &mut this.state.lock().log_file {
-                        let file = file.as_file_mut();
                         for event in &mut events {
                             json_bytes.clear();
                             serde_json::to_writer(&mut json_bytes, event)?;

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -22,8 +22,6 @@ use telemetry_events::{
     EventRequestBody, EventWrapper, ExtensionEvent, InlineCompletionEvent, MemoryEvent, ReplEvent,
     SettingEvent,
 };
-#[cfg(not(debug_assertions))]
-use util::ResultExt;
 use util::{ResultExt, TryFutureExt};
 use worktree::{UpdatedEntriesSet, WorktreeId};
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -999,7 +999,7 @@ fn open_telemetry_log_file(workspace: &mut Workspace, cx: &mut ViewContext<Works
         let app_state = workspace.app_state().clone();
         cx.spawn(|workspace, mut cx| async move {
             async fn fetch_log_string(app_state: &Arc<AppState>) -> Option<String> {
-                let path = app_state.client.telemetry().log_file_path()?;
+                let path = client::telemetry::Telemetry::log_file_path();
                 app_state.fs.load(&path).await.log_err()
             }
 


### PR DESCRIPTION
This still keeps a telemetry.log for the current session, but not one
file per load of zed.

Closes: #20045

Release Notes:

- Fixed a bug where Zed would create a new temporary file on each boot for telemetry logs
