### PR TITLE
ssh: Fix SSH to mac remotes

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1568,6 +1568,7 @@ impl SshRemoteConnection {
         // exclude armv5,6,7 as they are 32-bit.
         let arch = if arch.starts_with("armv8")
             || arch.starts_with("armv9")
+            || arch.starts_with("arm64")
             || arch.starts_with("aarch64")
         {
             "aarch64"


### PR DESCRIPTION
Restore ability to SSH to macOS arm remotes (`uname -m` on mac == `arm64`).

Fix regression introduced in https://github.com/zed-industries/zed/pull/20618

cc: @ConradIrwin 

Release Notes:

- N/A