### PR TITLE
Show workspace name before filename in window title

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3447,12 +3447,6 @@ impl Workspace {
             title = "empty project".to_string();
         }
 
-        if project.is_via_collab() {
-            title.push_str(" ↙");
-        } else if project.is_shared() {
-            title.push_str(" ↗");
-        }
-
         if let Some(path) = self.active_item(cx).and_then(|item| item.project_path(cx)) {
             let filename = path
                 .path
@@ -3471,6 +3465,12 @@ impl Workspace {
                 title.push_str(" — ");
                 title.push_str(filename.as_ref());
             }
+        }
+
+        if project.is_via_collab() {
+            title.push_str(" ↙");
+        } else if project.is_shared() {
+            title.push_str(" ↗");
         }
 
         cx.set_window_title(&title);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6211,7 +6211,7 @@ mod tests {
                     .map(|e| e.id)
             );
         });
-        assert_eq!(cx.window_title().as_deref(), Some("one.txt — root1"));
+        assert_eq!(cx.window_title().as_deref(), Some("root1 — one.txt"));
 
         // Add a second item to a non-empty pane
         workspace.update(cx, |workspace, cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3436,26 +3436,6 @@ impl Workspace {
         let project = self.project().read(cx);
         let mut title = String::new();
 
-        if let Some(path) = self.active_item(cx).and_then(|item| item.project_path(cx)) {
-            let filename = path
-                .path
-                .file_name()
-                .map(|s| s.to_string_lossy())
-                .or_else(|| {
-                    Some(Cow::Borrowed(
-                        project
-                            .worktree_for_id(path.worktree_id, cx)?
-                            .read(cx)
-                            .root_name(),
-                    ))
-                });
-
-            if let Some(filename) = filename {
-                title.push_str(filename.as_ref());
-                title.push_str(" — ");
-            }
-        }
-
         for (i, name) in project.worktree_root_names(cx).enumerate() {
             if i > 0 {
                 title.push_str(", ");
@@ -3471,6 +3451,26 @@ impl Workspace {
             title.push_str(" ↙");
         } else if project.is_shared() {
             title.push_str(" ↗");
+        }
+
+        if let Some(path) = self.active_item(cx).and_then(|item| item.project_path(cx)) {
+            let filename = path
+                .path
+                .file_name()
+                .map(|s| s.to_string_lossy())
+                .or_else(|| {
+                    Some(Cow::Borrowed(
+                        project
+                            .worktree_for_id(path.worktree_id, cx)?
+                            .read(cx)
+                            .root_name(),
+                    ))
+                });
+
+            if let Some(filename) = filename {
+                title.push_str(" — ");
+                title.push_str(filename.as_ref());
+            }
         }
 
         cx.set_window_title(&title);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6217,7 +6217,7 @@ mod tests {
         workspace.update(cx, |workspace, cx| {
             workspace.add_item_to_active_pane(Box::new(item2), None, true, cx)
         });
-        assert_eq!(cx.window_title().as_deref(), Some("two.txt — root1"));
+        assert_eq!(cx.window_title().as_deref(), Some("root1 — two.txt"));
         project.update(cx, |project, cx| {
             assert_eq!(
                 project.active_entry(),
@@ -6233,7 +6233,7 @@ mod tests {
         })
         .await
         .unwrap();
-        assert_eq!(cx.window_title().as_deref(), Some("one.txt — root1"));
+        assert_eq!(cx.window_title().as_deref(), Some("root1 — one.txt"));
         project.update(cx, |project, cx| {
             assert_eq!(
                 project.active_entry(),
@@ -6250,11 +6250,11 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(cx.window_title().as_deref(), Some("one.txt — root1, root2"));
+        assert_eq!(cx.window_title().as_deref(), Some("root1, root2 — one.txt"));
 
         // Remove a project folder
         project.update(cx, |project, cx| project.remove_worktree(worktree_id, cx));
-        assert_eq!(cx.window_title().as_deref(), Some("one.txt — root2"));
+        assert_eq!(cx.window_title().as_deref(), Some("root2 — one.txt"));
     }
 
     #[gpui::test]


### PR DESCRIPTION
when searching for the appropriate zed window, i scan a list of window titles. putting the workspace before the filename makes this list a lot easier to scan.

![CleanShot 2024-11-06 at 11 07 01@2x](https://github.com/user-attachments/assets/2dcbe96d-6f91-443e-bfd2-10bd1c81e679)

screenshot of [alt tab](https://alt-tab-macos.netlify.app/) in mac os demonstrating how putting the workspace first makes it easier to locate a project.


Release Notes:

- Improved window title by showing workspace name before filename
