### PR TITLE
title_bar: Remove dependency on recent_projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9684,6 +9684,7 @@ dependencies = [
  "ui",
  "util",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]
@@ -12594,7 +12595,6 @@ dependencies = [
  "notifications",
  "pretty_assertions",
  "project",
- "recent_projects",
  "remote",
  "rpc",
  "serde",

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -40,6 +40,7 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 paths.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -16,7 +16,6 @@ use picker::{
     Picker, PickerDelegate,
 };
 pub use remote_servers::RemoteServerProjects;
-use serde::Deserialize;
 use settings::Settings;
 pub use ssh_connections::SshSettings;
 use std::{
@@ -29,19 +28,7 @@ use workspace::{
     CloseIntent, ModalView, OpenOptions, SerializedWorkspaceLocation, Workspace, WorkspaceId,
     WORKSPACE_DB,
 };
-
-#[derive(PartialEq, Clone, Deserialize, Default)]
-pub struct OpenRecent {
-    #[serde(default = "default_create_new_window")]
-    pub create_new_window: bool,
-}
-
-fn default_create_new_window() -> bool {
-    false
-}
-
-gpui::impl_actions!(projects, [OpenRecent]);
-gpui::actions!(projects, [OpenRemote]);
+use zed_actions::{OpenRecent, OpenRemote};
 
 pub fn init(cx: &mut AppContext) {
     SshSettings::register(cx);

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -37,7 +37,6 @@ feature_flags.workspace = true
 gpui.workspace = true
 notifications.workspace = true
 project.workspace = true
-recent_projects.workspace = true
 remote.workspace = true
 rpc.workspace = true
 serde.workspace = true

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -100,7 +100,7 @@ impl Render for ApplicationMenu {
                         .action("Open a new Project...", Box::new(workspace::Open))
                         .action(
                             "Open Recent Projects...",
-                            Box::new(recent_projects::OpenRecent {
+                            Box::new(zed_actions::OpenRecent {
                                 create_new_window: false,
                             }),
                         )

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -284,9 +284,7 @@ impl TitleBar {
 
         let is_connecting_to_project = self
             .workspace
-            .update(cx, |workspace, cx| {
-                recent_projects::is_connecting_over_ssh(workspace, cx)
-            })
+            .update(cx, |workspace, cx| workspace.has_active_modal(cx))
             .unwrap_or(false);
 
         let room = room.read(cx);

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -18,7 +18,6 @@ use gpui::{
     StatefulInteractiveElement, Styled, Subscription, View, ViewContext, VisualContext, WeakView,
 };
 use project::{Project, RepositoryEntry};
-use recent_projects::{OpenRemote, RecentProjects};
 use rpc::proto;
 use smallvec::SmallVec;
 use std::sync::Arc;
@@ -30,7 +29,7 @@ use ui::{
 use util::ResultExt;
 use vcs_menu::{BranchList, OpenRecent as ToggleVcsMenu};
 use workspace::{notifications::NotifyResultExt, Workspace};
-use zed_actions::OpenBrowser;
+use zed_actions::{OpenBrowser, OpenRecent, OpenRemote};
 
 #[cfg(feature = "stories")]
 pub use stories::*;
@@ -397,7 +396,6 @@ impl TitleBar {
             "Open recent project".to_string()
         };
 
-        let workspace = self.workspace.clone();
         Button::new("project_name_trigger", name)
             .when(!is_project_selected, |b| b.color(Color::Muted))
             .style(ButtonStyle::Subtle)
@@ -405,18 +403,19 @@ impl TitleBar {
             .tooltip(move |cx| {
                 Tooltip::for_action(
                     "Recent Projects",
-                    &recent_projects::OpenRecent {
+                    &zed_actions::OpenRecent {
                         create_new_window: false,
                     },
                     cx,
                 )
             })
             .on_click(cx.listener(move |_, _, cx| {
-                if let Some(workspace) = workspace.upgrade() {
-                    workspace.update(cx, |workspace, cx| {
-                        RecentProjects::open(workspace, false, cx);
-                    })
-                }
+                cx.dispatch_action(
+                    OpenRecent {
+                        create_new_window: false,
+                    }
+                    .boxed_clone(),
+                );
             }))
     }
 

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -50,7 +50,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Open…", workspace::Open),
                 MenuItem::action(
                     "Open Recent...",
-                    recent_projects::OpenRecent {
+                    zed_actions::OpenRecent {
                         create_new_window: true,
                     },
                 ),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -50,3 +50,11 @@ pub struct InlineAssist {
 }
 
 impl_actions!(assistant, [InlineAssist]);
+
+#[derive(PartialEq, Clone, Deserialize, Default)]
+pub struct OpenRecent {
+    #[serde(default)]
+    pub create_new_window: bool,
+}
+gpui::impl_actions!(projects, [OpenRecent]);
+gpui::actions!(projects, [OpenRemote]);


### PR DESCRIPTION
Use actions defined in zed_actions to interface with that crate instead. One drawback of this is that we now hide call controls when any modal is visible (we used to hide them just when ssh modal was deployed).

Release Notes:

- N/A
