### PR TITLE
Show kernel options in a picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9668,6 +9668,7 @@ dependencies = [
  "menu",
  "multi_buffer",
  "nbformat",
+ "picker",
  "project",
  "runtimelib",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9165,6 +9165,7 @@ dependencies = [
  "editor",
  "gpui",
  "markdown_preview",
+ "picker",
  "repl",
  "search",
  "settings",

--- a/crates/quick_action_bar/Cargo.toml
+++ b/crates/quick_action_bar/Cargo.toml
@@ -24,6 +24,7 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
+picker.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View};
+use gpui::{percentage, Animation, AnimationExt, AnyElement, Entity, Transformation, View};
 use picker::Picker;
 use repl::{
     components::{KernelPickerDelegate, KernelSelector},
@@ -282,9 +282,17 @@ impl QuickActionBar {
         current_kernel_name: Option<SharedString>,
         _cx: &mut ViewContext<Self>,
     ) -> impl IntoElement {
+        let entity_id = if let Some(editor) = self.active_editor() {
+            editor.entity_id()
+        } else {
+            // todo!()
+            return div().into_any_element();
+        };
+
         let menu_handle: PopoverMenuHandle<Picker<KernelPickerDelegate>> =
             PopoverMenuHandle::default();
         KernelSelector::new(
+            entity_id,
             ButtonLike::new("kernel-selector")
                 .style(ButtonStyle::Subtle)
                 .child(
@@ -320,6 +328,7 @@ impl QuickActionBar {
                 .tooltip(move |cx| Tooltip::text("Select Kernel", cx)),
         )
         .with_handle(menu_handle.clone())
+        .into_any_element()
     }
 
     pub fn render_repl_setup(

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -248,9 +248,9 @@ impl QuickActionBar {
 
         Some(
             h_flex()
+                .child(self.render_kernel_selector(Some(menu_state.kernel_name.clone()), cx))
                 .child(button)
                 .child(dropdown_menu)
-                .child(self.render_kernel_selector(Some(menu_state.kernel_name.clone()), cx))
                 .into_any_element(),
         )
     }
@@ -264,6 +264,7 @@ impl QuickActionBar {
 
         Some(
             h_flex()
+                .child(self.render_kernel_selector(None, cx))
                 .child(
                     IconButton::new("toggle_repl_icon", IconName::ReplNeutral)
                         .size(ButtonSize::Compact)
@@ -272,7 +273,6 @@ impl QuickActionBar {
                         .tooltip(move |cx| Tooltip::text(tooltip.clone(), cx))
                         .on_click(|_, cx| cx.dispatch_action(Box::new(repl::Run {}))),
                 )
-                .child(self.render_kernel_selector(None, cx))
                 .into_any_element(),
         )
     }
@@ -280,7 +280,7 @@ impl QuickActionBar {
     pub fn render_kernel_selector(
         &self,
         current_kernel_name: Option<SharedString>,
-        cx: &mut ViewContext<Self>,
+        _cx: &mut ViewContext<Self>,
     ) -> impl IntoElement {
         let menu_handle: PopoverMenuHandle<Picker<KernelPickerDelegate>> =
             PopoverMenuHandle::default();

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -4,7 +4,8 @@ use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View
 use picker::Picker;
 use repl::{
     components::{KernelPickerDelegate, KernelSelector},
-    ExecutionState, JupyterSettings, Kernel, KernelOption, KernelStatus, Session, SessionSupport,
+    ExecutionState, JupyterSettings, Kernel, KernelSpecification, KernelStatus, Session,
+    SessionSupport,
 };
 use ui::{
     prelude::*, ButtonLike, ContextMenu, IconWithIndicator, Indicator, IntoElement, PopoverMenu,
@@ -255,7 +256,7 @@ impl QuickActionBar {
     }
     pub fn render_repl_launch_menu(
         &self,
-        kernel_specification: KernelOption,
+        kernel_specification: KernelSpecification,
         cx: &mut ViewContext<Self>,
     ) -> Option<AnyElement> {
         let tooltip: SharedString =

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -60,7 +60,6 @@ impl QuickActionBar {
         let session = match session {
             SessionSupport::ActiveSession(session) => session,
             SessionSupport::Inactive(spec) => {
-                let spec = *spec;
                 return self.render_repl_launch_menu(spec, cx);
             }
             SessionSupport::RequiresSetup(language) => {
@@ -287,15 +286,14 @@ impl QuickActionBar {
 
         let session = repl::session(editor.downgrade(), cx);
 
-        let current_kernel_name = match session {
-            SessionSupport::ActiveSession(view) => Some(view.read(cx).kernel_specification.name()),
-            SessionSupport::Inactive(kernel_specification) => Some(kernel_specification.name()),
+        let current_kernelspec = match session {
+            SessionSupport::ActiveSession(view) => Some(view.read(cx).kernel_specification.clone()),
+            SessionSupport::Inactive(kernel_specification) => Some(kernel_specification),
             SessionSupport::RequiresSetup(_language_name) => None,
             SessionSupport::Unsupported => None,
         };
 
-        // let current_kernel_name = self.current_kernelspec.as_ref().map(|spec| spec.name());
-        let current_kernelspec: Option<KernelSpecification> = None;
+        let current_kernel_name = current_kernelspec.as_ref().map(|spec| spec.name());
 
         let menu_handle: PopoverMenuHandle<Picker<KernelPickerDelegate>> =
             PopoverMenuHandle::default();
@@ -305,6 +303,7 @@ impl QuickActionBar {
                     repl::assign_kernelspec(kernelspec, editor.downgrade(), cx).ok();
                 })
             },
+            current_kernelspec.clone(),
             ButtonLike::new("kernel-selector")
                 .style(ButtonStyle::Subtle)
                 .child(

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -248,7 +248,7 @@ impl QuickActionBar {
 
         Some(
             h_flex()
-                .child(self.render_kernel_selector(Some(menu_state.kernel_name.clone()), cx))
+                .child(self.render_kernel_selector(cx))
                 .child(button)
                 .child(dropdown_menu)
                 .into_any_element(),
@@ -264,7 +264,7 @@ impl QuickActionBar {
 
         Some(
             h_flex()
-                .child(self.render_kernel_selector(None, cx))
+                .child(self.render_kernel_selector(cx))
                 .child(
                     IconButton::new("toggle_repl_icon", IconName::ReplNeutral)
                         .size(ButtonSize::Compact)
@@ -277,22 +277,24 @@ impl QuickActionBar {
         )
     }
 
-    pub fn render_kernel_selector(
-        &self,
-        current_kernel_name: Option<SharedString>,
-        _cx: &mut ViewContext<Self>,
-    ) -> impl IntoElement {
-        let entity_id = if let Some(editor) = self.active_editor() {
-            editor.entity_id()
+    pub fn render_kernel_selector(&self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let editor = if let Some(editor) = self.active_editor() {
+            editor
         } else {
             // todo!()
             return div().into_any_element();
         };
 
+        // let current_kernel_name = self.current_kernelspec.as_ref().map(|spec| spec.name());
+        let current_kernelspec: Option<KernelSpecification> = None;
+
         let menu_handle: PopoverMenuHandle<Picker<KernelPickerDelegate>> =
             PopoverMenuHandle::default();
         KernelSelector::new(
-            entity_id,
+            Box::new(|kernelspec, cx| {
+                // cx.new_view(|cx| Session::new(editor.downgrade(), fs, telemetry, kernelspec, cx));
+                dbg!(kernelspec);
+            }),
             ButtonLike::new("kernel-selector")
                 .style(ButtonStyle::Subtle)
                 .child(
@@ -305,13 +307,17 @@ impl QuickActionBar {
                                 .flex_grow()
                                 .whitespace_nowrap()
                                 .child(
-                                    Label::new(if let Some(name) = current_kernel_name.clone() {
-                                        name
-                                    } else {
-                                        SharedString::from("Select Kernel")
-                                    })
+                                    Label::new(
+                                        if let Some(name) =
+                                            current_kernelspec.as_ref().map(|spec| spec.name())
+                                        {
+                                            name
+                                        } else {
+                                            SharedString::from("Select Kernel")
+                                        },
+                                    )
                                     .size(LabelSize::Small)
-                                    .color(if current_kernel_name.is_some() {
+                                    .color(if current_kernelspec.is_some() {
                                         Color::Default
                                     } else {
                                         Color::Placeholder
@@ -339,7 +345,7 @@ impl QuickActionBar {
         let tooltip: SharedString = SharedString::from(format!("Setup Zed REPL for {}", language));
         Some(
             h_flex()
-                .child(self.render_kernel_selector(None, cx))
+                .child(self.render_kernel_selector(cx))
                 .child(
                     IconButton::new("toggle_repl_icon", IconName::ReplNeutral)
                         .size(ButtonSize::Compact)

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use gpui::{percentage, Animation, AnimationExt, AnyElement, Entity, Transformation, View};
+use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View};
 use picker::Picker;
 use repl::{
     components::{KernelPickerDelegate, KernelSelector},

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -4,8 +4,7 @@ use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View
 use picker::Picker;
 use repl::{
     components::{KernelPickerDelegate, KernelSelector},
-    ExecutionState, JupyterSettings, Kernel, KernelOption, KernelSpecification, KernelStatus,
-    Session, SessionSupport,
+    ExecutionState, JupyterSettings, Kernel, KernelOption, KernelStatus, Session, SessionSupport,
 };
 use ui::{
     prelude::*, ButtonLike, ContextMenu, IconWithIndicator, Indicator, IntoElement, PopoverMenu,

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -4,8 +4,8 @@ use gpui::{percentage, Animation, AnimationExt, AnyElement, Transformation, View
 use picker::Picker;
 use repl::{
     components::{KernelPickerDelegate, KernelSelector},
-    ExecutionState, JupyterSettings, Kernel, KernelSpecification, KernelStatus, Session,
-    SessionSupport,
+    ExecutionState, JupyterSettings, Kernel, KernelOption, KernelSpecification, KernelStatus,
+    Session, SessionSupport,
 };
 use ui::{
     prelude::*, ButtonLike, ContextMenu, IconWithIndicator, Indicator, IntoElement, PopoverMenu,
@@ -256,11 +256,11 @@ impl QuickActionBar {
     }
     pub fn render_repl_launch_menu(
         &self,
-        kernel_specification: KernelSpecification,
+        kernel_specification: KernelOption,
         cx: &mut ViewContext<Self>,
     ) -> Option<AnyElement> {
         let tooltip: SharedString =
-            SharedString::from(format!("Start REPL for {}", kernel_specification.name));
+            SharedString::from(format!("Start REPL for {}", kernel_specification.name()));
 
         Some(
             h_flex()
@@ -349,13 +349,8 @@ impl QuickActionBar {
 fn session_state(session: View<Session>, cx: &WindowContext) -> ReplMenuState {
     let session = session.read(cx);
 
-    let kernel_name: SharedString = session.kernel_specification.name.clone().into();
-    let kernel_language: SharedString = session
-        .kernel_specification
-        .kernelspec
-        .language
-        .clone()
-        .into();
+    let kernel_name = session.kernel_specification.name();
+    let kernel_language: SharedString = session.kernel_specification.language();
 
     let fill_fields = || {
         ReplMenuState {

--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -291,10 +291,11 @@ impl QuickActionBar {
         let menu_handle: PopoverMenuHandle<Picker<KernelPickerDelegate>> =
             PopoverMenuHandle::default();
         KernelSelector::new(
-            Box::new(|kernelspec, cx| {
-                // cx.new_view(|cx| Session::new(editor.downgrade(), fs, telemetry, kernelspec, cx));
-                dbg!(kernelspec);
-            }),
+            {
+                Box::new(move |kernelspec, cx| {
+                    repl::assign_kernelspec(kernelspec, editor.downgrade(), cx).ok();
+                })
+            },
             ButtonLike::new("kernel-selector")
                 .style(ButtonStyle::Subtle)
                 .child(

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -45,6 +45,7 @@ ui.workspace = true
 util.workspace = true
 uuid.workspace = true
 workspace.workspace = true
+picker.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true

--- a/crates/repl/src/components.rs
+++ b/crates/repl/src/components.rs
@@ -1,3 +1,5 @@
 mod kernel_list_item;
+mod kernel_options;
 
 pub use kernel_list_item::*;
+pub use kernel_options::*;

--- a/crates/repl/src/components/kernel_list_item.rs
+++ b/crates/repl/src/components/kernel_list_item.rs
@@ -1,18 +1,18 @@
 use gpui::AnyElement;
 use ui::{prelude::*, Indicator, ListItem};
 
-use crate::KernelSpecification;
+use crate::KernelOption;
 
 #[derive(IntoElement)]
 pub struct KernelListItem {
-    kernel_specification: KernelSpecification,
+    kernel_specification: KernelOption,
     status_color: Color,
     buttons: Vec<AnyElement>,
     children: Vec<AnyElement>,
 }
 
 impl KernelListItem {
-    pub fn new(kernel_specification: KernelSpecification) -> Self {
+    pub fn new(kernel_specification: KernelOption) -> Self {
         Self {
             kernel_specification,
             status_color: Color::Disabled,
@@ -46,7 +46,7 @@ impl ParentElement for KernelListItem {
 
 impl RenderOnce for KernelListItem {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
-        ListItem::new(SharedString::from(self.kernel_specification.name.clone()))
+        ListItem::new(SharedString::from(self.kernel_specification.name()))
             .selectable(false)
             .start_slot(
                 h_flex()

--- a/crates/repl/src/components/kernel_list_item.rs
+++ b/crates/repl/src/components/kernel_list_item.rs
@@ -46,7 +46,7 @@ impl ParentElement for KernelListItem {
 
 impl RenderOnce for KernelListItem {
     fn render(self, _cx: &mut WindowContext) -> impl IntoElement {
-        ListItem::new(SharedString::from(self.kernel_specification.name()))
+        ListItem::new(self.kernel_specification.name())
             .selectable(false)
             .start_slot(
                 h_flex()

--- a/crates/repl/src/components/kernel_list_item.rs
+++ b/crates/repl/src/components/kernel_list_item.rs
@@ -1,18 +1,18 @@
 use gpui::AnyElement;
 use ui::{prelude::*, Indicator, ListItem};
 
-use crate::KernelOption;
+use crate::KernelSpecification;
 
 #[derive(IntoElement)]
 pub struct KernelListItem {
-    kernel_specification: KernelOption,
+    kernel_specification: KernelSpecification,
     status_color: Color,
     buttons: Vec<AnyElement>,
     children: Vec<AnyElement>,
 }
 
 impl KernelListItem {
-    pub fn new(kernel_specification: KernelOption) -> Self {
+    pub fn new(kernel_specification: KernelSpecification) -> Self {
         Self {
             kernel_specification,
             status_color: Color::Disabled,

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -161,7 +161,7 @@ impl PickerDelegate for KernelPickerDelegate {
                             .gap_1p5()
                             .child(Label::new(kernel_name)) // TODO: Replace with actual kernel name
                             .child(
-                                Label::new("Kernel Type") // TODO: Replace with actual kernel type
+                                Label::new(kernel.type_name()) // TODO: Replace with actual kernel type
                                     .size(LabelSize::XSmall)
                                     .color(Color::Muted),
                             ),

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -1,4 +1,5 @@
 use crate::kernels::KernelOption;
+use crate::repl_store::ReplStore;
 use crate::KernelSpecification;
 
 // - [@nate] Add a split button for running/selecting kernels
@@ -206,6 +207,11 @@ impl<T: PopoverTrigger> RenderOnce for KernelSelector<T> {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         // TODO: Implement kernel selection logic
         let all_kernels = vec![KernelOption::Jupyter(KernelSpecification::deno_kernel())];
+        // TODO: read specs from store
+        let store = ReplStore::global(cx).read(cx);
+        for kernel_spec in store.kernel_specifications() {
+            dbg!(&kernel_spec);
+        }
 
         let delegate = KernelPickerDelegate {
             all_kernels: all_kernels.clone(),

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -47,8 +47,8 @@ pub struct KernelSelector<T: PopoverTrigger> {
 }
 
 pub struct KernelPickerDelegate {
-    all_kernels: Vec<KernelOption>,
-    filtered_kernels: Vec<KernelOption>,
+    all_kernels: Vec<&KernelOption>,
+    filtered_kernels: Vec<&KernelOption>,
     selected_index: usize,
 }
 
@@ -201,11 +201,8 @@ impl PickerDelegate for KernelPickerDelegate {
 impl<T: PopoverTrigger> RenderOnce for KernelSelector<T> {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         // TODO: Implement kernel selection logic
-        let mut all_kernels = Vec::new();
         let store = ReplStore::global(cx).read(cx);
-        for kernel_spec in store.kernel_specifications() {
-            all_kernels.push(KernelOption::Jupyter(kernel_spec.clone()));
-        }
+        let all_kernels: Vec<&KernelOption> = store.kernel_specifications().collect();
 
         let delegate = KernelPickerDelegate {
             all_kernels: all_kernels.clone(),

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -127,8 +127,27 @@ impl PickerDelegate for KernelPickerDelegate {
 
     fn confirm(&mut self, _secondary: bool, cx: &mut ViewContext<Picker<Self>>) {
         if let Some(kernelspec) = self.filtered_kernels.get(self.selected_index) {
-            let store = ReplStore::global(cx).read(cx);
-            store.set_kernelspec(self.entity_id, kernelspec);
+            let store = ReplStore::global(cx);
+
+            let mut session = store.read(cx).get_session(self.entity_id);
+
+            // if the session is already started, we're swapping kernelspec out and starting a new kernel
+            // if the session is None, we're making a new one
+            //
+            if let Some(session) = session {
+                //
+            } else {
+                // todo!(): ... we would need the weak_editor, the fs, the telemetry as well as the kernel_specification
+                // let session = cx.new_view(|cx| {
+                //     Session::new(weak_editor, fs, telemetry, kernel_specification, cx)
+                // });
+            }
+
+            store.update(cx, |store, cx| {
+                //
+                store.set_kernelspec(self.entity_id, kernelspec, cx);
+            });
+
             cx.emit(DismissEvent);
         }
     }

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -70,9 +70,9 @@ impl PickerDelegate for KernelPickerDelegate {
             self.filtered_kernels
                 .iter()
                 .position(|k| k == kernelspec)
-                .unwrap_or(2)
+                .unwrap_or(0)
         } else {
-            1
+            0
         }
     }
 

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -1,0 +1,227 @@
+use crate::kernels::KernelOption;
+use crate::KernelSpecification;
+
+// - [@nate] Add a split button for running/selecting kernels
+//   - In REPL editor mode show the REPL icon
+//   - In notebook editor mode show a play icon
+// - [@nate/@kyle] Display recently used kernels at the top of the menu, using namespaces for each category (`py:conda:agents-service`, `jupyter:deno`, `my-server:python3.9`)
+// - [ ] Categorize kernel options for selection
+//   - [ ] Local Kernel
+//   - [ ] Jupyter Kernel
+//   - [ ] Python Env
+//   - [ ] Remote Kernel
+// - [ ] Kernel selection via available Jupyter kernels in submenu
+//   - [ ] Display kernels like `deno`, `python3`, `rust`
+// - [ ] Kernel selection via available Python environments in submenu
+//   - [ ] Group listings by environment type (Pyenv, Poetry, Conda)
+//   - [ ] Display Python versions for each environment
+//   - [ ] List project-specific environments
+//   - [ ] Install ipykernel in the environment if necessary
+//   - [ ] Generate on-demand IPython kernelspec when selecting a python environment
+// - [ ] Remote kernel selection
+//   - [ ] Show server names for remote kernels
+//   - [ ] Each remote server has a submenu of kernels they offer
+//   - [ ] Allow adding new remote servers
+//     - [ ] Implement modal for new server input (name, URL, token)
+//   - [ ] Consider storing user's remote servers in their Zed.dev account
+//   - [ ] Treat kernel selection settings as the global default that gets overriden by project settings, a notebook, or selecting in the selector
+// ---
+use gpui::Action;
+use gpui::DismissEvent;
+
+use picker::Picker;
+use picker::PickerDelegate;
+use workspace::ShowConfiguration;
+
+use std::sync::Arc;
+use ui::ListItemSpacing;
+
+use gpui::SharedString;
+use gpui::Task;
+use ui::{prelude::*, ListItem, PopoverMenu, PopoverMenuHandle, PopoverTrigger};
+
+#[derive(IntoElement)]
+pub struct KernelSelector<T: PopoverTrigger> {
+    handle: Option<PopoverMenuHandle<Picker<KernelPickerDelegate>>>,
+    trigger: T,
+    info_text: Option<SharedString>,
+}
+
+pub struct KernelPickerDelegate {
+    all_kernels: Vec<KernelOption>,
+    filtered_kernels: Vec<KernelOption>,
+    selected_index: usize,
+}
+
+impl<T: PopoverTrigger> KernelSelector<T> {
+    pub fn new(trigger: T) -> Self {
+        KernelSelector {
+            handle: None,
+            trigger,
+            info_text: None,
+        }
+    }
+
+    pub fn with_handle(mut self, handle: PopoverMenuHandle<Picker<KernelPickerDelegate>>) -> Self {
+        self.handle = Some(handle);
+        self
+    }
+
+    pub fn with_info_text(mut self, text: impl Into<SharedString>) -> Self {
+        self.info_text = Some(text.into());
+        self
+    }
+}
+
+impl PickerDelegate for KernelPickerDelegate {
+    type ListItem = ListItem;
+
+    fn match_count(&self) -> usize {
+        self.filtered_kernels.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(&mut self, ix: usize, cx: &mut ViewContext<Picker<Self>>) {
+        self.selected_index = ix.min(self.filtered_kernels.len().saturating_sub(1));
+        cx.notify();
+    }
+
+    fn placeholder_text(&self, _cx: &mut WindowContext) -> Arc<str> {
+        "Select a kernel...".into()
+    }
+
+    fn update_matches(&mut self, query: String, cx: &mut ViewContext<Picker<Self>>) -> Task<()> {
+        let all_kernels = self.all_kernels.clone();
+        cx.spawn(|this, mut cx| async move {
+            let filtered_kernels = cx
+                .background_executor()
+                .spawn(async move {
+                    if query.is_empty() {
+                        all_kernels
+                    } else {
+                        all_kernels
+                            .into_iter()
+                            .filter(|kernel| {
+                                // TODO: there is probably an off the shelf way to do this fuzzy
+                                kernel.name().to_lowercase().contains(&query.to_lowercase())
+                            })
+                            .collect()
+                    }
+                })
+                .await;
+
+            this.update(&mut cx, |this, cx| {
+                this.delegate.filtered_kernels = filtered_kernels;
+                this.delegate.set_selected_index(0, cx);
+                cx.notify();
+            })
+            .ok();
+        })
+    }
+
+    fn confirm(&mut self, _secondary: bool, cx: &mut ViewContext<Picker<Self>>) {
+        if let Some(kernel) = self.filtered_kernels.get(self.selected_index) {
+            let kernel = kernel.clone();
+
+            todo!();
+
+            cx.emit(DismissEvent);
+        }
+    }
+
+    fn dismissed(&mut self, _cx: &mut ViewContext<Picker<Self>>) {}
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        cx: &mut ViewContext<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let kernel = self.filtered_kernels.get(ix)?;
+        let kernel_name = kernel.name();
+        let is_selected = self.selected_index == ix;
+
+        Some(
+            ListItem::new(ix)
+                .inset(true)
+                .spacing(ListItemSpacing::Sparse)
+                .selected(selected)
+                // .start_slot(
+                //     div().pr_0p5().child(
+                //         Icon::new(kernel_info.icon)
+                //             .color(Color::Muted)
+                //             .size(IconSize::Medium),
+                //     ),
+                // )
+                .child(
+                    h_flex().w_full().justify_between().min_w(px(200.)).child(
+                        h_flex()
+                            .gap_1p5()
+                            .child(Label::new(kernel_name)) // TODO: Replace with actual kernel name
+                            .child(
+                                Label::new("Kernel Type") // TODO: Replace with actual kernel type
+                                    .size(LabelSize::XSmall)
+                                    .color(Color::Muted),
+                            ),
+                    ),
+                )
+                .end_slot(div().when(is_selected, |this| {
+                    this.child(
+                        Icon::new(IconName::Check)
+                            .color(Color::Accent)
+                            .size(IconSize::Small),
+                    )
+                })),
+        )
+    }
+
+    fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<gpui::AnyElement> {
+        Some(
+            h_flex()
+                .w_full()
+                .border_t_1()
+                .border_color(cx.theme().colors().border_variant)
+                .p_1()
+                .gap_4()
+                .justify_between()
+                .child(
+                    Button::new("configure", "Configure")
+                        .icon(IconName::Settings)
+                        .icon_size(IconSize::Small)
+                        .icon_color(Color::Muted)
+                        .icon_position(IconPosition::Start)
+                        .on_click(|_, cx| {
+                            cx.dispatch_action(ShowConfiguration.boxed_clone());
+                        }),
+                )
+                .into_any(),
+        )
+    }
+}
+
+impl<T: PopoverTrigger> RenderOnce for KernelSelector<T> {
+    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+        // TODO: Implement kernel selection logic
+        let all_kernels = vec![KernelOption::Jupyter(KernelSpecification::deno_kernel())];
+
+        let delegate = KernelPickerDelegate {
+            all_kernels: all_kernels.clone(),
+            filtered_kernels: all_kernels,
+            selected_index: 0,
+        };
+
+        let picker_view = cx.new_view(|cx| {
+            let picker = Picker::uniform_list(delegate, cx).max_height(Some(rems(20.).into()));
+            picker
+        });
+
+        PopoverMenu::new("kernel-switcher")
+            .menu(move |_cx| Some(picker_view.clone()))
+            .trigger(self.trigger)
+            .attach(gpui::AnchorCorner::BottomLeft)
+            .when_some(self.handle, |menu, handle| menu.with_handle(handle))
+    }
+}

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -47,8 +47,8 @@ pub struct KernelSelector<T: PopoverTrigger> {
 }
 
 pub struct KernelPickerDelegate {
-    all_kernels: Vec<&KernelOption>,
-    filtered_kernels: Vec<&KernelOption>,
+    all_kernels: Vec<KernelOption>,
+    filtered_kernels: Vec<KernelOption>,
     selected_index: usize,
 }
 
@@ -202,7 +202,7 @@ impl<T: PopoverTrigger> RenderOnce for KernelSelector<T> {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         // TODO: Implement kernel selection logic
         let store = ReplStore::global(cx).read(cx);
-        let all_kernels: Vec<&KernelOption> = store.kernel_specifications().collect();
+        let all_kernels: Vec<KernelOption> = store.kernel_specifications().cloned().collect();
 
         let delegate = KernelPickerDelegate {
             all_kernels: all_kernels.clone(),

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -2,34 +2,8 @@ use crate::kernels::KernelSpecification;
 use crate::repl_store::ReplStore;
 use crate::KERNEL_DOCS_URL;
 
-// - [@nate] Add a split button for running/selecting kernels
-//   - In REPL editor mode show the REPL icon
-//   - In notebook editor mode show a play icon
-// - [@nate/@kyle] Display recently used kernels at the top of the menu, using namespaces for each category (`py:conda:agents-service`, `jupyter:deno`, `my-server:python3.9`)
-// - [ ] Categorize kernel options for selection
-//   - [ ] Local Kernel
-//   - [ ] Jupyter Kernel
-//   - [ ] Python Env
-//   - [ ] Remote Kernel
-// - [ ] Kernel selection via available Jupyter kernels in submenu
-//   - [ ] Display kernels like `deno`, `python3`, `rust`
-// - [ ] Kernel selection via available Python environments in submenu
-//   - [ ] Group listings by environment type (Pyenv, Poetry, Conda)
-//   - [ ] Display Python versions for each environment
-//   - [ ] List project-specific environments
-//   - [ ] Install ipykernel in the environment if necessary
-//   - [ ] Generate on-demand IPython kernelspec when selecting a python environment
-// - [ ] Remote kernel selection
-//   - [ ] Show server names for remote kernels
-//   - [ ] Each remote server has a submenu of kernels they offer
-//   - [ ] Allow adding new remote servers
-//     - [ ] Implement modal for new server input (name, URL, token)
-//   - [ ] Consider storing user's remote servers in their Zed.dev account
-//   - [ ] Treat kernel selection settings as the global default that gets overriden by project settings, a notebook, or selecting in the selector
-// ---
 use gpui::DismissEvent;
 
-use gpui::EntityId;
 use picker::Picker;
 use picker::PickerDelegate;
 

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -1,6 +1,5 @@
 use crate::kernels::KernelOption;
 use crate::repl_store::ReplStore;
-use crate::KernelSpecification;
 
 // - [@nate] Add a split button for running/selecting kernels
 //   - In REPL editor mode show the REPL icon
@@ -126,10 +125,10 @@ impl PickerDelegate for KernelPickerDelegate {
     fn confirm(&mut self, _secondary: bool, cx: &mut ViewContext<Picker<Self>>) {
         if let Some(kernel) = self.filtered_kernels.get(self.selected_index) {
             let kernel = kernel.clone();
-
-            todo!();
+            println!("Selected kernel: {:?}", kernel);
 
             cx.emit(DismissEvent);
+            todo!();
         }
     }
 
@@ -139,7 +138,7 @@ impl PickerDelegate for KernelPickerDelegate {
         &self,
         ix: usize,
         selected: bool,
-        cx: &mut ViewContext<Picker<Self>>,
+        _cx: &mut ViewContext<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let kernel = self.filtered_kernels.get(ix)?;
         let kernel_name = kernel.name();

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -1,4 +1,4 @@
-use crate::kernels::KernelOption;
+use crate::kernels::KernelSpecification;
 use crate::repl_store::ReplStore;
 use crate::KERNEL_DOCS_URL;
 
@@ -47,8 +47,8 @@ pub struct KernelSelector<T: PopoverTrigger> {
 }
 
 pub struct KernelPickerDelegate {
-    all_kernels: Vec<KernelOption>,
-    filtered_kernels: Vec<KernelOption>,
+    all_kernels: Vec<KernelSpecification>,
+    filtered_kernels: Vec<KernelSpecification>,
     selected_index: usize,
 }
 
@@ -202,7 +202,8 @@ impl<T: PopoverTrigger> RenderOnce for KernelSelector<T> {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         // TODO: Implement kernel selection logic
         let store = ReplStore::global(cx).read(cx);
-        let all_kernels: Vec<KernelOption> = store.kernel_specifications().cloned().collect();
+        let all_kernels: Vec<KernelSpecification> =
+            store.kernel_specifications().cloned().collect();
 
         let delegate = KernelPickerDelegate {
             all_kernels: all_kernels.clone(),

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -1,5 +1,6 @@
 use crate::kernels::KernelOption;
 use crate::repl_store::ReplStore;
+use crate::KERNEL_DOCS_URL;
 
 // - [@nate] Add a split button for running/selecting kernels
 //   - In REPL editor mode show the REPL icon
@@ -26,12 +27,10 @@ use crate::repl_store::ReplStore;
 //   - [ ] Consider storing user's remote servers in their Zed.dev account
 //   - [ ] Treat kernel selection settings as the global default that gets overriden by project settings, a notebook, or selecting in the selector
 // ---
-use gpui::Action;
 use gpui::DismissEvent;
 
 use picker::Picker;
 use picker::PickerDelegate;
-use workspace::ShowConfiguration;
 
 use std::sync::Arc;
 use ui::ListItemSpacing;
@@ -186,16 +185,13 @@ impl PickerDelegate for KernelPickerDelegate {
                 .border_color(cx.theme().colors().border_variant)
                 .p_1()
                 .gap_4()
-                .justify_between()
                 .child(
-                    Button::new("configure", "Configure")
-                        .icon(IconName::Settings)
-                        .icon_size(IconSize::Small)
+                    Button::new("kernel-docs", "Kernel Docs")
+                        .icon(IconName::ExternalLink)
+                        .icon_size(IconSize::XSmall)
                         .icon_color(Color::Muted)
-                        .icon_position(IconPosition::Start)
-                        .on_click(|_, cx| {
-                            cx.dispatch_action(ShowConfiguration.boxed_clone());
-                        }),
+                        .icon_position(IconPosition::End)
+                        .on_click(move |_, cx| cx.open_url(KERNEL_DOCS_URL)),
                 )
                 .into_any(),
         )

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -206,11 +206,10 @@ impl PickerDelegate for KernelPickerDelegate {
 impl<T: PopoverTrigger> RenderOnce for KernelSelector<T> {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         // TODO: Implement kernel selection logic
-        let all_kernels = vec![KernelOption::Jupyter(KernelSpecification::deno_kernel())];
-        // TODO: read specs from store
+        let mut all_kernels = Vec::new();
         let store = ReplStore::global(cx).read(cx);
         for kernel_spec in store.kernel_specifications() {
-            dbg!(&kernel_spec);
+            all_kernels.push(KernelOption::Jupyter(kernel_spec.clone()));
         }
 
         let delegate = KernelPickerDelegate {

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -36,6 +36,13 @@ impl KernelOption {
             Self::PythonEnv(spec) => spec.name.clone().into(),
         }
     }
+
+    pub fn type_name(&self) -> SharedString {
+        match self {
+            Self::Jupyter(_) => "Jupyter".into(),
+            Self::PythonEnv(_) => "Python Environment".into(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -19,12 +19,37 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
+use ui::SharedString;
 use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub enum KernelOption {
+    // TODO: Remote(RemoteKernelSpecification)
+    Jupyter(KernelSpecification),
+    PythonEnv(KernelSpecification),
+}
+
+impl KernelOption {
+    pub fn name(&self) -> SharedString {
+        match self {
+            Self::Jupyter(spec) => spec.name.clone().into(),
+            Self::PythonEnv(spec) => spec.name.clone().into(),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct KernelSpecification {
     pub name: String,
     pub path: PathBuf,
+    pub kernelspec: JupyterKernelspec,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteKernelSpecification {
+    pub name: String,
+    pub url: String,
+    pub token: String,
     pub kernelspec: JupyterKernelspec,
 }
 
@@ -62,6 +87,31 @@ impl KernelSpecification {
         }
 
         Ok(cmd)
+    }
+
+    pub(crate) fn deno_kernel() -> Self {
+        let kernelspec = JupyterKernelspec {
+            display_name: "Deno".to_string(),
+            language: "typescript".to_string(),
+            argv: vec![
+                "deno".to_string(),
+                "--unstable-ffi".to_string(),
+                "--unstable".to_string(),
+                "jupyter".to_string(),
+                "--kernel".to_string(),
+                "--conn".to_string(),
+                "{connection_file}".to_string(),
+            ],
+            env: None,
+            metadata: None,
+            interrupt_mode: None,
+        };
+
+        Self {
+            name: "deno".to_string(),
+            path: PathBuf::from("deno"),
+            kernelspec,
+        }
     }
 }
 

--- a/crates/repl/src/kernels.rs
+++ b/crates/repl/src/kernels.rs
@@ -22,7 +22,7 @@ use std::{
 use ui::SharedString;
 use uuid::Uuid;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KernelOption {
     // TODO: Remote(RemoteKernelSpecification)
     Jupyter(KernelSpecification),
@@ -52,6 +52,14 @@ pub struct KernelSpecification {
     pub kernelspec: JupyterKernelspec,
 }
 
+impl PartialEq for KernelSpecification {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.path == other.path
+    }
+}
+
+impl Eq for KernelSpecification {}
+
 #[derive(Debug, Clone)]
 pub struct RemoteKernelSpecification {
     pub name: String,
@@ -59,6 +67,14 @@ pub struct RemoteKernelSpecification {
     pub token: String,
     pub kernelspec: JupyterKernelspec,
 }
+
+impl PartialEq for RemoteKernelSpecification {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.url == other.url
+    }
+}
+
+impl Eq for RemoteKernelSpecification {}
 
 impl KernelSpecification {
     #[must_use]
@@ -445,7 +461,7 @@ async fn read_kernels_dir(path: PathBuf, fs: &dyn Fs) -> Result<Vec<KernelSpecif
     Ok(valid_kernelspecs)
 }
 
-pub async fn kernel_specifications(fs: Arc<dyn Fs>) -> Result<Vec<KernelSpecification>> {
+pub async fn local_kernel_specifications(fs: Arc<dyn Fs>) -> Result<Vec<KernelSpecification>> {
     let mut data_dirs = dirs::data_dirs();
 
     // Pick up any kernels from conda or conda environment

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -17,7 +17,7 @@ pub use runtimelib::ExecutionState;
 use settings::Settings as _;
 
 pub use crate::jupyter_settings::JupyterSettings;
-pub use crate::kernels::{Kernel, KernelOption, KernelStatus};
+pub use crate::kernels::{Kernel, KernelSpecification, KernelStatus};
 pub use crate::repl_editor::*;
 pub use crate::repl_sessions_ui::{
     ClearOutputs, Interrupt, ReplSessionsPage, Restart, Run, Sessions, Shutdown,

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -26,6 +26,8 @@ use crate::repl_store::ReplStore;
 pub use crate::session::Session;
 use client::telemetry::Telemetry;
 
+pub const KERNEL_DOCS_URL: &str = "https://zed.dev/docs/repl#changing-kernels";
+
 pub fn init(fs: Arc<dyn Fs>, telemetry: Arc<Telemetry>, cx: &mut AppContext) {
     set_dispatcher(zed_dispatcher(cx));
     JupyterSettings::register(cx);

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -1,4 +1,4 @@
-mod components;
+pub mod components;
 mod jupyter_settings;
 mod kernels;
 pub mod notebook;

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -17,7 +17,7 @@ pub use runtimelib::ExecutionState;
 use settings::Settings as _;
 
 pub use crate::jupyter_settings::JupyterSettings;
-pub use crate::kernels::{Kernel, KernelOption, KernelSpecification, KernelStatus};
+pub use crate::kernels::{Kernel, KernelOption, KernelStatus};
 pub use crate::repl_editor::*;
 pub use crate::repl_sessions_ui::{
     ClearOutputs, Interrupt, ReplSessionsPage, Restart, Run, Sessions, Shutdown,

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -17,7 +17,7 @@ pub use runtimelib::ExecutionState;
 use settings::Settings as _;
 
 pub use crate::jupyter_settings::JupyterSettings;
-pub use crate::kernels::{Kernel, KernelSpecification, KernelStatus};
+pub use crate::kernels::{Kernel, KernelOption, KernelSpecification, KernelStatus};
 pub use crate::repl_editor::*;
 pub use crate::repl_sessions_ui::{
     ClearOutputs, Interrupt, ReplSessionsPage, Restart, Run, Sessions, Shutdown,

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -10,7 +10,7 @@ use language::{BufferSnapshot, Language, LanguageName, Point};
 
 use crate::repl_store::ReplStore;
 use crate::session::SessionEvent;
-use crate::{KernelSpecification, Session};
+use crate::{KernelOption, Session};
 
 pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) -> Result<()> {
     let store = ReplStore::global(cx);
@@ -98,7 +98,7 @@ pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) ->
 
 pub enum SessionSupport {
     ActiveSession(View<Session>),
-    Inactive(Box<KernelSpecification>),
+    Inactive(Box<KernelOption>),
     RequiresSetup(LanguageName),
     Unsupported,
 }

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -148,7 +148,7 @@ pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) ->
 
 pub enum SessionSupport {
     ActiveSession(View<Session>),
-    Inactive(Box<KernelSpecification>),
+    Inactive(KernelSpecification),
     RequiresSetup(LanguageName),
     Unsupported,
 }
@@ -169,7 +169,7 @@ pub fn session(editor: WeakView<Editor>, cx: &mut WindowContext) -> SessionSuppo
     });
 
     match kernelspec {
-        Some(kernelspec) => SessionSupport::Inactive(Box::new(kernelspec)),
+        Some(kernelspec) => SessionSupport::Inactive(kernelspec),
         None => {
             if language_supported(&language) {
                 SessionSupport::RequiresSetup(language.name())

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -28,7 +28,9 @@ pub fn assign_kernelspec(
     if let Some(session) = store.read(cx).get_session(weak_editor.entity_id()).cloned() {
         // Drop previous session, start new one
         session.update(cx, |session, cx| {
+            session.clear_outputs(cx);
             session.shutdown(cx);
+            cx.notify();
         });
     }
 

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -10,7 +10,7 @@ use language::{BufferSnapshot, Language, LanguageName, Point};
 
 use crate::repl_store::ReplStore;
 use crate::session::SessionEvent;
-use crate::{KernelOption, Session};
+use crate::{KernelSpecification, Session};
 
 pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) -> Result<()> {
     let store = ReplStore::global(cx);
@@ -98,7 +98,7 @@ pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) ->
 
 pub enum SessionSupport {
     ActiveSession(View<Session>),
-    Inactive(Box<KernelOption>),
+    Inactive(Box<KernelSpecification>),
     RequiresSetup(LanguageName),
     Unsupported,
 }

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -12,6 +12,54 @@ use crate::repl_store::ReplStore;
 use crate::session::SessionEvent;
 use crate::{KernelSpecification, Session};
 
+pub fn assign_kernelspec(
+    kernel_specification: KernelSpecification,
+    weak_editor: WeakView<Editor>,
+    cx: &mut WindowContext,
+) -> Result<()> {
+    let store = ReplStore::global(cx);
+    if !store.read(cx).is_enabled() {
+        return Ok(());
+    }
+
+    let fs = store.read(cx).fs().clone();
+    let telemetry = store.read(cx).telemetry().clone();
+
+    if let Some(session) = store.read(cx).get_session(weak_editor.entity_id()).cloned() {
+        // Drop previous session, start new one
+        session.update(cx, |session, cx| {
+            session.shutdown(cx);
+        });
+    }
+
+    let session = cx
+        .new_view(|cx| Session::new(weak_editor.clone(), fs, telemetry, kernel_specification, cx));
+
+    weak_editor
+        .update(cx, |_editor, cx| {
+            cx.notify();
+
+            cx.subscribe(&session, {
+                let store = store.clone();
+                move |_this, _session, event, cx| match event {
+                    SessionEvent::Shutdown(shutdown_event) => {
+                        store.update(cx, |store, _cx| {
+                            store.remove_session(shutdown_event.entity_id());
+                        });
+                    }
+                }
+            })
+            .detach();
+        })
+        .ok();
+
+    store.update(cx, |store, _cx| {
+        store.insert_session(weak_editor.entity_id(), session.clone());
+    });
+
+    Ok(())
+}
+
 pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) -> Result<()> {
     let store = ReplStore::global(cx);
     if !store.read(cx).is_enabled() {

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -146,6 +146,7 @@ pub fn run(editor: WeakView<Editor>, move_down: bool, cx: &mut WindowContext) ->
     anyhow::Ok(())
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum SessionSupport {
     ActiveSession(View<Session>),
     Inactive(KernelSpecification),

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -12,7 +12,7 @@ use workspace::{item::Item, Workspace};
 
 use crate::jupyter_settings::JupyterSettings;
 use crate::repl_store::ReplStore;
-use crate::{KernelOption, KERNEL_DOCS_URL};
+use crate::{KernelSpecification, KERNEL_DOCS_URL};
 
 actions!(
     repl,
@@ -238,7 +238,7 @@ impl Render for ReplSessionsPage {
                 );
         }
 
-        let mut kernels_by_language: HashMap<SharedString, Vec<&KernelOption>> =
+        let mut kernels_by_language: HashMap<SharedString, Vec<&KernelSpecification>> =
             kernel_specifications
                 .iter()
                 .map(|spec| (spec.language(), spec))
@@ -253,7 +253,7 @@ impl Render for ReplSessionsPage {
         }
 
         // Convert to a sorted Vec of tuples
-        let mut sorted_kernels: Vec<(SharedString, Vec<&KernelOption>)> =
+        let mut sorted_kernels: Vec<(SharedString, Vec<&KernelSpecification>)> =
             kernels_by_language.into_iter().collect();
         sorted_kernels.sort_by(|a, b| a.0.cmp(&b.0));
 

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -1,9 +1,9 @@
-use collections::HashMap;
 use editor::Editor;
 use gpui::{
     actions, prelude::*, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView,
     FontWeight, Subscription, View,
 };
+use std::collections::HashMap;
 use ui::{prelude::*, ButtonLike, ElevationIndex, KeyBinding, ListItem, Tooltip};
 use util::ResultExt as _;
 use workspace::item::ItemEvent;
@@ -247,9 +247,8 @@ impl Render for ReplSessionsPage {
                     acc
                 });
 
-        // Sort each language's kernels by name
         for kernels in kernels_by_language.values_mut() {
-            kernels.sort_by(|a, b| a.name().cmp(&b.name()));
+            kernels.sort_by_key(|a| a.name())
         }
 
         // Convert to a sorted Vec of tuples

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -12,7 +12,7 @@ use workspace::{item::Item, Workspace};
 
 use crate::jupyter_settings::JupyterSettings;
 use crate::repl_store::ReplStore;
-use crate::KernelSpecification;
+use crate::{KernelSpecification, KERNEL_DOCS_URL};
 
 actions!(
     repl,
@@ -262,7 +262,7 @@ impl Render for ReplSessionsPage {
                             .child(Label::new("REPL documentation"))
                             .child(Icon::new(IconName::Link))
                             .on_click(move |_, cx| {
-                                cx.open_url("https://zed.dev/docs/repl#changing-kernels")
+                                cx.open_url(KERNEL_DOCS_URL)
                             }),
                     ),
             )

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -6,9 +6,11 @@ use collections::HashMap;
 use command_palette_hooks::CommandPaletteFilter;
 use gpui::{
     prelude::*, AppContext, EntityId, Global, Model, ModelContext, Subscription, Task, View,
+    ViewContext,
 };
 use project::Fs;
 use settings::{Settings, SettingsStore};
+use ui::WindowContext;
 
 use crate::kernels::local_kernel_specifications;
 use crate::{JupyterSettings, KernelSpecification, Session};
@@ -157,10 +159,18 @@ impl ReplStore {
             .cloned()
     }
 
-    pub fn set_kernelspec(&self, entity_id: EntityId, kernelspec: &KernelSpecification) {
+    pub fn set_kernelspec(
+        &mut self,
+        entity_id: EntityId,
+        kernelspec: &KernelSpecification,
+        cx: &mut ModelContext<Self>,
+    ) {
         dbg!("set_kernelspec");
         dbg!(entity_id);
         dbg!(kernelspec);
+
+        // We have to set it on the session or create a new one,
+        // but session is a `View<Session>` that we can't create using a `ModelContext`. We may have to pass a provisional `Session` in from the `confirm` flow...
     }
 
     pub fn get_session(&self, entity_id: EntityId) -> Option<&View<Session>> {

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -6,11 +6,9 @@ use collections::HashMap;
 use command_palette_hooks::CommandPaletteFilter;
 use gpui::{
     prelude::*, AppContext, EntityId, Global, Model, ModelContext, Subscription, Task, View,
-    ViewContext,
 };
 use project::Fs;
 use settings::{Settings, SettingsStore};
-use ui::WindowContext;
 
 use crate::kernels::local_kernel_specifications;
 use crate::{JupyterSettings, KernelSpecification, Session};
@@ -157,20 +155,6 @@ impl ReplStore {
                 _ => false,
             })
             .cloned()
-    }
-
-    pub fn set_kernelspec(
-        &mut self,
-        entity_id: EntityId,
-        kernelspec: &KernelSpecification,
-        cx: &mut ModelContext<Self>,
-    ) {
-        dbg!("set_kernelspec");
-        dbg!(entity_id);
-        dbg!(kernelspec);
-
-        // We have to set it on the session or create a new one,
-        // but session is a `View<Session>` that we can't create using a `ModelContext`. We may have to pass a provisional `Session` in from the `confirm` flow...
     }
 
     pub fn get_session(&self, entity_id: EntityId) -> Option<&View<Session>> {

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -11,7 +11,7 @@ use project::Fs;
 use settings::{Settings, SettingsStore};
 
 use crate::kernels::local_kernel_specifications;
-use crate::{JupyterSettings, KernelOption, Session};
+use crate::{JupyterSettings, KernelSpecification, Session};
 
 struct GlobalReplStore(Model<ReplStore>);
 
@@ -21,7 +21,7 @@ pub struct ReplStore {
     fs: Arc<dyn Fs>,
     enabled: bool,
     sessions: HashMap<EntityId, View<Session>>,
-    kernel_specifications: Vec<KernelOption>,
+    kernel_specifications: Vec<KernelSpecification>,
     telemetry: Arc<Telemetry>,
     _subscriptions: Vec<Subscription>,
 }
@@ -72,7 +72,7 @@ impl ReplStore {
         self.enabled
     }
 
-    pub fn kernel_specifications(&self) -> impl Iterator<Item = &KernelOption> {
+    pub fn kernel_specifications(&self) -> impl Iterator<Item = &KernelSpecification> {
         self.kernel_specifications.iter()
     }
 
@@ -112,7 +112,7 @@ impl ReplStore {
 
             let mut kernel_options = Vec::new();
             for kernel_specification in local_kernel_specifications {
-                kernel_options.push(KernelOption::Jupyter(kernel_specification));
+                kernel_options.push(KernelSpecification::Jupyter(kernel_specification));
             }
 
             this.update(&mut cx, |this, cx| {
@@ -122,7 +122,7 @@ impl ReplStore {
         })
     }
 
-    pub fn kernelspec(&self, language_name: &str, cx: &AppContext) -> Option<KernelOption> {
+    pub fn kernelspec(&self, language_name: &str, cx: &AppContext) -> Option<KernelSpecification> {
         let settings = JupyterSettings::get_global(cx);
         let selected_kernel = settings.kernel_selections.get(language_name);
 
@@ -130,7 +130,7 @@ impl ReplStore {
             .kernel_specifications
             .iter()
             .find(|runtime_specification| {
-                if let (Some(selected), KernelOption::Jupyter(runtime_specification)) =
+                if let (Some(selected), KernelSpecification::Jupyter(runtime_specification)) =
                     (selected_kernel, runtime_specification)
                 {
                     // Top priority is the selected kernel
@@ -147,7 +147,7 @@ impl ReplStore {
         self.kernel_specifications
             .iter()
             .find(|kernel_option| match kernel_option {
-                KernelOption::Jupyter(runtime_specification) => {
+                KernelSpecification::Jupyter(runtime_specification) => {
                     runtime_specification.kernelspec.language.to_lowercase()
                         == language_name.to_lowercase()
                 }

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -157,6 +157,12 @@ impl ReplStore {
             .cloned()
     }
 
+    pub fn set_kernelspec(&self, entity_id: EntityId, kernelspec: &KernelSpecification) {
+        dbg!("set_kernelspec");
+        dbg!(entity_id);
+        dbg!(kernelspec);
+    }
+
     pub fn get_session(&self, entity_id: EntityId) -> Option<&View<Session>> {
         self.sessions.get(&entity_id)
     }

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -1,6 +1,6 @@
 use crate::components::KernelListItem;
 use crate::{
-    kernels::{Kernel, KernelOption, RunningKernel},
+    kernels::{Kernel, KernelSpecification, RunningKernel},
     outputs::{ExecutionStatus, ExecutionView},
     KernelStatus,
 };
@@ -36,7 +36,7 @@ pub struct Session {
     blocks: HashMap<String, EditorBlock>,
     messaging_task: Option<Task<()>>,
     process_status_task: Option<Task<()>>,
-    pub kernel_specification: KernelOption,
+    pub kernel_specification: KernelSpecification,
     telemetry: Arc<Telemetry>,
     _buffer_subscription: Subscription,
 }
@@ -196,7 +196,7 @@ impl Session {
         editor: WeakView<Editor>,
         fs: Arc<dyn Fs>,
         telemetry: Arc<Telemetry>,
-        kernel_specification: KernelOption,
+        kernel_specification: KernelSpecification,
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let subscription = match editor.upgrade() {

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -1,8 +1,8 @@
 use crate::components::KernelListItem;
-use crate::KernelStatus;
 use crate::{
-    kernels::{Kernel, KernelSpecification, RunningKernel},
+    kernels::{Kernel, KernelOption, RunningKernel},
     outputs::{ExecutionStatus, ExecutionView},
+    KernelStatus,
 };
 use client::telemetry::Telemetry;
 use collections::{HashMap, HashSet};
@@ -36,7 +36,7 @@ pub struct Session {
     blocks: HashMap<String, EditorBlock>,
     messaging_task: Option<Task<()>>,
     process_status_task: Option<Task<()>>,
-    pub kernel_specification: KernelSpecification,
+    pub kernel_specification: KernelOption,
     telemetry: Arc<Telemetry>,
     _buffer_subscription: Subscription,
 }
@@ -196,7 +196,7 @@ impl Session {
         editor: WeakView<Editor>,
         fs: Arc<dyn Fs>,
         telemetry: Arc<Telemetry>,
-        kernel_specification: KernelSpecification,
+        kernel_specification: KernelOption,
         cx: &mut ViewContext<Self>,
     ) -> Self {
         let subscription = match editor.upgrade() {
@@ -224,7 +224,7 @@ impl Session {
     }
 
     fn start_kernel(&mut self, cx: &mut ViewContext<Self>) {
-        let kernel_language = self.kernel_specification.kernelspec.language.clone();
+        let kernel_language = self.kernel_specification.language();
         let entity_id = self.editor.entity_id();
         let working_directory = self
             .editor
@@ -233,7 +233,7 @@ impl Session {
             .unwrap_or_else(temp_dir);
 
         self.telemetry.report_repl_event(
-            kernel_language.clone(),
+            kernel_language.into(),
             KernelStatus::Starting.to_string(),
             cx.entity_id().to_string(),
         );
@@ -556,7 +556,7 @@ impl Session {
                 self.kernel.set_execution_state(&status.execution_state);
 
                 self.telemetry.report_repl_event(
-                    self.kernel_specification.kernelspec.language.clone(),
+                    self.kernel_specification.language().into(),
                     KernelStatus::from(&self.kernel).to_string(),
                     cx.entity_id().to_string(),
                 );
@@ -607,7 +607,7 @@ impl Session {
         }
 
         let kernel_status = KernelStatus::from(&kernel).to_string();
-        let kernel_language = self.kernel_specification.kernelspec.language.clone();
+        let kernel_language = self.kernel_specification.language().into();
 
         self.telemetry.report_repl_event(
             kernel_language,
@@ -749,7 +749,7 @@ impl Render for Session {
                 Kernel::Shutdown => Color::Disabled,
                 Kernel::Restarting => Color::Modified,
             })
-            .child(Label::new(self.kernel_specification.name.clone()))
+            .child(Label::new(self.kernel_specification.name()))
             .children(status_text.map(|status_text| Label::new(format!("({status_text})"))))
             .button(
                 Button::new("shutdown", "Shutdown")


### PR DESCRIPTION
Closes #18341

* [x] Remove "Change Kernel" Doc link from REPL menu
* [x] Remove chevron
* [x] Set a higher min width
* [x] Include the language along with the kernel name

Future PRs will address

* Add support for Python envs (#18291, #16757, #15563)
* Add support for Remote kernels
* Project settings support (#16898)

Release Notes:

- Added kernel picker for repl
