### PR TITLE
Docs: Update developing zed docs to match

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -6,10 +6,10 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 
-- Install [Rust](https://www.rust-lang.org/tools/install). If it's already installed, make sure it's up-to-date:
+- Install [rustup](https://www.rust-lang.org/tools/install)
 
   ```sh
-  rustup update
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
   ```
 
 - Install the necessary system libraries:

--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -8,10 +8,6 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 - Install [rustup](https://www.rust-lang.org/tools/install)
 
-  ```sh
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-  ```
-
 - Install the necessary system libraries:
 
   ```sh

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -8,10 +8,6 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 - Install [rustup](https://www.rust-lang.org/tools/install)
 
-  ```sh
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-  ```
-
 - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) from the macOS App Store, or from the [Apple Developer](https://developer.apple.com/download/all/) website. Note this requires a developer account.
 
 > Ensure you launch Xcode after installing, and install the macOS components, which is the default option.

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -6,16 +6,10 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 
-- Install [Rust](https://www.rust-lang.org/tools/install). If it's already installed, make sure it's up-to-date:
+- Install [rustup](https://www.rust-lang.org/tools/install)
 
   ```sh
-  rustup update
-  ```
-
-- Install the Rust wasm toolchain:
-
-  ```sh
-  rustup target add wasm32-wasip1
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
   ```
 
 - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) from the macOS App Store, or from the [Apple Developer](https://developer.apple.com/download/all/) website. Note this requires a developer account.

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -6,7 +6,18 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 
-- Install [Rust](https://www.rust-lang.org/tools/install)
+- Install [Rust](https://www.rust-lang.org/tools/install). If it's already installed, make sure it's up-to-date:
+
+  ```sh
+  rustup update
+  ```
+
+- Install the Rust wasm toolchain:
+
+  ```sh
+  rustup target add wasm32-wasip1
+  ```
+
 - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) from the macOS App Store, or from the [Apple Developer](https://developer.apple.com/download/all/) website. Note this requires a developer account.
 
 > Ensure you launch Xcode after installing, and install the macOS components, which is the default option.
@@ -22,12 +33,6 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
   ```sh
   sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
   sudo xcodebuild -license accept
-  ```
-
-- Install the Rust wasm toolchain:
-
-  ```sh
-  rustup target add wasm32-wasip1
   ```
 
 - Install `cmake` (required by [a dependency](https://docs.rs/wasmtime-c-api-impl/latest/wasmtime_c_api/))

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -22,7 +22,7 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 - Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional components `MSVC v*** - VS YYYY C++ x64/x86 build tools` and `MSVC v*** - VS YYYY C++ x64/x86 Spectre-mitigated libs (latest)` (`v***` is your VS version and `YYYY` is year when your VS was released. Pay attention to the architecture and change it to yours if needed.)
 - Install Windows 11 or 10 SDK depending on your system, but ensure that at least `Windows 10 SDK version 2104 (10.0.20348.0)` is installed on your machine. You can download it from the [Windows SDK Archive](https://developer.microsoft.com/windows/downloads/windows-sdk/)
-- Install [CMake](https://cmake.org/download)
+- Install [CMake](https://cmake.org/download) (required by [a dependency](https://docs.rs/wasmtime-c-api-impl/latest/wasmtime_c_api/))
 
 ## Backend dependencies
 

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -8,17 +8,7 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 
-- Install [Rust](https://www.rust-lang.org/tools/install). If it's already installed, make sure it's up-to-date:
-
-  ```sh
-  rustup update
-  ```
-
-- Install the Rust wasm toolchain:
-
-  ```sh
-  rustup target add wasm32-wasip1
-  ```
+- Install [rustup](https://www.rust-lang.org/tools/install)
 
 - Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional components `MSVC v*** - VS YYYY C++ x64/x86 build tools` and `MSVC v*** - VS YYYY C++ x64/x86 Spectre-mitigated libs (latest)` (`v***` is your VS version and `YYYY` is year when your VS was released. Pay attention to the architecture and change it to yours if needed.)
 - Install Windows 11 or 10 SDK depending on your system, but ensure that at least `Windows 10 SDK version 2104 (10.0.20348.0)` is installed on your machine. You can download it from the [Windows SDK Archive](https://developer.microsoft.com/windows/downloads/windows-sdk/)


### PR DESCRIPTION
Some changes just so the build docs for the different os matches each other :)

macos:
- moved `rust wasm toolchain install` up under `rust install` (match windows docs)
- add instructions to update rust if already installed (match windows and linux docs)

windows:
- add `(required by a dependency)` to cmake install (match macos docs)

Release Notes:

- N/A
