### PR TITLE
Use a different keybinding for `editor::AcceptPartialInlineCompletion` action

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -150,7 +150,7 @@
     "bindings": {
       "alt-]": "editor::NextInlineCompletion",
       "alt-[": "editor::PreviousInlineCompletion",
-      "cmd-right": "editor::AcceptPartialInlineCompletion"
+      "ctrl-right": "editor::AcceptPartialInlineCompletion"
     }
   },
   {


### PR DESCRIPTION
Both `editor::AcceptPartialInlineCompletion` and the keybinding for `editor::MoveToEndOfLine` had the same keybinding inside the editor, and with Supermaven's fast proposals, it's been very frequently used incorrectly.

Release Notes:

- (breaking change) Use `ctrl-right` instead of `cmd-right` as a macOS default for `editor::AcceptPartialInlineCompletion`
