### PR TITLE
Implement RunningKernel trait for native and remote kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9927,6 +9927,7 @@ dependencies = [
  "editor",
  "env_logger 0.11.5",
  "feature_flags",
+ "file_icons",
  "futures 0.3.31",
  "gpui",
  "http_client",

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -22,6 +22,7 @@ collections.workspace = true
 command_palette_hooks.workspace = true
 editor.workspace = true
 feature_flags.workspace = true
+file_icons.workspace = true
 futures.workspace = true
 gpui.workspace = true
 http_client.workspace = true

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -24,6 +24,7 @@ editor.workspace = true
 feature_flags.workspace = true
 futures.workspace = true
 gpui.workspace = true
+http_client.workspace = true
 image.workspace = true
 jupyter-websocket-client.workspace = true
 jupyter-protocol.workspace = true

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -39,9 +39,8 @@ fn truncate_path(path: &SharedString, max_length: usize) -> SharedString {
     if path.len() <= max_length {
         path.to_string().into()
     } else {
-        let mut truncated = path.chars().take(max_length - 3).collect::<String>();
-        truncated.push_str("...");
-        truncated.into()
+        let truncated = path.chars().rev().take(max_length - 3).collect::<String>();
+        format!("...{}", truncated.chars().rev().collect::<String>()).into()
     }
 }
 
@@ -138,12 +137,12 @@ impl PickerDelegate for KernelPickerDelegate {
             KernelSpecification::PythonEnv(_) => (
                 kernelspec.name(),
                 "Python Env",
-                Some(truncate_path(&kernelspec.path(), 30)),
+                Some(truncate_path(&kernelspec.path(), 42)),
             ),
             KernelSpecification::Remote(_) => (
                 kernelspec.name(),
                 "Remote",
-                Some(truncate_path(&kernelspec.path(), 20)),
+                Some(truncate_path(&kernelspec.path(), 42)),
             ),
         };
 
@@ -156,53 +155,44 @@ impl PickerDelegate for KernelPickerDelegate {
                     h_flex()
                         .w_full()
                         .gap_3()
+                        .child(icon.color(Color::Default).size(IconSize::Medium))
                         .child(
-                            h_flex()
-                                .gap_3()
-                                .child(icon.color(Color::Default).size(IconSize::Medium))
+                            v_flex()
+                                .flex_grow()
+                                .gap_0p5()
                                 .child(
-                                    v_flex()
-                                        .gap_0p5()
+                                    h_flex()
+                                        .justify_between()
                                         .child(
-                                            Label::new(name)
-                                                .weight(FontWeight::MEDIUM)
-                                                .size(LabelSize::Default),
+                                            div().w_48().text_ellipsis().child(
+                                                Label::new(name)
+                                                    .weight(FontWeight::MEDIUM)
+                                                    .size(LabelSize::Default),
+                                            ),
                                         )
-                                        .child(
-                                            h_flex()
-                                                .gap_1()
-                                                .child(
-                                                    Label::new(kernelspec.language())
-                                                        .size(LabelSize::Small)
-                                                        .color(Color::Muted),
-                                                )
-                                                .child(
-                                                    Label::new(kernel_type)
-                                                        .size(LabelSize::Small)
-                                                        .color(Color::Muted),
-                                                ),
-                                        ),
-                                ),
-                        )
-                        .when_some(path_or_url, |flex, path| {
-                            flex.child(
-                                div().flex_grow().justify_end().child(
+                                        .when_some(path_or_url.clone(), |flex, path| {
+                                            flex.text_ellipsis().child(
+                                                Label::new(path)
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                            )
+                                        }),
+                                )
+                                .child(
                                     h_flex()
                                         .gap_1()
                                         .child(
-                                            div()
-                                                .w(px(1.))
-                                                .h(rems(2.))
-                                                .bg(cx.theme().colors().border_variant),
+                                            Label::new(kernelspec.language())
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted),
                                         )
                                         .child(
-                                            Label::new(path)
+                                            Label::new(kernel_type)
                                                 .size(LabelSize::Small)
                                                 .color(Color::Muted),
                                         ),
                                 ),
-                            )
-                        }),
+                        ),
                 )
                 .when(is_selected, |item| {
                     item.end_slot(

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -34,6 +34,17 @@ pub struct KernelPickerDelegate {
     on_select: OnSelect,
 }
 
+// Helper function to truncate long paths
+fn truncate_path(path: &SharedString, max_length: usize) -> SharedString {
+    if path.len() <= max_length {
+        path.to_string().into()
+    } else {
+        let mut truncated = path.chars().take(max_length - 3).collect::<String>();
+        truncated.push_str("...");
+        truncated.into()
+    }
+}
+
 impl<T: PopoverTrigger> KernelSelector<T> {
     pub fn new(on_select: OnSelect, worktree_id: WorktreeId, trigger: T) -> Self {
         KernelSelector {
@@ -116,11 +127,25 @@ impl PickerDelegate for KernelPickerDelegate {
         &self,
         ix: usize,
         selected: bool,
-        _cx: &mut ViewContext<Picker<Self>>,
+        cx: &mut ViewContext<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let kernelspec = self.filtered_kernels.get(ix)?;
-
         let is_selected = self.selected_kernelspec.as_ref() == Some(kernelspec);
+        let icon = kernelspec.icon(cx);
+
+        let (name, kernel_type, path_or_url) = match kernelspec {
+            KernelSpecification::Jupyter(_) => (kernelspec.name(), "Jupyter", None),
+            KernelSpecification::PythonEnv(_) => (
+                kernelspec.name(),
+                "Python Env",
+                Some(truncate_path(&kernelspec.path(), 30)),
+            ),
+            KernelSpecification::Remote(_) => (
+                kernelspec.name(),
+                "Remote",
+                Some(truncate_path(&kernelspec.path(), 20)),
+            ),
+        };
 
         Some(
             ListItem::new(ix)
@@ -128,26 +153,56 @@ impl PickerDelegate for KernelPickerDelegate {
                 .spacing(ListItemSpacing::Sparse)
                 .selected(selected)
                 .child(
-                    v_flex()
-                        .min_w(px(600.))
+                    h_flex()
                         .w_full()
-                        .gap_0p5()
+                        .gap_3()
                         .child(
                             h_flex()
-                                .w_full()
-                                .gap_1()
-                                .child(Label::new(kernelspec.name()).weight(FontWeight::MEDIUM))
+                                .gap_3()
+                                .child(icon.color(Color::Default).size(IconSize::Medium))
                                 .child(
-                                    Label::new(kernelspec.language())
-                                        .size(LabelSize::Small)
-                                        .color(Color::Muted),
+                                    v_flex()
+                                        .gap_0p5()
+                                        .child(
+                                            Label::new(name)
+                                                .weight(FontWeight::MEDIUM)
+                                                .size(LabelSize::Default),
+                                        )
+                                        .child(
+                                            h_flex()
+                                                .gap_1()
+                                                .child(
+                                                    Label::new(kernelspec.language())
+                                                        .size(LabelSize::Small)
+                                                        .color(Color::Muted),
+                                                )
+                                                .child(
+                                                    Label::new(kernel_type)
+                                                        .size(LabelSize::Small)
+                                                        .color(Color::Muted),
+                                                ),
+                                        ),
                                 ),
                         )
-                        .child(
-                            Label::new(kernelspec.path())
-                                .size(LabelSize::XSmall)
-                                .color(Color::Muted),
-                        ),
+                        .when_some(path_or_url, |flex, path| {
+                            flex.child(
+                                div().flex_grow().justify_end().child(
+                                    h_flex()
+                                        .gap_1()
+                                        .child(
+                                            div()
+                                                .w(px(1.))
+                                                .h(rems(2.))
+                                                .bg(cx.theme().colors().border_variant),
+                                        )
+                                        .child(
+                                            Label::new(path)
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted),
+                                        ),
+                                ),
+                            )
+                        }),
                 )
                 .when(is_selected, |item| {
                     item.end_slot(
@@ -199,7 +254,9 @@ impl<T: PopoverTrigger> RenderOnce for KernelSelector<T> {
         };
 
         let picker_view = cx.new_view(|cx| {
-            let picker = Picker::uniform_list(delegate, cx).max_height(Some(rems(20.).into()));
+            let picker = Picker::uniform_list(delegate, cx)
+                .width(rems(30.))
+                .max_height(Some(rems(20.).into()));
             picker
         });
 

--- a/crates/repl/src/kernels/mod.rs
+++ b/crates/repl/src/kernels/mod.rs
@@ -6,7 +6,7 @@ use futures::{
     future::Shared,
     stream,
 };
-use gpui::{AppContext, Model, Task};
+use gpui::{AppContext, Model, Task, WindowContext};
 use language::LanguageName;
 pub use native_kernel::*;
 
@@ -147,7 +147,7 @@ pub trait RunningKernel: Send + Debug {
     fn set_execution_state(&mut self, state: ExecutionState);
     fn kernel_info(&self) -> Option<&KernelInfoReply>;
     fn set_kernel_info(&mut self, info: KernelInfoReply);
-    fn force_shutdown(&mut self) -> anyhow::Result<()>;
+    fn force_shutdown(&mut self, cx: &mut WindowContext) -> Task<anyhow::Result<()>>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/repl/src/kernels/mod.rs
+++ b/crates/repl/src/kernels/mod.rs
@@ -16,7 +16,7 @@ pub use remote_kernels::*;
 
 use anyhow::Result;
 use runtimelib::{ExecutionState, JupyterKernelspec, JupyterMessage, KernelInfoReply};
-use ui::SharedString;
+use ui::{Icon, IconName, SharedString};
 
 pub type JupyterMessageChannel = stream::SelectAll<Receiver<JupyterMessage>>;
 
@@ -58,6 +58,19 @@ impl KernelSpecification {
             Self::PythonEnv(spec) => spec.kernelspec.language.clone(),
             Self::Remote(spec) => spec.kernelspec.language.clone(),
         })
+    }
+
+    pub fn icon(&self, cx: &AppContext) -> Icon {
+        let lang_name = match self {
+            Self::Jupyter(spec) => spec.kernelspec.language.clone(),
+            Self::PythonEnv(spec) => spec.kernelspec.language.clone(),
+            Self::Remote(spec) => spec.kernelspec.language.clone(),
+        };
+
+        file_icons::FileIcons::get(cx)
+            .get_type_icon(&lang_name.to_lowercase())
+            .map(Icon::from_path)
+            .unwrap_or(Icon::new(IconName::ReplNeutral))
     }
 }
 

--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -5,7 +5,7 @@ use futures::{
     stream::{SelectAll, StreamExt},
     AsyncBufReadExt as _, SinkExt as _,
 };
-use gpui::{EntityId, Task, View};
+use gpui::{EntityId, Task, View, WindowContext};
 use jupyter_protocol::{JupyterMessage, JupyterMessageContent, KernelInfoReply};
 use project::Fs;
 use runtimelib::{dirs, ConnectionInfo, ExecutionState, JupyterKernelspec};
@@ -17,7 +17,6 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use ui::WindowContext;
 use uuid::Uuid;
 
 use crate::Session;
@@ -90,7 +89,7 @@ pub struct NativeRunningKernel {
     _control_task: Task<Result<()>>,
     _routing_task: Task<Result<()>>,
     connection_path: PathBuf,
-    process_status_task: Option<Task<()>>,
+    _process_status_task: Option<Task<()>>,
     pub working_directory: PathBuf,
     pub request_tx: mpsc::Sender<JupyterMessage>,
     pub execution_state: ExecutionState,
@@ -308,7 +307,7 @@ impl NativeRunningKernel {
                 process,
                 request_tx,
                 working_directory,
-                process_status_task: Some(process_status_task),
+                _process_status_task: Some(process_status_task),
                 _shell_task: shell_task,
                 _control_task: control_task,
                 _routing_task: routing_task,

--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context as _, Result};
 use futures::{
     channel::mpsc::{self},
+    io::BufReader,
     stream::{SelectAll, StreamExt},
-    SinkExt as _,
+    AsyncBufReadExt as _, SinkExt as _,
 };
 use gpui::{AppContext, EntityId, Task};
 use jupyter_protocol::{JupyterMessage, JupyterMessageContent, KernelInfoReply};
@@ -136,7 +137,7 @@ impl NativeRunningKernel {
 
             let mut cmd = kernel_specification.command(&connection_path)?;
 
-            let process = cmd
+            let mut process = cmd
                 .current_dir(&working_directory)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
@@ -220,6 +221,35 @@ impl NativeRunningKernel {
                     anyhow::Ok(())
                 }
             });
+
+            let stderr = process.stderr.take();
+
+            cx.spawn(|mut _cx| async move {
+                if stderr.is_none() {
+                    return;
+                }
+                let reader = BufReader::new(stderr.unwrap());
+                let mut lines = reader.lines();
+                while let Some(Ok(line)) = lines.next().await {
+                    // todo!(): Log stdout and stderr to something the session can show
+                    log::error!("kernel: {}", line);
+                }
+            })
+            .detach();
+
+            let stdout = process.stdout.take();
+
+            cx.spawn(|mut _cx| async move {
+                if stdout.is_none() {
+                    return;
+                }
+                let reader = BufReader::new(stdout.unwrap());
+                let mut lines = reader.lines();
+                while let Some(Ok(line)) = lines.next().await {
+                    log::info!("kernel: {}", line);
+                }
+            })
+            .detach();
 
             anyhow::Ok((
                 Self {

--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -5,7 +5,7 @@ use futures::{
     stream::{SelectAll, StreamExt},
     AsyncBufReadExt as _, SinkExt as _,
 };
-use gpui::{AppContext, EntityId, Task};
+use gpui::{EntityId, Task, View};
 use jupyter_protocol::{JupyterMessage, JupyterMessageContent, KernelInfoReply};
 use project::Fs;
 use runtimelib::{dirs, ConnectionInfo, ExecutionState, JupyterKernelspec};
@@ -17,9 +17,12 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
+use ui::WindowContext;
 use uuid::Uuid;
 
-use super::{JupyterMessageChannel, RunningKernel};
+use crate::Session;
+
+use super::RunningKernel;
 
 #[derive(Debug, Clone)]
 pub struct LocalKernelSpecification {
@@ -84,10 +87,10 @@ async fn peek_ports(ip: IpAddr) -> Result<[u16; 5]> {
 pub struct NativeRunningKernel {
     pub process: smol::process::Child,
     _shell_task: Task<Result<()>>,
-    _iopub_task: Task<Result<()>>,
     _control_task: Task<Result<()>>,
     _routing_task: Task<Result<()>>,
     connection_path: PathBuf,
+    process_status_task: Option<Task<()>>,
     pub working_directory: PathBuf,
     pub request_tx: mpsc::Sender<JupyterMessage>,
     pub execution_state: ExecutionState,
@@ -108,8 +111,10 @@ impl NativeRunningKernel {
         entity_id: EntityId,
         working_directory: PathBuf,
         fs: Arc<dyn Fs>,
-        cx: &mut AppContext,
-    ) -> Task<Result<(Self, JupyterMessageChannel)>> {
+        // todo: convert to weak view
+        session: View<Session>,
+        cx: &mut WindowContext,
+    ) -> Task<Result<Self>> {
         cx.spawn(|cx| async move {
             let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
             let ports = peek_ports(ip).await?;
@@ -156,8 +161,6 @@ impl NativeRunningKernel {
             let mut control_socket =
                 runtimelib::create_client_control_connection(&connection_info, &session_id).await?;
 
-            let (mut iopub, iosub) = futures::channel::mpsc::channel(100);
-
             let (request_tx, mut request_rx) =
                 futures::channel::mpsc::channel::<JupyterMessage>(100);
 
@@ -165,18 +168,41 @@ impl NativeRunningKernel {
             let (mut shell_reply_tx, shell_reply_rx) = futures::channel::mpsc::channel(100);
 
             let mut messages_rx = SelectAll::new();
-            messages_rx.push(iosub);
             messages_rx.push(control_reply_rx);
             messages_rx.push(shell_reply_rx);
 
-            let iopub_task = cx.background_executor().spawn({
-                async move {
-                    while let Ok(message) = iopub_socket.read().await {
-                        iopub.send(message).await?;
+            cx.spawn({
+                let session = session.clone();
+
+                |mut cx| async move {
+                    while let Some(message) = messages_rx.next().await {
+                        session
+                            .update(&mut cx, |session, cx| {
+                                session.route(&message, cx);
+                            })
+                            .ok();
                     }
                     anyhow::Ok(())
                 }
-            });
+            })
+            .detach();
+
+            // iopub task
+            cx.spawn({
+                let session = session.clone();
+
+                |mut cx| async move {
+                    while let Ok(message) = iopub_socket.read().await {
+                        session
+                            .update(&mut cx, |session, cx| {
+                                session.route(&message, cx);
+                            })
+                            .ok();
+                    }
+                    anyhow::Ok(())
+                }
+            })
+            .detach();
 
             let (mut control_request_tx, mut control_request_rx) =
                 futures::channel::mpsc::channel(100);
@@ -231,7 +257,6 @@ impl NativeRunningKernel {
                 let reader = BufReader::new(stderr.unwrap());
                 let mut lines = reader.lines();
                 while let Some(Ok(line)) = lines.next().await {
-                    // todo!(): Log stdout and stderr to something the session can show
                     log::error!("kernel: {}", line);
                 }
             })
@@ -251,21 +276,46 @@ impl NativeRunningKernel {
             })
             .detach();
 
-            anyhow::Ok((
-                Self {
-                    process,
-                    request_tx,
-                    working_directory,
-                    _shell_task: shell_task,
-                    _iopub_task: iopub_task,
-                    _control_task: control_task,
-                    _routing_task: routing_task,
-                    connection_path,
-                    execution_state: ExecutionState::Idle,
-                    kernel_info: None,
-                },
-                messages_rx,
-            ))
+            let status = process.status();
+
+            let process_status_task = cx.spawn(|mut cx| async move {
+                let error_message = match status.await {
+                    Ok(status) => {
+                        if status.success() {
+                            log::info!("kernel process exited successfully");
+                            return;
+                        }
+
+                        format!("kernel process exited with status: {:?}", status)
+                    }
+                    Err(err) => {
+                        format!("kernel process exited with error: {:?}", err)
+                    }
+                };
+
+                log::error!("{}", error_message);
+
+                session
+                    .update(&mut cx, |session, cx| {
+                        session.kernel_errored(error_message, cx);
+
+                        cx.notify();
+                    })
+                    .ok();
+            });
+
+            anyhow::Ok(Self {
+                process,
+                request_tx,
+                working_directory,
+                process_status_task: Some(process_status_task),
+                _shell_task: shell_task,
+                _control_task: control_task,
+                _routing_task: routing_task,
+                connection_path,
+                execution_state: ExecutionState::Idle,
+                kernel_info: None,
+            })
         })
     }
 }

--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -113,7 +113,7 @@ impl NativeRunningKernel {
         // todo: convert to weak view
         session: View<Session>,
         cx: &mut WindowContext,
-    ) -> Task<Result<Self>> {
+    ) -> Task<Result<Box<dyn RunningKernel>>> {
         cx.spawn(|cx| async move {
             let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
             let ports = peek_ports(ip).await?;
@@ -303,7 +303,7 @@ impl NativeRunningKernel {
                     .ok();
             });
 
-            anyhow::Ok(Self {
+            anyhow::Ok(Box::new(Self {
                 process,
                 request_tx,
                 working_directory,
@@ -314,7 +314,7 @@ impl NativeRunningKernel {
                 connection_path,
                 execution_state: ExecutionState::Idle,
                 kernel_info: None,
-            })
+            }) as Box<dyn RunningKernel>)
         })
     }
 }

--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -344,14 +344,17 @@ impl RunningKernel for NativeRunningKernel {
         self.kernel_info = Some(info);
     }
 
-    fn force_shutdown(&mut self) -> anyhow::Result<()> {
-        match self.process.kill() {
+    fn force_shutdown(&mut self, _cx: &mut WindowContext) -> Task<anyhow::Result<()>> {
+        self._process_status_task.take();
+        self.request_tx.close_channel();
+
+        Task::ready(match self.process.kill() {
             Ok(_) => Ok(()),
             Err(error) => Err(anyhow::anyhow!(
                 "Failed to kill the kernel process: {}",
                 error
             )),
-        }
+        })
     }
 }
 

--- a/crates/repl/src/kernels/remote_kernels.rs
+++ b/crates/repl/src/kernels/remote_kernels.rs
@@ -47,7 +47,7 @@ impl RemoteRunningKernel {
         };
 
         // todo: launch a kernel to get a kernel ID
-        let kernel_id = "not-implemented";
+        let kernel_id = "d77b481b-2f14-4528-af0a-6c4c9ca98085";
 
         let kernel_socket = remote_server.connect_to_kernel(kernel_id).await?;
 

--- a/crates/repl/src/kernels/remote_kernels.rs
+++ b/crates/repl/src/kernels/remote_kernels.rs
@@ -42,7 +42,7 @@ impl RemoteRunningKernel {
         working_directory: std::path::PathBuf,
         session: View<Session>,
         cx: &mut WindowContext,
-    ) -> Task<anyhow::Result<Self>> {
+    ) -> Task<Result<Box<dyn RunningKernel>>> {
         let remote_server = RemoteServer {
             base_url: kernelspec.url,
             token: kernelspec.token,
@@ -90,7 +90,7 @@ impl RemoteRunningKernel {
                 }
             });
 
-            anyhow::Ok(Self {
+            anyhow::Ok(Box::new(Self {
                 _routing_task: routing_task,
                 _receiving_task: receiving_task,
                 remote_server,
@@ -99,7 +99,7 @@ impl RemoteRunningKernel {
                 // todo(kyle): pull this from the kernel API to start with
                 execution_state: ExecutionState::Idle,
                 kernel_info: None,
-            })
+            }) as Box<dyn RunningKernel>)
         })
     }
 }

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -121,6 +121,11 @@ impl ReplStore {
         cx.notify();
     }
 
+    pub fn refresh_remote_kernelspecs() -> Task<Result<()>> {
+        //
+        todo!()
+    }
+
     pub fn refresh_python_kernelspecs(
         &mut self,
         worktree_id: WorktreeId,

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -144,35 +144,50 @@ impl ReplStore {
         })
     }
 
+    fn get_remote_kernel_specifications(
+        &self,
+        cx: &mut ModelContext<Self>,
+    ) -> Option<Task<Result<Vec<KernelSpecification>>>> {
+        match (
+            std::env::var("JUPYTER_SERVER"),
+            std::env::var("JUPYTER_TOKEN"),
+        ) {
+            (Ok(server), Ok(token)) => {
+                let remote_server = RemoteServer {
+                    base_url: server,
+                    token,
+                };
+                let http_client = cx.http_client();
+                Some(cx.spawn(|_, _| async move {
+                    list_remote_kernelspecs(remote_server, http_client)
+                        .await
+                        .map(|specs| specs.into_iter().map(KernelSpecification::Remote).collect())
+                }))
+            }
+            _ => None,
+        }
+    }
+
     pub fn refresh_kernelspecs(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
         let local_kernel_specifications = local_kernel_specifications(self.fs.clone());
 
-        // todo: iterate over all remote servers user has configured
-        let remote_server = RemoteServer {
-            base_url: std::env::var("JUPYTER_SERVER").expect("JUPYTER_TOKEN not set"),
-            token: std::env::var("JUPYTER_TOKEN").expect("JUPYTER_TOKEN not set"),
-        };
-
-        let http_client = cx.http_client();
-
-        let remote_kernel_specifications =
-            list_remote_kernelspecs(remote_server, http_client.clone());
+        let remote_kernel_specifications = self.get_remote_kernel_specifications(cx);
 
         cx.spawn(|this, mut cx| async move {
-            let local_kernel_specifications = local_kernel_specifications
+            let mut all_specs = local_kernel_specifications
                 .await?
                 .into_iter()
-                .map(KernelSpecification::Jupyter);
+                .map(KernelSpecification::Jupyter)
+                .collect::<Vec<_>>();
 
-            let remote_kernel_specifications = remote_kernel_specifications
-                .await?
-                .into_iter()
-                .map(KernelSpecification::Remote);
+            if let Some(remote_task) = remote_kernel_specifications {
+                if let Ok(remote_specs) = remote_task.await {
+                    all_specs.extend(remote_specs);
+                }
+            }
 
             this.update(&mut cx, |this, cx| {
-                this.kernel_specifications = local_kernel_specifications
-                    .chain(remote_kernel_specifications)
-                    .collect();
+                this.kernel_specifications = all_specs;
                 cx.notify();
             })
         })

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -213,27 +213,6 @@ impl Session {
             })
             .ok();
 
-        // Creating a baked in kernel specification to see if remoting is working
-        let kernel_specification = KernelSpecification::Remote(RemoteKernelSpecification {
-            name: "todo".to_string(),
-            url: "http://localhost:8888/".to_string(),
-            token: std::env::var("JUPYTER_TOKEN").expect("JUPYTER_TOKEN not set"),
-            kernelspec: JupyterKernelspec {
-                argv: vec![
-                    "python".to_string(),
-                    "-m".to_string(),
-                    "ipykernel_launcher".to_string(),
-                    "-f".to_string(),
-                    "{connection_file}".to_string(),
-                ],
-                env: None,
-                display_name: "Python 3 (ipykernel)".to_string(),
-                language: "python".to_string(),
-                interrupt_mode: Some("signal".to_string()),
-                metadata: None,
-            },
-        });
-
         let mut session = Self {
             fs,
             editor,

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -263,7 +263,7 @@ impl Session {
                 let kernel = kernel.await;
 
                 match kernel {
-                    Ok(mut kernel) => {
+                    Ok(kernel) => {
                         this.update(&mut cx, |session, cx| {
                             session.kernel(Kernel::RunningKernel(Box::new(kernel)), cx);
                         })

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -564,7 +564,7 @@ impl Session {
                     let message: JupyterMessage = ShutdownRequest { restart: false }.into();
                     request_tx.try_send(message).ok();
 
-                    forced.await;
+                    forced.await.log_err();
 
                     // Give the kernel a bit of time to clean up
                     cx.background_executor().timer(Duration::from_secs(3)).await;

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -267,35 +267,6 @@ impl Session {
                 match kernel {
                     Ok((mut kernel, mut messages_rx)) => {
                         this.update(&mut cx, |session, cx| {
-                            let stderr = kernel.process.stderr.take();
-
-                            cx.spawn(|_session, mut _cx| async move {
-                                if stderr.is_none() {
-                                    return;
-                                }
-                                let reader = BufReader::new(stderr.unwrap());
-                                let mut lines = reader.lines();
-                                while let Some(Ok(line)) = lines.next().await {
-                                    // todo!(): Log stdout and stderr to something the session can show
-                                    log::error!("kernel: {}", line);
-                                }
-                            })
-                            .detach();
-
-                            let stdout = kernel.process.stdout.take();
-
-                            cx.spawn(|_session, mut _cx| async move {
-                                if stdout.is_none() {
-                                    return;
-                                }
-                                let reader = BufReader::new(stdout.unwrap());
-                                let mut lines = reader.lines();
-                                while let Some(Ok(line)) = lines.next().await {
-                                    log::info!("kernel: {}", line);
-                                }
-                            })
-                            .detach();
-
                             let status = kernel.process.status();
                             session.kernel(Kernel::RunningKernel(Box::new(kernel)), cx);
 

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -331,18 +331,6 @@ impl Session {
                                         .ok();
                                 }
                             }));
-
-                            // todo!(@rgbkrk): send KernelInfoRequest once our shell channel read/writes are split
-                            // cx.spawn(|this, mut cx| async move {
-                            //     cx.background_executor()
-                            //         .timer(Duration::from_millis(120))
-                            //         .await;
-                            //     this.update(&mut cx, |this, cx| {
-                            //         this.send(KernelInfoRequest {}.into(), cx).ok();
-                            //     })
-                            //     .ok();
-                            // })
-                            // .detach();
                         })
                         .ok();
                     }


### PR DESCRIPTION
This PR introduces a unified interface for both native and remote kernels through the `RunningKernel` trait. When either the native kernel or the remote kernels are started, they return a `Box<dyn RunningKernel>` to make it easier to work with the session. As a bonus of this refactor, I've dropped some of the mpsc channels to instead opt for passing messages directly to `session.route(message)`. There was a lot of simplification of `Session` by moving responsibilities to `NativeRunningKernel`.

No release notes yet until this is finalized.

* [x] Detect remote kernelspecs from configured remote servers
* [x] Launch kernel on demand

For now, this allows you to set env vars `JUPYTER_SERVER` and `JUPYTER_TOKEN` to access a remote server. `JUPYTER_SERVER` should be a base path like `http://localhost:8888` or `https://notebooks.gesis.org/binder/jupyter/user/rubydata-binder-w6igpy4l/`

Release Notes:

- N/A
