### PR TITLE
Don't render invisibles with elements

### DIFF
--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -44,6 +44,21 @@ impl ShapedLine {
         self.layout.len
     }
 
+    /// Override the len, useful if you're rendering text a
+    /// as text b (e.g. rendering invisibles).
+    pub fn with_len(mut self, len: usize) -> Self {
+        let layout = self.layout.as_ref();
+        self.layout = Arc::new(LineLayout {
+            font_size: layout.font_size,
+            width: layout.width,
+            ascent: layout.ascent,
+            descent: layout.descent,
+            runs: layout.runs.clone(),
+            len,
+        });
+        self
+    }
+
     /// Paint the line of text to the window.
     pub fn paint(
         &self,

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -29,7 +29,7 @@ pub struct LineLayout {
 }
 
 /// A run of text that has been shaped .
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShapedRun {
     /// The font id for this run
     pub font_id: FontId,


### PR DESCRIPTION
Turns out that in the case you have a somehow valid utf-8 file that
contains almost all ascii control characters, we run out of element
arena space.

Fixes: #20652

Release Notes:

- Fixed a crash when opening a file containing a very large number of ascii control characters on one line.
