### PR TITLE
docs: Proto Language is by extension not native

### DIFF
--- a/docs/src/languages/proto.md
+++ b/docs/src/languages/proto.md
@@ -1,9 +1,44 @@
 # Proto
 
-Proto/proto3 (Protocol Buffers definition language) support is available natively in Zed.
+Proto/proto3 (Protocol Buffers definition language) support is available through the [Proto extension](https://github.com/zed-industries/zed/tree/main/extensions/proto).
 
 - Tree Sitter: [coder3101/tree-sitter-proto](https://github.com/coder3101/tree-sitter-proto)
-- Language Server: [protols](https://github.com/coder3101/protols)
+- Language Servers: [protobuf-language-server](https://github.com/lasorda/protobuf-language-server)
+
+<!--
+TBD: Clarify which language server(s) to use / Feature support.
+
+## Setup
+
+### Install protobuf-language-server
+
+Install protobuf-language-server and make sure it's in your PATH:
+
+```
+go install github.com/lasorda/protobuf-language-server@latest
+which protobuf-language-server
+```
+
+### Install ProtoLS
+
+Install protols and make sure it's in your PATH:
+
+```
+cargo install protols
+which protols
+```
+
+## Configuration
+
+```json
+"lsp": {
+  "protobuf-language-server": {
+    "binary": {
+      "path": "protols"
+    }
+  }
+}
+```
 
 ## Formatting
 
@@ -41,3 +76,4 @@ Or you can have zed directly invoke `clang-format` by specifying it as a [format
     },
   }
 ```
+-->


### PR DESCRIPTION
Fixes docs to reflect that Protobuf support is via extension.
Comment out references ProtoLS formatter.
Need to test both protols and protobuf-language-server to ensure both work.

- See: https://github.com/zed-industries/zed/issues/21057

Release Notes:

- N/A
