### PR TITLE
python: Highlight docstrings for classes and modules

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -84,7 +84,16 @@
   "def"
   name: (_)
   (parameters)?
-  body: (block (expression_statement (string) @string.doc)))
+  body: (block . (expression_statement (string) @string.doc)))
+
+(class_definition
+  body: (block
+    . (comment) @comment*
+    . (expression_statement (string) @string.doc)))
+
+(module
+  . (comment) @comment*
+  . (expression_statement (string) @string.doc))
 
 [
   "-"


### PR DESCRIPTION
Release Notes:

- Add `string.doc` python syntax highlighting to class and module-level docstrings.

Previously, only docstrings inside python functions were labeled as `string.doc`, but docstrings can exist at the class or module level too. This adds the more specific string type for each of those.

*Before*:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/5a6c4c9d-709c-40e2-8316-31c95084a1a9">

*After*:
<img width="294" alt="image" src="https://github.com/user-attachments/assets/8212bfa2-2288-4623-aa63-f748a2295ada">