### PR TITLE
Allow splitting the terminal panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12418,6 +12418,7 @@ name = "terminal_view"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-recursion 1.1.1",
  "breadcrumbs",
  "client",
  "collections",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -704,7 +704,7 @@
       "cmd-c": "terminal::Copy",
       "cmd-v": "terminal::Paste",
       "cmd-a": "editor::SelectAll",
-      "cmd-k": "terminal::Clear",
+      "cmd-shift-k": "terminal::Clear",
       "ctrl-enter": "assistant::InlineAssist",
       // Some nice conveniences
       "cmd-backspace": ["terminal::SendText", "\u0015"],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -704,7 +704,7 @@
       "cmd-c": "terminal::Copy",
       "cmd-v": "terminal::Paste",
       "cmd-a": "editor::SelectAll",
-      "cmd-shift-k": "terminal::Clear",
+      "cmd-k": "terminal::Clear",
       "ctrl-enter": "assistant::InlineAssist",
       // Some nice conveniences
       "cmd-backspace": ["terminal::SendText", "\u0015"],
@@ -732,7 +732,11 @@
       "cmd-end": "terminal::ScrollToBottom",
       "shift-home": "terminal::ScrollToTop",
       "shift-end": "terminal::ScrollToBottom",
-      "ctrl-shift-space": "terminal::ToggleViMode"
+      "ctrl-shift-space": "terminal::ToggleViMode",
+      "ctrl-k up": "pane::SplitUp",
+      "ctrl-k down": "pane::SplitDown",
+      "ctrl-k left": "pane::SplitLeft",
+      "ctrl-k right": "pane::SplitRight"
     }
   }
 ]

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -416,7 +416,6 @@ impl AssistantPanel {
                 ControlFlow::Break(())
             });
 
-            pane.set_can_split(false, cx);
             pane.set_can_navigate(true, cx);
             pane.display_nav_history_buttons(None);
             pane.set_should_display_tab_bar(|_| true);

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -47,7 +47,7 @@ use workspace::item::{BreadcrumbText, FollowEvent};
 use workspace::{
     item::{FollowableItem, Item, ItemEvent, ProjectItem},
     searchable::{Direction, SearchEvent, SearchableItem, SearchableItemHandle},
-    ItemId, ItemNavHistory, Pane, ToolbarItemLocation, ViewId, Workspace, WorkspaceId,
+    ItemId, ItemNavHistory, ToolbarItemLocation, ViewId, Workspace, WorkspaceId,
 };
 
 pub const MAX_TAB_TITLE_LEN: usize = 24;
