### PR TITLE
windows: Implement `ssh` using `NamedPipe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9868,6 +9868,7 @@ dependencies = [
  "thiserror 1.0.69",
  "util",
  "which 6.0.3",
+ "windows 0.58.0",
 ]
 
 [[package]]

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -40,6 +40,9 @@ util.workspace = true
 release_channel.workspace = true
 which.workspace = true
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows.workspace = true
+
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
 fs = { workspace = true, features = ["test-support"] }

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1359,16 +1359,6 @@ impl RemoteConnection for SshRemoteConnection {
 }
 
 impl SshRemoteConnection {
-    #[cfg(not(unix))]
-    async fn new(
-        _connection_options: SshConnectionOptions,
-        _delegate: Arc<dyn SshClientDelegate>,
-        _cx: &mut AsyncAppContext,
-    ) -> Result<Self> {
-        Err(anyhow!("ssh is not supported on this platform"))
-    }
-
-    #[cfg(unix)]
     async fn new(
         connection_options: SshConnectionOptions,
         delegate: Arc<dyn SshClientDelegate>,

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1452,25 +1452,20 @@ impl SshRemoteConnection {
             }
         });
 
-        anyhow::ensure!(
-            which::which("nc").is_ok(),
-            "Cannot find nc, which is required to connect over ssh."
-        );
-
-        anyhow::ensure!(
-            which::which("nc").is_ok(),
-            "Cannot find nc, which is required to connect over ssh."
-        );
+        // anyhow::ensure!(
+        //     which::which("nc").is_ok(),
+        //     "Cannot find nc, which is required to connect over ssh."
+        // );
         // Create an askpass script that communicates back to this process.
         // let askpass_script = format!(
         //     "{shebang}\n{print_args} | {nc} -U {askpass_socket} 2> /dev/null \n",
-            // on macOS `brew install netcat` provides the GNU netcat implementation
-            // which does not support -U.
-            nc = if cfg!(target_os = "macos") {
-                "/usr/bin/nc"
-            } else {
-                "nc"
-            },
+        // on macOS `brew install netcat` provides the GNU netcat implementation
+        // which does not support -U.
+        // nc = if cfg!(target_os = "macos") {
+        //     "/usr/bin/nc"
+        // } else {
+        //     "nc"
+        // },
         //     askpass_socket = askpass_socket.display(),
         //     print_args = "printf '%s\\0' \"$@\"",
         //     shebang = "#!/bin/sh",


### PR DESCRIPTION
Closes #ISSUE

Recently, I've been trying to implement the `remote ssh` feature for Windows. Due to my coursework, progress was slow, but anyway...

Given Zed’s current `remote ssh` implementation, here are two main issues that arise on Windows:

- The current implementation uses `UnixSocket` for inter-process communication, facilitating password entry between `ssh` and `zed`. However, Windows added support for `AF_UNIX` in the 2018 Fall Update of Windows 10, and even then, the support remains limited, as explained here: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/.
  
- Additionally, the current implementation leverages `UnixSocket` and the `ControlPath` option for SSH connection multiplexing, but this is unsupported on Windows. You can find more details here: https://github.com/PowerShell/Win32-OpenSSH/issues/405 and https://github.com/PowerShell/Win32-OpenSSH/wiki/Project-Scope.

After testing several approaches, I’ve narrowed it down to two possible solutions. These differ only in how they handle the first issue:

#### Solution 1 (This PR)

For the inter-process communication issue, this solution uses `NamedPipe`, which is recommended by Microsoft, to emulate `UnixSocket` functionality.

- **Pros**: No need for additional crates or helper programs.
- **Cons**: Requires further code abstraction for maintainability.

#### Solution 2 (#20587)

In this solution, I utilize the newly introduced `UnixSocket` on Windows for inter-process communication. However, due to its limited support, an auxiliary program `askpass_helper.exe` is required to play the `askpass.sh` script’s role.

- **Pros**: The logic is consist with Unix-based systems, making maintenance easier.
- **Cons**: Introduces an extra helper program and the `windows_net` crate.

For the second issue, since Windows doesn’t support connection multiplexing, my approach is to use a `password_helper.cmd` script to avoid prompting the user repeatedly for their password. The script relies on `SharedMemory` to retrieve the `ssh` password.

Currently, I’m not sure which solution to go with, so I’d love to hear Zed team’s thoughts.

Any feedback on these is welcome!

Some demo:


https://github.com/user-attachments/assets/fbf2f3a8-9acd-4ae2-a75d-b97c25c8ad22


https://github.com/user-attachments/assets/e4be912c-3466-4e65-a7f3-562cdac555c9

![Screenshot 2024-11-13 194040](https://github.com/user-attachments/assets/f46fe7d3-d44e-4c23-a36f-436286d51b75)



Release Notes:

- N/A *or* Added/Fixed/Improved ...
