### PR TITLE
assistant: Use a smaller icon for the "New Chat" button

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -450,6 +450,7 @@ impl AssistantPanel {
                     .gap(DynamicSpacing::Base02.rems(cx))
                     .child(
                         IconButton::new("new-chat", IconName::Plus)
+                            .icon_size(IconSize::Small)
                             .on_click(
                                 cx.listener(|_, _, cx| {
                                     cx.dispatch_action(NewContext.boxed_clone())


### PR DESCRIPTION
Assistant new chat icon is slightly larger than editor pane new icon.

Changes:
Adds `IconSize::Small` to assistant default size new chat icon, not really noticeable, but matches the new icon in editor pane, and the assistant dropdown menu that have icon size small.

|old|new|
|---|---|
|![image](https://github.com/user-attachments/assets/cbef5054-a465-4957-9409-b4a73e703363)|![image](https://github.com/user-attachments/assets/baee66ea-76d6-43b4-a4b9-ead34991ff85)|

Release Notes:

- N/A
