### PR TITLE
Expose "Column Git Blame" in the editor controls menu

### DIFF
--- a/assets/icons/cursor_i_beam.svg
+++ b/assets/icons/cursor_i_beam.svg
@@ -1,1 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-text-cursor"><path d="M17 22h-1a4 4 0 0 1-4-4V6a4 4 0 0 1 4-4h1"/><path d="M7 22h1a4 4 0 0 0 4-4v-1"/><path d="M7 2h1a4 4 0 0 1 4 4v1"/></svg>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 20H16C14.9391 20 13.9217 19.6629 13.1716 19.0627C12.4214 18.4626 12 17.6487 12 16.8V7.2C12 6.35131 12.4214 5.53737 13.1716 4.93726C13.9217 4.33714 14.9391 4 16 4H17" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 20H8C9.06087 20 10.0783 19.5786 10.8284 18.8284C11.5786 18.0783 12 17.0609 12 16V15" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 4H8C9.06087 4 10.0783 4.42143 10.8284 5.17157C11.5786 5.92172 12 6.93913 12 8V9" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11796,6 +11796,10 @@ impl Editor {
         self.blame.as_ref()
     }
 
+    pub fn show_git_blame_gutter(&self) -> bool {
+        self.show_git_blame_gutter
+    }
+
     pub fn render_git_blame_gutter(&mut self, cx: &mut WindowContext) -> bool {
         self.show_git_blame_gutter && self.has_blame_entries(cx)
     }

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -91,6 +91,7 @@ impl Render for QuickActionBar {
             inlay_hints_enabled,
             supports_inlay_hints,
             git_blame_inline_enabled,
+            show_git_blame_gutter,
             auto_signature_help_enabled,
         ) = {
             let editor = editor.read(cx);
@@ -98,6 +99,7 @@ impl Render for QuickActionBar {
             let inlay_hints_enabled = editor.inlay_hints_enabled();
             let supports_inlay_hints = editor.supports_inlay_hints(cx);
             let git_blame_inline_enabled = editor.git_blame_inline_enabled();
+            let show_git_blame_gutter = editor.show_git_blame_gutter();
             let auto_signature_help_enabled = editor.auto_signature_help_enabled(cx);
 
             (
@@ -105,6 +107,7 @@ impl Render for QuickActionBar {
                 inlay_hints_enabled,
                 supports_inlay_hints,
                 git_blame_inline_enabled,
+                show_git_blame_gutter,
                 auto_signature_help_enabled,
             )
         };
@@ -236,26 +239,6 @@ impl Render for QuickActionBar {
                     }
 
                     menu = menu.toggleable_entry(
-                        "Inline Git Blame",
-                        git_blame_inline_enabled,
-                        IconPosition::Start,
-                        Some(editor::actions::ToggleGitBlameInline.boxed_clone()),
-                        {
-                            let editor = editor.clone();
-                            move |cx| {
-                                editor
-                                    .update(cx, |editor, cx| {
-                                        editor.toggle_git_blame_inline(
-                                            &editor::actions::ToggleGitBlameInline,
-                                            cx,
-                                        )
-                                    })
-                                    .ok();
-                            }
-                        },
-                    );
-
-                    menu = menu.toggleable_entry(
                         "Selection Menu",
                         selection_menu_enabled,
                         IconPosition::Start,
@@ -289,6 +272,46 @@ impl Render for QuickActionBar {
                                             &editor::actions::ToggleAutoSignatureHelp,
                                             cx,
                                         );
+                                    })
+                                    .ok();
+                            }
+                        },
+                    );
+
+                    menu = menu.separator();
+
+                    menu = menu.toggleable_entry(
+                        "Inline Git Blame",
+                        git_blame_inline_enabled,
+                        IconPosition::Start,
+                        Some(editor::actions::ToggleGitBlameInline.boxed_clone()),
+                        {
+                            let editor = editor.clone();
+                            move |cx| {
+                                editor
+                                    .update(cx, |editor, cx| {
+                                        editor.toggle_git_blame_inline(
+                                            &editor::actions::ToggleGitBlameInline,
+                                            cx,
+                                        )
+                                    })
+                                    .ok();
+                            }
+                        },
+                    );
+
+                    menu = menu.toggleable_entry(
+                        "Column Git Blame",
+                        show_git_blame_gutter,
+                        IconPosition::Start,
+                        Some(editor::actions::ToggleGitBlame.boxed_clone()),
+                        {
+                            let editor = editor.clone();
+                            move |cx| {
+                                editor
+                                    .update(cx, |editor, cx| {
+                                        editor
+                                            .toggle_git_blame(&editor::actions::ToggleGitBlame, cx)
                                     })
                                     .ok();
                             }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/10196

I think having this action exposed in the editor controls menu, close to the inline Git Blame option, makes more sense than a more prominent item somewhere else in the app. Maybe having it there will increase its discoverability. I myself didn't know this until a few weeks ago! Next steps would be ensuring the menu exposes its keybindings.

(Quick note about the menu item name: I think maybe "_Git Blame Column_" would make more sense and feel grammatically more correct, but then we would have two Git Blame-related options, one with "Git Blame" at the start (Inline...) and another with "Git Blame" at the end (... Column). I guess one had to be sacrificed for the sake of consistency 😅.)

<img width="750" alt="Screenshot 2024-11-29 at 12 01 33" src="https://github.com/user-attachments/assets/2f3324ec-a2f0-4303-9582-714d0ee6bd31">

Release Notes:

- N/A
