### PR TITLE
Make Markdown images layout vertically instead of horizontally

### DIFF
--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -417,6 +417,7 @@ fn render_markdown_paragraph(parsed: &MarkdownParagraph, cx: &mut RenderContext)
     cx.with_common_p(div())
         .children(render_markdown_text(parsed, cx))
         .flex()
+        .flex_col()
         .into_any_element()
 }
 


### PR DESCRIPTION
Release Notes:

- Fixed a bug in the Markdown preview where images in the same paragraph would be rendered next to each other