### PR TITLE
Add .prettierignore support

### DIFF
--- a/crates/prettier/src/prettier_server.js
+++ b/crates/prettier/src/prettier_server.js
@@ -49,7 +49,7 @@ class Prettier {
     )}\n`,
   );
   process.stdin.resume();
-  handleBuffer(new Prettier(prettierPath, prettier, config, null));
+  handleBuffer(new Prettier(prettierPath, prettier, config));
 })();
 
 async function handleBuffer(prettier) {


### PR DESCRIPTION
Closes #11115

**Context**:

Consider a monorepo setup like this: the root has Prettier installed, but the individual monorepos do not. In this case, only one Prettier instance is used, with its installation located at the root. The monorepos also use this same instance for formatting.

However, monorepo can have its own `.prettierignore` file, which will take precedence over the `.prettierignore` file at the root level (if one exists) for files in that monorepo. 

<img src="https://github.com/user-attachments/assets/742f16ac-11ad-4d2f-a5a2-696e47a617b9" alt="prettier" width="200px" />

**Implementation**:

From the context above, we should keep ignore dir decoupled from the Prettier instance. This means that even if the project has only one Prettier installation (and thus a single Prettier instance), there can still be multiple `.prettierignore` in play.

This approach also allows us to respect `.prettierignore` even when the project does not have Prettier installed locally and instead relies on the editor’s Prettier instance.

**Tests**:

1. No Prettier in project, using editor Prettier: Ensures `.prettierignore` is respected even without a local Prettier installation.
2. Monorepo with root Prettier and child `.prettierignore`: Confirms that the child project’s ignore file is correctly used.
3. Monorepo with root and child `.prettierignore` files: Verifies the child ignore file takes precedence over the root’s.

Release Notes:

- Added `.prettierignore` support to the Prettier integration.
