### PR TITLE
nix: Fix language defaults to match RFC 166

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -990,6 +990,11 @@
         "allowed": true
       }
     },
+    "Nix": {
+      "hard_tabs": false,
+      "tab_size": 2,
+      "preferred_line_length": 100
+    },
     "PHP": {
       "language_servers": ["phpactor", "!intelephense", "..."],
       "prettier": {


### PR DESCRIPTION
Closes https://github.com/zed-extensions/nix/issues/11

Release Notes:

- Fixed Nix language defaults to match RFC 166
