### PR TITLE
Fix path canonicalization causing troubles on Windows

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1098,6 +1098,10 @@ impl Workspace {
         cx.spawn(|mut cx| async move {
             let mut paths_to_open = Vec::with_capacity(abs_paths.len());
             for path in abs_paths.into_iter() {
+                if cfg!(target_os = "windows") {
+                    paths_to_open.push(path);
+                    continue;
+                }
                 if let Some(canonical) = app_state.fs.canonicalize(&path).await.ok() {
                     paths_to_open.push(canonical)
                 } else {


### PR DESCRIPTION
[`fs.canonicalize`](https://doc.rust-lang.org/beta/std/fs/fn.canonicalize.html) converts the path to use the extended length path syntax, which may be incompatible with other applications (if passed to the application through a task or a terminal), including `cargo build` for the Zed project.

![image](https://github.com/user-attachments/assets/34c2c6e4-ef82-4bca-bba0-edb2df94babf)

![image](https://github.com/user-attachments/assets/dc69620e-7756-482d-bff0-3034052374e2)


