### PR TITLE
Pass through remote kernel's language on legacy selection

### DIFF
--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -258,8 +258,9 @@ impl ReplStore {
                     runtime_specification.kernelspec.language.to_lowercase()
                         == language_at_cursor.code_fence_block_name().to_lowercase()
                 }
-                KernelSpecification::Remote(_) => {
-                    unimplemented!()
+                KernelSpecification::Remote(remote_spec) => {
+                    remote_spec.kernelspec.language.to_lowercase()
+                        == language_at_cursor.code_fence_block_name().to_lowercase()
                 }
             })
             .cloned()


### PR DESCRIPTION
When selecting an active kernel based on legacy usage, have remote kernels defer to language within kernelspec.

Release Notes:

- N/A