### PR TITLE
vim: Fix : on welcome screen

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -578,7 +578,7 @@
     }
   },
   {
-    "context": "EmptyPane || SharedScreen || MarkdownPreview || KeyContextView",
+    "context": "EmptyPane || SharedScreen || MarkdownPreview || KeyContextView || Welcome",
     "use_layout_keys": true,
     "bindings": {
       ":": "command_palette::Toggle",

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -73,6 +73,7 @@ impl Render for WelcomePage {
         h_flex()
             .size_full()
             .bg(cx.theme().colors().editor_background)
+            .key_context("Welcome")
             .track_focus(&self.focus_handle(cx))
             .child(
                 v_flex()


### PR DESCRIPTION
Release Notes:

- vim: Fixed `:` on the welcome screen
