### PR TITLE
assistant: Show more details for assist errors

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3920,7 +3920,7 @@ impl ContextEditor {
             .child(
                 div()
                     .id("error-message")
-                    .max_h_24()
+                    .max_h_32()
                     .overflow_y_scroll()
                     .child(Label::new(error_message.clone())),
             )

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -2383,7 +2383,11 @@ impl Context {
                             });
                             Some(error.to_string())
                         } else {
-                            let error_message = error.to_string().trim().to_string();
+                            let error_message = error
+                                .chain()
+                                .map(|err| err.to_string())
+                                .collect::<Vec<_>>()
+                                .join("\n");
                             cx.emit(ContextEvent::ShowAssistError(SharedString::from(
                                 error_message.clone(),
                             )));


### PR DESCRIPTION
This PR updates the Assistant to show more detailed error messages when the user encounters an assist error.

Here are some examples:

<img width="415" alt="Screenshot 2024-11-15 at 1 47 03 PM" src="https://github.com/user-attachments/assets/5e7c5d5f-bd78-4af3-86ed-af4c6712770f">

<img width="417" alt="Screenshot 2024-11-15 at 2 11 14 PM" src="https://github.com/user-attachments/assets/02cb659b-1239-4e24-865f-3a512703a94f">

The notification will scroll if the error lines overflow the set maximum height.

Release Notes:

- Updated the Assistant to show more details in error cases.
