### PR TITLE
ci: Fix for checkout action with fetch-tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,8 +244,8 @@ jobs:
           #
           # 25 was chosen arbitrarily.
           fetch-depth: 25
-          fetch-tags: true
           clean: false
+          ref: ${{ github.ref }}
 
       - name: Limit target directory size
         run: script/clear-target-dir-if-larger-than 100


### PR DESCRIPTION
Today's releases failed with errors from `checkout_v4`:
- https://github.com/zed-industries/zed/actions/runs/11936859733/job/33272411499
- https://github.com/zed-industries/zed/actions/runs/11936859742/job/33272217001

This allows those releases to work.
I have already cherry-picked this commit to the v0.164.x and v0.163.x branches.

But breaks the `draft release notes` step ([example run](https://github.com/zed-industries/zed/actions/runs/11938377446/job/33277070203)):
<img width="1106" alt="Screenshot 2024-11-20 at 12 31 05" src="https://github.com/user-attachments/assets/68fd7be7-7f78-471d-9e65-36df2cbd70d9">

Previously:
- https://github.com/zed-industries/zed/pull/20885

CC: @ConradIrwin 

Release Notes:

- N/A