### PR TITLE
Add LSP Binary Search Options to Extension API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8316,7 +8316,7 @@ name = "perplexity"
 version = "0.1.0"
 dependencies = [
  "serde",
- "zed_extension_api 0.2.0",
+ "zed_extension_api 0.2.1",
 ]
 
 [[package]]
@@ -15738,6 +15738,17 @@ dependencies = [
 [[package]]
 name = "zed_extension_api"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd16b8b30a9dc920fc1678ff852f696b5bdf5b5843bc745a128be0aac29859e"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "zed_extension_api"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -15826,7 +15837,7 @@ dependencies = [
 name = "zed_test_extension"
 version = "0.1.0"
 dependencies = [
- "zed_extension_api 0.2.0",
+ "zed_extension_api 0.2.1",
 ]
 
 [[package]]
@@ -15847,7 +15858,7 @@ dependencies = [
 name = "zed_zig"
 version = "0.3.1"
 dependencies = [
- "zed_extension_api 0.1.0",
+ "zed_extension_api 0.2.0",
 ]
 
 [[package]]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10383,6 +10383,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "some other init value": false
                 })),
+                ..Default::default()
             },
         );
     });
@@ -10402,6 +10403,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "anotherInitValue": false
                 })),
+                ..Default::default()
             },
         );
     });
@@ -10421,6 +10423,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 initialization_options: Some(json!({
                     "anotherInitValue": false
                 })),
+                ..Default::default()
             },
         );
     });
@@ -10438,6 +10441,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut gpui::Test
                 binary: None,
                 settings: None,
                 initialization_options: None,
+                ..Default::default()
             },
         );
     });

--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_extension_api"
-version = "0.2.0"
+version = "0.2.1"
 description = "APIs for creating Zed extensions in Rust"
 repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/zed_extension_api"

--- a/crates/extension_api/src/settings.rs
+++ b/crates/extension_api/src/settings.rs
@@ -3,9 +3,33 @@
 #[path = "../wit/since_v0.2.0/settings.rs"]
 mod types;
 
-use crate::{wit, Project, Result, SettingsLocation, Worktree};
+use crate::{wit, Os, Project, Result, SettingsLocation, Worktree};
 use serde_json;
 pub use types::*;
