### PR TITLE
workspace: Sanitize pinned tab count before usage

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -755,7 +755,7 @@ impl Pane {
     }
 
     pub(crate) fn set_pinned_count(&mut self, count: usize) {
-        self.pinned_tab_count = count;
+        self.pinned_tab_count = count.min(self.items.len());
     }
 
     pub(crate) fn pinned_count(&self) -> usize {
@@ -1890,7 +1890,7 @@ impl Pane {
     fn unpin_tab_at(&mut self, ix: usize, cx: &mut ViewContext<'_, Self>) {
         maybe!({
             let pane = cx.view().clone();
-            self.pinned_tab_count = self.pinned_tab_count.checked_sub(1).unwrap();
+            self.pinned_tab_count = self.pinned_tab_count.checked_sub(1)?;
             let destination_index = self.pinned_tab_count;
 
             let id = self.item_for_index(ix)?.item_id();

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -755,7 +755,7 @@ impl Pane {
     }
 
     pub(crate) fn set_pinned_count(&mut self, count: usize) {
-        self.pinned_tab_count = count.min(self.items.len());
+        self.pinned_tab_count = count;
     }
 
     pub(crate) fn pinned_count(&self) -> usize {

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -473,7 +473,7 @@ impl SerializedPane {
             })?;
         }
         pane.update(cx, |pane, _| {
-            pane.set_pinned_count(self.pinned_count);
+            pane.set_pinned_count(self.pinned_count.min(items.len()));
         })?;
 
         anyhow::Ok(items)


### PR DESCRIPTION
Fixes all sorts of panics around usage of incorrect pinned tab count that has been fixed in app itself, yet persists in user db.

Closes #ISSUE

Release Notes:

- N/A
