### PR TITLE
ssh: Use openbsd nc on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9655,6 +9655,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "util",
+ "which 6.0.3",
 ]
 
 [[package]]

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -38,6 +38,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 util.workspace = true
 release_channel.workspace = true
+which.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/20604

Release Notes:

- ssh: Fixed accidentally using GNU netcat instead of nc provided by macos 
