### PR TITLE
Add `ui::ContentGroup`

### DIFF
--- a/crates/ui/src/components.rs
+++ b/crates/ui/src/components.rs
@@ -1,7 +1,7 @@
 mod avatar;
 mod button;
 mod checkbox;
-mod content_box;
+mod content_group;
 mod context_menu;
 mod disclosure;
 mod divider;
@@ -37,7 +37,7 @@ mod stories;
 pub use avatar::*;
 pub use button::*;
 pub use checkbox::*;
-pub use content_box::*;
+pub use content_group::*;
 pub use context_menu::*;
 pub use disclosure::*;
 pub use divider::*;

--- a/crates/ui/src/components.rs
+++ b/crates/ui/src/components.rs
@@ -1,6 +1,7 @@
 mod avatar;
 mod button;
 mod checkbox;
+mod content_box;
 mod context_menu;
 mod disclosure;
 mod divider;
@@ -36,6 +37,7 @@ mod stories;
 pub use avatar::*;
 pub use button::*;
 pub use checkbox::*;
+pub use content_box::*;
 pub use context_menu::*;
 pub use disclosure::*;
 pub use divider::*;

--- a/crates/ui/src/components/content_box.rs
+++ b/crates/ui/src/components/content_box.rs
@@ -1,0 +1,116 @@
+use crate::prelude::*;
+use gpui::{AnyElement, IntoElement, ParentElement, StyleRefinement, Styled};
+use smallvec::SmallVec;
+
+/// A flexible container component that can hold other elements.
+#[derive(IntoElement)]
+pub struct ContentBox {
+    base: Div,
+    border: bool,
+    fill: bool,
+    children: SmallVec<[AnyElement; 2]>,
+}
+
+impl ContentBox {
+    /// Creates a new [ContentBox].
+    pub fn new() -> Self {
+        Self {
+            base: div(),
+            border: true,
+            fill: true,
+            children: SmallVec::new(),
+        }
+    }
+
+    /// Removes the border from the [ContentBox].
+    pub fn borderless(mut self) -> Self {
+        self.border = false;
+        self
+    }
+
+    /// Removes the background fill from the [ContentBox].
+    pub fn unfilled(mut self) -> Self {
+        self.fill = false;
+        self
+    }
+}
+
+impl ParentElement for ContentBox {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements)
+    }
+}
+
+impl Styled for ContentBox {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+}
+
+impl RenderOnce for ContentBox {
+    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+        // TODO:
+        // Baked in padding will make scrollable views inside of content boxes awkward.
+        //
+        // Do we make the padding optional, or do we push to use a different component?
+
+        self.base
+            .when(self.fill, |this| {
+                this.bg(cx.theme().colors().text.opacity(0.05))
+            })
+            .when(self.border, |this| {
+                this.border_1().border_color(cx.theme().colors().border)
+            })
+            .rounded_md()
+            .p_2()
+            .children(self.children)
+    }
+}
+
+impl ComponentPreview for ContentBox {
+    fn description() -> impl Into<Option<&'static str>> {
+        "A flexible container component that can hold other elements. It can be customized with or without a border and background fill."
+    }
+
+    fn example_label_side() -> ExampleLabelSide {
+        ExampleLabelSide::Bottom
+    }
+
+    fn examples(_: &WindowContext) -> Vec<ComponentExampleGroup<Self>> {
+        vec![example_group(vec![
+            single_example(
+                "Default",
+                ContentBox::new()
+                    .flex_1()
+                    .items_center()
+                    .justify_center()
+                    .h_48()
+                    .child(Label::new("Default ContentBox")),
+            )
+            .grow(),
+            single_example(
+                "Without Border",
+                ContentBox::new()
+                    .flex_1()
+                    .items_center()
+                    .justify_center()
+                    .h_48()
+                    .borderless()
+                    .child(Label::new("Borderless ContentBox")),
+            )
+            .grow(),
+            single_example(
+                "Without Fill",
+                ContentBox::new()
+                    .flex_1()
+                    .items_center()
+                    .justify_center()
+                    .h_48()
+                    .unfilled()
+                    .child(Label::new("Unfilled ContentBox")),
+            )
+            .grow(),
+        ])
+        .grow()]
+    }
+}

