### PR TITLE
Update menu item from Twitter to X

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -185,9 +185,9 @@ pub fn app_menus() -> Vec<Menu> {
                     },
                 ),
                 MenuItem::action(
-                    "Zed Twitter",
+                    "Zed X Account",
                     super::OpenBrowser {
-                        url: "https://twitter.com/zeddotdev".into(),
+                        url: "https://x.com/zeddotdev".into(),
                     },
                 ),
                 MenuItem::action(

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -185,7 +185,7 @@ pub fn app_menus() -> Vec<Menu> {
                     },
                 ),
                 MenuItem::action(
-                    "Zed X Account",
+                    "Zed 𝕏 (formerly Twitter)",
                     super::OpenBrowser {
                         url: "https://x.com/zeddotdev".into(),
                     },


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixed help menu item from Zed Twitter to Zed 𝕏 (formerly Twitter)
