### PR TITLE
Add suggestion for CMake files

### DIFF
--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -17,6 +17,7 @@ const SUGGESTIONS_BY_EXTENSION_ID: &[(&str, &[&str])] = &[
     ("astro", &["astro"]),
     ("beancount", &["beancount"]),
     ("clojure", &["bb", "clj", "cljc", "cljs", "edn"]),
+    ("neocmake", &["CMakeLists.txt", "cmake"]),
     ("csharp", &["cs"]),
     ("dart", &["dart"]),
     ("dockerfile", &["Dockerfile"]),


### PR DESCRIPTION
Release Notes:

- Added NeoCMake extension suggestion for cmake files (`CMakeLists.txt` and `.cmake`)
