### PR TITLE
Disable hunk diff arrow buttons when there's only one hunk

### DIFF
--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -473,11 +473,12 @@ impl Editor {
                                 .child(
                                     h_flex()
                                         .gap_1()
-                                        .when(!is_branch_buffer && has_multiple_hunks, |row| {
+                                        .when(!is_branch_buffer, |row| {
                                             row.child(
                                                 IconButton::new("next-hunk", IconName::ArrowDown)
                                                     .shape(IconButtonShape::Square)
                                                     .icon_size(IconSize::Small)
+                                                    .disabled(!has_multiple_hunks)
                                                     .tooltip({
                                                         let focus_handle = editor.focus_handle(cx);
                                                         move |cx| {
@@ -506,6 +507,7 @@ impl Editor {
                                                 IconButton::new("prev-hunk", IconName::ArrowUp)
                                                     .shape(IconButtonShape::Square)
                                                     .icon_size(IconSize::Small)
+                                                    .disabled(!has_multiple_hunks)
                                                     .tooltip({
                                                         let focus_handle = editor.focus_handle(cx);
                                                         move |cx| {

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -399,6 +399,12 @@ impl Editor {
         }
     }
 
+    fn has_multiple_hunks(&self, cx: &AppContext) -> bool {
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let mut hunks = snapshot.git_diff_hunks_in_range(MultiBufferRow::MIN..MultiBufferRow::MAX);
+        hunks.nth(1).is_some()
+    }
+
     fn hunk_header_block(
         &self,
         hunk: &HoveredHunk,
@@ -428,6 +434,7 @@ impl Editor {
             render: Arc::new({
                 let editor = cx.view().clone();
                 let hunk = hunk.clone();
+                let has_multiple_hunks = self.has_multiple_hunks(cx);
 
                 move |cx| {
                     let hunk_controls_menu_handle =
@@ -466,7 +473,7 @@ impl Editor {
                                 .child(
                                     h_flex()
                                         .gap_1()
-                                        .when(!is_branch_buffer, |row| {
+                                        .when(!is_branch_buffer && has_multiple_hunks, |row| {
                                             row.child(
                                                 IconButton::new("next-hunk", IconName::ArrowDown)
                                                     .shape(IconButtonShape::Square)


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20817

| One hunk | Multiple hunks |
|--------|--------|
| <img width="800" alt="Screenshot 2024-12-03 at 09 42 49" src="https://github.com/user-attachments/assets/7c2ff80a-d4d9-4a74-84b8-891fadfd4e6c"> | <img width="800" alt="Screenshot 2024-12-02 at 23 36 38" src="https://github.com/user-attachments/assets/60ea94b8-0b23-43a2-afad-b816b4645d1f"> | 

Release Notes:

- Fixed showing prev/next hunk navigation buttons when there is only one hunk
