### PR TITLE
Fine-tune terminal tab bar actions spacing

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -26,8 +26,8 @@ use terminal::{
     Terminal,
 };
 use ui::{
-    div, h_flex, ButtonCommon, Clickable, ContextMenu, FluentBuilder, IconButton, IconSize,
-    InteractiveElement, PopoverMenu, Selectable, Tooltip,
+    prelude::*, ButtonCommon, Clickable, ContextMenu, FluentBuilder, PopoverMenu, Selectable,
+    Tooltip,
 };
 use util::{ResultExt, TryFutureExt};
 use workspace::{
@@ -139,14 +139,13 @@ impl TerminalPanel {
                 }
                 let focus_handle = pane.focus_handle(cx);
                 let right_children = h_flex()
-                    .gap_2()
-                    .children(assistant_tab_bar_button.clone())
+                    .gap(DynamicSpacing::Base02.rems(cx))
                     .child(
                         PopoverMenu::new("terminal-tab-bar-popover-menu")
                             .trigger(
                                 IconButton::new("plus", IconName::Plus)
                                     .icon_size(IconSize::Small)
-                                    .tooltip(|cx| Tooltip::text("New...", cx)),
+                                    .tooltip(|cx| Tooltip::text("New…", cx)),
                             )
                             .anchor(AnchorCorner::TopRight)
                             .with_handle(pane.new_item_context_menu_handle.clone())
@@ -170,6 +169,7 @@ impl TerminalPanel {
                                 Some(menu)
                             }),
                     )
+                    .children(assistant_tab_bar_button.clone())
                     .child(
                         PopoverMenu::new("terminal-pane-tab-bar-split")
                             .trigger(


### PR DESCRIPTION
Just quickly reducing the spacing between the terminal tab bar actions so they're tighter and matching other similar components.

| Before | After |
|--------|--------|
| <img width="800" alt="Screenshot 2024-12-01 at 19 20 50" src="https://github.com/user-attachments/assets/938336df-9ce1-42d3-8f3d-9c26b8e88453"> | <img width="800" alt="Screenshot 2024-12-01 at 19 18 19" src="https://github.com/user-attachments/assets/0a2b5915-f37c-4b8e-af2c-b8018c4750ab"> | 

Release Notes:

- N/A
