### PR TITLE
python: Fix detection of Poetry environments

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -399,6 +399,10 @@ impl ToolchainLister for PythonToolchainProvider {
         );
         let mut config = Configuration::default();
         config.workspace_directories = Some(vec![worktree_root]);
+        for locator in locators.iter() {
+            locator.configure(&config);
+        }
+
         let reporter = pet_reporter::collect::create_reporter();
         pet::find::find_and_report_envs(&reporter, config, &locators, &environment, None);
 


### PR DESCRIPTION
We were missing a .configure call, which let to discrepancies with PET output.

Release Notes:

- Improved detection of Poetry-based environments
