### PR TITLE
zed: Remove unnecessary `#[allow(non_snake_case)]` attribute

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1,5 +1,3 @@
-// Allow binary to be called Zed for a nice application menu when running executable directly
-#![allow(non_snake_case)]
 // Disable command line from opening on release mode
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 


### PR DESCRIPTION
This PR removes the `#[allow(non_snake_case)]` attribute from the `zed` crate, as it wasn't actually doing anything.

Release Notes:

- N/A
