### PR TITLE
Astro LSP path leading slash in Windows

### DIFF
--- a/extensions/astro/extension.toml
+++ b/extensions/astro/extension.toml
@@ -1,7 +1,7 @@
-id = "astro"
+id = "astro_1"
 name = "Astro"
 description = "Astro support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Alvaro Gaona <alvgaona@gmail.com>", "0xk1f0 <dev@k1f0.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/astro/extension.toml
+++ b/extensions/astro/extension.toml
@@ -1,4 +1,4 @@
-id = "astro_1"
+id = "astro"
 name = "Astro"
 description = "Astro support."
 version = "0.1.2"

--- a/extensions/astro/src/astro.rs
+++ b/extensions/astro/src/astro.rs
@@ -159,8 +159,6 @@ impl zed::Extension for AstroExtension {
 
         let script_path = astro_lsp_path(&server_path);
 
-        println!("Astro script path: {:?}", script_path);
-
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![script_path, "--stdio".to_string()],

--- a/extensions/astro/src/astro.rs
+++ b/extensions/astro/src/astro.rs
@@ -123,6 +123,25 @@ impl AstroExtension {
     }
 }
 
+#[cfg(target_os = "windows")]
+fn astro_lsp_path(server_path: &str) -> String {
+    env::current_dir()
+        .unwrap()
+        .join(&server_path)
+        .to_string_lossy()
+        .trim_start_matches("/")
+        .to_string()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn astro_lsp_path(server_path: &str) -> String {
+    env::current_dir()
+        .unwrap()
+        .join(&server_path)
+        .to_string_lossy()
+        .to_string()
+}
+
 impl zed::Extension for AstroExtension {
     fn new() -> Self {
         Self {
@@ -137,16 +156,14 @@ impl zed::Extension for AstroExtension {
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let server_path = self.server_script_path(language_server_id, worktree)?;
+
+        let script_path = astro_lsp_path(&server_path);
+
+        println!("Astro script path: {:?}", script_path);
+
         Ok(zed::Command {
             command: zed::node_binary_path()?,
-            args: vec![
-                env::current_dir()
-                    .unwrap()
-                    .join(&server_path)
-                    .to_string_lossy()
-                    .to_string(),
-                "--stdio".to_string(),
-            ],
+            args: vec![script_path, "--stdio".to_string()],
             env: Default::default(),
         })
     }


### PR DESCRIPTION
This PR attempts to fix the issue of Astro LSP not spinning up due to a message like this one:

```
Language server error: astro-language-server

oneshot canceled
-- stderr--
node:internal/modules/cjs/loader:1051
  throw err;
  ^

Error: Cannot find module 'E:\C:\Users\alvga\AppData\Local\Zed\extensions\work\astro_1\node_modules\@astrojs\language-server\bin\nodeServer.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Module._load (node:internal/modules/cjs/loader:901:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.5.0
```

The problem is related to the WASM runtime in which the extensions run. The `env::current_dir()` is abstracted away from the base platform in which Zed is running. You can check this with `env::constants::OS` which returns an empty string.

`env::current_dir()` returns this path: `"/C:\\Users\\alvga\\AppData\\Local\\Zed\\extensions\\work\\astro_1/node_modules/@astrojs/language-server/bin/nodeServer.js"`. You will see a leading forward slash which then is passed to the `zed::Command` and interprets it as some disk, and ultimately having the first presented log.

Release Notes:

- N/A