### PR TITLE
assistant: Use output indicator for summary prompt

### DIFF
--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -2896,7 +2896,7 @@ impl Context {
             request.messages.push(LanguageModelRequestMessage {
                 role: Role::User,
                 content: vec![
-                    "Generate a concise 3-7 word title for this conversation, omitting punctuation. Go straight to the title, without any preamble and prefix like `Here's a concise suggestion:...` or `Title:`"
+                    "Generate a concise 3-7 word title for this conversation, omitting punctuation.\nTitle:"
                         .into(),
                 ],
                 cache: false,


### PR DESCRIPTION
One more shot at improving the summarization prompt for the assistant panel using output indicator

Release Notes:

- Improving assistant panel summarization prompt