### PR TITLE
Add autoclosing braces for Shell Scripts

### DIFF
--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -9,4 +9,5 @@ brackets = [
     { start = "(", end = ")", close = true, newline = false },
     { start = "{", end = "}", close = true, newline = false },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]

--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -7,5 +7,6 @@ first_line_pattern = '^#!.*\b(?:ash|bash|dash|sh|zsh)\b'
 brackets = [
     { start = "[", end = "]", close = true, newline = false },
     { start = "(", end = ")", close = true, newline = false },
+    { start = "{", end = "}", close = true, newline = false },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
 ]


### PR DESCRIPTION
Release Notes:

- Add support for autoclosing braces `{}` and single quotes `''` in Shell Scripts
