### PR TITLE
Require save confirmation and prevent autosave for deleted files

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -727,6 +727,10 @@ impl Item for ProjectDiagnosticsEditor {
         self.excerpts.read(cx).is_dirty(cx)
     }
 
+    fn has_deleted_file(&self, cx: &AppContext) -> bool {
+        self.excerpts.read(cx).has_deleted_file(cx)
+    }
+
     fn has_conflict(&self, cx: &AppContext) -> bool {
         self.excerpts.read(cx).has_conflict(cx)
     }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -708,6 +708,10 @@ impl Item for Editor {
         self.buffer().read(cx).read(cx).is_dirty()
     }
 
+    fn has_deleted_file(&self, cx: &AppContext) -> bool {
+        self.buffer().read(cx).read(cx).has_deleted_file()
+    }
+
     fn has_conflict(&self, cx: &AppContext) -> bool {
         self.buffer().read(cx).read(cx).has_conflict()
     }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1749,13 +1749,20 @@ impl Buffer {
                     .map_or(false, |file| file.is_deleted() || !file.is_created()))
     }
 
+    pub fn is_deleted(&self) -> bool {
+        self.file.as_ref().map_or(false, |file| file.is_deleted())
+    }
+
     /// Checks if the buffer and its file have both changed since the buffer
     /// was last saved or reloaded.
     pub fn has_conflict(&self) -> bool {
-        self.has_conflict
-            || self.file.as_ref().map_or(false, |file| {
-                file.mtime() > self.saved_mtime && self.has_unsaved_edits()
-            })
+        if self.has_conflict {
+            return true;
+        }
+        let Some(file) = self.file.as_ref() else {
+            return false;
+        };
+        file.is_deleted() || (file.mtime() > self.saved_mtime && self.has_unsaved_edits())
     }
 
     /// Gets a [`Subscription`] that tracks all of the changes to the buffer's text.

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -228,6 +228,9 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
     fn is_dirty(&self, _: &AppContext) -> bool {
         false
     }
+    fn has_deleted_file(&self, _: &AppContext) -> bool {
+        false
+    }
     fn has_conflict(&self, _: &AppContext) -> bool {
         false
     }
@@ -405,6 +408,7 @@ pub trait ItemHandle: 'static + Send {
     fn item_id(&self) -> EntityId;
     fn to_any(&self) -> AnyView;
     fn is_dirty(&self, cx: &AppContext) -> bool;
+    fn has_deleted_file(&self, cx: &AppContext) -> bool;
     fn has_conflict(&self, cx: &AppContext) -> bool;
     fn can_save(&self, cx: &AppContext) -> bool;
     fn save(
@@ -766,6 +770,10 @@ impl<T: Item> ItemHandle for View<T> {
 
     fn is_dirty(&self, cx: &AppContext) -> bool {
         self.read(cx).is_dirty(cx)
+    }
+
+    fn has_deleted_file(&self, cx: &AppContext) -> bool {
+        self.read(cx).has_deleted_file(cx)
     }
 
     fn has_conflict(&self, cx: &AppContext) -> bool {


### PR DESCRIPTION
* `has_conflict` will now return true if the file has been deleted on
disk.  This is for treating multi-buffers as conflicted, and also
blocks auto-save.

* `has_deleted_file` is added so that the single-file buffer save can
specifically mention the delete conflict. This does not yet handle
discard (#20745).

Closes #9101
Closes #9568
Closes #20462

Release Notes:

- Improved handling of externally deleted files: auto-save will be disabled, multibuffers will treat this as a save conflict, and single buffers will ask for restore confirmation.