### PR TITLE
ocaml: Improve highlighting and bracketing

### DIFF
--- a/extensions/ocaml/languages/ocaml-interface/brackets.scm
+++ b/extensions/ocaml/languages/ocaml-interface/brackets.scm
@@ -1,3 +1,2 @@
 ("(" @open ")" @close)
 ("{" @open "}" @close)
-("<" @open ">" @close)

--- a/extensions/ocaml/languages/ocaml-interface/config.toml
+++ b/extensions/ocaml/languages/ocaml-interface/config.toml
@@ -2,11 +2,10 @@ name = "OCaml Interface"
 code_fence_block_name = "ocaml"
 grammar = "ocaml_interface"
 path_suffixes = ["mli"]
-block_comment = ["(* ", "*)"]
+block_comment = ["(* ", " *)"]
 autoclose_before = ";,=)}"
 brackets = [
   { start = "{", end = "}", close = true, newline = true },
-  { start = "<", end = ">", close = true, newline = true },
   { start = "[", end = "]", close = true, newline = true },
   { start = "(", end = ")", close = true, newline = true }
 ]

--- a/extensions/ocaml/languages/ocaml/brackets.scm
+++ b/extensions/ocaml/languages/ocaml/brackets.scm
@@ -2,5 +2,4 @@
 ("[" @open "]" @close)
 ("[|" @open "|]" @close)
 ("{" @open "}" @close)
-("<" @open ">" @close)
 ("\"" @open "\"" @close)

--- a/extensions/ocaml/languages/ocaml/config.toml
+++ b/extensions/ocaml/languages/ocaml/config.toml
@@ -1,11 +1,11 @@
 name = "OCaml"
 grammar = "ocaml"
 path_suffixes = ["ml"]
-block_comment = ["(* ", "*)"]
+block_comment = ["(* ", " *)"]
 autoclose_before = ";,=)}]"
 brackets = [
   { start = "{", end = "}", close = true, newline = true },
-  { start = "<", end = ">", close = true, newline = true },
+  { start = "{|", end = "|", close = true, newline = true, not_in = ["string"] },
   { start = "[", end = "]", close = true, newline = true },
   { start = "[|", end = "|", close = true, newline = true, not_in = ["string"] },
   { start = "(", end = ")", close = true, newline = true },

--- a/extensions/ocaml/languages/ocaml/highlights.scm
+++ b/extensions/ocaml/languages/ocaml/highlights.scm
@@ -44,12 +44,27 @@
 ; Variables
 ;----------
 
-[(type_variable) (value_pattern)] @variable
+(value_pattern) @variable
+
+(type_variable) @variable.special
 
 ; Properties
 ;-----------
 
-[(label_name) (field_name) (instance_variable_name)] @property
+[(field_name) (instance_variable_name)] @property
+
+; Labels
+;-------
+
+[(label_name) (parameter)] @label
+
+(parameter
+    pattern: (value_pattern) @label)
+; despite the above rule, we should still label value_pattern as a variable
+; when a label name is present
+(parameter
+    (label_name)
+    pattern: (value_pattern) @variable)
 
 ; Constants
 ;----------
@@ -112,7 +127,7 @@
 ; Punctuation
 ;------------
 
-["(" ")" "[" "]" "{" "}" "[|" "|]" "[<" "[>"] @punctuation.bracket
+["(" ")" "[" "]" "{" "}" "[|" "|]" "[<" "[>" "[@@" "[@" "[%"] @punctuation.bracket
 
 (object_type ["<" ">"] @punctuation.bracket)
 
@@ -132,7 +147,7 @@
   (item_extension)
   (quoted_extension)
   (quoted_item_extension)
-  "%"
+
 ] @attribute
 
 (attribute_id) @tag


### PR DESCRIPTION
Some small improvements to OCaml. Would happily split these into smaller changes, discard anything, etc.

Before:
<img width="441" alt="before" src="https://github.com/user-attachments/assets/2fb82b03-0d45-4c59-a94d-6f48d634fe19">

After:
<img width="448" alt="after" src="https://github.com/user-attachments/assets/aa232d8f-4b1b-48f8-93e2-2147de37a20d">

OCaml highlighting and bracketing improvements
    - Fixed bug where `<` was automatically closed with `>`.
    - Typing `{|` now automatically closes with `|}`
    - Type variables are now colored with `variable.special` instead of `variable`.
    - Argument names in function declarations and application are now colored with `label` instead of `property`, even if they are punned.
    - `[@@` and `[%` in macros are now colored as bracket punctuation to match the closing `]`, rather than colored as `attribute`

Release Notes:

- N/A