### PR TITLE
Fix toolchain detection for worktree-local paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6403,6 +6403,7 @@ dependencies = [
  "pet",
  "pet-conda",
  "pet-core",
+ "pet-fs",
  "pet-poetry",
  "pet-reporter",
  "project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,6 +381,7 @@ palette = { version = "0.7.5", default-features = false, features = ["std"] }
 parking_lot = "0.12.1"
 pathdiff = "0.2"
 pet = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "ffcbf3f28c46633abd5448a52b1f396c322e0d6c" }
+pet-fs = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "ffcbf3f28c46633abd5448a52b1f396c322e0d6c" }
 pet-conda = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "ffcbf3f28c46633abd5448a52b1f396c322e0d6c"  }
 pet-core = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "ffcbf3f28c46633abd5448a52b1f396c322e0d6c"  }
 pet-poetry = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "ffcbf3f28c46633abd5448a52b1f396c322e0d6c"  }

--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -7,6 +7,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
+use collections::HashMap;
 use gpui::{AsyncAppContext, SharedString};
 use settings::WorktreeId;
 
@@ -23,7 +24,11 @@ pub struct Toolchain {
 
 #[async_trait(?Send)]
 pub trait ToolchainLister: Send + Sync {
-    async fn list(&self, _: PathBuf) -> ToolchainList;
+    async fn list(
+        &self,
+        worktree_root: PathBuf,
+        project_env: Option<HashMap<String, String>>,
+    ) -> ToolchainList;
 }
 
 #[async_trait(?Send)]

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -47,6 +47,7 @@ lsp.workspace = true
 node_runtime.workspace = true
 paths.workspace = true
 pet.workspace = true
+pet-fs.workspace = true
 pet-core.workspace = true
 pet-conda.workspace = true
 pet-poetry.workspace = true

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -527,6 +527,7 @@ impl<'a> pet_core::os_environment::Environment for EnvironmentApi<'a> {
     }
 }
 
