### PR TITLE
gpui: Add paint_path example

### DIFF
--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -15,9 +15,9 @@ impl PaintingViewer {
 
         // draw a line
         let mut path = Path::new(point(px(50.), px(180.)));
-        path.curve_to(point(px(150.), px(120.)), point(px(150.3), px(120.3)));
-        path.curve_to(point(px(150.), px(180.)), point(px(150.3), px(180.3)));
-        path.curve_to(point(px(50.), px(180.)), point(px(50.3), px(180.3)));
+        path.line_to(point(px(150.), px(120.)));
+        path.line_to(point(px(151.), px(121.)));
+        path.line_to(point(px(51.), px(181.)));
         lines.push(path);
 
         // draw a lightening bolt ⚡

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    canvas, div, point, prelude::*, px, App, AppContext, MouseDownEvent, Path, Pixels, Point,
-    Render, ViewContext, WindowOptions,
+    canvas, div, point, prelude::*, px, size, App, AppContext, Bounds, MouseDownEvent, Path,
+    Pixels, Point, Render, ViewContext, WindowOptions,
 };
 struct PaintingViewer {
     default_lines: Vec<Path<Pixels>>,
@@ -40,6 +40,26 @@ impl PaintingViewer {
         path.line_to(point(px(270.), px(160.)));
         path.line_to(point(px(330.), px(160.)));
         path.line_to(point(px(350.), px(100.)));
+        lines.push(path);
+
+        let square_bounds = Bounds {
+            origin: point(px(450.), px(100.)),
+            size: size(px(200.), px(80.)),
+        };
+        let height = square_bounds.size.height;
+        let horizontal_offset = height;
+        let vertical_offset = px(30.);
+        let mut path = Path::new(square_bounds.lower_left());
+        path.curve_to(
+            square_bounds.origin + point(horizontal_offset, vertical_offset),
+            square_bounds.origin + point(px(0.0), vertical_offset),
+        );
+        path.line_to(square_bounds.upper_right() + point(-horizontal_offset, vertical_offset));
+        path.curve_to(
+            square_bounds.lower_right(),
+            square_bounds.upper_right() + point(px(0.0), vertical_offset),
+        );
+        path.line_to(square_bounds.lower_left());
         lines.push(path);
 
         Self {

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -95,6 +95,7 @@ impl Render for PaintingViewer {
                         canvas(
                             move |_, _| {},
                             move |_, _, cx| {
+                                const STROKE_WIDTH: Pixels = px(2.0);
                                 for path in default_lines {
                                     cx.paint_path(path, gpui::black());
                                 }
@@ -108,9 +109,9 @@ impl Render for PaintingViewer {
                                     for p in points.iter().rev() {
                                         let mut offset_x = px(0.);
                                         if last.x == p.x {
-                                            offset_x = px(1.);
+                                            offset_x = STROKE_WIDTH;
                                         }
-                                        path.line_to(point(p.x + offset_x, p.y  + px(1.)));
+                                        path.line_to(point(p.x + offset_x, p.y  + STROKE_WIDTH));
                                         last = p;
                                     }
 

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -104,8 +104,14 @@ impl Render for PaintingViewer {
                                         path.line_to(*p);
                                     }
 
+                                    let mut last = points.last().unwrap();
                                     for p in points.iter().rev() {
-                                         path.line_to(point(p.x, p.y + px(1.)));
+                                        let mut offset_x = px(0.);
+                                        if last.x == p.x {
+                                            offset_x = px(1.);
+                                        }
+                                        path.line_to(point(p.x + offset_x, p.y  + px(1.)));
+                                        last = p;
                                     }
 
                                     cx.paint_path(path, gpui::black());

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -16,7 +16,8 @@ impl PaintingViewer {
         // draw a line
         let mut path = Path::new(point(px(50.), px(180.)));
         path.line_to(point(px(100.), px(120.)));
-        path.close_line();
+        path.line_to(point(px(101.), px(121.)));
+        path.line_to(point(px(51.), px(181.)));
         lines.push(path);
 
         // draw a lightening bolt ⚡
@@ -101,8 +102,10 @@ impl Render for PaintingViewer {
                                     for p in points.iter().skip(1) {
                                         path.line_to(*p);
                                     }
-                                    path.close_line();
 
+                                    for p in points.iter().rev() {
+                                         path.curve_to(*p + point(px(1.), px(1.)), *p + point(px(0.5), px(0.5)) );
+                                    }
 
                                     cx.paint_path(path, gpui::black());
                                 }

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -15,9 +15,8 @@ impl PaintingViewer {
 
         // draw a line
         let mut path = Path::new(point(px(50.), px(180.)));
-        path.line_to(point(px(150.), px(120.)));
-        path.line_to(point(px(151.), px(121.)));
-        path.line_to(point(px(51.), px(181.)));
+        path.line_to(point(px(100.), px(120.)));
+        path.close_line();
         lines.push(path);
 
         // draw a lightening bolt ⚡
@@ -38,6 +37,7 @@ impl PaintingViewer {
         path.line_to(point(px(320.), px(200.)));
         path.line_to(point(px(270.), px(160.)));
         path.line_to(point(px(330.), px(160.)));
+        path.line_to(point(px(350.), px(100.)));
         lines.push(path);
 
         Self {
@@ -101,10 +101,8 @@ impl Render for PaintingViewer {
                                     for p in points.iter().skip(1) {
                                         path.line_to(*p);
                                     }
-                                    // Go back to close the path
-                                    for p in points.iter().rev() {
-                                        path.curve_to(*p - point(px(1.), px(1.)), *p - point(px(0.5), px(0.5)));
-                                    }
+                                    path.close_line();
+
 
                                     cx.paint_path(path, gpui::black());
                                 }

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -16,8 +16,9 @@ impl PaintingViewer {
         // draw a line
         let mut path = Path::new(point(px(50.), px(180.)));
         path.line_to(point(px(100.), px(120.)));
-        path.line_to(point(px(101.), px(121.)));
-        path.line_to(point(px(51.), px(181.)));
+        // go back to close the path
+        path.line_to(point(px(100.), px(121.)));
+        path.line_to(point(px(50.), px(181.)));
         lines.push(path);
 
         // draw a lightening bolt ⚡
@@ -104,7 +105,7 @@ impl Render for PaintingViewer {
                                     }
 
                                     for p in points.iter().rev() {
-                                         path.curve_to(*p + point(px(1.), px(1.)), *p + point(px(0.5), px(0.5)) );
+                                         path.line_to(point(p.x, p.y + px(1.)));
                                     }
 
                                     cx.paint_path(path, gpui::black());

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    canvas, div, point, prelude::*, px, App, AppContext, MouseDownEvent, MouseUpEvent, Path,
-    Pixels, Point, Render, ViewContext, WindowOptions,
+    canvas, div, point, prelude::*, px, App, AppContext, MouseDownEvent, Path, Pixels, Point,
+    Render, ViewContext, WindowOptions,
 };
 struct PaintingViewer {
     default_lines: Vec<Path<Pixels>>,
@@ -13,18 +13,31 @@ impl PaintingViewer {
     fn new() -> Self {
         let mut lines = vec![];
 
-        // Draw a line like a lightning
-        let mut path = Path::new(point(px(0.), px(0.)));
-        path.line_to(point(px(0.), px(80.)));
-        path.line_to(point(px(100.), px(20.)));
+        // draw a line
+        let mut path = Path::new(point(px(50.), px(180.)));
+        path.line_to(point(px(150.), px(120.)));
+        path.line_to(point(px(150.) - px(1.), px(120.) - px(1.)));
+        path.line_to(point(px(50.) - px(1.), px(180.) - px(1.)));
         lines.push(path);
 
-        // Draw a line like a Big Dipper
-        let mut path = Path::new(point(px(80.), px(120.)));
-        path.line_to(point(px(100.), px(140.)));
-        path.line_to(point(px(120.), px(120.)));
-        path.line_to(point(px(140.), px(140.)));
-        path.line_to(point(px(160.), px(120.)));
+        // draw a lightening bolt ⚡
+        let mut path = Path::new(point(px(150.), px(200.)));
+        path.line_to(point(px(200.), px(125.)));
+        path.line_to(point(px(200.), px(175.)));
+        path.line_to(point(px(250.), px(100.)));
+        lines.push(path);
+
+        // draw a ⭐
+        let mut path = Path::new(point(px(350.), px(100.)));
+        path.line_to(point(px(370.), px(160.)));
+        path.line_to(point(px(430.), px(160.)));
+        path.line_to(point(px(380.), px(200.)));
+        path.line_to(point(px(400.), px(260.)));
+        path.line_to(point(px(350.), px(220.)));
+        path.line_to(point(px(300.), px(260.)));
+        path.line_to(point(px(320.), px(200.)));
+        path.line_to(point(px(270.), px(160.)));
+        path.line_to(point(px(330.), px(160.)));
         lines.push(path);
 
         Self {
@@ -112,7 +125,7 @@ impl Render for PaintingViewer {
                     }))
                     .on_mouse_up(
                         gpui::MouseButton::Left,
-                        cx.listener(|this, ev: &MouseUpEvent, _| {
+                        cx.listener(|this, _, _| {
                             this._painting = false;
                         }),
                     ),

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -1,0 +1,135 @@
+use gpui::{
+    canvas, div, point, prelude::*, px, App, AppContext, MouseDownEvent, MouseUpEvent, Path,
+    Pixels, Point, Render, ViewContext, WindowOptions,
+};
+struct PaintingViewer {
+    default_lines: Vec<Path<Pixels>>,
+    lines: Vec<Path<Pixels>>,
+    start: Point<Pixels>,
+    _painting: bool,
+}
+
+impl PaintingViewer {
+    fn new() -> Self {
+        let mut lines = vec![];
+
+        // Draw a line like a lightning
+        let mut path = Path::new(point(px(0.), px(0.)));
+        path.line_to(point(px(0.), px(80.)));
+        path.line_to(point(px(100.), px(20.)));
+        lines.push(path);
+
+        // Draw a line like a Big Dipper
+        let mut path = Path::new(point(px(80.), px(120.)));
+        path.line_to(point(px(100.), px(140.)));
+        path.line_to(point(px(120.), px(120.)));
+        path.line_to(point(px(140.), px(140.)));
+        path.line_to(point(px(160.), px(120.)));
+        lines.push(path);
+
+        Self {
+            default_lines: lines.clone(),
+            lines: vec![],
+            start: point(px(0.), px(0.)),
+            _painting: false,
+        }
+    }
+
+    fn clear(&mut self, cx: &mut ViewContext<Self>) {
+        self.lines.clear();
+        cx.notify();
+    }
+}
+impl Render for PaintingViewer {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let default_lines = self.default_lines.clone();
+        let lines = self.lines.clone();
+        div()
+            .font_family(".SystemUIFont")
+            .bg(gpui::white())
+            .size_full()
+            .p_4()
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .flex()
+                    .gap_2()
+                    .justify_between()
+                    .items_center()
+                    .child("Mouse down any point and drag to draw lines.")
+                    .child(
+                        div()
+                            .id("clear")
+                            .child("Clean up")
+                            .bg(gpui::black())
+                            .text_color(gpui::white())
+                            .active(|this| this.opacity(0.8))
+                            .flex()
+                            .px_3()
+                            .py_1()
+                            .on_click(cx.listener(|this, _, cx| {
+                                this.clear(cx);
+                            })),
+                    ),
+            )
+            .child(
+                div()
+                    .size_full()
+                    .child(
+                        canvas(
+                            move |_, _| {},
+                            move |_, _, cx| {
+                                for path in default_lines {
+                                    cx.paint_path(path, gpui::black());
+                                }
+                                for path in lines {
+                                    cx.paint_path(path, gpui::black());
+                                }
+                            },
+                        )
+                        .size_full(),
+                    )
+                    .on_mouse_down(
+                        gpui::MouseButton::Left,
+                        cx.listener(|this, ev: &MouseDownEvent, _| {
+                            this._painting = true;
+                            this.start = ev.position;
+                            let path = Path::new(ev.position);
+                            this.lines.push(path);
+                        }),
+                    )
+                    .on_mouse_move(cx.listener(|this, ev: &gpui::MouseMoveEvent, cx| {
+                        if !this._painting {
+                            return;
+                        }
+
+                        if let Some(path) = this.lines.last_mut() {
+                            path.line_to(ev.position);
+                        }
+
+                        cx.notify();
+                    }))
+                    .on_mouse_up(
+                        gpui::MouseButton::Left,
+                        cx.listener(|this, ev: &MouseUpEvent, _| {
+                            this._painting = false;
+                        }),
+                    ),
+            )
+    }
+}
+
+fn main() {
+    App::new().run(|cx: &mut AppContext| {
+        cx.open_window(
+            WindowOptions {
+                focus: true,
+                ..Default::default()
+            },
+            |cx| cx.new_view(|_| PaintingViewer::new()),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -786,7 +786,6 @@ impl Path<Pixels> {
                 (point(0., 1.), point(0., 1.), point(0., 1.)),
             );
         }
-
         self.current = to;
     }
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -2,8 +2,8 @@
 #![cfg_attr(windows, allow(dead_code))]
 
 use crate::{
-    bounds_tree::BoundsTree, point, AtlasTextureId, AtlasTile, Bounds, ContentMask, Corners, Edges,
-    Hsla, Pixels, Point, Radians, ScaledPixels, Size,
+    bounds_tree::BoundsTree, point, px, AtlasTextureId, AtlasTile, Bounds, ContentMask, Corners,
+    Edges, Hsla, Pixels, Point, Radians, ScaledPixels, Size,
 };
 use std::{fmt::Debug, iter::Peekable, ops::Range, slice};
 
@@ -786,6 +786,10 @@ impl Path<Pixels> {
                 (point(0., 1.), point(0., 1.), point(0., 1.)),
             );
         }
+        self.push_triangle(
+            (self.current, to + point(px(0.5), px(0.5)), to),
+            (point(0., 0.), point(0.5, 0.), point(1., 1.)),
+        );
         self.current = to;
     }
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -2,8 +2,8 @@
 #![cfg_attr(windows, allow(dead_code))]
 
 use crate::{
-    bounds_tree::BoundsTree, point, px, AtlasTextureId, AtlasTile, Bounds, ContentMask, Corners,
-    Edges, Hsla, Pixels, Point, Radians, ScaledPixels, Size,
+    bounds_tree::BoundsTree, point, AtlasTextureId, AtlasTile, Bounds, ContentMask, Corners, Edges,
+    Hsla, Pixels, Point, Radians, ScaledPixels, Size,
 };
 use std::{fmt::Debug, iter::Peekable, ops::Range, slice};
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -790,15 +790,6 @@ impl Path<Pixels> {
         self.current = to;
     }
 
-    /// Draw a straight line from the current point to the given point with closed contour.
-    pub fn close_line(&mut self) {
-        for vertice in self.vertices.clone().into_iter() {
-            self.line_to(vertice.xy_position);
-        }
-
-        self.current = self.start;
-    }
-
     /// Draw a curve from the current point to the given point, using the given control point.
     pub fn curve_to(&mut self, to: Point<Pixels>, ctrl: Point<Pixels>) {
         self.contour_count += 1;

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -786,11 +786,17 @@ impl Path<Pixels> {
                 (point(0., 1.), point(0., 1.), point(0., 1.)),
             );
         }
-        self.push_triangle(
-            (self.current, to + point(px(0.5), px(0.5)), to),
-            (point(0., 0.), point(0.5, 0.), point(1., 1.)),
-        );
+
         self.current = to;
+    }
+
+    /// Draw a straight line from the current point to the given point with closed contour.
+    pub fn close_line(&mut self) {
+        for vertice in self.vertices.clone().into_iter() {
+            self.line_to(vertice.xy_position);
+        }
+
+        self.current = self.start;
     }
 
     /// Draw a curve from the current point to the given point, using the given control point.


### PR DESCRIPTION
Release Notes:

- N/A

---

```
cargo run -p gpui --example painting
```

I added this demo to verify the detailed support of Path drawing in GPUI.

Because of, when we actually used GPUI to draw a 2D line chart, we found that the straight line Path#line_to did not support `anti-aliasing`, and the drawn line looked very bad.

As shown in the demo image, if we zoom in on the image, we can clearly see that all the lines are jagged.

I read and tried to make some appropriate adjustments to the functions in Path, but since I have no experience in the graphics field, I still cannot achieve anti-aliasing support so far.

I don't know if I used it wrong somewhere. I checked `curve_to` and found that the curves drawn have anti-aliasing effects, as shown in the arc part of the figure below.

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/4dfb7603-e746-43e9-b737-cff56b56329f">
