### PR TITLE
assistant2: Include previous messages in the thread in the completion request

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -234,7 +234,7 @@ impl Render for AssistantPanel {
                     .p_2()
                     .overflow_y_scroll()
                     .bg(cx.theme().colors().panel_background)
-                    .children(self.thread.read(cx).messages.iter().map(|message| {
+                    .children(self.thread.read(cx).messages().map(|message| {
                         v_flex()
                             .p_2()
                             .border_1()


### PR DESCRIPTION
This PR makes it so previous messages in the thread are included when constructing the completion request, instead of only sending up the most recent user message.

Release Notes:

- N/A
