### PR TITLE
Improve styling for diff hunks

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3242,7 +3242,7 @@ impl EditorElement {
                         );
                         Some((
                             hunk_bounds,
-                            cx.theme().status().modified,
+                            cx.theme().status().modified_border,
                             Corners::all(px(0.)),
                         ))
                     }
@@ -3250,12 +3250,12 @@ impl EditorElement {
                         hitbox.as_ref().map(|hunk_hitbox| match status {
                             DiffHunkStatus::Added => (
                                 hunk_hitbox.bounds,
-                                cx.theme().status().created,
+                                cx.theme().status().created_border,
                                 Corners::all(px(0.)),
                             ),
                             DiffHunkStatus::Modified => (
                                 hunk_hitbox.bounds,
-                                cx.theme().status().modified,
+                                cx.theme().status().modified_border,
                                 Corners::all(px(0.)),
                             ),
                             DiffHunkStatus::Removed => (
@@ -3266,7 +3266,7 @@ impl EditorElement {
                                     ),
                                     size(hunk_hitbox.size.width * px(2.), hunk_hitbox.size.height),
                                 ),
-                                cx.theme().status().deleted,
+                                cx.theme().status().deleted_border,
                                 Corners::all(1. * line_height),
                             ),
                         })
@@ -3781,9 +3781,13 @@ impl EditorElement {
                                             end_display_row.0 -= 1;
                                         }
                                         let color = match hunk_status(&hunk) {
-                                            DiffHunkStatus::Added => theme.status().created,
-                                            DiffHunkStatus::Modified => theme.status().modified,
-                                            DiffHunkStatus::Removed => theme.status().deleted,
+                                            DiffHunkStatus::Added => theme.status().created_border,
+                                            DiffHunkStatus::Modified => {
+                                                theme.status().modified_border
+                                            }
+                                            DiffHunkStatus::Removed => {
+                                                theme.status().deleted_border
+                                            }
                                         };
                                         ColoredRange {
                                             start: start_display_row,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3264,7 +3264,7 @@ impl EditorElement {
                                         hunk_hitbox.origin.x - hunk_hitbox.size.width,
                                         hunk_hitbox.origin.y,
                                     ),
-                                    size(hunk_hitbox.size.width * px(2.5), hunk_hitbox.size.height),
+                                    size(hunk_hitbox.size.width * px(2.2), hunk_hitbox.size.height),
                                 ),
                                 cx.theme().status().deleted,
                                 Corners::all(1. * line_height),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3264,7 +3264,7 @@ impl EditorElement {
                                         hunk_hitbox.origin.x - hunk_hitbox.size.width,
                                         hunk_hitbox.origin.y,
                                     ),
-                                    size(hunk_hitbox.size.width * px(2.), hunk_hitbox.size.height),
+                                    size(hunk_hitbox.size.width * px(2.5), hunk_hitbox.size.height),
                                 ),
                                 cx.theme().status().deleted_border,
                                 Corners::all(1. * line_height),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3242,7 +3242,7 @@ impl EditorElement {
                         );
                         Some((
                             hunk_bounds,
-                            cx.theme().status().modified_border,
+                            cx.theme().status().modified,
                             Corners::all(px(0.)),
                         ))
                     }
@@ -3250,12 +3250,12 @@ impl EditorElement {
                         hitbox.as_ref().map(|hunk_hitbox| match status {
                             DiffHunkStatus::Added => (
                                 hunk_hitbox.bounds,
-                                cx.theme().status().created_border,
+                                cx.theme().status().created,
                                 Corners::all(px(0.)),
                             ),
                             DiffHunkStatus::Modified => (
                                 hunk_hitbox.bounds,
-                                cx.theme().status().modified_border,
+                                cx.theme().status().modified,
                                 Corners::all(px(0.)),
                             ),
                             DiffHunkStatus::Removed => (
@@ -3266,7 +3266,7 @@ impl EditorElement {
                                     ),
                                     size(hunk_hitbox.size.width * px(2.5), hunk_hitbox.size.height),
                                 ),
-                                cx.theme().status().deleted_border,
+                                cx.theme().status().deleted,
                                 Corners::all(1. * line_height),
                             ),
                         })
