### PR TITLE
extensions_ui: Remove dependency on `theme_selector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,7 +4233,6 @@ dependencies = [
  "smallvec",
  "snippet_provider",
  "theme",
- "theme_selector",
  "ui",
  "util",
  "vim_mode_setting",

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -38,7 +38,6 @@ settings.workspace = true
 smallvec.workspace = true
 snippet_provider.workspace = true
 theme.workspace = true
-theme_selector.workspace = true
 ui.workspace = true
 util.workspace = true
 vim_mode_setting.workspace = true

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -17,9 +17,9 @@ use editor::{Editor, EditorElement, EditorStyle};
 use extension_host::{ExtensionManifest, ExtensionOperation, ExtensionStore};
 use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{
-    actions, uniform_list, AppContext, EventEmitter, Flatten, FocusableView, InteractiveElement,
-    KeyContext, ParentElement, Render, Styled, Task, TextStyle, UniformListScrollHandle, View,
-    ViewContext, VisualContext, WeakView, WindowContext,
+    actions, uniform_list, Action, AppContext, EventEmitter, Flatten, FocusableView,
+    InteractiveElement, KeyContext, ParentElement, Render, Styled, Task, TextStyle,
+    UniformListScrollHandle, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use num_format::{Locale, ToFormattedString};
 use project::DirectoryLister;
@@ -254,14 +254,13 @@ impl ExtensionsPage {
             .collect::<Vec<_>>();
         if !themes.is_empty() {
             workspace
-                .update(cx, |workspace, cx| {
-                    theme_selector::toggle(
-                        workspace,
-                        &zed_actions::theme_selector::Toggle {
+                .update(cx, |_workspace, cx| {
+                    cx.dispatch_action(
+                        zed_actions::theme_selector::Toggle {
                             themes_filter: Some(themes),
-                        },
-                        cx,
-                    )
+                        }
+                        .boxed_clone(),
+                    );
                 })
                 .ok();
         }


### PR DESCRIPTION
This PR removes the dependency on `theme_selector` from `extensions_ui`, as we can just dispatch the action instead.

Release Notes:

- N/A
