### PR TITLE
Run dependency review for pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
           script/generate-licenses /tmp/zed_licenses_output
 
       - name: Check for new vulnerable dependencies
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4
         with:
           license-check: false


### PR DESCRIPTION
This was an oversight in the original PR, dependency-review-action won't work properly for `push` events ([example](https://github.com/zed-industries/zed/actions/runs/12130053580/job/33819624076)).

Release Notes:

- N/A
