### PR TITLE
Fix name of vcpp libs in windows build guide

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -20,7 +20,7 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
   rustup target add wasm32-wasip1
   ```
 
-- Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional components `MSVC v*** - VS YYYY C++ x64/x86 build tools` and `MSVC v*** - VS YYYY C++ x64/x86 Spectre-mitigated libs` (`v***` is your VS version and `YYYY` is year when your VS was released. Pay attention to the architecture and change it to yours if needed.)
+- Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional components `MSVC v*** - VS YYYY C++ x64/x86 build tools` and `MSVC v*** - VS YYYY C++ x64/x86 Spectre-mitigated libs (latest)` (`v***` is your VS version and `YYYY` is year when your VS was released. Pay attention to the architecture and change it to yours if needed.)
 - Install Windows 11 or 10 SDK depending on your system, but ensure that at least `Windows 10 SDK version 2104 (10.0.20348.0)` is installed on your machine. You can download it from the [Windows SDK Archive](https://developer.microsoft.com/windows/downloads/windows-sdk/)
 - Install [CMake](https://cmake.org/download)
 


### PR DESCRIPTION
It is not obvious that you need to choose the latest one from the same libraries, especially in non-English locales

Release Notes:

- N/A