### PR TITLE
Fix Rust LSP adapter on FreeBSD

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -36,6 +36,12 @@ impl RustLspAdapter {
     const ARCH_SERVER_NAME: &str = "unknown-linux-gnu";
 }
 
+#[cfg(target_os = "freebsd")]
+impl RustLspAdapter {
+    const GITHUB_ASSET_KIND: AssetKind = AssetKind::Gz;
+    const ARCH_SERVER_NAME: &str = "unknown-freebsd";
+}
+
 #[cfg(target_os = "windows")]
 impl RustLspAdapter {
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::Zip;


### PR DESCRIPTION
This PR fixes the Rust LSP adapter on FreeBSD. This issue was creating build errors.

Release Notes:

- Fixed Rust LSP adapter on FreeBSD
