### PR TITLE
editor: Minimap (looking for guidance)

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -402,6 +402,7 @@ pub struct EditorStyle {
     pub background: Hsla,
     pub local_player: PlayerColor,
     pub text: TextStyle,
+    pub minimap_width: Pixels,
     pub scrollbar_width: Pixels,
     pub syntax: Arc<SyntaxTheme>,
     pub status: StatusColors,
@@ -416,6 +417,7 @@ impl Default for EditorStyle {
             background: Hsla::default(),
             local_player: PlayerColor::default(),
             text: TextStyle::default(),
+            minimap_width: Pixels::default(),
             scrollbar_width: Pixels::default(),
             syntax: Default::default(),
             // HACK: Status colors don't have a real default.
@@ -14367,6 +14369,7 @@ impl Render for Editor {
                 background,
                 local_player: cx.theme().players().local(),
                 text: text_style,
+                minimap_width: EditorElement::MINIMAP_WIDTH,
                 scrollbar_width: EditorElement::SCROLLBAR_WIDTH,
                 syntax: cx.theme().syntax().clone(),
                 status: cx.theme().status().clone(),

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -98,7 +98,7 @@ pub struct Toolbar {
 }
 
 // TODO: minimap settings
-// how do migrations work?
+// how do migrations work when new settings are added?
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct Scrollbar {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -97,6 +97,9 @@ pub struct Toolbar {
     pub selections_menu: bool,
 }
 
+// TODO: minimap settings
+// how do migrations work?
+
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct Scrollbar {
     pub show: ShowScrollbar,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1158,6 +1158,7 @@ impl EditorElement {
         rows_per_page: f32,
         cx: &mut WindowContext,
     ) -> Option<MinimapLayout> {
+        // TODO: draw text (huge task, getting guidance)
         // TODO: minimap_settings: display_mode (visible, minimal, hidden)
         // TODO: dragging / other mouse interactions
         

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3565,7 +3565,38 @@ impl EditorElement {
             cursor.paint(layout.content_origin, cx);
         }
     }
-
+    
+    fn paint_minimap(&mut self, layout: &mut EditorLayout, cx: &mut WindowContext) {
+        let Some(scrollbar_layout) = layout.scrollbar_layout.as_ref() else {
+            return;
+        };
+        
+        let box_width = Pixels(100.0);
+        let box_height = Pixels(100.0);
+        let box_right_padding = Pixels(20.0);
+        
+        let mut test_box_bounds = scrollbar_layout.hitbox.bounds.clone();
+        test_box_bounds.origin -= point(box_width + box_right_padding, Pixels::ZERO);
+        test_box_bounds.size = size(box_width, box_height);
+        
+        cx.paint_layer(scrollbar_layout.hitbox.bounds, |cx| {
+            cx.paint_quad(quad(
+                test_box_bounds,
+                Corners::default(),
+                cx.theme().colors().scrollbar_thumb_background,
+                Edges {
+                    top: Pixels::ZERO,
+                    right: ScrollbarLayout::BORDER_WIDTH,
+                    bottom: ScrollbarLayout::BORDER_WIDTH,
+                    left: ScrollbarLayout::BORDER_WIDTH,
+                },
+                cx.theme().colors().scrollbar_thumb_border,
+                // Edges::default(),
+                // Hsla::transparent_black(),
+            ));
+        });
+    }
+    
     fn paint_scrollbar(&mut self, layout: &mut EditorLayout, cx: &mut WindowContext) {
         let Some(scrollbar_layout) = layout.scrollbar_layout.as_ref() else {
             return;
@@ -5750,6 +5781,7 @@ impl Element for EditorElement {
                         });
                     }
 
+                    self.paint_minimap(layout, cx);
                     self.paint_scrollbar(layout, cx);
                     self.paint_mouse_context_menu(layout, cx);
                 });


### PR DESCRIPTION
Closes #5308 

Release Notes:
- N/A (for now)

## Background
*This is not a complete minimap implementation at all. I am looking for some guidance on the high level approach to this, and the issue discussion is closed. If there's a better place to continue the discussion, I'm happy to close this and discuss elsewhere.*

### Basics
- I started this work by reading the existing issue thread. Its [final post](https://github.com/zed-industries/zed/issues/5308#issuecomment-2296446975) has some good guidance, but I struggled to follow exactly how to approach this, having not yet read the codebase. 
- I decided to start instead by understanding how the scroll bar works, and attempt to create a minimal minimap version of that. It seemed like these would be pretty analogous placement and behavior wise.
- I feel like I made good progress in the initial stages of this.
### Text
- However, the hardest part, and main point of the minimap is of course drawing the text / some abstract representation of it (how Xcode's minimap looks). 
- In the issue post, the suggestion (from what I gathered) was to wrap the buffer into a new editor with certain features disabled, position it correctly, and draw it.

This seems weird to me for a few reasons:
  - I would expect the minimap to only be drawn within the editor, next to the scroll bar.
  - All logic for scrollbar placement lives in the editor.
  - All logic for text positioning, syntax highlighting, etc also lives in the editor (`element.cs`). 
  - If you have another editor (or some sort of editor subset with reduced capabilities), would it be nested inside of the existing editor, or at a layer higher, where the current editor lives? Each possibility has some weirdness.
    - **Inside the editor:** Does this not create some sort of recursive case where we need to ensure the sub-editor does not also have it's own minimap, otherwise it's editors all the way down? I know my lack of understanding of the architecture here is showing, lol. 
    - **At a higher layer, where the current editor lives:** This seems silly because of the layout of text and scrollbar being so intertwined with editor. You would want the way text is drawn in the minimap to exactly align with that in the editor.  Does that mean all that logic would need to be extracted and made reusable by both? And, it would be confusing to me if this other editor at a higher layer was being drawn at a position dependent on the size/visibility of the scrollbar inside the existing editor...
  - Either way, using a whole new editor, even with many things disabled, seems like it would add a lot of overhead. But again, I'm really clueless here on how easy it would be to create a new editor with exactly the same text/scrollbar layout logic as the existing one without duplicating code.


To me, it seems like the minimap should be within the editor, similar to the scrollbar, and re-use the same logic/functions that the main editor window uses for text positioning, highlights, etc (rather than being a new editor variant that gets drawn on its own). I would love feedback on if this makes sense, as well as some initial direction on how to make it happen:


## What's done so far

- Added very initial minimap bones
  - drawing of minimap background and foreground as rects, mainly to nail down positions and sizing for both

## What's known to be missing (not exhaustive)
  - drawing of actual editor text content (dependent on result of architecture questions above)
  - proper offset to keep the minimap's visible region on screen
  - minimap settings
  - additional theme colors, if applicable
  - mouse/kb interactions
