### PR TITLE
Put context servers behind a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,7 @@ name = "context_servers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "collections",
  "command_palette_hooks",
  "futures 0.3.30",

--- a/crates/assistant/src/context_store.rs
+++ b/crates/assistant/src/context_store.rs
@@ -819,7 +819,7 @@ impl ContextStore {
             |context_server_manager, cx| {
                 for server in context_server_manager.servers() {
                     context_server_manager
-                        .restart_server(&server.id, cx)
+                        .restart_server(&server.id(), cx)
                         .detach_and_log_err(cx);
                 }
             },
@@ -850,7 +850,7 @@ impl ContextStore {
                         let server = server.clone();
                         let server_id = server_id.clone();
                         |this, mut cx| async move {
-                            let Some(protocol) = server.client.read().clone() else {
+                            let Some(protocol) = server.client() else {
                                 return;
                             };
 
@@ -889,7 +889,7 @@ impl ContextStore {
                                         tool_working_set.insert(
                                             Arc::new(tools::context_server_tool::ContextServerTool::new(
                                                 context_server_manager.clone(),
-                                                server.id.clone(),
+                                                server.id(),
                                                 tool,
                                             )),
                                         )

--- a/crates/assistant/src/tools/context_server_tool.rs
+++ b/crates/assistant/src/tools/context_server_tool.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, bail};
 use assistant_tool::Tool;
 use context_servers::manager::ContextServerManager;
@@ -6,14 +8,14 @@ use gpui::{Model, Task};
 
 pub struct ContextServerTool {
     server_manager: Model<ContextServerManager>,
-    server_id: String,
+    server_id: Arc<str>,
     tool: types::Tool,
 }
 
 impl ContextServerTool {
     pub fn new(
         server_manager: Model<ContextServerManager>,
-        server_id: impl Into<String>,
+        server_id: impl Into<Arc<str>>,
         tool: types::Tool,
     ) -> Self {
         Self {
@@ -55,7 +57,7 @@ impl Tool for ContextServerTool {
             cx.foreground_executor().spawn({
                 let tool_name = self.tool.name.clone();
                 async move {
-                    let Some(protocol) = server.client.read().clone() else {
+                    let Some(protocol) = server.client() else {
                         bail!("Context server not initialized");
                     };
 

--- a/crates/context_servers/Cargo.toml
+++ b/crates/context_servers/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/context_servers.rs"
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
 futures.workspace = true


### PR DESCRIPTION
This PR puts context servers behind the `ContextServer` trait to allow us to provide context servers from an extension.

Release Notes:

- N/A
