### PR TITLE
vim: Allow :cpplink for CopyPermalinkToLine

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -690,6 +690,7 @@ fn generate_commands(_: &AppContext) -> Vec<VimCommand> {
         VimCommand::new(("0", ""), StartOfDocument),
         VimCommand::new(("e", "dit"), editor::actions::ReloadFile)
             .bang(editor::actions::ReloadFile),
+        VimCommand::new(("cpp", "link"), editor::actions::CopyPermalinkToLine).range(act_on_range),
     ]
 }
 


### PR DESCRIPTION

Release Notes:

- vim: Added `:<range>cpplink` to copy a permanent git link to the highlighted range to the clipboard
