### PR TITLE
macos: Add default keybind for ctrl-home / ctrl-end

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -93,6 +93,8 @@
       "ctrl-e": "editor::MoveToEndOfLine",
       "cmd-up": "editor::MoveToBeginning",
       "cmd-down": "editor::MoveToEnd",
+      "ctrl-home": "editor::MoveToBeginning",
+      "ctrl-end": "editor::MoveToEnd",
       "shift-up": "editor::SelectUp",
       "ctrl-shift-p": "editor::SelectUp",
       "shift-down": "editor::SelectDown",


### PR DESCRIPTION
This matches the default behavior on native macos apps.
ctrl-fn-left == ctrl-home == MoveToBeginning
ctrl-fn-right == ctrl-end == MoveToEnd

Release Notes:

- macos: Add keybind for ctrl-home / ctrl-end (MoveToBeginning, MoveToEnd)
