### PR TITLE
Add the option to hide both the task and command lines in the task output

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -174,7 +174,7 @@ impl Project {
                     command_label: spawn_task.command_label,
                     hide: spawn_task.hide,
                     status: TaskStatus::Running,
-                    show_task: spawn_task.show_task,
+                    show_summary: spawn_task.show_summary,
                     show_command: spawn_task.show_command,
                     completion_rx,
                 });

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -174,8 +174,8 @@ impl Project {
                     command_label: spawn_task.command_label,
                     hide: spawn_task.hide,
                     status: TaskStatus::Running,
-                    hide_task: spawn_task.hide_task,
-                    hide_command: spawn_task.hide_command,
+                    show_task: spawn_task.show_task,
+                    show_command: spawn_task.show_command,
                     completion_rx,
                 });
 

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -174,6 +174,8 @@ impl Project {
                     command_label: spawn_task.command_label,
                     hide: spawn_task.hide,
                     status: TaskStatus::Running,
+                    hide_task: spawn_task.hide_task,
+                    hide_command: spawn_task.hide_command,
                     completion_rx,
                 });
 

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -51,8 +51,8 @@ pub struct SpawnInTerminal {
     pub hide: HideStrategy,
     /// Which shell to use when spawning the task.
     pub shell: Shell,
-    /// Whether to show the task line in the task output.
-    pub show_task: bool,
+    /// Whether to show the task summary line in the task output (sucess/failure).
+    pub show_summary: bool,
     /// Whether to show the command line in the task output.
     pub show_command: bool,
 }

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -51,6 +51,10 @@ pub struct SpawnInTerminal {
     pub hide: HideStrategy,
     /// Which shell to use when spawning the task.
     pub shell: Shell,
+    /// Wether to hide the task line in the task output.
+    pub hide_task: bool,
+    /// Weather to hide the command line in the task output.
+    pub hide_command: bool,
 }
 
 /// A final form of the [`TaskTemplate`], that got resolved with a particualar [`TaskContext`] and now is ready to spawn the actual task.

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -51,10 +51,10 @@ pub struct SpawnInTerminal {
     pub hide: HideStrategy,
     /// Which shell to use when spawning the task.
     pub shell: Shell,
-    /// Wether to hide the task line in the task output.
-    pub hide_task: bool,
-    /// Weather to hide the command line in the task output.
-    pub hide_command: bool,
+    /// Whether to show the task line in the task output.
+    pub show_task: bool,
+    /// Whether to show the command line in the task output.
+    pub show_command: bool,
 }
 
 /// A final form of the [`TaskTemplate`], that got resolved with a particualar [`TaskContext`] and now is ready to spawn the actual task.

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -57,6 +57,12 @@ pub struct TaskTemplate {
     /// Which shell to use when spawning the task.
     #[serde(default)]
     pub shell: Shell,
+    /// Wether to hide the task line in the task output.
+    #[serde(default)]
+    pub hide_task: bool,
+    /// Weather to hide the command line in the task output.
+    #[serde(default)]
+    pub hide_command: bool,
 }
 
 /// What to do with the terminal pane and tab, after the command was started.
@@ -230,6 +236,8 @@ impl TaskTemplate {
                 reveal: self.reveal,
                 hide: self.hide,
                 shell: self.shell.clone(),
+                hide_task: !self.hide_task,
+                hide_command: !self.hide_command,
             }),
         })
     }

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use util::serde::default_true;
 
 use anyhow::{bail, Context};
 use collections::{HashMap, HashSet};
@@ -57,12 +58,12 @@ pub struct TaskTemplate {
     /// Which shell to use when spawning the task.
     #[serde(default)]
     pub shell: Shell,
-    /// Wether to hide the task line in the task output.
-    #[serde(default)]
-    pub hide_task: bool,
-    /// Weather to hide the command line in the task output.
-    #[serde(default)]
-    pub hide_command: bool,
+    /// Whether to show the task line in the task output.
+    #[serde(default = "default_true")]
+    pub show_task: bool,
+    /// Whether to show the command line in the task output.
+    #[serde(default = "default_true")]
+    pub show_command: bool,
 }
 
 /// What to do with the terminal pane and tab, after the command was started.
@@ -236,8 +237,8 @@ impl TaskTemplate {
                 reveal: self.reveal,
                 hide: self.hide,
                 shell: self.shell.clone(),
-                hide_task: !self.hide_task,
-                hide_command: !self.hide_command,
+                show_task: self.show_task,
+                show_command: self.show_command,
             }),
         })
     }

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -60,7 +60,7 @@ pub struct TaskTemplate {
     pub shell: Shell,
     /// Whether to show the task line in the task output.
     #[serde(default = "default_true")]
-    pub show_task: bool,
+    pub show_summary: bool,
     /// Whether to show the command line in the task output.
     #[serde(default = "default_true")]
     pub show_command: bool,
@@ -237,7 +237,7 @@ impl TaskTemplate {
                 reveal: self.reveal,
                 hide: self.hide,
                 shell: self.shell.clone(),
-                show_task: self.show_task,
+                show_summary: self.show_summary,
                 show_command: self.show_command,
             }),
         })

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -639,8 +639,8 @@ pub struct TaskState {
     pub status: TaskStatus,
     pub completion_rx: Receiver<()>,
     pub hide: HideStrategy,
-    pub hide_task: bool,
-    pub hide_command: bool,
+    pub show_task: bool,
+    pub show_command: bool,
 }
 
 /// A status of the current terminal tab's task.
