### PR TITLE
macOS: Improve deadkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5657,7 +5657,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -580,7 +580,7 @@ impl Render for InputExample {
             .children(self.recent_keystrokes.iter().rev().map(|ks| {
                 format!(
                     "{:} {}",
-                    ks,
+                    ks.unparse(),
                     if let Some(ime_key) = ks.ime_key.as_ref() {
                         format!("-> {}", ime_key)
                     } else {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -671,6 +671,10 @@ impl PlatformInputHandler {
             .flatten()
     }
 
+    fn apple_press_and_hold_enabled(&mut self) -> bool {
+        self.handler.apple_press_and_hold_enabled()
+    }
+
     pub(crate) fn dispatch_input(&mut self, input: &str, cx: &mut WindowContext) {
         self.handler.replace_text_in_range(None, input, cx);
     }
@@ -768,6 +772,14 @@ pub trait InputHandler: 'static {
         range_utf16: Range<usize>,
         cx: &mut WindowContext,
     ) -> Option<Bounds<Pixels>>;
+
+    /// Allows a given input context to opt into getting raw key repeats instead of
+    /// sending these to the platform.
+    /// TODO: Ideally we should be able to set ApplePressAndHoldEnabled in NSUserDefaults
+    /// (which is how iTerm does it) but it doesn't seem to work for me.
+    fn apple_press_and_hold_enabled(&mut self) -> bool {
+        true
+    }
 }
 
 /// The variables that can be configured when creating a new window

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -671,6 +671,7 @@ impl PlatformInputHandler {
             .flatten()
     }
 
+    #[allow(dead_code)]
     fn apple_press_and_hold_enabled(&mut self) -> bool {
         self.handler.apple_press_and_hold_enabled()
     }
@@ -777,6 +778,7 @@ pub trait InputHandler: 'static {
     /// sending these to the platform.
     /// TODO: Ideally we should be able to set ApplePressAndHoldEnabled in NSUserDefaults
     /// (which is how iTerm does it) but it doesn't seem to work for me.
+    #[allow(dead_code)]
     fn apple_press_and_hold_enabled(&mut self) -> bool {
         true
     }

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -124,6 +124,9 @@ impl Keystroke {
     /// Produces a representation of this key that Parse can understand.
     pub fn unparse(&self) -> String {
         let mut str = String::new();
+        if self.modifiers.function {
+            str.push_str("fn-");
+        }
         if self.modifiers.control {
             str.push_str("ctrl-");
         }

--- a/crates/gpui/src/platform/mac/events.rs
+++ b/crates/gpui/src/platform/mac/events.rs
@@ -1,20 +1,20 @@
 use crate::{
-    platform::mac::NSStringExt, point, px, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers,
-    ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseExitEvent, MouseMoveEvent,
-    MouseUpEvent, NavigationDirection, Pixels, PlatformInput, ScrollDelta, ScrollWheelEvent,
-    TouchPhase,
+    platform::mac::{
+        kTISPropertyUnicodeKeyLayoutData, LMGetKbdType, NSStringExt,
+        TISCopyCurrentKeyboardLayoutInputSource, TISGetInputSourceProperty, UCKeyTranslate,
+    },
+    point, px, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton,
+    MouseDownEvent, MouseExitEvent, MouseMoveEvent, MouseUpEvent, NavigationDirection, Pixels,
+    PlatformInput, ScrollDelta, ScrollWheelEvent, TouchPhase,
 };
 use cocoa::{
     appkit::{NSEvent, NSEventModifierFlags, NSEventPhase, NSEventType},
     base::{id, YES},
 };
-use core_graphics::{
-    event::{CGEvent, CGEventFlags, CGKeyCode},
-    event_source::{CGEventSource, CGEventSourceStateID},
-};
-use metal::foreign_types::ForeignType as _;
-use objc::{class, msg_send, sel, sel_impl};
-use std::{borrow::Cow, mem, ptr, sync::Once};
+use core_foundation::data::{CFDataGetBytePtr, CFDataRef};
+use core_graphics::event::CGKeyCode;
+use objc::{msg_send, sel, sel_impl};
+use std::{borrow::Cow, ffi::c_void};
 
 const BACKSPACE_KEY: u16 = 0x7f;
 const SPACE_KEY: u16 = b' ' as u16;
@@ -23,24 +23,6 @@ const NUMPAD_ENTER_KEY: u16 = 0x03;
 const ESCAPE_KEY: u16 = 0x1b;
 const TAB_KEY: u16 = 0x09;
 const SHIFT_TAB_KEY: u16 = 0x19;
-
-fn synthesize_keyboard_event(code: CGKeyCode) -> CGEvent {
-    static mut EVENT_SOURCE: core_graphics::sys::CGEventSourceRef = ptr::null_mut();
-    static INIT_EVENT_SOURCE: Once = Once::new();
-
-    INIT_EVENT_SOURCE.call_once(|| {
-        let source = CGEventSource::new(CGEventSourceStateID::Private).unwrap();
-        unsafe {
-            EVENT_SOURCE = source.as_ptr();
-        };
-        mem::forget(source);
-    });
-
-    let source = unsafe { core_graphics::event_source::CGEventSource::from_ptr(EVENT_SOURCE) };
-    let event = CGEvent::new_keyboard_event(source.clone(), code, true).unwrap();
-    mem::forget(source);
-    event
-}
 
 pub fn key_to_native(key: &str) -> Cow<str> {
     use cocoa::appkit::*;
@@ -259,8 +241,8 @@ impl PlatformInput {
 unsafe fn parse_keystroke(native_event: id) -> Keystroke {
     use cocoa::appkit::*;
 
-    let mut chars_ignoring_modifiers = chars_for_modified_key(native_event.keyCode(), false, false);
-    let first_char = chars_ignoring_modifiers.chars().next().map(|ch| ch as u16);
+    let mut characters = native_event.characters().to_str().to_string();
+    let first_char = characters.chars().next().map(|ch| ch as u16);
     let modifiers = native_event.modifierFlags();
 
     let control = modifiers.contains(NSEventModifierFlags::NSControlKeyMask);
@@ -273,7 +255,7 @@ unsafe fn parse_keystroke(native_event: id) -> Keystroke {
         });
 
     #[allow(non_upper_case_globals)]
-    let key = match first_char {
+    let mut key = match first_char {
         Some(SPACE_KEY) => "space".to_string(),
         Some(BACKSPACE_KEY) => "backspace".to_string(),
         Some(ENTER_KEY) | Some(NUMPAD_ENTER_KEY) => "enter".to_string(),
@@ -321,6 +303,9 @@ unsafe fn parse_keystroke(native_event: id) -> Keystroke {
             // * Norwegian        7 | 7    | cmd-7 | cmd-/        (macOS reports cmd-shift-7 instead of cmd-/)
             // * Russian          7 | 7    | cmd-7 | cmd-&        (shift-7 is . but when cmd is down, should use cmd layout)
             // * German QWERTZ    ; | ö    | cmd-ö | cmd-Ö        (Zed's shift special case only applies to a-z)
+            //
+            let mut chars_ignoring_modifiers =
+                chars_for_modified_key(native_event.keyCode(), false, false);
             let mut chars_with_shift = chars_for_modified_key(native_event.keyCode(), false, true);
 
             // Handle Dvorak+QWERTY / Russian / Armeniam
@@ -341,7 +326,11 @@ unsafe fn parse_keystroke(native_event: id) -> Keystroke {
                 chars_ignoring_modifiers = chars_with_cmd;
             }
 
-            if shift && chars_ignoring_modifiers == chars_with_shift.to_ascii_lowercase() {
+            if shift
+                && chars_ignoring_modifiers
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase())
+            {
                 chars_ignoring_modifiers
             } else if shift {
                 shift = false;
@@ -350,6 +339,17 @@ unsafe fn parse_keystroke(native_event: id) -> Keystroke {
                 chars_ignoring_modifiers
             }
         }
+    };
+
+    // When typing a dead key, we don't want to pretend we have actual input.
+    // (but on a french keyboard, cmd-^ is a dead key and we want it to generate cmd-ˆ)
+    if characters.len() == 0 && !command && !control && !function {
+        key = "".to_string()
+    };
+    let ime_key = if characters.len() > 0 && characters != key {
+        Some(characters.clone())
+    } else {
+        None
     };
 
     Keystroke {
@@ -361,50 +361,105 @@ unsafe fn parse_keystroke(native_event: id) -> Keystroke {
             function,
         },
         key,
-        ime_key: None,
+        ime_key,
     }
 }
 
 fn always_use_command_layout() -> bool {
-    // look at the key to the right of "tab" ('a' in QWERTY)
-    // if it produces a non-ASCII character, but with command held produces ASCII,
-    // we default to the command layout for our keyboard system.
-    let event = synthesize_keyboard_event(0);
-    let without_cmd = unsafe {
-        let event: id = msg_send![class!(NSEvent), eventWithCGEvent: &*event];
-        event.characters().to_str().to_string()
-    };
-    if without_cmd.is_ascii() {
+    if chars_for_modified_key(0, false, false).is_ascii() {
         return false;
     }
 
-    event.set_flags(CGEventFlags::CGEventFlagCommand);
-    let with_cmd = unsafe {
-        let event: id = msg_send![class!(NSEvent), eventWithCGEvent: &*event];
-        event.characters().to_str().to_string()
-    };
-
-    with_cmd.is_ascii()
+    chars_for_modified_key(0, true, false).is_ascii()
 }
 
-fn chars_for_modified_key(code: CGKeyCode, cmd: bool, shift: bool) -> String {
-    // Ideally, we would use `[NSEvent charactersByApplyingModifiers]` but that
-    // always returns an empty string with certain keyboards, e.g. Japanese. Synthesizing
-    // an event with the given flags instead lets us access `characters`, which always
-    // returns a valid string.
-    let event = synthesize_keyboard_event(code);
+// fn chars_for_modified_key(code: CGKeyCode, cmd: bool, shift: bool) -> String {
+//     // Ideally, we would use `[NSEvent charactersByApplyingModifiers]` but that
+//     // always returns an empty string with certain keyboards, e.g. Japanese. Synthesizing
+//     // an event with the given flags instead lets us access `characters`, which always
+//     // returns a valid string.
+//     let event = synthesize_keyboard_event(code);
 
-    let mut flags = CGEventFlags::empty();
-    if cmd {
-        flags |= CGEventFlags::CGEventFlagCommand;
+//     let mut flags = CGEventFlags::empty();
+//     if cmd {
+//         flags |= CGEventFlags::CGEventFlagCommand;
+//     }
+//     if shift {
+//         flags |= CGEventFlags::CGEventFlagShift;
+//     }
+//     event.set_flags(flags);
+
+//     unsafe {
+//         let event: id = msg_send![class!(NSEvent), eventWithCGEvent: &*event];
+//         event.characters().to_str().to_string()
+//     }
+// }
+// TODO: AZERTY dead keys don't seem to work... cmd-[ (or cmd-^ dead key on Azerty)
+//  do we need to re-order with respect to IME?
+fn chars_for_modified_key(code: CGKeyCode, cmd: bool, shift: bool) -> String {
+    // Values from: https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h#L126
+    // shifted >> 8 for UCKeyTranslate
+    const CMD_MOD: u32 = 1;
+    const SHIFT_MOD: u32 = 2;
+    const CG_SPACE_KEY: u16 = 49;
+
+    // https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/Headers/UnicodeUtilities.h#L278
+    #[allow(non_upper_case_globals)]
+    const kUCKeyActionDown: u16 = 0;
+    #[allow(non_upper_case_globals)]
+    const kUCKeyTranslateNoDeadKeysMask: u32 = 0;
+
+    let keyboard_type = unsafe { LMGetKbdType() as u32 };
+    const BUFFER_SIZE: usize = 4;
+    let mut dead_key_state = 0;
+    let mut buffer: [u16; BUFFER_SIZE] = [0; BUFFER_SIZE];
+    let mut buffer_size: usize = 0;
+
+    let keyboard = unsafe { TISCopyCurrentKeyboardLayoutInputSource() };
+    if keyboard.is_null() {
+        return "".to_string();
     }
-    if shift {
-        flags |= CGEventFlags::CGEventFlagShift;
+    let layout_data = unsafe {
+        TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData as *const c_void)
+            as CFDataRef
+    };
+    if layout_data.is_null() {
+        unsafe {
+            let _: () = msg_send![keyboard, release];
+        }
+        return "".to_string();
     }
-    event.set_flags(flags);
+    let keyboard_layout = unsafe { CFDataGetBytePtr(layout_data) };
+    let modifiers = if cmd { CMD_MOD } else { 0 } | if shift { SHIFT_MOD } else { 0 };
 
     unsafe {
-        let event: id = msg_send![class!(NSEvent), eventWithCGEvent: &*event];
-        event.characters().to_str().to_string()
+        UCKeyTranslate(
+            keyboard_layout as *const c_void,
+            code,
+            kUCKeyActionDown,
+            modifiers,
+            keyboard_type,
+            kUCKeyTranslateNoDeadKeysMask,
+            &mut dead_key_state,
+            BUFFER_SIZE,
+            &mut buffer_size as *mut usize,
+            &mut buffer as *mut u16,
+        );
+        if dead_key_state != 0 {
+            UCKeyTranslate(
+                keyboard_layout as *const c_void,
+                CG_SPACE_KEY,
+                kUCKeyActionDown,
+                modifiers,
+                keyboard_type,
+                kUCKeyTranslateNoDeadKeysMask,
+                &mut dead_key_state,
+                BUFFER_SIZE,
+                &mut buffer_size as *mut usize,
+                &mut buffer as *mut u16,
+            );
+        }
+        let _: () = msg_send![keyboard, release];
     }
+    String::from_utf16(&buffer[..buffer_size]).unwrap_or_default()
 }

--- a/crates/gpui/src/platform/mac/events.rs
+++ b/crates/gpui/src/platform/mac/events.rs
@@ -373,36 +373,12 @@ fn always_use_command_layout() -> bool {
     chars_for_modified_key(0, true, false).is_ascii()
 }
 
-// fn chars_for_modified_key(code: CGKeyCode, cmd: bool, shift: bool) -> String {
-//     // Ideally, we would use `[NSEvent charactersByApplyingModifiers]` but that
-//     // always returns an empty string with certain keyboards, e.g. Japanese. Synthesizing
-//     // an event with the given flags instead lets us access `characters`, which always
-//     // returns a valid string.
-//     let event = synthesize_keyboard_event(code);
-
-//     let mut flags = CGEventFlags::empty();
-//     if cmd {
-//         flags |= CGEventFlags::CGEventFlagCommand;
-//     }
-//     if shift {
-//         flags |= CGEventFlags::CGEventFlagShift;
-//     }
-//     event.set_flags(flags);
-
-//     unsafe {
-//         let event: id = msg_send![class!(NSEvent), eventWithCGEvent: &*event];
-//         event.characters().to_str().to_string()
-//     }
-// }
-// TODO: AZERTY dead keys don't seem to work... cmd-[ (or cmd-^ dead key on Azerty)
-//  do we need to re-order with respect to IME?
 fn chars_for_modified_key(code: CGKeyCode, cmd: bool, shift: bool) -> String {
     // Values from: https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h#L126
     // shifted >> 8 for UCKeyTranslate
     const CMD_MOD: u32 = 1;
     const SHIFT_MOD: u32 = 2;
     const CG_SPACE_KEY: u16 = 49;
-
     // https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/Headers/UnicodeUtilities.h#L278
     #[allow(non_upper_case_globals)]
     const kUCKeyActionDown: u16 = 0;

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -1448,13 +1448,27 @@ unsafe fn ns_url_to_path(url: id) -> Result<PathBuf> {
 
 #[link(name = "Carbon", kind = "framework")]
 extern "C" {
-    fn TISCopyCurrentKeyboardLayoutInputSource() -> *mut Object;
-    fn TISGetInputSourceProperty(
+    pub(super) fn TISCopyCurrentKeyboardLayoutInputSource() -> *mut Object;
+    pub(super) fn TISGetInputSourceProperty(
         inputSource: *mut Object,
         propertyKey: *const c_void,
     ) -> *mut Object;
 
-    pub static kTISPropertyInputSourceID: CFStringRef;
+    pub(super) fn UCKeyTranslate(
+        keyLayoutPtr: *const ::std::os::raw::c_void,
+        virtualKeyCode: u16,
+        keyAction: u16,
+        modifierKeyState: u32,
+        keyboardType: u32,
+        keyTranslateOptions: u32,
+        deadKeyState: *mut u32,
+        maxStringLength: usize,
+        actualStringLength: *mut usize,
+        unicodeString: *mut u16,
+    ) -> u32;
+    pub(super) fn LMGetKbdType() -> u16;
+    pub(super) static kTISPropertyUnicodeKeyLayoutData: CFStringRef;
+    pub(super) static kTISPropertyInputSourceID: CFStringRef;
 }
 
 mod security {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1250,7 +1250,7 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
     // otherwise we only send to the input handler if we don't have a matching binding.
     // The input handler may call `do_command_by_selector` if it doesn't know how to handle
     // a key. If it does so, it will return YES so we won't send the key twice.
-    if is_composing {
+    if is_composing || event.keystroke.key.is_empty() {
         window_state.as_ref().lock().keystroke_for_do_command = Some(event.keystroke.clone());
         let handled: BOOL = unsafe {
             let input_context: id = msg_send![this, inputContext];
@@ -1298,11 +1298,10 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
         }
     }
 
-    let handled = unsafe {
+    unsafe {
         let input_context: id = msg_send![this, inputContext];
         msg_send![input_context, handleEvent: native_event]
-    };
-    handled
+    }
 }
 
 extern "C" fn handle_view_event(this: &Object, _: Sel, native_event: id) {

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1044,6 +1044,10 @@ impl InputHandler for TerminalInputHandler {
     ) -> Option<Bounds<Pixels>> {
         self.cursor_bounds
     }
+
+    fn apple_press_and_hold_enabled(&mut self) -> bool {
+        false
+    }
 }
 
 pub fn is_blank(cell: &IndexedCell) -> bool {


### PR DESCRIPTION
Closes #19738

This change refactors how we handle input on macOS to avoid simulating our own IME. This fixes a number of small edge-cases, and also lets us remove a bunch of code that had been added to work around bugs in the previous version.

Release Notes:

- On macOS: Keyboard shortcuts are now handled before activating the IME system, this enables using vim's default mode on keyboards that use IME menus (like Japanese). 
- On macOS: Improvements to handling of dead-keys. For example when typing `""` on a Brazillian keyboard, you now get a committed " and a new marked ", as happens in other apps. Also, you can now type cmd-^ on an AZERTY keyboard for indent; and ^ on a QWERTZ keyboard now goes to the beginning of line in vim normal mode, or `d i "` no requires no space to delete within quotes on Brazilian keyboards (though `d f " space` is still required as `f` relies on the input handler, not a binding).
- On macOS: In the terminal pane, holding down a key will now repeat that key (as happens in iTerm2) instead of opening the character selector.
