### PR TITLE
Do not reuse render cache for nested items whose parents are re-rendered

### DIFF
--- a/crates/gpui/src/view.rs
+++ b/crates/gpui/src/view.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use refineable::Refineable;
+use std::mem;
 use std::{
     any::{type_name, TypeId},
     fmt,
@@ -341,11 +342,13 @@ impl Element for AnyView {
                     }
                 }
 
+                let refreshing = mem::replace(&mut cx.window.refreshing, true);
                 let prepaint_start = cx.prepaint_index();
                 let mut element = (self.render)(self, cx);
                 element.layout_as_root(bounds.size.into(), cx);
                 element.prepaint_at(bounds.origin, cx);
                 let prepaint_end = cx.prepaint_index();
+                cx.window.refreshing = refreshing;
 
                 (
                     Some(element),
@@ -382,7 +385,9 @@ impl Element for AnyView {
                 let paint_start = cx.paint_index();
 
                 if let Some(element) = element {
+                    let refreshing = mem::replace(&mut cx.window.refreshing, true);
                     element.paint(cx);
+                    cx.window.refreshing = refreshing;
                 } else {
                     cx.reuse_paint(element_state.paint_range.clone());
                 }


### PR DESCRIPTION
Fixes a bug with terminal splits panicking during writing a command in the command input

Release Notes:

- N/A
