### PR TITLE
gpui: Add linear gradient support to fill background

### DIFF
--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -14,6 +14,8 @@ impl Render for GradientViewer {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
         let red = gpui::hsla(0., 1., 0.5, 1.);
         let blue = gpui::hsla(240. / 360., 1., 0.5, 1.);
+        let green = gpui::hsla(120. / 360., 1., 0.25, 1.);
+        let yellow = gpui::hsla(60. / 360., 1., 0.5, 1.);
 
         div()
             .font_family(".SystemUIFont")
@@ -62,29 +64,29 @@ impl Render for GradientViewer {
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         45.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     )))
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         135.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     )))
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         225.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     )))
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         315.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     ))),
             )
@@ -97,37 +99,37 @@ impl Render for GradientViewer {
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         0.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     )))
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         90.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     )))
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         180.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     )))
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         360.,
                         [
-                            BackgroundColorStop::new(0., red),
-                            BackgroundColorStop::new(1., blue),
+                            BackgroundColorStop::new(red, 0.),
+                            BackgroundColorStop::new(blue, 1.),
                         ],
                     ))),
             )
             .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                 180.,
                 [
-                    BackgroundColorStop::new(0., gpui::black()),
-                    BackgroundColorStop::new(1., gpui::white()),
+                    BackgroundColorStop::new(gpui::black(), 0.2),
+                    BackgroundColorStop::new(gpui::white(), 1.),
                 ],
             )))
             .child(
@@ -141,18 +143,18 @@ impl Render for GradientViewer {
                             .flex_1()
                             .gap_3()
                             .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
-                                0.,
+                                90.,
                                 [
-                                    BackgroundColorStop::new(0.3, blue),
-                                    BackgroundColorStop::new(0.7, gpui::green()),
+                                    BackgroundColorStop::new(blue, 0.5),
+                                    BackgroundColorStop::new(green, 0.5),
                                 ],
                             ))),
                     )
                     .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         180.,
                         [
-                            BackgroundColorStop::new(0.25, gpui::red()),
-                            BackgroundColorStop::new(0.8, gpui::green()),
+                            BackgroundColorStop::new(red, 0.25),
+                            BackgroundColorStop::new(yellow, 0.8),
                         ],
                     ))),
             )

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -12,8 +12,8 @@ impl GradientViewer {
 
 impl Render for GradientViewer {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let red = gpui::red();
-        let blue = gpui::blue();
+        let red = gpui::hsla(0., 1., 0.5, 1.);
+        let blue = gpui::hsla(240. / 360., 1., 0.5, 1.);
 
         div()
             .font_family(".SystemUIFont")
@@ -24,29 +24,34 @@ impl Render for GradientViewer {
             .flex_col()
             .gap_3()
             .child(
-div().flex().flex_1().gap_3().child(
-    div()
-        .h_24()
-        .w_full()
-        .rounded_lg()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(blue)
-        .text_color(gpui::white())
-        .child("Solid Color"),
-).child(
-    div()
-        .h_24()
-        .w_full()
-        .rounded_lg()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(red)
-        .text_color(gpui::white())
-        .child("Solid Color"),
-)
+                div()
+                    .flex()
+                    .flex_1()
+                    .gap_3()
+                    .child(
+                        div()
+                            .h_24()
+                            .w_full()
+                            .rounded_xl()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(blue)
+                            .text_color(gpui::white())
+                            .child("Solid Color"),
+                    )
+                    .child(
+                        div()
+                            .h_24()
+                            .w_full()
+                            .rounded_xl()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(red)
+                            .text_color(gpui::white())
+                            .child("Solid Color"),
+                    ),
             )
             .child(
                 div()
@@ -54,28 +59,28 @@ div().flex().flex_1().gap_3().child(
                     .flex_1()
                     .gap_3()
                     .h_24()
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         45.,
                         [
                             BackgroundColorStop::new(0., red),
                             BackgroundColorStop::new(1., blue),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         135.,
                         [
                             BackgroundColorStop::new(0., red),
                             BackgroundColorStop::new(1., blue),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         225.,
                         [
                             BackgroundColorStop::new(0., red),
                             BackgroundColorStop::new(1., blue),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         315.,
                         [
                             BackgroundColorStop::new(0., red),
@@ -89,28 +94,28 @@ div().flex().flex_1().gap_3().child(
                     .flex_1()
                     .gap_3()
                     .h_24()
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         0.,
                         [
                             BackgroundColorStop::new(0., red),
                             BackgroundColorStop::new(1., blue),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         90.,
                         [
                             BackgroundColorStop::new(0., red),
                             BackgroundColorStop::new(1., blue),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         180.,
                         [
                             BackgroundColorStop::new(0., red),
                             BackgroundColorStop::new(1., blue),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                         360.,
                         [
                             BackgroundColorStop::new(0., red),
@@ -118,11 +123,11 @@ div().flex().flex_1().gap_3().child(
                         ],
                     ))),
             )
-            .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+            .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                 180.,
                 [
-                    BackgroundColorStop::new(0., gpui::green()),
-                    BackgroundColorStop::new(1., gpui::yellow()),
+                    BackgroundColorStop::new(0., gpui::black()),
+                    BackgroundColorStop::new(1., gpui::white()),
                 ],
             )))
             .child(
@@ -131,27 +136,25 @@ div().flex().flex_1().gap_3().child(
                     .flex_1()
                     .gap_3()
                     .child(
-                        div().flex().flex_1().gap_3().child(
-                            div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                        div()
+                            .flex()
+                            .flex_1()
+                            .gap_3()
+                            .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
                                 0.,
                                 [
-                                    BackgroundColorStop::new(0.5, blue),
-                                    BackgroundColorStop::new(1., gpui::green()),
+                                    BackgroundColorStop::new(0.3, blue),
+                                    BackgroundColorStop::new(0.7, gpui::green()),
                                 ],
-                            )
-                            .opacity(0.8)),
-                        ),
+                            ))),
                     )
-                    .child(
-                        div().flex_1().rounded_lg().bg(Background::linear_gradient(
-                            180.,
-                            [
-                                BackgroundColorStop::new(0.25, gpui::yellow()),
-                                BackgroundColorStop::new(0.8, gpui::green()),
-                            ],
-                        )
-                        .opacity(0.8)),
-                    ),
+                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                        180.,
+                        [
+                            BackgroundColorStop::new(0.25, gpui::red()),
+                            BackgroundColorStop::new(0.8, gpui::green()),
+                        ],
+                    ))),
             )
     }
 }

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -38,40 +38,75 @@ impl Render for GradientViewer {
                     .flex_1()
                     .gap_3()
                     .h_24()
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
                         45.,
                         [
-                            BackgroundColorStop::new(0.5, gpui::green()),
-                            BackgroundColorStop::new(1., gpui::yellow()),
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
                         135.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::yellow()),
+                            BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
-                        -135.,
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                        225.,
                         [
-                            BackgroundColorStop::new(0.0, gpui::black()),
-                            BackgroundColorStop::new(1., gpui::red()),
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
-                        -45.,
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                        315.,
                         [
-                            BackgroundColorStop::new(0.0, gpui::yellow()),
-                            BackgroundColorStop::new(0.9, gpui::green()),
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::blue()),
+                        ],
+                    ))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_1()
+                    .gap_3()
+                    .h_24()
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                        0.,
+                        [
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::blue()),
+                        ],
+                    )))
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                        90.,
+                        [
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::blue()),
+                        ],
+                    )))
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                        180.,
+                        [
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::blue()),
+                        ],
+                    )))
+                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                        360.,
+                        [
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     ))),
             )
             .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
-                90.,
+                180.,
                 [
-                    BackgroundColorStop::new(0., gpui::black().opacity(0.3)),
-                    BackgroundColorStop::new(1., gpui::black().opacity(0.8)),
+                    BackgroundColorStop::new(0., gpui::green()),
+                    BackgroundColorStop::new(1., gpui::yellow()),
                 ],
             )))
             .child(

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -38,28 +38,28 @@ impl Render for GradientViewer {
                     .flex_1()
                     .gap_3()
                     .h_24()
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         45.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
                             BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         135.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
                             BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         225.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
                             BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         315.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
@@ -73,28 +73,28 @@ impl Render for GradientViewer {
                     .flex_1()
                     .gap_3()
                     .h_24()
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         0.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
                             BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         90.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
                             BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         180.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),
                             BackgroundColorStop::new(1., gpui::blue()),
                         ],
                     )))
-                    .child(div().size_24().rounded_lg().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         360.,
                         [
                             BackgroundColorStop::new(0., gpui::red()),

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -29,8 +29,8 @@ impl Render for GradientViewer {
         let color3 = Background::linear_gradient(
             0.,
             [
-                BackgroundColorStop::new(0.0, gpui::blue()),
-                BackgroundColorStop::new(0.15, gpui::green()),
+                BackgroundColorStop::new(0.0, gpui::green()),
+                BackgroundColorStop::new(0.15, gpui::yellow()),
             ],
         );
 

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    div, prelude::*, App, AppContext, Background, BackgroundColorStop, Render, ViewContext,
+    div, linear_color_stop, linear_gradient, prelude::*, App, AppContext, Render, ViewContext,
     WindowOptions,
 };
 struct GradientViewer {}
@@ -32,8 +32,7 @@ impl Render for GradientViewer {
                     .gap_3()
                     .child(
                         div()
-                            .h_24()
-                            .w_full()
+                            .size_full()
                             .rounded_xl()
                             .flex()
                             .items_center()
@@ -44,8 +43,7 @@ impl Render for GradientViewer {
                     )
                     .child(
                         div()
-                            .h_24()
-                            .w_full()
+                            .size_full()
                             .rounded_xl()
                             .flex()
                             .items_center()
@@ -61,33 +59,25 @@ impl Render for GradientViewer {
                     .flex_1()
                     .gap_3()
                     .h_24()
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         45.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     )))
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         135.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     )))
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         225.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     )))
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         315.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     ))),
             )
             .child(
@@ -96,41 +86,31 @@ impl Render for GradientViewer {
                     .flex_1()
                     .gap_3()
                     .h_24()
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         0.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     )))
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         90.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     )))
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         180.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     )))
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         360.,
-                        [
-                            BackgroundColorStop::new(red, 0.),
-                            BackgroundColorStop::new(blue, 1.),
-                        ],
+                        linear_color_stop(red, 0.),
+                        linear_color_stop(blue, 1.),
                     ))),
             )
-            .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+            .child(div().flex_1().rounded_xl().bg(linear_gradient(
                 180.,
-                [
-                    BackgroundColorStop::new(gpui::black(), 0.2),
-                    BackgroundColorStop::new(gpui::white(), 1.),
-                ],
+                linear_color_stop(gpui::black(), 0.2),
+                linear_color_stop(gpui::white(), 1.),
             )))
             .child(
                 div()
@@ -142,20 +122,16 @@ impl Render for GradientViewer {
                             .flex()
                             .flex_1()
                             .gap_3()
-                            .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                            .child(div().flex_1().rounded_xl().bg(linear_gradient(
                                 90.,
-                                [
-                                    BackgroundColorStop::new(blue, 0.5),
-                                    BackgroundColorStop::new(green, 0.5),
-                                ],
+                                linear_color_stop(blue, 0.5),
+                                linear_color_stop(green, 0.5),
                             ))),
                     )
-                    .child(div().flex_1().rounded_xl().bg(Background::linear_gradient(
+                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         180.,
-                        [
-                            BackgroundColorStop::new(red, 0.25),
-                            BackgroundColorStop::new(yellow, 0.8),
-                        ],
+                        linear_color_stop(red, 0.25),
+                        linear_color_stop(yellow, 0.8),
                     ))),
             )
     }

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -1,0 +1,63 @@
+use gpui::{
+    div, prelude::*, App, AppContext, Background, BackgroundColorStop, Render, ViewContext,
+    WindowOptions,
+};
+struct GradientViewer {}
+
+impl GradientViewer {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Render for GradientViewer {
+    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let color1 = Background::linear_gradient(
+            0.,
+            [
+                BackgroundColorStop::new(0.5, gpui::yellow()),
+                BackgroundColorStop::new(1., gpui::red()),
+            ],
+        );
+        let color2 = Background::linear_gradient(
+            90.,
+            [
+                BackgroundColorStop::new(0.5, gpui::blue()),
+                BackgroundColorStop::new(0.8, gpui::green()),
+            ],
+        );
+        let color3 = Background::linear_gradient(
+            0.,
+            [
+                BackgroundColorStop::new(0.0, gpui::blue()),
+                BackgroundColorStop::new(0.15, gpui::green()),
+            ],
+        );
+
+        div()
+            .font_family(".SystemUIFont")
+            .bg(gpui::white())
+            .size_full()
+            .p_4()
+            .flex()
+            .gap_3()
+            .child(div().size_32().rounded_lg().bg(gpui::blue()))
+            .child(div().size_32().rounded_lg().bg(color1))
+            .child(div().size_32().rounded_lg().bg(color2))
+            .child(div().size_32().rounded_lg().bg(color3))
+    }
+}
+
+fn main() {
+    App::new().run(|cx: &mut AppContext| {
+        cx.open_window(
+            WindowOptions {
+                focus: true,
+                ..Default::default()
+            },
+            |cx| cx.new_view(|_| GradientViewer::new()),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    div, linear_color_stop, linear_gradient, prelude::*, App, AppContext, Render, ViewContext,
-    WindowOptions,
+    canvas, div, linear_color_stop, linear_gradient, point, prelude::*, px, size, App, AppContext,
+    Bounds, Half, Render, ViewContext, WindowOptions,
 };
 struct GradientViewer {}
 
@@ -134,6 +134,37 @@ impl Render for GradientViewer {
                         linear_color_stop(yellow, 0.5),
                     ))),
             )
