### PR TITLE
assistant: Remove automatic diagnostic attachment to tab and file commands

### DIFF
--- a/crates/assistant/src/slash_command/file_command.rs
+++ b/crates/assistant/src/slash_command/file_command.rs
@@ -21,8 +21,6 @@ use ui::prelude::*;
 use util::ResultExt;
 use workspace::Workspace;
 
-use crate::slash_command::diagnostics_command::collect_buffer_diagnostics;
-
 pub(crate) struct FileSlashCommand;
 
 impl FileSlashCommand {
@@ -543,8 +541,6 @@ pub fn append_buffer_to_output(
     output.text.push('\n');
 
     let section_ix = output.sections.len();
-    collect_buffer_diagnostics(output, buffer, false);
-
     output.sections.insert(
         section_ix,
         build_entry_output_section(prev_len..output.text.len(), path, false, None),

--- a/crates/ui/src/components/stories/icon.rs
+++ b/crates/ui/src/components/stories/icon.rs
@@ -5,7 +5,7 @@ use strum::IntoEnumIterator;
 use crate::{prelude::*, DecoratedIcon, IconDecoration};
 use crate::{Icon, IconName};
 
-pub struct IconStory;
+pub struct IcoasdasdasdnStory;
 
 impl Render for IconStory {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {

--- a/crates/ui/src/components/stories/icon.rs
+++ b/crates/ui/src/components/stories/icon.rs
@@ -5,7 +5,7 @@ use strum::IntoEnumIterator;
 use crate::{prelude::*, DecoratedIcon, IconDecoration};
 use crate::{Icon, IconName};
 
-pub struct IcoasdasdasdnStory;
+pub struct IconStory;
 
 impl Render for IconStory {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {


### PR DESCRIPTION
This PR returns the `/tab` and `/file` commands to their original behavior of _not_ automatically including diagnostics. This is an assistant-only change, though, given that we can already pass the `/diagnostic` command by itself. The inline assistant will still have the diagnostics baked in to allow prompts such as "Fix this error."

Release Notes:

- Remove automatic diagnostic attachment to tab and file commands in the assistant panel
