### PR TITLE
assistant: Remove the selection action as an extra option

### DIFF
--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -4,10 +4,9 @@ use assistant_slash_command::SlashCommandRegistry;
 
 use gpui::{AnyElement, DismissEvent, SharedString, Task, WeakView};
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
-use ui::{prelude::*, KeyBinding, ListItem, ListItemSpacing, PopoverMenu, PopoverTrigger};
+use ui::{prelude::*, ListItem, ListItemSpacing, PopoverMenu, PopoverTrigger};
 
 use crate::assistant_panel::ContextEditor;
-use crate::QuoteSelection;
 
 #[derive(IntoElement)]
 pub(super) struct SlashCommandSelector<T: PopoverTrigger> {
@@ -32,7 +31,6 @@ enum SlashCommandEntry {
         renderer: fn(&mut WindowContext<'_>) -> AnyElement,
         on_confirm: fn(&mut WindowContext<'_>),
     },
-    QuoteButton,
 }
 
 impl AsRef<str> for SlashCommandEntry {
@@ -40,7 +38,6 @@ impl AsRef<str> for SlashCommandEntry {
         match self {
             SlashCommandEntry::Info(SlashCommandInfo { name, .. })
             | SlashCommandEntry::Advert { name, .. } => name,
-            SlashCommandEntry::QuoteButton => "Quote Selection",
         }
     }
 }
@@ -153,9 +150,6 @@ impl PickerDelegate for SlashCommandDelegate {
                         })
                         .ok();
                 }
-                SlashCommandEntry::QuoteButton => {
-                    cx.dispatch_action(Box::new(QuoteSelection));
-                }
                 SlashCommandEntry::Advert { on_confirm, .. } => {
                     on_confirm(cx);
                 }
@@ -223,40 +217,6 @@ impl PickerDelegate for SlashCommandDelegate {
                             ),
                     ),
             ),
-            SlashCommandEntry::QuoteButton => {
-                let focus = cx.focus_handle();
-                let key_binding = KeyBinding::for_action_in(&QuoteSelection, &focus, cx);
-
-                Some(
-                    ListItem::new(ix)
-                        .inset(true)
-                        .spacing(ListItemSpacing::Dense)
-                        .selected(selected)
-                        .child(
-                            v_flex()
-                                .child(
-                                    h_flex()
-                                        .gap_1p5()
-                                        .child(Icon::new(IconName::Quote).size(IconSize::XSmall))
-                                        .child(
-                                            div().font_buffer(cx).child(
-                                                Label::new("selection").size(LabelSize::Small),
-                                            ),
-                                        ),
-                                )
-                                .child(
-                                    h_flex()
-                                        .gap_1p5()
-                                        .child(
-                                            Label::new("Insert editor selection")
-                                                .color(Color::Muted)
-                                                .size(LabelSize::Small),
-                                        )
-                                        .children(key_binding.map(|kb| kb.render(cx))),
-                                ),
-                        ),
-                )
-            }
             SlashCommandEntry::Advert { renderer, .. } => Some(
                 ListItem::new(ix)
                     .inset(true)
@@ -290,47 +250,44 @@ impl<T: PopoverTrigger> RenderOnce for SlashCommandSelector<T> {
                     icon: command.icon(),
                 }))
             })
-            .chain([
-                SlashCommandEntry::Advert {
-                    name: "create-your-command".into(),
-                    renderer: |cx| {
-                        v_flex()
-                            .w_full()
-                            .child(
-                                h_flex()
-                                    .w_full()
-                                    .font_buffer(cx)
-                                    .items_center()
-                                    .justify_between()
-                                    .child(
-                                        h_flex()
-                                            .items_center()
-                                            .gap_1p5()
-                                            .child(Icon::new(IconName::Plus).size(IconSize::XSmall))
-                                            .child(
-                                                div().font_buffer(cx).child(
-                                                    Label::new("create-your-command")
-                                                        .size(LabelSize::Small),
-                                                ),
+            .chain([SlashCommandEntry::Advert {
+                name: "create-your-command".into(),
+                renderer: |cx| {
+                    v_flex()
+                        .w_full()
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .font_buffer(cx)
+                                .items_center()
+                                .justify_between()
+                                .child(
+                                    h_flex()
+                                        .items_center()
+                                        .gap_1p5()
+                                        .child(Icon::new(IconName::Plus).size(IconSize::XSmall))
+                                        .child(
+                                            div().font_buffer(cx).child(
+                                                Label::new("create-your-command")
+                                                    .size(LabelSize::Small),
                                             ),
-                                    )
-                                    .child(
-                                        Icon::new(IconName::ArrowUpRight)
-                                            .size(IconSize::XSmall)
-                                            .color(Color::Muted),
-                                    ),
-                            )
-                            .child(
-                                Label::new("Create your custom command")
-                                    .size(LabelSize::Small)
-                                    .color(Color::Muted),
-                            )
-                            .into_any_element()
-                    },
-                    on_confirm: |cx| cx.open_url("https://zed.dev/docs/extensions/slash-commands"),
+                                        ),
+                                )
+                                .child(
+                                    Icon::new(IconName::ArrowUpRight)
+                                        .size(IconSize::XSmall)
+                                        .color(Color::Muted),
+                                ),
+                        )
+                        .child(
+                            Label::new("Create your custom command")
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .into_any_element()
                 },
-                SlashCommandEntry::QuoteButton,
-            ])
+                on_confirm: |cx| cx.open_url("https://zed.dev/docs/extensions/slash-commands"),
+            }])
             .collect::<Vec<_>>();
 
         let delegate = SlashCommandDelegate {


### PR DESCRIPTION
This PR should only be merged after https://github.com/zed-industries/zed/pull/19988. Once the selection action is added as a "proper" slash command, there's no need to have it duplicate on the "Add Context" menu anymore. 😄 

Release Notes:

- N/A
