### PR TITLE
Hide AI hints on line ends so we can discuss more

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -492,7 +492,7 @@
     "enabled": true,
     // Whether to show inline hints showing the keybindings to use the inline assistant and the
     // assistant panel.
-    "show_hints": true,
+    "show_hints": false,
     // Whether to show the assistant panel button in the status bar.
     "button": true,
     // Where to dock the assistant panel. Can be 'left', 'right' or 'bottom'.


### PR DESCRIPTION
@bennetbo @as-cii @mrnugget I'm really not liking the hints about AI on every line. It feels too distracting to me and damaging to the user experience. I'm wondering if we can hide them and work with design for other ideas. Or at least talk it through.

Release Notes:

- N/A
