### PR TITLE
Fix project panel losing focus after file creation attempt

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -951,10 +951,12 @@ impl ProjectPanel {
         self.edit_state = None;
         self.update_visible_entries(None, cx);
         self.marked_entries.clear();
+
         if let Some(previous_focus) = self.previous_focus.take() {
             self.selection = Some(previous_focus);
             self.autoscroll(cx);
         }
+
         cx.focus(&self.focus_handle);
         cx.notify();
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/19771

### Before

When pressing <kbd>esc</kbd> after attempting to create a file, the focus is lost and you don't know where it went.

https://github.com/user-attachments/assets/2ccd82b7-b7d2-49e4-b1c7-1867331ab9dc

### After

Now, after pressing <kbd>esc</kbd>, the focus returns to where it was before trying to create a new file.

https://github.com/user-attachments/assets/a8eb1cf1-dfef-42eb-9f3d-2ab6200056c4

Release Notes:

- Fix project panel losing focus after file creation attempt ([#19771](https://github.com/zed-industries/zed/issues/19771))
