### PR TITLE
Add missing Sublime Text key binding

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -26,7 +26,8 @@
       "ctrl-k ctrl-l": "editor::ConvertToLowerCase",
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd"
+      "ctrl-delete": "editor::DeleteToNextWordEnd",
+      "alt-f3": "search::SelectAllMatches"
     }
   },
   {


### PR DESCRIPTION
Provide sublime text's default key binding for "Select All Matches Using Most Recent Pattern"

Closes #ISSUE

Release Notes:

- Added missing default key binding from sublime text for selecting all matches in the current file
