### PR TITLE
project panel: Don't change label color even when file has errors

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2452,14 +2452,8 @@ impl ProjectPanel {
                         .get(&(*worktree_id, entry.path.to_path_buf()))
                         .cloned();
 
-                    let filename_text_color = if entry.kind.is_file()
-                        && diagnostic_severity
-                            .map_or(false, |severity| severity == DiagnosticSeverity::ERROR)
-                    {
-                        Color::Error
-                    } else {
-                        entry_git_aware_label_color(status, entry.is_ignored, is_marked)
-                    };
+                    let filename_text_color =
+                        entry_git_aware_label_color(status, entry.is_ignored, is_marked);
 
                     let mut details = EntryDetails {
                         filename,


### PR DESCRIPTION
With this PR, Git status is now the only thing that can change an item's label color. So, the summary of how status colors operate in the project panel is:

- Item icon color is, by default, never changed, _not_ affected by either diagnostics or Git status
  - This should become configurable in the near future, though
- However, a little x or triangle icon shows up on top of the file type icon to display diagnostics status
- Label color is _not_ affected by diagnostics but it _is_ affected by Git status

This aims to reduce color noise and clarify/simplify how each element is affected.

Release Notes:

- N/A
