### PR TITLE
Add openbsd netcat to script/linux

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -37,6 +37,7 @@ if [[ -n $apt ]]; then
     cmake
     clang
     jq
+    netcat-openbsd
     git
     curl
     gettext-base
@@ -84,12 +85,14 @@ if [[ -n $dnf ]] || [[ -n $yum ]]; then
     tar
   )
   # perl used for building openssl-sys crate. See: https://docs.rs/openssl/latest/openssl/
+  # openbsd-netcat is unavailable in RHEL8/9 (and nmap-ncat doesn't support sockets)
   if grep -qP '^ID="(fedora)' /etc/os-release; then
     deps+=(
       perl-FindBin
       perl-IPC-Cmd
       perl-File-Compare
       perl-File-Copy
+      netcat
       mold
     )
   elif grep -qP '^ID="(rhel|rocky|alma|centos|ol)' /etc/os-release; then
@@ -120,7 +123,7 @@ if [[ -n $dnf ]] || [[ -n $yum ]]; then
     fi
   fi
 
-  $maysudo $pkg_cmd install -y "${deps[@]}"
+  $maysudo "$pkg_cmd" install -y "${deps[@]}"
   finalize
   exit 0
 fi
@@ -145,6 +148,7 @@ if [[ -n $zyp ]]; then
     libzstd-devel
     make
     mold
+    netcat-openbsd
     openssl-devel
     sqlite3-devel
     tar
@@ -169,6 +173,7 @@ if [[ -n $pacman ]]; then
     wayland
     libgit2
     libxkbcommon-x11
+    openbsd-netcat
     openssl
     zstd
     pkgconf
@@ -198,6 +203,7 @@ if [[ -n $xbps ]]; then
     libxcb-devel
     libxkbcommon-devel
     libzstd-devel
+    openbsd-netcat
     openssl-devel
     wayland-devel
     vulkan-loader
@@ -222,6 +228,7 @@ if [[ -n $emerge ]]; then
     media-libs/alsa-lib
     media-libs/fontconfig
     media-libs/vulkan-loader
+    net-analyzer/openbsd-netcat
     x11-libs/libxcb
     x11-libs/libxkbcommon
     sys-devel/mold


### PR DESCRIPTION
- Follow-up to: https://github.com/zed-industries/zed/pull/20751

openbsd-netcat is required for interactive SSH Remoting prompts (password, passphrase, 2fa, etc).

Release Notes:

- N/A