### PR TITLE
Clarify response format in the inline assistant prompts

### DIFF
--- a/assets/prompts/content_prompt.hbs
+++ b/assets/prompts/content_prompt.hbs
@@ -29,11 +29,8 @@ Generate {{content_type}} based on the following prompt:
 
 Match the indentation in the original file in the inserted {{content_type}}, don't include any indentation on blank lines.
 
-Immediately start with the following format with no remarks:
+Immediately start your response with no remarks before nor after, only the code to insert:
 
-```
-\{{INSERTED_CODE}}
-```
 {{else}}
 Edit the section of {{content_type}} in <rewrite_this></rewrite_this> tags based on the following prompt:
 
@@ -67,9 +64,6 @@ Only make changes that are necessary to fulfill the prompt, leave everything els
 
 Start at the indentation level in the original file in the rewritten {{content_type}}. Don't stop until you've rewritten the entire section, even if you have no more changes to make, always write out the whole section with no unnecessary elisions.
 
-Immediately start with the following format with no remarks:
+Immediately start your response with no remarks before nor after, only the rewritten code:
 
-```
-\{{REWRITTEN_CODE}}
-```
 {{/if}}


### PR DESCRIPTION
- It is not at all clear that REWRITTEN_CODE is a placeholder
- Likewise with INSERTED_CODE
- Thus models often append the placeholder before/after the response
- And, smaller models often mangle extra curly braces before/after

So, why not drop all of that and not have a response format. Instead, just tell the model to only return rewritten code and I threw in avoiding any commentary too.

Resolves #19471

Release Notes:

- Improved inline assistant prompt response format so responses don't randomly include placeholders `{{REWRITTEN_CODE}}`/`{{INSERTED_CODE}}` and other characters.