### PR TITLE
Fix assistant hint flickering to action name

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3070,7 +3070,7 @@ impl<'a> WindowContext<'a> {
         &self,
         action: &dyn Action,
         focus_handle: &FocusHandle,
-    ) -> String {
+    ) -> Option<String> {
         self.bindings_for_action_in(action, focus_handle)
             .into_iter()
             .next()
@@ -3082,7 +3082,6 @@ impl<'a> WindowContext<'a> {
                     .collect::<Vec<_>>()
                     .join(" ")
             })
-            .unwrap_or_else(|| action.name().to_string())
     }
 
     /// Dispatch a mouse or keyboard event on the window.

--- a/crates/zed/src/zed/assistant_hints.rs
+++ b/crates/zed/src/zed/assistant_hints.rs
@@ -81,9 +81,9 @@ impl ActiveLineTrailerProvider for AssistantHintsProvider {
         }
 
         let chat_keybinding =
-            cx.keystroke_text_for_action_in(&assistant::ToggleFocus, focus_handle);
+            cx.keystroke_text_for_action_in(&assistant::ToggleFocus, focus_handle)?;
         let generate_keybinding =
-            cx.keystroke_text_for_action_in(&zed_actions::InlineAssist::default(), focus_handle);
+            cx.keystroke_text_for_action_in(&zed_actions::InlineAssist::default(), focus_handle)?;
 
         Some(
             h_flex()


### PR DESCRIPTION
This is an attempt to fix #21029 but it doesn't 100% fix it: we only hide the message if the binding isn't available instead of showing the action name.

What I don't understand yet is why the binding isn't available in the first place when switching the tab, even though the editor is `focused()`, `within_focused()`, `contains_focused()`.

I do think not showing anything is better than showing the action name though, since that's too long.

Closes #21029

Release Notes:

- Fixed assistant hint in editor flickering to action name when switching tabs (Preview only)
