### PR TITLE
Update to embed-resource 3.0 (fixes build below windows \?\ path)

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -119,7 +119,7 @@ http_client = { workspace = true, features = ["test-support"] }
 unicode-segmentation.workspace = true
 
 [build-dependencies]
-embed-resource = "2.4"
+embed-resource = "3.0"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 bindgen = "0.70.0"

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -18,7 +18,9 @@ fn main() {
             let rc_file = std::path::Path::new("resources/windows/gpui.rc");
             println!("cargo:rerun-if-changed={}", manifest.display());
             println!("cargo:rerun-if-changed={}", rc_file.display());
-            embed_resource::compile(rc_file, embed_resource::NONE);
+            embed_resource::compile(rc_file, embed_resource::NONE)
+                .manifest_required()
+                .unwrap();
         }
         _ => (),
     };


### PR DESCRIPTION
Accd'g to https://github.com/zed-industries/zed/pull/9009#issuecomment-1983599232 the manifest is required

Followup for https://github.com/nabijaczleweli/rust-embed-resource/issues/71

Release Notes:
- N/A