### PR TITLE
markdown: Make `cx` the last parameter to the constructor

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -593,8 +593,8 @@ async fn parse_blocks(
                 combined_text,
                 markdown_style.clone(),
                 Some(language_registry.clone()),
-                cx,
                 fallback_language_name,
+                cx,
             )
         })
         .ok();

--- a/crates/markdown/examples/markdown.rs
+++ b/crates/markdown/examples/markdown.rs
@@ -178,7 +178,7 @@ impl MarkdownExample {
         cx: &mut WindowContext,
     ) -> Self {
         let markdown =
-            cx.new_view(|cx| Markdown::new(text, style, Some(language_registry), cx, None));
+            cx.new_view(|cx| Markdown::new(text, style, Some(language_registry), None, cx));
         Self { markdown }
     }
 }

--- a/crates/markdown/examples/markdown_as_child.rs
+++ b/crates/markdown/examples/markdown_as_child.rs
@@ -87,7 +87,7 @@ pub fn main() {
                     heading: Default::default(),
                 };
                 let markdown = cx.new_view(|cx| {
-                    Markdown::new(MARKDOWN_EXAMPLE.into(), markdown_style, None, cx, None)
+                    Markdown::new(MARKDOWN_EXAMPLE.into(), markdown_style, None, None, cx)
                 });
 
                 HelloWorld { markdown }

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -71,8 +71,8 @@ impl Markdown {
         source: String,
         style: MarkdownStyle,
         language_registry: Option<Arc<LanguageRegistry>>,
-        cx: &ViewContext<Self>,
         fallback_code_block_language: Option<String>,
+        cx: &ViewContext<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
         let mut this = Self {


### PR DESCRIPTION
I noticed that `Markdown::new` didn't have the `cx` as the final parameter, as is conventional.

This PR fixes that.

Release Notes:

- N/A
