### PR TITLE
docs: Fix broken link to context servers docs

### DIFF
--- a/docs/src/assistant/model-context-protocol.md
+++ b/docs/src/assistant/model-context-protocol.md
@@ -1,6 +1,6 @@
 # Model Context Protocol
 
-Zed uses the [Model Context Protocol](https://modelcontextprotocol.io/) to interact with [context servers](./context-server.md):
+Zed uses the [Model Context Protocol](https://modelcontextprotocol.io/) to interact with [context servers](./context-servers.md):
 
 > The Model Context Protocol (MCP) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. Whether you're building an AI-powered IDE, enhancing a chat interface, or creating custom AI workflows, MCP provides a standardized way to connect LLMs with the context they need.
 


### PR DESCRIPTION
This PR fixes a broken link to the context server docs.

Release Notes:

- N/A
