### PR TITLE
Don't name `ExtensionLspAdapter` in `ExtensionRegistrationHooks`

### DIFF
--- a/crates/extension_host/src/extension_lsp_adapter.rs
+++ b/crates/extension_host/src/extension_lsp_adapter.rs
@@ -45,9 +45,23 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
 }
 
 pub struct ExtensionLspAdapter {
-    pub(crate) extension: Arc<dyn Extension>,
-    pub(crate) language_server_id: LanguageServerName,
-    pub(crate) language_name: LanguageName,
+    extension: Arc<dyn Extension>,
+    language_server_id: LanguageServerName,
+    language_name: LanguageName,
+}
+
+impl ExtensionLspAdapter {
+    pub fn new(
+        extension: Arc<dyn Extension>,
+        language_server_id: LanguageServerName,
+        language_name: LanguageName,
+    ) -> Self {
+        Self {
+            extension,
+            language_server_id,
+            language_name,
+        }
+    }
 }
 
 #[async_trait(?Send)]

--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -177,20 +177,17 @@ impl HeadlessExtensionStore {
         let wasm_extension: Arc<dyn Extension> =
             Arc::new(WasmExtension::load(extension_dir, &manifest, wasm_host.clone(), &cx).await?);
 
-        for (language_server_name, language_server_config) in &manifest.language_servers {
+        for (language_server_id, language_server_config) in &manifest.language_servers {
             for language in language_server_config.languages() {
                 this.update(cx, |this, _cx| {
                     this.loaded_language_servers
                         .entry(manifest.id.clone())
                         .or_default()
-                        .push((language_server_name.clone(), language.clone()));
+                        .push((language_server_id.clone(), language.clone()));
                     this.registration_hooks.register_lsp_adapter(
+                        wasm_extension.clone(),
+                        language_server_id.clone(),
                         language.clone(),
-                        ExtensionLspAdapter {
-                            extension: wasm_extension.clone(),
-                            language_server_id: language_server_name.clone(),
-                            language_name: language,
-                        },
                     );
                 })?;
             }
@@ -344,10 +341,21 @@ impl ExtensionRegistrationHooks for HeadlessRegistrationHooks {
         self.language_registry
             .register_language(language, None, matcher, load)
     }
-    fn register_lsp_adapter(&self, language: LanguageName, adapter: ExtensionLspAdapter) {
+    fn register_lsp_adapter(
+        &self,
+        extension: Arc<dyn Extension>,
+        language_server_id: LanguageServerName,
+        language: LanguageName,
+    ) {
         log::info!("registering lsp adapter {:?}", language);
-        self.language_registry
-            .register_lsp_adapter(language, Arc::new(adapter) as _);
+        self.language_registry.register_lsp_adapter(
+            language.clone(),
+            Arc::new(ExtensionLspAdapter::new(
+                extension,
+                language_server_id,
+                language,
+            )),
+        );
     }
 
     fn register_wasm_grammars(&self, grammars: Vec<(Arc<str>, PathBuf)>) {

--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -341,6 +341,7 @@ impl ExtensionRegistrationHooks for HeadlessRegistrationHooks {
         self.language_registry
             .register_language(language, None, matcher, load)
     }
+
     fn register_lsp_adapter(
         &self,
         extension: Arc<dyn Extension>,

--- a/crates/extensions_ui/src/extension_registration_hooks.rs
+++ b/crates/extensions_ui/src/extension_registration_hooks.rs
@@ -11,7 +11,8 @@ use extension_host::{extension_lsp_adapter::ExtensionLspAdapter, wasm_host};
 use fs::Fs;
 use gpui::{AppContext, BackgroundExecutor, Model, Task};
 use indexed_docs::{ExtensionIndexedDocsProvider, IndexedDocsRegistry, ProviderId};
-use language::{LanguageRegistry, LanguageServerBinaryStatus, LoadedLanguage};
+use language::{LanguageName, LanguageRegistry, LanguageServerBinaryStatus, LoadedLanguage};
+use lsp::LanguageServerName;
 use snippet_provider::SnippetRegistry;
 use theme::{ThemeRegistry, ThemeSettings};
 use ui::SharedString;
@@ -159,11 +160,18 @@ impl extension_host::ExtensionRegistrationHooks for ConcreteExtensionRegistratio
 
     fn register_lsp_adapter(
         &self,
-        language_name: language::LanguageName,
-        adapter: ExtensionLspAdapter,
+        extension: Arc<dyn Extension>,
+        language_server_id: LanguageServerName,
+        language: LanguageName,
     ) {
-        self.language_registry
-            .register_lsp_adapter(language_name, Arc::new(adapter));
+        self.language_registry.register_lsp_adapter(
+            language.clone(),
+            Arc::new(ExtensionLspAdapter::new(
+                extension,
+                language_server_id,
+                language,
+            )),
+        );
     }
 
     fn remove_lsp_adapter(


### PR DESCRIPTION
This PR updates the `ExtensionRegistrationHooks` trait to not name the `ExtensionLspAdapter` type.

This helps decouple the two.

Release Notes:

- N/A
