### PR TITLE
Use eslint from the fork

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -412,7 +412,7 @@ impl LspAdapter for EsLintLspAdapter {
         _delegate: &dyn LspAdapterDelegate,
     ) -> Result<Box<dyn 'static + Send + Any>> {
         let url = build_asset_url(
-            "microsoft/vscode-eslint",
+            "zed-industries/vscode-eslint",
             Self::CURRENT_VERSION_TAG_NAME,
             Self::GITHUB_ASSET_KIND,
         )?;


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/21220

Microsoft had decided to switch over to a different releasing strategy, autogenerating all releases and not publishing tarballs anymore.
But it was not enough, and they had also removed old tarballs, including a relatively old `2.4.4` version release's tarballs, which broke Zed downloads.
See https://github.com/microsoft/vscode-eslint/issues/1954

This PR uses https://github.com/zed-industries/vscode-eslint/releases/tag/2.4.4 from Zed's fork, manually released for the same tag.

This approach is merely a stub before more sustainable solution is found, and I think we need to pivot into downloading *.vsix from https://open-vsx.org/extension/dbaeumer/vscode-eslint but this is quite a change so not done right now.

Release Notes:

- Fixed eslint 404 downloads
