### PR TITLE
Use a different keybinding for editor::AcceptPartialInlineCompletion action (Linux)

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -142,7 +142,7 @@
     "bindings": {
       "alt-]": "editor::NextInlineCompletion",
       "alt-[": "editor::PreviousInlineCompletion",
-      "ctrl-right": "editor::AcceptPartialInlineCompletion"
+      "alt-right": "editor::AcceptPartialInlineCompletion"
     }
   },
   {


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/20419

Release Notes:

- - (breaking change) Use `ctrl-right` instead of `cmd-right` as a macOS default for `editor::AcceptPartialInlineCompletion` (Linux)
