### PR TITLE
Add text objects to extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15768,7 +15768,7 @@ dependencies = [
 
 [[package]]
 name = "zed_erlang"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]
@@ -15802,7 +15802,7 @@ dependencies = [
 
 [[package]]
 name = "zed_haskell"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]
@@ -15816,28 +15816,28 @@ dependencies = [
 
 [[package]]
 name = "zed_lua"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]
 
 [[package]]
 name = "zed_php"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]
 
 [[package]]
 name = "zed_prisma"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]
 
 [[package]]
 name = "zed_proto"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]
@@ -15880,7 +15880,7 @@ dependencies = [
 
 [[package]]
 name = "zed_toml"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]
@@ -15894,7 +15894,7 @@ dependencies = [
 
 [[package]]
 name = "zed_zig"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/erlang/Cargo.toml
+++ b/extensions/erlang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_erlang"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/erlang/extension.toml
+++ b/extensions/erlang/extension.toml
@@ -1,7 +1,7 @@
 id = "erlang"
 name = "Erlang"
 description = "Erlang support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Dairon M <dairon.medina@gmail.com>", "Fabian Bergström <fabian@fmbb.se>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/erlang/languages/erlang/textobjects.scm
+++ b/extensions/erlang/languages/erlang/textobjects.scm
@@ -1,0 +1,6 @@
+(function_clause
+  body: (_ "->" (_)* @function.inside)) @function.around
+
+(type_alias ty: (_) @class.inside) @class.around
+
+(comment)+ @comment.around

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_haskell"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/haskell/extension.toml
+++ b/extensions/haskell/extension.toml
@@ -1,7 +1,7 @@
 id = "haskell"
 name = "Haskell"
 description = "Haskell support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = [
     "Pocæus <github@pocaeus.com>",

--- a/extensions/haskell/languages/haskell/textobjects.scm
+++ b/extensions/haskell/languages/haskell/textobjects.scm
@@ -1,0 +1,12 @@
+(comment)+ @comment.around
+
+[
+  (adt)
+  (type_alias)
+  (newtype)
+] @class.around
+
+(record_fields "{" (_)* @class.inside "}")
+
+((signature)? (function)+) @function.around
+(function rhs:(_) @function.inside)

--- a/extensions/lua/Cargo.toml
+++ b/extensions/lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_lua"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/lua/extension.toml
+++ b/extensions/lua/extension.toml
@@ -1,7 +1,7 @@
 id = "lua"
 name = "Lua"
 description = "Lua support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/lua/languages/lua/textobjects.scm
+++ b/extensions/lua/languages/lua/textobjects.scm
@@ -1,0 +1,7 @@
+(function_definition
+  body: (_) @function.inside) @function.around
+
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+(comment)+ @comment.around

--- a/extensions/php/Cargo.toml
+++ b/extensions/php/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_php"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/php/extension.toml
+++ b/extensions/php/extension.toml
@@ -1,7 +1,7 @@
 id = "php"
 name = "PHP"
 description = "PHP support."
-version = "0.2.2"
+version = "0.2.3"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/php/languages/php/textobjects.scm
+++ b/extensions/php/languages/php/textobjects.scm
@@ -1,0 +1,45 @@
+(function_definition
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}" )) @function.around
+
+(method_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}" )) @function.around
+
+(method_declaration) @function.around
+
+(class_declaration
+    body: (_
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+(interface_declaration
+    body: (_
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+(trait_declaration
+    body: (_
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+(enum_declaration
+    body: (_
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+(namespace_definition
+    body: (_
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+(comment)+ @comment.around

--- a/extensions/prisma/Cargo.toml
+++ b/extensions/prisma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_prisma"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/prisma/extension.toml
+++ b/extensions/prisma/extension.toml
@@ -1,7 +1,7 @@
 id = "prisma"
 name = "Prisma"
 description = "Prisma support."
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Matthew Gramigna <matthewgramigna@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/prisma/languages/prisma/textobjects.scm
+++ b/extensions/prisma/languages/prisma/textobjects.scm
@@ -1,0 +1,25 @@
+(model_declaration
+  (statement_block
+      "{"
+      (_)* @class.inside
+      "}")) @class.around
+
+(datasource_declaration
+  (statement_block
+      "{"
+      (_)* @class.inside
+      "}")) @class.around
+
+(generator_declaration
+  (statement_block
+      "{"
+      (_)* @class.inside
+      "}")) @class.around
+
+(enum_declaration
+  (enum_block
+      "{"
+      (_)* @class.inside
+      "}")) @class.around
+
+(developer_comment)+ @comment.around

--- a/extensions/proto/Cargo.toml
+++ b/extensions/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_proto"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/proto/extension.toml
+++ b/extensions/proto/extension.toml
@@ -1,7 +1,7 @@
 id = "proto"
 name = "Proto"
 description = "Protocol Buffers support."
-version = "0.2.0"
+version = "0.2.1"
 schema_version = 1
 authors = ["Zed Industries <support@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/proto/languages/proto/textobjects.scm
+++ b/extensions/proto/languages/proto/textobjects.scm
@@ -1,0 +1,18 @@
+(message (message_body
+    "{"
+    (_)* @class.inside
+    "}")) @class.around
+(enum (enum_body
+    "{"
+    (_)* @class.inside
+    "}")) @class.around
+(service
+    "service"
+    (_)
+    "{"
+    (_)* @class.inside
+    "}") @class.around
+
+(rpc) @function.around
+
+(comment)+ @comment.around

--- a/extensions/toml/Cargo.toml
+++ b/extensions/toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_toml"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/toml/extension.toml
+++ b/extensions/toml/extension.toml
@@ -1,7 +1,7 @@
 id = "toml"
 name = "TOML"
 description = "TOML support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = [
     "Max Brunsfeld <max@zed.dev>",

--- a/extensions/toml/languages/toml/textobjects.scm
+++ b/extensions/toml/languages/toml/textobjects.scm
@@ -1,0 +1,6 @@
+(comment)+ @comment
+(table "[" (_) "]"
+    (_)* @class.inside) @class.around
+
+(table_array_element "[[" (_) "]]"
+    (_)* @class.inside) @class.around

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_zig"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/zig/extension.toml
+++ b/extensions/zig/extension.toml
@@ -1,7 +1,7 @@
 id = "zig"
 name = "Zig"
 description = "Zig support."
-version = "0.3.1"
+version = "0.3.2"
 schema_version = 1
 authors = ["Allan Calix <contact@acx.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/zig/languages/zig/textobjects.scm
+++ b/extensions/zig/languages/zig/textobjects.scm
@@ -1,0 +1,27 @@
+(function_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(test_declaration
+    (block
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(variable_declaration
+  (struct_declaration
+    "struct"
+    "{"
+    [(_) ","]* @class.inside
+    "}")) @class.around
+
+(variable_declaration
+  (enum_declaration
+    "enum"
+    "{"
+    (_)* @class.inside
+    "}")) @class.around
+
+(comment)+ @comment.around

--- a/script/language-extension-version
+++ b/script/language-extension-version
@@ -26,4 +26,3 @@ fi
 
 sed -i '' -e "s/^version = \".*\"/version = \"$VERSION\"/" "$EXTENSION_TOML"
 sed -i '' -e "s/^version = \".*\"/version = \"$VERSION\"/" "$CARGO_TOML"
-cargo check


### PR DESCRIPTION
Release Notes:

- Adds textobject support to erlang, haskell, lua, php, prisma, proto, toml, and zig
