### PR TITLE
Filter LSP code actions based on the requested kinds

### DIFF
--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -835,7 +835,7 @@ impl RandomizedTest for ProjectCollaborationTest {
                         .map_ok(|_| ())
                         .boxed(),
                     LspRequestKind::CodeAction => project
-                        .code_actions(&buffer, offset..offset, cx)
+                        .code_actions(&buffer, offset..offset, None, cx)
                         .map(|_| Ok(()))
                         .boxed(),
                     LspRequestKind::Definition => project

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13741,7 +13741,9 @@ impl CodeActionProvider for Model<Project> {
         range: Range<text::Anchor>,
         cx: &mut WindowContext,
     ) -> Task<Result<Vec<CodeAction>>> {
-        self.update(cx, |project, cx| project.code_actions(buffer, range, cx))
+        self.update(cx, |project, cx| {
+            project.code_actions(buffer, range, None, cx)
+        })
     }
 
     fn apply_code_action(

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2100,16 +2100,15 @@ impl LspCommand for GetCodeActions {
             .unwrap_or_default()
             .into_iter()
             .filter_map(|entry| {
-                let lsp_action = match entry {
-                    lsp::CodeActionOrCommand::CodeAction(lsp_action) => lsp_action,
-                    _ => return None,
+                let lsp::CodeActionOrCommand::CodeAction(lsp_action) = entry else {
+                    return None;
                 };
 
-                if let Some(requested_kinds) = &requested_kinds_set {
-                    if let Some(kind) = &lsp_action.kind {
-                        if !requested_kinds.contains(kind) {
-                            return None;
-                        }
+                if let Some((requested_kinds, kind)) =
+                    requested_kinds_set.as_ref().zip(lsp_action.kind.as_ref())
+                {
+                    if !requested_kinds.contains(kind) {
+                        return None;
                     }
                 }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2020,6 +2020,7 @@ impl LspStore {
         &mut self,
         buffer_handle: &Model<Buffer>,
         range: Range<Anchor>,
+        kinds: Option<Vec<CodeActionKind>>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<Vec<CodeAction>>> {
         if let Some((upstream_client, project_id)) = self.upstream_client() {
@@ -2033,7 +2034,7 @@ impl LspStore {
                 request: Some(proto::multi_lsp_query::Request::GetCodeActions(
                     GetCodeActions {
                         range: range.clone(),
-                        kinds: None,
+                        kinds: kinds.clone(),
                     }
                     .to_proto(project_id, buffer_handle.read(cx)),
                 )),
@@ -2059,7 +2060,7 @@ impl LspStore {
                         .map(|code_actions_response| {
                             GetCodeActions {
                                 range: range.clone(),
-                                kinds: None,
+                                kinds: kinds.clone(),
                             }
                             .response_from_proto(
                                 code_actions_response,
@@ -2084,7 +2085,7 @@ impl LspStore {
                 Some(range.start),
                 GetCodeActions {
                     range: range.clone(),
-                    kinds: None,
+                    kinds: kinds.clone(),
                 },
                 cx,
             );

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -52,8 +52,8 @@ use language::{
     Transaction, Unclipped,
 };
 use lsp::{
-    CompletionContext, CompletionItemKind, DocumentHighlightKind, LanguageServer, LanguageServerId,
-    LanguageServerName, MessageActionItem,
+    CodeActionKind, CompletionContext, CompletionItemKind, DocumentHighlightKind, LanguageServer,
+    LanguageServerId, LanguageServerName, MessageActionItem,
 };
 use lsp_command::*;
 use node_runtime::NodeRuntime;
@@ -2830,12 +2830,13 @@ impl Project {
         &mut self,
         buffer_handle: &Model<Buffer>,
         range: Range<T>,
+        kinds: Option<Vec<CodeActionKind>>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<Vec<CodeAction>>> {
         let buffer = buffer_handle.read(cx);
         let range = buffer.anchor_before(range.start)..buffer.anchor_before(range.end);
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.code_actions(buffer_handle, range, cx)
+            lsp_store.code_actions(buffer_handle, range, kinds, cx)
         })
     }
 


### PR DESCRIPTION
I've observed that Zed's implementation of [Code Actions On Format](https://zed.dev/docs/configuring-zed#code-actions-on-format) uses the [CodeActionContext.only](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext) parameter to request specific code action kinds from the server. The issue is that it does not filter out code actions from the response, believing that the server will do it.

The [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext) says that the client is responsible for filtering out unwanted code actions:

```js
/**
* Requested kind of actions to return.
*
* Actions not of this kind are filtered out by the client before being
* shown. So servers can omit computing them.
*/
only?: CodeActionKind[];
```

This PR will filter out unwanted code action on the client side.

I have initially encountered this issue because the [ZLS language server](https://github.com/zigtools/zls) (until https://github.com/zigtools/zls/pull/2087) does not filter code action based on `CodeActionContext.only` so Zed runs all received code actions even if they are explicitly disabled in the `code_actions_on_format` setting.

Release Notes:

- Fix the `code_actions_on_format` setting when used with a language server like ZLS
