### PR TITLE
Add abstract classes to typescript outline query

### DIFF
--- a/crates/languages/src/tsx/outline.scm
+++ b/crates/languages/src/tsx/outline.scm
@@ -38,6 +38,11 @@
     "class" @context
     name: (_) @name) @item
 
+(abstract_class_declaration
+    "abstract" @context
+    "class" @context
+    name: (_) @name) @item
+
 (method_definition
     [
         "get"

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -38,6 +38,11 @@
     "class" @context
     name: (_) @name) @item
 
+(abstract_class_declaration
+    "abstract" @context
+    "class" @context
+    name: (_) @name) @item
+
 (method_definition
     [
         "get"


### PR DESCRIPTION
Closes #4553

Release Notes:

- Fixed a bug where abstract classes weren't shown correctly in the outline view when editing Typescript code.
