### PR TITLE
theme: Add color `darken` function

### DIFF
--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -484,14 +484,6 @@ impl Hsla {
             a: self.a * factor.clamp(0., 1.),
         }
     }
-
-    /// Darkens the color by reducing its lightness.
-    /// The resulting lightness is clamped to ensure it doesn't go below 0.0.
-    pub fn darken(&self, amount: f32) -> Self {
-        let mut hsla = *self;
-        hsla.l = (hsla.l - amount).max(0.0);
-        hsla
-    }
 }
 
 impl From<Rgba> for Hsla {

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -484,6 +484,14 @@ impl Hsla {
             a: self.a * factor.clamp(0., 1.),
         }
     }
+
+    /// Darkens the color by reducing its lightness.
+    /// The resulting lightness is clamped to ensure it doesn't go below 0.0.
+    pub fn darken(&self, amount: f32) -> Self {
+        let mut hsla = *self;
+        hsla.l = (hsla.l - amount).max(0.0);
+        hsla
+    }
 }
 
 impl From<Rgba> for Hsla {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -319,8 +319,7 @@ impl Theme {
     /// Darkens the color by reducing its lightness.
     /// The resulting lightness is clamped to ensure it doesn't go below 0.0.
     ///
-    /// The first value corresponds to how much to darken it in light appearance mode,
-    /// whereas the second is the oppposite.
+    /// The first value darkens light appearance mode, the second darkens appearance dark mode.
     ///
     /// Note: This is a tentative solution and may be replaced with a more robust color system.
     pub fn darken(&self, color: Hsla, light_amount: f32, dark_amount: f32) -> Hsla {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -315,6 +315,23 @@ impl Theme {
     pub fn window_background_appearance(&self) -> WindowBackgroundAppearance {
         self.styles.window_background_appearance
     }
+
+    /// Darkens the color by reducing its lightness.
+    /// The resulting lightness is clamped to ensure it doesn't go below 0.0.
+    ///
+    /// The first value corresponds to how much to darken it in light appearance mode,
+    /// whereas the second is the oppposite.
+    ///
+    /// Note: This is a tentative solution and may be replaced with a more robust color system.
+    pub fn darken(&self, color: Hsla, light_amount: f32, dark_amount: f32) -> Hsla {
+        let amount = match self.appearance {
+            Appearance::Light => light_amount,
+            Appearance::Dark => dark_amount,
+        };
+        let mut hsla = color;
+        hsla.l = (hsla.l - amount).max(0.0);
+        hsla
+    }
 }
 
 /// Compounds a color with an alpha value.

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -202,7 +202,11 @@ impl ButtonStyle {
                     icon_color: Color::Default.color(cx),
                 }
             }
-            ButtonStyle::Tinted(tint) => tint.button_like_style(cx),
+            ButtonStyle::Tinted(tint) => {
+                let mut styles = tint.button_like_style(cx);
+                styles.background = styles.background.darken(0.2);
+                styles
+            }
             ButtonStyle::Subtle => ButtonLikeStyles {
                 background: cx.theme().colors().ghost_element_hover,
                 border_color: transparent_black(),

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -2,6 +2,7 @@
 use gpui::{relative, CursorStyle, DefiniteLength, MouseButton};
 use gpui::{transparent_black, AnyElement, AnyView, ClickEvent, Hsla, Rems};
 use smallvec::SmallVec;
+use theme::Theme;
 
 use crate::{prelude::*, DynamicSpacing, ElevationIndex};
 
@@ -204,7 +205,8 @@ impl ButtonStyle {
             }
             ButtonStyle::Tinted(tint) => {
                 let mut styles = tint.button_like_style(cx);
-                styles.background = styles.background.darken(0.2);
+                let theme = cx.theme();
+                styles.background = theme.darken(styles.background, 0.05, 0.2);
                 styles
             }
             ButtonStyle::Subtle => ButtonLikeStyles {

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -2,7 +2,6 @@
 use gpui::{relative, CursorStyle, DefiniteLength, MouseButton};
 use gpui::{transparent_black, AnyElement, AnyView, ClickEvent, Hsla, Rems};
 use smallvec::SmallVec;
-use theme::Theme;
 
 use crate::{prelude::*, DynamicSpacing, ElevationIndex};
 


### PR DESCRIPTION
This PR adds a `darken` function that allows to reduce the lightness of a color by a certain factor. This popped up as I wanted to add hover styles to tinted-colors buttons.

Release Notes:

- N/A
