### PR TITLE
Status bar: Reduce right tools lateral margin

### DIFF
--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -71,7 +71,7 @@ impl StatusBar {
 
     fn render_right_tools(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         h_flex()
-            .gap(DynamicSpacing::Base08.rems(cx))
+            .gap(DynamicSpacing::Base04.rems(cx))
             .children(self.right_items.iter().rev().map(|item| item.to_any()))
     }
 }


### PR DESCRIPTION
Closes #21316

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/525d16b0-c1f0-4d93-9a8e-19112b927e78)| ![image](https://github.com/user-attachments/assets/c6947c3e-6b46-4498-a672-5f418f5faad0)|

Changes:
changed `Base08` to `Base04` in `render_right_tools`

Release Notes:

- N/A