### PR TITLE
Add keybinding to the language selector tooltip

### DIFF
--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -6,6 +6,8 @@ use workspace::{item::ItemHandle, StatusItemView, Workspace};
 
 use crate::LanguageSelector;
 
+gpui::actions!(language_selector, [Toggle]);
+
 pub struct ActiveBufferLanguage {
     active_language: Option<Option<LanguageName>>,
     workspace: WeakView<Workspace>,
@@ -54,7 +56,7 @@ impl Render for ActiveBufferLanguage {
                             });
                         }
                     }))
-                    .tooltip(|cx| Tooltip::text("Select Language", cx)),
+                    .tooltip(|cx| Tooltip::for_action("Select Language", &Toggle, cx)),
             )
         })
     }


### PR DESCRIPTION
Just making sure sure we're always making keyboard navigation discoverable.

<img width="700" alt="Screenshot 2024-11-28 at 16 05 40" src="https://github.com/user-attachments/assets/bd7611f0-190c-4e3b-ad69-9552060e37ea">

Release Notes:

- N/A
