### PR TITLE
Clarify rustup is requried

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -76,7 +76,7 @@ zed::register_extension!(MyExtension);
 
 ## Developing an Extension Locally
 
-Before starting to develop an extension for Zed, be sure to [install Rust](https://www.rust-lang.org/tools/install).
+Before starting to develop an extension for Zed, be sure to [install Rust via rustup](https://www.rust-lang.org/tools/install).
 
 When developing an extension, you can use it in Zed without needing to publish it by installing it as a _dev extension_.
 


### PR DESCRIPTION
Clarify that rustup is required to build developer extensions. Developer extensions fail silently to the logs because rustup isn't found, even when rust is installed.

Release Notes:

- N/A
