### PR TITLE
Add consistent placeholder text for terminal inline assist

### DIFF
--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -32,7 +32,7 @@ use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
 use terminal::Terminal;
 use terminal_view::TerminalView;
 use theme::ThemeSettings;
-use ui::{prelude::*, IconButtonShape, Tooltip};
+use ui::{prelude::*, text_for_action, IconButtonShape, Tooltip};
 use util::ResultExt;
 use workspace::{notifications::NotificationId, Toast, Workspace};
 
@@ -704,7 +704,7 @@ impl PromptEditor {
                 cx,
             );
             editor.set_soft_wrap_mode(language::language_settings::SoftWrap::EditorWidth, cx);
-            editor.set_placeholder_text("Add a prompt…", cx);
+            editor.set_placeholder_text(Self::placeholder_text(cx), cx);
             editor
         });
 
@@ -735,6 +735,14 @@ impl PromptEditor {
         this.count_tokens(cx);
         this.subscribe_to_editor(cx);
         this
+    }
+
+    fn placeholder_text(cx: &WindowContext) -> String {
+        let context_keybinding = text_for_action(&crate::ToggleFocus, cx)
+            .map(|keybinding| format!(" • {keybinding} for context"))
+            .unwrap_or_default();
+
+        format!("Generate…{context_keybinding} • ↓↑ for history")
     }
 
     fn subscribe_to_editor(&mut self, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
Ensuring it is consistent with the buffer inline assistant. Just thought of not having "Transform" here as that felt it made less sense for terminal-related prompts, where arguably more frequently, one would be suggesting for actual commands rather than code transformation.

<img width="700" alt="Screenshot 2024-12-02 at 09 11 00" src="https://github.com/user-attachments/assets/ad96d03e-0366-46e8-8056-581066712d59">

Release Notes:

- N/A


