### PR TITLE
Drop platform lock when setting menu

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -844,7 +844,9 @@ impl Platform for MacPlatform {
             let app: id = msg_send![APP_CLASS, sharedApplication];
             let mut state = self.0.lock();
             let actions = &mut state.menu_actions;
-            app.setMainMenu_(self.create_menu_bar(menus, NSWindow::delegate(app), actions, keymap));
+            let menu = self.create_menu_bar(menus, NSWindow::delegate(app), actions, keymap);
+            drop(state);
+            app.setMainMenu_(menu);
         }
     }
 


### PR DESCRIPTION
Turns out setting the menu (sometimes) calls `selected_range` on the input
handler.

https://zed-industries.slack.com/archives/C04S6T1T7TQ/p1732160078058279

Release Notes:

- Fixed a panic when reloading keymaps
