### PR TITLE
assistant: Adjust title summarization prompt

### DIFF
--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -2891,7 +2891,7 @@ impl Context {
             request.messages.push(LanguageModelRequestMessage {
                 role: Role::User,
                 content: vec![
-                    "Generate a concise 3-7 word title for this conversation, omitting punctuation"
+                    "Generate a concise 3-7 word title for this conversation, omitting punctuation. Go straight to the title, without any preamble and prefix like `Here's a concise suggestion:...` or `Title:`"
                         .into(),
                 ],
                 cache: false,


### PR DESCRIPTION
Meant to avoid the excessive use of "Here's a concise 3-7 word title..." and "Title:" instances we've been seeing lately.
Follow up to: https://github.com/zed-industries/zed/pull/19530

Release Notes:

- Improve prompt for generating title summaries, avoiding preambles