+            .child(div().h_24().child(canvas(
+                move |_, _| {},
+                move |bounds, _, cx| {
+                    let size = size(bounds.size.width * 0.8, px(80.));
+                    let square_bounds = Bounds {
+                        origin: point(
+                            bounds.size.width.half() - size.width.half(),
+                            bounds.origin.y,
+                        ),
+                        size,
+                    };
+                    let height = square_bounds.size.height;
+                    let horizontal_offset = height;
+                    let vertical_offset = px(30.);
+                    let mut path = gpui::Path::new(square_bounds.lower_left());
+                    path.line_to(square_bounds.origin + point(horizontal_offset, vertical_offset));
+                    path.line_to(
+                        square_bounds.upper_right() + point(-horizontal_offset, vertical_offset),
+                    );
+                    path.line_to(square_bounds.lower_right());
+                    path.line_to(square_bounds.lower_left());
+                    cx.paint_path(
+                        path,
+                        linear_gradient(
+                            180.,
+                            linear_color_stop(red, 0.),
+                            linear_color_stop(blue, 1.),
+                        ),
+                    );
+                },
+            )))
     }
 }
 

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -12,39 +12,96 @@ impl GradientViewer {
 
 impl Render for GradientViewer {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let color1 = Background::linear_gradient(
-            0.,
-            [
-                BackgroundColorStop::new(0.5, gpui::yellow()),
-                BackgroundColorStop::new(1., gpui::red()),
-            ],
-        );
-        let color2 = Background::linear_gradient(
-            90.,
-            [
-                BackgroundColorStop::new(0.5, gpui::blue()),
-                BackgroundColorStop::new(0.8, gpui::green()),
-            ],
-        );
-        let color3 = Background::linear_gradient(
-            0.,
-            [
-                BackgroundColorStop::new(0.0, gpui::green()),
-                BackgroundColorStop::new(0.15, gpui::yellow()),
-            ],
-        );
-
         div()
             .font_family(".SystemUIFont")
             .bg(gpui::white())
             .size_full()
             .p_4()
             .flex()
+            .flex_col()
             .gap_3()
-            .child(div().size_32().rounded_lg().bg(gpui::blue()))
-            .child(div().size_32().rounded_lg().bg(color1))
-            .child(div().size_32().rounded_lg().bg(color2))
-            .child(div().size_32().rounded_lg().bg(color3))
+            .child(
+                div()
+                    .h_24()
+                    .w_full()
+                    .rounded_lg()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .bg(gpui::blue())
+                    .text_color(gpui::white())
+                    .child("Solid Color"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_1()
+                    .gap_3()
+                    .h_24()
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                        45.,
+                        [
+                            BackgroundColorStop::new(0.5, gpui::green()),
+                            BackgroundColorStop::new(1., gpui::yellow()),
+                        ],
+                    )))
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                        135.,
+                        [
+                            BackgroundColorStop::new(0., gpui::red()),
+                            BackgroundColorStop::new(1., gpui::yellow()),
+                        ],
+                    )))
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                        -135.,
+                        [
+                            BackgroundColorStop::new(0.0, gpui::black()),
+                            BackgroundColorStop::new(1., gpui::red()),
+                        ],
+                    )))
+                    .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                        -45.,
+                        [
+                            BackgroundColorStop::new(0.0, gpui::yellow()),
+                            BackgroundColorStop::new(0.9, gpui::green()),
+                        ],
+                    ))),
+            )
+            .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                90.,
+                [
+                    BackgroundColorStop::new(0., gpui::black().opacity(0.3)),
+                    BackgroundColorStop::new(1., gpui::black().opacity(0.8)),
+                ],
+            )))
+            .child(
+                div()
+                    .flex()
+                    .flex_1()
+                    .gap_3()
+                    .child(
+                        div().flex().flex_1().gap_3().child(
+                            div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                                0.,
+                                [
+                                    BackgroundColorStop::new(0.5, gpui::blue()),
+                                    BackgroundColorStop::new(1., gpui::green()),
+                                ],
+                            )
+                            .opacity(0.8)),
+                        ),
+                    )
+                    .child(
+                        div().flex_1().rounded_lg().bg(Background::linear_gradient(
+                            180.,
+                            [
+                                BackgroundColorStop::new(0.25, gpui::yellow()),
+                                BackgroundColorStop::new(0.8, gpui::green()),
+                            ],
+                        )
+                        .opacity(0.8)),
+                    ),
+            )
     }
 }
 

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -108,9 +108,9 @@ impl Render for GradientViewer {
                     ))),
             )
             .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                180.,
-                linear_color_stop(gpui::black(), 0.2),
-                linear_color_stop(gpui::white(), 1.),
+                0.,
+                linear_color_stop(green, 0.05),
+                linear_color_stop(yellow, 0.95),
             )))
             .child(
                 div()
@@ -125,13 +125,13 @@ impl Render for GradientViewer {
                             .child(div().flex_1().rounded_xl().bg(linear_gradient(
                                 90.,
                                 linear_color_stop(blue, 0.5),
-                                linear_color_stop(green, 0.5),
+                                linear_color_stop(red, 0.5),
                             ))),
                     )
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         180.,
-                        linear_color_stop(red, 0.25),
-                        linear_color_stop(yellow, 0.8),
+                        linear_color_stop(green, 0.),
+                        linear_color_stop(yellow, 0.5),
                     ))),
             )
     }

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -12,6 +12,9 @@ impl GradientViewer {
 
 impl Render for GradientViewer {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let red = gpui::red();
+        let blue = gpui::blue();
+
         div()
             .font_family(".SystemUIFont")
             .bg(gpui::white())
@@ -21,16 +24,29 @@ impl Render for GradientViewer {
             .flex_col()
             .gap_3()
             .child(
-                div()
-                    .h_24()
-                    .w_full()
-                    .rounded_lg()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .bg(gpui::blue())
-                    .text_color(gpui::white())
-                    .child("Solid Color"),
+div().flex().flex_1().gap_3().child(
+    div()
+        .h_24()
+        .w_full()
+        .rounded_lg()
+        .flex()
+        .items_center()
+        .justify_center()
+        .bg(blue)
+        .text_color(gpui::white())
+        .child("Solid Color"),
+).child(
+    div()
+        .h_24()
+        .w_full()
+        .rounded_lg()
+        .flex()
+        .items_center()
+        .justify_center()
+        .bg(red)
+        .text_color(gpui::white())
+        .child("Solid Color"),
+)
             )
             .child(
                 div()
@@ -41,29 +57,29 @@ impl Render for GradientViewer {
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         45.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     )))
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         135.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     )))
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         225.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     )))
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         315.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     ))),
             )
@@ -76,29 +92,29 @@ impl Render for GradientViewer {
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         0.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     )))
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         90.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     )))
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         180.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     )))
                     .child(div().flex_1().rounded_lg().bg(Background::linear_gradient(
                         360.,
                         [
-                            BackgroundColorStop::new(0., gpui::red()),
-                            BackgroundColorStop::new(1., gpui::blue()),
+                            BackgroundColorStop::new(0., red),
+                            BackgroundColorStop::new(1., blue),
                         ],
                     ))),
             )
@@ -119,7 +135,7 @@ impl Render for GradientViewer {
                             div().flex_1().rounded_lg().bg(Background::linear_gradient(
                                 0.,
                                 [
-                                    BackgroundColorStop::new(0.5, gpui::blue()),
+                                    BackgroundColorStop::new(0.5, blue),
                                     BackgroundColorStop::new(1., gpui::green()),
                                 ],
                             )

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -1,36 +1,45 @@
 use gpui::{
     canvas, div, linear_color_stop, linear_gradient, point, prelude::*, px, size, App, AppContext,
-    Bounds, Half, Hsla, Render, ViewContext, WindowOptions,
+    Bounds, ColorInterpolationMethod, Half, Hsla, Render, ViewContext, WindowOptions,
 };
 
-const COLORS: [(Hsla, Hsla); 12] = [
+const COLORS: [(Hsla, Hsla); 16] = [
     (gpui::red(), gpui::blue()),
     (gpui::red(), gpui::green()),
     (gpui::red(), gpui::yellow()),
+    (gpui::red(), gpui::white()),
     (gpui::blue(), gpui::red()),
     (gpui::blue(), gpui::green()),
     (gpui::blue(), gpui::yellow()),
+    (gpui::blue(), gpui::white()),
     (gpui::green(), gpui::red()),
     (gpui::green(), gpui::blue()),
     (gpui::green(), gpui::yellow()),
+    (gpui::green(), gpui::white()),
     (gpui::yellow(), gpui::red()),
     (gpui::yellow(), gpui::blue()),
     (gpui::yellow(), gpui::green()),
+    (gpui::yellow(), gpui::white()),
 ];
 
 struct GradientViewer {
     color_ix: usize,
+    interpolation_method: ColorInterpolationMethod,
 }
 
 impl GradientViewer {
     fn new() -> Self {
-        Self { color_ix: 0 }
+        Self {
+            color_ix: 0,
+            interpolation_method: ColorInterpolationMethod::Oklab,
+        }
     }
 }
 
 impl Render for GradientViewer {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let (color0, color1) = COLORS[self.color_ix];
+        let method = self.interpolation_method;
 
         div()
             .font_family(".SystemUIFont")
@@ -49,19 +58,49 @@ impl Render for GradientViewer {
                     .child("Gradient Examples")
                     .child(
                         div()
-                            .id("next")
                             .flex()
-                            .px_3()
-                            .py_1()
-                            .text_sm()
-                            .bg(gpui::black())
-                            .text_color(gpui::white())
-                            .child("Switch Color")
-                            .active(|this| this.opacity(0.8))
-                            .on_click(cx.listener(move |this, _, cx| {
-                                this.color_ix = (this.color_ix + 1) % COLORS.len();
-                                cx.notify();
-                            })),
+                            .gap_2()
+                            .items_center()
+                            .child(
+                                div()
+                                    .id("method")
+                                    .flex()
+                                    .px_3()
+                                    .py_1()
+                                    .text_sm()
+                                    .bg(gpui::black())
+                                    .text_color(gpui::white())
+                                    .child(format!("{:?}", method))
+                                    .active(|this| this.opacity(0.8))
+                                    .on_click(cx.listener(move |this, _, cx| {
+                                        this.interpolation_method = match this.interpolation_method
+                                        {
+                                            ColorInterpolationMethod::Oklab => {
+                                                ColorInterpolationMethod::SrgbLinear
+                                            }
+                                            ColorInterpolationMethod::SrgbLinear => {
+                                                ColorInterpolationMethod::Oklab
+                                            }
+                                        };
+                                        cx.notify();
+                                    })),
+                            )
+                            .child(
+                                div()
+                                    .id("next")
+                                    .flex()
+                                    .px_3()
+                                    .py_1()
+                                    .text_sm()
+                                    .bg(gpui::black())
+                                    .text_color(gpui::white())
+                                    .child("Switch Color")
+                                    .active(|this| this.opacity(0.8))
+                                    .on_click(cx.listener(move |this, _, cx| {
+                                        this.color_ix = (this.color_ix + 1) % COLORS.len();
+                                        cx.notify();
+                                    })),
+                            ),
                     ),
             )
             .child(
@@ -104,21 +143,30 @@ impl Render for GradientViewer {
                         linear_color_stop(color0, 0.),
                         linear_color_stop(color1, 1.),
                     )))
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        135.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    )))
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        225.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    )))
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        315.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    ))),
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            135.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .interpolation_method(method)),
+                    )
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            225.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .interpolation_method(method)),
+                    )
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            315.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .interpolation_method(method)),
+                    ),
             )
             .child(
                 div()
@@ -127,58 +175,78 @@ impl Render for GradientViewer {
                     .gap_3()
                     .h_24()
                     .text_color(gpui::white())
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        0.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    )))
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        90.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    )))
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        180.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    )))
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        360.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    ))),
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            0.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .interpolation_method(method)),
+                    )
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            90.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .interpolation_method(method)),
+                    )
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            180.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .interpolation_method(method)),
+                    )
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            360.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .interpolation_method(method)),
+                    ),
             )
-            .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                0.,
-                linear_color_stop(color0, 0.05),
-                linear_color_stop(color1, 0.95),
-            )))
-            .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                90.,
-                linear_color_stop(color0, 0.05),
-                linear_color_stop(color1, 0.95),
-            )))
+            .child(
+                div().flex_1().rounded_xl().bg(linear_gradient(
+                    0.,
+                    linear_color_stop(color0, 0.05),
+                    linear_color_stop(color1, 0.95),
+                )
+                .interpolation_method(method)),
+            )
+            .child(
+                div().flex_1().rounded_xl().bg(linear_gradient(
+                    90.,
+                    linear_color_stop(color0, 0.05),
+                    linear_color_stop(color1, 0.95),
+                )
+                .interpolation_method(method)),
+            )
             .child(
                 div()
                     .flex()
                     .flex_1()
                     .gap_3()
                     .child(
-                        div()
-                            .flex()
-                            .flex_1()
-                            .gap_3()
-                            .child(div().flex_1().rounded_xl().bg(linear_gradient(
+                        div().flex().flex_1().gap_3().child(
+                            div().flex_1().rounded_xl().bg(linear_gradient(
                                 90.,
                                 linear_color_stop(color0, 0.5),
                                 linear_color_stop(color1, 0.5),
-                            ))),
+                            )
+                            .interpolation_method(method)),
+                        ),
                     )
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        180.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 0.5),
-                    ))),
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            180.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 0.5),
+                        )
+                        .interpolation_method(method)),
+                    ),
             )
             .child(div().h_24().child(canvas(
                 move |_, _| {},
@@ -207,7 +275,8 @@ impl Render for GradientViewer {
                             180.,
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
-                        ),
+                        )
+                        .interpolation_method(method),
                     );
                 },
             )))

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -1,17 +1,37 @@
 use gpui::{
     canvas, div, linear_color_stop, linear_gradient, point, prelude::*, px, size, App, AppContext,
-    Bounds, Half, Render, ViewContext, WindowOptions,
+    Bounds, Half, Hsla, Render, ViewContext, WindowOptions,
 };
