### PR TITLE
Add setting for making the tab's close button always visible

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -559,6 +559,8 @@
     "close_position": "right",
     // Whether to show the file icon for a tab.
     "file_icons": false,
+    // Whether to always show the close button on tabs.
+    "always_show_close_button": false,
     // What to do after closing the current tab.
     //
     // 1. Activate the tab that was open previously (default)

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -42,6 +42,7 @@ pub struct ItemSettings {
     pub close_position: ClosePosition,
     pub activate_on_close: ActivateOnClose,
     pub file_icons: bool,
+    pub always_show_close_button: bool,
 }
 
 #[derive(Deserialize)]
@@ -85,6 +86,10 @@ pub struct ItemSettingsContent {
     ///
     /// Default: history
     pub activate_on_close: Option<ActivateOnClose>,
+    /// Whether to always show the close button on tabs.
+    ///
+    /// Default: false
+    always_show_close_button: Option<bool>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1935,7 +1935,9 @@ impl Pane {
         };
 
         let icon = item.tab_icon(cx);
-        let close_side = &ItemSettings::get_global(cx).close_position;
+        let settings = ItemSettings::get_global(cx);
+        let close_side = &settings.close_position;
+        let always_show_close_button = settings.always_show_close_button;
         let indicator = render_item_indicator(item.boxed_clone(), cx);
         let item_id = item.item_id();
         let is_first_item = ix == 0;
@@ -2030,7 +2032,9 @@ impl Pane {
                     end_slot_action = &CloseActiveItem { save_intent: None };
                     end_slot_tooltip_text = "Close Tab";
                     IconButton::new("close tab", IconName::Close)
-                        .visible_on_hover("")
+                        .when(!always_show_close_button, |button| {
+                            button.visible_on_hover("")
+                        })
                         .shape(IconButtonShape::Square)
                         .icon_color(Color::Muted)
                         .size(ButtonSize::None)

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -634,7 +634,8 @@ List of `string` values
   "close_position": "right",
   "file_icons": false,
   "git_status": false,
-  "activate_on_close": "history"
+  "activate_on_close": "history",
+  "always_show_close_button": false
 },
 ```
 
@@ -689,6 +690,20 @@ List of `string` values
   "activate_on_close": "history"
 }
 ```
+
+2. Activate the neighbour tab (prefers the right one, if present):
+
+```json
+{
+  "activate_on_close": "neighbour"
+}
+```
+
+### Always show the close button
+
+- Description: Whether to always show the close button on tabs.
+- Setting: `always_show_close_button`
+- Default: `false`
 
 2. Activate the neighbour tab (prefers the right one, if present):
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -705,14 +705,6 @@ List of `string` values
 - Setting: `always_show_close_button`
 - Default: `false`
 
-2. Activate the neighbour tab (prefers the right one, if present):
-
-```json
-{
-  "activate_on_close": "neighbour"
-}
-```
-
 ## Editor Toolbar
 
 - Description: Whether or not to show various elements in the editor toolbar.


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20422

<img width="700" alt="Screenshot 2024-11-29 at 22 00 20" src="https://github.com/user-attachments/assets/4a17d00c-d64f-4b33-97a7-a57766ce6d17">

Release Notes:

- N/A
