### PR TITLE
assistant: Fine-tune crease feedback design

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2760,7 +2760,7 @@ impl ContextEditor {
                             .h_11()
                             .w_full()
                             .relative()
-                            .gap_1()
+                            .gap_1p5()
                             .child(sender)
                             .children(match &message.cache {
                                 Some(cache) if cache.is_final_anchor => match cache.status {
@@ -2774,7 +2774,7 @@ impl ContextEditor {
                                             )
                                             .tooltip(|cx| {
                                                 Tooltip::with_meta(
-                                                    "Context cached",
+                                                    "Context Cached",
                                                     None,
                                                     "Large messages cached to optimize performance",
                                                     cx,
@@ -2802,16 +2802,9 @@ impl ContextEditor {
                                         .selected_icon_color(Color::Error)
                                         .icon(IconName::XCircle)
                                         .icon_color(Color::Error)
-                                        .icon_size(IconSize::Small)
+                                        .icon_size(IconSize::XSmall)
                                         .icon_position(IconPosition::Start)
-                                        .tooltip(move |cx| {
-                                            Tooltip::with_meta(
-                                                "Error interacting with language model",
-                                                None,
-                                                "Click for more details",
-                                                cx,
-                                            )
-                                        })
+                                        .tooltip(move |cx| Tooltip::text("View Details", cx))
                                         .on_click({
                                             let context = context.clone();
                                             let error = error.clone();
@@ -2826,21 +2819,19 @@ impl ContextEditor {
                                         .into_any_element(),
                                 ),
                                 MessageStatus::Canceled => Some(
-                                    ButtonLike::new("canceled")
-                                        .child(Icon::new(IconName::XCircle).color(Color::Disabled))
+                                    h_flex()
+                                        .gap_1()
+                                        .items_center()
+                                        .child(
+                                            Icon::new(IconName::XCircle)
+                                                .color(Color::Disabled)
+                                                .size(IconSize::XSmall),
+                                        )
                                         .child(
                                             Label::new("Canceled")
                                                 .size(LabelSize::Small)
                                                 .color(Color::Disabled),
                                         )
-                                        .tooltip(move |cx| {
-                                            Tooltip::with_meta(
-                                                "Canceled",
-                                                None,
-                                                "Interaction with the assistant was canceled",
-                                                cx,
-                                            )
-                                        })
                                         .into_any_element(),
                                 ),
                                 _ => None,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/13414

Just polishing up how some of these look. Ever since the issue was opened, we added the "Error" label to the button, as well as automatically popping open the toast error whenever that happens. Lastly, there's a tooltip in there as well indicating that you can click on it to see the details of the error.

<img width="700" alt="Screenshot 2024-11-08 at 00 26 27" src="https://github.com/user-attachments/assets/ad0962e6-4621-4e8b-be0d-103d71fcf2e6">

Release Notes:

- N/A
