### PR TITLE
 python: Highlight attribute docstrings

### DIFF
--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -8,6 +8,7 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
+    { start = "\"\"\"", end = "\"\"\"", close = true, newline = false, not_in = ["string"] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
 ]

--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -8,7 +8,6 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "\"\"\"", end = "\"\"\"", close = true, newline = false, not_in = ["string"] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
 ]

--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -86,6 +86,25 @@
   (parameters)?
   body: (block (expression_statement (string) @string.doc)))
 
+(module
+  (expression_statement (assignment))
+  . (expression_statement (string) @string.doc))
+
+(class_definition
+  body: (block
+    (expression_statement (assignment))
+    . (expression_statement (string) @string.doc)))
+
+(class_definition
+  body: (block
+    (function_definition
+      name: (identifier) @function.method.constructor
+      (#match? @function.method.constructor "__init__")
+      body: (block
+        (expression_statement (assignment))
+        . (expression_statement (string) @string.doc)))))
+
+
 [
   "-"
   "-="

--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -99,7 +99,7 @@
   body: (block
     (function_definition
       name: (identifier) @function.method.constructor
-      (#match? @function.method.constructor "__init__")
+      (#eq? @function.method.constructor "__init__")
       body: (block
         (expression_statement (assignment))
         . (expression_statement (string) @string.doc)))))


### PR DESCRIPTION
Adds more docstring highlights missing from #20486.
[PEP257](https://peps.python.org/pep-0257/) defines attribute docstrings as
> String literals occurring immediately after a simple assignment at the top level of a module, class, or __init__ method are called “attribute docstrings”.

This PR adds `@string.doc` for such cases.
Before:
![Screenshot_20241116_162257](https://github.com/user-attachments/assets/6b471cff-717e-4755-9291-d596da927dc6)
After:
![Screenshot_20241116_162457](https://github.com/user-attachments/assets/96674157-9c86-45b6-8ce9-e433ca0ae8ea)

Release Notes:

- Added Python syntax highlighting for attribute docstrings.
