### PR TITLE
Styling for Apply/Discard buttons

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -522,7 +522,7 @@
   {
     "context": "ProposedChangesEditor",
     "bindings": {
-      "ctrl-shift-y": "editor::ApplyDiffHunk",
+      "ctrl-shift-y": "editor::ApplySelectedDiffHunks",
       "ctrl-alt-a": "editor::ApplyAllDiffHunks"
     }
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -550,7 +550,7 @@
   {
     "context": "ProposedChangesEditor",
     "bindings": {
-      "cmd-shift-y": "editor::ApplyDiffHunk",
+      "cmd-shift-y": "editor::ApplySelectedDiffHunks",
       "cmd-shift-a": "editor::ApplyAllDiffHunks"
     }
   },

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -209,7 +209,7 @@ gpui::actions!(
         AddSelectionAbove,
         AddSelectionBelow,
         ApplyAllDiffHunks,
-        ApplyDiffHunk,
+        ApplySelectedDiffHunks,
         Backspace,
         Cancel,
         CancelLanguageServerWork,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -99,7 +99,8 @@ use language::{
 use language::{point_to_lsp, BufferRow, CharClassifier, Runnable, RunnableRange};
 use linked_editing_ranges::refresh_linked_ranges;
 pub use proposed_changes_editor::{
-    ProposedChangeLocation, ProposedChangesEditor, ProposedChangesEditorToolbar,
+    ProposedChangeLocation, ProposedChangesEditor, ProposedChangesToolbar,
+    ProposedChangesToolbarControls,
 };
 use similar::{ChangeTag, TextDiff};
 use std::iter::Peekable;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -161,7 +161,7 @@ use theme::{
 };
 use ui::{
     h_flex, prelude::*, ButtonSize, ButtonStyle, Disclosure, IconButton, IconName, IconSize,
-    ListItem, Popover, PopoverMenuHandle, Tooltip,
+    ListItem, Popover, Tooltip,
 };
 use util::{defer, maybe, post_inc, RangeExt, ResultExt, TryFutureExt};
 use workspace::item::{ItemHandle, PreviewTabsSettings};
@@ -600,7 +600,6 @@ pub struct Editor {
     nav_history: Option<ItemNavHistory>,
     context_menu: RwLock<Option<ContextMenu>>,
     mouse_context_menu: Option<MouseContextMenu>,
-    hunk_controls_menu_handle: PopoverMenuHandle<ui::ContextMenu>,
     completion_tasks: Vec<(CompletionId, Task<Option<()>>)>,
     signature_help_state: SignatureHelpState,
     auto_signature_help: Option<bool>,
@@ -2123,7 +2122,6 @@ impl Editor {
             nav_history: None,
             context_menu: RwLock::new(None),
             mouse_context_menu: None,
-            hunk_controls_menu_handle: PopoverMenuHandle::default(),
             completion_tasks: Default::default(),
             signature_help_state: SignatureHelpState::default(),
             auto_signature_help: None,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -12358,7 +12358,7 @@ async fn test_edits_around_expanded_insertion_hunks(
     executor.run_until_parked();
     cx.assert_diff_hunks(
         r#"
-        use some::mod1;
+      - use some::mod1;
       - use some::mod2;
       -
       - const A: u32 = 42;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2519,6 +2519,7 @@ impl EditorElement {
                 element,
                 available_space: size(AvailableSpace::MinContent, element_size.height.into()),
                 style: BlockStyle::Fixed,
+                is_zero_height: block.height() == 0,
             });
         }
         for (row, block) in non_fixed_blocks {
@@ -2565,6 +2566,7 @@ impl EditorElement {
                 element,
                 available_space: size(width.into(), element_size.height.into()),
                 style,
+                is_zero_height: block.height() == 0,
             });
         }
 
@@ -2612,6 +2614,7 @@ impl EditorElement {
                             element,
                             available_space: size(width, element_size.height.into()),
                             style,
+                            is_zero_height: block.height() == 0,
                         });
                     }
                 }
@@ -3957,8 +3960,23 @@ impl EditorElement {
     }
 
     fn paint_blocks(&mut self, layout: &mut EditorLayout, cx: &mut WindowContext) {
-        for mut block in layout.blocks.drain(..) {
-            block.element.paint(cx);
+        cx.paint_layer(layout.text_hitbox.bounds, |cx| {
+            layout.blocks.retain_mut(|block| {
+                if !block.is_zero_height {
+                    block.element.paint(cx);
+                }
+
+                block.is_zero_height
+            });
+        });
+
+        // Paint all the zero-height blocks in a higher layer (if there were any remaining to paint).
+        if !layout.blocks.is_empty() {
+            cx.paint_layer(layout.text_hitbox.bounds, |cx| {
+                for mut block in layout.blocks.drain(..) {
+                    block.element.paint(cx);
+                }
+            });
         }
     }
 
@@ -6021,6 +6039,7 @@ struct BlockLayout {
     element: AnyElement,
     available_space: Size<AvailableSpace>,
     style: BlockStyle,
+    is_zero_height: bool,
 }
 
 fn layout_line(

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -1,6 +1,6 @@
 use collections::{hash_map, HashMap, HashSet};
 use git::diff::DiffHunkStatus;
-use gpui::{Action, AnchorCorner, AppContext, CursorStyle, Hsla, Model, MouseButton, Task, View};
+use gpui::{AppContext, CursorStyle, Hsla, Model, MouseButton, Task, View};
 use language::{Buffer, BufferId, Point};
 use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptRange, MultiBuffer, MultiBufferDiffHunk, MultiBufferRow,
@@ -9,9 +9,8 @@ use multi_buffer::{
 use std::{ops::Range, sync::Arc};
 use text::OffsetRangeExt;
 use ui::{
-    prelude::*, ActiveTheme, ButtonLike, ContextMenu, ElevationIndex, IconButtonShape,
-    InteractiveElement, IntoElement, KeyBinding, ParentElement, PopoverMenu, Styled, TintColor,
-    Tooltip, ViewContext, VisualContext,
+    prelude::*, ActiveTheme, ElevationIndex, IconButtonShape, InteractiveElement, IntoElement,
+    KeyBinding, ParentElement, Styled, TintColor, Tooltip, ViewContext, VisualContext,
 };
 use util::RangeExt;
 use workspace::Item;
@@ -20,7 +19,7 @@ use crate::{
     editor_settings::CurrentLineHighlight, hunk_status, hunks_for_selections, ApplyAllDiffHunks,
     ApplyDiffHunk, BlockPlacement, BlockProperties, BlockStyle, CustomBlockId, DiffRowHighlight,
     DisplayRow, DisplaySnapshot, Editor, EditorElement, ExpandAllHunkDiffs, GoToHunk, GoToPrevHunk,
-    RevertFile, RevertSelectedHunks, ToDisplayPoint, ToggleHunkDiff,
+    RevertSelectedHunks, ToDisplayPoint, ToggleHunkDiff,
 };
 
 #[derive(Debug, Clone)]
@@ -58,7 +57,6 @@ pub enum DisplayDiffHunk {
     Folded {
         display_row: DisplayRow,
     },
-
     Unfolded {
         diff_base_byte_range: Range<usize>,
         display_row_range: Range<DisplayRow>,

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -508,7 +508,6 @@ impl Editor {
 
                     h_flex()
                         .id(cx.block_id)
-                        .block_mouse_down()
                         .pr_5()
                         .w_full()
                         .justify_end()

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -455,7 +455,6 @@ impl Editor {
                     h_flex()
                         .id(cx.block_id)
                         .block_mouse_down()
-                        // .h(cx.line_height())
                         .pr_5()
                         .w_full()
                         .justify_end()
@@ -470,10 +469,10 @@ impl Editor {
                                 .rounded_b_lg()
                                 .bg(cx.theme().colors().editor_background)
                                 .shadow(smallvec::smallvec![gpui::BoxShadow {
-                                    color: gpui::hsla(0.0, 0.0, 0.0, 0.15),
+                                    color: gpui::hsla(0.0, 0.0, 0.0, 0.1),
                                     blur_radius: px(1.0),
                                     spread_radius: px(1.0),
-                                    offset: gpui::point(px(0.), px(2.0)),
+                                    offset: gpui::point(px(0.), px(1.5)),
                                 }])
                                 .when(!is_branch_buffer, |row| {
                                     row.child(

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -10,8 +10,8 @@ use std::{ops::Range, sync::Arc};
 use text::OffsetRangeExt;
 use ui::{
     prelude::*, ActiveTheme, ButtonLike, ContextMenu, ElevationIndex, IconButtonShape,
-    InteractiveElement, IntoElement, KeyBinding, ParentElement, PopoverMenu, Styled, Tooltip,
-    ViewContext, VisualContext,
+    InteractiveElement, IntoElement, KeyBinding, ParentElement, PopoverMenu, Styled, TintColor,
+    Tooltip, ViewContext, VisualContext,
 };
 use util::RangeExt;
 use workspace::Item;
@@ -431,6 +431,8 @@ impl Editor {
                     let hunk_controls_menu_handle =
                         editor.read(cx).hunk_controls_menu_handle.clone();
 
+                    let focus_handle = editor.focus_handle(cx);
+
                     h_flex()
                         .id(cx.block_id)
                         .block_mouse_down()
@@ -440,7 +442,7 @@ impl Editor {
                         .child(
                             h_flex()
                                 .gap_1()
-                                .pr_4()
+                                .pr_5()
                                 .when(!is_branch_buffer, |row| {
                                     row.child(
                                         IconButton::new("next-hunk", IconName::ArrowDown)
@@ -500,31 +502,13 @@ impl Editor {
                                     )
                                 })
                                 .child(
-                                    ButtonLike::new("discard")
-                                        .tooltip({
-                                            let focus_handle = editor.focus_handle(cx);
-                                            move |cx| {
-                                                Tooltip::for_action_in(
-                                                    "Discard Hunk",
-                                                    &RevertSelectedHunks,
-                                                    &focus_handle,
-                                                    cx,
-                                                )
-                                            }
-                                        })
-                                        // .when_some(tooltip, |button, tooltip| {
-                                        //     button.tooltip(move |_| tooltip.clone())
-                                        // })
-                                        .child(Label::new("Discard"))
-                                        .children({
-                                            let focus_handle = editor.focus_handle(cx);
-                                            KeyBinding::for_action_in(
-                                                &RevertSelectedHunks,
-                                                &focus_handle,
-                                                cx,
-                                            )
-                                            .map(|binding| binding.into_any_element())
-                                        })
+                                    Button::new("discard", "Discard")
+                                        .style(ButtonStyle::Tinted(TintColor::Negative))
+                                        .key_binding(KeyBinding::for_action_in(
+                                            &RevertSelectedHunks,
+                                            &focus_handle,
+                                            cx,
+                                        ))
                                         .on_click({
                                             let editor = editor.clone();
                                             let hunk = hunk.clone();
@@ -554,20 +538,14 @@ impl Editor {
                                 )
                                 .when(is_branch_buffer, |this| {
                                     this.child(
-                                        IconButton::new("apply", IconName::Check)
-                                            .shape(IconButtonShape::Square)
-                                            .icon_size(IconSize::Small)
-                                            .tooltip({
-                                                let focus_handle = editor.focus_handle(cx);
-                                                move |cx| {
-                                                    Tooltip::for_action_in(
-                                                        "Apply Hunk",
-                                                        &ApplyDiffHunk,
-                                                        &focus_handle,
-                                                        cx,
-                                                    )
-                                                }
-                                            })
+                                        Button::new("apply", "Apply")
+                                            .style(ButtonStyle::Tinted(TintColor::Positive))
+                                            .layer(ElevationIndex::Wash)
+                                            .key_binding(KeyBinding::for_action_in(
+                                                &ApplyDiffHunk,
+                                                &focus_handle,
+                                                cx,
+                                            ))
                                             .on_click({
                                                 let editor = editor.clone();
                                                 let hunk = hunk.clone();

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -437,157 +437,154 @@ impl Editor {
                         .id(cx.block_id)
                         .block_mouse_down()
                         .h(cx.line_height())
+                        .gap_0p5()
+                        .pr_5()
                         .w_full()
                         .justify_end()
-                        .child(
-                            h_flex()
-                                .gap_1()
-                                .pr_5()
-                                .when(!is_branch_buffer, |row| {
-                                    row.child(
-                                        IconButton::new("next-hunk", IconName::ArrowDown)
-                                            .shape(IconButtonShape::Square)
-                                            .icon_size(IconSize::Small)
-                                            .tooltip({
-                                                let focus_handle = editor.focus_handle(cx);
-                                                move |cx| {
-                                                    Tooltip::for_action_in(
-                                                        "Next Hunk",
-                                                        &GoToHunk,
-                                                        &focus_handle.clone(),
-                                                        cx,
-                                                    )
-                                                }
-                                            })
-                                            .on_click({
-                                                let editor = editor.clone();
-                                                let hunk = hunk.clone();
-                                                move |_event, cx| {
-                                                    editor.update(cx, |editor, cx| {
-                                                        editor.go_to_subsequent_hunk(
-                                                            hunk.multi_buffer_range.end,
-                                                            cx,
-                                                        );
-                                                    });
-                                                }
-                                            }),
-                                    )
-                                    .child(
-                                        IconButton::new("prev-hunk", IconName::ArrowUp)
-                                            .shape(IconButtonShape::Square)
-                                            .icon_size(IconSize::Small)
-                                            .tooltip({
-                                                let focus_handle = editor.focus_handle(cx);
-                                                move |cx| {
-                                                    Tooltip::for_action_in(
-                                                        "Previous Hunk",
-                                                        &GoToPrevHunk,
-                                                        &focus_handle,
-                                                        cx,
-                                                    )
-                                                }
-                                            })
-                                            .on_click({
-                                                let editor = editor.clone();
-                                                let hunk = hunk.clone();
-                                                move |_event, cx| {
-                                                    editor.update(cx, |editor, cx| {
-                                                        editor.go_to_preceding_hunk(
-                                                            hunk.multi_buffer_range.start,
-                                                            cx,
-                                                        );
-                                                    });
-                                                }
-                                            }),
-                                    )
-                                })
-                                .child(
-                                    Button::new("discard", "Discard")
-                                        .style(ButtonStyle::Tinted(TintColor::Negative))
-                                        .key_binding(KeyBinding::for_action_in(
-                                            &RevertSelectedHunks,
-                                            &focus_handle,
-                                            cx,
-                                        ))
-                                        .on_click({
-                                            let editor = editor.clone();
-                                            let hunk = hunk.clone();
-                                            move |_event, cx| {
-                                                let multi_buffer = editor.read(cx).buffer().clone();
-                                                let multi_buffer_snapshot =
-                                                    multi_buffer.read(cx).snapshot(cx);
-                                                let mut revert_changes = HashMap::default();
-                                                if let Some(hunk) = crate::hunk_diff::to_diff_hunk(
-                                                    &hunk,
-                                                    &multi_buffer_snapshot,
-                                                ) {
-                                                    Editor::prepare_revert_change(
-                                                        &mut revert_changes,
-                                                        &multi_buffer,
-                                                        &hunk,
-                                                        cx,
-                                                    );
-                                                }
-                                                if !revert_changes.is_empty() {
-                                                    editor.update(cx, |editor, cx| {
-                                                        editor.revert(revert_changes, cx)
-                                                    });
-                                                }
-                                            }
-                                        }),
-                                )
-                                .when(is_branch_buffer, |this| {
-                                    this.child(
-                                        Button::new("apply", "Apply")
-                                            .style(ButtonStyle::Tinted(TintColor::Positive))
-                                            .layer(ElevationIndex::Wash)
-                                            .key_binding(KeyBinding::for_action_in(
-                                                &ApplyDiffHunk,
+                        .when(!is_branch_buffer, |row| {
+                            row.child(
+                                IconButton::new("next-hunk", IconName::ArrowDown)
+                                    .shape(IconButtonShape::Square)
+                                    .icon_size(IconSize::Small)
+                                    .tooltip({
+                                        let focus_handle = editor.focus_handle(cx);
+                                        move |cx| {
+                                            Tooltip::for_action_in(
+                                                "Next Hunk",
+                                                &GoToHunk,
+                                                &focus_handle.clone(),
+                                                cx,
+                                            )
+                                        }
+                                    })
+                                    .on_click({
+                                        let editor = editor.clone();
+                                        let hunk = hunk.clone();
+                                        move |_event, cx| {
+                                            editor.update(cx, |editor, cx| {
+                                                editor.go_to_subsequent_hunk(
+                                                    hunk.multi_buffer_range.end,
+                                                    cx,
+                                                );
+                                            });
+                                        }
+                                    }),
+                            )
+                            .child(
+                                IconButton::new("prev-hunk", IconName::ArrowUp)
+                                    .shape(IconButtonShape::Square)
+                                    .icon_size(IconSize::Small)
+                                    .tooltip({
+                                        let focus_handle = editor.focus_handle(cx);
+                                        move |cx| {
+                                            Tooltip::for_action_in(
+                                                "Previous Hunk",
+                                                &GoToPrevHunk,
                                                 &focus_handle,
                                                 cx,
-                                            ))
-                                            .on_click({
-                                                let editor = editor.clone();
-                                                let hunk = hunk.clone();
-                                                move |_event, cx| {
-                                                    editor.update(cx, |editor, cx| {
-                                                        editor.apply_diff_hunks_in_range(
-                                                            hunk.multi_buffer_range.clone(),
-                                                            cx,
-                                                        );
-                                                    });
-                                                }
-                                            }),
-                                    )
-                                })
-                                .when(!is_branch_buffer, |div| {
-                                    div.child(
-                                        IconButton::new("collapse", IconName::Close)
-                                            .shape(IconButtonShape::Square)
-                                            .icon_size(IconSize::Small)
-                                            .tooltip({
-                                                let focus_handle = editor.focus_handle(cx);
-                                                move |cx| {
-                                                    Tooltip::for_action_in(
-                                                        "Collapse Hunk",
-                                                        &ToggleHunkDiff,
-                                                        &focus_handle,
-                                                        cx,
-                                                    )
-                                                }
-                                            })
-                                            .on_click({
-                                                let editor = editor.clone();
-                                                let hunk = hunk.clone();
-                                                move |_event, cx| {
-                                                    editor.update(cx, |editor, cx| {
-                                                        editor.toggle_hovered_hunk(&hunk, cx);
-                                                    });
-                                                }
-                                            }),
-                                    )
+                                            )
+                                        }
+                                    })
+                                    .on_click({
+                                        let editor = editor.clone();
+                                        let hunk = hunk.clone();
+                                        move |_event, cx| {
+                                            editor.update(cx, |editor, cx| {
+                                                editor.go_to_preceding_hunk(
+                                                    hunk.multi_buffer_range.start,
+                                                    cx,
+                                                );
+                                            });
+                                        }
+                                    }),
+                            )
+                        })
+                        .child(
+                            Button::new("discard", "Discard")
+                                .style(ButtonStyle::Tinted(TintColor::Negative))
+                                .key_binding(KeyBinding::for_action_in(
+                                    &RevertSelectedHunks,
+                                    &focus_handle,
+                                    cx,
+                                ))
+                                .on_click({
+                                    let editor = editor.clone();
+                                    let hunk = hunk.clone();
+                                    move |_event, cx| {
+                                        let multi_buffer = editor.read(cx).buffer().clone();
+                                        let multi_buffer_snapshot =
+                                            multi_buffer.read(cx).snapshot(cx);
+                                        let mut revert_changes = HashMap::default();
+                                        if let Some(hunk) = crate::hunk_diff::to_diff_hunk(
+                                            &hunk,
+                                            &multi_buffer_snapshot,
+                                        ) {
+                                            Editor::prepare_revert_change(
+                                                &mut revert_changes,
+                                                &multi_buffer,
+                                                &hunk,
+                                                cx,
+                                            );
+                                        }
+                                        if !revert_changes.is_empty() {
+                                            editor.update(cx, |editor, cx| {
+                                                editor.revert(revert_changes, cx)
+                                            });
+                                        }
+                                    }
                                 }),
                         )
+                        .when(is_branch_buffer, |this| {
+                            this.child(
+                                Button::new("apply", "Apply")
+                                    .style(ButtonStyle::Tinted(TintColor::Positive))
+                                    .layer(ElevationIndex::Wash)
+                                    .key_binding(KeyBinding::for_action_in(
+                                        &ApplyDiffHunk,
+                                        &focus_handle,
+                                        cx,
+                                    ))
+                                    .on_click({
+                                        let editor = editor.clone();
+                                        let hunk = hunk.clone();
+                                        move |_event, cx| {
+                                            editor.update(cx, |editor, cx| {
+                                                editor.apply_diff_hunks_in_range(
+                                                    hunk.multi_buffer_range.clone(),
+                                                    cx,
+                                                );
+                                            });
+                                        }
+                                    }),
+                            )
+                        })
+                        .when(!is_branch_buffer, |div| {
+                            div.child(
+                                IconButton::new("collapse", IconName::Close)
+                                    .shape(IconButtonShape::Square)
+                                    .icon_size(IconSize::Small)
+                                    .tooltip({
+                                        let focus_handle = editor.focus_handle(cx);
+                                        move |cx| {
+                                            Tooltip::for_action_in(
+                                                "Collapse Hunk",
+                                                &ToggleHunkDiff,
+                                                &focus_handle,
+                                                cx,
+                                            )
+                                        }
+                                    })
+                                    .on_click({
+                                        let editor = editor.clone();
+                                        let hunk = hunk.clone();
+                                        move |_event, cx| {
+                                            editor.update(cx, |editor, cx| {
+                                                editor.toggle_hovered_hunk(&hunk, cx);
+                                            });
+                                        }
+                                    }),
+                            )
+                        })
                         .into_any_element()
                 }
             }),

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -421,11 +421,6 @@ impl Editor {
                 buffer.read(cx).diff_base_buffer().is_some()
             });
 
-        let bg_color = match hunk.status {
-            DiffHunkStatus::Added => added_hunk_color(cx),
-            DiffHunkStatus::Modified | DiffHunkStatus::Removed => deleted_hunk_color(cx),
-        };
-
         BlockProperties {
             placement: BlockPlacement::Above(hunk.multi_buffer_range.start),
             height: 0,

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -455,165 +455,179 @@ impl Editor {
                     h_flex()
                         .id(cx.block_id)
                         .block_mouse_down()
-                        .h(cx.line_height())
-                        .gap_0p5()
+                        // .h(cx.line_height())
                         .pr_5()
                         .w_full()
                         .justify_end()
-                        .when(!is_branch_buffer, |row| {
-                            row.child(
-                                IconButton::new("next-hunk", IconName::ArrowDown)
-                                    .shape(IconButtonShape::Square)
-                                    .icon_size(IconSize::Small)
-                                    .tooltip({
-                                        let focus_handle = editor.focus_handle(cx);
-                                        move |cx| {
-                                            Tooltip::for_action_in(
-                                                "Next Hunk",
-                                                &GoToHunk,
-                                                &focus_handle.clone(),
-                                                cx,
-                                            )
-                                        }
-                                    })
-                                    .on_click({
-                                        let editor = editor.clone();
-                                        let hunk = hunk.clone();
-                                        move |_event, cx| {
-                                            editor.update(cx, |editor, cx| {
-                                                editor.go_to_subsequent_hunk(
-                                                    hunk.multi_buffer_range.end,
-                                                    cx,
-                                                );
-                                            });
-                                        }
-                                    }),
-                            )
-                            .child(
-                                IconButton::new("prev-hunk", IconName::ArrowUp)
-                                    .shape(IconButtonShape::Square)
-                                    .icon_size(IconSize::Small)
-                                    .tooltip({
-                                        let focus_handle = editor.focus_handle(cx);
-                                        move |cx| {
-                                            Tooltip::for_action_in(
-                                                "Previous Hunk",
-                                                &GoToPrevHunk,
-                                                &focus_handle,
-                                                cx,
-                                            )
-                                        }
-                                    })
-                                    .on_click({
-                                        let editor = editor.clone();
-                                        let hunk = hunk.clone();
-                                        move |_event, cx| {
-                                            editor.update(cx, |editor, cx| {
-                                                editor.go_to_preceding_hunk(
-                                                    hunk.multi_buffer_range.start,
-                                                    cx,
-                                                );
-                                            });
-                                        }
-                                    }),
-                            )
-                        })
-                        .child({
-                            let button = Button::new("discard", "Discard")
-                                .style(ButtonStyle::Tinted(TintColor::Negative))
-                                .on_click({
-                                    let editor = editor.clone();
-                                    let hunk = hunk.clone();
-                                    move |_event, cx| {
-                                        let multi_buffer = editor.read(cx).buffer().clone();
-                                        let multi_buffer_snapshot =
-                                            multi_buffer.read(cx).snapshot(cx);
-                                        let mut revert_changes = HashMap::default();
-                                        if let Some(hunk) = crate::hunk_diff::to_diff_hunk(
-                                            &hunk,
-                                            &multi_buffer_snapshot,
-                                        ) {
-                                            Editor::prepare_revert_change(
-                                                &mut revert_changes,
-                                                &multi_buffer,
-                                                &hunk,
-                                                cx,
-                                            );
-                                        }
-                                        if !revert_changes.is_empty() {
-                                            editor.update(cx, |editor, cx| {
-                                                editor.revert(revert_changes, cx)
-                                            });
-                                        }
+                        .child(
+                            h_flex()
+                                .gap_1()
+                                .px_1()
+                                .pb_1()
+                                .border_x_1()
+                                .border_b_1()
+                                .border_color(cx.theme().colors().border_variant)
+                                .rounded_b_lg()
+                                .bg(cx.theme().colors().editor_background)
+                                .shadow(smallvec::smallvec![gpui::BoxShadow {
+                                    color: gpui::hsla(0.0, 0.0, 0.0, 0.15),
+                                    blur_radius: px(1.0),
+                                    spread_radius: px(1.0),
+                                    offset: gpui::point(px(0.), px(2.0)),
+                                }])
+                                .when(!is_branch_buffer, |row| {
+                                    row.child(
+                                        IconButton::new("next-hunk", IconName::ArrowDown)
+                                            .shape(IconButtonShape::Square)
+                                            .icon_size(IconSize::Small)
+                                            .tooltip({
+                                                let focus_handle = editor.focus_handle(cx);
+                                                move |cx| {
+                                                    Tooltip::for_action_in(
+                                                        "Next Hunk",
+                                                        &GoToHunk,
+                                                        &focus_handle.clone(),
+                                                        cx,
+                                                    )
+                                                }
+                                            })
+                                            .on_click({
+                                                let editor = editor.clone();
+                                                let hunk = hunk.clone();
+                                                move |_event, cx| {
+                                                    editor.update(cx, |editor, cx| {
+                                                        editor.go_to_subsequent_hunk(
+                                                            hunk.multi_buffer_range.end,
+                                                            cx,
+                                                        );
+                                                    });
+                                                }
+                                            }),
+                                    )
+                                    .child(
+                                        IconButton::new("prev-hunk", IconName::ArrowUp)
+                                            .shape(IconButtonShape::Square)
+                                            .icon_size(IconSize::Small)
+                                            .tooltip({
+                                                let focus_handle = editor.focus_handle(cx);
+                                                move |cx| {
+                                                    Tooltip::for_action_in(
+                                                        "Previous Hunk",
+                                                        &GoToPrevHunk,
+                                                        &focus_handle,
+                                                        cx,
+                                                    )
+                                                }
+                                            })
+                                            .on_click({
+                                                let editor = editor.clone();
+                                                let hunk = hunk.clone();
+                                                move |_event, cx| {
+                                                    editor.update(cx, |editor, cx| {
+                                                        editor.go_to_preceding_hunk(
+                                                            hunk.multi_buffer_range.start,
+                                                            cx,
+                                                        );
+                                                    });
+                                                }
+                                            }),
+                                    )
+                                })
+                                .child({
+                                    let button = Button::new("discard", "Discard")
+                                        .style(ButtonStyle::Tinted(TintColor::Negative))
+                                        .on_click({
+                                            let editor = editor.clone();
+                                            let hunk = hunk.clone();
+                                            move |_event, cx| {
+                                                let multi_buffer = editor.read(cx).buffer().clone();
+                                                let multi_buffer_snapshot =
+                                                    multi_buffer.read(cx).snapshot(cx);
+                                                let mut revert_changes = HashMap::default();
+                                                if let Some(hunk) = crate::hunk_diff::to_diff_hunk(
+                                                    &hunk,
+                                                    &multi_buffer_snapshot,
+                                                ) {
+                                                    Editor::prepare_revert_change(
+                                                        &mut revert_changes,
+                                                        &multi_buffer,
+                                                        &hunk,
+                                                        cx,
+                                                    );
+                                                }
+                                                if !revert_changes.is_empty() {
+                                                    editor.update(cx, |editor, cx| {
+                                                        editor.revert(revert_changes, cx)
+                                                    });
+                                                }
+                                            }
+                                        });
+                                    if is_first_hunk {
+                                        button.key_binding(KeyBinding::for_action_in(
+                                            &RevertSelectedHunks,
+                                            &focus_handle,
+                                            cx,
+                                        ))
+                                    } else {
+                                        button
                                     }
-                                });
-
-                            if is_first_hunk {
-                                button.key_binding(KeyBinding::for_action_in(
-                                    &RevertSelectedHunks,
-                                    &focus_handle,
-                                    cx,
-                                ))
-                            } else {
-                                button
-                            }
-                        })
-                        .when(is_branch_buffer, |this| {
-                            this.child({
-                                let button = Button::new("apply", "Apply")
-                                    .style(ButtonStyle::Tinted(TintColor::Positive))
-                                    .layer(ElevationIndex::Wash)
-                                    .on_click({
-                                        let editor = editor.clone();
-                                        let hunk = hunk.clone();
-                                        move |_event, cx| {
-                                            editor.update(cx, |editor, cx| {
-                                                editor.apply_diff_hunks_in_range(
-                                                    hunk.multi_buffer_range.clone(),
-                                                    cx,
-                                                );
+                                })
+                                .when(is_branch_buffer, |this| {
+                                    this.child({
+                                        let button = Button::new("apply", "Apply")
+                                            .style(ButtonStyle::Tinted(TintColor::Positive))
+                                            .layer(ElevationIndex::Wash)
+                                            .on_click({
+                                                let editor = editor.clone();
+                                                let hunk = hunk.clone();
+                                                move |_event, cx| {
+                                                    editor.update(cx, |editor, cx| {
+                                                        editor.apply_diff_hunks_in_range(
+                                                            hunk.multi_buffer_range.clone(),
+                                                            cx,
+                                                        );
+                                                    });
+                                                }
                                             });
-                                        }
-                                    });
-
-                                if is_first_hunk {
-                                    button.key_binding(KeyBinding::for_action_in(
-                                        &ApplySelectedDiffHunks,
-                                        &focus_handle,
-                                        cx,
-                                    ))
-                                } else {
-                                    button
-                                }
-                            })
-                        })
-                        .when(!is_branch_buffer, |div| {
-                            div.child(
-                                IconButton::new("collapse", IconName::Close)
-                                    .shape(IconButtonShape::Square)
-                                    .icon_size(IconSize::Small)
-                                    .tooltip({
-                                        let focus_handle = editor.focus_handle(cx);
-                                        move |cx| {
-                                            Tooltip::for_action_in(
-                                                "Collapse Hunk",
-                                                &ToggleHunkDiff,
+                                        if is_first_hunk {
+                                            button.key_binding(KeyBinding::for_action_in(
+                                                &ApplySelectedDiffHunks,
                                                 &focus_handle,
                                                 cx,
-                                            )
+                                            ))
+                                        } else {
+                                            button
                                         }
                                     })
-                                    .on_click({
-                                        let editor = editor.clone();
-                                        let hunk = hunk.clone();
-                                        move |_event, cx| {
-                                            editor.update(cx, |editor, cx| {
-                                                editor.toggle_hovered_hunk(&hunk, cx);
-                                            });
-                                        }
-                                    }),
-                            )
-                        })
+                                })
+                                .when(!is_branch_buffer, |div| {
+                                    div.child(
+                                        IconButton::new("collapse", IconName::Close)
+                                            .shape(IconButtonShape::Square)
+                                            .icon_size(IconSize::Small)
+                                            .tooltip({
+                                                let focus_handle = editor.focus_handle(cx);
+                                                move |cx| {
+                                                    Tooltip::for_action_in(
+                                                        "Collapse Hunk",
+                                                        &ToggleHunkDiff,
+                                                        &focus_handle,
+                                                        cx,
+                                                    )
+                                                }
+                                            })
+                                            .on_click({
+                                                let editor = editor.clone();
+                                                let hunk = hunk.clone();
+                                                move |_event, cx| {
+                                                    editor.update(cx, |editor, cx| {
+                                                        editor.toggle_hovered_hunk(&hunk, cx);
+                                                    });
+                                                }
+                                            }),
+                                    )
+                                }),
+                        )
                         .into_any_element()
                 }
             }),

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -9,7 +9,7 @@ use settings::Settings;
 use smol::stream::StreamExt;
 use std::{any::TypeId, ops::Range, rc::Rc, time::Duration};
 use text::ToOffset;
-use ui::{prelude::*, ButtonLike, KeyBinding};
+use ui::{prelude::*, KeyBinding};
 use workspace::{
     searchable::SearchableItemHandle, Item, ItemHandle as _, ToolbarItemEvent, ToolbarItemLocation,
     ToolbarItemView, Workspace,

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -255,7 +255,7 @@ impl Item for ProposedChangesEditor {
     type Event = EditorEvent;
 
     fn tab_icon(&self, _cx: &ui::WindowContext) -> Option<Icon> {
-        Some(Icon::new(IconName::Diff))
+        Some(Icon::new(IconName::ZedAssistant))
     }
 
     fn tab_content_text(&self, _cx: &WindowContext) -> Option<SharedString> {

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -34,7 +34,11 @@ struct BufferEntry {
     _subscription: Subscription,
 }
 
-pub struct ProposedChangesEditorToolbar {
+pub struct ProposedChangesToolbarControls {
+    current_editor: Option<View<ProposedChangesEditor>>,
+}
+
+pub struct ProposedChangesToolbar {
     current_editor: Option<View<ProposedChangesEditor>>,
 }
 
@@ -317,7 +321,7 @@ impl Item for ProposedChangesEditor {
     }
 }
 
-impl ProposedChangesEditorToolbar {
+impl ProposedChangesToolbarControls {
     pub fn new() -> Self {
         Self {
             current_editor: None,
@@ -333,7 +337,7 @@ impl ProposedChangesEditorToolbar {
     }
 }
 
-impl Render for ProposedChangesEditorToolbar {
+impl Render for ProposedChangesToolbarControls {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let button_like = ButtonLike::new("apply-changes").child(Label::new("Apply All"));
 
@@ -352,9 +356,54 @@ impl Render for ProposedChangesEditorToolbar {
     }
 }
 
-impl EventEmitter<ToolbarItemEvent> for ProposedChangesEditorToolbar {}
+impl EventEmitter<ToolbarItemEvent> for ProposedChangesToolbarControls {}
 
-impl ToolbarItemView for ProposedChangesEditorToolbar {
+impl ToolbarItemView for ProposedChangesToolbarControls {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn workspace::ItemHandle>,
+        _cx: &mut ViewContext<Self>,
+    ) -> workspace::ToolbarItemLocation {
+        self.current_editor =
+            active_pane_item.and_then(|item| item.downcast::<ProposedChangesEditor>());
+        self.get_toolbar_item_location()
+    }
+}
+
+impl ProposedChangesToolbar {
+    pub fn new() -> Self {
+        Self {
+            current_editor: None,
+        }
+    }
+
+    fn get_toolbar_item_location(&self) -> ToolbarItemLocation {
+        if self.current_editor.is_some() {
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+}
+
+impl Render for ProposedChangesToolbar {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        if let Some(editor) = &self.current_editor {
+            h_flex()
+                .gap_2()
+                .relative()
+                .child(Icon::new(IconName::ZedAssistant).size(IconSize::Medium))
+                .child(Label::new(editor.read(cx).title.clone()).single_line())
+                .into_any_element()
+        } else {
+            gpui::Empty.into_any_element()
+        }
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for ProposedChangesToolbar {}
+
+impl ToolbarItemView for ProposedChangesToolbar {
     fn set_active_pane_item(
         &mut self,
         active_pane_item: Option<&dyn workspace::ItemHandle>,

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -378,7 +378,7 @@ impl Render for ProposedChangesToolbarControls {
                 let focus_handle = editor.focus_handle(cx);
                 let action = {
                     let todo = (); // TODO Change this to Undo All, once we actually have that action.
-                    &ApplyAllDiffHunks
+                    &RevertFile
                 };
                 let keybinding = KeyBinding::for_action_in(action, &focus_handle, cx);
 

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -5,6 +5,7 @@ use gpui::{AppContext, EventEmitter, FocusableView, Model, Render, Subscription,
 use language::{Buffer, BufferEvent, Capability};
 use multi_buffer::{ExcerptRange, MultiBuffer};
 use project::Project;
+use settings::Settings;
 use smol::stream::StreamExt;
 use std::{any::TypeId, ops::Range, rc::Rc, time::Duration};
 use text::ToOffset;
@@ -356,17 +357,17 @@ impl Render for ProposedChangesToolbarControls {
         if let Some(editor) = &self.current_editor {
             let focus_handle = editor.focus_handle(cx);
             let action = &ApplyAllDiffHunks;
-            let keybinding = KeyBinding::for_action_in(action, &focus_handle, cx)
-                .map(|binding| binding.into_any_element());
+            let keybinding = KeyBinding::for_action_in(action, &focus_handle, cx);
+
             let editor = editor.read(cx);
 
             let apply_all_button = if editor.all_changes_accepted() {
                 None
             } else {
                 Some(
-                    ButtonLike::new("apply-changes")
-                        .child(Label::new("Apply All"))
-                        .children(keybinding)
+                    Button::new("apply-changes", "Apply All")
+                        .style(ButtonStyle::Filled)
+                        .key_binding(keybinding)
                         .on_click(move |_event, cx| focus_handle.dispatch_action(action, cx)),
                 )
             };
@@ -379,18 +380,18 @@ impl Render for ProposedChangesToolbarControls {
                     let todo = (); // TODO Change this to Undo All, once we actually have that action.
                     &ApplyAllDiffHunks
                 };
-                let keybinding = KeyBinding::for_action_in(action, &focus_handle, cx)
-                    .map(|binding| binding.into_any_element());
+                let keybinding = KeyBinding::for_action_in(action, &focus_handle, cx);
 
                 Some(
-                    ButtonLike::new("undo-applied")
-                        .child(Label::new("Undo Applied"))
-                        .children(keybinding)
+                    Button::new("undo-applied", "Undo Applied")
+                        .style(ButtonStyle::Filled)
+                        .key_binding(keybinding)
                         .on_click(move |_event, cx| focus_handle.dispatch_action(action, cx)),
                 )
             };
 
             h_flex()
+                .gap_1()
                 .children([undo_all_button, apply_all_button].into_iter().flatten())
                 .into_any_element()
         } else {
@@ -441,11 +442,12 @@ impl Render for ProposedChangesToolbar {
             };
 
             h_flex()
-                .gap_2()
-                .relative()
-                .child(icon.size(IconSize::Medium))
+                .gap_2p5()
+                .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
+                .child(icon.size(IconSize::Small))
                 .child(
                     Label::new(editor.title.clone())
+                        .color(Color::Muted)
                         .single_line()
                         .strikethrough(all_changes_accepted),
                 )

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -232,6 +232,11 @@ impl ProposedChangesEditor {
             _ => (),
         }
     }
+
+    fn all_changes_accepted(&self) -> bool {
+        // TODO actually compute this!
+        true
+    }
 }
 
 impl Render for ProposedChangesEditor {
@@ -255,7 +260,13 @@ impl Item for ProposedChangesEditor {
     type Event = EditorEvent;
 
     fn tab_icon(&self, _cx: &ui::WindowContext) -> Option<Icon> {
-        Some(Icon::new(IconName::ZedAssistant))
+        let icon_name = if self.all_changes_accepted() {
+            IconName::Check
+        } else {
+            IconName::ZedAssistant
+        };
+
+        Some(Icon::new(icon_name).color(Color::Success))
     }
 
     fn tab_content_text(&self, _cx: &WindowContext) -> Option<SharedString> {
@@ -389,11 +400,27 @@ impl ProposedChangesToolbar {
 impl Render for ProposedChangesToolbar {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         if let Some(editor) = &self.current_editor {
+            let editor = editor.read(cx);
+            let all_changes_accepted = editor.all_changes_accepted();
+            let icon_name = if all_changes_accepted {
+                IconName::Check
+            } else {
+                IconName::ZedAssistant
+            };
+
             h_flex()
                 .gap_2()
                 .relative()
-                .child(Icon::new(IconName::ZedAssistant).size(IconSize::Medium))
-                .child(Label::new(editor.read(cx).title.clone()).single_line())
+                .child(
+                    Icon::new(icon_name)
+                        .color(Color::Success)
+                        .size(IconSize::Medium),
+                )
+                .child(
+                    Label::new(editor.title.clone())
+                        .single_line()
+                        .strikethrough(all_changes_accepted),
+                )
                 .into_any_element()
         } else {
             gpui::Empty.into_any_element()

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -1,4 +1,4 @@
-use crate::{ApplyAllDiffHunks, Editor, EditorEvent, SemanticsProvider};
+use crate::{ApplyAllDiffHunks, Editor, EditorEvent, RevertFile, SemanticsProvider};
 use collections::HashSet;
 use futures::{channel::mpsc, future::join_all};
 use gpui::{AppContext, EventEmitter, FocusableView, Model, Render, Subscription, Task, View};

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -366,27 +366,9 @@ impl Render for ProposedChangesToolbarControls {
                 )
             };
 
-            let undo_all_button = if editor.any_changes_applied() {
-                None
-            } else {
-                let focus_handle = editor.focus_handle(cx);
-                let action = {
-                    let todo = (); // TODO Change this to Undo All, once we actually have that action.
-                    &RevertFile
-                };
-                let keybinding = KeyBinding::for_action_in(action, &focus_handle, cx);
-
-                Some(
-                    Button::new("undo-applied", "Undo Applied")
-                        .style(ButtonStyle::Filled)
-                        .key_binding(keybinding)
-                        .on_click(move |_event, cx| focus_handle.dispatch_action(action, cx)),
-                )
-            };
-
             h_flex()
                 .gap_1()
-                .children([undo_all_button, apply_all_button].into_iter().flatten())
+                .children([apply_all_button].into_iter().flatten())
                 .into_any_element()
         } else {
             gpui::Empty.into_any_element()

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -1,4 +1,4 @@
-use crate::{ApplyAllDiffHunks, Editor, EditorEvent, RevertFile, SemanticsProvider};
+use crate::{ApplyAllDiffHunks, Editor, EditorEvent, SemanticsProvider};
 use collections::HashSet;
 use futures::{channel::mpsc, future::join_all};
 use gpui::{AppContext, EventEmitter, FocusableView, Model, Render, Subscription, Task, View};
@@ -235,13 +235,7 @@ impl ProposedChangesEditor {
     }
 
     fn all_changes_accepted(&self) -> bool {
-        let todo = (); // TODO actually compute this!
-        false
-    }
-
-    fn any_changes_applied(&self) -> bool {
-        let todo = (); // TODO actually compute this!
-        false
+        false // In the future, we plan to compute this based on the current state of patches.
     }
 }
 

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -85,36 +85,6 @@ impl TintColor {
     }
 }
 
-// To remove?
-
-// fn added_hunk_color(cx: &WindowContext) -> Hsla {
-//     let mut created_color = cx.theme().status().git().created;
-//     created_color.fade_out(0.7);
-//     created_color
-// }
-
-// fn accept_hunk_color(cx: &WindowContext) -> Hsla {
-//     cx.theme()
-//         .colors()
-//         .editor_background
-//         .blend(added_hunk_color(cx))
-//         .opacity(1.0)
-// }
-
-// fn deleted_hunk_color(cx: &WindowContext) -> Hsla {
-//     let mut deleted_color = cx.theme().status().deleted;
-//     deleted_color.fade_out(0.7);
-//     deleted_color
-// }
-
-// fn discard_hunk_color(cx: &WindowContext) -> Hsla {
-//     cx.theme()
-//         .colors()
-//         .editor_background
-//         .blend(deleted_hunk_color(cx))
-//         .opacity(1.0)
-// }
-
 impl From<TintColor> for Color {
     fn from(tint: TintColor) -> Self {
         match tint {

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -64,7 +64,7 @@ impl TintColor {
                 icon_color: cx.theme().colors().text,
             },
             TintColor::Negative => ButtonLikeStyles {
-                background: cx.theme().status().error_background,
+                background: discard_hunk_color(cx),
                 border_color: cx.theme().status().error_border,
                 label_color: cx.theme().colors().text,
                 icon_color: cx.theme().colors().text,
@@ -76,13 +76,41 @@ impl TintColor {
                 icon_color: cx.theme().colors().text,
             },
             TintColor::Positive => ButtonLikeStyles {
-                background: cx.theme().status().success_background,
+                background: accept_hunk_color(cx),
                 border_color: cx.theme().status().success_border,
                 label_color: cx.theme().colors().text,
                 icon_color: cx.theme().colors().text,
             },
         }
     }
+}
+
+fn added_hunk_color(cx: &WindowContext) -> Hsla {
+    let mut created_color = cx.theme().status().git().created;
+    created_color.fade_out(0.7);
+    created_color
+}
+
+fn accept_hunk_color(cx: &WindowContext) -> Hsla {
+    cx.theme()
+        .colors()
+        .editor_background
+        .blend(added_hunk_color(cx))
+        .opacity(1.0)
+}
+
+fn deleted_hunk_color(cx: &WindowContext) -> Hsla {
+    let mut deleted_color = cx.theme().status().deleted;
+    deleted_color.fade_out(0.7);
+    deleted_color
+}
+
+fn discard_hunk_color(cx: &WindowContext) -> Hsla {
+    cx.theme()
+        .colors()
+        .editor_background
+        .blend(deleted_hunk_color(cx))
+        .opacity(1.0)
 }
 
 impl From<TintColor> for Color {

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -64,7 +64,7 @@ impl TintColor {
                 icon_color: cx.theme().colors().text,
             },
             TintColor::Negative => ButtonLikeStyles {
-                background: discard_hunk_color(cx),
+                background: cx.theme().status().error_background,
                 border_color: cx.theme().status().error_border,
                 label_color: cx.theme().colors().text,
                 icon_color: cx.theme().colors().text,
@@ -76,7 +76,7 @@ impl TintColor {
                 icon_color: cx.theme().colors().text,
             },
             TintColor::Positive => ButtonLikeStyles {
-                background: accept_hunk_color(cx),
+                background: cx.theme().status().success_background,
                 border_color: cx.theme().status().success_border,
                 label_color: cx.theme().colors().text,
                 icon_color: cx.theme().colors().text,
@@ -85,33 +85,35 @@ impl TintColor {
     }
 }
 
-fn added_hunk_color(cx: &WindowContext) -> Hsla {
-    let mut created_color = cx.theme().status().git().created;
-    created_color.fade_out(0.7);
-    created_color
-}
+// To remove?
 
-fn accept_hunk_color(cx: &WindowContext) -> Hsla {
-    cx.theme()
-        .colors()
-        .editor_background
-        .blend(added_hunk_color(cx))
-        .opacity(1.0)
-}
+// fn added_hunk_color(cx: &WindowContext) -> Hsla {
+//     let mut created_color = cx.theme().status().git().created;
+//     created_color.fade_out(0.7);
+//     created_color
+// }
 
-fn deleted_hunk_color(cx: &WindowContext) -> Hsla {
-    let mut deleted_color = cx.theme().status().deleted;
-    deleted_color.fade_out(0.7);
-    deleted_color
-}
+// fn accept_hunk_color(cx: &WindowContext) -> Hsla {
+//     cx.theme()
+//         .colors()
+//         .editor_background
+//         .blend(added_hunk_color(cx))
+//         .opacity(1.0)
+// }
 
-fn discard_hunk_color(cx: &WindowContext) -> Hsla {
-    cx.theme()
-        .colors()
-        .editor_background
-        .blend(deleted_hunk_color(cx))
-        .opacity(1.0)
-}
+// fn deleted_hunk_color(cx: &WindowContext) -> Hsla {
+//     let mut deleted_color = cx.theme().status().deleted;
+//     deleted_color.fade_out(0.7);
+//     deleted_color
+// }
+
+// fn discard_hunk_color(cx: &WindowContext) -> Hsla {
+//     cx.theme()
+//         .colors()
+//         .editor_background
+//         .blend(deleted_hunk_color(cx))
+//         .opacity(1.0)
+// }
 
 impl From<TintColor> for Color {
     fn from(tint: TintColor) -> Self {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -15,8 +15,8 @@ use breadcrumbs::Breadcrumbs;
 use client::{zed_urls, ZED_URL_SCHEME};
 use collections::VecDeque;
 use command_palette_hooks::CommandPaletteFilter;
-use editor::ProposedChangesEditorToolbar;
 use editor::{scroll::Autoscroll, Editor, MultiBuffer};
+use editor::{ProposedChangesToolbar, ProposedChangesToolbarControls};
 use feature_flags::FeatureFlagAppExt;
 use gpui::{
     actions, point, px, AppContext, AsyncAppContext, Context, FocusableView, MenuItem,
@@ -621,8 +621,10 @@ fn initialize_pane(workspace: &Workspace, pane: &View<Pane>, cx: &mut ViewContex
             let buffer_search_bar = cx.new_view(search::BufferSearchBar::new);
             toolbar.add_item(buffer_search_bar.clone(), cx);
 
-            let proposed_change_bar = cx.new_view(|_| ProposedChangesEditorToolbar::new());
-            toolbar.add_item(proposed_change_bar, cx);
+            let proposed_changes_bar = cx.new_view(|_| ProposedChangesToolbar::new());
+            toolbar.add_item(proposed_changes_bar, cx);
+            let proposed_changes_controls = cx.new_view(|_| ProposedChangesToolbarControls::new());
+            toolbar.add_item(proposed_changes_controls, cx);
             let quick_action_bar =
                 cx.new_view(|cx| QuickActionBar::new(buffer_search_bar, workspace, cx));
             toolbar.add_item(quick_action_bar, cx);


### PR DESCRIPTION
Change the "Apply" and "Discard" buttons to match @danilo-leal's design! Here are some different states:

### Cursor in the first hunk

Now that the cursor is in a particular hunk, we show the "Apply" and "Discard" names, and the keyboard shortcut. If I press the keyboard shortcut, it will only apply to this hunk.

<img width="759" alt="Screenshot 2024-11-23 at 10 54 45 PM" src="https://github.com/user-attachments/assets/68e0f109-9493-4ca2-a99c-dfcbb4d1ce0c">

### Cursor in the second hunk

Moving the cursor to a different hunk changes which buttons get the keyboard shortcut treatment. Now the keyboard shortcut is shown next to the hunk that will actually be affected if you press that shortcut.

<img width="749" alt="Screenshot 2024-11-23 at 10 56 27 PM" src="https://github.com/user-attachments/assets/59c2ace3-6972-4a60-b806-f45e8c25eaae">


Release Notes:

- Restyled Apply/Discard buttons
