### PR TITLE
Treat `.pcss` files as CSS

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -127,6 +127,7 @@
     "ogg": "audio",
     "opus": "audio",
     "otf": "font",
+    "pcss": "css",
     "pdb": "storage",
     "pdf": "document",
     "php": "php",

--- a/crates/languages/src/css/config.toml
+++ b/crates/languages/src/css/config.toml
@@ -1,6 +1,6 @@
 name = "CSS"
 grammar = "css"
-path_suffixes = ["css", "pcss", "postcss"]
+path_suffixes = ["css", "postcss", "pcss"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/css/config.toml
+++ b/crates/languages/src/css/config.toml
@@ -1,6 +1,6 @@
 name = "CSS"
 grammar = "css"
-path_suffixes = ["css", "postcss"]
+path_suffixes = ["css", "pcss", "postcss"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
This addresses https://github.com/zed-industries/zed/pull/19416#discussion_r1865019293 and also follows the [associated PostCSS file extensions for VS Code](https://github.com/csstools/postcss-language/blob/5d003170c5ed962b09b9a0f3725a6cae885df292/package.json#L37).

Release Notes:

- `.pcss` files are now recognized as CSS
