### PR TITLE
Fix file finder menu actions

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -650,10 +650,15 @@
     }
   },
   {
+    "context": "FileFinder",
+    "bindings": {
+      "ctrl": "file_finder::ToggleMenu"
+    }
+  },
+  {
     "context": "FileFinder && !menu_open",
     "bindings": {
       "ctrl-shift-p": "file_finder::SelectPrev",
-      "ctrl": "file_finder::OpenMenu",
       "ctrl-j": "pane::SplitDown",
       "ctrl-k": "pane::SplitUp",
       "ctrl-h": "pane::SplitLeft",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -651,10 +651,15 @@
     }
   },
   {
+    "context": "FileFinder",
+    "bindings": {
+      "cmd": "file_finder::ToggleMenu"
+    }
+  },
+  {
     "context": "FileFinder && !menu_open",
     "bindings": {
       "cmd-shift-p": "file_finder::SelectPrev",
-      "cmd": "file_finder::OpenMenu",
       "cmd-j": "pane::SplitDown",
       "cmd-k": "pane::SplitUp",
       "cmd-h": "pane::SplitLeft",

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -3,7 +3,7 @@ use crate::PlatformStyle;
 use crate::{h_flex, prelude::*, Icon, IconName, IconSize};
 use gpui::{relative, Action, FocusHandle, IntoElement, Keystroke, WindowContext};
 
-#[derive(IntoElement, Clone)]
+#[derive(Debug, IntoElement, Clone)]
 pub struct KeyBinding {
     /// A keybinding consists of a key and a set of modifier keys.
     /// More then one keybinding produces a chord.


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21077

* BREAKING: rename `file_finder::OpenMenu` into `file_finder::ToggleMenu`
* Display the keybinding for menu toggling when the menu is open
* Fix `enter` not working in the menu

Release Notes:

- Fixed enter not working and menu toggle binding not shown in the file finder menu