### PR TITLE
python: Fix toolchains not getting picked up after workspace deserialization

### DIFF
--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -66,7 +66,7 @@ impl StatusItemView for ActiveBufferLanguage {
         active_pane_item: Option<&dyn ItemHandle>,
         cx: &mut ViewContext<Self>,
     ) {
-        if let Some(editor) = active_pane_item.and_then(|item| item.act_as::<Editor>(cx)) {
+        if let Some(editor) = active_pane_item.and_then(|item| item.downcast::<Editor>()) {
             self._observe_active_editor = Some(cx.observe(&editor, Self::update_language));
             self.update_language(editor, cx);
         } else {


### PR DESCRIPTION
Closes #20476

Release Notes:

- Fixed a bug in toolchain selector that caused it to not pick up venvs for tabs before user interacted with them.
- Fixed a bug in language selector that caused it to pick up Markdown as the language for a buffer up until the tab was interacted with.
