### PR TITLE
vim: Add indent text object

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -381,7 +381,9 @@
       "shift-b": "vim::CurlyBrackets",
       "<": "vim::AngleBrackets",
       ">": "vim::AngleBrackets",
-      "a": "vim::Argument"
+      "a": "vim::Argument",
+      "i": "vim::IndentObj",
+      "shift-i": ["vim::IndentObj", { "includeBelow": true }]
     }
   },
   {


### PR DESCRIPTION
Added support for the popular vim [indent-text-object](https://github.com/michaeljsmith/vim-indent-object). This is especially useful in indentation-sensitive languages like python.

Release Notes:

- vim: Added `vii`, `vai` and `vaI` for selecting [indent-text-object](https://github.com/michaeljsmith/vim-indent-object)s.
