### PR TITLE
docs: Document exec flags for GDScript

### DIFF
--- a/docs/src/languages/gdscript.md
+++ b/docs/src/languages/gdscript.md
@@ -14,7 +14,7 @@ Report issues to: [https://github.com/grndctrl/zed-gdscript/issues](https://gith
 4. In Godot, Editor Menu -> Editor Settings; scroll down the left sidebar to `Text Editor -> External`
    1. Use External Editor: "✅ On"
    2. Exec path: `/Applications/Zed.app/Contents/MacOS/zed`
-   3. Exec flags: `{project} {file}`
+   3. Exec flags: `{project} {file}:{line}:{col}`
    4. Close settings to save.
 5. In Godot double click on a \*.gd script and Zed will launch
 


### PR DESCRIPTION
While looking up the GDScript extension docs, I noticed that the original extension repo mentions of `{line}:{col}` placeholders too in addition to `{project} {file}` that the Zed docs suggest adding.

This PR Improves the docs to add those missing options to the suggested flags.

https://github.com/GDQuest/zed-gdscript?tab=readme-ov-file#opening-gdscript-files-in-zed-instead-of-godot
https://github.com/zed-industries/zed/blob/56c93be4de4f3792b4578c381e68332665aba74a/docs/src/languages/gdscript.md#setup

Release Notes:

- N/A
