### PR TITLE
Remove non-existent call event types

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -1420,8 +1420,6 @@ fn for_snowflake(
                     "enable screen share" => "Screen Share Enabled".to_string(),
                     "disable screen share" => "Screen Share Disabled".to_string(),
                     "decline incoming" => "Incoming Call Declined".to_string(),
-                    "enable camera" => "Camera Enabled".to_string(),
-                    "disable camera" => "Camera Disabled".to_string(),
                     _ => format!("Unknown Call Event: {}", e.operation),
                 };
 


### PR DESCRIPTION
These are not real (from Clickhouse):

```
    ┌─operation────────────┬──────c─┐
 1. │ join channel         │ 136221 │
 2. │ open channel notes   │  95529 │
 3. │ hang up              │  66264 │
 4. │ disable microphone   │  34116 │
 5. │ enable microphone    │  25090 │
 6. │ enable screen share  │  20751 │
 7. │ invite               │  15827 │
 8. │ share project        │  14580 │
 9. │ accept incoming      │  13708 │
10. │ disable screen share │  10440 │
11. │ unshare project      │   9556 │
12. │ decline incoming     │    455 │
13. │ enable camera        │      6 │
14. │ disable camera       │      4 │
    └──────────────────────┴────────┘
```

Release Notes:

- N/A
