### PR TITLE
zed_extension_api: Release v0.2.0

### DIFF
--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -8,9 +8,6 @@ keywords = ["zed", "extension"]
 edition = "2021"
 license = "Apache-2.0"
 
-# Remove when we're ready to publish v0.2.0.
-publish = false
-
 [lints]
 workspace = true
 

--- a/crates/extension_api/README.md
+++ b/crates/extension_api/README.md
@@ -63,6 +63,7 @@ Here is the compatibility of the `zed_extension_api` with versions of Zed:
 
 | Zed version | `zed_extension_api` version |
 | ----------- | --------------------------- |
+| `0.162.x`   | `0.0.1` - `0.2.0`           |
 | `0.149.x`   | `0.0.1` - `0.1.0`           |
 | `0.131.x`   | `0.0.1` - `0.0.6`           |
 | `0.130.x`   | `0.0.1` - `0.0.5`           |

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -22,7 +22,6 @@ use wasmtime::component::{Linker, Resource};
 use super::latest;
 
 pub const MIN_VERSION: SemanticVersion = SemanticVersion::new(0, 1, 0);
-pub const MAX_VERSION: SemanticVersion = SemanticVersion::new(0, 1, 0);
 
 wasmtime::component::bindgen!({
     async: true,


### PR DESCRIPTION
This PR releases v0.2.0 of the Zed extension API.

Support for this version of the extension API will land in Zed v0.162.x.

Release Notes:

- N/A
