### PR TITLE
editor: Do not show inline completion if snippet is active

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2489,6 +2489,10 @@ impl Editor {
         buffer_position: language::Anchor,
         cx: &AppContext,
     ) -> bool {
+        if !self.snippet_stack.is_empty() {
+            return false;
+        }
+
         if let Some(provider) = self.inline_completion_provider() {
             if let Some(show_inline_completions) = self.show_inline_completions_override {
                 show_inline_completions


### PR DESCRIPTION
This avoids inline completions being shown (and overriding `<tab>` behavior) when a snippet is active and the user wants to go through snippet placeholders with `<tab>`.

Easy to reproduce:

Open a Rust file and use the `tfn` snippet to produce a test function. Delete the placeholder. Without the change here, the inline provider would suggest a function name. If you `<tab>`, you accept it, but then you can't `<tab>` into the function body.

With this change the inline completions are deactivated as long as a snippet is active.

Closes #19484 

Release Notes:

- Fixed inline completions (Copilot, Supermaven, ...) taking over when a snippet completion was active. That resulted in `tab` not working to jump to the next placeholder in the snippet.