### PR TITLE
Force code actions to be single line

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1690,7 +1690,9 @@ impl CodeActionsMenu {
                                     }),
                                 )
                                 // TASK: It would be good to make lsp_action.title a SharedString to avoid allocating here.
-                                .child(SharedString::from(action.lsp_action.title.clone()))
+                                .child(SharedString::from(
+                                    action.lsp_action.title.replace("\n", ""),
+                                ))
                             })
                             .when_some(action.as_task(), |this, task| {
                                 this.on_mouse_down(
@@ -1707,7 +1709,7 @@ impl CodeActionsMenu {
                                         }
                                     }),
                                 )
-                                .child(SharedString::from(task.resolved_label.clone()))
+                                .child(SharedString::from(task.resolved_label.replace("\n", "")))
                             })
                     })
                     .collect()


### PR DESCRIPTION
Addresses #21403 partially. Is consistent with the behaviour in VSCode

Before:
<img width="332" alt="391571084-1bef4ef9-b8f5-4c8f-9a32-9c0ab6c91af1" src="https://github.com/user-attachments/assets/d4d83826-23a1-43a1-94f9-feb0b0ddd5ce">

After:
<img width="330" alt="Screenshot 2024-12-02 at 18 35 11" src="https://github.com/user-attachments/assets/c04f0494-4f34-476a-a090-1443d61851e5">

Release Notes:

- Fixed an issue with multiline code actions' rendering by forcing them to be single line
