### PR TITLE
settings: Add allow_user_npmrc option

### DIFF
--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -67,6 +67,10 @@ pub struct NodeBinarySettings {
     /// If disabled, zed will download its own copy of node.
     #[serde(default)]
     pub ignore_system_version: Option<bool>,
+    /// Allow using user's npmrc
+    ///
+    /// default: false
+    pub allow_user_npmrc: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -69,7 +69,7 @@ pub struct NodeBinarySettings {
     pub ignore_system_version: Option<bool>,
     /// Allow using user's npmrc
     ///
-    /// default: false
+    /// Default: false
     pub allow_user_npmrc: Option<bool>,
 }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -298,6 +298,7 @@ fn main() {
                 allow_path_lookup: !settings.ignore_system_version.unwrap_or_default(),
                 // TODO: Expose this setting
                 allow_binary_download: true,
+                allow_user_npmrc: settings.allow_user_npmrc.unwrap_or_else(|| false),
                 use_paths: settings.path.as_ref().map(|node_path| {
                     let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                     let npm_path = settings


### PR DESCRIPTION
Closes #19806

Add `allow_user_npmrc` to `node` section. Set `true` to allow npm install packages with user's .npmrc. 

Settings looks like this:

```jsonc
{
  // ...
  "node": {
    "allow_user_npmrc": true
  },
  // ...
}
```

Release Notes:

- Added a `allow_user_npmrc` option to enable user's .npmrc instead of  a blank npmrc when npm installing packages.