--- a/crates/ui/src/components/content_group.rs
+++ b/crates/ui/src/components/content_group.rs
@@ -7,6 +7,20 @@ pub fn content_group() -> ContentGroup {
     ContentGroup::new()
 }
 
+/// A [ContentGroup] that vertically stacks its children.
+///
+/// This is a convenience function that simply combines [`ContentGroup`] and [`v_flex`](crate::v_flex).
+pub fn v_group() -> ContentGroup {
+    content_group().v_flex()
+}
+
+/// Creates a new horizontal [ContentGroup].
+///
+/// This is a convenience function that simply combines [`ContentGroup`] and [`h_flex`](crate::h_flex).
+pub fn h_group() -> ContentGroup {
+    content_group().h_flex()
+}
+
 /// A flexible container component that can hold other elements.
 #[derive(IntoElement)]
 pub struct ContentGroup {

--- a/crates/ui/src/components/content_group.rs
+++ b/crates/ui/src/components/content_group.rs
@@ -2,6 +2,11 @@ use crate::prelude::*;
 use gpui::{AnyElement, IntoElement, ParentElement, StyleRefinement, Styled};
 use smallvec::SmallVec;
 
+/// Creates a new [ContentGroup].
+pub fn content_group() -> ContentGroup {
+    ContentGroup::new()
+}
+
 /// A flexible container component that can hold other elements.
 #[derive(IntoElement)]
 pub struct ContentGroup {

--- a/crates/ui/src/components/content_group.rs
+++ b/crates/ui/src/components/content_group.rs
@@ -4,14 +4,14 @@ use smallvec::SmallVec;
 
 /// A flexible container component that can hold other elements.
 #[derive(IntoElement)]
-pub struct ContentBox {
+pub struct ContentGroup {
     base: Div,
     border: bool,
     fill: bool,
     children: SmallVec<[AnyElement; 2]>,
 }
 
-impl ContentBox {
+impl ContentGroup {
     /// Creates a new [ContentBox].
     pub fn new() -> Self {
         Self {
@@ -35,19 +35,19 @@ impl ContentBox {
     }
 }
 
-impl ParentElement for ContentBox {
+impl ParentElement for ContentGroup {
     fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
         self.children.extend(elements)
     }
 }
 
-impl Styled for ContentBox {
+impl Styled for ContentGroup {
     fn style(&mut self) -> &mut StyleRefinement {
         self.base.style()
     }
 }
 
-impl RenderOnce for ContentBox {
+impl RenderOnce for ContentGroup {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         // TODO:
         // Baked in padding will make scrollable views inside of content boxes awkward.
@@ -67,7 +67,7 @@ impl RenderOnce for ContentBox {
     }
 }
 
-impl ComponentPreview for ContentBox {
+impl ComponentPreview for ContentGroup {
     fn description() -> impl Into<Option<&'static str>> {
         "A flexible container component that can hold other elements. It can be customized with or without a border and background fill."
     }
@@ -80,7 +80,7 @@ impl ComponentPreview for ContentBox {
         vec![example_group(vec![
             single_example(
                 "Default",
-                ContentBox::new()
+                ContentGroup::new()
                     .flex_1()
                     .items_center()
                     .justify_center()
@@ -90,7 +90,7 @@ impl ComponentPreview for ContentBox {
             .grow(),
             single_example(
                 "Without Border",
-                ContentBox::new()
+                ContentGroup::new()
                     .flex_1()
                     .items_center()
                     .justify_center()
@@ -101,7 +101,7 @@ impl ComponentPreview for ContentBox {
             .grow(),
             single_example(
                 "Without Fill",
-                ContentBox::new()
+                ContentGroup::new()
                     .flex_1()
                     .items_center()
                     .justify_center()

--- a/crates/ui/src/prelude.rs
+++ b/crates/ui/src/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::traits::selectable::*;
 pub use crate::traits::styled_ext::*;
 pub use crate::traits::visible_on_hover::*;
 pub use crate::DynamicSpacing;
-pub use crate::{h_flex, v_flex};
+pub use crate::{h_flex, h_group, v_flex, v_group};
 pub use crate::{Button, ButtonSize, ButtonStyle, IconButton, SelectableButton};
 pub use crate::{ButtonCommon, Color};
 pub use crate::{Headline, HeadlineSize};

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -267,13 +267,8 @@ impl Render for WelcomePage {
                             ),
                     )
                     .child(
-                        v_flex()
-                            .p_3()
+                        v_group()
                             .gap_2()
-                            .bg(cx.theme().colors().element_background)
-                            .border_1()
-                            .border_color(cx.theme().colors().border_variant)
-                            .rounded_md()
                             .child(CheckboxWithLabel::new(
                                 "enable-vim",
                                 Label::new("Enable Vim Mode"),

--- a/crates/workspace/src/theme_preview.rs
+++ b/crates/workspace/src/theme_preview.rs
@@ -5,7 +5,7 @@ use theme::all_theme_colors;
 use ui::{
     element_cell, prelude::*, string_cell, utils::calculate_contrast_ratio, AudioStatus,
     Availability, Avatar, AvatarAudioStatusIndicator, AvatarAvailabilityIndicator, ButtonLike,
-    Checkbox, CheckboxWithLabel, ContentBox, DecoratedIcon, ElevationIndex, Facepile,
+    Checkbox, CheckboxWithLabel, ContentGroup, DecoratedIcon, ElevationIndex, Facepile,
     IconDecoration, Indicator, Table, TintColor, Tooltip,
 };
 
@@ -510,7 +510,7 @@ impl ThemePreview {
             .overflow_scroll()
             .size_full()
             .gap_2()
-            .child(ContentBox::render_component_previews(cx))
+            .child(ContentGroup::render_component_previews(cx))
             .child(IconDecoration::render_component_previews(cx))
             .child(DecoratedIcon::render_component_previews(cx))
             .child(Checkbox::render_component_previews(cx))

--- a/crates/workspace/src/theme_preview.rs
+++ b/crates/workspace/src/theme_preview.rs
@@ -5,8 +5,8 @@ use theme::all_theme_colors;
 use ui::{
     element_cell, prelude::*, string_cell, utils::calculate_contrast_ratio, AudioStatus,
     Availability, Avatar, AvatarAudioStatusIndicator, AvatarAvailabilityIndicator, ButtonLike,
-    Checkbox, CheckboxWithLabel, DecoratedIcon, ElevationIndex, Facepile, IconDecoration,
-    Indicator, Table, TintColor, Tooltip,
+    Checkbox, CheckboxWithLabel, ContentBox, DecoratedIcon, ElevationIndex, Facepile,
+    IconDecoration, Indicator, Table, TintColor, Tooltip,
 };
 
 use crate::{Item, Workspace};
@@ -510,6 +510,7 @@ impl ThemePreview {
             .overflow_scroll()
             .size_full()
             .gap_2()
+            .child(ContentBox::render_component_previews(cx))
             .child(IconDecoration::render_component_previews(cx))
             .child(DecoratedIcon::render_component_previews(cx))
             .child(Checkbox::render_component_previews(cx))


### PR DESCRIPTION
TL;DR our version of [HIG's Box](https://developer.apple.com/design/human-interface-guidelines/boxes)

We can't use the name `Box` (because rust) or `ContentBox` (because taffy/styles/css).

---

This PR introduces the `ContentGroup` component, a flexible container inspired by HIG's `Box` component. It's designed to hold and organize various UI elements with options to toggle borders and background fills.

**Example usage**:

```rust
ContentGroup::new()
    .flex_1()
    .items_center()
    .justify_center()
    .h_48()
    .child(Label::new("Flexible ContentBox"))
```

Here are some configurations:

- Default: Includes both border and fill.
- Borderless: No border for a clean look.
- Unfilled: No background fill for a transparent appearance.

**Preview**:

![CleanShot 2024-11-14 at 07 05 15@2x](https://github.com/user-attachments/assets/c838371e-e24f-46f0-94b4-43c078e8f14e)

---

_This PR was written by a large language model with input from the author._

Release Notes:

- N/A
