### PR TITLE
collab: Add feature flag to bypass account age check

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -4031,7 +4031,10 @@ async fn get_llm_api_token(
     }
 
     let has_llm_subscription = session.has_llm_subscription(&db).await?;
-    if !has_llm_subscription {
+
+    let bypass_account_age_check =
+        has_llm_subscription || flags.iter().any(|flag| flag == "bypass-account-age-check");
+    if !bypass_account_age_check {
         let mut account_created_at = user.created_at;
         if let Some(github_created_at) = user.github_user_created_at {
             account_created_at = account_created_at.min(github_created_at);


### PR DESCRIPTION
This PR adds a `bypass-account-age-check` feature flag that can be used to bypass the minimum account age check.

Release Notes:

- N/A