### PR TITLE
Factor out language model selector into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "indoc",
  "language",
  "language_model",
+ "language_model_selector",
  "language_models",
  "languages",
  "log",
@@ -6601,6 +6602,20 @@ dependencies = [
  "strum 0.25.0",
  "ui",
  "util",
+]
+
+[[package]]
+name = "language_model_selector"
+version = "0.1.0"
+dependencies = [
+ "feature_flags",
+ "gpui",
+ "language_model",
+ "picker",
+ "proto",
+ "ui",
+ "workspace",
+ "zed_actions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "crates/language",
     "crates/language_extension",
     "crates/language_model",
+    "crates/language_model_selector",
     "crates/language_models",
     "crates/language_selector",
     "crates/language_tools",
@@ -236,6 +237,7 @@ journal = { path = "crates/journal" }
 language = { path = "crates/language" }
 language_extension = { path = "crates/language_extension" }
 language_model = { path = "crates/language_model" }
+language_model_selector = { path = "crates/language_model_selector" }
 language_models = { path = "crates/language_models" }
 language_selector = { path = "crates/language_selector" }
 language_tools = { path = "crates/language_tools" }

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -50,6 +50,7 @@ indexed_docs.workspace = true
 indoc.workspace = true
 language.workspace = true
 language_model.workspace = true
+language_model_selector.workspace = true
 language_models.workspace = true
 log.workspace = true
 lsp.workspace = true

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -5,7 +5,6 @@ pub mod assistant_settings;
 mod context;
 pub mod context_store;
 mod inline_assistant;
-mod model_selector;
 mod patch;
 mod prompt_library;
 mod prompts;
@@ -37,7 +36,6 @@ pub(crate) use inline_assistant::*;
 use language_model::{
     LanguageModelId, LanguageModelProviderId, LanguageModelRegistry, LanguageModelResponseMessage,
 };
-pub(crate) use model_selector::*;
 pub use patch::*;
 pub use prompts::PromptBuilder;
 use prompts::PromptLoadingParams;

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -55,7 +55,7 @@ use language_model::{
     LanguageModelProvider, LanguageModelProviderId, LanguageModelRegistry, Role,
     ZED_CLOUD_PROVIDER_ID,
 };
-use language_model_selector::{ModelPickerDelegate, ModelSelector};
+use language_model_selector::{LanguageModelPickerDelegate, LanguageModelSelector};
 use multi_buffer::MultiBufferRow;
 use picker::{Picker, PickerDelegate};
 use project::lsp_store::LocalLspAdapterDelegate;
@@ -143,7 +143,7 @@ pub struct AssistantPanel {
     languages: Arc<LanguageRegistry>,
     fs: Arc<dyn Fs>,
     subscriptions: Vec<Subscription>,
-    model_selector_menu_handle: PopoverMenuHandle<Picker<ModelPickerDelegate>>,
+    model_selector_menu_handle: PopoverMenuHandle<Picker<LanguageModelPickerDelegate>>,
     model_summary_editor: View<Editor>,
     authenticate_provider_task: Option<(LanguageModelProviderId, Task<()>)>,
     configuration_subscription: Option<Subscription>,
@@ -4458,13 +4458,13 @@ pub struct ContextEditorToolbarItem {
     fs: Arc<dyn Fs>,
     active_context_editor: Option<WeakView<ContextEditor>>,
     model_summary_editor: View<Editor>,
-    model_selector_menu_handle: PopoverMenuHandle<Picker<ModelPickerDelegate>>,
+    model_selector_menu_handle: PopoverMenuHandle<Picker<LanguageModelPickerDelegate>>,
 }
 
 impl ContextEditorToolbarItem {
     pub fn new(
         workspace: &Workspace,
-        model_selector_menu_handle: PopoverMenuHandle<Picker<ModelPickerDelegate>>,
+        model_selector_menu_handle: PopoverMenuHandle<Picker<LanguageModelPickerDelegate>>,
         model_summary_editor: View<Editor>,
     ) -> Self {
         Self {
@@ -4560,7 +4560,7 @@ impl Render for ContextEditorToolbarItem {
             //         .map(|remaining_items| format!("Files to scan: {}", remaining_items))
             // })
             .child(
-                ModelSelector::new(
+                LanguageModelSelector::new(
                     {
                         let fs = self.fs.clone();
                         move |model, cx| {

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -33,7 +33,7 @@ use language_model::{
     LanguageModel, LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage,
     LanguageModelTextStream, Role,
 };
-use language_model_selector::ModelSelector;
+use language_model_selector::LanguageModelSelector;
 use language_models::report_assistant_event;
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
@@ -1501,7 +1501,7 @@ impl Render for PromptEditor {
                     .justify_center()
                     .gap_2()
                     .child(
-                        ModelSelector::new(
+                        LanguageModelSelector::new(
                             {
                                 let fs = self.fs.clone();
                                 move |model, cx| {
@@ -1531,7 +1531,7 @@ impl Render for PromptEditor {
                                     )
                                 }),
                         )
-                        .with_info_text(
+                        .info_text(
                             "Inline edits use context\n\
                             from the currently selected\n\
                             assistant panel tab.",

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1,7 +1,7 @@
 use crate::{
     assistant_settings::AssistantSettings, humanize_token_count, prompts::PromptBuilder,
     AssistantPanel, AssistantPanelEvent, CharOperation, CycleNextInlineAssist,
-    CyclePreviousInlineAssist, LineDiff, LineOperation, ModelSelector, RequestType, StreamingDiff,
+    CyclePreviousInlineAssist, LineDiff, LineOperation, RequestType, StreamingDiff,
 };
 use anyhow::{anyhow, Context as _, Result};
 use client::{telemetry::Telemetry, ErrorExt};
@@ -33,12 +33,13 @@ use language_model::{
     LanguageModel, LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage,
     LanguageModelTextStream, Role,
 };
+use language_model_selector::ModelSelector;
 use language_models::report_assistant_event;
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
 use project::{CodeAction, ProjectTransaction};
 use rope::Rope;
-use settings::{Settings, SettingsStore};
+use settings::{update_settings_file, Settings, SettingsStore};
 use smol::future::FutureExt;
 use std::{
     cmp,
@@ -1501,7 +1502,16 @@ impl Render for PromptEditor {
                     .gap_2()
                     .child(
                         ModelSelector::new(
-                            self.fs.clone(),
+                            {
+                                let fs = self.fs.clone();
+                                move |model, cx| {
+                                    update_settings_file::<AssistantSettings>(
+                                        fs.clone(),
+                                        cx,
+                                        move |settings, _| settings.set_model(model.clone()),
+                                    );
+                                }
+                            },
                             IconButton::new("context", IconName::SettingsAlt)
                                 .shape(IconButtonShape::Square)
                                 .icon_size(IconSize::Small)

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -1,6 +1,7 @@
+use crate::assistant_settings::AssistantSettings;
 use crate::{
-    humanize_token_count, prompts::PromptBuilder, AssistantPanel, AssistantPanelEvent,
-    ModelSelector, RequestType, DEFAULT_CONTEXT_LINES,
+    humanize_token_count, prompts::PromptBuilder, AssistantPanel, AssistantPanelEvent, RequestType,
+    DEFAULT_CONTEXT_LINES,
 };
 use anyhow::{Context as _, Result};
 use client::telemetry::Telemetry;
@@ -19,8 +20,9 @@ use language::Buffer;
 use language_model::{
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
+use language_model_selector::ModelSelector;
 use language_models::report_assistant_event;
-use settings::Settings;
+use settings::{update_settings_file, Settings};
 use std::{
     cmp,
     sync::Arc,
@@ -613,7 +615,16 @@ impl Render for PromptEditor {
                     .justify_center()
                     .gap_2()
                     .child(ModelSelector::new(
-                        self.fs.clone(),
+                        {
+                            let fs = self.fs.clone();
+                            move |model, cx| {
+                                update_settings_file::<AssistantSettings>(
+                                    fs.clone(),
+                                    cx,
+                                    move |settings, _| settings.set_model(model.clone()),
+                                );
+                            }
+                        },
                         IconButton::new("context", IconName::SettingsAlt)
                             .shape(IconButtonShape::Square)
                             .icon_size(IconSize::Small)

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -20,7 +20,7 @@ use language::Buffer;
 use language_model::{
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
-use language_model_selector::ModelSelector;
+use language_model_selector::LanguageModelSelector;
 use language_models::report_assistant_event;
 use settings::{update_settings_file, Settings};
 use std::{
@@ -614,7 +614,7 @@ impl Render for PromptEditor {
                     .w_12()
                     .justify_center()
                     .gap_2()
-                    .child(ModelSelector::new(
+                    .child(LanguageModelSelector::new(
                         {
                             let fs = self.fs.clone();
                             move |model, cx| {

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "language_model_selector"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/language_model_selector.rs"
+
+[dependencies]
+feature_flags.workspace = true
+gpui.workspace = true
+language_model.workspace = true
+picker.workspace = true
+proto.workspace = true
+ui.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true

--- a/crates/language_model_selector/LICENSE-GPL
+++ b/crates/language_model_selector/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -13,14 +13,14 @@ const TRY_ZED_PRO_URL: &str = "https://zed.dev/pro";
 type OnModelChanged = Arc<dyn Fn(Arc<dyn LanguageModel>, &AppContext) + 'static>;
 
 #[derive(IntoElement)]
-pub struct ModelSelector<T: PopoverTrigger> {
-    handle: Option<PopoverMenuHandle<Picker<ModelPickerDelegate>>>,
+pub struct LanguageModelSelector<T: PopoverTrigger> {
+    handle: Option<PopoverMenuHandle<Picker<LanguageModelPickerDelegate>>>,
     on_model_changed: OnModelChanged,
     trigger: T,
     info_text: Option<SharedString>,
 }
 
-pub struct ModelPickerDelegate {
+pub struct LanguageModelPickerDelegate {
     on_model_changed: OnModelChanged,
     all_models: Vec<ModelInfo>,
     filtered_models: Vec<ModelInfo>,
@@ -35,12 +35,12 @@ struct ModelInfo {
     is_selected: bool,
 }
 
-impl<T: PopoverTrigger> ModelSelector<T> {
+impl<T: PopoverTrigger> LanguageModelSelector<T> {
     pub fn new(
         on_model_changed: impl Fn(Arc<dyn LanguageModel>, &AppContext) + 'static,
         trigger: T,
     ) -> Self {
-        ModelSelector {
+        LanguageModelSelector {
             handle: None,
             on_model_changed: Arc::new(on_model_changed),
             trigger,
@@ -48,18 +48,21 @@ impl<T: PopoverTrigger> ModelSelector<T> {
         }
     }
 
-    pub fn with_handle(mut self, handle: PopoverMenuHandle<Picker<ModelPickerDelegate>>) -> Self {
+    pub fn with_handle(
+        mut self,
+        handle: PopoverMenuHandle<Picker<LanguageModelPickerDelegate>>,
+    ) -> Self {
         self.handle = Some(handle);
         self
     }
 
-    pub fn with_info_text(mut self, text: impl Into<SharedString>) -> Self {
+    pub fn info_text(mut self, text: impl Into<SharedString>) -> Self {
         self.info_text = Some(text.into());
         self
     }
 }
 
-impl PickerDelegate for ModelPickerDelegate {
+impl PickerDelegate for LanguageModelPickerDelegate {
     type ListItem = ListItem;
 
     fn match_count(&self) -> usize {
@@ -294,7 +297,7 @@ impl PickerDelegate for ModelPickerDelegate {
     }
 }
 
-impl<T: PopoverTrigger> RenderOnce for ModelSelector<T> {
+impl<T: PopoverTrigger> RenderOnce for LanguageModelSelector<T> {
     fn render(self, cx: &mut WindowContext) -> impl IntoElement {
         let selected_provider = LanguageModelRegistry::read_global(cx)
             .active_provider()
@@ -329,7 +332,7 @@ impl<T: PopoverTrigger> RenderOnce for ModelSelector<T> {
             })
             .collect::<Vec<_>>();
 
-        let delegate = ModelPickerDelegate {
+        let delegate = LanguageModelPickerDelegate {
             on_model_changed: self.on_model_changed.clone(),
             all_models: all_models.clone(),
             filtered_models: all_models,


### PR DESCRIPTION
This PR factors the language model selector out into its own `language_model_selector` crate so that it can be reused in `assistant2`.

Also renamed it from `ModelSelector` to `LanguageModelSelector` to be a bit more specific.

Release Notes:

- N/A
