### PR TITLE
Expose active key equivalents in the keymap context view

### DIFF
--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -4,6 +4,7 @@ use gpui::{
 };
 use itertools::Itertools;
 use serde_json::json;
+use settings::get_key_equivalents;
 use ui::{
     div, h_flex, px, v_flex, ButtonCommon, Clickable, FluentBuilder, InteractiveElement, Label,
     LabelCommon, LabelSize, ParentElement, SharedString, StatefulInteractiveElement, Styled,
@@ -167,6 +168,7 @@ impl Item for KeyContextView {
 impl Render for KeyContextView {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl ui::IntoElement {
         use itertools::Itertools;
+        let key_equivalents = get_key_equivalents(cx.keyboard_layout());
         v_flex()
             .id("key-context-view")
             .overflow_scroll()
@@ -273,6 +275,18 @@ impl Render for KeyContextView {
                                     .child(div().min_w(px(200.)).child(Label::new(name.clone())))
                                     .child(Label::new(predicate.clone()))
                                     .child(Label::new(text).color(color))
+                            }),
+                    )
+            })
+            .when_some(key_equivalents, |el, key_equivalents| {
+                el.child(Label::new("Key Equivalents").mt_4().size(LabelSize::Large))
+                    .child(Label::new("Shortcuts defined using some characters have been remapped so that shortcuts can be typed without holding option."))
+                    .children(
+                        key_equivalents
+                            .iter()
+                            .sorted()
+                            .map(|(key, equivalent)| {
+                                Label::new(format!("cmd-{} => cmd-{}", key, equivalent)).ml_8()
                             }),
                     )
             })

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -12,6 +12,7 @@ use util::asset_str;
 
 pub use editable_setting_control::*;
 pub use json_schema::*;
+pub use key_equivalents::*;
 pub use keymap_file::KeymapFile;
 pub use settings_file::*;
 pub use settings_store::{


### PR DESCRIPTION
Release Notes:

- Added macOS key equivalents to cmd-shift-p `debug: Open Key Context View`
