### PR TITLE
python: Improve handling of triple-quoted strings

### DIFF
--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -5,6 +5,8 @@ first_line_pattern = '^#!.*\bpython[0-9.]*\b'
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"
 brackets = [
+    { start = "\"\"\"", end = "\"\"\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'''", end = "'''", close = true, newline = false, not_in = ["string"] },
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },


### PR DESCRIPTION
Closes #13998

/cc @notpeter would you mind giving this branch a go to see if this is pleasant to use? This impl is not quite what VSC has, but I think it feels okay?

In this PR, the sequence goes as follows:
1st keypress: "|"
2nd keypress: ""|
3rd keypress: """|"""

Release Notes:

- Improved handling of triple-quote strings in Python.
