### PR TITLE
title_bar: Remove dependency on `vcs_menu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12641,7 +12641,6 @@ dependencies = [
  "tree-sitter-md",
  "ui",
  "util",
- "vcs_menu",
  "windows 0.58.0",
  "workspace",
  "zed_actions",
@@ -13653,6 +13652,7 @@ dependencies = [
  "ui",
  "util",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -44,7 +44,6 @@ story = { workspace = true, optional = true }
 theme.workspace = true
 ui.workspace = true
 util.workspace = true
-vcs_menu.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -27,7 +27,6 @@ use ui::{
     IconSize, IconWithIndicator, Indicator, PopoverMenu, Tooltip,
 };
 use util::ResultExt;
-use vcs_menu::{BranchList, OpenRecent as ToggleVcsMenu};
 use workspace::{notifications::NotifyResultExt, Workspace};
 use zed_actions::{OpenBrowser, OpenRecent, OpenRemote};
 
@@ -442,14 +441,14 @@ impl TitleBar {
                 .tooltip(move |cx| {
                     Tooltip::with_meta(
                         "Recent Branches",
-                        Some(&ToggleVcsMenu),
+                        Some(&zed_actions::branches::OpenRecent),
                         "Local branches only",
                         cx,
                     )
                 })
                 .on_click(move |_, cx| {
-                    let _ = workspace.update(cx, |this, cx| {
-                        BranchList::open(this, &Default::default(), cx);
+                    let _ = workspace.update(cx, |_this, cx| {
+                        cx.dispatch_action(zed_actions::branches::OpenRecent.boxed_clone());
                     });
                 }),
         )

--- a/crates/vcs_menu/Cargo.toml
+++ b/crates/vcs_menu/Cargo.toml
@@ -18,3 +18,4 @@ project.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -2,10 +2,9 @@ use anyhow::{anyhow, Context, Result};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use git::repository::Branch;
 use gpui::{
-    actions, rems, AnyElement, AppContext, AsyncAppContext, DismissEvent, EventEmitter,
-    FocusHandle, FocusableView, InteractiveElement, IntoElement, ParentElement, Render,
-    SharedString, Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView,
-    WindowContext,
+    rems, AnyElement, AppContext, AsyncAppContext, DismissEvent, EventEmitter, FocusHandle,
+    FocusableView, InteractiveElement, IntoElement, ParentElement, Render, SharedString, Styled,
+    Subscription, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use picker::{Picker, PickerDelegate};
 use project::ProjectPath;
@@ -14,8 +13,7 @@ use ui::{prelude::*, HighlightedLabel, ListItem, ListItemSpacing};
 use util::ResultExt;
 use workspace::notifications::DetachAndPromptErr;
 use workspace::{ModalView, Workspace};
-
-actions!(branches, [OpenRecent]);
+use zed_actions::branches::OpenRecent;
 
 pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(|workspace: &mut Workspace, _| {

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -44,6 +44,12 @@ actions!(
     ]
 );
 
+pub mod branches {
+    use gpui::actions;
+
+    actions!(branches, [OpenRecent]);
+}
+
 pub mod command_palette {
     use gpui::actions;
 


### PR DESCRIPTION
This PR removes the `title_bar` crate's dependency on the `vcs_menu`.

The `vcs_menu::OpenRecent` action now resides at `zed_actions::branches::OpenRecent`.

Release Notes:

- N/A