@@ -954,7 +954,7 @@ impl SerializableItem for Editor {
         workspace: WeakView<Workspace>,
         workspace_id: workspace::WorkspaceId,
         item_id: ItemId,
-        cx: &mut ViewContext<Pane>,
+        cx: &mut WindowContext,
     ) -> Task<Result<View<Self>>> {
         let serialized_editor = match DB
             .get_serialized_editor(item_id, workspace_id)
@@ -989,7 +989,7 @@ impl SerializableItem for Editor {
                 contents: Some(contents),
                 language,
                 ..
-            } => cx.spawn(|pane, mut cx| {
+            } => cx.spawn(|mut cx| {
                 let project = project.clone();
                 async move {
                     let language = if let Some(language_name) = language {
@@ -1019,7 +1019,7 @@ impl SerializableItem for Editor {
                         buffer.set_text(contents, cx);
                     })?;
 
-                    pane.update(&mut cx, |_, cx| {
+                    cx.update(|cx| {
                         cx.new_view(|cx| {
                             let mut editor = Editor::for_buffer(buffer, Some(project), cx);
 
@@ -1046,7 +1046,7 @@ impl SerializableItem for Editor {
 
                 match project_item {
                     Some(project_item) => {
-                        cx.spawn(|pane, mut cx| async move {
+                        cx.spawn(|mut cx| async move {
                             let (_, project_item) = project_item.await?;
                             let buffer = project_item.downcast::<Buffer>().map_err(|_| {
                                 anyhow!("Project item at stored path was not a buffer")
@@ -1073,7 +1073,7 @@ impl SerializableItem for Editor {
                                 })?;
                             }
 
-                            pane.update(&mut cx, |_, cx| {
+                            cx.update(|cx| {
                                 cx.new_view(|cx| {
                                     let mut editor = Editor::for_buffer(buffer, Some(project), cx);
 
@@ -1087,7 +1087,7 @@ impl SerializableItem for Editor {
                         let open_by_abs_path = workspace.update(cx, |workspace, cx| {
                             workspace.open_abs_path(abs_path.clone(), false, cx)
                         });
-                        cx.spawn(|_, mut cx| async move {
+                        cx.spawn(|mut cx| async move {
                             let editor = open_by_abs_path?.await?.downcast::<Editor>().with_context(|| format!("Failed to downcast to Editor after opening abs path {abs_path:?}"))?;
                             editor.update(&mut cx, |editor, cx| {
                                 editor.read_scroll_position_from_db(item_id, workspace_id, cx);

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1578,7 +1578,7 @@ pub struct AnyDrag {
     pub view: AnyView,
 
     /// The value of the dragged item, to be dropped
-    pub value: Box<dyn Any>,
+    pub value: Arc<dyn Any>,
 
     /// This is used to render the dragged item in the same place
     /// on the original element that the drag was initiated

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -35,6 +35,7 @@ use std::{
     mem,
     ops::DerefMut,
     rc::Rc,
+    sync::Arc,
     time::Duration,
 };
 use taffy::style::Overflow;
@@ -61,6 +62,7 @@ pub struct DragMoveEvent<T> {
     /// The bounds of this element.
     pub bounds: Bounds<Pixels>,
     drag: PhantomData<T>,
+    dragged_item: Arc<dyn Any>,
 }
 
 impl<T: 'static> DragMoveEvent<T> {
@@ -70,6 +72,11 @@ impl<T: 'static> DragMoveEvent<T> {
             .as_ref()
             .and_then(|drag| drag.value.downcast_ref::<T>())
             .expect("DragMoveEvent is only valid when the stored active drag is of the same type.")
+    }
+
+    /// An item that is about to be dropped.
+    pub fn dragged_item(&self) -> &dyn Any {
+        self.dragged_item.as_ref()
     }
 }
 
@@ -243,20 +250,20 @@ impl Interactivity {
     {
         self.mouse_move_listeners
             .push(Box::new(move |event, phase, hitbox, cx| {
-                if phase == DispatchPhase::Capture
-                    && cx
-                        .active_drag
-                        .as_ref()
-                        .is_some_and(|drag| drag.value.as_ref().type_id() == TypeId::of::<T>())
-                {
-                    (listener)(
-                        &DragMoveEvent {
-                            event: event.clone(),
-                            bounds: hitbox.bounds,
-                            drag: PhantomData,
-                        },
-                        cx,
-                    );
+                if phase == DispatchPhase::Capture {
+                    if let Some(drag) = &cx.active_drag {
+                        if drag.value.as_ref().type_id() == TypeId::of::<T>() {
+                            (listener)(
+                                &DragMoveEvent {
+                                    event: event.clone(),
+                                    bounds: hitbox.bounds,
+                                    drag: PhantomData,
+                                    dragged_item: Arc::clone(&drag.value),
+                                },
+                                cx,
+                            );
+                        }
+                    }
                 }
             }));
     }
@@ -454,7 +461,7 @@ impl Interactivity {
             "calling on_drag more than once on the same element is not supported"
         );
         self.drag_listener = Some((
-            Box::new(value),
+            Arc::new(value),
             Box::new(move |value, offset, cx| {
                 constructor(value.downcast_ref().unwrap(), offset, cx).into()
             }),
@@ -1292,7 +1299,7 @@ pub struct Interactivity {
     pub(crate) drop_listeners: Vec<(TypeId, DropListener)>,
     pub(crate) can_drop_predicate: Option<CanDropPredicate>,
     pub(crate) click_listeners: Vec<ClickListener>,
-    pub(crate) drag_listener: Option<(Box<dyn Any>, DragListener)>,
+    pub(crate) drag_listener: Option<(Arc<dyn Any>, DragListener)>,
     pub(crate) hover_listener: Option<Box<dyn Fn(&bool, &mut WindowContext)>>,
     pub(crate) tooltip_builder: Option<TooltipBuilder>,
     pub(crate) occlude_mouse: bool,

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -385,20 +385,28 @@ impl LineLayoutCache {
         let mut previous_frame = &mut *self.previous_frame.lock();
         let mut current_frame = &mut *self.current_frame.write();
 
-        for key in &previous_frame.used_lines[range.start.lines_index..range.end.lines_index] {
-            if let Some((key, line)) = previous_frame.lines.remove_entry(key) {
-                current_frame.lines.insert(key, line);
+        if let Some(cached_keys) = previous_frame
+            .used_lines
+            .get(range.start.lines_index..range.end.lines_index)
+        {
+            for key in cached_keys {
+                if let Some((key, line)) = previous_frame.lines.remove_entry(key) {
+                    current_frame.lines.insert(key, line);
+                }
+                current_frame.used_lines.push(key.clone());
             }
-            current_frame.used_lines.push(key.clone());
         }
 
-        for key in &previous_frame.used_wrapped_lines
-            [range.start.wrapped_lines_index..range.end.wrapped_lines_index]
+        if let Some(cached_keys) = previous_frame
+            .used_wrapped_lines
+            .get(range.start.wrapped_lines_index..range.end.wrapped_lines_index)
         {
-            if let Some((key, line)) = previous_frame.wrapped_lines.remove_entry(key) {
-                current_frame.wrapped_lines.insert(key, line);
+            for key in cached_keys {
+                if let Some((key, line)) = previous_frame.wrapped_lines.remove_entry(key) {
+                    current_frame.wrapped_lines.insert(key, line);
+                }
+                current_frame.used_wrapped_lines.push(key.clone());
             }
-            current_frame.used_wrapped_lines.push(key.clone());
         }
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1752,12 +1752,18 @@ impl<'a> WindowContext<'a> {
                 .iter_mut()
                 .map(|listener| listener.take()),
         );
-        window.next_frame.accessed_element_states.extend(
-            window.rendered_frame.accessed_element_states[range.start.accessed_element_states_index
-                ..range.end.accessed_element_states_index]
-                .iter()
-                .map(|(id, type_id)| (GlobalElementId(id.0.clone()), *type_id)),
-        );
+        if let Some(element_states) = window
+            .rendered_frame
+            .accessed_element_states
+            .get(range.start.accessed_element_states_index..range.end.accessed_element_states_index)
+        {
+            window.next_frame.accessed_element_states.extend(
+                element_states
+                    .iter()
+                    .map(|(id, type_id)| (GlobalElementId(id.0.clone()), *type_id)),
+            );
+        }
+
         window
             .text_system
             .reuse_layouts(range.start.line_layout_index..range.end.line_layout_index);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3126,7 +3126,7 @@ impl<'a> WindowContext<'a> {
                     self.window.mouse_position = position;
                     if self.active_drag.is_none() {
                         self.active_drag = Some(AnyDrag {
-                            value: Box::new(paths.clone()),
+                            value: Arc::new(paths.clone()),
                             view: self.new_view(|_| paths).into(),
                             cursor_offset: position,
                         });

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -16,7 +16,7 @@ use settings::Settings;
 use util::paths::PathExt;
 use workspace::{
     item::{BreadcrumbText, Item, ProjectItem, SerializableItem, TabContentParams},
-    ItemId, ItemSettings, Pane, ToolbarItemLocation, Workspace, WorkspaceId,
+    ItemId, ItemSettings, ToolbarItemLocation, Workspace, WorkspaceId,
 };
 
 const IMAGE_VIEWER_KIND: &str = "ImageView";
@@ -172,9 +172,9 @@ impl SerializableItem for ImageView {
         _workspace: WeakView<Workspace>,
         workspace_id: WorkspaceId,
         item_id: ItemId,
-        cx: &mut ViewContext<Pane>,
+        cx: &mut WindowContext,
     ) -> Task<gpui::Result<View<Self>>> {
-        cx.spawn(|_pane, mut cx| async move {
+        cx.spawn(|mut cx| async move {
             let image_path = IMAGE_VIEWER
                 .get_image_path(item_id, workspace_id)?
                 .ok_or_else(|| anyhow::anyhow!("No image path found"))?;

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+async-recursion.workspace = true
 breadcrumbs.workspace = true
 collections.workspace = true
 db.workspace = true

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -1,14 +1,25 @@
 use anyhow::Result;
+use async_recursion::async_recursion;
 use collections::HashSet;
-use gpui::{Axis, View};
+use futures::{stream::FuturesUnordered, StreamExt as _};
+use gpui::{AsyncWindowContext, Axis, Model, Task, View, WeakView};
+use project::{terminals::TerminalKind, Project};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use ui::{Pixels, WindowContext};
+use ui::{Pixels, ViewContext, VisualContext as _, WindowContext};
+use util::ResultExt as _;
 
 use db::{define_connection, query, sqlez::statement::Statement, sqlez_macros::sql};
-use workspace::{ItemId, Member, Pane, PaneAxis, PaneGroup, WorkspaceDb, WorkspaceId};
+use workspace::{
+    ItemHandle, ItemId, Member, Pane, PaneAxis, PaneGroup, SerializableItem as _, Workspace,
+    WorkspaceDb, WorkspaceId,
+};
 
-use crate::TerminalView;
+use crate::{
+    default_working_directory,
+    terminal_panel::{new_terminal_pane, TerminalPanel},
+    TerminalView,
+};
 
 pub(crate) fn serialize_pane_group(
     pane_group: &PaneGroup,
@@ -37,15 +48,13 @@ fn build_serialized_pane_group(
                 .collect::<Vec<_>>(),
             flexes: Some(flexes.lock().clone()),
         },
-        Member::Pane(pane_handle) => SerializedPaneGroup::Pane(serialize_pane_handle(
-            pane_handle,
-            pane_handle == active_pane,
-            cx,
-        )),
+        Member::Pane(pane_handle) => {
+            SerializedPaneGroup::Pane(serialize_pane(pane_handle, pane_handle == active_pane, cx))
+        }
     }
 }
 
-fn serialize_pane_handle(pane: &View<Pane>, active: bool, cx: &WindowContext) -> SerializedPane {
+fn serialize_pane(pane: &View<Pane>, active: bool, cx: &WindowContext) -> SerializedPane {
     let mut items_to_serialize = HashSet::default();
     let pane = pane.read(cx);
     let children = pane
@@ -71,6 +80,210 @@ fn serialize_pane_handle(pane: &View<Pane>, active: bool, cx: &WindowContext) ->
         children,
         active_item,
     }
+}
+
+pub(crate) fn deserialize_terminal_panel(
+    workspace: WeakView<Workspace>,
+    project: Model<Project>,
+    database_id: WorkspaceId,
+    serialized_panel: SerializedTerminalPanel,
+    cx: &mut WindowContext,
+) -> Task<anyhow::Result<View<TerminalPanel>>> {
+    cx.spawn(move |mut cx| async move {
+        let terminal_panel = workspace.update(&mut cx, |workspace, cx| {
+            cx.new_view(|cx| {
+                let mut panel = TerminalPanel::new(workspace, cx);
+                panel.height = serialized_panel.height.map(|h| h.round());
+                panel.width = serialized_panel.width.map(|w| w.round());
+                panel
+            })
+        })?;
+        match &serialized_panel.items {
+            SerializedItems::NoSplits(item_ids) => {
+                let items = deserialize_terminal_views(
+                    database_id,
+                    project,
+                    workspace,
+                    item_ids.as_slice(),
+                    &mut cx,
+                )
+                .await;
+                let active_item = serialized_panel.active_item_id;
+                terminal_panel.update(&mut cx, |terminal_panel, cx| {
+                    terminal_panel.active_pane.update(cx, |pane, cx| {
+                        populate_pane_items(pane, items, active_item, cx);
+                    });
+                })?;
+            }
+            SerializedItems::WithSplits(serialized_pane_group) => {
+                let center_pane = deserialize_pane_group(
+                    workspace,
+                    project,
+                    terminal_panel.clone(),
+                    database_id,
+                    serialized_pane_group,
+                    &mut cx,
+                )
+                .await;
+                if let Some((center_group, active_pane)) = center_pane {
+                    terminal_panel.update(&mut cx, |terminal_panel, _| {
+                        terminal_panel.center = PaneGroup::with_root(center_group);
+                        if let Some(active_pane) = active_pane
+                            .or_else(|| terminal_panel.center.panes().first().map(|&p| p.clone()))
+                        {
+                            terminal_panel.active_pane = active_pane;
+                        }
+                    })?;
+                }
+            }
+        }
+
+        Ok(terminal_panel)
+    })
+}
+
+fn populate_pane_items(
+    pane: &mut Pane,
+    items: Vec<View<TerminalView>>,
+    active_item: Option<u64>,
+    cx: &mut ViewContext<'_, Pane>,
+) {
+    let mut item_index = pane.items_len();
+    for item in items {
+        let activate_item = Some(item.item_id().as_u64()) == active_item;
+        pane.add_item(Box::new(item), false, false, None, cx);
+        item_index += 1;
+        if activate_item {
+            pane.activate_item(item_index, false, false, cx);
+        }
+    }
+}
+
+#[async_recursion(?Send)]
+async fn deserialize_pane_group(
+    workspace: WeakView<Workspace>,
+    project: Model<Project>,
+    panel: View<TerminalPanel>,
+    workspace_id: WorkspaceId,
+    serialized: &SerializedPaneGroup,
+    cx: &mut AsyncWindowContext,
+) -> Option<(Member, Option<View<Pane>>)> {
+    match serialized {
+        SerializedPaneGroup::Group {
+            axis,
+            flexes,
+            children,
+        } => {
+            let mut current_active_pane = None;
+            let mut members = Vec::new();
+            for child in children {
+                if let Some((new_member, active_pane)) = deserialize_pane_group(
+                    workspace.clone(),
+                    project.clone(),
+                    panel.clone(),
+                    workspace_id,
+                    child,
+                    cx,
+                )
+                .await
+                {
+                    members.push(new_member);
+                    current_active_pane = current_active_pane.or(active_pane);
+                }
+            }
+
+            if members.is_empty() {
+                return None;
+            }
+
+            if members.len() == 1 {
+                return Some((members.remove(0), current_active_pane));
+            }
+
+            Some((
+                Member::Axis(PaneAxis::load(axis.0, members, flexes.clone())),
+                current_active_pane,
+            ))
+        }
+        SerializedPaneGroup::Pane(serialized_pane) => {
+            let pane = panel
+                .update(cx, |_, cx| {
+                    new_terminal_pane(workspace.clone(), project.clone(), cx).downgrade()
+                })
+                .log_err()?;
+            let active = serialized_pane.active;
+            let new_items = deserialize_terminal_views(
+                workspace_id,
+                project.clone(),
+                workspace.clone(),
+                serialized_pane.children.as_slice(),
+                cx,
+            )
+            .await;
+
+            let pane = pane.upgrade()?;
+            let active_item = serialized_pane.active_item;
+            pane.update(cx, |pane, cx| {
+                populate_pane_items(pane, new_items, active_item, cx);
+                // Avoid blank panes in splits
+                if pane.items_len() == 0 {
+                    let working_directory = workspace
+                        .update(cx, |workspace, cx| default_working_directory(workspace, cx))
+                        .ok()
+                        .flatten();
+                    let kind = TerminalKind::Shell(working_directory);
+                    let window = cx.window_handle();
+                    let terminal = project
+                        .update(cx, |project, cx| project.create_terminal(kind, window, cx))
+                        .log_err()?;
+                    let terminal_view = Box::new(cx.new_view(|cx| {
+                        TerminalView::new(
+                            terminal.clone(),
+                            workspace.clone(),
+                            Some(workspace_id),
+                            cx,
+                        )
+                    }));
+                    pane.add_item(terminal_view, true, false, None, cx);
+                }
+                Some(())
+            })
+            .ok()
+            .flatten()?;
+            Some((Member::Pane(pane.clone()), active.then_some(pane)))
+        }
+    }
+}
+
+async fn deserialize_terminal_views(
+    workspace_id: WorkspaceId,
+    project: Model<Project>,
+    workspace: WeakView<Workspace>,
+    item_ids: &[u64],
+    cx: &mut AsyncWindowContext,
+) -> Vec<View<TerminalView>> {
+    let mut items = Vec::with_capacity(item_ids.len());
+    let mut deserialized_items = item_ids
+        .iter()
+        .map(|item_id| {
+            cx.update(|cx| {
+                TerminalView::deserialize(
+                    project.clone(),
+                    workspace.clone(),
+                    workspace_id,
+                    *item_id,
+                    cx,
+                )
+            })
+            .unwrap_or_else(|e| Task::ready(Err(e.context("no window present"))))
+        })
+        .collect::<FuturesUnordered<_>>();
+    while let Some(item) = deserialized_items.next().await {
+        if let Some(item) = item.log_err() {
+            items.push(item);
+        }
+    }
+    items
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -30,7 +30,7 @@ use workspace::{
     item::SerializableItem,
     pane,
     ui::IconName,
-    DraggedTab, ItemId, NewTerminal, Pane, PaneGroup, ToggleZoom, Workspace,
+    DraggedTab, ItemId, NewTerminal, Pane, PaneGroup, SplitDirection, ToggleZoom, Workspace,
 };
 
 use anyhow::Result;
@@ -90,7 +90,6 @@ impl TerminalPanel {
             pane.display_nav_history_buttons(None);
             pane.set_should_display_tab_bar(|_| true);
 
-            let is_local = workspace.project().read(cx).is_local();
             let buffer_search_bar = cx.new_view(search::BufferSearchBar::new);
             pane.toolbar()
                 .update(cx, |toolbar, cx| toolbar.add_item(buffer_search_bar, cx));
@@ -101,8 +100,6 @@ impl TerminalPanel {
             cx.subscribe(&pane, Self::handle_pane_event),
         ];
         let center = PaneGroup::new(pane.clone());
-        // TODO kb this will not update the state of the panel
-        let closure_center = center.clone();
         let is_local = workspace.project().read(cx).is_local();
         let workspace_handle = workspace.weak_handle();
         pane.update(cx, |pane, cx| {
@@ -114,9 +111,11 @@ impl TerminalPanel {
                         tab.pane.read(cx).item_for_index(tab.ix)
                     };
                     if let Some(item) = item {
+                        // TODO kb need to "move" task terminals instead of splitting them + create new terminal in the old pane, if the task terminal was the last one
                         if item.downcast::<TerminalView>().is_some() {
-                            // TODO kb how to do self.center.split() here??
-                            // return ControlFlow::Continue(());
+                            cx.emit(pane::Event::Split(
+                                pane.drag_split_direction.unwrap_or(SplitDirection::Right),
+                            ));
                             return ControlFlow::Break(());
                         } else if let Some(project_path) = item.project_path(cx) {
                             if let Some(entry_path) = workspace_handle
@@ -363,7 +362,7 @@ impl TerminalPanel {
 
     fn handle_pane_event(
         &mut self,
-        _pane: View<Pane>,
+        pane: View<Pane>,
         event: &pane::Event,
         cx: &mut ViewContext<Self>,
     ) {
@@ -381,8 +380,68 @@ impl TerminalPanel {
                 }
             }
 
+            pane::Event::Split(direction) => {
+                let Some(new_pane) = self.add_pane(cx) else {
+                    return;
+                };
+                self.center.split(&pane, &new_pane, *direction).log_err();
+            }
+
             _ => {}
         }
+    }
+
+    fn add_pane(&mut self, cx: &mut ViewContext<Self>) -> Option<View<Pane>> {
+        let workspace = self.workspace.clone();
+        let (project, database_id, kind) = workspace
+            .update(cx, |workspace, cx| {
+                let kind = TerminalKind::Shell(default_working_directory(workspace, cx));
+                (workspace.project().clone(), workspace.database_id(), kind)
+            })
+            .ok()?;
+        // TODO kb reuse the old terminal's data (pwd, etc.)
+        let window = cx.window_handle();
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal(kind, window, cx))
+            .log_err()?;
+        // TODO kb deduplicate + store panes and new subscriptions somewhere
+        let pane = cx.new_view(|cx| {
+            let mut pane = Pane::new(
+                workspace.clone(),
+                project.clone(),
+                Default::default(),
+                None,
+                NewTerminal.boxed_clone(),
+                cx,
+            );
+            // TODO kb need to only allow splits for terminal tabs
+            // pane.set_can_split(false, cx);
+            pane.set_can_navigate(false, cx);
+            pane.display_nav_history_buttons(None);
+            pane.set_should_display_tab_bar(|_| true);
+
+            let buffer_search_bar = cx.new_view(search::BufferSearchBar::new);
+            pane.toolbar()
+                .update(cx, |toolbar, cx| toolbar.add_item(buffer_search_bar, cx));
+
+            let terminal_view = Box::new(cx.new_view(|cx| {
+                TerminalView::new(terminal.clone(), workspace.clone(), database_id, cx)
+            }));
+            pane.add_item(terminal_view, true, true, None, cx);
+
+            pane
+        });
+        cx.subscribe(&pane, Self::handle_pane_event).detach();
+        // TODO kb needed?
+        // self.panes.push(pane.clone());
+        cx.focus_view(&pane);
+        workspace
+            .update(cx, |_, cx| {
+                cx.emit(workspace::Event::PaneAdded(pane.clone()))
+            })
+            .ok()?;
+
+        Some(pane)
     }
 
     pub fn open_terminal(

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -346,7 +346,6 @@ impl TerminalPanel {
             TerminalView::new(terminal.clone(), self.workspace.clone(), database_id, cx)
         }));
         let pane = workspace.update(cx, |workspace, cx| new_terminal_pane(workspace, cx));
-        // TODO kb new panes have a blank space on top where the search buffer should be
         self.apply_tab_bar_buttons(&pane, cx);
         pane.update(cx, |pane, cx| {
             pane.add_item(terminal_view, true, true, None, cx);
@@ -757,8 +756,11 @@ fn new_terminal_pane(workspace: &Workspace, cx: &mut WindowContext) -> View<Pane
         })));
 
         let buffer_search_bar = cx.new_view(search::BufferSearchBar::new);
-        pane.toolbar()
-            .update(cx, |toolbar, cx| toolbar.add_item(buffer_search_bar, cx));
+        let breadcrumbs = cx.new_view(|_| Breadcrumbs::new());
+        pane.toolbar().update(cx, |toolbar, cx| {
+            toolbar.add_item(buffer_search_bar, cx);
+            toolbar.add_item(breadcrumbs, cx);
+        });
 
         pane.set_custom_drop_handle(cx, move |pane, dropped_item, cx| {
             if let Some(tab) = dropped_item.downcast_ref::<DraggedTab>() {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -46,7 +46,7 @@ pub fn init(cx: &mut AppContext) {
             // TODO kb new actions (which keybindings to use?? cmd-k is taken on macOS):
             // * ActivatePaneInDirection, ActivateNextPane, ActivatePreviousPane, ActivatePane,
             // * CloseAllItemsAndPanes, CloseInactiveTabsAndPanes, SwapPaneInDirection,
-            // * SwapItemLeft, SwapItemRight, SplitLeft, SplitUp, SplitRight, SplitDown, SplitHorizontal, SplitVertical,
+            // * SwapItemLeft, SwapItemRight
             workspace.register_action(TerminalPanel::new_terminal);
             workspace.register_action(TerminalPanel::open_terminal);
             workspace.register_action(|workspace, _: &ToggleFocus, cx| {
@@ -212,7 +212,6 @@ impl TerminalPanel {
                     panel.height = serialized_panel.height.map(|h| h.round());
                     panel.width = serialized_panel.width.map(|w| w.round());
                     // TODO kb (de)serialization of the center pane
-                    // TODO kb something panics, if I call cmd-p twice to split, on ond and then on the new pane
                     panel.active_pane.update(cx, |_, cx| {
                         serialized_panel
                             .items

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -618,6 +618,7 @@ impl TerminalPanel {
         })
     }
 
+    // TODO kb debounce
     fn serialize(&mut self, cx: &mut ViewContext<Self>) {
         let height = self.height;
         let width = self.width;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1,19 +1,18 @@
 use std::{cmp, ops::ControlFlow, path::PathBuf, sync::Arc};
 
-use crate::{default_working_directory, TerminalView};
+use crate::{default_working_directory, persistence::SerializedTerminalPanel, TerminalView};
 use breadcrumbs::Breadcrumbs;
 use collections::{HashMap, HashSet};
 use db::kvp::KEY_VALUE_STORE;
 use futures::future::join_all;
 use gpui::{
-    actions, Action, AnchorCorner, AnyView, AppContext, AsyncWindowContext, Entity, EventEmitter,
+    actions, Action, AnchorCorner, AnyView, AppContext, AsyncWindowContext, EventEmitter,
     ExternalPaths, FocusHandle, FocusableView, IntoElement, Model, ParentElement, Pixels, Render,
     Styled, Task, View, ViewContext, VisualContext, WeakView, WindowContext,
 };
 use itertools::Itertools;
 use project::{terminals::TerminalKind, Fs, Project, ProjectEntryId};
 use search::{buffer_search::DivRegistrar, BufferSearchBar};
-use serde::{Deserialize, Serialize};
 use settings::Settings;
 use task::{RevealStrategy, Shell, SpawnInTerminal, TaskId};
 use terminal::{
@@ -209,7 +208,6 @@ impl TerminalPanel {
                     cx.notify();
                     panel.height = serialized_panel.height.map(|h| h.round());
                     panel.width = serialized_panel.width.map(|w| w.round());
-                    // TODO kb (de)serialization of the center pane
                     panel.active_pane.update(cx, |_, cx| {
                         serialized_panel
                             .items
@@ -1160,14 +1158,6 @@ impl Render for InlineAssistTabBarButton {
                 Tooltip::for_action_in("Inline Assist", &InlineAssist::default(), &focus_handle, cx)
             })
     }
-}
-
-#[derive(Serialize, Deserialize)]
-struct SerializedTerminalPanel {
-    items: Vec<u64>,
-    active_item_id: Option<u64>,
-    width: Option<Pixels>,
-    height: Option<Pixels>,
 }
 
 fn retrieve_system_shell() -> Option<String> {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -210,7 +210,6 @@ impl TerminalPanel {
                     panel.height = serialized_panel.height.map(|h| h.round());
                     panel.width = serialized_panel.width.map(|w| w.round());
                     // TODO kb (de)serialization of the center pane
-                    // TODO kb proper macos bindings
                     panel.active_pane.update(cx, |_, cx| {
                         serialized_panel
                             .items

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -33,8 +33,8 @@ use workspace::{
     notifications::NotifyResultExt,
     register_serializable_item,
     searchable::{SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle},
-    CloseActiveItem, NewCenterTerminal, NewTerminal, OpenVisible, Pane, ToolbarItemLocation,
-    Workspace, WorkspaceId,
+    CloseActiveItem, NewCenterTerminal, NewTerminal, OpenVisible, ToolbarItemLocation, Workspace,
+    WorkspaceId,
 };
 
 use anyhow::Context;
@@ -1222,10 +1222,10 @@ impl SerializableItem for TerminalView {
         workspace: WeakView<Workspace>,
         workspace_id: workspace::WorkspaceId,
         item_id: workspace::ItemId,
-        cx: &mut ViewContext<Pane>,
+        cx: &mut WindowContext,
     ) -> Task<anyhow::Result<View<Self>>> {
         let window = cx.window_handle();
-        cx.spawn(|pane, mut cx| async move {
+        cx.spawn(|mut cx| async move {
             let cwd = cx
                 .update(|cx| {
                     let from_db = TERMINAL_DB
@@ -1249,7 +1249,7 @@ impl SerializableItem for TerminalView {
             let terminal = project.update(&mut cx, |project, cx| {
                 project.create_terminal(TerminalKind::Shell(cwd), window, cx)
             })??;
-            pane.update(&mut cx, |_, cx| {
+            cx.update(|cx| {
                 cx.new_view(|cx| TerminalView::new(terminal, workspace, Some(workspace_id), cx))
             })
         })

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -315,7 +315,7 @@ pub trait SerializableItem: Item {
         _workspace: WeakView<Workspace>,
         _workspace_id: WorkspaceId,
         _item_id: ItemId,
-        _cx: &mut ViewContext<Pane>,
+        _cx: &mut WindowContext,
     ) -> Task<Result<View<Self>>>;
 
     fn serialize(
@@ -1032,7 +1032,7 @@ impl<T: FollowableItem> WeakFollowableItemHandle for WeakView<T> {
 #[cfg(any(test, feature = "test-support"))]
 pub mod test {
     use super::{Item, ItemEvent, SerializableItem, TabContentParams};
-    use crate::{ItemId, ItemNavHistory, Pane, Workspace, WorkspaceId};
+    use crate::{ItemId, ItemNavHistory, Workspace, WorkspaceId};
     use gpui::{
         AnyElement, AppContext, Context as _, EntityId, EventEmitter, FocusableView,
         InteractiveElement, IntoElement, Model, Render, SharedString, Task, View, ViewContext,
@@ -1040,6 +1040,7 @@ pub mod test {
     };
     use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
     use std::{any::Any, cell::Cell, path::Path};
+    use ui::WindowContext;
 
     pub struct TestProjectItem {
         pub entry_id: Option<ProjectEntryId>,
@@ -1339,7 +1340,7 @@ pub mod test {
             _workspace: WeakView<Workspace>,
             workspace_id: WorkspaceId,
             _item_id: ItemId,
-            cx: &mut ViewContext<Pane>,
+            cx: &mut WindowContext,
         ) -> Task<anyhow::Result<View<Self>>> {
             let view = cx.new_view(|cx| Self::new_deserialized(workspace_id, cx));
             Task::ready(Ok(view))

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -287,8 +287,7 @@ pub struct Pane {
     toolbar: View<Toolbar>,
     pub(crate) workspace: WeakView<Workspace>,
     project: Model<Project>,
-    // TODO kb revert?
-    pub drag_split_direction: Option<SplitDirection>,
+    drag_split_direction: Option<SplitDirection>,
     can_drop_predicate: Option<Arc<dyn Fn(&dyn Any, &mut WindowContext) -> bool>>,
     custom_drop_handle:
         Option<Arc<dyn Fn(&mut Pane, &dyn Any, &mut ViewContext<Pane>) -> ControlFlow<(), ()>>>,
@@ -2693,6 +2692,10 @@ impl Pane {
                 }
             })
             .collect()
+    }
+
+    pub fn drag_split_direction(&self) -> Option<SplitDirection> {
+        self.drag_split_direction
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -287,7 +287,8 @@ pub struct Pane {
     toolbar: View<Toolbar>,
     pub(crate) workspace: WeakView<Workspace>,
     project: Model<Project>,
-    drag_split_direction: Option<SplitDirection>,
+    // TODO kb revert?
+    pub drag_split_direction: Option<SplitDirection>,
     can_drop_predicate: Option<Arc<dyn Fn(&dyn Any, &mut WindowContext) -> bool>>,
     custom_drop_handle:
         Option<Arc<dyn Fn(&mut Pane, &dyn Any, &mut ViewContext<Pane>) -> ControlFlow<(), ()>>>,

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -150,7 +150,7 @@ impl PaneGroup {
         panes
     }
 
-    pub(crate) fn first_pane(&self) -> View<Pane> {
+    pub fn first_pane(&self) -> View<Pane> {
         self.root.first_pane()
     }
 
@@ -187,7 +187,7 @@ impl PaneGroup {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Member {
     Axis(PaneAxis),
     Pane(View<Pane>),
@@ -391,7 +391,7 @@ impl Member {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PaneAxis {
     pub axis: Axis,
     pub members: Vec<Member>,

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -31,7 +31,7 @@ pub struct PaneGroup {
 }
 
 impl PaneGroup {
-    pub(crate) fn with_root(root: Member) -> Self {
+    pub fn with_root(root: Member) -> Self {
         Self { root }
     }
 

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -122,7 +122,7 @@ impl PaneGroup {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn render(
+    pub fn render(
         &self,
         project: &Model<Project>,
         follower_states: &HashMap<PeerId, FollowerState>,

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -144,7 +144,7 @@ impl PaneGroup {
         )
     }
 
-    pub(crate) fn panes(&self) -> Vec<&View<Pane>> {
+    pub fn panes(&self) -> Vec<&View<Pane>> {
         let mut panes = Vec::new();
         self.root.collect_panes(&mut panes);
         panes

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -153,6 +153,38 @@ impl PaneGroup {
     pub(crate) fn first_pane(&self) -> View<Pane> {
         self.root.first_pane()
     }
+
+    pub fn find_pane_in_direction(
+        &mut self,
+        active_pane: &View<Pane>,
+        direction: SplitDirection,
+        cx: &WindowContext,
+    ) -> Option<&View<Pane>> {
+        let bounding_box = self.bounding_box_for_pane(active_pane)?;
+        let cursor = active_pane.read(cx).pixel_position_of_cursor(cx);
+        let center = match cursor {
+            Some(cursor) if bounding_box.contains(&cursor) => cursor,
+            _ => bounding_box.center(),
+        };
+
+        let distance_to_next = crate::HANDLE_HITBOX_SIZE;
+
+        let target = match direction {
+            SplitDirection::Left => {
+                Point::new(bounding_box.left() - distance_to_next.into(), center.y)
+            }
+            SplitDirection::Right => {
+                Point::new(bounding_box.right() + distance_to_next.into(), center.y)
+            }
+            SplitDirection::Up => {
+                Point::new(center.x, bounding_box.top() - distance_to_next.into())
+            }
+            SplitDirection::Down => {
+                Point::new(center.x, bounding_box.bottom() + distance_to_next.into())
+            }
+        };
+        self.pane_at_pixel_position(target)
+    }
 }
 
 #[derive(Clone)]

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -27,7 +27,7 @@ const VERTICAL_MIN_SIZE: f32 = 100.;
 /// Single-pane group is a regular pane.
 #[derive(Clone)]
 pub struct PaneGroup {
-    pub(crate) root: Member,
+    pub root: Member,
 }
 
 impl PaneGroup {
@@ -188,7 +188,7 @@ impl PaneGroup {
 }
 
 #[derive(Clone)]
-pub(crate) enum Member {
+pub enum Member {
     Axis(PaneAxis),
     Pane(View<Pane>),
 }
@@ -392,7 +392,7 @@ impl Member {
 }
 
 #[derive(Clone)]
-pub(crate) struct PaneAxis {
+pub struct PaneAxis {
     pub axis: Axis,
     pub members: Vec<Member>,
     pub flexes: Arc<Mutex<Vec<f32>>>,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -729,7 +729,8 @@ type PromptForOpenPath = Box<
 pub struct Workspace {
     weak_self: WeakView<Self>,
     workspace_actions: Vec<Box<dyn Fn(Div, &mut ViewContext<Self>) -> Div>>,
-    zoomed: Option<AnyWeakView>,
+    // TODO kb revert
+    pub zoomed: Option<AnyWeakView>,
     zoomed_position: Option<DockPosition>,
     center: PaneGroup,
     left_dock: View<Dock>,
@@ -777,7 +778,7 @@ pub struct ViewId {
     pub id: u64,
 }
 
-struct FollowerState {
+pub struct FollowerState {
     center_pane: View<Pane>,
     dock_pane: Option<View<Pane>>,
     active_view_id: Option<ViewId>,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -888,14 +888,16 @@ impl Workspace {
         let pane_history_timestamp = Arc::new(AtomicUsize::new(0));
 
         let center_pane = cx.new_view(|cx| {
-            Pane::new(
+            let mut center_pane = Pane::new(
                 weak_handle.clone(),
                 project.clone(),
                 pane_history_timestamp.clone(),
                 None,
                 NewFile.boxed_clone(),
                 cx,
-            )
+            );
+            center_pane.set_can_split(Some(Arc::new(|_, _, _| true)));
+            center_pane
         });
         cx.subscribe(&center_pane, Self::handle_pane_event).detach();
 
@@ -2465,14 +2467,16 @@ impl Workspace {
 
     fn add_pane(&mut self, cx: &mut ViewContext<Self>) -> View<Pane> {
         let pane = cx.new_view(|cx| {
-            Pane::new(
+            let mut pane = Pane::new(
                 self.weak_handle(),
                 self.project.clone(),
                 self.pane_history_timestamp.clone(),
                 None,
                 NewFile.boxed_clone(),
                 cx,
-            )
+            );
+            pane.set_can_split(Some(Arc::new(|_, _, _| true)));
+            pane
         });
         cx.subscribe(&pane, Self::handle_pane_event).detach();
         self.panes.push(pane.clone());

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6126,6 +6126,7 @@ fn join_pane_into_active(active_pane: &View<Pane>, pane: &View<Pane>, cx: &mut W
         return;
     } else if pane.read(cx).items_len() == 0 {
         pane.update(cx, |_, cx| {
+            dbg!("????");
             cx.emit(pane::Event::Remove {
                 focus_on_pane: None,
             });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6126,7 +6126,6 @@ fn join_pane_into_active(active_pane: &View<Pane>, pane: &View<Pane>, cx: &mut W
         return;
     } else if pane.read(cx).items_len() == 0 {
         pane.update(cx, |_, cx| {
-            dbg!("????");
             cx.emit(pane::Event::Remove {
                 focus_on_pane: None,
             });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2959,30 +2959,9 @@ impl Workspace {
         direction: SplitDirection,
         cx: &WindowContext,
     ) -> Option<View<Pane>> {
-        let bounding_box = self.center.bounding_box_for_pane(&self.active_pane)?;
-        let cursor = self.active_pane.read(cx).pixel_position_of_cursor(cx);
-        let center = match cursor {
-            Some(cursor) if bounding_box.contains(&cursor) => cursor,
-            _ => bounding_box.center(),
-        };
-
-        let distance_to_next = pane_group::HANDLE_HITBOX_SIZE;
-
-        let target = match direction {
-            SplitDirection::Left => {
-                Point::new(bounding_box.left() - distance_to_next.into(), center.y)
-            }
-            SplitDirection::Right => {
-                Point::new(bounding_box.right() + distance_to_next.into(), center.y)
-            }
-            SplitDirection::Up => {
-                Point::new(center.x, bounding_box.top() - distance_to_next.into())
-            }
-            SplitDirection::Down => {
-                Point::new(center.x, bounding_box.bottom() + distance_to_next.into())
-            }
-        };
-        self.center.pane_at_pixel_position(target).cloned()
+        self.center
+            .find_pane_in_direction(&self.active_pane, direction, cx)
+            .cloned()
     }
 
     pub fn swap_pane_in_direction(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -729,8 +729,7 @@ type PromptForOpenPath = Box<
 pub struct Workspace {
     weak_self: WeakView<Self>,
     workspace_actions: Vec<Box<dyn Fn(Div, &mut ViewContext<Self>) -> Div>>,
-    // TODO kb revert
-    pub zoomed: Option<AnyWeakView>,
+    zoomed: Option<AnyWeakView>,
     zoomed_position: Option<DockPosition>,
     center: PaneGroup,
     left_dock: View<Dock>,
@@ -4595,6 +4594,10 @@ impl Workspace {
     pub fn for_window(cx: &mut WindowContext) -> Option<View<Workspace>> {
         let window = cx.window_handle().downcast::<Workspace>()?;
         cx.read_window(&window, |workspace, _| workspace).ok()
+    }
+
+    pub fn zoomed_item(&self) -> Option<&AnyWeakView> {
+        self.zoomed.as_ref()
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/4351

![it_splits](https://github.com/user-attachments/assets/40de03c9-2173-4441-ba96-8e91537956e0)

Applies the same splitting mechanism, as Zed's central pane has, to the terminal panel.
Similar navigation, splitting and (de)serialization capabilities are supported.

Notable caveats:
* zooming keeps the terminal splits' ratio, rather expanding the terminal pane
* on macOs, central panel is split with `cmd-k up/down/etc.` but `cmd-k` is a "standard" terminal clearing keybinding on macOS, so terminal panel splitting is done via `ctrl-k up/down/etc.`
* task terminals are "split" into regular terminals, and also not persisted (same as currently in the terminal)

Seems ok for the initial version, we can revisit and polish things later.

Release Notes:

- Added the ability to split the terminal panel

