### PR TITLE
Fixed incorrect path for emmet server on Windows

### DIFF
--- a/extensions/emmet/src/emmet.rs
+++ b/extensions/emmet/src/emmet.rs
@@ -67,14 +67,23 @@ impl zed::Extension for EmmetExtension {
         _worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let server_path = self.server_script_path(language_server_id)?;
-        Ok(zed::Command {
-            command: zed::node_binary_path()?,
-            args: vec![
-                env::current_dir()
+
+        let full_path = env::current_dir()
                     .unwrap()
                     .join(&server_path)
                     .to_string_lossy()
-                    .to_string(),
+                    .to_string();
+
+        #[cfg(target_os = "windows")]
+		let path: String = full_path.split_off(3);
+
+		#[cfg(not(target_os = "windows"))]
+		let path: String = full_path;
+
+        Ok(zed::Command {
+            command: zed::node_binary_path()?,
+            args: vec![
+                path,
                 "--stdio".to_string(),
             ],
             env: Default::default(),


### PR DESCRIPTION
Emmet extension was unable to find the file for emmet server on Windows due to an incorrect path

The path on Windows was generating something like `F:\C:\` which is not valid

```
Language server error: emmet-language-server

oneshot canceled
-- stderr--
node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module 'F:\C:\Users\Shess\AppData\Local\Zed\extensions\work\emmet\node_modules\.bin\emmet-language-server'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.18.0
```
