### PR TITLE
Fix ctrl-alt-X shortcuts

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1253,7 +1253,10 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
     // otherwise we only send to the input handler if we don't have a matching binding.
     // The input handler may call `do_command_by_selector` if it doesn't know how to handle
     // a key. If it does so, it will return YES so we won't send the key twice.
-    if is_composing || event.keystroke.key_char.is_none() {
+    // We also do this for non-printing keys (like arrow keys and escape) as the IME menu
+    // may need them even if there is no marked text;
+    // however we skip keys with control or the input handler adds control-characters to the buffer.
+    if is_composing || (event.keystroke.key_char.is_none() && !event.keystroke.modifiers.control) {
         {
             let mut lock = window_state.as_ref().lock();
             lock.keystroke_for_do_command = Some(event.keystroke.clone());


### PR DESCRIPTION
The macOS input handler assumes that you want to insert control sequences when
you type ctrl-alt-X (you probably don't...).

Release Notes:

- (nightly only) fix ctrl-alt-X shortcuts
