### PR TITLE
Fix file missing or duplicated when copying multiple items in project panel + Fix marked files not being deselected after selecting a directory

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1737,7 +1737,6 @@ impl ProjectPanel {
                 })
                 .collect::<Vec<_>>()
         };
-        println!("abs_file_paths: {:?}", abs_file_paths);
         if !abs_file_paths.is_empty() {
             cx.write_to_clipboard(ClipboardItem::new_string(abs_file_paths.join("\n")));
         }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1721,7 +1721,7 @@ impl ProjectPanel {
     fn copy_path(&mut self, _: &CopyPath, cx: &mut ViewContext<Self>) {
         let abs_file_paths = {
             let project = self.project.read(cx);
-            self.selected_and_marked_entries()
+            self.marked_entries()
                 .into_iter()
                 .filter_map(|entry| {
                     let entry_path = project.path_for_entry(entry.entry_id, cx)?.path;
@@ -1745,7 +1745,7 @@ impl ProjectPanel {
     fn copy_relative_path(&mut self, _: &CopyRelativePath, cx: &mut ViewContext<Self>) {
         let file_paths = {
             let project = self.project.read(cx);
-            self.selected_and_marked_entries()
+            self.marked_entries()
                 .into_iter()
                 .filter_map(|entry| {
                     Some(
@@ -1929,7 +1929,7 @@ impl ProjectPanel {
     }
 
     fn disjoint_entries(&self, cx: &AppContext) -> BTreeSet<SelectedEntry> {
-        let marked_entries = self.selected_and_marked_entries();
+        let marked_entries = self.marked_entries();
         let mut sanitized_entries = BTreeSet::new();
         if marked_entries.is_empty() {
             return sanitized_entries;
@@ -1977,7 +1977,7 @@ impl ProjectPanel {
     }
 
     // Returns the union of the currently selected entry and all marked entries.
-    fn selected_and_marked_entries(&self) -> BTreeSet<SelectedEntry> {
+    fn marked_entries(&self) -> BTreeSet<SelectedEntry> {
         let mut entries = self
             .marked_entries
             .iter()
@@ -1988,12 +1988,10 @@ impl ProjectPanel {
             .collect::<BTreeSet<_>>();
 
         if let Some(selection) = self.selection {
-            if !entries.contains(&selection) {
-                entries.insert(SelectedEntry {
-                    entry_id: self.resolve_entry(selection.entry_id),
-                    worktree_id: selection.worktree_id,
-                });
-            }
+            entries.insert(SelectedEntry {
+                entry_id: self.resolve_entry(selection.entry_id),
+                worktree_id: selection.worktree_id,
+            });
         }
 
         entries

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1990,7 +1990,7 @@ impl ProjectPanel {
         if let Some(selection) = self.selection {
             if !entries.contains(&selection) {
                 entries.insert(SelectedEntry {
-                    entry_id: selection.entry_id,
+                    entry_id: self.resolve_entry(selection.entry_id),
                     worktree_id: selection.worktree_id,
                 });
             }


### PR DESCRIPTION
Closes #20858

This fix depends on the sanitization logic implemented in PR #20577. Since that branch may undergo further changes, this branch will be periodically rebased on it. Once #20577 is merged, the dependency will no longer apply.

Release Notes:

- Fix missing or duplicated files when copying multiple items in the project panel.
- Fix marked files not being deselected after selecting a directory on primary click.
- Fix "copy path" and "copy path relative" with multiple items selected in project panel.

**Problem**:

In this case, `dir1` is selected while `dir2`, `dir3`, and `dir1/file` are marked. Using the `marked_entries` function results in only `dir1`, which is incorrect.

<img height="120" src="https://github.com/user-attachments/assets/d4d92cc5-c998-4948-9a58-25c4f54167f2" />

Currently, the `marked_entries` function is used in five actions, which all produce incorrect results:

1. Delete (via the disjoint function)
2. Copy 
3. Cut
4. Copy Path
5. Copy Path Relative

**Solution**:

1. `marked_entries` function should not use  "When currently selected entry is not marked, it's treated as the only marked entry." logic. There is no grand scheme behind this logic as confirmed by piotr [here](https://github.com/zed-industries/zed/issues/17746#issuecomment-2464765963).
2. `copy` and `cut` actions should use the disjoint function to prevent obivous failures.
3. `copy path` and `copy path relative` should keep using *fixed* `marked_entries` as that is expected behavior for these actions. 

---

1. Before/After: Partial Copy

Select `dir1` and `c.txt` (in that order, reverse order works!), and copy it and paste in `dir2`. `c.txt` is not copied in `dir2`.

<img height="170" src="https://github.com/user-attachments/assets/a09fcb40-f38f-46ef-b0b4-e44ec01dda18" />
<img height="170" src="https://github.com/user-attachments/assets/bb87dbe5-8e2e-4ca4-a565-42be5755ec8a" />

---
2. Before/After: Duplicate Copy

Select `a.txt`, `dir1` and `c.txt` (in that order), and copy it and paste in `dir2`. `a.txt` is duplicated in `dir2`.

<img height="170" src="https://github.com/user-attachments/assets/6f999d22-3607-48d7-9ff6-2e27494002f8" />
<img height="170" src="https://github.com/user-attachments/assets/b4b6ff7d-0df7-45ea-83e4-50a0acb18457" />

---
3. Before/After: Directory Selection

Simply primary click on any file, now primary click on any dir. That previous file is still marked.

<img height="170" src="https://github.com/user-attachments/assets/9f1948ce-7445-4377-9733-06490ed6a324" />
<img height="170" src="https://github.com/user-attachments/assets/e78203bc-96ba-424b-b588-c038992a9f0e" />

---
4. Before/After: Copy Path and Copy Path Relative

Upon `copy path` (ctrl + alt + c):

Before: Only `/home/tims/test/dir2/a.txt` was copied.
After: All three paths `/home/tims/test/dir2`,  `/home/tims/test/c.txt` and `/home/tims/test/dir2/a.txt` are copied. 

This is also how VSCode also copies path when multiple are selected.

<img height="170" src="https://github.com/user-attachments/assets/e20423ea-1682-4efd-b208-631e2edd3771" />


