### PR TITLE
gpui: Implement hover for Windows

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -7,6 +7,7 @@ use windows::Win32::{
     Graphics::Gdi::*,
     System::SystemServices::*,
     UI::{
+        Controls::*,
         HiDpi::*,
         Input::{Ime::*, KeyboardAndMouse::*},
         WindowsAndMessaging::*,
@@ -43,7 +44,8 @@ pub(crate) fn handle_msg(
         WM_PAINT => handle_paint_msg(handle, state_ptr),
         WM_CLOSE => handle_close_msg(state_ptr),
         WM_DESTROY => handle_destroy_msg(handle, state_ptr),
-        WM_MOUSEMOVE => handle_mouse_move_msg(lparam, wparam, state_ptr),
+        WM_MOUSEMOVE => handle_mouse_move_msg(handle, lparam, wparam, state_ptr),
+        WM_MOUSELEAVE => handle_mouse_leave_msg(state_ptr),
         WM_NCMOUSEMOVE => handle_nc_mouse_move_msg(handle, lparam, state_ptr),
         WM_NCLBUTTONDOWN => {
             handle_nc_mouse_down_msg(handle, MouseButton::Left, wparam, lparam, state_ptr)
@@ -234,10 +236,32 @@ fn handle_destroy_msg(handle: HWND, state_ptr: Rc<WindowsWindowStatePtr>) -> Opt
 }
 
 fn handle_mouse_move_msg(
+    handle: HWND,
     lparam: LPARAM,
     wparam: WPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
+    let mut lock = state_ptr.state.borrow_mut();
+    if !lock.hovered {
+        lock.hovered = true;
+        unsafe {
+            TrackMouseEvent(&mut TRACKMOUSEEVENT {
+                cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
+                dwFlags: TME_LEAVE,
+                hwndTrack: handle,
+                dwHoverTime: HOVER_DEFAULT,
+            })
+            .log_err()
+        };
+        if let Some(mut callback) = lock.callbacks.hovered_status_change.take() {
+            drop(lock);
+            callback(true);
+            state_ptr.state.borrow_mut().callbacks.hovered_status_change = Some(callback);
+        }
+    } else {
+        drop(lock);
+    }
+
     let mut lock = state_ptr.state.borrow_mut();
     if let Some(mut callback) = lock.callbacks.input.take() {
         let scale_factor = lock.scale_factor;
@@ -270,6 +294,18 @@ fn handle_mouse_move_msg(
         return result;
     }
     Some(1)
+}
+
+fn handle_mouse_leave_msg(state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
+    let mut lock = state_ptr.state.borrow_mut();
+    lock.hovered = false;
+    if let Some(mut callback) = lock.callbacks.hovered_status_change.take() {
+        drop(lock);
+        callback(false);
+        state_ptr.state.borrow_mut().callbacks.hovered_status_change = Some(callback);
+    }
+
+    Some(0)
 }
 
 fn handle_syskeydown_msg(

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1241,7 +1241,11 @@ impl<'a> WindowContext<'a> {
     /// that currently owns the mouse cursor.
     /// On mac, this is equivalent to `is_window_active`.
     pub fn is_window_hovered(&self) -> bool {
-        if cfg!(any(target_os = "linux", target_os = "freebsd")) {
+        if cfg!(any(
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )) {
             self.window.hovered.get()
         } else {
             self.is_window_active()


### PR DESCRIPTION
On Windows the window that the cursor is hovering over should react and update the cursor icon, for example when it hovers over a button on a unfocussed window it should change the cursor icon to a pointerHand icon, this deviates with how macOS works.

Currently `is_window_hovered` handles Windows the same way macOS works which is wrong. This causes GPUI not to update the cursor icon if the window is not activated which leads to the cursor icon being misrepresented if the user hovers their cursor over a element which is supposed to change the cursor icon.

This PR fixes this issue by implementing the necessary hover functionality for Windows and changing the `is_window_hovered` to use the `hovered` status rather than `is_window_active`.

Example comparison between File Explorer and Zed, which you can see Zed not updating cursor Icon when unfocussed but File Explorer does.

https://github.com/user-attachments/assets/2041dc7a-839a-414d-b66a-7cb0260f186b


Release Notes:

- N/A