### PR TITLE
vim: Fix readonly mode

### DIFF
--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -439,9 +439,7 @@ impl Vim {
                     ))
                 }
 
-                editor.buffer().update(cx, |buffer, cx| {
-                    buffer.edit(edits, None, cx);
-                });
+                editor.edit(edits, cx);
                 editor.set_clip_at_line_ends(true, cx);
                 editor.change_selections(None, cx, |s| {
                     s.move_with(|map, selection| {

--- a/crates/vim/src/normal/case.rs
+++ b/crates/vim/src/normal/case.rs
@@ -163,15 +163,12 @@ impl Vim {
             editor.transact(cx, |editor, cx| {
                 for range in ranges.into_iter().rev() {
                     let snapshot = editor.buffer().read(cx).snapshot(cx);
-                    editor.buffer().update(cx, |buffer, cx| {
-                        let text = snapshot
-                            .text_for_range(range.start..range.end)
-                            .flat_map(|s| s.chars())
-                            .flat_map(transform)
-                            .collect::<String>();
-
-                        buffer.edit([(range, text)], None, cx)
-                    })
+                    let text = snapshot
+                        .text_for_range(range.start..range.end)
+                        .flat_map(|s| s.chars())
+                        .flat_map(transform)
+                        .collect::<String>();
+                    editor.edit([(range, text)], cx)
                 }
                 editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.select_ranges(cursor_positions)

--- a/crates/vim/src/replace.rs
+++ b/crates/vim/src/replace.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use editor::{display_map::ToDisplayPoint, Bias, Editor, ToPoint};
 use gpui::{actions, ViewContext};
-use language::{AutoindentMode, Point};
+use language::Point;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -58,15 +58,7 @@ impl Vim {
                     })
                     .collect::<Vec<_>>();
 
-                editor.buffer().update(cx, |buffer, cx| {
-                    buffer.edit(
-                        edits.clone(),
-                        Some(AutoindentMode::Block {
-                            original_indent_columns: Vec::new(),
-                        }),
-                        cx,
-                    );
-                });
+                editor.edit_with_block_indent(edits.clone(), Vec::new(), cx);
 
                 editor.change_selections(None, cx, |s| {
                     s.select_anchor_ranges(edits.iter().map(|(range, _)| range.end..range.end));
@@ -113,9 +105,7 @@ impl Vim {
                     })
                     .collect::<Vec<_>>();
 
-                editor.buffer().update(cx, |buffer, cx| {
-                    buffer.edit(edits, None, cx);
-                });
+                editor.edit(edits, cx);
 
                 editor.change_selections(None, cx, |s| {
                     s.select_ranges(new_selections);

--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -119,9 +119,7 @@ impl Vim {
                     }
                 }
 
-                editor.buffer().update(cx, |buffer, cx| {
-                    buffer.edit(edits, None, cx);
-                });
+                editor.edit(edits, cx);
                 editor.set_clip_at_line_ends(true, cx);
                 editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     if mode == Mode::VisualBlock {
@@ -220,9 +218,7 @@ impl Vim {
                     s.select_ranges(anchors);
                 });
                 edits.sort_by_key(|(range, _)| range.start);
-                editor.buffer().update(cx, |buffer, cx| {
-                    buffer.edit(edits, None, cx);
-                });
+                editor.edit(edits, cx);
                 editor.set_clip_at_line_ends(true, cx);
             });
         });
@@ -320,9 +316,7 @@ impl Vim {
                         })
                         .collect::<Vec<_>>();
                     edits.sort_by_key(|(range, _)| range.start);
-                    editor.buffer().update(cx, |buffer, cx| {
-                        buffer.edit(edits, None, cx);
-                    });
+                    editor.edit(edits, cx);
                     editor.set_clip_at_line_ends(true, cx);
                     editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                         s.select_anchor_ranges(stable_anchors);

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -530,9 +530,7 @@ impl Vim {
                     }
                 }
 
-                editor.buffer().update(cx, |buffer, cx| {
-                    buffer.edit(edits, None, cx);
-                });
+                editor.edit(edits, cx);
                 editor.change_selections(None, cx, |s| s.select_ranges(stable_anchors));
             });
         });


### PR DESCRIPTION
Closes #18854

Release Notes:

- vim: Fixed `r`, `~` etc. appearing to modify readonly buffers
