### PR TITLE
assistant2: Render messages in the thread using a `list`

### DIFF
--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -56,7 +56,7 @@ impl MessageEditor {
         });
 
         self.thread.update(cx, |thread, cx| {
-            thread.insert_user_message(user_message);
+            thread.insert_user_message(user_message, cx);
             let mut request = thread.to_completion_request(request_kind, cx);
 
             if self.use_tools {


### PR DESCRIPTION
This PR updates the rendering of the messages in the current thread to use a `gpui::list`.

Release Notes:

- N/A
