### PR TITLE
assistant: Add model names in alternative inline tooltips

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1907,14 +1907,13 @@ impl PromptEditor {
 
         let get_model_name = |index: usize| -> String {
             let name = |model: &Arc<dyn LanguageModel>| model.name().0.to_string();
-            let default_value = || String::new();
 
             match index {
-                0 => default_model.as_ref().map_or_else(default_value, name),
+                0 => default_model.as_ref().map_or_else(String::new, name),
                 index if index <= alternative_models.len() => alternative_models
                     .get(index - 1)
-                    .map_or_else(default_value, name),
-                _ => default_value(),
+                    .map_or_else(String::new, name),
+                _ => String::new(),
             }
         };
 

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1935,17 +1935,25 @@ impl PromptEditor {
             .child(
                 IconButton::new("previous", IconName::ChevronLeft)
                     .icon_color(Color::Muted)
-                    .disabled(disabled)
+                    .disabled(disabled || current_index == 0)
                     .shape(IconButtonShape::Square)
                     .tooltip({
                         let focus_handle = self.editor.focus_handle(cx);
                         move |cx| {
-                            Tooltip::for_action_in(
-                                "Previous Alternative",
-                                &CyclePreviousInlineAssist,
-                                &focus_handle,
-                                cx,
-                            )
+                            cx.new_view(|cx| {
+                                let mut tooltip = Tooltip::new("Previous Alternative").key_binding(
+                                    KeyBinding::for_action_in(
+                                        &CyclePreviousInlineAssist,
+                                        &focus_handle,
+                                        cx,
+                                    ),
+                                );
+                                if !disabled && current_index != 0 {
+                                    tooltip = tooltip.meta(prev_model_name.clone());
+                                }
+                                tooltip
+                            })
+                            .into()
                         }
                     })
                     .on_click(cx.listener(|this, _, cx| {
@@ -1969,17 +1977,25 @@ impl PromptEditor {
             .child(
                 IconButton::new("next", IconName::ChevronRight)
                     .icon_color(Color::Muted)
-                    .disabled(disabled)
+                    .disabled(disabled || current_index == total_models - 1)
                     .shape(IconButtonShape::Square)
                     .tooltip({
                         let focus_handle = self.editor.focus_handle(cx);
                         move |cx| {
-                            Tooltip::for_action_in(
-                                "Next Alternative",
-                                &CycleNextInlineAssist,
-                                &focus_handle,
-                                cx,
-                            )
+                            cx.new_view(|cx| {
+                                let mut tooltip = Tooltip::new("Next Alternative").key_binding(
+                                    KeyBinding::for_action_in(
+                                        &CycleNextInlineAssist,
+                                        &focus_handle,
+                                        cx,
+                                    ),
+                                );
+                                if !disabled && current_index != total_models - 1 {
+                                    tooltip = tooltip.meta(next_model_name.clone());
+                                }
+                                tooltip
+                            })
+                            .into()
                         }
                     })
                     .on_click(cx.listener(|this, _, cx| {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/18826

This PR adds the model name to the tooltips on the alternative inline assistant icon buttons. The default model should be the first, so every other one set as an alternative appears after.

https://github.com/user-attachments/assets/46faccaa-447c-45a4-b927-49ea3c4f3be1


Release Notes:

- Improve knowledge of which model is used when with alternative inline models turned on
