### PR TITLE
Fix panics from spawn_local tasks dropped on other threads in remote server

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1074,7 +1074,7 @@ impl SshRemoteClient {
                 c.connections.insert(
                     opts.clone(),
                     ConnectionPoolEntry::Connecting(
-                        cx.foreground_executor()
+                        cx.background_executor()
                             .spawn({
                                 let connection = connection.clone();
                                 async move { Ok(connection.clone()) }


### PR DESCRIPTION
Closes #21020

Release Notes:

- Fixed remote server panic of "local task dropped by a thread that didn't spawn it"