### PR TITLE
Fix item closing overtly triggering save dialogues

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -716,7 +716,7 @@ impl Item for ProjectDiagnosticsEditor {
     fn for_each_project_item(
         &self,
         cx: &AppContext,
-        f: &mut dyn FnMut(gpui::EntityId, &dyn project::Item),
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
     ) {
         self.editor.for_each_project_item(cx, f)
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -125,7 +125,7 @@ use parking_lot::{Mutex, RwLock};
 use project::{
     lsp_store::{FormatTarget, FormatTrigger},
     project_settings::{GitGutterSetting, ProjectSettings},
-    CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, Item, Location,
+    CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, ProjectItem, Location,
     LocationLink, Project, ProjectTransaction, TaskSourceKind,
 };
 use rand::prelude::*;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -125,8 +125,8 @@ use parking_lot::{Mutex, RwLock};
 use project::{
     lsp_store::{FormatTarget, FormatTrigger},
     project_settings::{GitGutterSetting, ProjectSettings},
-    CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, ProjectItem, Location,
-    LocationLink, Project, ProjectTransaction, TaskSourceKind,
+    CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, Location, LocationLink,
+    Project, ProjectItem, ProjectTransaction, TaskSourceKind,
 };
 use rand::prelude::*;
 use rpc::{proto::*, ErrorExt};

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -10,7 +10,7 @@ use gpui::{Model, ModelContext, Subscription, Task};
 use http_client::HttpClient;
 use language::{markdown, Bias, Buffer, BufferSnapshot, Edit, LanguageRegistry, ParsedMarkdown};
 use multi_buffer::MultiBufferRow;
-use project::{Item, Project};
+use project::{Project, ProjectItem};
 use smallvec::SmallVec;
 use sum_tree::SumTree;
 use url::Url;

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -22,7 +22,7 @@ use language::{
 use lsp::DiagnosticSeverity;
 use multi_buffer::AnchorRangeExt;
 use project::{
-    lsp_store::FormatTrigger, project_settings::ProjectSettings, search::SearchQuery, Item as _,
+    lsp_store::FormatTrigger, project_settings::ProjectSettings, search::SearchQuery, ProjectItem as _,
     Project, ProjectPath,
 };
 use rpc::proto::{self, update_view, PeerId};
@@ -665,7 +665,7 @@ impl Item for Editor {
     fn for_each_project_item(
         &self,
         cx: &AppContext,
-        f: &mut dyn FnMut(EntityId, &dyn project::Item),
+        f: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
     ) {
         self.buffer
             .read(cx)

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -22,8 +22,8 @@ use language::{
 use lsp::DiagnosticSeverity;
 use multi_buffer::AnchorRangeExt;
 use project::{
-    lsp_store::FormatTrigger, project_settings::ProjectSettings, search::SearchQuery, ProjectItem as _,
-    Project, ProjectPath,
+    lsp_store::FormatTrigger, project_settings::ProjectSettings, search::SearchQuery, Project,
+    ProjectItem as _, ProjectPath,
 };
 use rpc::proto::{self, update_view, PeerId};
 use settings::Settings;

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -78,7 +78,7 @@ impl Item for ImageView {
     fn for_each_project_item(
         &self,
         cx: &AppContext,
-        f: &mut dyn FnMut(gpui::EntityId, &dyn project::Item),
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
     ) {
         f(self.image_item.entity_id(), self.image_item.read(cx))
     }

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -36,7 +36,7 @@ use language::{BufferId, BufferSnapshot, OffsetRangeExt, OutlineItem};
 use menu::{Cancel, SelectFirst, SelectLast, SelectNext, SelectPrev};
 
 use outline_panel_settings::{OutlinePanelDockPosition, OutlinePanelSettings, ShowIndentGuides};
-use project::{File, Fs, Item, Project};
+use project::{File, Fs, Project, ProjectItem};
 use search::{BufferSearchBar, ProjectSearchView};
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1,7 +1,7 @@
 use crate::{
     search::SearchQuery,
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
-    Item, ProjectPath,
+    ProjectItem as _, ProjectPath,
 };
 use ::git::{parse_git_remote_url, BuildPermalinkParams, GitHostingProviderRegistry};
 use anyhow::{anyhow, Context as _, Result};

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
-    Project, ProjectEntryId, ProjectPath,
+    Project, ProjectEntryId, ProjectItem, ProjectPath,
 };
 use anyhow::{Context as _, Result};
 use collections::{hash_map, HashMap, HashSet};
@@ -114,7 +114,7 @@ impl ImageItem {
     }
 }
 
-impl project::ProjectItem for ImageItem {
+impl ProjectItem for ImageItem {
     fn try_open(
         project: &Model<Project>,
         path: &ProjectPath,

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -114,7 +114,7 @@ impl ImageItem {
     }
 }
 
-impl crate::Item for ImageItem {
+impl project::ProjectItem for ImageItem {
     fn try_open(
         project: &Model<Project>,
         path: &ProjectPath,
@@ -150,6 +150,10 @@ impl crate::Item for ImageItem {
 
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath> {
         Some(self.project_path(cx).clone())
+    }
+
+    fn is_dirty(&self) -> bool {
+        false
     }
 }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -10,7 +10,7 @@ use crate::{
     toolchain_store::{EmptyToolchainStore, ToolchainStoreEvent},
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
     yarn::YarnPathStore,
-    CodeAction, Completion, CoreCompletion, Hover, InlayHint, Item as _, ProjectPath,
+    CodeAction, Completion, CoreCompletion, Hover, InlayHint, ProjectItem as _, ProjectPath,
     ProjectTransaction, ResolveState, Symbol, ToolchainStore,
 };
 use anyhow::{anyhow, Context as _, Result};

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -111,7 +111,7 @@ const MAX_PROJECT_SEARCH_HISTORY_SIZE: usize = 500;
 const MAX_SEARCH_RESULT_FILES: usize = 5_000;
 const MAX_SEARCH_RESULT_RANGES: usize = 10_000;
 
-pub trait Item {
+pub trait ProjectItem {
     fn try_open(
         project: &Model<Project>,
         path: &ProjectPath,
@@ -121,6 +121,7 @@ pub trait Item {
         Self: Sized;
     fn entry_id(&self, cx: &AppContext) -> Option<ProjectEntryId>;
     fn project_path(&self, cx: &AppContext) -> Option<ProjectPath>;
+    fn is_dirty(&self) -> bool;
 }
 
 #[derive(Clone)]
@@ -4354,7 +4355,7 @@ impl ResolvedPath {
     }
 }
 
-impl Item for Buffer {
+impl ProjectItem for Buffer {
     fn try_open(
         project: &Model<Project>,
         path: &ProjectPath,
@@ -4362,7 +4363,6 @@ impl Item for Buffer {
     ) -> Option<Task<Result<Model<Self>>>> {
         Some(project.update(cx, |project, cx| project.open_buffer(path.clone(), cx)))
     }
-
     fn entry_id(&self, cx: &AppContext) -> Option<ProjectEntryId> {
         File::from_dyn(self.file()).and_then(|file| file.project_entry_id(cx))
     }
@@ -4372,6 +4372,10 @@ impl Item for Buffer {
             worktree_id: file.worktree_id(cx),
             path: file.path().clone(),
         })
+    }
+
+    fn is_dirty(&self) -> bool {
+        self.is_dirty()
     }
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4363,6 +4363,7 @@ impl ProjectItem for Buffer {
     ) -> Option<Task<Result<Model<Self>>>> {
         Some(project.update(cx, |project, cx| project.open_buffer(path.clone(), cx)))
     }
+
     fn entry_id(&self, cx: &AppContext) -> Option<ProjectEntryId> {
         File::from_dyn(self.file()).and_then(|file| file.project_entry_id(cx))
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -7511,7 +7511,7 @@ mod tests {
         path: ProjectPath,
     }
 
-    impl project::Item for TestProjectItem {
+    impl project::ProjectItem for TestProjectItem {
         fn try_open(
             _project: &Model<Project>,
             path: &ProjectPath,
@@ -7527,6 +7527,10 @@ mod tests {
 
         fn project_path(&self, _: &AppContext) -> Option<ProjectPath> {
             Some(self.path.clone())
+        }
+
+        fn is_dirty(&self) -> bool {
+            false
         }
     }
 

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -158,16 +158,6 @@ impl NotebookEditor {
         })
     }
 
-    fn is_dirty(&self, cx: &AppContext) -> bool {
-        self.cell_map.values().any(|cell| {
-            if let Cell::Code(code_cell) = cell {
-                code_cell.read(cx).is_dirty(cx)
-            } else {
-                false
-            }
-        })
-    }
-
     fn clear_outputs(&mut self, cx: &mut ViewContext<Self>) {
         for cell in self.cell_map.values() {
             if let Cell::Code(code_cell) = cell {
@@ -500,7 +490,7 @@ pub struct NotebookItem {
     id: ProjectEntryId,
 }
 
-impl project::Item for NotebookItem {
+impl project::ProjectItem for NotebookItem {
     fn try_open(
         project: &Model<Project>,
         path: &ProjectPath,
@@ -560,6 +550,10 @@ impl project::Item for NotebookItem {
 
     fn project_path(&self, _: &AppContext) -> Option<ProjectPath> {
         Some(self.project_path.clone())
+    }
+
+    fn is_dirty(&self) -> bool {
+        false
     }
 }
 
@@ -656,7 +650,7 @@ impl Item for NotebookEditor {
     fn for_each_project_item(
         &self,
         cx: &AppContext,
-        f: &mut dyn FnMut(gpui::EntityId, &dyn project::Item),
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
     ) {
         f(self.notebook_item.entity_id(), self.notebook_item.read(cx))
     }
@@ -734,8 +728,13 @@ impl Item for NotebookEditor {
     }
 
     fn is_dirty(&self, cx: &AppContext) -> bool {
-        // self.is_dirty(cx) TODO
-        false
+        self.cell_map.values().any(|cell| {
+            if let Cell::Code(code_cell) = cell {
+                code_cell.read(cx).is_dirty(cx)
+            } else {
+                false
+            }
+        })
     }
 }
 

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use editor::Editor;
 use gpui::{prelude::*, Entity, View, WeakView, WindowContext};
 use language::{BufferSnapshot, Language, LanguageName, Point};
-use project::{Item as _, WorktreeId};
+use project::{ProjectItem as _, WorktreeId};
 
 use crate::repl_store::ReplStore;
 use crate::session::SessionEvent;

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -3,7 +3,7 @@ use gpui::{
     actions, prelude::*, AnyElement, AppContext, EventEmitter, FocusHandle, FocusableView,
     Subscription, View,
 };
-use project::Item as _;
+use project::ProjectItem as _;
 use ui::{prelude::*, ButtonLike, ElevationIndex, KeyBinding};
 use util::ResultExt as _;
 use workspace::item::ItemEvent;

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -449,7 +449,7 @@ impl Item for ProjectSearchView {
     fn for_each_project_item(
         &self,
         cx: &AppContext,
-        f: &mut dyn FnMut(EntityId, &dyn project::Item),
+        f: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
     ) {
         self.results_editor.for_each_project_item(cx, f)
     }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1112,10 +1112,6 @@ pub mod test {
                 is_dirty: false,
             })
         }
-
-        pub fn with_dirty(self, is_dirty: bool) -> Self {
-            Self { is_dirty, ..self }
-        }
     }
 
     impl TestItem {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -208,7 +208,7 @@ pub trait Item: FocusableView + EventEmitter<Self::Event> {
     fn for_each_project_item(
         &self,
         _: &AppContext,
-        _: &mut dyn FnMut(EntityId, &dyn project::Item),
+        _: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
     ) {
     }
     fn is_singleton(&self, _cx: &AppContext) -> bool {
@@ -386,7 +386,7 @@ pub trait ItemHandle: 'static + Send {
     fn for_each_project_item(
         &self,
         _: &AppContext,
-        _: &mut dyn FnMut(EntityId, &dyn project::Item),
+        _: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
     );
     fn is_singleton(&self, cx: &AppContext) -> bool;
     fn boxed_clone(&self) -> Box<dyn ItemHandle>;
@@ -563,7 +563,7 @@ impl<T: Item> ItemHandle for View<T> {
     fn for_each_project_item(
         &self,
         cx: &AppContext,
-        f: &mut dyn FnMut(EntityId, &dyn project::Item),
+        f: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
     ) {
         self.read(cx).for_each_project_item(cx, f)
     }
@@ -891,7 +891,7 @@ impl<T: Item> WeakItemHandle for WeakView<T> {
 }
 
 pub trait ProjectItem: Item {
-    type Item: project::Item;
+    type Item: project::ProjectItem;
 
     fn for_project_item(
         project: Model<Project>,
@@ -1045,6 +1045,7 @@ pub mod test {
     pub struct TestProjectItem {
         pub entry_id: Option<ProjectEntryId>,
         pub project_path: Option<ProjectPath>,
+        pub is_dirty: bool,
     }
 
     pub struct TestItem {
@@ -1065,7 +1066,7 @@ pub mod test {
         focus_handle: gpui::FocusHandle,
     }
 
-    impl project::Item for TestProjectItem {
+    impl project::ProjectItem for TestProjectItem {
         fn try_open(
             _project: &Model<Project>,
             _path: &ProjectPath,
@@ -1073,13 +1074,16 @@ pub mod test {
         ) -> Option<Task<gpui::Result<Model<Self>>>> {
             None
         }
-
         fn entry_id(&self, _: &AppContext) -> Option<ProjectEntryId> {
             self.entry_id
         }
 
         fn project_path(&self, _: &AppContext) -> Option<ProjectPath> {
             self.project_path.clone()
+        }
+
+        fn is_dirty(&self) -> bool {
+            self.is_dirty
         }
     }
 
@@ -1097,6 +1101,7 @@ pub mod test {
             cx.new_model(|_| Self {
                 entry_id,
                 project_path,
+                is_dirty: false,
             })
         }
 
@@ -1104,7 +1109,12 @@ pub mod test {
             cx.new_model(|_| Self {
                 project_path: None,
                 entry_id: None,
+                is_dirty: false,
             })
+        }
+
+        pub fn with_dirty(self, is_dirty: bool) -> Self {
+            Self { is_dirty, ..self }
         }
     }
 
@@ -1225,7 +1235,7 @@ pub mod test {
         fn for_each_project_item(
             &self,
             cx: &AppContext,
-            f: &mut dyn FnMut(EntityId, &dyn project::Item),
+            f: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
         ) {
             self.project_items
                 .iter()

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1346,9 +1346,7 @@ impl Pane {
                 let (item_ix, mut project_item_ids) = pane.update(&mut cx, |pane, cx| {
                     (pane.index_for_item(&*item), item.project_item_model_ids(cx))
                 })?;
-                let item_ix = if let Some(ix) = item_ix {
-                    ix
-                } else {
+                let Some(item_ix) = item_ix else {
                     continue;
                 };
 
@@ -1377,7 +1375,7 @@ impl Pane {
                 // (can we even check that?)
                 // * dirty singletons should close without a prompt if there's a dirty multibuffer open with the same file (as it works now already)
                 // * when closing multiple buffers and mentioning their filenames, omit multibuffers that contain all the files that are dirty and nothing else
-                cx.update(|_, cx| {
+                cx.update(|cx| {
                     dbg!((
                         item.tab_tooltip_text(cx).map(|t| t.to_string()),
                         item.item_id(),
@@ -1392,7 +1390,7 @@ impl Pane {
                         dbg!(&multibuffer_model_ids);
                         item.for_each_project_item(cx, &mut |id, item| {
                             if multibuffer_model_ids.contains(dbg!(&id)) {
-                                dbg!(item.entry_id(cx));
+                                dbg!(item.entry_id(cx), item.is_dirty());
                             }
                         });
                     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1371,6 +1371,34 @@ impl Pane {
                     .iter()
                     .any(|id| saved_project_items_ids.insert(*id));
 
+                // TODO kb
+                // * all dirty buffers without a project path should be saved when they are closed (due to another file select prompt needed)
+                // * dirty multibuffers should only propose saving if there are some files inside it that are dirty and not open in the pane
+                // (can we even check that?)
+                // * dirty singletons should close without a prompt if there's a dirty multibuffer open with the same file (as it works now already)
+                // * when closing multiple buffers and mentioning their filenames, omit multibuffers that contain all the files that are dirty and nothing else
+                cx.update(|_, cx| {
+                    dbg!((
+                        item.tab_tooltip_text(cx).map(|t| t.to_string()),
+                        item.item_id(),
+                        item.is_dirty(cx),
+                        item.is_singleton(cx),
+                        item.project_path(cx),
+                        save_intent,
+                        should_save,
+                    ));
+                    if !item.is_singleton(cx) {
+                        let multibuffer_model_ids = item.project_item_model_ids(cx);
+                        dbg!(&multibuffer_model_ids);
+                        item.for_each_project_item(cx, &mut |id, item| {
+                            if multibuffer_model_ids.contains(dbg!(&id)) {
+                                dbg!(item.entry_id(cx));
+                            }
+                        });
+                    }
+                })
+                .unwrap();
+
                 if should_save
                     && !Self::save_item(
                         project.clone(),

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1339,6 +1339,14 @@ impl Pane {
                 }
             }
             let mut saved_project_items_ids = HashSet::default();
+            dbg!((
+                "???",
+                &saved_project_items_ids,
+                items_to_close
+                    .iter()
+                    .map(|item| item.item_id())
+                    .collect::<Vec<_>>()
+            ));
             for item in items_to_close.clone() {
                 // Find the item's current index and its set of project item models. Avoid
                 // storing these in advance, in case they have changed since this task
@@ -1350,6 +1358,8 @@ impl Pane {
                     continue;
                 };
 
+                dbg!(("@@@@before cleanup", &project_item_ids));
+
                 // Check if this view has any project items that are not open anywhere else
                 // in the workspace, AND that the user has not already been prompted to save.
                 // If there are any such project entries, prompt the user to save this item.
@@ -1360,11 +1370,13 @@ impl Pane {
                             .any(|item_to_close| item_to_close.item_id() == item.item_id())
                         {
                             let other_project_item_ids = item.project_item_model_ids(cx);
+                            dbg!(&other_project_item_ids);
                             project_item_ids.retain(|id| !other_project_item_ids.contains(id));
                         }
                     }
                     workspace.project().clone()
                 })?;
+                dbg!(("@@@@after cleanup", &project_item_ids));
                 let should_save = project_item_ids
                     .iter()
                     .any(|id| saved_project_items_ids.insert(*id));

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6422,24 +6422,26 @@ mod tests {
         let item1 = cx.new_view(|cx| {
             TestItem::new(cx)
                 .with_dirty(true)
-                .with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
+                .with_project_items(&[dirty_project_item(1, "1.txt", cx)])
         });
         let item2 = cx.new_view(|cx| {
             TestItem::new(cx)
                 .with_dirty(true)
                 .with_conflict(true)
-                .with_project_items(&[TestProjectItem::new(2, "2.txt", cx)])
+                .with_project_items(&[dirty_project_item(2, "2.txt", cx)])
         });
         let item3 = cx.new_view(|cx| {
             TestItem::new(cx)
                 .with_dirty(true)
                 .with_conflict(true)
-                .with_project_items(&[TestProjectItem::new(3, "3.txt", cx)])
+                .with_project_items(&[dirty_project_item(3, "3.txt", cx)])
         });
         let item4 = cx.new_view(|cx| {
-            TestItem::new(cx)
-                .with_dirty(true)
-                .with_project_items(&[TestProjectItem::new_untitled(cx)])
+            TestItem::new(cx).with_dirty(true).with_project_items(&[{
+                let project_item = TestProjectItem::new_untitled(cx);
+                project_item.update(cx, |project_item, _| project_item.is_dirty = true);
+                project_item
+            }])
         });
         let pane = workspace.update(cx, |workspace, cx| {
             workspace.add_item_to_active_pane(Box::new(item1.clone()), None, true, cx);
@@ -6531,7 +6533,7 @@ mod tests {
                 cx.new_view(|cx| {
                     TestItem::new(cx)
                         .with_dirty(true)
-                        .with_project_items(&[TestProjectItem::new(
+                        .with_project_items(&[dirty_project_item(
                             project_entry_id,
                             &format!("{project_entry_id}.txt"),
                             cx,
@@ -6713,6 +6715,9 @@ mod tests {
                 })
             });
             item.is_dirty = true;
+            for project_item in &mut item.project_items {
+                project_item.update(cx, |project_item, _| project_item.is_dirty = true);
+            }
         });
 
         pane.update(cx, |pane, cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2721,7 +2721,7 @@ impl Workspace {
     where
         T: ProjectItem,
     {
-        use project::Item as _;
+        use project::ProjectItem as _;
         let project_item = project_item.read(cx);
         let entry_id = project_item.entry_id(cx);
         let project_path = project_item.project_path(cx);
@@ -7446,11 +7446,28 @@ mod tests {
         });
         let multibuffer_with_both_files_id = dirty_multibuffer_with_both.item_id();
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer.clone()), cx);
-            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer_2.clone()), cx);
+            workspace.add_item(
+                pane.clone(),
+                Box::new(dirty_regular_buffer.clone()),
+                None,
+                false,
+                false,
+                cx,
+            );
+            workspace.add_item(
+                pane.clone(),
+                Box::new(dirty_regular_buffer_2.clone()),
+                None,
+                false,
+                false,
+                cx,
+            );
             workspace.add_item(
                 pane.clone(),
                 Box::new(dirty_multibuffer_with_both.clone()),
+                None,
+                false,
+                false,
                 cx,
             );
         });
@@ -7468,6 +7485,7 @@ mod tests {
                 pane.close_inactive_items(
                     &CloseInactiveItems {
                         save_intent: Some(SaveIntent::Close),
+                        close_pinned: true,
                     },
                     cx,
                 )
@@ -7536,6 +7554,7 @@ mod tests {
         });
     }
 
+    // TODO kb this test is expected to fail but it does not
     #[gpui::test]
     async fn test_no_save_prompt_when_dirty_multibuffer_closed_with_all_its_dirty_items_present_in_the_pane(
         cx: &mut TestAppContext,
@@ -7571,11 +7590,28 @@ mod tests {
         });
         let multibuffer_with_both_files_id = dirty_multibuffer_with_both.item_id();
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer.clone()), cx);
-            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer_2.clone()), cx);
+            workspace.add_item(
+                pane.clone(),
+                Box::new(dirty_regular_buffer.clone()),
+                None,
+                false,
+                false,
+                cx,
+            );
+            workspace.add_item(
+                pane.clone(),
+                Box::new(dirty_regular_buffer_2.clone()),
+                None,
+                false,
+                false,
+                cx,
+            );
             workspace.add_item(
                 pane.clone(),
                 Box::new(dirty_multibuffer_with_both.clone()),
+                None,
+                false,
+                false,
                 cx,
             );
         });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7530,19 +7530,16 @@ mod tests {
         );
         cx.simulate_prompt_answer(0);
         cx.background_executor.run_until_parked();
-        cx.simulate_new_path_selection(|_| Some(PathBuf::default()));
-        cx.background_executor.run_until_parked();
         close_multi_buffer_task
             .await
             .expect("Closing the multi buffer failed");
         pane.update(cx, |pane, cx| {
-            assert_eq!(dirty_regular_buffer.read(cx).save_count, 0);
             assert_eq!(
                 dirty_multi_buffer_with_both.read(cx).save_count,
-                0,
-                "Multi buffer itself should not be saved"
+                1,
+                "Multi buffer item should get be saved"
             );
-            assert_eq!(dirty_regular_buffer_2.read(cx).save_count, 0);
+            // Test impl does not save inner items, so we do not assert them
             assert_eq!(
                 pane.items_len(),
                 0,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7484,7 +7484,7 @@ mod tests {
             .update(cx, |pane, cx| {
                 pane.close_inactive_items(
                     &CloseInactiveItems {
-                        save_intent: Some(SaveIntent::Close),
+                        save_intent: Some(SaveIntent::Save),
                         close_pinned: true,
                     },
                     cx,
@@ -7554,7 +7554,7 @@ mod tests {
         });
     }
 
-    // TODO kb this test is expected to fail but it does not
+    // TODO kb write the same test when one dirty item is not in the pane: should prompt to save
     #[gpui::test]
     async fn test_no_save_prompt_when_dirty_multibuffer_closed_with_all_its_dirty_items_present_in_the_pane(
         cx: &mut TestAppContext,
@@ -7578,6 +7578,12 @@ mod tests {
                 .with_label("2.txt")
                 .with_project_items(&[dirty_project_item(2, "2.txt", cx)])
         });
+        let clear_regular_buffer = cx.new_view(|cx| {
+            TestItem::new(cx)
+                .with_label("3.txt")
+                .with_project_items(&[TestProjectItem::new(3, "3.txt", cx)])
+        });
+
         let dirty_multibuffer_with_both = cx.new_view(|cx| {
             TestItem::new(cx)
                 .with_dirty(true)
@@ -7586,6 +7592,7 @@ mod tests {
                 .with_project_items(&[
                     dirty_regular_buffer.read(cx).project_items[0].clone(),
                     dirty_regular_buffer_2.read(cx).project_items[0].clone(),
+                    clear_regular_buffer.read(cx).project_items[0].clone(),
                 ])
         });
         let multibuffer_with_both_files_id = dirty_multibuffer_with_both.item_id();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7412,7 +7412,9 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_prompting_to_save_only_on_non_multibuffer_file(cx: &mut TestAppContext) {
+    async fn test_no_save_prompt_when_multibuffer_contains_all_items_closed(
+        cx: &mut TestAppContext,
+    ) {
         init_test(cx);
 
         let fs = FakeFs::new(cx.background_executor.clone());
@@ -7424,12 +7426,13 @@ mod tests {
             TestItem::new(cx)
                 .with_dirty(true)
                 .with_label("1.txt")
-                .with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
+                .with_project_items(&[dirty_project_item(1, "1.txt", cx)])
         });
-        let dirty_untitled_buffer = cx.new_view(|cx| {
+        let dirty_regular_buffer_2 = cx.new_view(|cx| {
             TestItem::new(cx)
                 .with_dirty(true)
-                .with_project_items(&[TestProjectItem::new_untitled(cx)])
+                .with_label("2.txt")
+                .with_project_items(&[dirty_project_item(2, "2.txt", cx)])
         });
         let dirty_multibuffer_with_both = cx.new_view(|cx| {
             TestItem::new(cx)
@@ -7438,13 +7441,13 @@ mod tests {
                 .with_label("Fake Project Search")
                 .with_project_items(&[
                     dirty_regular_buffer.read(cx).project_items[0].clone(),
-                    dirty_untitled_buffer.read(cx).project_items[0].clone(),
+                    dirty_regular_buffer_2.read(cx).project_items[0].clone(),
                 ])
         });
         let multibuffer_with_both_files_id = dirty_multibuffer_with_both.item_id();
         workspace.update(cx, |workspace, cx| {
             workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer.clone()), cx);
-            workspace.add_item(pane.clone(), Box::new(dirty_untitled_buffer.clone()), cx);
+            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer_2.clone()), cx);
             workspace.add_item(
                 pane.clone(),
                 Box::new(dirty_multibuffer_with_both.clone()),
@@ -7460,7 +7463,6 @@ mod tests {
                 "Should select the multibuffer in the pane"
             );
         });
-        // When closing both the unsaved buffer and the multibuffer that contains it, we should only prompt to save the unsaved buffer.
         let close_all_but_multibuffer_task = pane
             .update(cx, |pane, cx| {
                 pane.close_inactive_items(
@@ -7476,15 +7478,13 @@ mod tests {
             !cx.has_pending_prompt(),
             "Multibuffer still has the unsaved buffer inside, so no save prompt should be shown"
         );
-        assert!(!cx.did_prompt_for_new_path());
         close_all_but_multibuffer_task
             .await
             .expect("Closing all buffers but the multibuffer failed");
         pane.update(cx, |pane, cx| {
             assert_eq!(dirty_regular_buffer.read(cx).save_count, 0);
             assert_eq!(dirty_multibuffer_with_both.read(cx).save_count, 0);
-            assert_eq!(dirty_untitled_buffer.read(cx).save_count, 0);
-            assert_eq!(dirty_untitled_buffer.read(cx).save_as_count, 0);
+            assert_eq!(dirty_regular_buffer_2.read(cx).save_count, 0);
             assert_eq!(pane.items_len(), 1);
             assert_eq!(
                 pane.active_item().unwrap().item_id(),
@@ -7514,7 +7514,6 @@ mod tests {
         );
         cx.simulate_prompt_answer(0);
         cx.background_executor.run_until_parked();
-        assert!(cx.did_prompt_for_new_path(), "Multibuffer prompt's save option should invoke the path selection for the unsaved buffer");
         cx.simulate_new_path_selection(|_| Some(PathBuf::default()));
         cx.background_executor.run_until_parked();
         close_multibuffer_task
@@ -7527,23 +7526,98 @@ mod tests {
                 0,
                 "Multibuffer itself should not be saved"
             );
-            assert_eq!(
-                dirty_multibuffer_with_both.read(cx).save_as_count,
-                0,
-                "Multibuffer itself should not be saved as"
-            );
-            assert_eq!(dirty_untitled_buffer.read(cx).save_count, 0);
-            assert_eq!(
-                dirty_untitled_buffer.read(cx).save_as_count,
-                1,
-                "After the path selection, multibuffer should have been saved"
-            );
+            assert_eq!(dirty_regular_buffer_2.read(cx).save_count, 0);
             assert_eq!(
                 pane.items_len(),
                 0,
                 "No more items should be left in the pane"
             );
             assert!(pane.active_item().is_none());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_no_save_prompt_when_dirty_multibuffer_closed_with_all_its_dirty_items_present_in_the_pane(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) = cx.add_window_view(|cx| Workspace::test_new(project, cx));
+        let pane = workspace.update(cx, |workspace, _| workspace.active_pane().clone());
+
+        let dirty_regular_buffer = cx.new_view(|cx| {
+            TestItem::new(cx)
+                .with_dirty(true)
+                .with_label("1.txt")
+                .with_project_items(&[dirty_project_item(1, "1.txt", cx)])
+        });
+        let dirty_regular_buffer_2 = cx.new_view(|cx| {
+            TestItem::new(cx)
+                .with_dirty(true)
+                .with_label("2.txt")
+                .with_project_items(&[dirty_project_item(2, "2.txt", cx)])
+        });
+        let dirty_multibuffer_with_both = cx.new_view(|cx| {
+            TestItem::new(cx)
+                .with_dirty(true)
+                .with_singleton(false)
+                .with_label("Fake Project Search")
+                .with_project_items(&[
+                    dirty_regular_buffer.read(cx).project_items[0].clone(),
+                    dirty_regular_buffer_2.read(cx).project_items[0].clone(),
+                ])
+        });
+        let multibuffer_with_both_files_id = dirty_multibuffer_with_both.item_id();
+        workspace.update(cx, |workspace, cx| {
+            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer.clone()), cx);
+            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer_2.clone()), cx);
+            workspace.add_item(
+                pane.clone(),
+                Box::new(dirty_multibuffer_with_both.clone()),
+                cx,
+            );
+        });
+
+        pane.update(cx, |pane, cx| {
+            pane.activate_item(2, true, true, cx);
+            assert_eq!(
+                pane.active_item().unwrap().item_id(),
+                multibuffer_with_both_files_id,
+                "Should select the multibuffer in the pane"
+            );
+        });
+        let close_multibuffer_task = pane
+            .update(cx, |pane, cx| {
+                pane.close_active_item(&CloseActiveItem { save_intent: None }, cx)
+            })
+            .expect("should have active multi buffer to close");
+        cx.background_executor.run_until_parked();
+        assert!(
+            !cx.has_pending_prompt(),
+            "All dirty items from the multibuffer are in the pane still, no save prompts should be shown"
+        );
+        close_multibuffer_task
+            .await
+            .expect("Closing multibuffer failed");
+        pane.update(cx, |pane, cx| {
+            assert_eq!(dirty_regular_buffer.read(cx).save_count, 0);
+            assert_eq!(dirty_multibuffer_with_both.read(cx).save_count, 0);
+            assert_eq!(dirty_regular_buffer_2.read(cx).save_count, 0);
+            assert_eq!(
+                pane.items()
+                    .map(|item| item.item_id())
+                    .sorted()
+                    .collect::<Vec<_>>(),
+                vec![
+                    dirty_regular_buffer.item_id(),
+                    dirty_regular_buffer_2.item_id(),
+                ],
+                "Should have no multibuffer left in the pane"
+            );
+            assert!(dirty_regular_buffer.read(cx).is_dirty);
+            assert!(dirty_regular_buffer_2.read(cx).is_dirty);
         });
     }
 
@@ -7845,5 +7919,13 @@ mod tests {
             crate::init_settings(cx);
             Project::init_settings(cx);
         });
+    }
+
+    fn dirty_project_item(id: u64, path: &str, cx: &mut AppContext) -> Model<TestProjectItem> {
+        let item = TestProjectItem::new(id, path, cx);
+        item.update(cx, |item, _| {
+            item.is_dirty = true;
+        });
+        item
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -391,12 +391,12 @@ impl Global for ProjectItemOpeners {}
 pub fn register_project_item<I: ProjectItem>(cx: &mut AppContext) {
     let builders = cx.default_global::<ProjectItemOpeners>();
     builders.push(|project, project_path, cx| {
-        let project_item = <I::Item as project::Item>::try_open(project, project_path, cx)?;
+        let project_item = <I::Item as project::ProjectItem>::try_open(project, project_path, cx)?;
         let project = project.clone();
         Some(cx.spawn(|cx| async move {
             let project_item = project_item.await?;
             let project_entry_id: Option<ProjectEntryId> =
-                project_item.read_with(&cx, project::Item::entry_id)?;
+                project_item.read_with(&cx, project::ProjectItem::entry_id)?;
             let build_workspace_item = Box::new(|cx: &mut ViewContext<Pane>| {
                 Box::new(cx.new_view(|cx| I::for_project_item(project, project_item, cx)))
                     as Box<dyn ItemHandle>
@@ -7443,9 +7443,13 @@ mod tests {
         });
         let multibuffer_with_both_files_id = dirty_multibuffer_with_both.item_id();
         workspace.update(cx, |workspace, cx| {
-            workspace.add_item(Box::new(dirty_regular_buffer.clone()), cx);
-            workspace.add_item(Box::new(dirty_untitled_buffer.clone()), cx);
-            workspace.add_item(Box::new(dirty_multibuffer_with_both.clone()), cx);
+            workspace.add_item(pane.clone(), Box::new(dirty_regular_buffer.clone()), cx);
+            workspace.add_item(pane.clone(), Box::new(dirty_untitled_buffer.clone()), cx);
+            workspace.add_item(
+                pane.clone(),
+                Box::new(dirty_multibuffer_with_both.clone()),
+                cx,
+            );
         });
 
         pane.update(cx, |pane, cx| {
@@ -7459,7 +7463,12 @@ mod tests {
         // When closing both the unsaved buffer and the multibuffer that contains it, we should only prompt to save the unsaved buffer.
         let close_all_but_multibuffer_task = pane
             .update(cx, |pane, cx| {
-                pane.close_inactive_items(&CloseInactiveItems, cx)
+                pane.close_inactive_items(
+                    &CloseInactiveItems {
+                        save_intent: Some(SaveIntent::Close),
+                    },
+                    cx,
+                )
             })
             .expect("should have inactive files to close");
         cx.background_executor.run_until_parked();
@@ -7550,7 +7559,7 @@ mod tests {
         // Model
         struct TestPngItem {}
 
-        impl project::Item for TestPngItem {
+        impl project::ProjectItem for TestPngItem {
             fn try_open(
                 _project: &Model<Project>,
                 path: &ProjectPath,
@@ -7569,6 +7578,10 @@ mod tests {
 
             fn project_path(&self, _: &AppContext) -> Option<ProjectPath> {
                 None
+            }
+
+            fn is_dirty(&self) -> bool {
+                false
             }
         }
 
@@ -7612,7 +7625,7 @@ mod tests {
         // Model
         struct TestIpynbItem {}
 
-        impl project::Item for TestIpynbItem {
+        impl project::ProjectItem for TestIpynbItem {
             fn try_open(
                 _project: &Model<Project>,
                 path: &ProjectPath,
@@ -7631,6 +7644,10 @@ mod tests {
 
             fn project_path(&self, _: &AppContext) -> Option<ProjectPath> {
                 None
+            }
+
+            fn is_dirty(&self) -> bool {
+                false
             }
         }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -29,7 +29,7 @@ use gpui::{
 pub use open_listener::*;
 use outline_panel::OutlinePanel;
 use paths::{local_settings_file_relative_path, local_tasks_file_relative_path};
-use project::{DirectoryLister, Item};
+use project::{DirectoryLister, ProjectItem};
 use project_panel::ProjectPanel;
 use quick_action_bar::QuickActionBar;
 use recent_projects::open_ssh_project;


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/12029

Allows to introspect project items inside items more deeply, checking them for being dirty.
For that:
* renames `project::Item` into `project::ProjectItem`
* adds an `is_dirty(&self) -> bool` method to the renamed trait
* changes the closing logic to only care about dirty project items when checking for save prompts conditions
* save prompts are raised only if the item is singleton without a project path; or if the item has dirty project items that are not open elsewhere

Release Notes:

- Fixed item closing overtly triggering save dialogues
