### PR TITLE
welcome: Remove dependency on `theme_selector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14422,7 +14422,6 @@ dependencies = [
  "schemars",
  "serde",
  "settings",
- "theme_selector",
  "ui",
  "util",
  "vim_mode_setting",

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -27,7 +27,6 @@ project.workspace = true
 schemars.workspace = true
 serde.workspace = true
 settings.workspace = true
-theme_selector.workspace = true
 ui.workspace = true
 util.workspace = true
 vim_mode_setting.workspace = true

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -5,7 +5,7 @@ mod multibuffer_hint;
 use client::{telemetry::Telemetry, TelemetrySettings};
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{
-    actions, svg, AppContext, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
+    actions, svg, Action, AppContext, EventEmitter, FocusHandle, FocusableView, InteractiveElement,
     ParentElement, Render, Styled, Subscription, Task, View, ViewContext, VisualContext, WeakView,
     WindowContext,
 };
@@ -133,12 +133,8 @@ impl Render for WelcomePage {
                                                     "welcome page: change theme".to_string(),
                                                 );
                                                 this.workspace
-                                                    .update(cx, |workspace, cx| {
-                                                        theme_selector::toggle(
-                                                            workspace,
-                                                            &Default::default(),
-                                                            cx,
-                                                        )
+                                                    .update(cx, |_workspace, cx| {
+                                                        cx.dispatch_action(zed_actions::theme_selector::Toggle::default().boxed_clone());
                                                     })
                                                     .ok();
                                             })),


### PR DESCRIPTION
This PR removes the dependency on `theme_selector` from `welcome`, as we can just dispatch the action instead.

Release Notes:

- N/A