+
+/// The result of searching for a language server binary.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum LanguageServerPath {
+    /// A binary was located.
+    Command(wit::Command),
+    /// A cached binary was located.
+    CachedCommand(wit::Command),
+    /// A binary was not located and it should be automatically downloaded.
+    AutomaticDownload,
+    /// No binary was located and should be considered unavailable.
+    None,
+}
+
+impl From<LanguageServerPath> for Option<wit::Command> {
+    #[inline]
+    fn from(path: LanguageServerPath) -> Self {
+        match path {
+            LanguageServerPath::Command(command) => Some(command),
+            _ => None,
+        }
+    }
+}
 
 impl LanguageSettings {
     /// Returns the [`LanguageSettings`] for the given language.
@@ -19,6 +43,106 @@ impl LspSettings {
     pub fn for_worktree(language_server_name: &str, worktree: &Worktree) -> Result<Self> {
         get_settings("lsp", Some(language_server_name), Some(worktree.id()))
     }
+}
+
+/// Information about an LSP server binary.
+#[derive(Debug, Default)]
+pub struct LspServerInfo {
+    /// The name of the binary to search for in the PATH.
+    pub binary_name: Option<String>,
+    /// The path to the cached binary from a previous automatic download.
+    pub cached_binary_path: Option<String>,
+    /// The default arguments to pass to the binary if both the binary and arguments are not set.
+    pub default_arguments: Vec<String>,
+}
+
+impl Worktree {
+    /// Creates a [`wit::Command`] from the given [`CommandSettings`] and path. The environment variables are merged
+    /// with the shell environment.
+    pub fn create_command(&self, command: &CommandSettings, path: String) -> wit::Command {
+        let (platform, _) = crate::current_platform();
+        let env = match platform {
+            Os::Mac | Os::Linux => self.shell_env(),
+            Os::Windows => Default::default(),
+        };
+
+        let env = env
+            .into_iter()
+            .chain(
+                command
+                    .env
+                    .iter()
+                    .flatten()
+                    .map(|(k, v)| (k.clone(), v.clone())),
+            )
+            .collect();
+
+        wit::Command {
+            command: path,
+            args: command.arguments.clone().unwrap_or_default(),
+            env,
+        }
+    }
+
+    /// Searches for a language server binary.
+    ///
+    /// This function will search for the binary in the PATH, then check the configured binary path, and finally check
+    /// the cached binary path.
+    pub fn find_language_server(
+        &self,
+        settings: &LspSettings,
+        info: &LspServerInfo,
+    ) -> LanguageServerPath {
+        let mut path = None;
+        if let Some(binary_name) = settings
+            .allow_path_search
+            .unwrap_or(true)
+            .then_some(info.binary_name.as_deref())
+            .flatten()
+        {
+            path = check_exists(self.which(binary_name));
+        }
+
+        path = path.or_else(|| check_exists(settings.binary.as_ref().and_then(|v| v.path.clone())));
+
+        let is_cached = path.is_none();
+        if settings.allow_automatic_download.unwrap_or(true) {
+            path = path.or_else(|| check_exists(info.cached_binary_path.clone()));
+        }
+
+        let default = CommandSettings::default();
+        let mut command = path.map(|command| {
+            self.create_command(settings.binary.as_ref().unwrap_or(&default), command)
+        });
+
+        if settings
+            .binary
+            .as_ref()
+            .map_or(true, |v| v.path.is_none() && v.arguments.is_none())
+        {
+            if let Some(ref mut command) = command {
+                command.args.extend(info.default_arguments.iter().cloned());
+            }
+        }
+
+        match command {
+            Some(command) if is_cached => LanguageServerPath::CachedCommand(command),
+            Some(command) => LanguageServerPath::Command(command),
+            None if settings.allow_automatic_download.unwrap_or(true) => {
+                LanguageServerPath::AutomaticDownload
+            }
+            _ => LanguageServerPath::None,
+        }
+    }
+}
+
+fn check_exists(mut path: Option<String>) -> Option<String> {
+    if !path.as_deref().map_or(true, |path| {
+        std::fs::metadata(path).map_or(false, |stat| stat.is_file())
+    }) {
+        path = None;
+    }
+    path
 }
 
 impl ContextServerSettings {

--- a/crates/extension_api/wit/since_v0.2.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.2.0/settings.rs
@@ -17,6 +17,10 @@ pub struct LspSettings {
     pub initialization_options: Option<serde_json::Value>,
     /// The settings to pass to language server.
     pub settings: Option<serde_json::Value>,
+    /// Whether to search for the binary in the PATH.
+    pub allow_path_search: Option<bool>,
+    /// Whether to automatically download the binary.
+    pub allow_automatic_download: Option<bool>,
 }
 
 /// The settings for a particular context server.
@@ -29,7 +33,7 @@ pub struct ContextServerSettings {
 }
 
 /// The settings for a command.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommandSettings {
     /// The path to the command.
     pub path: Option<String>,

--- a/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
@@ -634,6 +634,8 @@ impl ExtensionImports for WasmState {
                             }),
                             settings: settings.settings,
                             initialization_options: settings.initialization_options,
+                            allow_path_search: settings.allow_path_search,
+                            allow_automatic_download: settings.allow_automatic_download,
                         })?)
                     }
                     "context_servers" => {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -179,6 +179,8 @@ pub struct LspSettings {
     pub binary: Option<BinarySettings>,
     pub initialization_options: Option<serde_json::Value>,
     pub settings: Option<serde_json::Value>,
+    pub allow_path_search: Option<bool>,
+    pub allow_automatic_download: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/zig.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.1.0"
+zed_extension_api = "0.2.1"

--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -1,7 +1,7 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.3.1"
+version = "0.3.2"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Adds options to the extension API that control how LSP server binary discovery works. In addition, functionality to create commands has been added to the extension API. `create_command` will create a command from a `CommandSettings` with the correct environment set up. `find_language_server` will search for the language server binary in the order: `which`, explicit configuration, automatic download. The relevant attempts will be skipped according to the configuration.

Release Notes:

- N/A