### PR TITLE
Improve file_types in default.json

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -844,15 +844,8 @@
   //
   "file_types": {
     "Plain Text": ["txt"],
-    "JSON": ["flake.lock"],
-    "JSONC": [
-      "**/.zed/**/*.json",
-      "**/zed/**/*.json",
-      "**/Zed/**/*.json",
-      "tsconfig.json",
-      "pyrightconfig.json"
-    ],
-    "TOML": ["uv.lock"]
+    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json"],
+    "Shell Script": [".env.*"]
   },
   /// By default use a recent system version of node, or install our own.
   /// You can override this to use a version of node that is not in $PATH with:

--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 grammar = "json"
-path_suffixes = ["json"]
+path_suffixes = ["json", "flake.lock"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [

--- a/crates/languages/src/jsonc/config.toml
+++ b/crates/languages/src/jsonc/config.toml
@@ -1,6 +1,6 @@
 name = "JSONC"
 grammar = "jsonc"
-path_suffixes = ["jsonc"]
+path_suffixes = ["jsonc", "tsconfig.json", "pyrightconfig.json"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [

--- a/extensions/toml/languages/toml/config.toml
+++ b/extensions/toml/languages/toml/config.toml
@@ -1,6 +1,6 @@
 name = "TOML"
 grammar = "toml"
-path_suffixes = ["Cargo.lock", "toml", "Pipfile"]
+path_suffixes = ["Cargo.lock", "toml", "Pipfile", "uv.lock"]
 line_comments = ["# "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
Detect .env.* as Shell Script
Move non glob json/jsonc/toml file_types into langauges/*/config.toml

- Closes https://github.com/zed-industries/zed/issues/8466

Release Notes:

- Improved detection of `.env.*` files as Shell Scripts by default