### PR TITLE
Fix tab switch behavior for the Sublime Text keymap

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -4,9 +4,7 @@
       "ctrl-shift-[": "pane::ActivatePrevItem",
       "ctrl-shift-]": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
-      "ctrl-pagedown": "pane::ActivateNextItem",
-      "ctrl-tab": "pane::ActivateNextItem",
-      "ctrl-shift-tab": "pane::ActivatePrevItem"
+      "ctrl-pagedown": "pane::ActivateNextItem"
     }
   },
   {

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -4,9 +4,7 @@
       "cmd-shift-[": "pane::ActivatePrevItem",
       "cmd-shift-]": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
-      "ctrl-pagedown": "pane::ActivateNextItem",
-      "ctrl-tab": "pane::ActivateNextItem",
-      "ctrl-shift-tab": "pane::ActivatePrevItem"
+      "ctrl-pagedown": "pane::ActivateNextItem"
     }
   },
   {


### PR DESCRIPTION
The tab switching behavior is not match to the Sublime Text.

The `ctrl-tab` should be the most recent tab instead of the next item

Here is the comparison 

https://github.com/user-attachments/assets/3cafd474-b6fb-4806-9a05-94b089f85fa5

Release Notes:

- Improved tab switching in Sublime Text Keymap