### PR TITLE
assistant2: Style messages

### DIFF
--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -18,7 +18,7 @@ pub enum RequestKind {
 }
 
 /// A message in a [`Thread`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Message {
     pub role: Role,
     pub text: String,


### PR DESCRIPTION
This PR styles the messages in `assistant2` so they don't look quite as rough:

<img width="1138" alt="Screenshot 2024-11-25 at 8 36 32 PM" src="https://github.com/user-attachments/assets/9cc423fa-feff-4c69-9d2b-d28970559547">

Release Notes:

- N/A
