### PR TITLE
gpui: Support translation for the services submenu name

### DIFF
--- a/crates/gpui/examples/set_menus.rs
+++ b/crates/gpui/examples/set_menus.rs
@@ -25,7 +25,13 @@ fn main() {
         // Add menu items
         cx.set_menus(vec![Menu {
             name: "set_menus".into(),
-            items: vec![MenuItem::action("Quit", Quit)],
+            items: vec![
+                MenuItem::services_submenu(Menu {
+                    name: "Services".into(),
+                    items: vec![],
+                }),
+                MenuItem::action("Quit", Quit),
+            ],
         }]);
         cx.open_window(WindowOptions::default(), |cx| {
             cx.new_view(|_cx| SetMenus {})

--- a/crates/gpui/src/platform/app_menu.rs
+++ b/crates/gpui/src/platform/app_menu.rs
@@ -28,6 +28,9 @@ pub enum MenuItem {
     /// A submenu
     Submenu(Menu),
 
+    /// A submenu which should contain the (macOS) services menu
+    ServicesSubmenu(Menu),
+
     /// An action that can be performed
     Action {
         /// The name of this menu item
@@ -51,6 +54,11 @@ impl MenuItem {
     /// Creates a new menu item that is a submenu
     pub fn submenu(menu: Menu) -> Self {
         Self::Submenu(menu)
+    }
+
+    /// Creates a new menu item which should contain the (macOS) services menu
+    pub fn services_submenu(menu: Menu) -> Self {
+        Self::ServicesSubmenu(menu)
     }
 
     /// Creates a new menu item that invokes an action
@@ -80,6 +88,7 @@ impl MenuItem {
         match self {
             MenuItem::Separator => OwnedMenuItem::Separator,
             MenuItem::Submenu(submenu) => OwnedMenuItem::Submenu(submenu.owned()),
+            MenuItem::ServicesSubmenu(submenu) => OwnedMenuItem::ServicesSubmenu(submenu.owned()),
             MenuItem::Action {
                 name,
                 action,
@@ -111,6 +120,9 @@ pub enum OwnedMenuItem {
     /// A submenu
     Submenu(OwnedMenu),
 
+    /// A submenu which should contain the (macOS) services menu
+    ServicesSubmenu(OwnedMenu),
+
     /// An action that can be performed
     Action {
         /// The name of this menu item
@@ -130,6 +142,9 @@ impl Clone for OwnedMenuItem {
         match self {
             OwnedMenuItem::Separator => OwnedMenuItem::Separator,
             OwnedMenuItem::Submenu(submenu) => OwnedMenuItem::Submenu(submenu.clone()),
+            OwnedMenuItem::ServicesSubmenu(submenu) => {
+                OwnedMenuItem::ServicesSubmenu(submenu.clone())
+            }
             OwnedMenuItem::Action {
                 name,
                 action,

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -30,7 +30,7 @@ pub fn app_menus() -> Vec<Menu> {
                     ],
                 }),
                 MenuItem::separator(),
-                MenuItem::submenu(Menu {
+                MenuItem::services_submenu(Menu {
                     name: "Services".into(),
                     items: vec![],
                 }),


### PR DESCRIPTION
This PR adds support for translating the services submenu name in the macOS menu bar.
Previously the name was hard-coded to "Services", which forbids translations.

This PR allows to change the name by introducing a new specific submenu type for the services menu item.
