### PR TITLE
context_server: Add missing types for MCP spec to protocol 2024-11-05

### DIFF
--- a/crates/assistant/src/slash_command/context_server_command.rs
+++ b/crates/assistant/src/slash_command/context_server_command.rs
@@ -164,7 +164,7 @@ impl SlashCommand for ContextServerSlashCommand {
                     .messages
                     .into_iter()
                     .filter_map(|msg| match msg.content {
-                        context_server::types::MessageContent::Text { text } => Some(text),
+                        context_server::types::MessageContent::Text { text, .. } => Some(text),
                         _ => None,
                     })
                     .collect::<Vec<String>>()


### PR DESCRIPTION
This commit syncs missing types for the mcp spec 2024-11-05.

Release Notes:

- N/A
