### PR TITLE
Add a way to use splits when opening in file finder

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -651,10 +651,16 @@
     "context": "FileFinder",
     "bindings": {
       "ctrl-shift-p": "file_finder::SelectPrev",
-      "ctrl-k up": "pane::SplitUp",
-      "ctrl-k down": "pane::SplitDown",
-      "ctrl-k left": "pane::SplitLeft",
-      "ctrl-k right": "pane::SplitRight"
+      "ctrl-k": "file_finder::OpenMenu"
+    }
+  },
+  {
+    "context": "FileFinder && menu_open",
+    "bindings": {
+      "u": "pane::SplitUp",
+      "d": "pane::SplitDown",
+      "l": "pane::SplitLeft",
+      "r": "pane::SplitRight"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -651,8 +651,10 @@
     "context": "FileFinder",
     "bindings": {
       "ctrl-shift-p": "file_finder::SelectPrev",
-      "ctrl-shift-r": "pane::SplitRight",
-      "ctrl-shift-b": "pane::SplitDown"
+      "ctrl-k up": "pane::SplitUp",
+      "ctrl-k down": "pane::SplitDown",
+      "ctrl-k left": "pane::SplitLeft",
+      "ctrl-k right": "pane::SplitRight"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -649,7 +649,11 @@
   },
   {
     "context": "FileFinder",
-    "bindings": { "ctrl-shift-p": "file_finder::SelectPrev" }
+    "bindings": {
+      "ctrl-shift-p": "file_finder::SelectPrev",
+      "ctrl-shift-r": "pane::SplitRight",
+      "ctrl-shift-b": "pane::SplitDown"
+    }
   },
   {
     "context": "TabSwitcher",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -649,7 +649,11 @@
   },
   {
     "context": "FileFinder",
-    "bindings": { "cmd-shift-p": "file_finder::SelectPrev" }
+    "bindings": {
+      "cmd-shift-p": "file_finder::SelectPrev",
+      "cmd-shift-r": "pane::SplitRight",
+      "cmd-shift-b": "pane::SplitDown"
+    }
   },
   {
     "context": "TabSwitcher",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -651,10 +651,16 @@
     "context": "FileFinder",
     "bindings": {
       "cmd-shift-p": "file_finder::SelectPrev",
-      "cmd-k up": "pane::SplitUp",
-      "cmd-k down": "pane::SplitDown",
-      "cmd-k left": "pane::SplitLeft",
-      "cmd-k right": "pane::SplitRight"
+      "cmd-k": "file_finder::OpenMenu"
+    }
+  },
+  {
+    "context": "FileFinder && menu_open",
+    "bindings": {
+      "u": "pane::SplitUp",
+      "d": "pane::SplitDown",
+      "l": "pane::SplitLeft",
+      "r": "pane::SplitRight"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -651,8 +651,10 @@
     "context": "FileFinder",
     "bindings": {
       "cmd-shift-p": "file_finder::SelectPrev",
-      "cmd-shift-r": "pane::SplitRight",
-      "cmd-shift-b": "pane::SplitDown"
+      "cmd-k up": "pane::SplitUp",
+      "cmd-k down": "pane::SplitDown",
+      "cmd-k left": "pane::SplitLeft",
+      "cmd-k right": "pane::SplitRight"
     }
   },
   {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -34,7 +34,7 @@ use std::{
 use text::Point;
 use ui::{
     prelude::*, ButtonLike, ContextMenu, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing,
-    PopoverMenu, PopoverMenuHandle,
+    PopoverMenu, PopoverMenuHandle, TintColor,
 };
 use util::{paths::PathWithPosition, post_inc, ResultExt};
 use workspace::{
@@ -1222,6 +1222,7 @@ impl PickerDelegate for FileFinderDelegate {
     }
 
     fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<AnyElement> {
+        let menu_open = self.popover_menu_handle.is_focused(cx);
         Some(
             h_flex()
                 .w_full()
@@ -1246,6 +1247,8 @@ impl PickerDelegate for FileFinderDelegate {
                             .anchor(gpui::AnchorCorner::BottomRight)
                             .trigger(
                                 ButtonLike::new("menu-trigger")
+                                    .selected(menu_open)
+                                    .selected_style(ButtonStyle::Tinted(TintColor::Accent))
                                     .when_some(
                                         KeyBinding::for_action_in(
                                             &OpenMenu,

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -14,7 +14,9 @@ use file_finder_settings::FileFinderSettings;
 use file_icons::FileIcons;
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{
-    actions, rems, Action, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, KeyContext, Model, Modifiers, ModifiersChangedEvent, ParentElement, Render, Styled, Task, View, ViewContext, VisualContext, WeakView
+    actions, rems, Action, AnyElement, AppContext, DismissEvent, EventEmitter, FocusHandle,
+    FocusableView, KeyContext, Model, Modifiers, ModifiersChangedEvent, ParentElement, Render,
+    Styled, Task, View, ViewContext, VisualContext, WeakView,
 };
 use new_path_prompt::NewPathPrompt;
 use open_path_prompt::OpenPathPrompt;
@@ -1234,33 +1236,37 @@ impl PickerDelegate for FileFinderDelegate {
                             button.child(key)
                         })
                         .child(Label::new("Open"))
-                        .on_click(|_, cx| cx.dispatch_action(menu::Confirm.boxed_clone()))
+                        .on_click(|_, cx| cx.dispatch_action(menu::Confirm.boxed_clone())),
                 )
                 .child(
-                    div()
-                        .pl_2()
-                        .child(
-                            PopoverMenu::new("menu-popover")
-                                .with_handle(self.popover_menu_handle.clone())
-                                .trigger(
-                                        ButtonLike::new("menu-trigger")
-                                            .when_some(KeyBinding::for_action_in(&OpenMenu, &self.focus_handle, cx), |button, key| {
-                                                button.child(key)
-                                            })
-                                            .child(Label::new("More actions"))
-                                )
-                                .menu({
-                                    move |cx| {
-                                        Some(ContextMenu::build(cx, move |menu, _| {
-                                            menu.action("Split left", pane::SplitLeft.boxed_clone())
-                                                .action("Split right", pane::SplitRight.boxed_clone())
-                                                .action("Split up", pane::SplitUp.boxed_clone())
-                                                .action("Split down", pane::SplitDown.boxed_clone())
-                                        }))
-                                    }
-                                }
+                    div().pl_2().child(
+                        PopoverMenu::new("menu-popover")
+                            .with_handle(self.popover_menu_handle.clone())
+                            .attach(gpui::AnchorCorner::TopRight)
+                            .anchor(gpui::AnchorCorner::BottomRight)
+                            .trigger(
+                                ButtonLike::new("menu-trigger")
+                                    .when_some(
+                                        KeyBinding::for_action_in(
+                                            &OpenMenu,
+                                            &self.focus_handle,
+                                            cx,
+                                        ),
+                                        |button, key| button.child(key),
+                                    )
+                                    .child(Label::new("More actions")),
                             )
-                        )
+                            .menu({
+                                move |cx| {
+                                    Some(ContextMenu::build(cx, move |menu, _| {
+                                        menu.action("Split left", pane::SplitLeft.boxed_clone())
+                                            .action("Split right", pane::SplitRight.boxed_clone())
+                                            .action("Split up", pane::SplitUp.boxed_clone())
+                                            .action("Split down", pane::SplitDown.boxed_clone())
+                                    }))
+                                }
+                            }),
+                    ),
                 )
                 .into_any(),
         )

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1193,7 +1193,6 @@ impl PickerDelegate for FileFinderDelegate {
     }
 
     fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<AnyElement> {
-        let weak_self = cx.view().downgrade();
         Some(
             h_flex()
                 .w_full()
@@ -1219,74 +1218,12 @@ impl PickerDelegate for FileFinderDelegate {
                                 .tooltip(|cx| Tooltip::text("Open in split", cx)),
                         )
                         .menu({
-                            let weak_self = weak_self.clone();
                             move |cx| {
-                                let weak_self = weak_self.clone();
-                                Some(ContextMenu::build(cx, move |menu, cx| {
-                                    let context = weak_self
-                                        .update(cx, |this, cx| {
-                                            this.delegate.workspace.upgrade().and_then(
-                                                |workspace| {
-                                                    Some(
-                                                        workspace
-                                                            .read(cx)
-                                                            .active_item_as::<Editor>(cx)?
-                                                            .focus_handle(cx),
-                                                    )
-                                                },
-                                            )
-                                        })
-                                        .ok()
-                                        .flatten();
-                                    menu.when_some(context, |menu, context| menu.context(context))
-                                        .entry("Split left", None, {
-                                            let weak_self = weak_self.clone();
-                                            move |cx| {
-                                                weak_self
-                                                    .update(cx, |_, cx| {
-                                                        cx.dispatch_action(
-                                                            pane::SplitLeft.boxed_clone(),
-                                                        )
-                                                    })
-                                                    .ok();
-                                            }
-                                        })
-                                        .entry("Split right", None, {
-                                            let weak_self = weak_self.clone();
-                                            move |cx| {
-                                                weak_self
-                                                    .update(cx, |_, cx| {
-                                                        cx.dispatch_action(
-                                                            pane::SplitRight.boxed_clone(),
-                                                        )
-                                                    })
-                                                    .ok();
-                                            }
-                                        })
-                                        .entry("Split up", None, {
-                                            let weak_self = weak_self.clone();
-                                            move |cx| {
-                                                weak_self
-                                                    .update(cx, |_, cx| {
-                                                        cx.dispatch_action(
-                                                            pane::SplitUp.boxed_clone(),
-                                                        )
-                                                    })
-                                                    .ok();
-                                            }
-                                        })
-                                        .entry("Split down", None, {
-                                            let weak_self = weak_self.clone();
-                                            move |cx| {
-                                                weak_self
-                                                    .update(cx, |_, cx| {
-                                                        cx.dispatch_action(
-                                                            pane::SplitDown.boxed_clone(),
-                                                        )
-                                                    })
-                                                    .ok();
-                                            }
-                                        })
+                                Some(ContextMenu::build(cx, move |menu, _| {
+                                    menu.action("Split left", pane::SplitLeft.boxed_clone())
+                                        .action("Split right", pane::SplitRight.boxed_clone())
+                                        .action("Split up", pane::SplitUp.boxed_clone())
+                                        .action("Split down", pane::SplitDown.boxed_clone())
                                 }))
                             }
                         }),

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -32,7 +32,10 @@ use std::{
     },
 };
 use text::Point;
-use ui::{prelude::*, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing};
+use ui::{
+    prelude::*, ButtonLike, ContextMenu, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing,
+    PopoverMenu, Tooltip,
+};
 use util::{paths::PathWithPosition, post_inc, ResultExt};
 use workspace::{
     item::PreviewTabsSettings, notifications::NotifyResultExt, pane, ModalView, SplitDirection,
@@ -1181,10 +1184,7 @@ impl PickerDelegate for FileFinderDelegate {
     }
 
     fn render_footer(&self, cx: &mut ViewContext<Picker<Self>>) -> Option<AnyElement> {
-        let action_source = self
-            .workspace
-            .update(cx, |workspace, cx| workspace.active_pane().focus_handle(cx))
-            .ok()?;
+        let weak_self = cx.view().downgrade();
         Some(
             h_flex()
                 .w_full()
@@ -1193,26 +1193,93 @@ impl PickerDelegate for FileFinderDelegate {
                 .pr_2()
                 .border_color(cx.theme().colors().border)
                 .justify_end()
-                .gap_4()
                 .child(
-                    Button::new("split_right", "Split right")
-                        .label_size(LabelSize::Small)
-                        .key_binding(KeyBinding::for_action_in(
-                            &pane::SplitRight,
-                            &action_source,
-                            cx,
-                        ))
-                        .on_click(|_, cx| cx.dispatch_action(pane::SplitRight.boxed_clone())),
+                    ButtonLike::new("open-selection")
+                        .when_some(KeyBinding::for_action(&menu::Confirm, cx), |button, key| {
+                            button.child(key)
+                        })
+                        .child(Label::new("Open"))
+                        .on_click(|_, cx| cx.dispatch_action(menu::Confirm.boxed_clone())),
                 )
                 .child(
-                    Button::new("split_down", "Split down")
-                        .label_size(LabelSize::Small)
-                        .key_binding(KeyBinding::for_action_in(
-                            &pane::SplitDown,
-                            &action_source,
-                            cx,
-                        ))
-                        .on_click(|_, cx| cx.dispatch_action(pane::SplitDown.boxed_clone())),
+                    PopoverMenu::new("split-popover")
+                        .trigger(
+                            IconButton::new("split-trigger", IconName::EllipsisVertical)
+                                .icon_size(IconSize::Small)
+                                .tooltip(|cx| Tooltip::text("Open in split", cx)),
+                        )
+                        .menu({
+                            let weak_self = weak_self.clone();
+                            move |cx| {
+                                let weak_self = weak_self.clone();
+                                Some(ContextMenu::build(cx, move |menu, cx| {
+                                    let context = weak_self
+                                        .update(cx, |this, cx| {
+                                            this.delegate.workspace.upgrade().and_then(
+                                                |workspace| {
+                                                    Some(
+                                                        workspace
+                                                            .read(cx)
+                                                            .active_item_as::<Editor>(cx)?
+                                                            .focus_handle(cx),
+                                                    )
+                                                },
+                                            )
+                                        })
+                                        .ok()
+                                        .flatten();
+                                    menu.when_some(context, |menu, context| menu.context(context))
+                                        .entry("Split left", None, {
+                                            let weak_self = weak_self.clone();
+                                            move |cx| {
+                                                weak_self
+                                                    .update(cx, |_, cx| {
+                                                        cx.dispatch_action(
+                                                            pane::SplitLeft.boxed_clone(),
+                                                        )
+                                                    })
+                                                    .ok();
+                                            }
+                                        })
+                                        .entry("Split right", None, {
+                                            let weak_self = weak_self.clone();
+                                            move |cx| {
+                                                weak_self
+                                                    .update(cx, |_, cx| {
+                                                        cx.dispatch_action(
+                                                            pane::SplitRight.boxed_clone(),
+                                                        )
+                                                    })
+                                                    .ok();
+                                            }
+                                        })
+                                        .entry("Split up", None, {
+                                            let weak_self = weak_self.clone();
+                                            move |cx| {
+                                                weak_self
+                                                    .update(cx, |_, cx| {
+                                                        cx.dispatch_action(
+                                                            pane::SplitUp.boxed_clone(),
+                                                        )
+                                                    })
+                                                    .ok();
+                                            }
+                                        })
+                                        .entry("Split down", None, {
+                                            let weak_self = weak_self.clone();
+                                            move |cx| {
+                                                weak_self
+                                                    .update(cx, |_, cx| {
+                                                        cx.dispatch_action(
+                                                            pane::SplitDown.boxed_clone(),
+                                                        )
+                                                    })
+                                                    .ok();
+                                            }
+                                        })
+                                }))
+                            }
+                        }),
                 )
                 .into_any(),
         )

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -66,7 +66,7 @@ impl<M: ManagedView> PopoverMenuHandle<M> {
             .map_or(false, |state| state.menu.borrow().as_ref().is_some())
     }
 
-    pub fn is_focused(&self, cx: &mut WindowContext) -> bool {
+    pub fn is_focused(&self, cx: &WindowContext) -> bool {
         self.0.borrow().as_ref().map_or(false, |state| {
             state
                 .menu

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2631,13 +2631,14 @@ impl Workspace {
         path: impl Into<ProjectPath>,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<Box<dyn ItemHandle>, anyhow::Error>> {
-        self.split_path_preview(path, false, cx)
+        self.split_path_preview(path, false, None, cx)
     }
 
     pub fn split_path_preview(
         &mut self,
         path: impl Into<ProjectPath>,
         allow_preview: bool,
+        split_direction: Option<SplitDirection>,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<Box<dyn ItemHandle>, anyhow::Error>> {
         let pane = self.last_active_center_pane.clone().unwrap_or_else(|| {
@@ -2658,7 +2659,8 @@ impl Workspace {
             let (project_entry_id, build_item) = task.await?;
             this.update(&mut cx, move |this, cx| -> Option<_> {
                 let pane = pane.upgrade()?;
-                let new_pane = this.split_pane(pane, SplitDirection::Right, cx);
+                let new_pane =
+                    this.split_pane(pane, split_direction.unwrap_or(SplitDirection::Right), cx);
                 new_pane.update(cx, |new_pane, cx| {
                     Some(new_pane.open_item(project_entry_id, true, allow_preview, cx, build_item))
                 })


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/18187

<img width="550" alt="image" src="https://github.com/user-attachments/assets/23b56e6e-0659-490d-871a-e7acd6f3be3e">

<img width="708" alt="image" src="https://github.com/user-attachments/assets/35c23a6b-7ea5-4bcd-9a2d-122998dc9f91">


Release Notes:

- Added a way to use splits when opening in file finder
