### PR TITLE
Implement LSP and Node download prevention

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -861,16 +861,21 @@
   /// You can override this to use a version of node that is not in $PATH with:
   /// {
   ///   "node": {
-  ///     "path": "/path/to/node"
-  ///     "npm_path": "/path/to/npm" (defaults to node_path/../npm)
+  ///     "path": "/path/to/node",
+  ///     "npm_path": "/path/to/npm" // (defaults to node_path/../npm)
   ///   }
   /// }
-  /// or to ensure Zed always downloads and installs an isolated version of node:
+  /// to ensure Zed always downloads and installs an isolated version of node:
   /// {
   ///   "node": {
   ///     "ignore_system_version": true,
   ///   }
-  /// NOTE: changing this setting currently requires restarting Zed.
+  /// to ensure Zed never downloads and installs node:
+  /// {
+  ///   "node": {
+  ///     "allow_download": false,
+  ///   }
+  /// NOTE: changing these settings currently requires restarting Zed.
   "node": {},
   // The extensions that Zed should automatically install on startup.
   //
@@ -1076,6 +1081,12 @@
   "lsp": {
     // Specify the LSP name as a key here.
     // "rust-analyzer": {
+    //     "binary": {
+    //         "path_lookup": true,
+    //         "path": "rust-analyzer"
+    //         // Allow zed to download the binary if it's not found in the path
+    //         "allow_download": true
+    //     },
     //     // These initialization options are merged into Zed's defaults
     //     "initialization_options": {
     //         "check": {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5491,7 +5491,6 @@ impl LspStore {
         &self,
         adapter: Arc<CachedLspAdapter>,
         delegate: Arc<dyn LspAdapterDelegate>,
-        allow_binary_download: bool,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<LanguageServerBinary>> {
         let settings = ProjectSettings::get(
@@ -5525,7 +5524,10 @@ impl LspStore {
                 .as_ref()
                 .and_then(|b| b.ignore_system_version)
                 .unwrap_or_default(),
-            allow_binary_download,
+            allow_binary_download: settings
+                .as_ref()
+                .and_then(|b| b.allow_download)
+                .unwrap_or(true),
         };
         cx.spawn(|_, mut cx| async move {
             let binary_result = adapter
@@ -5595,7 +5597,7 @@ impl LspStore {
             adapter.name.0
         );
 
-        let binary = self.get_language_server_binary(adapter.clone(), delegate.clone(), true, cx);
+        let binary = self.get_language_server_binary(adapter.clone(), delegate.clone(), cx);
 
         let pending_server = cx.spawn({
             let adapter = adapter.clone();

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -67,6 +67,9 @@ pub struct NodeBinarySettings {
     /// If disabled, zed will download its own copy of node.
     #[serde(default)]
     pub ignore_system_version: Option<bool>,
+    /// If disabled, zed will not be allowed to download a copy of node.
+    #[serde(default)]
+    pub allow_download: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -171,6 +174,7 @@ pub struct BinarySettings {
     pub path: Option<String>,
     pub arguments: Option<Vec<String>>,
     pub ignore_system_version: Option<bool>,
+    pub allow_download: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -776,8 +776,7 @@ fn initialize_settings(
         log::info!("Got new node settings: {:?}", settings);
         let options = NodeBinaryOptions {
             allow_path_lookup: !settings.ignore_system_version.unwrap_or_default(),
-            // TODO: Implement this setting
-            allow_binary_download: true,
+            allow_binary_download: !settings.allow_download.unwrap_or(true),
             use_paths: settings.path.as_ref().map(|node_path| {
                 let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                 let npm_path = settings

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -296,8 +296,7 @@ fn main() {
             let settings = &ProjectSettings::get_global(cx).node;
             let options = NodeBinaryOptions {
                 allow_path_lookup: !settings.ignore_system_version.unwrap_or_default(),
-                // TODO: Expose this setting
-                allow_binary_download: true,
+                allow_binary_download: !settings.allow_download.unwrap_or(true),
                 use_paths: settings.path.as_ref().map(|node_path| {
                     let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                     let npm_path = settings


### PR DESCRIPTION
This addresses the TODO for allowing/disallowing binary downloads for LSPs, alongside the implied TODO for node.

Release Notes:

- Added support for preventing download of language servers and node.
