### PR TITLE
Detect wider variety of usernames for SSH-based remotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,6 +4999,7 @@ dependencies = [
  "log",
  "parking_lot",
  "pretty_assertions",
+ "regex",
  "rope",
  "serde",
  "serde_json",

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -22,6 +22,7 @@ gpui.workspace = true
 http_client.workspace = true
 log.workspace = true
 parking_lot.workspace = true
+regex.workspace = true
 rope.workspace = true
 serde.workspace = true
 smol.workspace = true
@@ -30,7 +31,6 @@ text.workspace = true
 time.workspace = true
 url.workspace = true
 util.workspace = true
-regex.workspace = true
 
 [dev-dependencies]
 unindent.workspace = true

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -30,6 +30,7 @@ text.workspace = true
 time.workspace = true
 url.workspace = true
 util.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 unindent.workspace = true

--- a/crates/git/src/remote.rs
+++ b/crates/git/src/remote.rs
@@ -1,17 +1,23 @@
+use std::sync::LazyLock;
+
 use derive_more::Deref;
+use regex::Regex;
 use url::Url;
 
 /// The URL to a Git remote.
 #[derive(Debug, PartialEq, Eq, Clone, Deref)]
 pub struct RemoteUrl(Url);
 
+static USERNAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[0-9a-zA-Z\-_]+@").expect("Failed to create USERNAME_REGEX"));
+
 impl std::str::FromStr for RemoteUrl {
     type Err = url::ParseError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        if input.starts_with("git@") {
+        if USERNAME_REGEX.is_match(input) {
             // Rewrite remote URLs like `git@github.com:user/repo.git` to `ssh://git@github.com/user/repo.git`
-            let ssh_url = input.replacen(':', "/", 1).replace("git@", "ssh://git@");
+            let ssh_url = format!("ssh://{}", input.replacen(':', "/", 1));
             Ok(RemoteUrl(Url::parse(&ssh_url)?))
         } else {
             Ok(RemoteUrl(Url::parse(input)?))
@@ -36,6 +42,12 @@ mod tests {
             ),
             (
                 "git@github.com:octocat/zed.git",
+                "ssh",
+                "github.com",
+                "/octocat/zed.git",
+            ),
+            (
+                "org-000000@github.com:octocat/zed.git",
                 "ssh",
                 "github.com",
                 "/octocat/zed.git",


### PR DESCRIPTION
Closes #21507

Release Notes:

- Fixed detection of git remotes when using SSH and username is not "git".
