### PR TITLE
Fix scrollbar not always being on top

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2982,8 +2982,9 @@ impl ProjectPanel {
                 .right_1()
                 .top_1()
                 .bottom_1()
-                .w(px(12.))
+                .w(px(8.))
                 .cursor_default()
+                .elevation_1_borderless(cx)
                 .children(Scrollbar::vertical(
                     // percentage as f32..end_offset as f32,
                     self.vertical_scrollbar_state.clone(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2982,9 +2982,8 @@ impl ProjectPanel {
                 .right_1()
                 .top_1()
                 .bottom_1()
-                .w(px(8.))
+                .w(px(12.))
                 .cursor_default()
-                .elevation_1_borderless(cx)
                 .children(Scrollbar::vertical(
                     // percentage as f32..end_offset as f32,
                     self.vertical_scrollbar_state.clone(),

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -228,7 +228,9 @@ impl Element for Scrollbar {
     ) {
         cx.with_content_mask(Some(ContentMask { bounds }), |cx| {
             let colors = cx.theme().colors();
-            let thumb_background = colors.surface_background.blend(colors.scrollbar_thumb_background);
+            let thumb_background = colors
+                .surface_background
+                .blend(colors.scrollbar_thumb_background);
             let is_vertical = self.kind == ScrollbarAxis::Vertical;
             let extra_padding = px(5.0);
             let padded_bounds = if is_vertical {

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -228,7 +228,7 @@ impl Element for Scrollbar {
     ) {
         cx.with_content_mask(Some(ContentMask { bounds }), |cx| {
             let colors = cx.theme().colors();
-            let thumb_background = colors.scrollbar_thumb_background;
+            let thumb_background = colors.surface_background.blend(colors.scrollbar_thumb_background);
             let is_vertical = self.kind == ScrollbarAxis::Vertical;
             let extra_padding = px(5.0);
             let padded_bounds = if is_vertical {


### PR DESCRIPTION
Set the elevation of the scrollbar to 1 borderless, so that the blue outline is no longer above the scrollbar.

Closes #19875

Release Notes:

- N/A
