### PR TITLE
Allow Unicode-3.0 license in checks

### DIFF
--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -9,6 +9,7 @@ accepted = [
     "BSD-2-Clause",
     "ISC",
     "CC0-1.0",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "OpenSSL",
     "Zlib",


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/pull/20334

The license is on par with other licenses in the list: https://www.unicode.org/license.txt

Release Notes:

- N/A