### PR TITLE
nix: Return to building with crane

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-watch_file nix/shell.nix
-use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.direnv
+.envrc
 .idea
 **/target
 **/cargo-target

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1732407143,
+        "narHash": "sha256-qJOGDT6PACoX+GbNH2PPx2ievlmtT1NVeTB80EkRLys=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "f2b4b472983817021d9ffb60838b2b36b9376b20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "locked": {
         "lastModified": 1696426674,
@@ -33,6 +48,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,17 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    crane.url = "github:ipetkov/crane";
     flake-compat.url = "github:edolstra/flake-compat";
   };
 
   outputs =
-    { nixpkgs, rust-overlay, ... }:
+    {
+      nixpkgs,
+      rust-overlay,
+      crane,
+      ...
+    }:
     let
       systems = [
         "x86_64-linux"
@@ -27,10 +33,8 @@
         };
         zed-editor = final: prev: {
           zed-editor = final.callPackage ./nix/build.nix {
-            rustPlatform = final.makeRustPlatform {
-              cargo = final.rustToolchain;
-              rustc = final.rustToolchain;
-            };
+            crane = crane.mkLib final;
+            rustToolchain = final.rustToolchain;
           };
         };
       };

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,6 +1,7 @@
 {
   lib,
-  rustPlatform,
+  crane,
+  rustToolchain,
   fetchpatch,
   clang,
   cmake,
@@ -26,7 +27,6 @@
   vulkan-loader,
   envsubst,
   cargo-about,
-  versionCheckHook,
   cargo-bundle,
   git,
   apple-sdk_15,
@@ -50,207 +50,199 @@ let
     in
     !(
       inRootDir
-      && (
-        baseName == "docs"
-        || baseName == ".github"
-        || baseName == "script"
-        || baseName == ".git"
-        || baseName == "target"
-      )
+      && (baseName == "docs" || baseName == ".github" || baseName == ".git" || baseName == "target")
     );
-in
-rustPlatform.buildRustPackage rec {
-  pname = "zed-editor";
-  version = "nightly";
-
-  src = lib.cleanSourceWith {
+  craneLib = crane.overrideToolchain rustToolchain;
+  commonSrc = lib.cleanSourceWith {
     src = nix-gitignore.gitignoreSource [ ] ../.;
     filter = includeFilter;
     name = "source";
   };
+  commonArgs = rec {
+    pname = "zed-editor";
+    version = "nightly";
 
-  patches =
-    [
-      # Zed uses cargo-install to install cargo-about during the script execution.
-      # We provide cargo-about ourselves and can skip this step.
-      # Until https://github.com/zed-industries/zed/issues/19971 is fixed,
-      # we also skip any crate for which the license cannot be determined.
-      (fetchpatch {
-        url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fd02d90c6c097f91349df35da62d36c19359ba7/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch";
-        hash = "sha256-cLgqLDXW1JtQ2OQFLd5UolAjfy7bMoTw40lEx2jA2pk=";
-      })
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Livekit requires Swift 6
-      # We need this until livekit-rust sdk is used
-      (fetchpatch {
-        url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fd02d90c6c097f91349df35da62d36c19359ba7/pkgs/by-name/ze/zed-editor/0002-disable-livekit-darwin.patch";
-        hash = "sha256-whZ7RaXv8hrVzWAveU3qiBnZSrvGNEHTuyNhxgMIo5w=";
-      })
-    ];
+    src = commonSrc;
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-KURM1W9UP65BU9gbvEBgQj3jwSYfQT7X18gcSmOMguI=";
+    nativeBuildInputs =
+      [
+        clang
+        cmake
+        copyDesktopItems
+        curl
+        perl
+        pkg-config
+        protobuf
+        cargo-about
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ cargo-bundle ];
 
-  nativeBuildInputs =
-    [
-      clang
-      cmake
-      copyDesktopItems
-      curl
-      perl
-      pkg-config
-      protobuf
-      rustPlatform.bindgenHook
-      cargo-about
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cargo-bundle ];
-
-  dontUseCmakeConfigure = true;
-
-  buildInputs =
-    [
-      curl
-      fontconfig
-      freetype
-      libgit2
-      openssl
-      sqlite
-      zlib
-      zstd
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      alsa-lib
-      libxkbcommon
-      wayland
-      xorg.libxcb
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      apple-sdk_15
-      (darwinMinVersionHook "10.15")
-    ];
-
-  cargoBuildFlags = [
-    "--package=zed"
-    "--package=cli"
-  ];
-
-  buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
-
-  env = {
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-    FONTCONFIG_FILE = makeFontsConf {
-      fontDirectories = [
-        "${src}/assets/fonts/plex-mono"
-        "${src}/assets/fonts/plex-sans"
+    buildInputs =
+      [
+        curl
+        fontconfig
+        freetype
+        libgit2
+        openssl
+        sqlite
+        zlib
+        zstd
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        alsa-lib
+        libxkbcommon
+        wayland
+        xorg.libxcb
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        apple-sdk_15
+        (darwinMinVersionHook "10.15")
       ];
+
+    env = {
+      ZSTD_SYS_USE_PKG_CONFIG = true;
+      FONTCONFIG_FILE = makeFontsConf {
+        fontDirectories = [
+          "${src}/assets/fonts/plex-mono"
+          "${src}/assets/fonts/plex-sans"
+        ];
+      };
+      ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
+      RELEASE_VERSION = version;
     };
-    ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
-    RELEASE_VERSION = version;
   };
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+in
+craneLib.buildPackage (
+  commonArgs
+  // rec {
+    inherit cargoArtifacts;
 
-  RUSTFLAGS = if withGLES then "--cfg gles" else "";
-  gpu-lib = if withGLES then libglvnd else vulkan-loader;
+    patches =
+      [
+        # Zed uses cargo-install to install cargo-about during the script execution.
+        # We provide cargo-about ourselves and can skip this step.
+        # Until https://github.com/zed-industries/zed/issues/19971 is fixed,
+        # we also skip any crate for which the license cannot be determined.
+        (fetchpatch {
+          url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fd02d90c6c097f91349df35da62d36c19359ba7/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch";
+          hash = "sha256-cLgqLDXW1JtQ2OQFLd5UolAjfy7bMoTw40lEx2jA2pk=";
+        })
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        # Livekit requires Swift 6
+        # We need this until livekit-rust sdk is used
+        (fetchpatch {
+          url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fd02d90c6c097f91349df35da62d36c19359ba7/pkgs/by-name/ze/zed-editor/0002-disable-livekit-darwin.patch";
+          hash = "sha256-whZ7RaXv8hrVzWAveU3qiBnZSrvGNEHTuyNhxgMIo5w=";
+        })
+      ];
 
-  preBuild = ''
-    bash script/generate-licenses
-  '';
+    cargoExtraArgs = "--package=zed --package=cli --features=gpui/runtime_shaders";
 
-  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*
-    patchelf --add-rpath ${wayland}/lib $out/libexec/*
-    wrapProgram $out/libexec/zed-editor --suffix PATH : ${lib.makeBinPath [ nodejs_22 ]}
-  '';
+    dontUseCmakeConfigure = true;
+    preBuild = ''
+      bash script/generate-licenses
+    '';
 
-  preCheck = ''
-    export HOME=$(mktemp -d);
-  '';
+    postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*
+      patchelf --add-rpath ${wayland}/lib $out/libexec/*
+      wrapProgram $out/libexec/zed-editor --suffix PATH : ${lib.makeBinPath [ nodejs_22 ]}
+    '';
 
-  checkFlags =
-    [
-      # Flaky: unreliably fails on certain hosts (including Hydra)
-      "--skip=zed::tests::test_window_edit_state_restoring_enabled"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      # Fails on certain hosts (including Hydra) for unclear reason
-      "--skip=test_open_paths_action"
-    ];
+    RUSTFLAGS = if withGLES then "--cfg gles" else "";
+    gpu-lib = if withGLES then libglvnd else vulkan-loader;
 
-  installPhase =
-    if stdenv.hostPlatform.isDarwin then
-      ''
-        runHook preInstall
+    preCheck = ''
+      export HOME=$(mktemp -d);
+    '';
 
-        # cargo-bundle expects the binary in target/release
-        mv target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/zed target/release/zed
+    cargoTestExtraArgs =
+      "-- "
+      + lib.concatStringsSep " " (
+        [
+          # Flaky: unreliably fails on certain hosts (including Hydra)
+          "--skip=zed::tests::test_window_edit_state_restoring_enabled"
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [
+          # Fails on certain hosts (including Hydra) for unclear reason
+          "--skip=test_open_paths_action"
+        ]
+      );
 
-        pushd crates/zed
+    installPhase =
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          runHook preInstall
 
-        # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
-        sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
-        export CARGO_BUNDLE_SKIP_BUILD=true
-        app_path=$(cargo bundle --release | xargs)
+          # cargo-bundle expects the binary in target/release
+          mv target/release/zed target/release/zed
 
-        # We're not using the fork of cargo-bundle, so we must manually append plist extensions
-        # Remove closing tags from Info.plist (last two lines)
-        head -n -2 $app_path/Contents/Info.plist > Info.plist
-        # Append extensions
-        cat resources/info/*.plist >> Info.plist
-        # Add closing tags
-        printf "</dict>\n</plist>\n" >> Info.plist
-        mv Info.plist $app_path/Contents/Info.plist
+          pushd crates/zed
 
-        popd
+          # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
+          sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
+          export CARGO_BUNDLE_SKIP_BUILD=true
+          app_path=$(cargo bundle --release | xargs)
 
-        mkdir -p $out/Applications $out/bin
-        # Zed expects git next to its own binary
-        ln -s ${git}/bin/git $app_path/Contents/MacOS/git
-        mv target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cli $app_path/Contents/MacOS/cli
-        mv $app_path $out/Applications/
+          # We're not using the fork of cargo-bundle, so we must manually append plist extensions
+          # Remove closing tags from Info.plist (last two lines)
+          head -n -2 $app_path/Contents/Info.plist > Info.plist
+          # Append extensions
+          cat resources/info/*.plist >> Info.plist
+          # Add closing tags
+          printf "</dict>\n</plist>\n" >> Info.plist
+          mv Info.plist $app_path/Contents/Info.plist
 
-        # Physical location of the CLI must be inside the app bundle as this is used
-        # to determine which app to start
-        ln -s $out/Applications/Zed.app/Contents/MacOS/cli $out/bin/zed
+          popd
 
-        runHook postInstall
-      ''
-    else
-      ''
-        runHook preInstall
+          mkdir -p $out/Applications $out/bin
+          # Zed expects git next to its own binary
+          ln -s ${git}/bin/git $app_path/Contents/MacOS/git
+          mv target/release/cli $app_path/Contents/MacOS/cli
+          mv $app_path $out/Applications/
 
-        mkdir -p $out/bin $out/libexec
-        cp target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/zed $out/libexec/zed-editor
-        cp target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cli $out/bin/zed
+          # Physical location of the CLI must be inside the app bundle as this is used
+          # to determine which app to start
+          ln -s $out/Applications/Zed.app/Contents/MacOS/cli $out/bin/zed
 
-        install -D ${src}/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
-        install -D ${src}/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
+          runHook postInstall
+        ''
+      else
+        ''
+          runHook preInstall
 
-        # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
-        # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
-        (
-          export DO_STARTUP_NOTIFY="true"
-          export APP_CLI="zed"
-          export APP_ICON="zed"
-          export APP_NAME="Zed"
-          export APP_ARGS="%U"
-          mkdir -p "$out/share/applications"
-          ${lib.getExe envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
-        )
+          mkdir -p $out/bin $out/libexec
+          cp target/release/zed $out/libexec/zed-editor
+          cp target/release/cli $out/bin/zed
 
-        runHook postInstall
-      '';
+          install -D ${commonSrc}/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
+          install -D ${commonSrc}/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+          # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
+          # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
+          (
+            export DO_STARTUP_NOTIFY="true"
+            export APP_CLI="zed"
+            export APP_ICON="zed"
+            export APP_NAME="Zed"
+            export APP_ARGS="%U"
+            mkdir -p "$out/share/applications"
+            ${lib.getExe envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
+          )
 
-  meta = {
-    description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
-    homepage = "https://zed.dev";
-    changelog = "https://zed.dev/releases/preview";
-    license = lib.licenses.gpl3Only;
-    mainProgram = "zed";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-  };
-}
+          runHook postInstall
+        '';
+
+    meta = {
+      description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
+      homepage = "https://zed.dev";
+      changelog = "https://zed.dev/releases/preview";
+      license = lib.licenses.gpl3Only;
+      mainProgram = "zed";
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
+  }
+)


### PR DESCRIPTION
This removes .envrc, putting it into gitignore as well as building with crane, as it does not require an up to date hash for a FOD. 

Release Notes:

- N/A

cc @mrnugget @jaredramirez