### PR TITLE
Add a split button to terminal panes

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -36,8 +36,8 @@ use workspace::{
     move_item, pane,
     ui::IconName,
     ActivateNextPane, ActivatePane, ActivatePaneInDirection, ActivatePreviousPane, DraggedTab,
-    ItemId, NewTerminal, Pane, PaneGroup, SplitDirection, SwapPaneInDirection, ToggleZoom,
-    Workspace,
+    ItemId, NewTerminal, Pane, PaneGroup, SplitDirection, SplitDown, SplitLeft, SplitRight,
+    SplitUp, SwapPaneInDirection, ToggleZoom, Workspace,
 };
 
 use anyhow::Result;
@@ -164,6 +164,25 @@ impl TerminalPanel {
                                 });
 
                                 Some(menu)
+                            }),
+                    )
+                    .child(
+                        PopoverMenu::new("terminal-pane-tab-bar-split")
+                            .trigger(
+                                IconButton::new("terminal-pane-split", IconName::Split)
+                                    .icon_size(IconSize::Small)
+                                    .tooltip(|cx| Tooltip::text("Split Pane", cx)),
+                            )
+                            .anchor(AnchorCorner::TopRight)
+                            .with_handle(pane.split_item_context_menu_handle.clone())
+                            .menu(move |cx| {
+                                ContextMenu::build(cx, |menu, _| {
+                                    menu.action("Split Right", SplitRight.boxed_clone())
+                                        .action("Split Left", SplitLeft.boxed_clone())
+                                        .action("Split Up", SplitUp.boxed_clone())
+                                        .action("Split Down", SplitDown.boxed_clone())
+                                })
+                                .into()
                             }),
                     )
                     .child({

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -303,7 +303,7 @@ pub struct Pane {
     double_click_dispatch_action: Box<dyn Action>,
     save_modals_spawned: HashSet<EntityId>,
     pub new_item_context_menu_handle: PopoverMenuHandle<ContextMenu>,
-    split_item_context_menu_handle: PopoverMenuHandle<ContextMenu>,
+    pub split_item_context_menu_handle: PopoverMenuHandle<ContextMenu>,
     pinned_tab_count: usize,
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/21238

<img width="873" alt="image" src="https://github.com/user-attachments/assets/8cf2d8ea-a1df-4a6a-95d6-5867e0ee287d">

Release Notes:

- N/A
