### PR TITLE
python: Fix highlighting for forward references

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -10,6 +10,12 @@
   (tuple (identifier) @type)
 )
 
+; Forward references
+(type
+  (string) @type
+)
+
+
 ; Function calls
 
 (decorator) @function


### PR DESCRIPTION
[PEP484](https://peps.python.org/pep-0484/) defines "Forward references" for undefined types. This PR treats such annotations as types rather than strings.
Release Notes:

- Added Python syntax highlighting for forward references.