-struct GradientViewer {}
+
+const COLORS: [(Hsla, Hsla); 12] = [
+    (gpui::red(), gpui::blue()),
+    (gpui::red(), gpui::green()),
+    (gpui::red(), gpui::yellow()),
+    (gpui::blue(), gpui::red()),
+    (gpui::blue(), gpui::green()),
+    (gpui::blue(), gpui::yellow()),
+    (gpui::green(), gpui::red()),
+    (gpui::green(), gpui::blue()),
+    (gpui::green(), gpui::yellow()),
+    (gpui::yellow(), gpui::red()),
+    (gpui::yellow(), gpui::blue()),
+    (gpui::yellow(), gpui::green()),
+];
+
+struct GradientViewer {
+    color_ix: usize,
+}
 
 impl GradientViewer {
     fn new() -> Self {
-        Self {}
+        Self { color_ix: 0 }
     }
 }
 
 impl Render for GradientViewer {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let (color0, color1) = COLORS[self.color_ix];
+
         div()
             .font_family(".SystemUIFont")
             .bg(gpui::white())
@@ -23,6 +43,30 @@ impl Render for GradientViewer {
             .child(
                 div()
                     .flex()
+                    .gap_2()
+                    .justify_between()
+                    .items_center()
+                    .child("Gradient Examples")
+                    .child(
+                        div()
+                            .id("next")
+                            .flex()
+                            .px_3()
+                            .py_1()
+                            .text_sm()
+                            .bg(gpui::black())
+                            .text_color(gpui::white())
+                            .child("Switch Color")
+                            .active(|this| this.opacity(0.8))
+                            .on_click(cx.listener(move |this, _, cx| {
+                                this.color_ix = (this.color_ix + 1) % COLORS.len();
+                                cx.notify();
+                            })),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
                     .flex_1()
                     .gap_3()
                     .child(
@@ -32,7 +76,7 @@ impl Render for GradientViewer {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .bg(gpui::blue())
+                            .bg(color0)
                             .text_color(gpui::white())
                             .child("Solid Color"),
                     )
@@ -43,7 +87,7 @@ impl Render for GradientViewer {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .bg(gpui::red())
+                            .bg(color1)
                             .text_color(gpui::white())
                             .child("Solid Color"),
                     ),
@@ -54,25 +98,26 @@ impl Render for GradientViewer {
                     .flex_1()
                     .gap_3()
                     .h_24()
+                    .text_color(gpui::white())
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         45.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         135.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         225.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         315.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     ))),
             )
             .child(
@@ -81,31 +126,37 @@ impl Render for GradientViewer {
                     .flex_1()
                     .gap_3()
                     .h_24()
+                    .text_color(gpui::white())
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         0.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         90.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         180.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         360.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 1.),
                     ))),
             )
             .child(div().flex_1().rounded_xl().bg(linear_gradient(
                 0.,
-                linear_color_stop(gpui::green(), 0.05),
-                linear_color_stop(gpui::yellow(), 0.95),
+                linear_color_stop(color0, 0.05),
+                linear_color_stop(color1, 0.95),
+            )))
+            .child(div().flex_1().rounded_xl().bg(linear_gradient(
+                90.,
+                linear_color_stop(color0, 0.05),
+                linear_color_stop(color1, 0.95),
             )))
             .child(
                 div()
@@ -119,14 +170,14 @@ impl Render for GradientViewer {
                             .gap_3()
                             .child(div().flex_1().rounded_xl().bg(linear_gradient(
                                 90.,
-                                linear_color_stop(gpui::blue(), 0.5),
-                                linear_color_stop(gpui::red(), 0.5),
+                                linear_color_stop(color0, 0.5),
+                                linear_color_stop(color1, 0.5),
                             ))),
                     )
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         180.,
-                        linear_color_stop(gpui::green(), 0.),
-                        linear_color_stop(gpui::yellow(), 0.5),
+                        linear_color_stop(color0, 0.),
+                        linear_color_stop(color1, 0.5),
                     ))),
             )
             .child(div().h_24().child(canvas(
@@ -154,8 +205,8 @@ impl Render for GradientViewer {
                         path,
                         linear_gradient(
                             180.,
-                            linear_color_stop(gpui::red(), 0.),
-                            linear_color_stop(gpui::blue(), 1.),
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
                         ),
                     );
                 },

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -3,22 +3,16 @@ use gpui::{
     Bounds, ColorSpace, Half, Hsla, Render, ViewContext, WindowOptions,
 };
 
-const COLORS: [(Hsla, Hsla); 16] = [
+const COLORS: [(Hsla, Hsla); 10] = [
     (gpui::red(), gpui::blue()),
     (gpui::red(), gpui::green()),
     (gpui::red(), gpui::yellow()),
-    (gpui::red(), gpui::white()),
-    (gpui::blue(), gpui::red()),
     (gpui::blue(), gpui::green()),
     (gpui::blue(), gpui::yellow()),
-    (gpui::blue(), gpui::white()),
-    (gpui::green(), gpui::red()),
-    (gpui::green(), gpui::blue()),
     (gpui::green(), gpui::yellow()),
+    (gpui::red(), gpui::white()),
+    (gpui::blue(), gpui::white()),
     (gpui::green(), gpui::white()),
-    (gpui::yellow(), gpui::red()),
-    (gpui::yellow(), gpui::blue()),
-    (gpui::yellow(), gpui::green()),
     (gpui::yellow(), gpui::white()),
 ];
 

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -118,8 +118,8 @@ impl Render for GradientViewer {
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             315.,
-                            linear_color_stop(gpui::yellow(), 0.),
-                            linear_color_stop(gpui::green(), 1.),
+                            linear_color_stop(gpui::green(), 0.),
+                            linear_color_stop(gpui::yellow(), 1.),
                         )
                         .color_space(color_space)),
                     ),
@@ -167,8 +167,8 @@ impl Render for GradientViewer {
             .child(
                 div().flex_1().rounded_xl().bg(linear_gradient(
                     0.,
-                    linear_color_stop(gpui::blue(), 0.05),
-                    linear_color_stop(gpui::green(), 0.95),
+                    linear_color_stop(gpui::green(), 0.05),
+                    linear_color_stop(gpui::yellow(), 0.95),
                 )
                 .color_space(color_space)),
             )

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -1,6 +1,6 @@
 use gpui::{
     canvas, div, linear_color_stop, linear_gradient, point, prelude::*, px, size, App, AppContext,
-    Bounds, ColorInterpolationMethod, Half, Hsla, Render, ViewContext, WindowOptions,
+    Bounds, ColorSpace, Half, Hsla, Render, ViewContext, WindowOptions,
 };
 
 const COLORS: [(Hsla, Hsla); 16] = [
@@ -24,14 +24,14 @@ const COLORS: [(Hsla, Hsla); 16] = [
 
 struct GradientViewer {
     color_ix: usize,
-    interpolation_method: ColorInterpolationMethod,
+    color_space: ColorSpace,
 }
 
 impl GradientViewer {
     fn new() -> Self {
         Self {
             color_ix: 0,
-            interpolation_method: ColorInterpolationMethod::Oklab,
+            color_space: ColorSpace::default(),
         }
     }
 }
@@ -39,7 +39,7 @@ impl GradientViewer {
 impl Render for GradientViewer {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let (color0, color1) = COLORS[self.color_ix];
-        let method = self.interpolation_method;
+        let color_space = self.color_space;
 
         div()
             .font_family(".SystemUIFont")
@@ -70,17 +70,12 @@ impl Render for GradientViewer {
                                     .text_sm()
                                     .bg(gpui::black())
                                     .text_color(gpui::white())
-                                    .child(format!("{:?}", method))
+                                    .child(format!("{}", color_space))
                                     .active(|this| this.opacity(0.8))
                                     .on_click(cx.listener(move |this, _, cx| {
-                                        this.interpolation_method = match this.interpolation_method
-                                        {
-                                            ColorInterpolationMethod::Oklab => {
-                                                ColorInterpolationMethod::SrgbLinear
-                                            }
-                                            ColorInterpolationMethod::SrgbLinear => {
-                                                ColorInterpolationMethod::Oklab
-                                            }
+                                        this.color_space = match this.color_space {
+                                            ColorSpace::Oklab => ColorSpace::Srgb,
+                                            ColorSpace::Srgb => ColorSpace::Oklab,
                                         };
                                         cx.notify();
                                     })),
@@ -138,18 +133,21 @@ impl Render for GradientViewer {
                     .gap_3()
                     .h_24()
                     .text_color(gpui::white())
-                    .child(div().flex_1().rounded_xl().bg(linear_gradient(
-                        45.,
-                        linear_color_stop(color0, 0.),
-                        linear_color_stop(color1, 1.),
-                    )))
+                    .child(
+                        div().flex_1().rounded_xl().bg(linear_gradient(
+                            45.,
+                            linear_color_stop(color0, 0.),
+                            linear_color_stop(color1, 1.),
+                        )
+                        .color_space(color_space)),
+                    )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             135.,
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
@@ -157,7 +155,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
@@ -165,7 +163,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     ),
             )
             .child(
@@ -181,7 +179,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
@@ -189,7 +187,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
@@ -197,7 +195,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
@@ -205,7 +203,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     ),
             )
             .child(
@@ -214,7 +212,7 @@ impl Render for GradientViewer {
                     linear_color_stop(color0, 0.05),
                     linear_color_stop(color1, 0.95),
                 )
-                .interpolation_method(method)),
+                .color_space(color_space)),
             )
             .child(
                 div().flex_1().rounded_xl().bg(linear_gradient(
@@ -222,7 +220,7 @@ impl Render for GradientViewer {
                     linear_color_stop(color0, 0.05),
                     linear_color_stop(color1, 0.95),
                 )
-                .interpolation_method(method)),
+                .color_space(color_space)),
             )
             .child(
                 div()
@@ -236,7 +234,7 @@ impl Render for GradientViewer {
                                 linear_color_stop(color0, 0.5),
                                 linear_color_stop(color1, 0.5),
                             )
-                            .interpolation_method(method)),
+                            .color_space(color_space)),
                         ),
                     )
                     .child(
@@ -245,7 +243,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 0.5),
                         )
