### PR TITLE
Fix issue with image output from Jupyter kernels that didn't use base64 padding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6360,12 +6360,11 @@ dependencies = [
 
 [[package]]
 name = "jupyter-serde"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b96de099fc23d5c21e05de32cc087c8326983895b7f6c242562af01f7d4c81"
+checksum = "dd71aa17c4fa65e6d7536ab2728881a41f8feb2ee5841c2240516c3c3d65d8b3"
 dependencies = [
  "anyhow",
- "chrono",
  "serde",
  "serde_json",
  "thiserror",
@@ -7367,9 +7366,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8a9ab08b34237c2c1d0504b794c2ff01c08dfc46a060d160f004a7f479c31"
+checksum = "c9ffb2ca556072f114bcaf2ca01dde7f1bc8a4946097dd804cb5a22d8af7d6df"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10182,9 +10181,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "0.16.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7fe3c17675445fe89de68d130be00b7115104924fbcf53a9b0a84b0283fc81"
+checksum = "fe23ba9967355bbb1be2fb9a8e51bd239ffdf9c791fad5a9b765122ee2bde2e4"
 dependencies = [
  "anyhow",
  "async-dispatcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,7 @@ linkify = "0.10.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
 markup5ever_rcdom = "0.3.0"
 nanoid = "0.4"
-nbformat = "0.3.2"
+nbformat = "0.5.0"
 nix = "0.29"
 num-format = "0.4.4"
 once_cell = "1.19.0"
@@ -408,7 +408,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "fd110f
     "stream",
 ] }
 rsa = "0.9.6"
-runtimelib = { version = "0.16.1", default-features = false, features = [
+runtimelib = { version = "0.19.0", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }
 rustc-demangle = "0.1.23"

--- a/crates/repl/src/outputs/image.rs
+++ b/crates/repl/src/outputs/image.rs
@@ -16,9 +16,12 @@ pub struct ImageView {
 
 impl ImageView {
     pub fn from(base64_encoded_data: &str) -> Result<Self> {
-        let bytes = BASE64_STANDARD.decode(base64_encoded_data.trim())?;
+        let filtered =
+            base64_encoded_data.replace(&[' ', '\n', '\t', '\r', '\x0b', '\x0c'][..], "");
+        let bytes = BASE64_STANDARD_NO_PAD.decode(filtered)?;
 
         let format = image::guess_format(&bytes)?;
+
         let mut data = image::load_from_memory_with_format(&bytes, format)?.into_rgba8();
 
         // Convert from RGBA to BGRA.


### PR DESCRIPTION
This upgrades `nbformat` and `runtimelib` to handle jupyter types with even more validation and flexiblity. This also processes any multiline string data coming from the kernel, including with image data (like `image/png`). While I was at it I also fixed a longstanding issue around images by eliminating all whitespace (something `atob` does) and using the no pad decoder.

Fixes: #17956

**Before:**

<img width="741" alt="image" src="https://github.com/user-attachments/assets/37ec2cae-ce78-4475-aaa3-4d785e4015d0">

**After:**

<img width="727" alt="image" src="https://github.com/user-attachments/assets/e2431ba2-048b-4205-9898-54f357795a9c">


Release Notes:

- Fixed issue with image output from REPL kernels that didn't use base64 padding
