### PR TITLE
Use vim-like keybindings for splitting out of the file finder

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -648,19 +648,23 @@
     }
   },
   {
-    "context": "FileFinder",
+    "context": "FileFinder && !menu_open",
     "bindings": {
       "ctrl-shift-p": "file_finder::SelectPrev",
-      "ctrl-k": "file_finder::OpenMenu"
+      "ctrl": "file_finder::OpenMenu",
+      "ctrl-j": "pane::SplitDown",
+      "ctrl-k": "pane::SplitUp",
+      "ctrl-h": "pane::SplitLeft",
+      "ctrl-l": "pane::SplitRight"
     }
   },
   {
     "context": "FileFinder && menu_open",
     "bindings": {
-      "u": "pane::SplitUp",
-      "d": "pane::SplitDown",
-      "l": "pane::SplitLeft",
-      "r": "pane::SplitRight"
+      "j": "pane::SplitDown",
+      "k": "pane::SplitUp",
+      "h": "pane::SplitLeft",
+      "l": "pane::SplitRight"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -648,19 +648,23 @@
     }
   },
   {
-    "context": "FileFinder",
+    "context": "FileFinder && !menu_open",
     "bindings": {
       "cmd-shift-p": "file_finder::SelectPrev",
-      "cmd-k": "file_finder::OpenMenu"
+      "cmd": "file_finder::OpenMenu",
+      "cmd-j": "pane::SplitDown",
+      "cmd-k": "pane::SplitUp",
+      "cmd-h": "pane::SplitLeft",
+      "cmd-l": "pane::SplitRight"
     }
   },
   {
     "context": "FileFinder && menu_open",
     "bindings": {
-      "u": "pane::SplitUp",
-      "d": "pane::SplitDown",
-      "l": "pane::SplitLeft",
-      "r": "pane::SplitRight"
+      "j": "pane::SplitDown",
+      "k": "pane::SplitUp",
+      "h": "pane::SplitLeft",
+      "l": "pane::SplitRight"
     }
   },
   {


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/20507

Release Notes:

- (breaking Preview) Adjusted file finder split keybindings to be less conflicting
