### PR TITLE
Update docker command in linux.md

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -32,7 +32,7 @@ If you are developing collaborative features of Zed, you'll need to install the 
 Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
 
 ```sh
-docker compose up -d
+docker-compose up -d
 ```
 
 ## Building from source


### PR DESCRIPTION
The command to launch the docker for postgres said `docker compose` when I think it needed to be `docker-compose`, hyphenated. I got errors without the hyphen, and it worked without. I don't know if this is some version drift thing in the docker ecosystem, or a simple typo in the docs.

Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
