### PR TITLE
Add HTML injections for markdown

### DIFF
--- a/crates/languages/src/markdown/injections.scm
+++ b/crates/languages/src/markdown/injections.scm
@@ -5,3 +5,6 @@
 
 ((inline) @content
  (#set! "language" "markdown-inline"))
+
+((html_block) @content
+  (#set! "language" "html"))


### PR DESCRIPTION
Closes https://github.com/zed-industries/extensions/issues/1588.

| Before | After |
| --- | --- |
| ![CleanShot 2024-11-11 at 22 48 43](https://github.com/user-attachments/assets/9470e6a8-6a37-4b8f-8daa-5c8c5ed2bb17) | ![CleanShot 2024-11-11 at 22 49 43](https://github.com/user-attachments/assets/f2b858d0-9274-4332-b30e-61c13ac347c6) |

Release Notes:

- Added HTML injections for markdown syntax highlighting
