### PR TITLE
Improve install-cmake script

### DIFF
--- a/script/install-cmake
+++ b/script/install-cmake
@@ -35,7 +35,7 @@ CMAKE_VERSION="${CMAKE_VERSION:-${1:-3.30.4}}"
 
 if [ "$(whoami)" = root ]; then SUDO=; else SUDO="$(command -v sudo || command -v doas || true)"; fi
 
-if cmake --version | grep -q "$CMAKE_VERSION"; then
+if cmake --version 2>/dev/null | grep -q "$CMAKE_VERSION"; then
   echo "CMake $CMAKE_VERSION is already installed."
   exit 0
 elif [ -e /usr/local/bin/cmake ]; then

--- a/script/install-cmake
+++ b/script/install-cmake
@@ -51,7 +51,7 @@ elif [ -e /etc/lsb-release ] && grep -qP 'DISTRIB_ID=Ubuntu' /etc/lsb-release; t
   echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
     | $SUDO tee /etc/apt/sources.list.d/kitware.list >/dev/null
   $SUDO apt-get update
-  $SUDO apt-get install -y kitware-archive-keyring cmake==$CMAKE_VERSION
+  $SUDO apt-get install -y kitware-archive-keyring cmake
 else
   arch="$(uname -m)"
   if [ "$arch" != "x86_64" ] && [ "$arch" != "aarch64" ]; then


### PR DESCRIPTION
- Don't output junk to stderr when cmake unavailable
- Kitware PPA does not include up to date bins for all distros (e.g. Ubuntu 24 only has 3.30.2 although 3.30.4 has been out for a while) so don't try to force install a specific version. Take the best we can get. 

Release Notes:

- N/A
