### PR TITLE
Revert "macos: Add default keybind for ctrl-home / ctrl-end (#21007)"

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -93,8 +93,6 @@
       "ctrl-e": "editor::MoveToEndOfLine",
       "cmd-up": "editor::MoveToBeginning",
       "cmd-down": "editor::MoveToEnd",
-      "ctrl-home": "editor::MoveToBeginning",
-      "ctrl-end": "editor::MoveToEnd",
       "shift-up": "editor::SelectUp",
       "ctrl-shift-p": "editor::SelectUp",
       "shift-down": "editor::SelectDown",


### PR DESCRIPTION
This reverts commit 614b3b979b7373aaa6dee84dfbc824fce1a86ea8.

This conflicts with the macOS `ctrl-fn-left/right` bindings for moving windows around (new in Sequoia).

If you want these use:
```
  {
    "context": "Editor",
    "bindings": {
      "ctrl-home": "editor::MoveToBeginning",
      "ctrl-end": "editor::MoveToEnd"
    }
  },
```

Release Notes:

- N/A
