### PR TITLE
Maintain selection on file/dir deletion in project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1347,19 +1347,23 @@ impl ProjectPanel {
             .position(|sibling| sibling.id == last_marked_entry.id)?;
 
         // Try next sibling
-        if let Some(next_sibling) = remaining_siblings.get(deleted_entry_position + 1) {
-            return Some(SelectedEntry {
-                worktree_id: last_worktree_id,
-                entry_id: next_sibling.id,
-            });
+        if deleted_entry_position + 1 < remaining_siblings.len() {
+            if let Some(next_sibling) = remaining_siblings.get(deleted_entry_position + 1) {
+                return Some(SelectedEntry {
+                    worktree_id: last_worktree_id,
+                    entry_id: next_sibling.id,
+                });
+            }
         }
 
         // Try previous sibling
-        if let Some(prev_sibling) = remaining_siblings.get(deleted_entry_position - 1) {
-            return Some(SelectedEntry {
-                worktree_id: last_worktree_id,
-                entry_id: prev_sibling.id,
-            });
+        if deleted_entry_position > 0 {
+            if let Some(prev_sibling) = remaining_siblings.get(deleted_entry_position - 1) {
+                return Some(SelectedEntry {
+                    worktree_id: last_worktree_id,
+                    entry_id: prev_sibling.id,
+                });
+            }
         }
 
         // Fall back to parent
@@ -6555,8 +6559,8 @@ mod tests {
             &[
                 "v root",
                 "    v dir1",
-                "        > subdir1",
-                "    v dir2  <== selected",
+                "        > subdir1  <== selected",
+                "    v dir2",
                 "        > subdir2",
                 "          file3.txt",
                 "          file4.txt",
@@ -6696,7 +6700,7 @@ mod tests {
                 "          file2.txt  <== marked",
                 "      file3.txt  <== selected  <== marked",
             ],
-            "Initial state before deleting mixed files across levels"
+            "Initial state before deleting"
         );
 
         submit_deletion(&panel, cx);
@@ -6704,11 +6708,11 @@ mod tests {
             visible_entries_as_strings(&panel, 0..15, cx),
             &[
                 "v root",
-                "    v dir2",
+                "    v dir2  <== selected",
                 "        v subdir2",
-                "              d.txt  <== selected",
+                "              d.txt",
             ],
-            "Should select next available file after mixed deletion"
+            "Should select sibling directory"
         );
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1260,17 +1260,6 @@ impl ProjectPanel {
                 None
             };
             let next_selection = self.find_next_selection_after_deletion(cx);
-            println!(
-                "next_selection: {:?}",
-                next_selection.and_then(|s| self
-                    .project
-                    .read(cx)
-                    .worktree_for_id(s.worktree_id, cx)
-                    .and_then(|worktree| worktree
-                        .read(cx)
-                        .entry_for_id(s.entry_id)
-                        .map(|e| &e.path)))
-            );
             cx.spawn(|panel, mut cx| async move {
                 if let Some(answer) = answer {
                     if answer.await != Ok(0) {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6626,14 +6626,12 @@ mod tests {
         let cx = &mut VisualTestContext::from_window(*workspace, cx);
         let panel = workspace.update(cx, ProjectPanel::new).unwrap();
 
-        // Expand all directories for testing
         toggle_expand_dir(&panel, "src/dir1", cx);
         toggle_expand_dir(&panel, "src/dir1/subdir1", cx);
         toggle_expand_dir(&panel, "src/dir1/subdir1/nested", cx);
         toggle_expand_dir(&panel, "src/dir1/subdir2", cx);
         toggle_expand_dir(&panel, "src/dir2", cx);
 
-        // Test case 1: Delete nested files and verify selection moves to next sibling
         cx.simulate_modifiers_change(gpui::Modifiers {
             control: true,
             ..Default::default()
@@ -6688,7 +6686,6 @@ mod tests {
             "Should select next file after nested files deletion"
         );
 
-        // Test case 2: Delete directory and its parent simultaneously
         select_path_with_mark(&panel, "src/dir1/subdir1/nested", cx);
         select_path_with_mark(&panel, "src/dir1/subdir1", cx);
 
@@ -6733,7 +6730,6 @@ mod tests {
             "Should select first entry in next directory after deleting directory with parent"
         );
 
-        // Test case 3: Delete mixed files and directories across different levels
         select_path_with_mark(&panel, "src/dir1/subdir2/c.rs", cx);
         select_path_with_mark(&panel, "src/dir2", cx);
         select_path_with_mark(&panel, "src/root1.rs", cx);
@@ -6823,7 +6819,7 @@ mod tests {
                         entry_id,
                     };
                     if !panel.marked_entries.contains(&entry) {
-                        panel.marked_entries.insert(entry.clone());
+                        panel.marked_entries.insert(entry);
                     }
                     panel.selection = Some(entry);
                     return;

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -378,7 +378,15 @@ pub fn compare_paths(
                         .as_deref()
                         .map(NumericPrefixWithSuffix::from_numeric_prefixed_str);
 
-                    num_and_remainder_a.cmp(&num_and_remainder_b)
+                    num_and_remainder_a.cmp(&num_and_remainder_b).then_with(|| {
+                        if a_is_file && b_is_file {
+                            let ext_a = path_a.extension().and_then(|s| s.to_str()).unwrap_or("");
+                            let ext_b = path_b.extension().and_then(|s| s.to_str()).unwrap_or("");
+                            ext_a.cmp(ext_b)
+                        } else {
+                            cmp::Ordering::Equal
+                        }
+                    })
                 });
                 if !ordering.is_eq() {
                     return ordering;
@@ -429,6 +437,28 @@ mod tests {
             vec![
                 (Path::new("root1/one.txt"), true),
                 (Path::new("root1/one.two.txt"), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn compare_paths_with_same_name_different_extensions() {
+        let mut paths = vec![
+            (Path::new("test_dirs/file.rs"), true),
+            (Path::new("test_dirs/file.txt"), true),
+            (Path::new("test_dirs/file.md"), true),
+            (Path::new("test_dirs/file"), true),
+            (Path::new("test_dirs/file.a"), true),
+        ];
+        paths.sort_by(|&a, &b| compare_paths(a, b));
+        assert_eq!(
+            paths,
+            vec![
+                (Path::new("test_dirs/file"), true),
+                (Path::new("test_dirs/file.a"), true),
+                (Path::new("test_dirs/file.md"), true),
+                (Path::new("test_dirs/file.rs"), true),
+                (Path::new("test_dirs/file.txt"), true),
             ]
         );
     }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -380,8 +380,8 @@ pub fn compare_paths(
 
                     num_and_remainder_a.cmp(&num_and_remainder_b).then_with(|| {
                         if a_is_file && b_is_file {
-                            let ext_a = path_a.extension().and_then(|s| s.to_str()).unwrap_or("");
-                            let ext_b = path_b.extension().and_then(|s| s.to_str()).unwrap_or("");
+                            let ext_a = path_a.extension().unwrap_or_default();
+                            let ext_b = path_b.extension().unwrap_or_default();
                             ext_a.cmp(ext_b)
                         } else {
                             cmp::Ordering::Equal

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -48,7 +48,7 @@ use ui::{v_flex, ContextMenu};
 use util::{debug_panic, maybe, truncate_and_remove_front, ResultExt};
 
 /// A selected entry in e.g. project panel.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectedEntry {
     pub worktree_id: WorktreeId,
     pub entry_id: ProjectEntryId,


### PR DESCRIPTION
Closes #20444

- Focus on next file/dir on deletion.
- Focus on prev file/dir in case where it's last item in worktree.
- Tested when multiple files/dirs are being deleted.

Release Notes:

- Maintain selection on file/dir deletion in project panel.
