### PR TITLE
toolchains: Run listing tasks on background thread

### DIFF
--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -24,7 +24,7 @@ pub struct Toolchain {
     pub as_json: serde_json::Value,
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait ToolchainLister: Send + Sync {
     async fn list(
         &self,

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -536,7 +536,7 @@ fn env_priority(kind: Option<PythonEnvironmentKind>) -> usize {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl ToolchainLister for PythonToolchainProvider {
     async fn list(
         &self,

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -312,11 +312,12 @@ impl LocalToolchainStore {
                 .ok()?
                 .await;
             let language = registry.language_for_name(&language_name.0).await.ok()?;
-            let toolchains = language
-                .toolchain_lister()?
-                .list(root.to_path_buf(), project_env)
-                .await;
-            Some(toolchains)
+            let toolchains = language.toolchain_lister()?;
+            Some(
+                cx.background_executor()
+                    .spawn(async move { toolchains.list(root.to_path_buf(), project_env).await })
+                    .await,
+            )
         })
     }
     pub(crate) fn active_toolchain(

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -311,13 +311,14 @@ impl LocalToolchainStore {
                 })
                 .ok()?
                 .await;
-            let language = registry.language_for_name(&language_name.0).await.ok()?;
-            let toolchains = language.toolchain_lister()?;
-            Some(
-                cx.background_executor()
-                    .spawn(async move { toolchains.list(root.to_path_buf(), project_env).await })
-                    .await,
-            )
+
+            cx.background_executor()
+                .spawn(async move {
+                    let language = registry.language_for_name(&language_name.0).await.ok()?;
+                    let toolchains = language.toolchain_lister()?;
+                    Some(toolchains.list(root.to_path_buf(), project_env).await)
+                })
+                .await
         })
     }
     pub(crate) fn active_toolchain(


### PR DESCRIPTION
Potentially fixes #21404

This is a speculative fix, as while I was trying to repro this issue I've noticed that introducing artificial delays in ToolchainLister::list could impact apps responsiveness. These delays were essentially there to stimulate PET taking a while to find venvs.

Release Notes:

- Improved app responsiveness in environments with multiple Python virtual environments