@@ -1762,21 +1762,19 @@ impl Terminal {
         };
 
         let (finished_successfully, task_line, command_line) = task_summary(task, error_code);
-        // Decide whether to display the task and/or command lines based on user preferences.
         let mut lines_to_show = Vec::new();
-        if task.hide_task {
+        if task.show_task {
             lines_to_show.push(task_line.as_str());
         }
-        if task.hide_command {
+        if task.show_command {
             lines_to_show.push(command_line.as_str());
         }
 
-        // SAFETY: the invocation happens on non `TaskStatus::Running` tasks, once,
-        // after either `AlacTermEvent::Exit` or `AlacTermEvent::ChildExit` events that are spawned
-        // when Zed task finishes and no more output is made.
-        // After the task summary is output once, no more text is appended to the terminal.
-        // Only append text if there are lines to show
         if !lines_to_show.is_empty() {
+            // SAFETY: the invocation happens on non `TaskStatus::Running` tasks, once,
+            // after either `AlacTermEvent::Exit` or `AlacTermEvent::ChildExit` events that are spawned
+            // when Zed task finishes and no more output is made.
+            // After the task summary is output once, no more text is appended to the terminal.
             unsafe { append_text_to_term(&mut self.term.lock(), &lines_to_show) };
         }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -639,6 +639,8 @@ pub struct TaskState {
     pub status: TaskStatus,
     pub completion_rx: Receiver<()>,
     pub hide: HideStrategy,
+    pub hide_task: bool,
+    pub hide_command: bool,
 }
 
 /// A status of the current terminal tab's task.
@@ -1760,11 +1762,24 @@ impl Terminal {
         };
 
         let (finished_successfully, task_line, command_line) = task_summary(task, error_code);
+        // Decide whether to display the task and/or command lines based on user preferences.
+        let mut lines_to_show = Vec::new();
+        if task.hide_task {
+            lines_to_show.push(task_line.as_str());
+        }
+        if task.hide_command {
+            lines_to_show.push(command_line.as_str());
+        }
+
         // SAFETY: the invocation happens on non `TaskStatus::Running` tasks, once,
         // after either `AlacTermEvent::Exit` or `AlacTermEvent::ChildExit` events that are spawned
         // when Zed task finishes and no more output is made.
         // After the task summary is output once, no more text is appended to the terminal.
-        unsafe { append_text_to_term(&mut self.term.lock(), &[&task_line, &command_line]) };
+        // Only append text if there are lines to show
+        if !lines_to_show.is_empty() {
+            unsafe { append_text_to_term(&mut self.term.lock(), &lines_to_show) };
+        }
+
         match task.hide {
             HideStrategy::Never => {}
             HideStrategy::Always => {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -639,7 +639,7 @@ pub struct TaskState {
     pub status: TaskStatus,
     pub completion_rx: Receiver<()>,
     pub hide: HideStrategy,
-    pub show_task: bool,
+    pub show_summary: bool,
     pub show_command: bool,
 }
 
@@ -1763,7 +1763,7 @@ impl Terminal {
 
         let (finished_successfully, task_line, command_line) = task_summary(task, error_code);
         let mut lines_to_show = Vec::new();
-        if task.show_task {
+        if task.show_summary {
             lines_to_show.push(task_line.as_str());
         }
         if task.show_command {

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -41,7 +41,11 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     //           "args": ["--login"]
     //         }
     //     }
-    "shell": "system"
+    "shell": "system",
+    // Whether to show the task line in the ouput of the spawned task, defaults to `true`.
+    "show_task": true,
+    // Whether to show the command line in the ouput of the spawned task, defaults to `true`.
+    "show_output": true
   }
 ]
 ```

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -42,9 +42,9 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     //         }
     //     }
     "shell": "system",
-    // Whether to show the task line in the ouput of the spawned task, defaults to `true`.
+    // Whether to show the task line in the output of the spawned task, defaults to `true`.
     "show_task": true,
-    // Whether to show the command line in the ouput of the spawned task, defaults to `true`.
+    // Whether to show the command line in the output of the spawned task, defaults to `true`.
     "show_output": true
   }
 ]

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -43,7 +43,7 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     //     }
     "shell": "system",
     // Whether to show the task line in the output of the spawned task, defaults to `true`.
-    "show_task": true,
+    "show_summary": true,
     // Whether to show the command line in the output of the spawned task, defaults to `true`.
     "show_output": true
   }


### PR DESCRIPTION
The goal is to be able to hide these lines from a task output:

```sh
⏵ Task `...` finished successfully
⏵ Command: ...
```

Here is a video that describes the functionality:
https://github.com/user-attachments/assets/4f17e530-ca53-46df-bbbd-84bcc618ac86
(feel free to watch it in 2x as it's almost 2 minutes long)

Release Notes:

- Added a way to hide both the task and command lines in the task output