### PR TITLE
Improve JavaScript runnable detection followup

### DIFF
--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -70,9 +70,9 @@
                 object: [
                     (identifier) @_name
                     (member_expression object: (identifier) @_name)
-                ]*
+                ]
             )
-        ]* @context
+        ] @context
         (#any-of? @_name "it" "test" "describe")
         arguments: (
             arguments . (string (string_fragment) @name)

--- a/crates/languages/src/javascript/runnables.scm
+++ b/crates/languages/src/javascript/runnables.scm
@@ -8,7 +8,7 @@
                 object: [
                     (identifier) @_name
                     (member_expression object: (identifier) @_name)
-                ]*
+                ]
             )
         ]
         (#any-of? @_name "it" "test" "describe")

--- a/crates/languages/src/tsx/outline.scm
+++ b/crates/languages/src/tsx/outline.scm
@@ -78,9 +78,9 @@
                 object: [
                     (identifier) @_name
                     (member_expression object: (identifier) @_name)
-                ]*
+                ]
             )
-        ]* @context
+        ] @context
         (#any-of? @_name "it" "test" "describe")
         arguments: (
             arguments . (string (string_fragment) @name)

--- a/crates/languages/src/tsx/runnables.scm
+++ b/crates/languages/src/tsx/runnables.scm
@@ -8,7 +8,7 @@
                 object: [
                     (identifier) @_name
                     (member_expression object: (identifier) @_name)
-                ]*
+                ]
             )
         ]
         (#any-of? @_name "it" "test" "describe")

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -78,9 +78,9 @@
                 object: [
                     (identifier) @_name
                     (member_expression object: (identifier) @_name)
-                ]*
+                ]
             )
-        ]* @context
+        ] @context
         (#any-of? @_name "it" "test" "describe")
         arguments: (
             arguments . (string (string_fragment) @name)

--- a/crates/languages/src/typescript/runnables.scm
+++ b/crates/languages/src/typescript/runnables.scm
@@ -8,7 +8,7 @@
                 object: [
                     (identifier) @_name
                     (member_expression object: (identifier) @_name)
-                ]*
+                ]
             )
         ]
         (#any-of? @_name "it" "test" "describe")


### PR DESCRIPTION
Followup: https://github.com/zed-industries/zed/pull/21246

**Before**
<img width="545" alt="Screenshot 2024-11-30 at 13 27 15" src="https://github.com/user-attachments/assets/3346e485-96c8-482d-b5fd-85b86f37d662">
**After**
<img width="537" alt="Screenshot 2024-11-30 at 13 27 36" src="https://github.com/user-attachments/assets/3cedcaa5-e285-47fb-909d-16d37d9844ca">

We did not need to add the `*` as it was already matching one of them, we actually need at least one of them, so making it optional was a mistake.

Don't think we need to add release notes, as the change is only on main the branch now.

Release Notes:

- N/A
