### PR TITLE
image viewer: Ensure images can never be loaded twice

### DIFF
--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -669,7 +669,7 @@ mod tests {
         let fs = FakeFs::new(cx.executor());
 
         fs.insert_tree("/root", json!({})).await;
-        // Create a png file that with a single white pixel
+        // Create a png file that consists of a single white pixel
         fs.insert_file(
             "/root/image_1.png",
             vec![

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -702,6 +702,6 @@ mod tests {
         let image1 = task1.await.unwrap();
         let image2 = task2.await.unwrap();
 
-        assert_eq!(image1.entity_id(), image2.entity_id());
+        assert_eq!(image1, image2);
     }
 }

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -267,7 +267,7 @@ impl ImageStore {
 
         let loading_watch = match self.loading_images_by_path.entry(project_path.clone()) {
             // If the given path is already being loaded, then wait for that existing
-            // task to complete and return the same buffer.
+            // task to complete and return the same image.
             hash_map::Entry::Occupied(e) => e.get().clone(),
 
             // Otherwise, record the fact that this path is now being loaded.
@@ -283,10 +283,10 @@ impl ImageStore {
                 cx.spawn(move |this, mut cx| async move {
                     let load_result = load_image.await;
                     *tx.borrow_mut() = Some(this.update(&mut cx, |this, _cx| {
-                        // Record the fact that the buffer is no longer loading.
+                        // Record the fact that the image is no longer loading.
                         this.loading_images_by_path.remove(&project_path);
-                        let buffer = load_result.map_err(Arc::new)?;
-                        Ok(buffer)
+                        let image = load_result.map_err(Arc::new)?;
+                        Ok(image)
                     })?);
                     anyhow::Ok(())
                 })
@@ -310,7 +310,7 @@ impl ImageStore {
         loop {
             if let Some(result) = receiver.borrow().as_ref() {
                 match result {
-                    Ok(buffer) => return Ok(buffer.to_owned()),
+                    Ok(image) => return Ok(image.to_owned()),
                     Err(e) => return Err(e.to_owned()),
                 }
             }


### PR DESCRIPTION
Follow up to #20374, this prevents a race condition where we could load images twice.

Release Notes:

- N/A
