### PR TITLE
Fix draft-releaase-notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
           #
           # 25 was chosen arbitrarily.
           fetch-depth: 25
+          fetch-tags: true
           clean: false
 
       - name: Limit target directory size
@@ -261,6 +262,9 @@ jobs:
           mkdir -p target/
           # Ignore any errors that occur while drafting release notes to not fail the build.
           script/draft-release-notes "$RELEASE_VERSION" "$RELEASE_CHANNEL" > target/release-notes.md || true
+          script/create-draft-release target/release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate license file
         run: script/generate-licenses
@@ -306,7 +310,6 @@ jobs:
             target/aarch64-apple-darwin/release/Zed-aarch64.dmg
             target/x86_64-apple-darwin/release/Zed-x86_64.dmg
             target/release/Zed.dmg
-          body_path: target/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -399,21 +402,5 @@ jobs:
           files: |
             target/zed-remote-server-linux-aarch64.gz
             target/release/zed-linux-aarch64.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  auto-publish-release:
-    timeout-minutes: 60
-    name: Create a Linux bundle
-    runs-on:
-      - self-hosted
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-pre') && !endsWith(github.ref, '.0-pre') }}
-    needs: [bundle-mac, bundle-linux-aarch64, bundle-linux]
-    steps:
-      - name: Upload app bundle to release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          draft: false
-          prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/script/create-draft-release
+++ b/script/create-draft-release
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+preview=""
+if [[ "$GITHUB_REF_NAME" == *"-pre" ]]; then
+    preview="-p"
+fi
+
+gh release create -d "$GITHUB_REF_NAME" -F "$1" $preview


### PR DESCRIPTION
Turns out this was broken because (a) we didn't have tags fetched,
and (b) because the gh-release action we use is buggy.

Release Notes:

- N/A
