### PR TITLE
Fix tab strikethrough logic

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -635,12 +635,13 @@ impl Item for Editor {
             Some(util::truncate_and_trailoff(description, MAX_TAB_TITLE_LEN))
         });
 
-        let is_deleted: bool = self
+        // Whether the file was saved in the past but is now deleted.
+        let was_deleted: bool = self
             .buffer()
             .read(cx)
             .as_singleton()
             .and_then(|buffer| buffer.read(cx).file())
-            .map_or(true, |file| file.is_deleted());
+            .map_or(false, |file| file.is_deleted() && file.is_created());
 
         h_flex()
             .gap_2()
@@ -648,7 +649,7 @@ impl Item for Editor {
                 Label::new(self.title(cx).to_string())
                     .color(label_color)
                     .italic(params.preview)
-                    .strikethrough(is_deleted),
+                    .strikethrough(was_deleted),
             )
             .when_some(description, |this, description| {
                 this.child(


### PR DESCRIPTION
This fix was in downstream commits before splitting out #20711, should have tested locally before merging.

Release Notes:

- N/A