### PR TITLE
title_bar: Remove dependency on `feedback`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,6 +4347,7 @@ dependencies = [
  "urlencoding",
  "util",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]
@@ -12625,7 +12626,6 @@ dependencies = [
  "collections",
  "editor",
  "feature_flags",
- "feedback",
  "gpui",
  "http_client",
  "notifications",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12624,7 +12624,6 @@ dependencies = [
  "call",
  "client",
  "collections",
- "editor",
  "feature_flags",
  "gpui",
  "http_client",

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -22,8 +22,8 @@ db.workspace = true
 editor.workspace = true
 futures.workspace = true
 gpui.workspace = true
-human_bytes = "0.4.1"
 http_client.workspace = true
+human_bytes = "0.4.1"
 language.workspace = true
 log.workspace = true
 menu.workspace = true
@@ -39,6 +39,7 @@ ui.workspace = true
 urlencoding = "2.1.2"
 util.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -5,8 +5,6 @@ use workspace::Workspace;
 
 pub mod feedback_modal;
 
-actions!(feedback, [GiveFeedback, SubmitFeedback]);
-
 mod system_specs;
 
 actions!(

--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -18,8 +18,9 @@ use serde_derive::Serialize;
 use ui::{prelude::*, Button, ButtonStyle, IconPosition, Tooltip};
 use util::ResultExt;
 use workspace::{DismissDecision, ModalView, Workspace};
+use zed_actions::feedback::GiveFeedback;
 
-use crate::{system_specs::SystemSpecs, GiveFeedback, OpenZedRepo};
+use crate::{system_specs::SystemSpecs, OpenZedRepo};
 
 // For UI testing purposes
 const SEND_SUCCESS_IN_DEV_MODE: bool = true;

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -31,7 +31,6 @@ test-support = [
 auto_update.workspace = true
 call.workspace = true
 client.workspace = true
-feedback.workspace = true
 feature_flags.workspace = true
 gpui.workspace = true
 notifications.workspace = true

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -19,7 +19,6 @@ test-support = [
     "call/test-support",
     "client/test-support",
     "collections/test-support",
-    "editor/test-support",
     "gpui/test-support",
     "http_client/test-support",
     "project/test-support",
@@ -53,7 +52,6 @@ windows.workspace = true
 call = { workspace = true, features = ["test-support"] }
 client = { workspace = true, features = ["test-support"] }
 collections = { workspace = true, features = ["test-support"] }
-editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 notifications = { workspace = true, features = ["test-support"] }

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -116,7 +116,10 @@ impl Render for ApplicationMenu {
                                 url: "https://zed.dev/docs".into(),
                             }),
                         )
-                        .action("Give Feedback", Box::new(feedback::GiveFeedback))
+                        .action(
+                            "Give Feedback",
+                            Box::new(zed_actions::feedback::GiveFeedback),
+                        )
                         .action("Check for Updates", Box::new(auto_update::Check))
                         .action("View Telemetry", Box::new(zed_actions::OpenTelemetryLog))
                         .action(

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -179,7 +179,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("View Telemetry", zed_actions::OpenTelemetryLog),
                 MenuItem::action("View Dependency Licenses", zed_actions::OpenLicenses),
                 MenuItem::action("Show Welcome", workspace::Welcome),
-                MenuItem::action("Give Feedback...", feedback::GiveFeedback),
+                MenuItem::action("Give Feedback...", zed_actions::feedback::GiveFeedback),
                 MenuItem::separator(),
                 MenuItem::action(
                     "Documentation",

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -56,6 +56,12 @@ pub mod command_palette {
     actions!(command_palette, [Toggle]);
 }
 
+pub mod feedback {
+    use gpui::actions;
+
+    actions!(feedback, [GiveFeedback]);
+}
+
 pub mod theme_selector {
     use gpui::impl_actions;
     use serde::Deserialize;


### PR DESCRIPTION
This PR removes the `title_bar` crate's dependency on the `feedback` crate.

The `feedback::GiveFeedback` action now resides at `zed_actions::feedback::GiveFeedback`.

`title_bar` now no longer depends on `editor` 🥳 

Release Notes:

- N/A
