### PR TITLE
assistant: Improve UI feedback when inserting `/delta` without new changes

### DIFF
--- a/crates/assistant/src/slash_command/delta_command.rs
+++ b/crates/assistant/src/slash_command/delta_command.rs
@@ -58,6 +58,7 @@ impl SlashCommand for DeltaSlashCommand {
         let mut paths = HashSet::default();
         let mut file_command_old_outputs = Vec::new();
         let mut file_command_new_outputs = Vec::new();
+
         for section in context_slash_command_output_sections.iter().rev() {
             if let Some(metadata) = section
                 .metadata
@@ -84,6 +85,7 @@ impl SlashCommand for DeltaSlashCommand {
 
         cx.background_executor().spawn(async move {
             let mut output = SlashCommandOutput::default();
+            let mut changes_detected = false;
 
             let file_command_new_outputs = future::join_all(file_command_new_outputs).await;
             for (old_text, new_output) in file_command_old_outputs
@@ -96,6 +98,7 @@ impl SlashCommand for DeltaSlashCommand {
                         if let Some(file_command_range) = new_output.sections.first() {
                             let new_text = &new_output.text[file_command_range.range.clone()];
                             if old_text.chars().ne(new_text.chars()) {
+                                changes_detected = true;
                                 output.sections.extend(new_output.sections.into_iter().map(
                                     |section| SlashCommandOutputSection {
                                         range: output.text.len() + section.range.start
@@ -110,6 +113,10 @@ impl SlashCommand for DeltaSlashCommand {
                         }
                     }
                 }
+            }
+
+            if !changes_detected {
+                return Err(anyhow!("no new changes detected"));
             }
 
             Ok(output.to_event_stream())


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/18488

### Before

No feedback when inserting `/delta` without new changes.

https://github.com/user-attachments/assets/4cc76ff4-419d-4a3f-a6a2-8712856b1aa8

### After

You now see an error within the `delta` crease.

https://github.com/user-attachments/assets/c56654bb-776f-4dac-a499-db4625a4f1bd

Release Notes:

- Improve UI feedback when inserting `/delta` without new changes
