### PR TITLE
Don't send key equivalents to the input hanlder

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1298,6 +1298,12 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
         }
     }
 
+    // Don't send key equivalents to the input handler,
+    // or macOS shortcuts like cmd-` will stop working.
+    if key_equivalent {
+        return NO;
+    }
+
     unsafe {
         let input_context: id = msg_send![this, inputContext];
         msg_send![input_context, handleEvent: native_event]


### PR DESCRIPTION
Release Notes:

- Fix `cmd-backtick` to change windows 
