### PR TITLE
Fix slash command picker overflowing description labels

### DIFF
--- a/crates/assistant/src/slash_command_picker.rs
+++ b/crates/assistant/src/slash_command_picker.rs
@@ -182,6 +182,7 @@ impl PickerDelegate for SlashCommandDelegate {
                             .group(format!("command-entry-label-{ix}"))
                             .w_full()
                             .min_w(px(250.))
+                            .py_0p5()
                             .child(
                                 h_flex()
                                     .gap_1p5()
@@ -210,9 +211,11 @@ impl PickerDelegate for SlashCommandDelegate {
                                     )),
                             )
                             .child(
-                                Label::new(info.description.clone())
-                                    .size(LabelSize::Small)
-                                    .color(Color::Muted),
+                                div().overflow_hidden().text_ellipsis().child(
+                                    Label::new(info.description.clone())
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                ),
                             ),
                     ),
             ),


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20678

Note that this doesn't yet feel like the _ideal_ solution as in certain scenarios, like this one using a monospaced font as the UI font, you wouldn't be able to _read_ the full description, even though the design is technically now fixed.

| Before | After |
|--------|--------|
| <img width="800" alt="Screenshot 2024-12-03 at 00 21 26" src="https://github.com/user-attachments/assets/573b3d4c-7410-4c57-b768-f524551e4f00"> | <img width="800" alt="Screenshot 2024-12-03 at 00 20 10" src="https://github.com/user-attachments/assets/0a4a8d1a-2422-4963-810c-badbe5a39a94"> | 

Release Notes:

- N/A
