### PR TITLE
Fine-tune status bar left-side spacing

### DIFF
--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -1,7 +1,7 @@
 use editor::Editor;
 use gpui::{
-    rems, EventEmitter, IntoElement, ParentElement, Render, Styled, Subscription, View,
-    ViewContext, WeakView,
+    EventEmitter, IntoElement, ParentElement, Render, Styled, Subscription, View, ViewContext,
+    WeakView,
 };
 use language::Diagnostic;
 use ui::{h_flex, prelude::*, Button, ButtonLike, Color, Icon, IconName, Label, Tooltip};
@@ -77,8 +77,10 @@ impl Render for DiagnosticIndicator {
         };
 
         h_flex()
-            .h(rems(1.375))
             .gap_2()
+            .pl_1()
+            .border_l_1()
+            .border_color(cx.theme().colors().border)
             .child(
                 ButtonLike::new("diagnostic-indicator")
                     .child(diagnostic_indicator)

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -64,7 +64,7 @@ impl Render for StatusBar {
 impl StatusBar {
     fn render_left_tools(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         h_flex()
-            .gap(DynamicSpacing::Base08.rems(cx))
+            .gap(DynamicSpacing::Base04.rems(cx))
             .overflow_x_hidden()
             .children(self.left_items.iter().map(|item| item.to_any()))
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21291

This PR also adds a small divider separating the panel-opening controls from the other items that appear on the left side of the status bar. The spacing was a bit bigger before because all three items on the left open panels, whereas each other item does different things (e.g., open the diagnostics tab, update the app, display language server status, etc.). Therefore, they needed to be separated somehow to communicate the difference in behavior. Hopefully, now, the border will help sort of figuring this out.

| With error | Normal state |
|--------|--------|
| <img width="1179" alt="Screenshot 2024-11-28 at 18 52 58" src="https://github.com/user-attachments/assets/bf4bad19-5588-481a-9d08-91b2227e44e6"> | <img width="1234" alt="Screenshot 2024-11-28 at 18 53 03" src="https://github.com/user-attachments/assets/4443a16a-9982-44ce-9005-64d4df46f4f0"> | 

Release Notes:

- N/A 
