### PR TITLE
Disable editor autoscroll on mouse clicks

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -287,7 +287,7 @@
   "scroll_beyond_last_line": "one_page",
   // The number of lines to keep above/below the cursor when scrolling.
   "vertical_scroll_margin": 3,
-  // Auto-scrolling by `vertical_scroll_margin` is not applied through mouse interactions.
+  // Whether to scroll when clicking near the edge of the visible text area.
   "autoscroll_on_clicks": false,
   // Scroll sensitivity multiplier. This multiplier is applied
   // to both the horizontal and vertical delta values while scrolling.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -287,6 +287,8 @@
   "scroll_beyond_last_line": "one_page",
   // The number of lines to keep above/below the cursor when scrolling.
   "vertical_scroll_margin": 3,
+  // Auto-scrolling by `vertical_scroll_margin` is not applied through mouse interactions.
+  "vertical_scroll_margin_ignore_mouse_interaction": false,
   // Scroll sensitivity multiplier. This multiplier is applied
   // to both the horizontal and vertical delta values while scrolling.
   "scroll_sensitivity": 1.0,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -288,7 +288,7 @@
   // The number of lines to keep above/below the cursor when scrolling.
   "vertical_scroll_margin": 3,
   // Auto-scrolling by `vertical_scroll_margin` is not applied through mouse interactions.
-  "vertical_scroll_margin_ignore_mouse_interaction": false,
+  "autoscroll_on_clicks": false,
   // Scroll sensitivity multiplier. This multiplier is applied
   // to both the horizontal and vertical delta values while scrolling.
   "scroll_sensitivity": 1.0,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2864,8 +2864,7 @@ impl Editor {
                 auto_scroll = false;
             }
         }
-        auto_scroll &=
-            !EditorSettings::get_global(cx).vertical_scroll_margin_ignore_mouse_interaction;
+        auto_scroll &= !EditorSettings::get_global(cx).autoscroll_on_clicks;
 
         let point_to_delete: Option<usize> = {
             let selected_points: Vec<Selection<Point>> =

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2828,20 +2828,17 @@ impl Editor {
         let start;
         let end;
         let mode;
-        let auto_scroll;
         match click_count {
             1 => {
                 start = buffer.anchor_before(position.to_point(&display_map));
                 end = start;
                 mode = SelectMode::Character;
-                auto_scroll = true;
             }
             2 => {
                 let range = movement::surrounding_word(&display_map, position);
                 start = buffer.anchor_before(range.start.to_point(&display_map));
                 end = buffer.anchor_before(range.end.to_point(&display_map));
                 mode = SelectMode::Word(start..end);
-                auto_scroll = true;
             }
             3 => {
                 let position = display_map
@@ -2855,13 +2852,11 @@ impl Editor {
                 start = buffer.anchor_before(line_start);
                 end = buffer.anchor_before(next_line_start);
                 mode = SelectMode::Line(start..end);
-                auto_scroll = true;
             }
             _ => {
                 start = buffer.anchor_before(0);
                 end = buffer.anchor_before(buffer.len());
                 mode = SelectMode::All;
-                auto_scroll = false;
             }
         }
 
@@ -2886,7 +2881,7 @@ impl Editor {
 
         let selections_count = self.selections.count();
 
-        self.change_selections(auto_scroll.then(Autoscroll::newest), cx, |s| {
+        self.change_selections(None, cx, |s| {
             if let Some(point_to_delete) = point_to_delete {
                 s.delete(point_to_delete);
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -18,7 +18,7 @@ pub struct EditorSettings {
     pub gutter: Gutter,
     pub scroll_beyond_last_line: ScrollBeyondLastLine,
     pub vertical_scroll_margin: f32,
-    pub vertical_scroll_margin_ignore_mouse_interaction: bool,
+    pub autoscroll_on_clicks: bool,
     pub scroll_sensitivity: f32,
     pub relative_line_numbers: bool,
     pub seed_search_query_from_cursor: SeedQuerySetting,
@@ -226,7 +226,7 @@ pub struct EditorSettingsContent {
     /// Auto-scrolling by `vertical_scroll_margin` is not applied through mouse interactions.
     ///
     /// Default: false
-    pub vertical_scroll_margin_ignore_mouse_interaction: Option<bool>,
+    pub autoscroll_on_clicks: Option<bool>,
     /// Scroll sensitivity multiplier. This multiplier is applied
     /// to both the horizontal and vertical delta values while scrolling.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -18,6 +18,7 @@ pub struct EditorSettings {
     pub gutter: Gutter,
     pub scroll_beyond_last_line: ScrollBeyondLastLine,
     pub vertical_scroll_margin: f32,
+    pub vertical_scroll_margin_ignore_mouse_interaction: bool,
     pub scroll_sensitivity: f32,
     pub relative_line_numbers: bool,
     pub seed_search_query_from_cursor: SeedQuerySetting,
@@ -222,6 +223,10 @@ pub struct EditorSettingsContent {
     ///
     /// Default: 3.
     pub vertical_scroll_margin: Option<f32>,
+    /// Auto-scrolling by `vertical_scroll_margin` is not applied through mouse interactions.
+    ///
+    /// Default: false
+    pub vertical_scroll_margin_ignore_mouse_interaction: Option<bool>,
     /// Scroll sensitivity multiplier. This multiplier is applied
     /// to both the horizontal and vertical delta values while scrolling.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -223,7 +223,7 @@ pub struct EditorSettingsContent {
     ///
     /// Default: 3.
     pub vertical_scroll_margin: Option<f32>,
-    /// Auto-scrolling by `vertical_scroll_margin` is not applied through mouse interactions.
+    /// Whether to scroll when clicking near the edge of the visible text area.
     ///
     /// Default: false
     pub autoscroll_on_clicks: Option<bool>,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -117,6 +117,16 @@ Define extensions which should be installed (`true`) or never installed (`false`
 }
 ```
 
+## Autoscroll on Clicks
+
+- Description: Whether to scroll when clicking near the edge of the visible text area.
+- Setting: `autoscroll_on_clicks`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
 ## Auto Update
 
 - Description: Whether or not to automatically check for updates.


### PR DESCRIPTION
Closes #18148

Release Notes:

- Stop scrolling when clicking to the edges of the visible text area. Use `autoscroll_on_clicks` to configure this behavior.

https://github.com/user-attachments/assets/3afd5cbb-5957-4e39-94c6-cd2e927038fd

