### PR TITLE
Use the project env when running LSPs

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5540,16 +5540,9 @@ impl LspStore {
                 binary.arguments = arguments.into_iter().map(Into::into).collect();
             }
 
-            // If we do have a project environment (either by spawning a shell in in the project directory
-            // or by getting it from the CLI) and the language server command itself
-            // doesn't have an environment, then we use the project environment.
-            if binary.env.is_none() {
-                log::info!(
-                    "using project environment for language server {:?}",
-                    adapter.name()
-                );
-                binary.env = Some(delegate.shell_env().await);
-            }
+            let mut shell_env = delegate.shell_env().await;
+            shell_env.extend(binary.env.unwrap_or_default());
+            binary.env = Some(shell_env);
             Ok(binary)
         })
     }


### PR DESCRIPTION
This change ensures we always run LSPs with the project environment (in
addition to any overrides they provide). This helps ensure the environment is
set correctly on remotes where we don't load the login shell environment and
assign it to the current process.

Also fixed the go language to use the project env to find the go command.

Release Notes:

- Improved environment variable handling for SSH remotes
