### PR TITLE
title_bar: Remove dependency on `command_palette`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12607,7 +12607,6 @@ dependencies = [
  "call",
  "client",
  "collections",
- "command_palette",
  "editor",
  "feature_flags",
  "feedback",

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -11,7 +11,7 @@ use command_palette_hooks::{
 };
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, Action, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Global,
+    Action, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView, Global,
     ParentElement, Render, Styled, Task, UpdateGlobal, View, ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
@@ -21,9 +21,7 @@ use settings::Settings;
 use ui::{h_flex, prelude::*, v_flex, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing};
 use util::ResultExt;
 use workspace::{ModalView, Workspace, WorkspaceSettings};
-use zed_actions::OpenZedUrl;
-
-actions!(command_palette, [Toggle]);
+use zed_actions::{command_palette::Toggle, OpenZedUrl};
 
 pub fn init(cx: &mut AppContext) {
     client::init_settings(cx);

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -31,7 +31,6 @@ test-support = [
 auto_update.workspace = true
 call.workspace = true
 client.workspace = true
-command_palette.workspace = true
 feedback.workspace = true
 feature_flags.workspace = true
 gpui.workspace = true

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -18,7 +18,10 @@ impl Render for ApplicationMenu {
             .menu(move |cx| {
                 ContextMenu::build(cx, move |menu, cx| {
                     menu.header("Workspace")
-                        .action("Open Command Palette", Box::new(command_palette::Toggle))
+                        .action(
+                            "Open Command Palette",
+                            Box::new(zed_actions::command_palette::Toggle),
+                        )
                         .when_some(cx.focused(), |menu, focused| menu.context(focused))
                         .custom_row(move |cx| {
                             h_flex()

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -146,7 +146,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Back", workspace::GoBack),
                 MenuItem::action("Forward", workspace::GoForward),
                 MenuItem::separator(),
-                MenuItem::action("Command Palette...", command_palette::Toggle),
+                MenuItem::action("Command Palette...", zed_actions::command_palette::Toggle),
                 MenuItem::separator(),
                 MenuItem::action("Go to File...", workspace::ToggleFileFinder::default()),
                 // MenuItem::action("Go to Symbol in Project", project_symbols::Toggle),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -44,6 +44,12 @@ actions!(
     ]
 );
 
+pub mod command_palette {
+    use gpui::actions;
+
+    actions!(command_palette, [Toggle]);
+}
+
 #[derive(Clone, Default, Deserialize, PartialEq)]
 pub struct InlineAssist {
     pub prompt: Option<String>,


### PR DESCRIPTION
This PR removes the `title_bar` crate's dependency on the `command_palette`.

The `command_palette::Toggle` action now resides at `zed_actions::command_palette::Toggle`.

Release Notes:

- N/A
