### PR TITLE
Add musl-gcc as dependency

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -67,6 +67,7 @@ yum=$(command -v yum || true)
 if [[ -n $dnf ]] || [[ -n $yum ]]; then
   pkg_cmd="${dnf:-${yum}}"
   deps=(
+    musl-gcc
     gcc
     clang
     cmake


### PR DESCRIPTION
This addition comes after attempting building Zed from source.

As part of the process, one of the components (a crate I presume) called `ring` failed to compile due to the following sequence of console messages:

```log
warning: ring@0.17.8: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `musl-gcc` installed?
warning: ring@0.17.8: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `musl-gcc` installed?

error: failed to run custom build command for `ring v0.17.8`
```

Adding this library should help fix the issue on Fedora 41 at least, and possibly will help fixing it for other RedHat based distributions as well.

Closes #ISSUE

Release Notes:

- Add musl-gcc as dependency
