### PR TITLE
project panel: Fix entries being marked when switching between tabs

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2145,12 +2145,6 @@ impl ProjectPanel {
                 worktree_id,
                 entry_id,
             });
-            if cx.modifiers().shift {
-                self.marked_entries.insert(SelectedEntry {
-                    worktree_id,
-                    entry_id,
-                });
-            }
         }
     }
 


### PR DESCRIPTION
This is a follow-up (or related to) #20412.

It fixes entries being marked when navigating between tabs with `cmd-[` and `cmd-]`.

Turns out that deep in the bowels of the project panel, we check whether a `shift` modifier was pressed - which is the case with `cmd-[` on a US ANSI layout - and if so mark an entry.

I think that's a left-over, because all the other code paths that select/reveal an entry mark it explicitly too.

Release Notes:

- Fixed entries in project panel being marked when navigating between tabs with keybinding that uses `shift` modifier. (Nightly only)