### PR TITLE
assistant2: Remove unnecessary `Pane`

### DIFF
--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -1,5 +1,5 @@
 use editor::{Editor, EditorElement, EditorStyle};
-use gpui::{AppContext, Model, TextStyle, View};
+use gpui::{AppContext, FocusableView, Model, TextStyle, View};
 use language_model::{
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, MessageContent, Role,
 };
@@ -94,6 +94,12 @@ impl MessageEditor {
         };
 
         request
+    }
+}
+
+impl FocusableView for MessageEditor {
+    fn focus_handle(&self, cx: &AppContext) -> gpui::FocusHandle {
+        self.editor.focus_handle(cx)
     }
 }
 


### PR DESCRIPTION
This PR removes an unnecessary `Pane` that was copied over from `assistant::AssistantPanel` to `assistant2::AssistantPanel`.

Release Notes:

- N/A
