### PR TITLE
Revert: "a" for "vim::AngleBrackets"

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -381,8 +381,7 @@
       "shift-b": "vim::CurlyBrackets",
       "<": "vim::AngleBrackets",
       ">": "vim::AngleBrackets",
-      "a": "vim::AngleBrackets",
-      "g": "vim::Argument"
+      "a": "vim::Argument"
     }
   },
   {

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1407,7 +1407,7 @@ mod test {
 
         // Generic arguments
         cx.set_state("fn boop<A: ˇDebug, B>() {}", Mode::Normal);
-        cx.simulate_keystrokes("v i g");
+        cx.simulate_keystrokes("v i a");
         cx.assert_state("fn boop<«A: Debugˇ», B>() {}", Mode::Visual);
 
         // Function arguments
@@ -1415,11 +1415,11 @@ mod test {
             "fn boop(ˇarg_a: (Tuple, Of, Types), arg_b: String) {}",
             Mode::Normal,
         );
-        cx.simulate_keystrokes("d a g");
+        cx.simulate_keystrokes("d a a");
         cx.assert_state("fn boop(ˇarg_b: String) {}", Mode::Normal);
 
         cx.set_state("std::namespace::test(\"strinˇg\", a.b.c())", Mode::Normal);
-        cx.simulate_keystrokes("v a g");
+        cx.simulate_keystrokes("v a a");
         cx.assert_state("std::namespace::test(«\"string\", ˇ»a.b.c())", Mode::Visual);
 
         // Tuple, vec, and array arguments
@@ -1427,34 +1427,34 @@ mod test {
             "fn boop(arg_a: (Tuple, Ofˇ, Types), arg_b: String) {}",
             Mode::Normal,
         );
-        cx.simulate_keystrokes("c i g");
+        cx.simulate_keystrokes("c i a");
         cx.assert_state(
             "fn boop(arg_a: (Tuple, ˇ, Types), arg_b: String) {}",
             Mode::Insert,
         );
 
         cx.set_state("let a = (test::call(), 'p', my_macro!{ˇ});", Mode::Normal);
-        cx.simulate_keystrokes("c a g");
+        cx.simulate_keystrokes("c a a");
         cx.assert_state("let a = (test::call(), 'p'ˇ);", Mode::Insert);
 
         cx.set_state("let a = [test::call(ˇ), 300];", Mode::Normal);
-        cx.simulate_keystrokes("c i g");
+        cx.simulate_keystrokes("c i a");
         cx.assert_state("let a = [ˇ, 300];", Mode::Insert);
 
         cx.set_state(
             "let a = vec![Vec::new(), vecˇ![test::call(), 300]];",
             Mode::Normal,
         );
-        cx.simulate_keystrokes("c a g");
+        cx.simulate_keystrokes("c a a");
         cx.assert_state("let a = vec![Vec::new()ˇ];", Mode::Insert);
 
         // Cursor immediately before / after brackets
         cx.set_state("let a = [test::call(first_arg)ˇ]", Mode::Normal);
-        cx.simulate_keystrokes("v i g");
+        cx.simulate_keystrokes("v i a");
         cx.assert_state("let a = [«test::call(first_arg)ˇ»]", Mode::Visual);
 
         cx.set_state("let a = [test::callˇ(first_arg)]", Mode::Normal);
-        cx.simulate_keystrokes("v i g");
+        cx.simulate_keystrokes("v i a");
         cx.assert_state("let a = [«test::call(first_arg)ˇ»]", Mode::Visual);
     }
 


### PR DESCRIPTION
The replacement "g" didn't seem to work for everyone.

Closes #20912
Updates #20104

Release Notes:

- vim: Restores `dia` to mean "delete in argument" instead of "delete within angle brackets". To keep this in your own keymap use:
    ```
    {
        "context": "vim_operator == a || vim_operator == i || vim_operator == cs",
        "use_layout_keys": true,
        "bindings": {
            "a": "vim::AngleBrackets"
        }
    }
    ```
