### PR TITLE
Configure Highlight settings on yank vim

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1129,7 +1129,6 @@
     "use_system_clipboard": "always",
     "use_multiline_find": false,
     "use_smartcase_find": false,
-    "highlight_on_copy": true,
     "highlight_on_copy_duration": 200,
     "custom_digraphs": {}
   },

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1129,7 +1129,8 @@
     "use_system_clipboard": "always",
     "use_multiline_find": false,
     "use_smartcase_find": false,
-    "highlight_on_copy": false,
+    "highlight_on_copy": true,
+    "highlight_on_copy_duration": 200,
     "custom_digraphs": {}
   },
   // The server to connect to. If the environment variable

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1129,7 +1129,7 @@
     "use_system_clipboard": "always",
     "use_multiline_find": false,
     "use_smartcase_find": false,
-    "highlight_on_copy_duration": 200,
+    "highlight_on_yank_duration": 200,
     "custom_digraphs": {}
   },
   // The server to connect to. If the environment variable

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1129,6 +1129,7 @@
     "use_system_clipboard": "always",
     "use_multiline_find": false,
     "use_smartcase_find": false,
+    "highlight_on_copy": false,
     "custom_digraphs": {}
   },
   // The server to connect to. If the environment variable

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -196,7 +196,7 @@ impl Vim {
             )
         });
 
-        let highlight_duration = VimSettings::get_global(cx).highlight_on_copy_duration;
+        let highlight_duration = VimSettings::get_global(cx).highlight_on_yank_duration;
         if !is_yank || self.mode == Mode::Visual || highlight_duration == 0 {
             return;
         }

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -202,6 +202,8 @@ impl Vim {
             return;
         }
 
