### PR TITLE
Disable repl in non-local projects

### DIFF
--- a/crates/quick_action_bar/src/repl_menu.rs
+++ b/crates/quick_action_bar/src/repl_menu.rs
@@ -43,6 +43,16 @@ impl QuickActionBar {
 
         let editor = self.active_editor()?;
 
+        let is_local_project = editor
+            .read(cx)
+            .workspace()
+            .map(|workspace| workspace.read(cx).project().read(cx).is_local())
+            .unwrap_or(false);
+
+        if !is_local_project {
+            return None;
+        }
+
         let has_nonempty_selection = {
             editor.update(cx, |this, cx| {
                 this.selections

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -61,6 +61,15 @@ pub fn init(cx: &mut AppContext) {
             return;
         }
 
+        let is_local_project = editor
+            .workspace()
+            .map(|workspace| workspace.read(cx).project().read(cx).is_local())
+            .unwrap_or(false);
+
+        if !is_local_project {
+            return;
+        }
+
         let editor_handle = cx.view().downgrade();
 
         editor


### PR DESCRIPTION
Release Notes:

- Disable REPL buttons and actions for remote projects and collaboration (only the host should have access).
