### PR TITLE
Avoid creating occlusions for editor blocks, since these block mouse wheel events

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -24,9 +24,9 @@ use futures::{
     join, SinkExt, Stream, StreamExt,
 };
 use gpui::{
-    anchored, deferred, point, AnyElement, AppContext, ClickEvent, EventEmitter, FocusHandle,
-    FocusableView, FontWeight, Global, HighlightStyle, Model, ModelContext, Subscription, Task,
-    TextStyle, UpdateGlobal, View, ViewContext, WeakView, WindowContext,
+    anchored, deferred, point, AnyElement, AppContext, ClickEvent, CursorStyle, EventEmitter,
+    FocusHandle, FocusableView, FontWeight, Global, HighlightStyle, Model, ModelContext,
+    Subscription, Task, TextStyle, UpdateGlobal, View, ViewContext, WeakView, WindowContext,
 };
 use language::{Buffer, IndentKind, Point, Selection, TransactionId};
 use language_model::{
@@ -1199,7 +1199,7 @@ impl InlineAssistant {
                     style: BlockStyle::Flex,
                     render: Arc::new(move |cx| {
                         div()
-                            .occlude()
+                            .block_mouse_down()
                             .bg(cx.theme().status().deleted_background)
                             .size_full()
                             .h(height as f32 * cx.line_height())
@@ -1481,7 +1481,8 @@ impl Render for PromptEditor {
         h_flex()
             .key_context("PromptEditor")
             .bg(cx.theme().colors().editor_background)
-            .occlude()
+            .block_mouse_down()
+            .cursor(CursorStyle::Arrow)
             .border_y_1()
             .border_color(cx.theme().status().info_border)
             .size_full()

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -795,7 +795,7 @@ fn diagnostic_header_renderer(diagnostic: Diagnostic) -> RenderBlock {
         let highlight_style: HighlightStyle = cx.theme().colors().text_accent.into();
         h_flex()
             .id(DIAGNOSTIC_HEADER)
-            .occlude()
+            .block_mouse_down()
             .h(2. * cx.line_height())
             .pl_10()
             .pr_5()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10431,7 +10431,7 @@ impl Editor {
                                         text_style = text_style.highlight(highlight_style);
                                     }
                                     div()
-                                        .occlude()
+                                        .block_mouse_down()
                                         .pl(cx.anchor_x)
                                         .child(EditorElement::new(
                                             &rename_editor,
@@ -14681,7 +14681,7 @@ pub fn diagnostic_block_renderer(
             .group(group_id.clone())
             .relative()
             .size_full()
-            .occlude()
+            .block_mouse_down()
             .pl(cx.gutter_dimensions.width)
             .w(cx.max_width - cx.gutter_dimensions.full_width())
             .child(

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -435,7 +435,7 @@ impl Editor {
 
                     h_flex()
                         .id(cx.block_id)
-                        .occlude()
+                        .block_mouse_down()
                         .h(cx.line_height())
                         .w_full()
                         .border_t_1()
@@ -714,7 +714,7 @@ impl Editor {
 
                 h_flex()
                     .id(cx.block_id)
-                    .occlude()
+                    .block_mouse_down()
                     .bg(deleted_hunk_color)
                     .h(height as f32 * cx.line_height())
                     .w_full()

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -511,7 +511,7 @@ impl Interactivity {
     }
 
     /// Block the mouse from interacting with this element or any of its children
-    /// The imperative API equivalent to [`InteractiveElement::block_mouse`]
+    /// The imperative API equivalent to [`InteractiveElement::occlude`]
     pub fn occlude_mouse(&mut self) {
         self.occlude_mouse = true;
     }
@@ -874,10 +874,16 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Block the mouse from interacting with this element or any of its children
-    /// The fluent API equivalent to [`Interactivity::block_mouse`]
+    /// The fluent API equivalent to [`Interactivity::occlude_mouse`]
     fn occlude(mut self) -> Self {
         self.interactivity().occlude_mouse();
         self
+    }
+
+    /// Block the mouse from interacting with this element or any of its children
+    /// The fluent API equivalent to [`Interactivity::occlude_mouse`]
+    fn block_mouse_down(mut self) -> Self {
+        self.on_mouse_down(MouseButton::Left, |_, cx| cx.stop_propagation())
     }
 }
 

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -163,7 +163,7 @@ impl EditorBlock {
 
             div()
                 .id(cx.block_id)
-                .occlude()
+                .block_mouse_down()
                 .flex()
                 .items_start()
                 .min_h(text_line_height)


### PR DESCRIPTION
Just block mouse down events, and in the case of the inline assist prompt, set the default cursor.

Release Notes:

- N/A
