### PR TITLE
Allow overrides for json-language-server settings

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -148,6 +148,12 @@ pub fn merge_json_value_into(source: serde_json::Value, target: &mut serde_json:
             }
         }
 
+        (Value::Array(source), Value::Array(target)) => {
+            for value in source {
+                target.push(value);
+            }
+        }
+
         (source, target) => *target = source,
     }
 }


### PR DESCRIPTION
Closes #20739

The JSON LSP adapter now merges user settings with cached settings, and util::merge_json_value_into pushes array contents from source to target.

Release Notes:

- Added json-language-server configuration via settings