### PR TITLE
Disable signature help shown by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -157,7 +157,7 @@
   "auto_signature_help": false,
   /// Whether to show the signature help after completion or a bracket pair inserted.
   /// If `auto_signature_help` is enabled, this setting will be treated as enabled also.
-  "show_signature_help_after_edits": true,
+  "show_signature_help_after_edits": false,
   // Whether to show wrap guides (vertical rulers) in the editor.
   // Setting this to true will show a guide at the 'preferred_line_length' value
   // if 'soft_wrap' is set to 'preferred_line_length', and will show any

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -279,7 +279,7 @@ pub struct EditorSettingsContent {
 
     /// Whether to show the signature help pop-up after completions or bracket pairs inserted.
     ///
-    /// Default: true
+    /// Default: false
     pub show_signature_help_after_edits: Option<bool>,
 
     /// Jupyter REPL settings.


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20725

Stop showing the pop-up that gets an issue open every now and then.

Release Notes:

- Stopped showing signature help after completions by default
