### PR TITLE
title_bar: Remove dependency on `theme_selector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12410,6 +12410,7 @@ dependencies = [
  "ui",
  "util",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]
@@ -12637,7 +12638,6 @@ dependencies = [
  "smallvec",
  "story",
  "theme",
- "theme_selector",
  "tree-sitter-md",
  "ui",
  "util",

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -257,7 +257,7 @@ impl ExtensionsPage {
                 .update(cx, |workspace, cx| {
                     theme_selector::toggle(
                         workspace,
-                        &theme_selector::Toggle {
+                        &zed_actions::theme_selector::Toggle {
                             themes_filter: Some(themes),
                         },
                         cx,

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -25,5 +25,6 @@ theme.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -2,25 +2,18 @@ use client::telemetry::Telemetry;
 use fs::Fs;
 use fuzzy::{match_strings, StringMatch, StringMatchCandidate};
 use gpui::{
-    actions, impl_actions, AppContext, DismissEvent, EventEmitter, FocusableView, Render,
-    UpdateGlobal, View, ViewContext, VisualContext, WeakView,
+    actions, AppContext, DismissEvent, EventEmitter, FocusableView, Render, UpdateGlobal, View,
+    ViewContext, VisualContext, WeakView,
 };
 use picker::{Picker, PickerDelegate};
-use serde::Deserialize;
 use settings::{update_settings_file, SettingsStore};
 use std::sync::Arc;
 use theme::{Appearance, Theme, ThemeMeta, ThemeRegistry, ThemeSettings};
 use ui::{prelude::*, v_flex, ListItem, ListItemSpacing};
 use util::ResultExt;
 use workspace::{ui::HighlightedLabel, ModalView, Workspace};
+use zed_actions::theme_selector::Toggle;
 
-#[derive(PartialEq, Clone, Default, Debug, Deserialize)]
-pub struct Toggle {
-    /// A list of theme names to filter the theme selector down to.
-    pub themes_filter: Option<Vec<String>>,
-}
-
-impl_actions!(theme_selector, [Toggle]);
 actions!(theme_selector, [Reload]);
 
 pub fn init(cx: &mut AppContext) {

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -42,7 +42,6 @@ serde.workspace = true
 smallvec.workspace = true
 story = { workspace = true, optional = true }
 theme.workspace = true
-theme_selector.workspace = true
 ui.workspace = true
 util.workspace = true
 vcs_menu.workspace = true

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -579,7 +579,10 @@ impl TitleBar {
                         })
                         .action("Settings", zed_actions::OpenSettings.boxed_clone())
                         .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
-                        .action("Themes…", theme_selector::Toggle::default().boxed_clone())
+                        .action(
+                            "Themes…",
+                            zed_actions::theme_selector::Toggle::default().boxed_clone(),
+                        )
                         .action("Extensions", zed_actions::Extensions.boxed_clone())
                         .separator()
                         .link(
@@ -615,7 +618,10 @@ impl TitleBar {
                     ContextMenu::build(cx, |menu, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
-                            .action("Themes…", theme_selector::Toggle::default().boxed_clone())
+                            .action(
+                                "Themes…",
+                                zed_actions::theme_selector::Toggle::default().boxed_clone(),
+                            )
                             .action("Extensions", zed_actions::Extensions.boxed_clone())
                             .separator()
                             .link(

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -23,7 +23,10 @@ pub fn app_menus() -> Vec<Menu> {
                             zed_actions::OpenDefaultKeymap,
                         ),
                         MenuItem::action("Open Project Settings", super::OpenProjectSettings),
-                        MenuItem::action("Select Theme...", theme_selector::Toggle::default()),
+                        MenuItem::action(
+                            "Select Theme...",
+                            zed_actions::theme_selector::Toggle::default(),
+                        ),
                     ],
                 }),
                 MenuItem::separator(),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -50,6 +50,19 @@ pub mod command_palette {
     actions!(command_palette, [Toggle]);
 }
 
+pub mod theme_selector {
+    use gpui::impl_actions;
+    use serde::Deserialize;
+
+    #[derive(PartialEq, Clone, Default, Debug, Deserialize)]
+    pub struct Toggle {
+        /// A list of theme names to filter the theme selector down to.
+        pub themes_filter: Option<Vec<String>>,
+    }
+
+    impl_actions!(theme_selector, [Toggle]);
+}
+
 #[derive(Clone, Default, Deserialize, PartialEq)]
 pub struct InlineAssist {
     pub prompt: Option<String>,


### PR DESCRIPTION
This PR removes the `title_bar` crate's dependency on the `theme_selector`.

The `theme_selector::Toggle` action now resides at `zed_actions::theme_selector::Toggle`.

Release Notes:

- N/A
