### PR TITLE
client: Remove unneeded `return`

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -341,7 +341,7 @@ impl Telemetry {
         let state = self.state.lock();
         let enabled = state.settings.metrics;
         drop(state);
-        return enabled;
+        enabled
     }
 
     pub fn set_authenticated_user_info(


### PR DESCRIPTION
This PR removes an unneeded `return` that was introduced in #19928.

Release Notes:

- N/A
