### PR TITLE
Add missing field to `impl Hash for RenderGlyphParams`

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -668,6 +668,7 @@ impl Hash for RenderGlyphParams {
         self.font_size.0.to_bits().hash(state);
         self.subpixel_variant.hash(state);
         self.scale_factor.to_bits().hash(state);
+        self.is_emoji.hash(state);
     }
 }
 


### PR DESCRIPTION
Unlikely to cause any behavior change but seems more correct to include `is_emoji` in the hash.

Release Notes:

- N/A