### PR TITLE
context_servers: Make `settings` field show up in settings completions

### DIFF
--- a/crates/context_servers/src/manager.rs
+++ b/crates/context_servers/src/manager.rs
@@ -24,6 +24,8 @@ use gpui::{AsyncAppContext, EventEmitter, Model, ModelContext, Subscription, Tas
 use log;
 use parking_lot::RwLock;
 use project::Project;
+use schemars::gen::SchemaGenerator;
+use schemars::schema::{InstanceType, Schema, SchemaObject};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources, SettingsStore};
@@ -43,7 +45,15 @@ pub struct ContextServerSettings {
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, JsonSchema, Debug, Default)]
 pub struct ServerConfig {
     pub command: Option<ServerCommand>,
+    #[schemars(schema_with = "server_config_settings_json_schema")]
     pub settings: Option<serde_json::Value>,
+}
+
+fn server_config_settings_json_schema(_generator: &mut SchemaGenerator) -> Schema {
+    Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        ..Default::default()
+    })
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, JsonSchema, Debug)]


### PR DESCRIPTION
This PR fixes an issue where the `settings` field for a context server would not show up in the completions when editing the Zed settings.

It seems that `schemars` doesn't like the `serde_json::Value` as a setting type when generating the JSON Schema. To address this, we are using a custom schema of an empty object (as we don't yet have any other information as to the structure of a given context server's settings).

Release Notes:

- context_servers: Fixed `settings` field not being suggested in completions when editing `settings.json`.
