### PR TITLE
status bar: reduce right tools lateral margin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "2.5.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68b6f9f63a0b6a38bc447d4ce84e2b388f3ec95c99c641c8ff0dd3ef89a6379"
+checksum = "4762ce03154ba57ebaeee60cc631901ceae4f18219cbb874e464347471594742"
 dependencies = [
  "cc",
  "memchr",

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -71,7 +71,7 @@ impl StatusBar {
 
     fn render_right_tools(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         h_flex()
-            .gap(DynamicSpacing::Base08.rems(cx))
+            .gap(DynamicSpacing::Base04.rems(cx))
             .children(self.right_items.iter().rev().map(|item| item.to_any()))
     }
 }


### PR DESCRIPTION
Closes #21316

| before | after |
|--------|-------|
| <img width="342" alt="image" src="https://github.com/user-attachments/assets/25c69144-f665-4e49-8cea-83fc7a28830c"> | <img width="321" alt="image" src="https://github.com/user-attachments/assets/ea02b1de-1c8b-4151-b199-9fdc45704412"> |

changes:
changed `Base08` to `Base04` in `render_right_tools`

Release Notes:

- N/A
