### PR TITLE
Update Copilot Chat max_tokens soft limits

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -90,8 +90,8 @@ impl Model {
             Self::Gpt4o => 128000,
             Self::Gpt4 => 8192,
             Self::Gpt3_5Turbo => 16385,
-            Self::O1Mini => 128000,
-            Self::O1Preview => 128000,
+            Self::O1Mini => 20000,
+            Self::O1Preview => 20000,
             Self::Claude3_5Sonnet => 200_000,
         }
     }

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -87,9 +87,9 @@ impl Model {
 
     pub fn max_token_count(&self) -> usize {
         match self {
-            Self::Gpt4o => 128000,
-            Self::Gpt4 => 8192,
-            Self::Gpt3_5Turbo => 16385,
+            Self::Gpt4o => 64000,
+            Self::Gpt4 => 32768,
+            Self::Gpt3_5Turbo => 12288,
             Self::O1Mini => 20000,
             Self::O1Preview => 20000,
             Self::Claude3_5Sonnet => 200_000,


### PR DESCRIPTION
Closes #20362 

Release Notes:

- Fixed max_token soft-limits for GitHub Copilot Chat models
