### PR TITLE
Check for vulnerable dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
           script/check-licenses
           script/generate-licenses /tmp/zed_licenses_output
 
+      - name: Check for new vulnerable dependencies
+        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4
+        with:
+          license-check: false
+
       - name: Run tests
         uses: ./.github/actions/run_tests
 


### PR DESCRIPTION
This PR adds GitHub's dependency review action to CI, to flag PRs that introduce new Cargo.lock entries for vulnerable crates according to the GHSA database.

An alternative would be to run `cargo audit`, which checks against the RustSec database. The state of synchronization between these two databases seems a bit messy, but as far as I can tell GHSA has most recent RustSec advisories on file, while RustSec is missing a larger number of recent GHSA advisories.

The dependency review action should be smart enough not to flag PRs because an untouched entry in Cargo.lock has a new advisory.

I've turned off the "license check" functionality since we have a separate CI step for that.

Release Notes:

- N/A
