### PR TITLE
vim: Maintain block cursor for navigating/non-modifying operators

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -629,7 +629,6 @@ impl Vim {
                         // Navigation operators -> Block cursor
                         Operator::FindForward { .. }
                         | Operator::FindBackward { .. }
-                        | Operator::Literal { .. }
                         | Operator::Mark => CursorShape::Block,
 
                         // All other operators -> Underline cursor

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -624,10 +624,16 @@ impl Vim {
     pub fn cursor_shape(&self) -> CursorShape {
         match self.mode {
             Mode::Normal => {
-                if self.operator_stack.is_empty() {
-                    CursorShape::Block
+                if let Some(operator) = self.operator_stack.last() {
+                    match operator {
+                        Operator::Change
+                        | Operator::Delete
+                        | Operator::Yank
+                        | Operator::Replace => CursorShape::Underline,
+                        _ => CursorShape::Block,
+                    }
                 } else {
-                    CursorShape::Underline
+                    CursorShape::Block
                 }
             }
             Mode::Replace => CursorShape::Underline,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -629,7 +629,11 @@ impl Vim {
                         // Navigation operators -> Block cursor
                         Operator::FindForward { .. }
                         | Operator::FindBackward { .. }
-                        | Operator::Mark => CursorShape::Block,
+                        | Operator::Mark
+                        | Operator::Jump { .. }
+                        | Operator::Register
+                        | Operator::RecordRegister
+                        | Operator::ReplayRegister => CursorShape::Block,
 
                         // All other operators -> Underline cursor
                         _ => CursorShape::Underline,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -626,13 +626,17 @@ impl Vim {
             Mode::Normal => {
                 if let Some(operator) = self.operator_stack.last() {
                     match operator {
-                        Operator::Change
-                        | Operator::Delete
-                        | Operator::Yank
-                        | Operator::Replace => CursorShape::Underline,
-                        _ => CursorShape::Block,
+                        // Navigation operators -> Block cursor
+                        Operator::FindForward { .. }
+                        | Operator::FindBackward { .. }
+                        | Operator::Literal { .. }
+                        | Operator::Mark => CursorShape::Block,
+
+                        // All other operators -> Underline cursor
+                        _ => CursorShape::Underline,
                     }
                 } else {
+                    // No operator active -> Block cursor
                     CursorShape::Block
                 }
             }


### PR DESCRIPTION
The cursor shape now only changes to underline for operators that modify text (like: delete, change, yank) while maintaining block shape for navigation operators (like: find, till).

This better matches Vim/Nvim's behavior where the cursor only changes shape when an operator that will modify text is pending.

Release Notes:

- vim: Improved cursor shape behavior to better match Vim