-                        .interpolation_method(method)),
+                        .color_space(color_space)),
                     ),
             )
             .child(div().h_24().child(canvas(
@@ -276,7 +274,7 @@ impl Render for GradientViewer {
                             linear_color_stop(color0, 0.),
                             linear_color_stop(color1, 1.),
                         )
-                        .interpolation_method(method),
+                        .color_space(color_space),
                     );
                 },
             )))

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -12,11 +12,6 @@ impl GradientViewer {
 
 impl Render for GradientViewer {
     fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let red = gpui::hsla(0., 1., 0.5, 1.);
-        let blue = gpui::hsla(240. / 360., 1., 0.5, 1.);
-        let green = gpui::hsla(120. / 360., 1., 0.25, 1.);
-        let yellow = gpui::hsla(60. / 360., 1., 0.5, 1.);
-
         div()
             .font_family(".SystemUIFont")
             .bg(gpui::white())
@@ -37,7 +32,7 @@ impl Render for GradientViewer {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .bg(blue)
+                            .bg(gpui::blue())
                             .text_color(gpui::white())
                             .child("Solid Color"),
                     )
@@ -48,7 +43,7 @@ impl Render for GradientViewer {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .bg(red)
+                            .bg(gpui::red())
                             .text_color(gpui::white())
                             .child("Solid Color"),
                     ),
@@ -61,23 +56,23 @@ impl Render for GradientViewer {
                     .h_24()
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         45.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         135.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         225.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         315.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     ))),
             )
             .child(
@@ -88,29 +83,29 @@ impl Render for GradientViewer {
                     .h_24()
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         0.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         90.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         180.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     )))
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         360.,
-                        linear_color_stop(red, 0.),
-                        linear_color_stop(blue, 1.),
+                        linear_color_stop(gpui::red(), 0.),
+                        linear_color_stop(gpui::blue(), 1.),
                     ))),
             )
             .child(div().flex_1().rounded_xl().bg(linear_gradient(
                 0.,
-                linear_color_stop(green, 0.05),
-                linear_color_stop(yellow, 0.95),
+                linear_color_stop(gpui::green(), 0.05),
+                linear_color_stop(gpui::yellow(), 0.95),
             )))
             .child(
                 div()
@@ -124,14 +119,14 @@ impl Render for GradientViewer {
                             .gap_3()
                             .child(div().flex_1().rounded_xl().bg(linear_gradient(
                                 90.,
-                                linear_color_stop(blue, 0.5),
-                                linear_color_stop(red, 0.5),
+                                linear_color_stop(gpui::blue(), 0.5),
+                                linear_color_stop(gpui::red(), 0.5),
                             ))),
                     )
                     .child(div().flex_1().rounded_xl().bg(linear_gradient(
                         180.,
-                        linear_color_stop(green, 0.),
-                        linear_color_stop(yellow, 0.5),
+                        linear_color_stop(gpui::green(), 0.),
+                        linear_color_stop(gpui::yellow(), 0.5),
                     ))),
             )
             .child(div().h_24().child(canvas(
@@ -159,8 +154,8 @@ impl Render for GradientViewer {
                         path,
                         linear_gradient(
                             180.,
-                            linear_color_stop(red, 0.),
-                            linear_color_stop(blue, 1.),
+                            linear_color_stop(gpui::red(), 0.),
+                            linear_color_stop(gpui::blue(), 1.),
                         ),
                     );
                 },

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -1,30 +1,15 @@
 use gpui::{
     canvas, div, linear_color_stop, linear_gradient, point, prelude::*, px, size, App, AppContext,
-    Bounds, ColorSpace, Half, Hsla, Render, ViewContext, WindowOptions,
+    Bounds, ColorSpace, Half, Render, ViewContext, WindowOptions,
 };
 
-const COLORS: [(Hsla, Hsla); 10] = [
-    (gpui::red(), gpui::blue()),
-    (gpui::red(), gpui::green()),
-    (gpui::red(), gpui::yellow()),
-    (gpui::blue(), gpui::green()),
-    (gpui::blue(), gpui::yellow()),
-    (gpui::green(), gpui::yellow()),
-    (gpui::red(), gpui::white()),
-    (gpui::blue(), gpui::white()),
-    (gpui::green(), gpui::white()),
-    (gpui::yellow(), gpui::white()),
-];
-
 struct GradientViewer {
-    color_ix: usize,
     color_space: ColorSpace,
 }
 
 impl GradientViewer {
     fn new() -> Self {
         Self {
-            color_ix: 0,
             color_space: ColorSpace::default(),
         }
     }
@@ -32,7 +17,6 @@ impl GradientViewer {
 
 impl Render for GradientViewer {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let (color0, color1) = COLORS[self.color_ix];
         let color_space = self.color_space;
 
         div()
@@ -51,45 +35,25 @@ impl Render for GradientViewer {
                     .items_center()
                     .child("Gradient Examples")
                     .child(
-                        div()
-                            .flex()
-                            .gap_2()
-                            .items_center()
-                            .child(
-                                div()
-                                    .id("method")
-                                    .flex()
-                                    .px_3()
-                                    .py_1()
-                                    .text_sm()
-                                    .bg(gpui::black())
-                                    .text_color(gpui::white())
-                                    .child(format!("{}", color_space))
-                                    .active(|this| this.opacity(0.8))
-                                    .on_click(cx.listener(move |this, _, cx| {
-                                        this.color_space = match this.color_space {
-                                            ColorSpace::Oklab => ColorSpace::Srgb,
-                                            ColorSpace::Srgb => ColorSpace::Oklab,
-                                        };
-                                        cx.notify();
-                                    })),
-                            )
-                            .child(
-                                div()
-                                    .id("next")
-                                    .flex()
-                                    .px_3()
-                                    .py_1()
-                                    .text_sm()
-                                    .bg(gpui::black())
-                                    .text_color(gpui::white())
-                                    .child("Switch Color")
-                                    .active(|this| this.opacity(0.8))
-                                    .on_click(cx.listener(move |this, _, cx| {
-                                        this.color_ix = (this.color_ix + 1) % COLORS.len();
-                                        cx.notify();
-                                    })),
-                            ),
+                        div().flex().gap_2().items_center().child(
+                            div()
+                                .id("method")
+                                .flex()
+                                .px_3()
+                                .py_1()
+                                .text_sm()
+                                .bg(gpui::black())
+                                .text_color(gpui::white())
+                                .child(format!("{}", color_space))
+                                .active(|this| this.opacity(0.8))
+                                .on_click(cx.listener(move |this, _, cx| {
+                                    this.color_space = match this.color_space {
+                                        ColorSpace::Oklab => ColorSpace::Srgb,
+                                        ColorSpace::Srgb => ColorSpace::Oklab,
+                                    };
+                                    cx.notify();
+                                })),
+                        ),
                     ),
             )
             .child(
@@ -104,7 +68,7 @@ impl Render for GradientViewer {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .bg(color0)
+                            .bg(gpui::red())
                             .text_color(gpui::white())
                             .child("Solid Color"),
                     )
@@ -115,7 +79,7 @@ impl Render for GradientViewer {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .bg(color1)
+                            .bg(gpui::blue())
                             .text_color(gpui::white())
                             .child("Solid Color"),
                     ),
@@ -130,32 +94,32 @@ impl Render for GradientViewer {
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             45.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::red(), 0.),
+                            linear_color_stop(gpui::blue(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             135.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::red(), 0.),
+                            linear_color_stop(gpui::green(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             225.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::green(), 0.),
+                            linear_color_stop(gpui::blue(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             315.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::yellow(), 0.),
+                            linear_color_stop(gpui::green(), 1.),
                         )
                         .color_space(color_space)),
                     ),
@@ -170,32 +134,32 @@ impl Render for GradientViewer {
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             0.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::red(), 0.),
+                            linear_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             90.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::blue(), 0.),
+                            linear_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             180.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::green(), 0.),
+                            linear_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             360.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::yellow(), 0.),
+                            linear_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     ),
@@ -203,16 +167,16 @@ impl Render for GradientViewer {
             .child(
                 div().flex_1().rounded_xl().bg(linear_gradient(
                     0.,
-                    linear_color_stop(color0, 0.05),
-                    linear_color_stop(color1, 0.95),
+                    linear_color_stop(gpui::blue(), 0.05),
+                    linear_color_stop(gpui::green(), 0.95),
                 )
                 .color_space(color_space)),
             )
             .child(
                 div().flex_1().rounded_xl().bg(linear_gradient(
                     90.,
-                    linear_color_stop(color0, 0.05),
-                    linear_color_stop(color1, 0.95),
+                    linear_color_stop(gpui::blue(), 0.05),
+                    linear_color_stop(gpui::red(), 0.95),
                 )
                 .color_space(color_space)),
             )
@@ -225,8 +189,8 @@ impl Render for GradientViewer {
                         div().flex().flex_1().gap_3().child(
                             div().flex_1().rounded_xl().bg(linear_gradient(
                                 90.,
-                                linear_color_stop(color0, 0.5),
-                                linear_color_stop(color1, 0.5),
+                                linear_color_stop(gpui::blue(), 0.5),
+                                linear_color_stop(gpui::red(), 0.5),
                             )
                             .color_space(color_space)),
                         ),
@@ -234,8 +198,8 @@ impl Render for GradientViewer {
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             180.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 0.5),
+                            linear_color_stop(gpui::green(), 0.),
+                            linear_color_stop(gpui::blue(), 0.5),
                         )
                         .color_space(color_space)),
                     ),
@@ -265,8 +229,8 @@ impl Render for GradientViewer {
                         path,
                         linear_gradient(
                             180.,
-                            linear_color_stop(color0, 0.),
-                            linear_color_stop(color1, 1.),
+                            linear_color_stop(gpui::red(), 0.),
+                            linear_color_stop(gpui::blue(), 1.),
                         )
                         .color_space(color_space),
                     );

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -716,4 +716,32 @@ mod tests {
 
         assert_eq!(actual, rgba(0xdeadbeef))
     }
+
+    #[test]
+    fn test_background_solid() {
+        let color = Hsla::from(rgba(0xff0099ff));
+        let mut background = Background::from(color);
+        assert_eq!(background.tag, BackgroundTag::Solid);
+        assert_eq!(background.solid, color);
+
+        assert_eq!(background.opacity(0.5).solid, color.opacity(0.5));
+        assert_eq!(background.is_transparent(), false);
+        background.solid = hsla(0.0, 0.0, 0.0, 0.0);
+        assert_eq!(background.is_transparent(), true);
+    }
+
+    #[test]
+    fn test_background_linear_gradient() {
+        let from = linear_color_stop(rgba(0xff0099ff), 0.0);
+        let to = linear_color_stop(rgba(0x00ff99ff), 1.0);
+        let background = linear_gradient(90.0, from, to);
+        assert_eq!(background.tag, BackgroundTag::LinearGradient);
+        assert_eq!(background.colors[0], from);
+        assert_eq!(background.colors[1], to);
+
+        assert_eq!(background.opacity(0.5).colors[0], from.opacity(0.5));
+        assert_eq!(background.opacity(0.5).colors[1], to.opacity(0.5));
+        assert_eq!(background.is_transparent(), false);
+        assert_eq!(background.opacity(0.0).is_transparent(), true);
+    }
 }

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -603,7 +603,7 @@ impl Background {
     /// Creates a LinearGradient background color.
     pub fn linear_gradient(angle: f32, stops: [impl Into<BackgroundColorStop>; 2]) -> Self {
         Self::LinearGradient {
-            angle: angle.clamp(0., 360.),
+            angle: angle.clamp(-360., 360.),
             stops: stops.map(Into::into),
         }
     }

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -566,7 +566,6 @@ pub struct Background {
 }
 
 impl Eq for Background {}
-
 impl Default for Background {
     fn default() -> Self {
         Self {
@@ -660,7 +659,6 @@ impl From<Hsla> for Background {
         }
     }
 }
-
 impl From<Rgba> for Background {
     fn from(value: Rgba) -> Self {
         Background {

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -575,7 +575,7 @@ impl Default for Background {
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[repr(C)]
 pub struct BackgroundColorStop {
-    /// The percentage of the gradient where the color stop is located.
+    /// The percentage of the gradient, in the range 0.0 to 1.0.
     pub percentage: f32,
     /// The color of the color stop.
     pub color: Hsla,
@@ -583,7 +583,7 @@ pub struct BackgroundColorStop {
 
 impl BackgroundColorStop {
     /// Creates a new color stop.
-    pub fn new(percentage: f32, color: impl Into<Hsla>) -> Self {
+    pub fn new(color: impl Into<Hsla>, percentage: f32) -> Self {
         Self {
             percentage,
             color: color.into(),

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -603,7 +603,7 @@ impl Background {
     /// Creates a LinearGradient background color.
     pub fn linear_gradient(angle: f32, stops: [impl Into<BackgroundColorStop>; 2]) -> Self {
         Self::LinearGradient {
-            angle: angle.clamp(-360., 360.),
+            angle,
             stops: stops.map(Into::into),
         }
     }

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -559,7 +559,7 @@ pub enum Background {
         /// The angle of the gradient.
         angle: f32,
         /// The color stops of the gradient.
-        stops: [BackgroundColorStop; 2],
+        stops: [LinearColorStop; 2],
     },
 }
 
@@ -571,25 +571,47 @@ impl Default for Background {
     }
 }
 
-/// A color stop in a linear gradient.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
-#[repr(C)]
-pub struct BackgroundColorStop {
-    /// The percentage of the gradient, in the range 0.0 to 1.0.
-    pub percentage: f32,
-    /// The color of the color stop.
-    pub color: Hsla,
+/// Creates a LinearGradient background color.
+///
+/// The gradient line's angle of direction. A value of `0.` is equivalent to to top; increasing values rotate clockwise from there.
+///
+/// The `angle` is in degrees value in the range 0.0 to 360.0.
+///
+/// https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient
+pub fn linear_gradient(
+    angle: f32,
+    from: impl Into<LinearColorStop>,
+    to: impl Into<LinearColorStop>,
+) -> Background {
+    Background::LinearGradient {
+        angle,
+        stops: [from.into(), to.into()],
+    }
 }
 
-impl BackgroundColorStop {
-    /// Creates a new color stop.
-    pub fn new(color: impl Into<Hsla>, percentage: f32) -> Self {
-        Self {
-            percentage,
-            color: color.into(),
-        }
-    }
+/// A color stop in a linear gradient.
+///
+/// https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#linear-color-stop
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[repr(C)]
+pub struct LinearColorStop {
+    /// The color of the color stop.
+    pub color: Hsla,
+    /// The percentage of the gradient, in the range 0.0 to 1.0.
+    pub percentage: f32,
+}
 
+/// Creates a new linear color stop.
+///
+/// The percentage of the gradient, in the range 0.0 to 1.0.
+pub fn linear_color_stop(color: impl Into<Hsla>, percentage: f32) -> LinearColorStop {
+    LinearColorStop {
+        color: color.into(),
+        percentage,
+    }
+}
+
+impl LinearColorStop {
     /// Returns a new color stop with the same color, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
         Self {
@@ -600,14 +622,6 @@ impl BackgroundColorStop {
 }
 
 impl Background {
-    /// Creates a LinearGradient background color.
-    pub fn linear_gradient(angle: f32, stops: [impl Into<BackgroundColorStop>; 2]) -> Self {
-        Self::LinearGradient {
-            angle,
-            stops: stops.map(Into::into),
-        }
-    }
-
     /// Returns a new background color with the same hue, saturation, and lightness, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
         match self {

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -635,7 +635,7 @@ impl LinearColorStop {
 impl Background {
     /// Returns a new background color with the same hue, saturation, and lightness, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
-        let mut background = self.clone();
+        let mut new = *self;
         background.solid = background.solid.opacity(factor);
         background.colors = [
             self.colors[0].opacity(factor),

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -632,7 +632,7 @@ impl LinearColorStop {
 impl Background {
     /// Returns a new background color with the same hue, saturation, and lightness, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
-        let mut new = *self;
+        let mut background = *self;
         background.solid = background.solid.opacity(factor);
         background.colors = [
             self.colors[0].opacity(factor),

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -559,8 +559,6 @@ pub(crate) enum BackgroundTag {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct Background {
-    /// 0 is a solid color
-    /// 1 is a linear gradient.
     pub(crate) tag: BackgroundTag,
     pub(crate) solid: Hsla,
     pub(crate) angle: f32,

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -557,15 +557,26 @@ pub(crate) enum BackgroundTag {
 
 /// A color space for color interpolation.
 ///
-/// https://developer.mozilla.org/en-US/docs/Web/CSS/color-interpolation-method
+/// References:
+/// - https://developer.mozilla.org/en-US/docs/Web/CSS/color-interpolation-method
+/// - https://www.w3.org/TR/css-color-4/#typedef-color-space
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[repr(C)]
-pub enum ColorInterpolationMethod {
+pub enum ColorSpace {
     #[default]
-    /// The sRGB linear color space.
-    SrgbLinear = 0,
+    /// The sRGB color space.
+    Srgb = 0,
     /// The Oklab color space.
     Oklab = 1,
+}
+
+impl Display for ColorSpace {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ColorSpace::Srgb => write!(f, "sRGB"),
+            ColorSpace::Oklab => write!(f, "Oklab"),
+        }
+    }
 }
 
 /// A background color, which can be either a solid color or a linear gradient.
@@ -573,7 +584,7 @@ pub enum ColorInterpolationMethod {
 #[repr(C)]
 pub struct Background {
     pub(crate) tag: BackgroundTag,
-    pub(crate) interpolation_method: ColorInterpolationMethod,
+    pub(crate) color_space: ColorSpace,
     pub(crate) solid: Hsla,
     pub(crate) angle: f32,
     pub(crate) colors: [LinearColorStop; 2],
@@ -587,7 +598,7 @@ impl Default for Background {
         Self {
             tag: BackgroundTag::Solid,
             solid: Hsla::default(),
-            interpolation_method: ColorInterpolationMethod::default(),
+            color_space: ColorSpace::default(),
             angle: 0.0,
             colors: [LinearColorStop::default(), LinearColorStop::default()],
             pad: 0,
@@ -651,8 +662,8 @@ impl Background {
     /// Use specified color space for color interpolation.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/CSS/color-interpolation-method
-    pub fn interpolation_method(mut self, method: ColorInterpolationMethod) -> Self {
-        self.interpolation_method = method;
+    pub fn color_space(mut self, color_space: ColorSpace) -> Self {
+        self.color_space = color_space;
         self
     }
 

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -555,14 +555,30 @@ pub(crate) enum BackgroundTag {
     LinearGradient = 1,
 }
 
+/// A color space for color interpolation.
+///
+/// https://developer.mozilla.org/en-US/docs/Web/CSS/color-interpolation-method
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[repr(C)]
+pub enum ColorInterpolationMethod {
+    #[default]
+    /// The sRGB linear color space.
+    SrgbLinear = 0,
+    /// The Oklab color space.
+    Oklab = 1,
+}
+
 /// A background color, which can be either a solid color or a linear gradient.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct Background {
     pub(crate) tag: BackgroundTag,
+    pub(crate) interpolation_method: ColorInterpolationMethod,
     pub(crate) solid: Hsla,
     pub(crate) angle: f32,
     pub(crate) colors: [LinearColorStop; 2],
+    /// Padding for alignment for repr(C) layout.
+    pad: u32,
 }
 
 impl Eq for Background {}
@@ -571,8 +587,10 @@ impl Default for Background {
         Self {
             tag: BackgroundTag::Solid,
             solid: Hsla::default(),
+            interpolation_method: ColorInterpolationMethod::default(),
             angle: 0.0,
             colors: [LinearColorStop::default(), LinearColorStop::default()],
+            pad: 0,
         }
     }
 }
@@ -630,6 +648,14 @@ impl LinearColorStop {
 }
 
 impl Background {
+    /// Use specified color space for color interpolation.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/CSS/color-interpolation-method
+    pub fn interpolation_method(mut self, method: ColorInterpolationMethod) -> Self {
+        self.interpolation_method = method;
+        self
+    }
+
     /// Returns a new background color with the same hue, saturation, and lightness, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
         let mut background = *self;

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -3,7 +3,7 @@
 
 use super::{BladeAtlas, PATH_TEXTURE_FORMAT};
 use crate::{
-    AtlasTextureKind, AtlasTile, Bounds, ContentMask, DevicePixels, GPUSpecs, Hsla,
+    AtlasTextureKind, AtlasTile, Background, Bounds, ContentMask, DevicePixels, GPUSpecs,
     MonochromeSprite, Path, PathId, PathVertex, PolychromeSprite, PrimitiveBatch, Quad,
     ScaledPixels, Scene, Shadow, Size, Underline,
 };
@@ -174,7 +174,7 @@ struct ShaderSurfacesData {
 #[repr(C)]
 struct PathSprite {
     bounds: Bounds<ScaledPixels>,
-    color: Hsla,
+    color: Background,
     tile: AtlasTile,
 }
 

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -278,15 +278,8 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     } else if (input.background_tag == 1u) {
         // Linear gradient background.
         let position = input.position.xy;
-        // Normalize the angle to be within the range of -360 to 360 degrees.
-        var normalized_angle = input.background_angle % 360.0;
-        if (normalized_angle < -360.0) {
-            normalized_angle += 360.0;
-        } else if (normalized_angle > 360.0) {
-            normalized_angle -= 360.0;
-        }
         // -90 degrees to match the CSS gradient angle.
-        let radians = (normalized_angle - 90.0) * M_PI_F / 180.0;
+        let radians = (input.background_angle % 360.0 - 90.0) * M_PI_F / 180.0;
         let direction = vec2<f32>(cos(radians), sin(radians));
         let stop0_percentage = input.background_stop0_percentage;
         let stop1_percentage = input.background_stop1_percentage;

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -271,6 +271,9 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     }
 
     let quad = b_quads[input.quad_id];
+    let half_size = quad.bounds.size / 2.0;
+    let center = quad.bounds.origin + half_size;
+    let center_to_point = input.position.xy - center;
 
     var background_color = vec4<f32>(0.0);
     if (input.background_tag == 0u) {
@@ -285,15 +288,12 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
         let stop1_percentage = input.background_stop1_percentage;
 
         // Get the t value for the linear gradient with the color stop percentages.
-        let half_size = vec2<f32>(quad.bounds.size.x / 2.0, quad.bounds.size.y / 2.0);
-        let center = vec2<f32>(quad.bounds.origin.x + half_size.x, quad.bounds.origin.y + half_size.y);;
-        let position_from_center = position - center;
-        var t = dot(position_from_center, direction) / length(direction);
+        var t = dot(center_to_point, direction) / length(direction);
         // Check the direct to determine the use x or y
         if (abs(direction.x) > abs(direction.y)) {
-            t = (t + half_size.x) / (2 * half_size.x);
+            t = (t + half_size.x) / quad.bounds.size.x;
         } else {
-            t = (t + half_size.y) / (2 * half_size.y);
+            t = (t + half_size.y) / quad.bounds.size.y;
         }
 
         // Adjust t based on the stop percentages
@@ -315,12 +315,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
         return blend_color(background_color, 1.0);
     }
 
-    let half_size = quad.bounds.size / 2.0;
-    let center = quad.bounds.origin + half_size;
-    let center_to_point = input.position.xy - center;
-
     let corner_radius = pick_corner_radius(center_to_point, quad.corner_radii);
-
     let rounded_edge_to_point = abs(center_to_point) - half_size + corner_radius;
     let distance =
       length(max(vec2<f32>(0.0), rounded_edge_to_point)) +

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -278,13 +278,13 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     } else if (input.background_tag == 1u) {
         // Linear gradient background.
         let position = input.position.xy;
+        // Normalize the angle to be within the range of -360 to 360 degrees.
         var normalized_angle = input.background_angle % 360.0;
         if (normalized_angle < -360.0) {
             normalized_angle += 360.0;
         } else if (normalized_angle > 360.0) {
             normalized_angle -= 360.0;
         }
-
         // -90 degrees to match the CSS gradient angle.
         let radians = (normalized_angle - 90.0) * M_PI_F / 180.0;
         let direction = vec2<f32>(cos(radians), sin(radians));
@@ -312,7 +312,6 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
 
         background_color = mix(color0, color1, t);
     }
-
 
     // Fast path when the quad is not rounded and doesn't have any border.
     if (quad.corner_radii.top_left == 0.0 && quad.corner_radii.bottom_left == 0.0 &&

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -135,6 +135,7 @@ fn srgba_to_linear(color: vec4<f32>) -> vec4<f32> {
     return vec4<f32>(srgb_to_linear(color.rgb), color.a);
 }
 
+/// Hsla to linear RGBA conversion.
 fn hsla_to_rgba(hsla: Hsla) -> vec4<f32> {
     let h = hsla.h * 6.0; // Now, it's an angle but scaled in [0, 6) range
     let s = hsla.s;
@@ -314,9 +315,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
 
             switch (background.color_space) {
                 default: {
-                    let color = mix(color0, color1, t);
-                    // Convert back to linear space for blending.
-                    background_color = srgba_to_linear(color);
+                    background_color = srgba_to_linear(mix(color0, color1, t));
                 }
                 case 1u: {
                     let oklab_color0 = linear_srgb_to_oklab(color0);
@@ -366,8 +365,8 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     if (quad.background.tag == 0u) {
         out.background_solid = hsla_to_rgba(quad.background.solid);
     } else if (quad.background.tag == 1u) {
-        out.background_color0 = linear_to_srgba(hsla_to_rgba(quad.background.colors[0].color));
-        out.background_color1 = linear_to_srgba(hsla_to_rgba(quad.background.colors[1].color));
+        out.background_color0 = hsla_to_rgba(quad.background.colors[0].color);
+        out.background_color1 = hsla_to_rgba(quad.background.colors[1].color);
     }
     out.border_color = hsla_to_rgba(quad.border_color);
     out.quad_id = instance_id;
@@ -578,8 +577,8 @@ fn vs_path(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     if (sprite.color.tag == 0u) {
         out.color_solid = hsla_to_rgba(sprite.color.solid);
     } else if (sprite.color.tag == 1u) {
-        out.color0 = linear_to_srgba(hsla_to_rgba(sprite.color.colors[0].color));
-        out.color1 = linear_to_srgba(hsla_to_rgba(sprite.color.colors[1].color));
+        out.color0 = hsla_to_rgba(sprite.color.colors[0].color);
+        out.color1 = hsla_to_rgba(sprite.color.colors[1].color);
     }
     return out;
 }

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -364,7 +364,6 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
         out.background_solid = hsla_to_rgba(quad.background.solid);
     } else if (quad.background.tag == 1u) {
         let color_space = quad.background.color_space;
-
         // The hsla_to_rgba is returns a linear sRGB color
         out.background_color0 = hsla_to_rgba(quad.background.colors[0].color);
         out.background_color1 = hsla_to_rgba(quad.background.colors[1].color);
@@ -590,17 +589,18 @@ fn vs_path(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     if (sprite.color.tag == 0u) {
         out.color_solid = hsla_to_rgba(sprite.color.solid);
     } else if (sprite.color.tag == 1u) {
+        let color_space = sprite.color.color_space;
         // The hsla_to_rgba is returns a linear sRGB color
         out.color0 = hsla_to_rgba(sprite.color.colors[0].color);
         out.color1 = hsla_to_rgba(sprite.color.colors[1].color);
 
         // Prepare color space in vertex for avoid conversion
         // in fragment shader for performance reasons
-        if (sprite.color.color_space == 0u) {
+        if (color_space == 0u) {
             // sRGB
             out.color0 = linear_to_srgba(out.color0);
             out.color1 = linear_to_srgba(out.color1);
-        } else if (sprite.color.color_space == 1u) {
+        } else if (color_space == 1u) {
             // Oklab
             out.color0 = linear_srgb_to_oklab(out.color0);
             out.color1 = linear_srgb_to_oklab(out.color1);

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -365,8 +365,8 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     if (quad.background.tag == 0u) {
         out.background_solid = hsla_to_rgba(quad.background.solid);
     } else if (quad.background.tag == 1u) {
-        out.background_color0 = hsla_to_rgba(quad.background.colors[0].color);
-        out.background_color1 = hsla_to_rgba(quad.background.colors[1].color);
+        out.background_color0 = linear_to_srgba(hsla_to_rgba(quad.background.colors[0].color));
+        out.background_color1 = linear_to_srgba(hsla_to_rgba(quad.background.colors[1].color));
     }
     out.border_color = hsla_to_rgba(quad.border_color);
     out.quad_id = instance_id;
@@ -577,8 +577,8 @@ fn vs_path(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     if (sprite.color.tag == 0u) {
         out.color_solid = hsla_to_rgba(sprite.color.solid);
     } else if (sprite.color.tag == 1u) {
-        out.color0 = hsla_to_rgba(sprite.color.colors[0].color);
-        out.color1 = hsla_to_rgba(sprite.color.colors[1].color);
+        out.color0 = linear_to_srgba(hsla_to_rgba(sprite.color.colors[0].color));
+        out.color1 = linear_to_srgba(hsla_to_rgba(sprite.color.colors[1].color));
     }
     return out;
 }

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -364,7 +364,7 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     var out = QuadVarying();
     out.position = to_device_position(unit_vertex, quad.bounds);
     if (quad.background.tag == 0u) {
-        out.background_solid = linear_to_srgba(hsla_to_rgba(quad.background.solid));
+        out.background_solid = hsla_to_rgba(quad.background.solid);
     } else if (quad.background.tag == 1u) {
         out.background_color0 = linear_to_srgba(hsla_to_rgba(quad.background.colors[0].color));
         out.background_color1 = linear_to_srgba(hsla_to_rgba(quad.background.colors[1].color));
@@ -576,7 +576,7 @@ fn vs_path(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
     out.instance_id = instance_id;
     if (sprite.color.tag == 0u) {
-        out.color_solid = linear_to_srgba(hsla_to_rgba(sprite.color.solid));
+        out.color_solid = hsla_to_rgba(sprite.color.solid);
     } else if (sprite.color.tag == 1u) {
         out.color0 = linear_to_srgba(hsla_to_rgba(sprite.color.colors[0].color));
         out.color1 = linear_to_srgba(hsla_to_rgba(sprite.color.colors[1].color));

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -48,7 +48,7 @@ struct Background {
     tag: u32,
     // 0u is sRGB linear color
     // 1u is Oklab color
-    interpolation_method: u32,
+    color_space: u32,
     solid: Hsla,
     angle: f32,
     colors: array<LinearColorStop, 2>,
@@ -312,7 +312,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             t = (t - stop0_percentage) / (stop1_percentage - stop0_percentage);
             t = clamp(t, 0.0, 1.0);
 
-            switch (background.interpolation_method) {
+            switch (background.color_space) {
                 default: {
                     let color = mix(color0, color1, t);
                     // Convert back to linear space for blending.

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -46,11 +46,13 @@ struct Background {
     // 0u is Solid
     // 1u is LinearGradient
     tag: u32,
-    // 0u is sRGB linear color, 1u is Oklab color
+    // 0u is sRGB linear color
+    // 1u is Oklab color
     interpolation_method: u32,
     solid: Hsla,
     angle: f32,
     colors: array<LinearColorStop, 2>,
+    pad: u32,
 }
 
 struct AtlasTextureId {

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -322,7 +322,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
                     let oklab_color0 = linear_srgb_to_oklab(color0);
                     let oklab_color1 = linear_srgb_to_oklab(color1);
                     let oklab_color = mix(oklab_color0, oklab_color1, t);
-                    background_color = srgba_to_linear(oklab_to_linear_srgb(oklab_color));
+                    background_color = oklab_to_linear_srgb(oklab_color);
                 }
             }
         }

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -1,7 +1,7 @@
 use super::metal_atlas::MetalAtlas;
 use crate::{
-    point, size, AtlasTextureId, AtlasTextureKind, AtlasTile, Bounds, ContentMask, DevicePixels,
-    Hsla, MonochromeSprite, PaintSurface, Path, PathId, PathVertex, PolychromeSprite,
+    point, size, AtlasTextureId, AtlasTextureKind, AtlasTile, Background, Bounds, ContentMask,
+    DevicePixels, MonochromeSprite, PaintSurface, Path, PathId, PathVertex, PolychromeSprite,
     PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, Surface, Underline,
 };
 use anyhow::{anyhow, Result};
@@ -1242,7 +1242,7 @@ enum PathRasterizationInputIndex {
 #[repr(C)]
 pub struct PathSprite {
     pub bounds: Bounds<ScaledPixels>,
-    pub color: Hsla,
+    pub color: Background,
     pub tile: AtlasTile,
 }
 

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -112,19 +112,22 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
         float radians = (normalized_angle - 90.0) * (M_PI_F / 180.0);
         float2 direction = float2(cos(radians), sin(radians));
 
+        float stop1_percentage = input.background_stop0_percentage;
+        float stop2_percentage = input.background_stop1_percentage;
+
+        // Get the t value for the linear gradient with the color stop percentages.
         float2 half_size = float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
         float2 center = float2(quad.bounds.origin.x, quad.bounds.origin.y) + half_size;
         float2 position_from_center = position - center;
         float t = dot(position_from_center, direction) / length(direction);
         t = (t + half_size.x) / (2. * half_size.x);
 
+        // Adjust t based on the stop percentages
+        t = (t - stop1_percentage) / (stop2_percentage - stop1_percentage);
+        t = clamp(t, 0.0, 1.0);
+
         float4 color1 = input.background_stop0_color;
         float4 color2 = input.background_stop1_color;
-
-        // Adjust t based on background_stop0_percentage and background_stop1_percentage
-        float stop0 = input.background_stop0_percentage;
-        float stop1 = input.background_stop1_percentage;
-        t = (t - stop0) / (stop1 - stop0);
 
         color = mix(color1, color2, t);
         break;

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -96,21 +96,22 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
 
   float4 color;
   switch (input.background_tag) {
-    case Background_Solid:
-      color = input.background_solid;
-      break;
-    case Background_LinearGradient: {
-      float2 position = input.position.xy;
-      // Normalize the angle to be within the range of -360 to 360 degrees.
-      float normalized_angle = fmod(input.background_angle, 360.0);
-      if (normalized_angle < -360.0) {
-        normalized_angle += 360.0;
-      } else if (normalized_angle > 360.0) {
-        normalized_angle -= 360.0;
-      }
-      // -90 degrees to match the CSS gradient angle.
-      float radians = (normalized_angle - 90.0) * (M_PI_F / 180.0);
-      float2 direction = float2(cos(radians), sin(radians));
+      case Background_Solid:
+        color = input.background_solid;
+        break;
+      case Background_LinearGradient: {
+        float2 position = input.position.xy;
+        // Normalize the angle to be within the range of -360 to 360 degrees.
+        float normalized_angle = fmod(input.background_angle, 360.0);
+        if (normalized_angle < -360.0) {
+          normalized_angle += 360.0;
+        } else if (normalized_angle > 360.0) {
+          normalized_angle -= 360.0;
+        }
+        // -90 degrees to match the CSS gradient angle.
+        float radians = (normalized_angle - 90.0) * (M_PI_F / 180.0);
+        float2 direction = float2(cos(radians), sin(radians));
+
         float2 half_size = float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
         float2 center = float2(quad.bounds.origin.x, quad.bounds.origin.y) + half_size;
         float2 position_from_center = position - center;
@@ -120,9 +121,14 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
         float4 color1 = input.background_stop0_color;
         float4 color2 = input.background_stop1_color;
 
-      color = mix(color1, color2, t);
-      break;
-    }
+        // Adjust t based on background_stop0_percentage and background_stop1_percentage
+        float stop0 = input.background_stop0_percentage;
+        float stop1 = input.background_stop1_percentage;
+        t = (t - stop0) / (stop1 - stop0);
+
+        color = mix(color1, color2, t);
+        break;
+      }
   }
 
   // Fast path when the quad is not rounded and doesn't have any border.

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -68,11 +68,11 @@ vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
   Background background = quad.background;
   uint background_tag = background.tag;
   float4 background_solid = hsla_to_rgba(background.solid);
-  float background_angle = background.linear_gradient.angle;
-  float background_stop0_percentage = background.linear_gradient.stops[0].percentage;
-  float4 background_stop0_color = hsla_to_rgba(background.linear_gradient.stops[0].color);
-  float background_stop1_percentage = background.linear_gradient.stops[1].percentage;
-  float4 background_stop1_color = hsla_to_rgba(background.linear_gradient.stops[1].color);
+  float background_angle = background.angle;
+  float background_stop0_percentage = background.colors[0].percentage;
+  float4 background_stop0_color = hsla_to_rgba(background.colors[0].color);
+  float background_stop1_percentage = background.colors[1].percentage;
+  float4 background_stop1_color = hsla_to_rgba(background.colors[1].color);
   float4 border_color = hsla_to_rgba(quad.border_color);
 
   return QuadVertexOutput{
@@ -96,10 +96,10 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
 
   float4 color;
   switch (input.background_tag) {
-      case Background_Solid:
+      case 0:
         color = input.background_solid;
         break;
-      case Background_LinearGradient: {
+      case 1: {
         float2 position = input.position.xy;
         // Normalize the angle to be within the range of -360 to 360 degrees.
         float normalized_angle = fmod(input.background_angle, 360.0);

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -737,10 +737,6 @@ float4 gradient_color(Background background,
                       float4 solid_color, float4 color0, float4 color1) {
   float4 color;
 
-  float2 half_size = float2(bounds.size.width, bounds.size.height) / 2.;
-  float2 center = float2(bounds.origin.x, bounds.origin.y) + half_size;
-  float2 center_to_point = position - center;
-
   switch (background.tag) {
       case 0:
         color = solid_color;
@@ -750,7 +746,17 @@ float4 gradient_color(Background background,
         float radians = (fmod(background.angle, 360.0) - 90.0) * (M_PI_F / 180.0);
         float2 direction = float2(cos(radians), sin(radians));
 
+        // Expand the short side to be the same as the long side
+        if (bounds.size.width > bounds.size.height) {
+          direction.y *= bounds.size.height / bounds.size.width;
+        } else {
+          direction.x *=  bounds.size.width / bounds.size.height;
+        }
+
         // Get the t value for the linear gradient with the color stop percentages.
+        float2 half_size = float2(bounds.size.width, bounds.size.height) / 2.;
+        float2 center = float2(bounds.origin.x, bounds.origin.y) + half_size;
+        float2 center_to_point = position - center;
         float t = dot(center_to_point, direction) / length(direction);
         // Check the direct to determine the use x or y
         if (abs(direction.x) > abs(direction.y)) {

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -101,8 +101,8 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
       break;
     case Background_LinearGradient: {
       float2 position = input.position.xy;
-      float angle = radians(input.background_angle);
-      float2 gradient_direction = normalize(float2(cos(angle), sin(angle)));
+      float degrees = fmod(input.background_angle, 360.) * (M_PI_F / 180.);
+      float2 gradient_direction = normalize(float2(cos(degrees), sin(degrees)));
 
       // Calculate the start and end points of the gradient
       float2 start_point = {quad.bounds.origin.x, quad.bounds.origin.y};
@@ -751,8 +751,4 @@ float4 over(float4 below, float4 above) {
       (above.rgb * above.a + below.rgb * below.a * (1.0 - above.a)) / alpha;
   result.a = alpha;
   return result;
-}
-
-float radians(float degrees) {
-  return degrees * (M_PI_F / 360.0);
 }

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -100,15 +100,8 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
         break;
       case 1: {
         float2 position = input.position.xy;
-        // Normalize the angle to be within the range of -360 to 360 degrees.
-        float normalized_angle = fmod(input.background_angle, 360.0);
-        if (normalized_angle < -360.0) {
-          normalized_angle += 360.0;
-        } else if (normalized_angle > 360.0) {
-          normalized_angle -= 360.0;
-        }
         // -90 degrees to match the CSS gradient angle.
-        float radians = (normalized_angle - 90.0) * (M_PI_F / 180.0);
+        float radians = (fmod(input.background_angle, 360.0) - 90.0) * (M_PI_F / 180.0);
         float2 direction = float2(cos(radians), sin(radians));
 
         float stop0_percentage = input.background_stop0_percentage;

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -92,6 +92,9 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
                               constant Quad *quads
                               [[buffer(QuadInputIndex_Quads)]]) {
   Quad quad = quads[input.quad_id];
+  float2 half_size = float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
+  float2 center = float2(quad.bounds.origin.x, quad.bounds.origin.y) + half_size;
+  float2 center_to_point = input.position.xy - center;
 
   float4 color;
   switch (input.background_tag) {
@@ -108,15 +111,12 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
         float stop1_percentage = input.background_stop1_percentage;
 
         // Get the t value for the linear gradient with the color stop percentages.
-        float2 half_size = float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
-        float2 center = float2(quad.bounds.origin.x, quad.bounds.origin.y) + half_size;
-        float2 position_from_center = position - center;
-        float t = dot(position_from_center, direction) / length(direction);
+        float t = dot(center_to_point, direction) / length(direction);
         // Check the direct to determine the use x or y
         if (abs(direction.x) > abs(direction.y)) {
-           t = (t + half_size.x) / (2. * half_size.x);
+           t = (t + half_size.x) / quad.bounds.size.width;
         } else {
-           t = (t + half_size.y) / (2. * half_size.y);
+           t = (t + half_size.y) / quad.bounds.size.height;
         }
 
         // Adjust t based on the stop percentages
@@ -140,11 +140,6 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
     return color;
   }
 
-  float2 half_size =
-      float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
-  float2 center =
-      float2(quad.bounds.origin.x, quad.bounds.origin.y) + half_size;
-  float2 center_to_point = input.position.xy - center;
   float corner_radius;
   if (center_to_point.x < 0.) {
     if (center_to_point.y < 0.) {

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -101,22 +101,21 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
       break;
     case Background_LinearGradient: {
       float2 position = input.position.xy;
-      float degrees = fmod(input.background_angle, 360.) * (M_PI_F / 180.);
-      float2 gradient_direction = normalize(float2(cos(degrees), sin(degrees)));
+      float radians = fmod(input.background_angle, 360.0) * (M_PI_F / 180.0);
+      float2 direction = normalize(float2(cos(radians), sin(radians)));
 
       // Calculate the start and end points of the gradient
-      float2 start_point = {quad.bounds.origin.x, quad.bounds.origin.y};
-      float2 end_point = start_point + float2(quad.bounds.size.width * gradient_direction.x,
-                                              quad.bounds.size.height * gradient_direction.y);
+      float2 start_point = float2(quad.bounds.origin.x, quad.bounds.origin.y);
+      float2 end_point = start_point + direction * float2(quad.bounds.size.width, quad.bounds.size.height);
 
       // Calculate the projection of the position on the gradient direction
-      float gradient_length = dot(position - start_point, gradient_direction);
+      float gradient_length = dot(position - start_point, direction);
       float total_length = length(end_point - start_point);
 
       // Calculate the percentage along the gradient
       float percentage = gradient_length / total_length;
 
-      // Apply the stop percentages
+      // Apply the stop percentages, the stop is 0.0..1.0
       float stop0 = input.background_stop0_percentage;
       float stop1 = input.background_stop1_percentage;
 

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -27,7 +27,6 @@ struct QuadVertexOutput {
   float4 position [[position]];
   uint background_tag;
   float4 background_solid [[flat]];
-  // The degrees of the angle of the linear gradient.
   float background_angle;
   float background_stop0_percentage;
   float4 background_stop0_color [[flat]];

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -120,7 +120,12 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
         float2 center = float2(quad.bounds.origin.x, quad.bounds.origin.y) + half_size;
         float2 position_from_center = position - center;
         float t = dot(position_from_center, direction) / length(direction);
-        t = (t + half_size.x) / (2. * half_size.x);
+        // Check the direct to determine the use x or y
+        if (abs(direction.x) > abs(direction.y)) {
+           t = (t + half_size.x) / (2. * half_size.x);
+        } else {
+           t = (t + half_size.y) / (2. * half_size.y);
+        }
 
         // Adjust t based on the stop percentages
         t = (t - stop1_percentage) / (stop2_percentage - stop1_percentage);

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -22,32 +22,26 @@ float blur_along_x(float x, float y, float sigma, float corner,
                    float2 half_size);
 float4 over(float4 below, float4 above);
 float radians(float degrees);
+float4 gradient_color(Background background, float2 position, Bounds_ScaledPixels bounds,
+  float4 solid_color, float4 color0, float4 color1);
 
 struct QuadVertexOutput {
-  float4 position [[position]];
-  uint background_tag;
-  float4 background_solid [[flat]];
-  float background_angle;
-  float background_stop0_percentage;
-  float4 background_stop0_color [[flat]];
-  float background_stop1_percentage;
-  float4 background_stop1_color [[flat]];
-  float4 border_color [[flat]];
   uint quad_id [[flat]];
+  float4 position [[position]];
+  float4 border_color [[flat]];
+  float4 background_solid [[flat]];
+  float4 background_color0 [[flat]];
+  float4 background_color1 [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
 struct QuadFragmentInput {
-  float4 position [[position]];
-  uint background_tag;
-  float4 background_solid [[flat]];
-  float background_angle;
-  float background_stop0_percentage;
-  float4 background_stop0_color [[flat]];
-  float background_stop1_percentage;
-  float4 background_stop1_color [[flat]];
-  float4 border_color [[flat]];
   uint quad_id [[flat]];
+  float4 position [[position]];
+  float4 border_color [[flat]];
+  float4 background_solid [[flat]];
+  float4 background_color0 [[flat]];
+  float4 background_color1 [[flat]];
 };
 
 vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
@@ -64,27 +58,25 @@ vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
       to_device_position(unit_vertex, quad.bounds, viewport_size);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds,
                                                  quad.content_mask.bounds);
-  Background background = quad.background;
-  uint background_tag = background.tag;
-  float4 background_solid = hsla_to_rgba(background.solid);
-  float background_angle = background.angle;
-  float background_stop0_percentage = background.colors[0].percentage;
-  float4 background_stop0_color = hsla_to_rgba(background.colors[0].color);
-  float background_stop1_percentage = background.colors[1].percentage;
-  float4 background_stop1_color = hsla_to_rgba(background.colors[1].color);
   float4 border_color = hsla_to_rgba(quad.border_color);
 
+  float4 background_solid = float4(0., 0., 0., 0.);
+  float4 background_color0 = float4(0., 0., 0., 0.);
+  float4 background_color1 = float4(0., 0., 0., 0.);
+  if (quad.background.tag == 0) {
+    background_solid = hsla_to_rgba(quad.background.solid);
+  } else if (quad.background.tag == 1) {
+    background_color0 = hsla_to_rgba(quad.background.colors[0].color);
+    background_color1 = hsla_to_rgba(quad.background.colors[1].color);
+  }
+
   return QuadVertexOutput{
-      device_position,
-      background_tag,
-      background_solid,
-      background_angle,
-      background_stop0_percentage,
-      background_stop0_color,
-      background_stop1_percentage,
-      background_stop1_color,
-      border_color,
       quad_id,
+      device_position,
+      border_color,
+      background_solid,
+      background_color0,
+      background_color1,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
@@ -95,41 +87,8 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   float2 half_size = float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
   float2 center = float2(quad.bounds.origin.x, quad.bounds.origin.y) + half_size;
   float2 center_to_point = input.position.xy - center;
-
-  float4 color;
-  switch (input.background_tag) {
-      case 0:
-        color = input.background_solid;
-        break;
-      case 1: {
-        float2 position = input.position.xy;
-        // -90 degrees to match the CSS gradient angle.
-        float radians = (fmod(input.background_angle, 360.0) - 90.0) * (M_PI_F / 180.0);
-        float2 direction = float2(cos(radians), sin(radians));
-
-        float stop0_percentage = input.background_stop0_percentage;
-        float stop1_percentage = input.background_stop1_percentage;
-
-        // Get the t value for the linear gradient with the color stop percentages.
-        float t = dot(center_to_point, direction) / length(direction);
-        // Check the direct to determine the use x or y
-        if (abs(direction.x) > abs(direction.y)) {
-           t = (t + half_size.x) / quad.bounds.size.width;
-        } else {
-           t = (t + half_size.y) / quad.bounds.size.height;
-        }
-
-        // Adjust t based on the stop percentages
-        t = (t - stop0_percentage) / (stop1_percentage - stop0_percentage);
-        t = clamp(t, 0.0, 1.0);
-
-        float4 color0 = input.background_stop0_color;
-        float4 color1 = input.background_stop1_color;
-
-        color = mix(color0, color1, t);
-        break;
-      }
-  }
+  float4 color = gradient_color(quad.background, input.position.xy, quad.bounds,
+    input.background_solid, input.background_color0, input.background_color1);
 
   // Fast path when the quad is not rounded and doesn't have any border.
   if (quad.corner_radii.top_left == 0. && quad.corner_radii.bottom_left == 0. &&
@@ -494,7 +453,10 @@ fragment float4 path_rasterization_fragment(PathRasterizationFragmentInput input
 struct PathSpriteVertexOutput {
   float4 position [[position]];
   float2 tile_position;
-  float4 color [[flat]];
+  uint sprite_id [[flat]];
+  float4 solid_color [[flat]];
+  float4 color0 [[flat]];
+  float4 color1 [[flat]];
 };
 
 vertex PathSpriteVertexOutput path_sprite_vertex(
@@ -513,8 +475,25 @@ vertex PathSpriteVertexOutput path_sprite_vertex(
   float4 device_position =
       to_device_position(unit_vertex, sprite.bounds, viewport_size);
   float2 tile_position = to_tile_position(unit_vertex, sprite.tile, atlas_size);
-  float4 color = hsla_to_rgba(sprite.color);
-  return PathSpriteVertexOutput{device_position, tile_position, color};
+
+  float4 solid_color = float4(0., 0., 0., 0.);
+  float4 color0 = float4(0., 0., 0., 0.);
+  float4 color1 = float4(0., 0., 0., 0.);
+  if (sprite.color.tag == 0) {
+    solid_color = hsla_to_rgba(sprite.color.solid);
+  } else if (sprite.color.tag == 1) {
+    color0 = hsla_to_rgba(sprite.color.colors[0].color);
+    color1 = hsla_to_rgba(sprite.color.colors[1].color);
+  }
+
+  return PathSpriteVertexOutput{
+    device_position,
+    tile_position,
+    sprite_id,
+    solid_color,
+    color0,
+    color1
+  };
 }
 
 fragment float4 path_sprite_fragment(
@@ -526,7 +505,10 @@ fragment float4 path_sprite_fragment(
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
   float mask = 1. - abs(1. - fmod(sample.r, 2.));
-  float4 color = input.color;
+  PathSprite sprite = sprites[input.sprite_id];
+  Background background = sprite.color;
+  float4 color = gradient_color(background, input.position.xy, sprite.bounds,
+    input.solid_color, input.color0, input.color1);
   color.a *= mask;
   return color;
 }
@@ -747,4 +729,44 @@ float4 over(float4 below, float4 above) {
       (above.rgb * above.a + below.rgb * below.a * (1.0 - above.a)) / alpha;
   result.a = alpha;
   return result;
+}
+
+float4 gradient_color(Background background,
+                      float2 position,
+                      Bounds_ScaledPixels bounds,
+                      float4 solid_color, float4 color0, float4 color1) {
+  float4 color;
+
+  float2 half_size = float2(bounds.size.width, bounds.size.height) / 2.;
+  float2 center = float2(bounds.origin.x, bounds.origin.y) + half_size;
+  float2 center_to_point = position - center;
+
+  switch (background.tag) {
+      case 0:
+        color = solid_color;
+        break;
+      case 1: {
+        // -90 degrees to match the CSS gradient angle.
+        float radians = (fmod(background.angle, 360.0) - 90.0) * (M_PI_F / 180.0);
+        float2 direction = float2(cos(radians), sin(radians));
+
+        // Get the t value for the linear gradient with the color stop percentages.
+        float t = dot(center_to_point, direction) / length(direction);
+        // Check the direct to determine the use x or y
+        if (abs(direction.x) > abs(direction.y)) {
+           t = (t + half_size.x) / bounds.size.width;
+        } else {
+           t = (t + half_size.y) / bounds.size.height;
+        }
+
+        // Adjust t based on the stop percentages
+        t = (t - background.colors[0].percentage) / (background.colors[1].percentage - background.colors[0].percentage);
+        t = clamp(t, 0.0, 1.0);
+
+        color = mix(color0, color1, t);
+        break;
+      }
+  }
+
+  return color;
 }

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -112,8 +112,8 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
         float radians = (normalized_angle - 90.0) * (M_PI_F / 180.0);
         float2 direction = float2(cos(radians), sin(radians));
 
-        float stop1_percentage = input.background_stop0_percentage;
-        float stop2_percentage = input.background_stop1_percentage;
+        float stop0_percentage = input.background_stop0_percentage;
+        float stop1_percentage = input.background_stop1_percentage;
 
         // Get the t value for the linear gradient with the color stop percentages.
         float2 half_size = float2(quad.bounds.size.width, quad.bounds.size.height) / 2.;
@@ -128,13 +128,13 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
         }
 
         // Adjust t based on the stop percentages
-        t = (t - stop1_percentage) / (stop2_percentage - stop1_percentage);
+        t = (t - stop0_percentage) / (stop1_percentage - stop0_percentage);
         t = clamp(t, 0.0, 1.0);
 
-        float4 color1 = input.background_stop0_color;
-        float4 color2 = input.background_stop1_color;
+        float4 color0 = input.background_stop0_color;
+        float4 color1 = input.background_stop1_color;
 
-        color = mix(color1, color2, t);
+        color = mix(color0, color1, t);
         break;
       }
   }

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -4,8 +4,10 @@
 using namespace metal;
 
 float4 hsla_to_rgba(Hsla hsla);
-float4 linear_srgb_to_oklab(float4 c);
-float4 oklab_to_linear_srgb(float4 c);
+float4 linear_srgb_to_oklab(float4 color);
+float4 oklab_to_linear_srgb(float4 color);
+float4 srgb_to_linear(float4 color);
+float4 linear_to_srgb(float4 color);
 float4 to_device_position(float2 unit_vertex, Bounds_ScaledPixels bounds,
                           constant Size_DevicePixels *viewport_size);
 float4 to_device_position_transformed(float2 unit_vertex, Bounds_ScaledPixels bounds,
@@ -618,38 +620,45 @@ float4 hsla_to_rgba(Hsla hsla) {
 // Converts a linear sRGB color to the Oklab color space.
 // Reference: https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab
 float4 linear_srgb_to_oklab(float4 color) {
-	float l = 0.4122214708 * color.r + 0.5363325363 * color.g + 0.0514459929 * color.b;
-	float m = 0.2119034982 * color.r + 0.6806995451 * color.g + 0.1073969566 * color.b;
-	float s = 0.0883024619 * color.r + 0.2817188376 * color.g + 0.6299787005 * color.b;
+  float l = 0.4122214708 * color.r + 0.5363325363 * color.g + 0.0514459929 * color.b;
+  float m = 0.2119034982 * color.r + 0.6806995451 * color.g + 0.1073969566 * color.b;
+  float s = 0.0883024619 * color.r + 0.2817188376 * color.g + 0.6299787005 * color.b;
 
-	float l_ = pow(l, 1.0/3.0);
-	float m_ = pow(m, 1.0/3.0);
-	float s_ = pow(s, 1.0/3.0);
+  float l_ = pow(l, 1.0/3.0);
+  float m_ = pow(m, 1.0/3.0);
+  float s_ = pow(s, 1.0/3.0);
 
-	return float4(
-		0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
-		1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
-		0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_,
-		color.a
-	);
+  return float4(
+    0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
+    1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+    0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_,
+    color.a
+  );
 }
 
-// Converts an Oklab color to the linear sRGB color space.
 float4 oklab_to_linear_srgb(float4 color) {
-	float l_ = color.r + 0.3963377774 * color.g + 0.2158037573 * color.b;
-	float m_ = color.r - 0.1055613458 * color.g - 0.0638541728 * color.b;
-	float s_ = color.r - 0.0894841775 * color.g - 1.2914855480 * color.b;
+  float l_ = color.r + 0.3963377774 * color.g + 0.2158037573 * color.b;
+  float m_ = color.r - 0.1055613458 * color.g - 0.0638541728 * color.b;
+  float s_ = color.r - 0.0894841775 * color.g - 1.2914855480 * color.b;
 
-	float l = l_ * l_ * l_;
-	float m = m_ * m_ * m_;
-	float s = s_ * s_ * s_;
+  float l = l_ * l_ * l_;
+  float m = m_ * m_ * m_;
+  float s = s_ * s_ * s_;
 
-	return float4(
-		4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
-		-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
-		-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
-		color.a
-	);
+  return float4(
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
+    color.a
+  );
+}
+
+float4 linear_to_srgb(float4 color) {
+  return float4(pow(color.rgb, float3(1.0 / 2.2)), color.a);
+}
+
+float4 srgb_to_linear(float4 color) {
+  return float4(pow(color.rgb, float3(2.2)), color.a);
 }
 
 float4 to_device_position(float2 unit_vertex, Bounds_ScaledPixels bounds,
@@ -813,10 +822,10 @@ float4 gradient_color(Background background,
           color = mix(color0, color1, t);
           break;
         case 1: {
-          float4 oklab_color0 = linear_srgb_to_oklab(color0);
-          float4 oklab_color1 = linear_srgb_to_oklab(color1);
+          float4 oklab_color0 = linear_srgb_to_oklab(srgb_to_linear(color0));
+          float4 oklab_color1 = linear_srgb_to_oklab(srgb_to_linear(color1));
           float4 oklab_color = mix(oklab_color0, oklab_color1, t);
-          color = oklab_to_linear_srgb(oklab_color);
+          color = linear_to_srgb(oklab_to_linear_srgb(oklab_color));
           break;
         }
       }

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -808,7 +808,7 @@ float4 gradient_color(Background background,
       t = (t - background.colors[0].percentage) / (background.colors[1].percentage - background.colors[0].percentage);
       t = clamp(t, 0.0, 1.0);
 
-      switch (background.interpolation_method) {
+      switch (background.color_space) {
         case 0:
           color = mix(color0, color1, t);
           break;

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -6,8 +6,7 @@ using namespace metal;
 float4 hsla_to_rgba(Hsla hsla);
 float4 linear_srgb_to_oklab(float4 color);
 float4 oklab_to_linear_srgb(float4 color);
-float4 srgb_to_linear(float4 color);
-float4 linear_to_srgb(float4 color);
+float4 linear_to_srgba(float4 color);
 float4 to_device_position(float2 unit_vertex, Bounds_ScaledPixels bounds,
                           constant Size_DevicePixels *viewport_size);
 float4 to_device_position_transformed(float2 unit_vertex, Bounds_ScaledPixels bounds,
@@ -617,6 +616,7 @@ float4 hsla_to_rgba(Hsla hsla) {
   return rgba;
 }
 
+
 // Converts a linear sRGB color to the Oklab color space.
 // Reference: https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab
 float4 linear_srgb_to_oklab(float4 color) {
@@ -629,13 +629,14 @@ float4 linear_srgb_to_oklab(float4 color) {
   float s_ = pow(s, 1.0/3.0);
 
   return float4(
-    0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
-    1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
-    0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_,
-    color.a
+   	0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
+   	1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+   	0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_,
+   	color.a
   );
 }
 
+// Converts an Oklab color to the linear sRGB color space.
 float4 oklab_to_linear_srgb(float4 color) {
   float l_ = color.r + 0.3963377774 * color.g + 0.2158037573 * color.b;
   float m_ = color.r - 0.1055613458 * color.g - 0.0638541728 * color.b;
@@ -646,19 +647,15 @@ float4 oklab_to_linear_srgb(float4 color) {
   float s = s_ * s_ * s_;
 
   return float4(
-    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
-    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
-    -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
-    color.a
+   	4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+   	-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+   	-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
+   	color.a
   );
 }
 
-float4 linear_to_srgb(float4 color) {
+float4 linear_to_srgba(float4 color) {
   return float4(pow(color.rgb, float3(1.0 / 2.2)), color.a);
-}
-
-float4 srgb_to_linear(float4 color) {
-  return float4(pow(color.rgb, float3(2.2)), color.a);
 }
 
 float4 to_device_position(float2 unit_vertex, Bounds_ScaledPixels bounds,
@@ -822,10 +819,10 @@ float4 gradient_color(Background background,
           color = mix(color0, color1, t);
           break;
         case 1: {
-          float4 oklab_color0 = linear_srgb_to_oklab(srgb_to_linear(color0));
-          float4 oklab_color1 = linear_srgb_to_oklab(srgb_to_linear(color1));
+          float4 oklab_color0 = linear_srgb_to_oklab(color0);
+          float4 oklab_color1 = linear_srgb_to_oklab(color1);
           float4 oklab_color = mix(oklab_color0, oklab_color1, t);
-          color = linear_to_srgb(oklab_to_linear_srgb(oklab_color));
+          color = linear_to_srgba(oklab_to_linear_srgb(oklab_color));
           break;
         }
       }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -2,8 +2,8 @@
 #![cfg_attr(windows, allow(dead_code))]
 
 use crate::{
-    bounds_tree::BoundsTree, point, AtlasTextureId, AtlasTile, Bounds, ContentMask, Corners, Edges,
-    Hsla, Pixels, Point, Radians, ScaledPixels, Size,
+    bounds_tree::BoundsTree, point, AtlasTextureId, AtlasTile, Background, Bounds, ContentMask,
+    Corners, Edges, Hsla, Pixels, Point, Radians, ScaledPixels, Size,
 };
 use std::{fmt::Debug, iter::Peekable, ops::Range, slice};
 
@@ -456,7 +456,7 @@ pub(crate) struct Quad {
     pub pad: u32, // align to 8 bytes
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub background: Hsla,
+    pub background: Background,
     pub border_color: Hsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -748,7 +748,7 @@ pub struct Path<P: Clone + Default + Debug> {
     pub(crate) bounds: Bounds<P>,
     pub(crate) content_mask: ContentMask<P>,
     pub(crate) vertices: Vec<PathVertex<P>>,
-    pub(crate) color: Hsla,
+    pub(crate) color: Background,
     start: Point<P>,
     current: Point<P>,
     contour_count: usize,

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -5,10 +5,11 @@ use std::{
 };
 
 use crate::{
-    black, phi, point, quad, rems, size, AbsoluteLength, Background, Bounds, ContentMask, Corners,
-    CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, Hsla, Length, Pixels, Point,
-    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, WindowContext,
+    black, phi, point, quad, rems, size, AbsoluteLength, Background, BackgroundTag, Bounds,
+    ContentMask, Corners, CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges,
+    EdgesRefinement, Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, Hsla, Length,
+    Pixels, Point, PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun,
+    WindowContext,
 };
 use collections::HashSet;
 use refineable::Refineable;
@@ -573,11 +574,13 @@ impl Style {
         let background_color = self.background.as_ref().and_then(Fill::color);
         if background_color.map_or(false, |color| !color.is_transparent()) {
             let mut border_color = match background_color {
-                Some(color) => match color {
-                    Background::Solid(c) => c,
-                    Background::LinearGradient { stops, .. } => {
-                        stops.first().map(|stop| stop.color).unwrap_or_default()
-                    }
+                Some(color) => match color.tag {
+                    BackgroundTag::Solid => color.solid,
+                    BackgroundTag::LinearGradient => color
+                        .colors
+                        .first()
+                        .map(|stop| stop.color)
+                        .unwrap_or_default(),
                 },
                 None => Hsla::default(),
             };

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    black, phi, point, quad, rems, size, AbsoluteLength, Bounds, ContentMask, Corners,
+    black, phi, point, quad, rems, size, AbsoluteLength, Background, Bounds, ContentMask, Corners,
     CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
     FontFallbacks, FontFeatures, FontStyle, FontWeight, Hsla, Length, Pixels, Point,
     PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, WindowContext,
@@ -572,7 +572,15 @@ impl Style {
 
         let background_color = self.background.as_ref().and_then(Fill::color);
         if background_color.map_or(false, |color| !color.is_transparent()) {
-            let mut border_color = background_color.unwrap_or_default();
+            let mut border_color = match background_color {
+                Some(color) => match color {
+                    Background::Solid(c) => c,
+                    Background::LinearGradient { stops, .. } => {
+                        stops.first().map(|stop| stop.color).unwrap_or_default()
+                    }
+                },
+                None => Hsla::default(),
+            };
             border_color.a = 0.;
             cx.paint_quad(quad(
                 bounds,
@@ -737,12 +745,14 @@ pub struct StrikethroughStyle {
 #[derive(Clone, Debug)]
 pub enum Fill {
     /// A solid color fill.
-    Color(Hsla),
+    Color(Background),
 }
 
 impl Fill {
     /// Unwrap this fill into a solid color, if it is one.
-    pub fn color(&self) -> Option<Hsla> {
+    ///
+    /// If the fill is not a solid color, this method returns `None`.
+    pub fn color(&self) -> Option<Background> {
         match self {
             Fill::Color(color) => Some(*color),
         }
@@ -751,19 +761,25 @@ impl Fill {
 
 impl Default for Fill {
     fn default() -> Self {
-        Self::Color(Hsla::default())
+        Self::Color(Background::default())
     }
 }
 
 impl From<Hsla> for Fill {
     fn from(color: Hsla) -> Self {
-        Self::Color(color)
+        Self::Color(color.into())
     }
 }
 
 impl From<Rgba> for Fill {
     fn from(color: Rgba) -> Self {
         Self::Color(color.into())
+    }
+}
+
+impl From<Background> for Fill {
+    fn from(background: Background) -> Self {
+        Self::Color(background)
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2321,7 +2321,7 @@ impl<'a> WindowContext<'a> {
     /// Paint the given `Path` into the scene for the next frame at the current z-index.
     ///
     /// This method should only be called as part of the paint phase of element drawing.
-    pub fn paint_path(&mut self, mut path: Path<Pixels>, color: impl Into<Hsla>) {
+    pub fn paint_path(&mut self, mut path: Path<Pixels>, color: impl Into<Background>) {
         debug_assert_eq!(
             self.window.draw_phase,
             DrawPhase::Paint,
@@ -2332,7 +2332,8 @@ impl<'a> WindowContext<'a> {
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
         path.content_mask = content_mask;
-        path.color = color.into().opacity(opacity);
+        let color: Background = color.into();
+        path.color = color.opacity(opacity);
         self.window
             .next_frame
             .scene

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1,7 +1,7 @@
 use crate::{
     point, prelude::*, px, size, transparent_black, Action, AnyDrag, AnyElement, AnyTooltip,
-    AnyView, AppContext, Arena, Asset, AsyncWindowContext, AvailableSpace, Bounds, BoxShadow,
-    Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
+    AnyView, AppContext, Arena, Asset, AsyncWindowContext, AvailableSpace, Background, Bounds,
+    BoxShadow, Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
     DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
     FileDropEvent, Flatten, FontId, GPUSpecs, Global, GlobalElementId, GlyphId, Hsla, InputHandler,
     IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent,
@@ -4976,7 +4976,7 @@ pub struct PaintQuad {
     /// The radii of the quad's corners.
     pub corner_radii: Corners<Pixels>,
     /// The background color of the quad.
-    pub background: Hsla,
+    pub background: Background,
     /// The widths of the quad's borders.
     pub border_widths: Edges<Pixels>,
     /// The color of the quad's borders.
@@ -5009,7 +5009,7 @@ impl PaintQuad {
     }
 
     /// Sets the background color of the quad.
-    pub fn background(self, background: impl Into<Hsla>) -> Self {
+    pub fn background(self, background: impl Into<Background>) -> Self {
         PaintQuad {
             background: background.into(),
             ..self
@@ -5021,7 +5021,7 @@ impl PaintQuad {
 pub fn quad(
     bounds: Bounds<Pixels>,
     corner_radii: impl Into<Corners<Pixels>>,
-    background: impl Into<Hsla>,
+    background: impl Into<Background>,
     border_widths: impl Into<Edges<Pixels>>,
     border_color: impl Into<Hsla>,
 ) -> PaintQuad {
@@ -5035,7 +5035,7 @@ pub fn quad(
 }
 
 /// Creates a filled quad with the given bounds and background color.
-pub fn fill(bounds: impl Into<Bounds<Pixels>>, background: impl Into<Hsla>) -> PaintQuad {
+pub fn fill(bounds: impl Into<Bounds<Pixels>>, background: impl Into<Background>) -> PaintQuad {
     PaintQuad {
         bounds: bounds.into(),
         corner_radii: (0.).into(),
@@ -5050,7 +5050,7 @@ pub fn outline(bounds: impl Into<Bounds<Pixels>>, border_color: impl Into<Hsla>)
     PaintQuad {
         bounds: bounds.into(),
         corner_radii: (0.).into(),
-        background: transparent_black(),
+        background: transparent_black().into(),
         border_widths: (1.).into(),
         border_color: border_color.into(),
     }


### PR DESCRIPTION
Release Notes:

- gpui: Add linear gradient support to fill background

Run example:

```
cargo run -p gpui --example gradient
cargo run -p gpui --example gradient --features macos-blade
```

## Demo

In GPUI (sRGB):

<img width="761" alt="image" src="https://github.com/user-attachments/assets/568c02e8-3065-43c2-b5c2-5618d553dd6e">

In GPUI (Oklab):

<img width="761" alt="image" src="https://github.com/user-attachments/assets/b008b0de-2705-4f99-831d-998ce48eed42">

In CSS (sRGB): 

https://codepen.io/huacnlee/pen/rNXgxBY

<img width="505" alt="image" src="https://github.com/user-attachments/assets/239f4b65-24b3-4797-9491-a13eea420158">

In CSS (Oklab):

https://codepen.io/huacnlee/pen/wBwBKOp

<img width="658" alt="image" src="https://github.com/user-attachments/assets/56fdd55f-d219-45de-922f-7227f535b210">


---

Currently only support 2 color stops with linear-gradient. I think this is we first introduce the gradient feature in GPUI, and the linear-gradient is most popular for use. So we can just add this first and then to add more other supports.

