### PR TITLE
linux: Fix file not opening from file explorer

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -125,7 +125,7 @@ linux() {
     desktop_file_path="$HOME/.local/share/applications/${appid}.desktop"
     cp "$HOME/.local/zed$suffix.app/share/applications/zed$suffix.desktop" "${desktop_file_path}"
     sed -i "s|Icon=zed|Icon=$HOME/.local/zed$suffix.app/share/icons/hicolor/512x512/apps/zed.png|g" "${desktop_file_path}"
-    sed -i "s|Exec=zed|Exec=$HOME/.local/zed$suffix.app/libexec/zed-editor|g" "${desktop_file_path}"
+    sed -i "s|Exec=zed|Exec=$HOME/.local/zed$suffix.app/bin/zed|g" "${desktop_file_path}"
 }
 
 macos() {


### PR DESCRIPTION
Closes #20070

Release Notes:

- Fixed issue where files wouldn't open from the file explorer.
- Fixed "Open a new workspace" option on the desktop entry right-click menu.

Context:

Zed consists of two binaries:

- `zed` (CLI component, located at `crates/cli/main.rs`)
- `zed-editor` (GUI component, located at `crates/zed/main.rs`)

When `zed` is used in the terminal, it checks if an existing instance is running. If one is found, it sends data via a socket to open the specified file. Otherwise, it launches a new instance of `zed-editor`. For more details, see the `detect` and `boot_background` functions in `crates/cli/main.rs`.

Root Cause:

Install process creates directories like `.local/zed.app` and `.local/zed-preview.app`, which contain desktop entries for the corresponding release. For example, `.local/zed.app/share/applications` contains `zed.desktop`.

This desktop entry includes a generic `Exec` field, which is correct by default:

```sh
Comment=A high-performance, multiplayer code editor.
TryExec=zed
StartupNotify=true
```

The issue is in the `install.sh` script. This script copies the above desktop file to the common directory for desktop entries (.local/share/applications). During this process, it replaces the `TryExec` value from `zed` with the exact binary path to avoid relying on the shell's PATH resolution and to make it explicit.

However, replacement incorrectly uses the path for `zed-editor` instead of the `zed` CLI binary. This results in not opening a file as if you use `zed-editor` directly to do this it will throw `zed is already running` error on production and open new instance on dev.


Note: This PR solves it for new users. For existing users, they will either have to update `.desktop` file manually, or use `install.sh` script again. I'm not aware of zed auto-update method, if it runs `install.sh` under the hood.
 
