### PR TITLE
Fixes and improvements to `pane` context menu

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2212,7 +2212,8 @@ impl Pane {
                             .read(cx)
                             .item_for_entry(entry, cx)
                             .and_then(|item| item.project_path(cx))
-                            .map(|project_path| project_path.path);
+                            .map(|project_path| project_path.path)
+                            .map_or(None, |path| if path.exists() { Some(path) } else { None });
 
                         let entry_id = entry.to_proto();
                         menu = menu

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2214,6 +2214,7 @@ impl Pane {
                             .and_then(|item| item.project_path(cx))
                             .map(|project_path| project_path.path)
                             .map_or(None, |path| if path.exists() { Some(path) } else { None });
+                        let has_relative_path = relative_path.is_some();
 
                         let entry_id = entry.to_proto();
                         menu = menu
@@ -2242,19 +2243,21 @@ impl Pane {
                             })
                             .map(pin_tab_entries)
                             .separator()
-                            .entry(
-                                "Reveal In Project Panel",
-                                Some(Box::new(RevealInProjectPanel {
-                                    entry_id: Some(entry_id),
-                                })),
-                                cx.handler_for(&pane, move |pane, cx| {
-                                    pane.project.update(cx, |_, cx| {
-                                        cx.emit(project::Event::RevealInProjectPanel(
-                                            ProjectEntryId::from_proto(entry_id),
-                                        ))
-                                    });
-                                }),
-                            )
+                            .when(has_relative_path, |menu| {
+                                menu.entry(
+                                    "Reveal In Project Panel",
+                                    Some(Box::new(RevealInProjectPanel {
+                                        entry_id: Some(entry_id),
+                                    })),
+                                    cx.handler_for(&pane, move |pane, cx| {
+                                        pane.project.update(cx, |_, cx| {
+                                            cx.emit(project::Event::RevealInProjectPanel(
+                                                ProjectEntryId::from_proto(entry_id),
+                                            ))
+                                        });
+                                    }),
+                                )
+                            })
                             .when_some(parent_abs_path, |menu, parent_abs_path| {
                                 menu.entry(
                                     "Open in Terminal",

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -144,6 +144,10 @@ pub struct RevealInProjectPanel {
     pub entry_id: Option<u64>,
 }
 
+#[derive(Clone, PartialEq, Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RevealInFileManager {}
+
 #[derive(Default, PartialEq, Clone, Deserialize)]
 pub struct DeploySearch {
     #[serde(default)]
@@ -161,6 +165,7 @@ impl_actions!(
         CloseInactiveItems,
         ActivateItem,
         RevealInProjectPanel,
+        RevealInFileManager,
         DeploySearch,
     ]
 );
@@ -2255,6 +2260,21 @@ impl Pane {
                                                 ProjectEntryId::from_proto(entry_id),
                                             ))
                                         });
+                                    }),
+                                )
+                            })
+                            .when_some(parent_abs_path.clone(), |menu, parent_abs_path| {
+                                let reveal_in_finder_label = if cfg!(target_os = "macos") {
+                                    "Reveal in Finder"
+                                } else {
+                                    "Reveal in File Manager"
+                                };
+
+                                menu.entry(
+                                    reveal_in_finder_label,
+                                    Some(Box::new(RevealInFileManager {})),
+                                    cx.handler_for(&pane, move |_, cx| {
+                                        cx.reveal_path(&parent_abs_path);
                                     }),
                                 )
                             })


### PR DESCRIPTION
Small bunch of QoL changes that I've noticed today.

For the out-of-project files action "Copy Relative Path" was available, but copied empty string. Check for this action was in place, but the relative path was empty string and not `None`. For the same out-of-project file action "Reveal in Project Panel" was available and did nothing.

And new action "Reveal in File Manager" that allows to open this file in the file manager. This is especially useful for the same out-of-project file.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
