### PR TITLE
Fix casing of key bindings shown in command picker

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -135,7 +135,7 @@ impl RenderOnce for KeyBinding {
                     })
                     .map(|el| match key_icon {
                         Some(icon) => el.child(KeyIcon::new(icon)),
-                        None => el.child(Key::new(keystroke.key.clone())),
+                        None => el.child(Key::new(&keystroke.key)),
                     })
             }))
     }

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -135,7 +135,7 @@ impl RenderOnce for KeyBinding {
                     })
                     .map(|el| match key_icon {
                         Some(icon) => el.child(KeyIcon::new(icon)),
-                        None => el.child(Key::new(keystroke.key.to_uppercase())),
+                        None => el.child(Key::new(keystroke.key.clone())),
                     })
             }))
     }


### PR DESCRIPTION
Currently key bindings shown next to command names in the command picker are always upper case, which is not right. For example, "editor: fold all" with the default vim key bindings is `z M`, but it's shown as `Z M`. This fixes the casing.

Release Notes:

- Fixed casing of key bindings shown next to command names in the command picker.