### PR TITLE
title_bar: Remove dependency on `extensions_ui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,6 +4218,7 @@ dependencies = [
  "vim",
  "wasmtime-wasi",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]
@@ -12575,7 +12576,6 @@ dependencies = [
  "collections",
  "command_palette",
  "editor",
- "extensions_ui",
  "feature_flags",
  "feedback",
  "gpui",
@@ -14358,7 +14358,6 @@ dependencies = [
  "client",
  "db",
  "editor",
- "extensions_ui",
  "fuzzy",
  "gpui",
  "inline_completion_button",

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -44,6 +44,7 @@ util.workspace = true
 vim.workspace = true
 wasmtime-wasi.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -38,12 +38,12 @@ use crate::extension_version_selector::{
     ExtensionVersionSelector, ExtensionVersionSelectorDelegate,
 };
 
-actions!(zed, [Extensions, InstallDevExtension]);
+actions!(zed, [InstallDevExtension]);
 
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(move |workspace: &mut Workspace, cx| {
         workspace
-            .register_action(move |workspace, _: &Extensions, cx| {
+            .register_action(move |workspace, _: &zed_actions::Extensions, cx| {
                 let existing = workspace
                     .active_pane()
                     .read(cx)

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -32,7 +32,6 @@ auto_update.workspace = true
 call.workspace = true
 client.workspace = true
 command_palette.workspace = true
-extensions_ui.workspace = true
 feedback.workspace = true
 feature_flags.workspace = true
 gpui.workspace = true

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -581,7 +581,7 @@ impl TitleBar {
                         .action("Settings", zed_actions::OpenSettings.boxed_clone())
                         .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
                         .action("Themes…", theme_selector::Toggle::default().boxed_clone())
-                        .action("Extensions", extensions_ui::Extensions.boxed_clone())
+                        .action("Extensions", zed_actions::Extensions.boxed_clone())
                         .separator()
                         .link(
                             "Book Onboarding",
@@ -617,7 +617,7 @@ impl TitleBar {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
                             .action("Themes…", theme_selector::Toggle::default().boxed_clone())
-                            .action("Extensions", extensions_ui::Extensions.boxed_clone())
+                            .action("Extensions", zed_actions::Extensions.boxed_clone())
                             .separator()
                             .link(
                                 "Book Onboarding",

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -18,7 +18,6 @@ test-support = []
 anyhow.workspace = true
 client.workspace = true
 db.workspace = true
-extensions_ui.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 inline_completion_button.workspace = true

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -250,7 +250,7 @@ impl Render for WelcomePage {
                                                     "welcome page: open extensions".to_string(),
                                                 );
                                                 cx.dispatch_action(Box::new(
-                                                    extensions_ui::Extensions,
+                                                    zed_actions::Extensions,
                                                 ));
                                             })),
                                     )

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -32,7 +32,7 @@ pub fn app_menus() -> Vec<Menu> {
                     items: vec![],
                 }),
                 MenuItem::separator(),
-                MenuItem::action("Extensions", extensions_ui::Extensions),
+                MenuItem::action("Extensions", zed_actions::Extensions),
                 MenuItem::action("Install CLI", install_cli::Install),
                 MenuItem::separator(),
                 MenuItem::action("Hide Zed", super::Hide),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -32,6 +32,7 @@ actions!(
         Quit,
         OpenKeymap,
         About,
+        Extensions,
         OpenLicenses,
         OpenTelemetryLog,
         DecreaseBufferFontSize,


### PR DESCRIPTION
This PR removes a dependency on the `extensions_ui` from the `title_bar` crate.

This dependency only existed to reference the `Extensions` action, which has now been moved to the `zed_actions` crate.

This allows `title_bar` to move up in the crate dependency graph.

Release Notes:

- N/A
