### PR TITLE
pane: Update pinned tab counts when unnamed buffer is discarded

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1593,8 +1593,13 @@ impl Pane {
                             Ok(0) => {}
                             Ok(1) => {
                                 // Don't save this file
-                                pane.update(cx, |_, cx| item.discarded(project, cx))
-                                    .log_err();
+                                pane.update(cx, |pane, cx| {
+                                    if pane.is_tab_pinned(item_ix) && !item.can_save(cx) {
+                                        pane.pinned_tab_count -= 1;
+                                    }
+                                    item.discarded(project, cx)
+                                })
+                                .log_err();
                                 return Ok(true);
                             }
                             _ => return Ok(false), // Cancel


### PR DESCRIPTION
Closes #19492

Release Notes:

- Fixed a crash that could happen when closing a workspace with pinned untitled buffers.
