### PR TITLE
Remove project panel trash action for remote projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9313,6 +9313,7 @@ dependencies = [
  "anyhow",
  "client",
  "collections",
+ "command_palette_hooks",
  "db",
  "editor",
  "file_icons",

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true
+command_palette_hooks.workspace = true
 db.workspace = true
 editor.workspace = true
 file_icons.workspace = true

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -655,9 +655,11 @@ impl ProjectPanel {
                             .action("Copy Relative Path", Box::new(CopyRelativePath))
                             .separator()
                             .action("Rename", Box::new(Rename))
-                            .when(!is_root, |menu| {
+                            .when(!is_root & is_remote, |menu| {
                                 menu.action("Trash", Box::new(Trash { skip_prompt: false }))
-                                    .action("Delete", Box::new(Delete { skip_prompt: false }))
+                            })
+                            .when(!is_root, |menu| {
+                                menu.action("Delete", Box::new(Delete { skip_prompt: false }))
                             })
                             .when(!is_remote & is_root, |menu| {
                                 menu.separator()

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -17,6 +17,7 @@ use file_icons::FileIcons;
 
 use anyhow::{anyhow, Context as _, Result};
 use collections::{hash_map, BTreeSet, HashMap};
+use command_palette_hooks::CommandPaletteFilter;
 use git::repository::GitFileStatus;
 use gpui::{
     actions, anchored, deferred, div, impl_actions, point, px, size, uniform_list, Action,
@@ -38,6 +39,7 @@ use project_panel_settings::{
 };
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+use std::any::TypeId;
 use std::{
     cell::OnceCell,
     cmp,
@@ -310,6 +312,15 @@ impl ProjectPanel {
                 _ => {}
             })
             .detach();
+
+            let tash_action = [TypeId::of::<Trash>()];
+            let is_remote = project.read(cx).is_via_collab();
+
+            if !is_remote {
+                CommandPaletteFilter::update_global(cx, |filter, _cx| {
+                    filter.hide_action_types(&tash_action);
+                });
+            }
 
             let filename_editor = cx.new_view(Editor::single_line);
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -316,7 +316,7 @@ impl ProjectPanel {
             let tash_action = [TypeId::of::<Trash>()];
             let is_remote = project.read(cx).is_via_collab();
 
-            if !is_remote {
+            if is_remote {
                 CommandPaletteFilter::update_global(cx, |filter, _cx| {
                     filter.hide_action_types(&tash_action);
                 });

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -666,7 +666,7 @@ impl ProjectPanel {
                             .action("Copy Relative Path", Box::new(CopyRelativePath))
                             .separator()
                             .action("Rename", Box::new(Rename))
-                            .when(!is_root & is_remote, |menu| {
+                            .when(!is_root & !is_remote, |menu| {
                                 menu.action("Trash", Box::new(Trash { skip_prompt: false }))
                             })
                             .when(!is_root, |menu| {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -313,12 +313,12 @@ impl ProjectPanel {
             })
             .detach();
 
-            let tash_action = [TypeId::of::<Trash>()];
+            let trash_action = [TypeId::of::<Trash>()];
             let is_remote = project.read(cx).is_via_collab();
 
             if is_remote {
                 CommandPaletteFilter::update_global(cx, |filter, _cx| {
-                    filter.hide_action_types(&tash_action);
+                    filter.hide_action_types(&trash_action);
                 });
             }
 


### PR DESCRIPTION
Closes #20845

I'm uncertain about my placement for the logic to remove actions from the command palette list. If anyone has insights or alternative approaches, I'm open to changing the code.

Release Notes:

- Removed project panel `Trash` action for remote projects.