### PR TITLE
docs: Update Zig Tree-sitter grammar link

### DIFF
--- a/docs/src/languages/zig.md
+++ b/docs/src/languages/zig.md
@@ -2,5 +2,5 @@
 
 Zig support is available through the [Zig extension](https://github.com/zed-industries/zed/tree/main/extensions/zig).
 
-- Tree-Sitter: [tree-sitter-zig](https://github.com/maxxnino/tree-sitter-zig)
+- Tree-Sitter: [tree-sitter-zig](https://github.com/tree-sitter-grammars/tree-sitter-zig)
 - Language Server: [zls](https://github.com/zigtools/zls)


### PR DESCRIPTION
lines up with https://github.com/zed-industries/zed/blob/main/extensions/zig/extension.toml

Release Notes:

- N/A
