### PR TITLE
project panel: Fix preview tabs not working when enabled

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2665,7 +2665,7 @@ impl ProjectPanel {
                             entry_id,
                             cx.modifiers().secondary(),
                             !preview_tabs_enabled || click_count > 1,
-                            !preview_tabs_enabled && click_count == 1,
+                            preview_tabs_enabled && click_count == 1,
                             cx,
                         );
                     }


### PR DESCRIPTION
PR #20154 introduced a regression and essentially disabled preview tabs in code.

This fixes it and restores the old preview tabs behavior.

Release Notes:

- Fixed preview tabs being disabled in code, even if they were enabled in the settings.
