### PR TITLE
Store inlay hint enabledness in user settings

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4259,6 +4259,15 @@ impl Editor {
             InlayHintRefreshReason::Toggle(!self.inlay_hint_cache.enabled),
             cx,
         );
+
+        let Some(workspace) = self.workspace() else {
+            return;
+        };
+        let fs = workspace.read(cx).app_state().fs.clone();
+        let current_enabled = self.inlay_hint_cache.enabled;
+        update_settings_file::<InlayHintSettings>(fs, cx, move |setting, _| {
+            setting.enabled = Some(current_enabled);
+        });
     }
 
     pub fn inlay_hints_enabled(&self) -> bool {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -802,6 +802,24 @@ pub struct InlayHintSettings {
     pub scroll_debounce_ms: u64,
 }
 
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct InlayHintSettingsContent {
+    /// Whether or not to enable inlay hints in the editor.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+}
+
+impl Settings for InlayHintSettings {
+    const KEY: Option<&'static str> = Some("inlay_hints");
+
+    type FileContent = InlayHintSettingsContent;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut AppContext) -> Result<Self> {
+        sources.json_merge()
+    }
+}
+
 fn edit_debounce_ms() -> u64 {
     700
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -44,6 +44,7 @@ pub use item::{
     ProjectItem, SerializableItem, SerializableItemHandle, WeakItemHandle,
 };
 use itertools::Itertools;
+use language::language_settings::InlayHintSettings;
 use language::{LanguageRegistry, Rope};
 pub use modal_layer::*;
 use node_runtime::NodeRuntime;
@@ -318,6 +319,7 @@ pub fn init_settings(cx: &mut AppContext) {
     ItemSettings::register(cx);
     PreviewTabsSettings::register(cx);
     TabBarSettings::register(cx);
+    InlayHintSettings::register(cx);
 }
 
 pub fn init(app_state: Arc<AppState>, cx: &mut AppContext) {


### PR DESCRIPTION
This is my stab at fixing #15909. 

`Editor::toggle_tab_bar()` function is taken as an example for this. This seems to work, but there is following message in the console `[2024-11-21T11:09:53+03:00 ERROR settings] invalid type: null, expected struct InlayHintSettingsContent` and a stacktrace that I can't figure out.

<details>
<summary>stacktrace</summary>

```
Stack backtrace:
   0: std::backtrace_rs::backtrace::dbghelp64::trace
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\..\..\backtrace\src\backtrace\dbghelp64.rs:91
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2: std::backtrace::Backtrace::create
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\backtrace.rs:331
   3: std::backtrace::Backtrace::capture
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\backtrace.rs:296
   4: anyhow::error::impl$1::from<serde_json::error::Error>
             at C:\Users\Joe\.cargo\registry\src\index.crates.io-6f17d22bba15001f\anyhow-1.0.93\src\backtrace.rs:27
   5: core::result::impl$27::from_residual<settings::settings_store::DeserializedSetting,serde_json::error::Error,anyhow::Error>
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\core\src\result.rs:1989
   6: settings::settings_store::impl$7::deserialize_setting<language::language_settings::InlayHintSettings>
             at .\crates\settings\src\settings_store.rs:1094
   7: settings::settings_store::SettingsStore::recompute_values
             at .\crates\settings\src\settings_store.rs:860
   8: settings::settings_store::SettingsStore::set_extension_settings<language::language_settings::AllLanguageSettingsContent>
             at .\crates\settings\src\settings_store.rs:694
   9: languages::init::closure$2::async_block$0::closure$0::closure$0
             at .\crates\languages\src\lib.rs:294
  10: gpui::impl$1::update_global<gpui::app::AppContext,settings::settings_store::SettingsStore,tuple$<>,languages::init::closure$2::async_block$0::closure$0::closure_env$0>
             at .\crates\gpui\src\gpui.rs:315
  11: gpui::global::impl$1::update_global<settings::settings_store::SettingsStore,gpui::app::AppContext,languages::init::closure$2::async_block$0::closure$0::closure_env$0,tuple$<> >
             at .\crates\gpui\src\global.rs:66
  12: languages::init::closure$2::async_block$0::closure$0
             at .\crates\languages\src\lib.rs:293
  13: gpui::app::async_context::AsyncAppContext::update<tuple$<>,languages::init::closure$2::async_block$0::closure_env$0>
             at .\crates\gpui\src\app\async_context.rs:137
  14: languages::init::closure$2::async_block$0
             at .\crates\languages\src\lib.rs:292
  15: core::future::future::impl$1::poll<alloc::boxed::Box<dyn$<core::future::future::Future<assoc$<Output,enum2$<core::result::Result<tuple$<>,anyhow::Error> > > > >,alloc::alloc::Global> >
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\core\src\future\future.rs:123
  16: async_task::runnable::impl$6::spawn_local::impl$1::poll<core::pin::Pin<alloc::boxed::Box<dyn$<core::future::future::Future<assoc$<Output,enum2$<core::result::Result<tuple$<>,anyhow::Error> > > > >,alloc::alloc::Global> > >
             at C:\Users\Joe\.cargo\registry\src\index.crates.io-6f17d22bba15001f\async-task-4.7.1\src\runnable.rs:455
  17: async_task::raw::RawTask::run<async_task::runnable::impl$6::spawn_local::Checked<core::pin::Pin<alloc::boxed::Box<dyn$<core::future::future::Future<assoc$<Output,enum2$<core::result::Result<tuple$<>,anyhow::Error> > > > >,alloc::alloc::Global> > >,enum2$<c
             at C:\Users\Joe\.cargo\registry\src\index.crates.io-6f17d22bba15001f\async-task-4.7.1\src\raw.rs:557
  18: async_task::runnable::Runnable::run<tuple$<> >
             at C:\Users\Joe\.cargo\registry\src\index.crates.io-6f17d22bba15001f\async-task-4.7.1\src\runnable.rs:781
  19: gpui::platform::windows::platform::WindowsPlatform::run_foreground_tasks
             at .\crates\gpui\src\platform\windows\platform.rs:171
  20: gpui::platform::windows::platform::impl$2::run
             at .\crates\gpui\src\platform\windows\platform.rs:226
  21: gpui::app::App::run<zed::main::closure_env$5>
             at .\crates\gpui\src\app.rs:161
  22: zed::main
             at .\crates\zed\src\main.rs:253
  23: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\core\src\ops\function.rs:250
  24: core::hint::black_box
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\core\src\hint.rs:389
  25: std::sys::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\std\src\sys\backtrace.rs:152
  26: std::rt::lang_start::closure$0<tuple$<> >
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\std\src\rt.rs:162
  27: std::rt::lang_start_internal::closure$2
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\rt.rs:141
  28: std::panicking::try::do_call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\panicking.rs:557
  29: std::panicking::try
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\panicking.rs:521
  30: std::panic::catch_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\panic.rs:350
  31: std::rt::lang_start_internal
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library\std\src\rt.rs:141
  32: std::rt::lang_start<tuple$<> >
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c\library\std\src\rt.rs:161
  33: main
  34: invoke_main
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  35: __scrt_common_main_seh
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  36: BaseThreadInitThunk
  37: RtlUserThreadStart
```

</details>

I think there is something that must be done, but I don't know what. Help and comments are very much welcomed and appreciated.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
