### PR TITLE
Use Zed handler for undo and redo macOS actions

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -294,8 +294,10 @@ impl MacPlatform {
                     Some(crate::OsAction::Copy) => selector("copy:"),
                     Some(crate::OsAction::Paste) => selector("paste:"),
                     Some(crate::OsAction::SelectAll) => selector("selectAll:"),
-                    Some(crate::OsAction::Undo) => selector("undo:"),
-                    Some(crate::OsAction::Redo) => selector("redo:"),
+                    // "undo:" and "redo:" are always disabled in our case, as
+                    // we don't have a NSTextView/NSTextField to enable them on.
+                    Some(crate::OsAction::Undo) => selector("handleGPUIMenuItem:"),
+                    Some(crate::OsAction::Redo) => selector("handleGPUIMenuItem:"),
                     None => selector("handleGPUIMenuItem:"),
                 };
 


### PR DESCRIPTION
Those seem to require a corresponding NSTextView/NSTextField with explicitly enabled `allowsUndo` property. But Zed does not use any of these *Text* elements, so there's nothing to allow undo on. Hence, use the Zed handler, making both actions always enabled instead of being always disabled.

Closes https://github.com/zed-industries/zed/issues/12335

Release Notes:

- Fixed undo and redo macOS menu items being always disabled ([#12335](https://github.com/zed-industries/zed/issues/12335))
