### PR TITLE
Add YAML/TOML frontmatter injections for markdown

### DIFF
--- a/crates/languages/src/markdown/injections.scm
+++ b/crates/languages/src/markdown/injections.scm
@@ -9,5 +9,8 @@
 ((html_block) @content
   (#set! "language" "html"))
 
-([(minus_metadata) (plus_metadata)] @content
+([(minus_metadata)] @content
   (#set! "language" "yaml"))
+
+([(plus_metadata)] @content
+  (#set! "language" "toml"))

--- a/crates/languages/src/markdown/injections.scm
+++ b/crates/languages/src/markdown/injections.scm
@@ -8,3 +8,6 @@
 
 ((html_block) @content
   (#set! "language" "html"))
+
+([(minus_metadata) (plus_metadata)] @content
+  (#set! "language" "yaml"))

--- a/crates/languages/src/markdown/injections.scm
+++ b/crates/languages/src/markdown/injections.scm
@@ -9,8 +9,6 @@
 ((html_block) @content
   (#set! "language" "html"))
 
-([(minus_metadata)] @content
-  (#set! "language" "yaml"))
+((minus_metadata) @content (#set! "language" "yaml"))
 
-([(plus_metadata)] @content
-  (#set! "language" "toml"))
+((plus_metadata) @content (#set! "language" "toml"))


### PR DESCRIPTION
Closes #7938. Adds the frontmatter injections, as done in https://github.com/tree-sitter-grammars/tree-sitter-markdown/blob/split_parser/tree-sitter-markdown/queries/injections.scm.

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-03 at 22 24 01](https://github.com/user-attachments/assets/a0d55c3c-878d-4b44-b1a1-88497428c8e4) | ![CleanShot 2024-12-03 at 22 24 31](https://github.com/user-attachments/assets/6e624134-52cc-4d0f-b35b-129769fd8b7e) |

Release Notes:

- Added YAML and TOML frontmatter highlighting for markdown
