### PR TITLE
Refactor scripts to use `command -v` instead of `which`

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -11,7 +11,7 @@ else
 fi
 
 # Install sqlx-cli if needed
-if [[ "$(sqlx --version)" != "sqlx-cli 0.7.2" ]]; then
+if ! [[ "$(command -v sqlx)" && "$(sqlx --version)" == "sqlx-cli 0.7.2" ]]; then
     echo "sqlx-cli not found or not the required version, installing version 0.7.2..."
     cargo install sqlx-cli --version 0.7.2
 fi

--- a/script/install.sh
+++ b/script/install.sh
@@ -33,11 +33,11 @@ main() {
             ;;
     esac
 
-    if which curl >/dev/null 2>&1; then
+    if command -v curl >/dev/null 2>&1; then
         curl () {
             command curl -fL "$@"
         }
-    elif which wget >/dev/null 2>&1; then
+    elif command -v wget >/dev/null 2>&1; then
         curl () {
             wget -O- "$@"
         }
@@ -48,7 +48,7 @@ main() {
 
     "$platform" "$@"
 
-    if [ "$(which "zed")" = "$HOME/.local/bin/zed" ]; then
+    if [ "$(command -v zed)" = "$HOME/.local/bin/zed" ]; then
         echo "Zed has been installed. Run with 'zed'"
     else
         echo "To run Zed from your terminal, you must add ~/.local/bin to your PATH"


### PR DESCRIPTION
`which` is not a core package is some distributions.
Included changes from #20309 

Release Notes:

- N/A
