### PR TITLE
ci: Add shellcheck for scripts

### DIFF
--- a/.github/workflows/script_checks.yml
+++ b/.github/workflows/script_checks.yml
@@ -1,4 +1,4 @@
-name: Script Checks
+name: Script
 
 on:
   pull_request:

--- a/.github/workflows/script_checks.yml
+++ b/.github/workflows/script_checks.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Shellcheck ./scripts
         run: |
-          ./scripts/shellcheck-scripts error
+          ./script/shellcheck-scripts error

--- a/.github/workflows/script_checks.yml
+++ b/.github/workflows/script_checks.yml
@@ -1,0 +1,21 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - "script/**"
+  push:
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    name: "Check formatting"
+    if: github.repository_owner == 'zed-industries'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Shellcheck ./scripts
+        run: |
+          ./scripts/shellcheck-scripts error

--- a/.github/workflows/script_checks.yml
+++ b/.github/workflows/script_checks.yml
@@ -1,4 +1,4 @@
-name: Docs
+name: Script Checks
 
 on:
   pull_request:

--- a/.github/workflows/script_checks.yml
+++ b/.github/workflows/script_checks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   shellcheck:
-    name: "Check formatting"
+    name: "ShellCheck Scripts"
     if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
 

--- a/script/analyze_highlights.py
+++ b/script/analyze_highlights.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This script analyzes all the highlight.scm files in our embedded languages and extensions.
 It counts the number of unique instances of @{name} and the languages in which they are used.

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -69,7 +69,9 @@ strip --strip-debug "${target_dir}/${remote_server_triple}/release/remote_server
 
 
 # Ensure that remote_server does not depend on libssl nor libcrypto, as we got rid of these deps.
-! ldd "${target_dir}/${remote_server_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'
+if ldd "${target_dir}/${remote_server_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'; then
+    echo "Error: remote_server still depends on libssl or libcrypto" && exit 1
+fi
 
 suffix=""
 if [ "$channel" != "stable" ]; then
@@ -89,8 +91,8 @@ cp "${target_dir}/${target_triple}/release/cli" "${zed_dir}/bin/zed"
 # Libs
 find_libs() {
     ldd ${target_dir}/${target_triple}/release/zed |\
-    cut -d' ' -f3 |\
-    grep -v '\<\(libstdc++.so\|libc.so\|libgcc_s.so\|libm.so\|libpthread.so\|libdl.so\)'
+        cut -d' ' -f3 |\
+        grep -v '\<\(libstdc++.so\|libc.so\|libgcc_s.so\|libm.so\|libpthread.so\|libdl.so\)'
 }
 
 mkdir -p "${zed_dir}/lib"

--- a/script/clear-target-dir-if-larger-than
+++ b/script/clear-target-dir-if-larger-than
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [[ $# < 1 ]]; then
+if [[ $# -ne 1 ]]; then
     echo "usage: $0 <MAX_SIZE_IN_GB>"
     exit 1
 fi

--- a/script/deploy-postgrest
+++ b/script/deploy-postgrest
@@ -3,7 +3,7 @@
 set -eu
 source script/lib/deploy-helpers.sh
 
-if [[ $# < 1 ]]; then
+if [[ $# != 1 ]]; then
   echo "Usage: $0 <production|staging> (postgrest not needed on preview or nightly)"
   exit 1
 fi

--- a/script/get-crate-version
+++ b/script/get-crate-version
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [[ $# < 1 ]]; then
+if [[ $# -ne 1 ]]; then
   echo "Usage: $0 <crate_name>" >&2
   exit 1
 fi

--- a/script/kube-shell
+++ b/script/kube-shell
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $# < 1 ]]; then
+if [[ $# -ne 1 ]]; then
   echo "Usage: $0 [production|staging|...]"
   exit 1
 fi

--- a/script/metal-debug
+++ b/script/metal-debug
@@ -10,4 +10,4 @@ export GPUProfilerEnabled="YES"
 export METAL_DEBUG_ERROR_MODE=0
 export LD_LIBRARY_PATH="/Applications/Xcode.app/Contents/Developer/../SharedFrameworks/"
 
-cargo run $@
+cargo run "$@"

--- a/script/shellcheck-scripts
+++ b/script/shellcheck-scripts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode=${1:-error}
+[[ "$mode" =~ ^(error|warning)$ ]] || { echo "Usage: $0 [error|warning]"; exit 1; }
+
+cd "$(dirname "$0")/.." || exit 1
+
+find script -maxdepth 1 -type f -print0 |
+  xargs -0 grep -l -E '^#!(/bin/|/usr/bin/env )(sh|bash|dash)' |
+  xargs -r shellcheck -x -S "$mode" -C

--- a/script/upload-nightly
+++ b/script/upload-nightly
@@ -19,12 +19,12 @@ if [[ -n "${1:-}" ]]; then
         target="$1"
     else
         echo "Error: Target '$1' is not allowed"
-        echo "Usage: $0 [${allowed_targets[@]}]"
+        echo "Usage: $0 [${allowed_targets[*]}]"
         exit 1
     fi
 else
 echo "Error: Target is not specified"
-echo "Usage: $0 [${allowed_targets[@]}]"
+echo "Usage: $0 [${allowed_targets[*]}]"
 exit 1
 fi
 echo "Uploading nightly for target: $target"

--- a/script/what-is-deployed
+++ b/script/what-is-deployed
@@ -28,3 +28,5 @@ git fetch >/dev/null
 if [[ "$(git rev-parse tags/$tag)" != $deployed_image_id ]]; then
     echo "NOTE: tags/$tag $(git rev-parse tags/$tag) is not yet deployed"
 fi;
+
+echo '>afsdjklasd;

--- a/script/what-is-deployed
+++ b/script/what-is-deployed
@@ -28,5 +28,3 @@ git fetch >/dev/null
 if [[ "$(git rev-parse tags/$tag)" != $deployed_image_id ]]; then
     echo "NOTE: tags/$tag $(git rev-parse tags/$tag) is not yet deployed"
 fi;
-
-echo '>afsdjklasd;


### PR DESCRIPTION
Fixes shellcheck errors in script/*
Adds a couple trailing newlines.
Adds `script/shellcheck-scripts` and associated CI machinery.
Current set ultra-conservative, does not output warnings.

Designed to catch this sort of thing before merge:
- https://github.com/zed-industries/zed/pull/20613

This is what a failure looks like:
https://github.com/zed-industries/zed/actions/runs/11826764680/job/32953507544?pr=20631

Release Notes:

- N/A