### PR TITLE
Add editor::SelectAllMatches to SublimeText base keymap

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -26,7 +26,8 @@
       "ctrl-k ctrl-l": "editor::ConvertToLowerCase",
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd"
+      "ctrl-delete": "editor::DeleteToNextWordEnd",
+      "alt-f3": "search::SelectAllMatches"
     }
   },
   {

--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -16,6 +16,7 @@
       "ctrl-shift-l": "editor::SplitSelectionIntoLines",
       "ctrl-shift-a": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-d": "editor::DuplicateLineDown",
+      "alt-f3": "editor::SelectAllMatches", // find_all_under
       "f12": "editor::GoToDefinition",
       "ctrl-f12": "editor::GoToDefinitionSplit",
       "shift-f12": "editor::FindAllReferences",
@@ -26,8 +27,7 @@
       "ctrl-k ctrl-l": "editor::ConvertToLowerCase",
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd",
-      "alt-f3": "search::SelectAllMatches"
+      "ctrl-delete": "editor::DeleteToNextWordEnd"
     }
   },
   {

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -19,6 +19,7 @@
       "cmd-shift-l": "editor::SplitSelectionIntoLines",
       "cmd-shift-a": "editor::SelectLargerSyntaxNode",
       "cmd-shift-d": "editor::DuplicateLineDown",
+      "ctrl-cmd-g": "editor::SelectAllMatches", // find_all_under
       "shift-f12": "editor::FindAllReferences",
       "alt-cmd-down": "editor::GoToDefinition",
       "ctrl-alt-cmd-down": "editor::GoToDefinitionSplit",


### PR DESCRIPTION
- Supersedes: https://github.com/zed-industries/zed/pull/20861

`alt-f3` on Linux
`ctrl-cmd-g` on MacOS

Reference:
- [Default (OSX).sublime-keymap](https://gist.github.com/notpeter/d00e37c93ef4c145e1b39b1040bbf4bd)
- [Default (Linux).sublime-keymap](https://gist.github.com/notpeter/1685cfc649ad68fc5569f651cfa7f6c4)

Release Notes:

- Sublime Keymap: Add `editor::SelectAllMatches` compatibility bind (`find_all_under`). Mac: `ctrl-cmd-g` and Linux: `alt-f3`