### PR TITLE
terminal: Prevent `[]` from being sanitized into clickable file link

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -924,18 +924,22 @@ impl Terminal {
                 } else if let Some(word_match) = regex_match_at(term, point, &mut self.word_regex) {
                     let file_path = term.bounds_to_string(*word_match.start(), *word_match.end());
 
-                    let (sanitized_match, sanitized_word) =
-                        if file_path.starts_with('[') && file_path.ends_with(']') {
-                            (
-                                Match::new(
-                                    word_match.start().add(term, Boundary::Cursor, 1),
-                                    word_match.end().sub(term, Boundary::Cursor, 1),
-                                ),
-                                file_path[1..file_path.len() - 1].to_owned(),
-                            )
-                        } else {
-                            (word_match, file_path)
-                        };
+                    let (sanitized_match, sanitized_word) = if file_path.starts_with('[')
+                        && file_path.ends_with(']')
+                        // this is to avoid sanitizing the match '[]' to an empty string,
+                        // which would be considered a valid navigation target
+                        && file_path.len() > 2
+                    {
+                        (
+                            Match::new(
+                                word_match.start().add(term, Boundary::Cursor, 1),
+                                word_match.end().sub(term, Boundary::Cursor, 1),
+                            ),
+                            file_path[1..file_path.len() - 1].to_owned(),
+                        )
+                    } else {
+                        (word_match, file_path)
+                    };
 
                     Some((sanitized_word, false, sanitized_match))
                 } else {


### PR DESCRIPTION
This PR prevents `[]` from being sanitized into an empty string and thus becoming a "valid", clickable file link in the integrated terminal.


Whenever you type `[]` into the terminal and hover over it while pressing `cmd`, an empty popup appears and the cursor indicates that this is a clickable element. Once you click on the brackets, the worktree root is selected and focused within the file picker.

 <img width="87" alt="grafik" src="https://github.com/user-attachments/assets/01790323-88be-4373-a1ec-a345bcf2521e">


This is because in #2906 support was added for sanititzing file links like `[/some/path/[slug].tsx]` to `/some/path/[slug].tsx`. In the case `[]` where an empty string is returned from the sanitation, the string is considered a valid file path and thus `[]` becomes a valid and clickable navigation target.

Given that this an edge-case just for this specific one set of brackets and otherwise no empty strings are matched from the regexes `URL_REGEX` and `WORD_REGEX`, it seemed that this was the best place to fix this bug.

Release Notes:

- `[]` is no longer considered a clickable link in the terminal