+        let highlight_duration = VimSettings::get_global(cx).highlight_on_copy_duration;
+
         editor.highlight_background::<HighlightOnYank>(
             &ranges_to_highlight,
             |colors| colors.editor_document_highlight_read_background,
@@ -209,7 +211,7 @@ impl Vim {
         );
         cx.spawn(|this, mut cx| async move {
             cx.background_executor()
-                .timer(Duration::from_millis(200))
+                .timer(Duration::from_millis(highlight_duration))
                 .await;
             this.update(&mut cx, |editor, cx| {
                 editor.clear_background_highlights::<HighlightOnYank>(cx)

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -196,13 +196,10 @@ impl Vim {
             )
         });
 
-        let highlight = VimSettings::get_global(cx).highlight_on_copy;
-
-        if !is_yank || self.mode == Mode::Visual || !highlight {
+        let highlight_duration = VimSettings::get_global(cx).highlight_on_copy_duration;
+        if !is_yank || self.mode == Mode::Visual || highlight_duration == 0 {
             return;
         }
-
-        let highlight_duration = VimSettings::get_global(cx).highlight_on_copy_duration;
 
         editor.highlight_background::<HighlightOnYank>(
             &ranges_to_highlight,

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -4,13 +4,14 @@ use crate::{
     motion::Motion,
     object::Object,
     state::{Mode, Register},
-    Vim,
+    Vim, VimSettings,
 };
 use collections::HashMap;
 use editor::{ClipboardSelection, Editor};
 use gpui::ViewContext;
 use language::Point;
 use multi_buffer::MultiBufferRow;
+use settings::Settings;
 
 struct HighlightOnYank;
 
@@ -195,7 +196,9 @@ impl Vim {
             )
         });
 
-        if !is_yank || self.mode == Mode::Visual {
+        let highlight = VimSettings::get_global(cx).highlight_on_copy;
+
+        if !is_yank || self.mode == Mode::Visual || !highlight {
             return;
         }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1188,7 +1188,6 @@ struct VimSettings {
     pub use_multiline_find: bool,
     pub use_smartcase_find: bool,
     pub custom_digraphs: HashMap<String, Arc<str>>,
-    pub highlight_on_copy: bool,
     pub highlight_on_copy_duration: u64,
 }
 
@@ -1199,7 +1198,6 @@ struct VimSettingsContent {
     pub use_multiline_find: Option<bool>,
     pub use_smartcase_find: Option<bool>,
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
-    pub highlight_on_copy: Option<bool>,
     pub highlight_on_copy_duration: Option<u64>,
 }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1188,6 +1188,7 @@ struct VimSettings {
     pub use_multiline_find: bool,
     pub use_smartcase_find: bool,
     pub custom_digraphs: HashMap<String, Arc<str>>,
+    pub highlight_on_copy: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -1197,6 +1198,7 @@ struct VimSettingsContent {
     pub use_multiline_find: Option<bool>,
     pub use_smartcase_find: Option<bool>,
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
+    pub highlight_on_copy: Option<bool>,
 }
 
 impl Settings for VimSettings {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1188,7 +1188,7 @@ struct VimSettings {
     pub use_multiline_find: bool,
     pub use_smartcase_find: bool,
     pub custom_digraphs: HashMap<String, Arc<str>>,
-    pub highlight_on_copy_duration: u64,
+    pub highlight_on_yank_duration: u64,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -1198,7 +1198,7 @@ struct VimSettingsContent {
     pub use_multiline_find: Option<bool>,
     pub use_smartcase_find: Option<bool>,
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
-    pub highlight_on_copy_duration: Option<u64>,
+    pub highlight_on_yank_duration: Option<u64>,
 }
 
 impl Settings for VimSettings {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1189,6 +1189,7 @@ struct VimSettings {
     pub use_smartcase_find: bool,
     pub custom_digraphs: HashMap<String, Arc<str>>,
     pub highlight_on_copy: bool,
+    pub highlight_on_copy_duration: u64,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -1199,6 +1200,7 @@ struct VimSettingsContent {
     pub use_smartcase_find: Option<bool>,
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
     pub highlight_on_copy: Option<bool>,
+    pub highlight_on_copy_duration: Option<u64>,
 }
 
 impl Settings for VimSettings {

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -409,7 +409,7 @@ You can change the following settings to modify vim mode's behavior:
 | use_smartcase_find           | If `true`, `f` and `t` motions are case-insensitive when the target letter is lowercase.                                                                                                      | false         |
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
-| highlight_on_copy_duration   | The duration of the higlight animation(in ms). Set to `0` to disable                                                                                                                                 | 200           |
+| highlight_on_copy_duration   | The duration of the highlight animation(in ms). Set to `0` to disable                                                                                                                         | 200           |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -409,7 +409,7 @@ You can change the following settings to modify vim mode's behavior:
 | use_smartcase_find           | If `true`, `f` and `t` motions are case-insensitive when the target letter is lowercase.                                                                                                      | false         |
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
-| highlight_on_copy_duration   | The duration of the higlight animation(in ms). Set to `0` to disable                                                                                                                                 | 200           |
+| highlight_on_yank_duration   | The duration of the higlight animation(in ms). Set to `0` to disable                                                                                                                                 | 200           |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 
@@ -432,7 +432,7 @@ Here's an example of these settings changed:
     "use_multiline_find": true,
     "use_smartcase_find": true,
     "toggle_relative_line_numbers": true,
-    "highlight_on_copy_duration": 50,
+    "highlight_on_yank_duration": 50,
     "custom_digraphs": {
       "fz": "🧟‍♀️"
     }

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -409,7 +409,7 @@ You can change the following settings to modify vim mode's behavior:
 | use_smartcase_find           | If `true`, `f` and `t` motions are case-insensitive when the target letter is lowercase.                                                                                                      | false         |
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
-| highlight_on_copy_duration   | The duration of the highlight animation(in ms). Set to `0` to disable                                                                                                                         | 200           |
+| highlight_on_yank_duration   | The duration of the highlight animation(in ms). Set to `0` to disable                                                                                                                         | 200           |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -409,6 +409,7 @@ You can change the following settings to modify vim mode's behavior:
 | use_smartcase_find           | If `true`, `f` and `t` motions are case-insensitive when the target letter is lowercase.                                                                                                      | false         |
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
+| highlight_on_copy_duration   | The duration of the higlight animation. Set to `0` to disable                                                                                                                                 | 200           |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -409,7 +409,7 @@ You can change the following settings to modify vim mode's behavior:
 | use_smartcase_find           | If `true`, `f` and `t` motions are case-insensitive when the target letter is lowercase.                                                                                                      | false         |
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
-| highlight_on_copy_duration   | The duration of the higlight animation. Set to `0` to disable                                                                                                                                 | 200           |
+| highlight_on_copy_duration   | The duration of the higlight animation(in ms). Set to `0` to disable                                                                                                                                 | 200           |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 
@@ -432,6 +432,7 @@ Here's an example of these settings changed:
     "use_multiline_find": true,
     "use_smartcase_find": true,
     "toggle_relative_line_numbers": true,
+    "highlight_on_copy_duration": 50,
     "custom_digraphs": {
       "fz": "🧟‍♀️"
     }


### PR DESCRIPTION
Release Notes:

- Add settings / config variables to control `highlight_on_yank` or `highlight_on_copy`
