### PR TITLE
Use `ui_font_size` in chat panel

### DIFF
--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -311,7 +311,7 @@ impl ChatPanel {
             None => {
                 return div().child(
                     h_flex()
-                        .text_ui_xs(cx)
+                        .text_ui(cx)
                         .my_0p5()
                         .px_0p5()
                         .gap_x_1()
@@ -320,7 +320,7 @@ impl ChatPanel {
                         .when(reply_to_message.is_none(), |el| {
                             el.child(
                                 Label::new("Message has been deleted...")
-                                    .size(LabelSize::XSmall)
+                                    .size(LabelSize::Small)
                                     .color(Color::Muted),
                             )
                         }),
@@ -346,7 +346,7 @@ impl ChatPanel {
         div().child(
             h_flex()
                 .id(message_element_id)
-                .text_ui_xs(cx)
+                .text_ui(cx)
                 .my_0p5()
                 .px_0p5()
                 .gap_x_1()
@@ -357,14 +357,14 @@ impl ChatPanel {
                 .child(Avatar::new(user_being_replied_to.avatar_uri.clone()).size(rems(0.7)))
                 .child(
                     Label::new(format!("@{}", user_being_replied_to.github_login))
-                        .size(LabelSize::XSmall)
+                        .size(LabelSize::Default)
                         .weight(FontWeight::SEMIBOLD)
                         .color(Color::Muted),
                 )
                 .child(
                     div().overflow_y_hidden().child(
                         Label::new(message_being_replied_to.body.replace('\n', " "))
-                            .size(LabelSize::XSmall)
+                            .size(LabelSize::Default)
                             .color(Color::Default),
                     ),
                 )
@@ -491,14 +491,14 @@ impl ChatPanel {
                             this.child(
                                 h_flex()
                                     .gap_2()
-                                    .text_ui_sm(cx)
+                                    .text_ui(cx)
                                     .child(
                                         Avatar::new(message.sender.avatar_uri.clone())
                                             .size(rems(1.)),
                                     )
                                     .child(
                                         Label::new(message.sender.github_login.clone())
-                                            .size(LabelSize::Small)
+                                            .size(LabelSize::Default)
                                             .weight(FontWeight::BOLD),
                                     )
                                     .child(
@@ -508,7 +508,7 @@ impl ChatPanel {
                                             self.local_timezone,
                                             time_format::TimestampFormat::EnhancedAbsolute,
                                         ))
-                                        .size(LabelSize::Small)
+                                        .size(LabelSize::Default)
                                         .color(Color::Muted),
                                     ),
                             )
@@ -528,7 +528,7 @@ impl ChatPanel {
                         el.child(
                             v_flex()
                                 .w_full()
-                                .text_ui_sm(cx)
+                                .text_ui(cx)
                                 .id(element_id)
                                 .child(text.element("body".into(), cx)),
                         )
@@ -551,7 +551,7 @@ impl ChatPanel {
                                 div()
                                     .px_1()
                                     .rounded_md()
-                                    .text_ui_xs(cx)
+                                    .text_ui(cx)
                                     .bg(cx.theme().colors().background)
                                     .child("New messages"),
                             )
@@ -962,7 +962,7 @@ impl Render for ChatPanel {
                             .p_4()
                             .child(
                                 Label::new("Select a channel to chat in.")
-                                    .size(LabelSize::Small)
+                                    .size(LabelSize::Default)
                                     .color(Color::Muted),
                             )
                             .child(
@@ -990,7 +990,7 @@ impl Render for ChatPanel {
                 el.child(
                     h_flex()
                         .px_2()
-                        .text_ui_xs(cx)
+                        .text_ui(cx)
                         .justify_between()
                         .border_t_1()
                         .border_color(cx.theme().colors().border)
@@ -1034,13 +1034,13 @@ impl Render for ChatPanel {
                                 div().flex_shrink().overflow_hidden().child(
                                     h_flex()
                                         .id(("reply-preview", reply_to_message_id))
-                                        .child(Label::new("Replying to ").size(LabelSize::Small))
+                                        .child(Label::new("Replying to ").size(LabelSize::Default))
                                         .child(
                                             Label::new(format!(
                                                 "@{}",
                                                 user_being_replied_to.github_login.clone()
                                             ))
-                                            .size(LabelSize::Small)
+                                            .size(LabelSize::Default)
                                             .weight(FontWeight::BOLD),
                                         )
                                         .when_some(channel_id, |this, channel_id| {

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -17,7 +17,7 @@ use project::{search::SearchQuery, Completion};
 use settings::Settings;
 use std::{ops::Range, sync::Arc, sync::LazyLock, time::Duration};
 use theme::ThemeSettings;
-use ui::{prelude::*, TextSize};
+use ui::prelude::*;
 
 use crate::panel_settings::MessageEditorSettings;
 
@@ -528,7 +528,7 @@ impl Render for MessageEditor {
             font_family: settings.ui_font.family.clone(),
             font_features: settings.ui_font.features.clone(),
             font_fallbacks: settings.ui_font.fallbacks.clone(),
-            font_size: TextSize::Small.rems(cx).into(),
+            font_size: gpui::AbsoluteLength::Pixels(settings.ui_font_size),
             font_weight: settings.ui_font.weight,
             font_style: FontStyle::Normal,
             line_height: relative(1.3),

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2144,7 +2144,7 @@ impl CollabPanel {
             font_family: settings.ui_font.family.clone(),
             font_features: settings.ui_font.features.clone(),
             font_fallbacks: settings.ui_font.fallbacks.clone(),
-            font_size: rems(0.875).into(),
+            font_size: gpui::AbsoluteLength::Pixels(settings.ui_font_size),
             font_weight: settings.ui_font.weight,
             font_style: FontStyle::Normal,
             line_height: relative(1.3),


### PR DESCRIPTION
Current chat panel font size is tiny and not usable for anyone. To make it useable we can increase the ui_font_size setting, but this makes the ui too big. The ui looks great with the default size, so lets make the chat look good with the default setting.

Change the chat panel to use to ui font size:
- Change items using text_ui_sm and text_ui_xs to text_ui
- Change LabelSize::Small to LabelSize:Default

I kept LabelSize:Small for text about delete message. This is a case when we can use smaller font size.

Maybe we can tweak some items to use little bit smaller font later.

Example window with new font size:

<img width="1759" alt="Screenshot 2024-11-26 at 23 49 09" src="https://github.com/user-attachments/assets/e4ae8d11-c8c3-4c07-b086-cd8976bf3de6">

Closes #21037

Release Notes:

- Collab panel readability improved to use the ui_font_size setting.