+#[cfg(unix)]
 static LINUX_SYSTEM_SEARCH_PATHS: LazyLock<[PathBuf; 27]> = LazyLock::new(|| {
     [
         PathBuf::from("/bin"),

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -527,37 +527,38 @@ impl<'a> pet_core::os_environment::Environment for EnvironmentApi<'a> {
 }
 
 #[cfg(unix)]
-static LINUX_SYSTEM_SEARCH_PATHS: std::sync::LazyLock<[PathBuf; 27]> = std::sync::LazyLock::new(|| {
-    [
-        PathBuf::from("/bin"),
-        PathBuf::from("/etc"),
-        PathBuf::from("/lib"),
-        PathBuf::from("/lib/x86_64-linux-gnu"),
-        PathBuf::from("/lib64"),
-        PathBuf::from("/sbin"),
-        PathBuf::from("/snap/bin"),
-        PathBuf::from("/usr/bin"),
-        PathBuf::from("/usr/games"),
-        PathBuf::from("/usr/include"),
-        PathBuf::from("/usr/lib"),
-        PathBuf::from("/usr/lib/x86_64-linux-gnu"),
-        PathBuf::from("/usr/lib64"),
-        PathBuf::from("/usr/libexec"),
-        PathBuf::from("/usr/local"),
-        PathBuf::from("/usr/local/bin"),
-        PathBuf::from("/usr/local/etc"),
-        PathBuf::from("/usr/local/games"),
-        PathBuf::from("/usr/local/lib"),
-        PathBuf::from("/usr/local/sbin"),
-        PathBuf::from("/usr/sbin"),
-        PathBuf::from("/usr/share"),
-        PathBuf::from("/home/bin"),
-        PathBuf::from("/home/sbin"),
-        PathBuf::from("/opt"),
-        PathBuf::from("/opt/bin"),
-        PathBuf::from("/opt/sbin"),
-    ]
-});
+static LINUX_SYSTEM_SEARCH_PATHS: std::sync::LazyLock<[PathBuf; 27]> =
+    std::sync::LazyLock::new(|| {
+        [
+            PathBuf::from("/bin"),
+            PathBuf::from("/etc"),
+            PathBuf::from("/lib"),
+            PathBuf::from("/lib/x86_64-linux-gnu"),
+            PathBuf::from("/lib64"),
+            PathBuf::from("/sbin"),
+            PathBuf::from("/snap/bin"),
+            PathBuf::from("/usr/bin"),
+            PathBuf::from("/usr/games"),
+            PathBuf::from("/usr/include"),
+            PathBuf::from("/usr/lib"),
+            PathBuf::from("/usr/lib/x86_64-linux-gnu"),
+            PathBuf::from("/usr/lib64"),
+            PathBuf::from("/usr/libexec"),
+            PathBuf::from("/usr/local"),
+            PathBuf::from("/usr/local/bin"),
+            PathBuf::from("/usr/local/etc"),
+            PathBuf::from("/usr/local/games"),
+            PathBuf::from("/usr/local/lib"),
+            PathBuf::from("/usr/local/sbin"),
+            PathBuf::from("/usr/sbin"),
+            PathBuf::from("/usr/share"),
+            PathBuf::from("/home/bin"),
+            PathBuf::from("/home/sbin"),
+            PathBuf::from("/opt"),
+            PathBuf::from("/opt/bin"),
+            PathBuf::from("/opt/sbin"),
+        ]
+    });
 
 #[cfg(test)]
 mod tests {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -463,29 +463,6 @@ impl<'a> EnvironmentApi<'a> {
     }
 }
 
-#[cfg(windows)]
-impl<'a> pet_core::os_environment::Environment for EnvironmentApi<'a> {
-    fn get_user_home(&self) -> Option<PathBuf> {
-        self.user_home()
-    }
-
-    fn get_root(&self) -> Option<PathBuf> {
-        None
-    }
-
-    fn get_env_var(&self, key: String) -> Option<String> {
-        self.project_env
-            .get(&key)
-            .cloned()
-            .or_else(|| self.pet_env.get_env_var(key))
-    }
-
-    fn get_know_global_search_locations(&self) -> Vec<PathBuf> {
-        self.global_search_locations.lock().unwrap().clone()
-    }
-}
-
-#[cfg(unix)]
 impl<'a> pet_core::os_environment::Environment for EnvironmentApi<'a> {
     fn get_user_home(&self) -> Option<PathBuf> {
         self.user_home()

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -16,7 +16,6 @@ use pet_core::Configuration;
 use project::lsp_store::language_server_settings;
 use serde_json::Value;
 
-use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::{
     any::Any,
@@ -528,7 +527,7 @@ impl<'a> pet_core::os_environment::Environment for EnvironmentApi<'a> {
 }
 
 #[cfg(unix)]
-static LINUX_SYSTEM_SEARCH_PATHS: LazyLock<[PathBuf; 27]> = LazyLock::new(|| {
+static LINUX_SYSTEM_SEARCH_PATHS: std::sync::LazyLock<[PathBuf; 27]> = std::sync::LazyLock::new(|| {
     [
         PathBuf::from("/bin"),
         PathBuf::from("/etc"),

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -108,8 +108,14 @@ impl HeadlessProject {
             observer.shared(SSH_PROJECT_ID, session.clone().into(), cx);
             observer
         });
-        let toolchain_store =
-            cx.new_model(|cx| ToolchainStore::local(languages.clone(), worktree_store.clone(), cx));
+        let toolchain_store = cx.new_model(|cx| {
+            ToolchainStore::local(
+                languages.clone(),
+                worktree_store.clone(),
+                environment.clone(),
+                cx,
+            )
+        });
         let lsp_store = cx.new_model(|cx| {
             let mut lsp_store = LspStore::new_local(
                 buffer_store.clone(),


### PR DESCRIPTION
Reimplements `pet::EnvironmentApi`, trying to access the `project_env` first
Closes #20177 

Release Notes:

- Fixed python toolchain detection when worktree local path is set