@@ -3781,13 +3781,9 @@ impl EditorElement {
                                             end_display_row.0 -= 1;
                                         }
                                         let color = match hunk_status(&hunk) {
-                                            DiffHunkStatus::Added => theme.status().created_border,
-                                            DiffHunkStatus::Modified => {
-                                                theme.status().modified_border
-                                            }
-                                            DiffHunkStatus::Removed => {
-                                                theme.status().deleted_border
-                                            }
+                                            DiffHunkStatus::Added => theme.status().created,
+                                            DiffHunkStatus::Modified => theme.status().modified,
+                                            DiffHunkStatus::Removed => theme.status().deleted,
                                         };
                                         ColoredRange {
                                             start: start_display_row,

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -415,9 +415,9 @@ impl Editor {
         let border_color = cx.theme().colors().border_variant;
         let bg_color = cx.theme().colors().editor_background;
         let gutter_color = match hunk.status {
-            DiffHunkStatus::Added => cx.theme().status().created_border,
-            DiffHunkStatus::Modified => cx.theme().status().modified_border,
-            DiffHunkStatus::Removed => cx.theme().status().deleted_border,
+            DiffHunkStatus::Added => cx.theme().status().created,
+            DiffHunkStatus::Modified => cx.theme().status().modified,
+            DiffHunkStatus::Removed => cx.theme().status().deleted,
         };
 
         BlockProperties {
@@ -694,8 +694,8 @@ impl Editor {
     ) -> BlockProperties<Anchor> {
         let gutter_color = match hunk.status {
             DiffHunkStatus::Added => unreachable!(),
-            DiffHunkStatus::Modified => cx.theme().status().modified_border,
-            DiffHunkStatus::Removed => cx.theme().status().deleted_border,
+            DiffHunkStatus::Modified => cx.theme().status().modified,
+            DiffHunkStatus::Removed => cx.theme().status().deleted,
         };
         let deleted_hunk_color = deleted_hunk_color(cx);
         let (editor_height, editor_with_deleted_text) =

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -1051,13 +1051,16 @@ fn create_diff_base_buffer(buffer: &Model<Buffer>, cx: &mut AppContext) -> Optio
             })
         })
 }
-
 fn added_hunk_color(cx: &AppContext) -> Hsla {
-    cx.theme().status().created_background
+    let mut created_color = cx.theme().status().git().created;
+    created_color.fade_out(0.8);
+    created_color
 }
 
 fn deleted_hunk_color(cx: &AppContext) -> Hsla {
-    cx.theme().status().deleted_background
+    let mut deleted_color = cx.theme().status().deleted;
+    deleted_color.fade_out(0.8);
+    deleted_color
 }
 
 fn editor_with_deleted_text(

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -415,9 +415,9 @@ impl Editor {
         let border_color = cx.theme().colors().border_variant;
         let bg_color = cx.theme().colors().editor_background;
         let gutter_color = match hunk.status {
-            DiffHunkStatus::Added => cx.theme().status().created,
-            DiffHunkStatus::Modified => cx.theme().status().modified,
-            DiffHunkStatus::Removed => cx.theme().status().deleted,
+            DiffHunkStatus::Added => cx.theme().status().created_border,
+            DiffHunkStatus::Modified => cx.theme().status().modified_border,
+            DiffHunkStatus::Removed => cx.theme().status().deleted_border,
         };
 
         BlockProperties {
@@ -694,8 +694,8 @@ impl Editor {
     ) -> BlockProperties<Anchor> {
         let gutter_color = match hunk.status {
             DiffHunkStatus::Added => unreachable!(),
-            DiffHunkStatus::Modified => cx.theme().status().modified,
-            DiffHunkStatus::Removed => cx.theme().status().deleted,
+            DiffHunkStatus::Modified => cx.theme().status().modified_border,
+            DiffHunkStatus::Removed => cx.theme().status().deleted_border,
         };
         let deleted_hunk_color = deleted_hunk_color(cx);
         let (editor_height, editor_with_deleted_text) =
@@ -1053,15 +1053,11 @@ fn create_diff_base_buffer(buffer: &Model<Buffer>, cx: &mut AppContext) -> Optio
 }
 
 fn added_hunk_color(cx: &AppContext) -> Hsla {
-    let mut created_color = cx.theme().status().git().created;
-    created_color.fade_out(0.7);
-    created_color
+    cx.theme().status().created_background
 }
 
 fn deleted_hunk_color(cx: &AppContext) -> Hsla {
-    let mut deleted_color = cx.theme().status().deleted;
-    deleted_color.fade_out(0.7);
-    deleted_color
+    cx.theme().status().deleted_background
 }
 
 fn editor_with_deleted_text(


### PR DESCRIPTION
This PR changes the background of the created and deleted diff hunks to use the `created_background` and `deleted_background` styles, respectively, and it makes the folded indicator for deleted hunks much more visible. Without this, the backgrounds just use a faded version of the foregrounds, which can make it hard to design themes where the gutter marker is sufficiently bright or saturated and the background is sufficiently dark or unsaturated.

Here are some screenshots with a few different themes. Old is on the left, new is on the right.

Andromeda:
<img width="856" alt="image" src="https://github.com/user-attachments/assets/65d62175-5310-4f05-ade9-0427a1e74373">

Summercamp: 
<img width="805" alt="image" src="https://github.com/user-attachments/assets/ae95a4b7-672b-4eff-b8c3-7c6b0090e5d9">

Rosé Pine Dawn:
<img width="806" alt="image" src="https://github.com/user-attachments/assets/9bbc7ff9-4950-4419-ad34-366498f938f7">

Release Notes:

- Diff hunks now use the `created_background` and `deleted_background` colors from the theme.
- The deleted diff gutter indicator is larger.
