### PR TITLE
windows: Fix rust-analyzer download

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -139,7 +139,7 @@ impl LspAdapter for RustLspAdapter {
             #[cfg(not(windows))]
             {
                 fs::set_permissions(
-                    &extract_path,
+                    &bin_path,
                     <fs::Permissions as fs::unix::PermissionsExt>::from_mode(0o755),
                 )
                 .await?;

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -79,13 +79,14 @@ impl LspAdapter for RustLspAdapter {
             delegate.http_client(),
         )
         .await?;
-        let os = match consts::OS {
-            "macos" => "apple-darwin",
-            "linux" => "unknown-linux-gnu",
-            "windows" => "pc-windows-msvc",
+        let os_file = match consts::OS {
+            "macos" => "apple-darwin.gz",
+            "linux" => "unknown-linux-gnu.gz",
+            "windows" => "pc-windows-msvc.zip",
             other => bail!("Running on unsupported os: {other}"),
         };
-        let asset_name = format!("rust-analyzer-{}-{os}.gz", consts::ARCH);
+        let arch = consts::ARCH;
+        let asset_name = format!("rust-analyzer-{arch}-{os_file}");
         let asset = release
             .assets
             .iter()


### PR DESCRIPTION
After https://github.com/rust-lang/rust-analyzer/pull/18412, there is no longer a .gz file for windows rust-analyzer targets, and the rust analyzer LSP fails to download. This fixes it by using the .zip version on windows.

The .zip also extracts to a _folder_ containing rust-analyzer.exe rather than just a file. I've handled it in this code, but am not 100% sure if other parts of the code need too be aware of it.

Release Notes:

- N/A