### PR TITLE
linux: Fix Zed not visible in "Open With" list in file manager for Flatpak

### DIFF
--- a/crates/zed/resources/flatpak/manifest-template.json
+++ b/crates/zed/resources/flatpak/manifest-template.json
@@ -32,7 +32,7 @@
           "BRANDING_LIGHT": "$BRANDING_LIGHT",
           "BRANDING_DARK": "$BRANDING_DARK",
           "APP_CLI": "zed",
-          "APP_ARGS": "--foreground",
+          "APP_ARGS": "--foreground %U",
           "DO_STARTUP_NOTIFY": "false"
         }
       },


### PR DESCRIPTION
- Closes #19030

When `%U` is used in desktop entries, file managers pick this and use it:

- When you right-click a file and choose "Open with..."
- When you drag and drop files onto an application icon

<img src="https://github.com/user-attachments/assets/ea5aa008-b81c-4f10-9302-b82332f6b174" width="200px" alt="image">

Adding it to CLI args, changes Flatpak desktop entry `Exec` from:

```diff
- Exec=/usr/bin/flatpak run --branch=master --arch=x86_64 --command=zed dev.zed.ZedDev --foreground
+ Exec=/usr/bin/flatpak run --branch=master --arch=x86_64 --command=zed --file-forwarding dev.zed.ZedDev --foreground @@u %U @@
```

This is Flatpak's way of doing `%U`, by adding `--file-forwarding` and wrapping arg with `@@u` and `@@`.
Read more below ([source](https://docs.flatpak.org/en/latest/flatpak-command-reference.html)):

> --file-forwarding
>
> If this option is specified, the remaining arguments are scanned, and all arguments that are enclosed between a pair of '@@' arguments are interpreted as file paths, exported in the document store, and passed to the command in the form of the resulting document path. Arguments between "@@u" and "@@" are considered URIs, and any "file:" URIs are exported. The exports are non-persistent and with read and write permissions for the application. 

Release Notes:

- Fixed Zed not visible in the "Open with" list in the file manager for Flatpak.