### PR TITLE
Register repl actions with editor after session started

### DIFF
--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -10,7 +10,9 @@ use language::{BufferSnapshot, Language, LanguageName, Point};
 
 use crate::repl_store::ReplStore;
 use crate::session::SessionEvent;
-use crate::{KernelSpecification, Session};
+use crate::{
+    ClearOutputs, Interrupt, JupyterSettings, KernelSpecification, Restart, Session, Shutdown,
+};
 
 pub fn assign_kernelspec(
     kernel_specification: KernelSpecification,
@@ -238,6 +240,60 @@ pub fn restart(editor: WeakView<Editor>, cx: &mut WindowContext) {
         session.restart(cx);
         cx.notify();
     });
+}
+
+pub fn setup_editor_session_actions(editor: &mut Editor, editor_handle: WeakView<Editor>) {
+    editor
+        .register_action({
+            let editor_handle = editor_handle.clone();
+            move |_: &ClearOutputs, cx| {
+                if !JupyterSettings::enabled(cx) {
+                    return;
+                }
+
+                crate::clear_outputs(editor_handle.clone(), cx);
+            }
+        })
+        .detach();
+
+    editor
+        .register_action({
+            let editor_handle = editor_handle.clone();
+            move |_: &Interrupt, cx| {
+                if !JupyterSettings::enabled(cx) {
+                    return;
+                }
+
+                crate::interrupt(editor_handle.clone(), cx);
+            }
+        })
+        .detach();
+
+    editor
+        .register_action({
+            let editor_handle = editor_handle.clone();
+            move |_: &Shutdown, cx| {
+                if !JupyterSettings::enabled(cx) {
+                    return;
+                }
+
+                crate::shutdown(editor_handle.clone(), cx);
+            }
+        })
+        .detach();
+
+    editor
+        .register_action({
+            let editor_handle = editor_handle.clone();
+            move |_: &Restart, cx| {
+                if !JupyterSettings::enabled(cx) {
+                    return;
+                }
+
+                crate::restart(editor_handle.clone(), cx);
+            }
+        })
+        .detach();
 }
 
 fn cell_range(buffer: &BufferSnapshot, start_row: u32, end_row: u32) -> Range<Point> {

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -97,58 +97,6 @@ pub fn init(cx: &mut AppContext) {
                 }
             })
             .detach();
-
-        editor
-            .register_action({
-                let editor_handle = editor_handle.clone();
-                move |_: &ClearOutputs, cx| {
-                    if !JupyterSettings::enabled(cx) {
-                        return;
-                    }
-
-                    crate::clear_outputs(editor_handle.clone(), cx);
-                }
-            })
-            .detach();
-
-        editor
-            .register_action({
-                let editor_handle = editor_handle.clone();
-                move |_: &Interrupt, cx| {
-                    if !JupyterSettings::enabled(cx) {
-                        return;
-                    }
-
-                    crate::interrupt(editor_handle.clone(), cx);
-                }
-            })
-            .detach();
-
-        editor
-            .register_action({
-                let editor_handle = editor_handle.clone();
-                move |_: &Shutdown, cx| {
-                    if !JupyterSettings::enabled(cx) {
-                        return;
-                    }
-
-                    crate::shutdown(editor_handle.clone(), cx);
-                }
-            })
-            .detach();
-
-        editor
-            .register_action({
-                let editor_handle = editor_handle.clone();
-                move |_: &Restart, cx| {
-                    if !JupyterSettings::enabled(cx) {
-                        return;
-                    }
-
-                    crate::restart(editor_handle.clone(), cx);
-                }
-            })
-            .detach();
     })
     .detach();
 }

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -1,4 +1,5 @@
 use crate::components::KernelListItem;
+use crate::setup_editor_session_actions;
 use crate::{
     kernels::{Kernel, KernelSpecification, RunningKernel},
     outputs::{ExecutionStatus, ExecutionView},
@@ -206,6 +207,14 @@ impl Session {
             }
             None => Subscription::new(|| {}),
         };
+
+        let editor_handle = editor.clone();
+
+        editor
+            .update(cx, |editor, _cx| {
+                setup_editor_session_actions(editor, editor_handle);
+            })
+            .ok();
 
         let mut session = Self {
             fs,


### PR DESCRIPTION
Makes repl actions that are specific to running kernels only come up after a session has been started at least once for the editor.

Release Notes:

- Only show session oriented `repl::` actions for editors after a session has been created