### PR TITLE
Make MultiBufferPoint its own type

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -33,7 +33,7 @@ use editor::{
     },
     scroll::{Autoscroll, AutoscrollStrategy},
     Anchor, Editor, EditorEvent, ProposedChangeLocation, ProposedChangesEditor, RowExt,
-    ToOffset as _, ToPoint,
+    ToMultiBufferPoint, ToOffset as _,
 };
 use editor::{display_map::CreaseId, FoldPlaceholder};
 use fs::Fs;

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -14,7 +14,7 @@ use editor::{
     },
     Anchor, AnchorRangeExt, CodeActionProvider, Editor, EditorElement, EditorEvent, EditorMode,
     EditorStyle, ExcerptId, ExcerptRange, GutterDimensions, MultiBuffer, MultiBufferSnapshot,
-    ToOffset as _, ToPoint,
+    ToMultiBufferPoint, ToOffset as _,
 };
 use feature_flags::{FeatureFlagAppExt as _, ZedPro};
 use fs::Fs;

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -51,7 +51,7 @@ use language::{
 use lsp::DiagnosticSeverity;
 use multi_buffer::{
     Anchor, AnchorRangeExt, MultiBuffer, MultiBufferPoint, MultiBufferRow, MultiBufferSnapshot,
-    ToOffset, ToPoint,
+    ToMultiBufferPoint, ToOffset,
 };
 use serde::Deserialize;
 use std::{
@@ -688,7 +688,10 @@ impl DisplaySnapshot {
         self.buffer_snapshot.max_buffer_row()
     }
 
-    pub fn prev_line_boundary(&self, mut point: MultiBufferPoint) -> (Point, DisplayPoint) {
+    pub fn prev_line_boundary(
+        &self,
+        mut point: MultiBufferPoint,
+    ) -> (MultiBufferPoint, DisplayPoint) {
         loop {
             let mut inlay_point = self.inlay_snapshot.to_inlay_point(point);
             let mut fold_point = self.fold_snapshot.to_fold_point(inlay_point, Bias::Left);

--- a/crates/editor/src/display_map/crease_map.rs
+++ b/crates/editor/src/display_map/crease_map.rs
@@ -1,6 +1,8 @@
 use collections::HashMap;
 use gpui::{AnyElement, IntoElement};
-use multi_buffer::{Anchor, AnchorRangeExt, MultiBufferRow, MultiBufferSnapshot, ToPoint};
+use multi_buffer::{
+    Anchor, AnchorRangeExt, MultiBufferRow, MultiBufferSnapshot, ToMultiBufferPoint,
+};
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt::Debug, ops::Range, sync::Arc};
 use sum_tree::{Bias, SeekTarget, SumTree};

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1380,7 +1380,7 @@ pub type FoldEdit = Edit<FoldOffset>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{display_map::inlay_map::InlayMap, MultiBuffer, ToPoint};
+    use crate::{display_map::inlay_map::InlayMap, MultiBuffer, ToMultiBufferPoint};
     use collections::HashSet;
     use rand::prelude::*;
     use settings::SettingsStore;

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -3,7 +3,8 @@ use collections::{BTreeMap, BTreeSet};
 use gpui::HighlightStyle;
 use language::{Chunk, Edit, Point, TextSummary};
 use multi_buffer::{
-    Anchor, MultiBufferChunks, MultiBufferRow, MultiBufferRows, MultiBufferSnapshot, ToOffset,
+    Anchor, MultiBufferChunks, MultiBufferPoint, MultiBufferRow, MultiBufferRows,
+    MultiBufferSnapshot, ToOffset,
 };
 use std::{
     any::TypeId,
@@ -777,7 +778,7 @@ impl InlaySnapshot {
             None => self.len(),
         }
     }
-    pub fn to_buffer_point(&self, point: InlayPoint) -> Point {
+    pub fn to_buffer_point(&self, point: InlayPoint) -> MultiBufferPoint {
         let mut cursor = self.transforms.cursor::<(InlayPoint, Point)>(&());
         cursor.seek(&point, Bias::Right, &());
         match cursor.item() {
@@ -835,7 +836,7 @@ impl InlaySnapshot {
             }
         }
     }
-    pub fn to_inlay_point(&self, point: Point) -> InlayPoint {
+    pub fn to_inlay_point(&self, point: MultiBufferPoint) -> InlayPoint {
         let mut cursor = self.transforms.cursor::<(Point, InlayPoint)>(&());
         cursor.seek(&point, Bias::Left, &());
         loop {

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -3,7 +3,7 @@ use super::{
     Highlights,
 };
 use language::{Chunk, Point};
-use multi_buffer::MultiBufferSnapshot;
+use multi_buffer::{MultiBufferPoint, MultiBufferSnapshot};
 use std::{cmp, mem, num::NonZeroU32, ops::Range};
 use sum_tree::Bias;
 
@@ -316,13 +316,13 @@ impl TabSnapshot {
         )
     }
 
-    pub fn make_tab_point(&self, point: Point, bias: Bias) -> TabPoint {
+    pub fn make_tab_point(&self, point: MultiBufferPoint, bias: Bias) -> TabPoint {
         let inlay_point = self.fold_snapshot.inlay_snapshot.to_inlay_point(point);
         let fold_point = self.fold_snapshot.to_fold_point(inlay_point, bias);
         self.to_tab_point(fold_point)
     }
 
-    pub fn to_point(&self, point: TabPoint, bias: Bias) -> Point {
+    pub fn to_point(&self, point: TabPoint, bias: Bias) -> MultiBufferPoint {
         let fold_point = self.to_fold_point(point, bias).0;
         let inlay_point = fold_point.to_inlay_point(&self.fold_snapshot);
         self.fold_snapshot

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use gpui::{AppContext, Context, Font, LineWrapper, Model, ModelContext, Pixels, Task};
 use language::{Chunk, Point};
-use multi_buffer::MultiBufferSnapshot;
+use multi_buffer::{MultiBufferPoint, MultiBufferSnapshot};
 use smol::future::yield_now;
 use std::sync::LazyLock;
 use std::{cmp, collections::VecDeque, mem, ops::Range, time::Duration};
@@ -747,11 +747,11 @@ impl WrapSnapshot {
         TabPoint(tab_point)
     }
 
-    pub fn to_point(&self, point: WrapPoint, bias: Bias) -> Point {
+    pub fn to_point(&self, point: WrapPoint, bias: Bias) -> MultiBufferPoint {
         self.tab_snapshot.to_point(self.to_tab_point(point), bias)
     }
 
-    pub fn make_wrap_point(&self, point: Point, bias: Bias) -> WrapPoint {
+    pub fn make_wrap_point(&self, point: MultiBufferPoint, bias: Bias) -> WrapPoint {
         self.tab_point_to_wrap_point(self.tab_snapshot.make_tab_point(point, bias))
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -114,8 +114,8 @@ use lsp::{
 use mouse_context_menu::MouseContextMenu;
 use movement::TextLayoutDetails;
 pub use multi_buffer::{
-    Anchor, AnchorRangeExt, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot, ToOffset,
-    ToPoint,
+    Anchor, AnchorRangeExt, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot,
+    ToMultiBufferPoint, ToOffset,
 };
 use multi_buffer::{
     ExpandExcerptDirection, MultiBufferDiffHunk, MultiBufferPoint, MultiBufferRow, ToOffsetUtf16,
@@ -14703,7 +14703,7 @@ trait SelectionExt {
     ) -> Range<MultiBufferRow>;
 }
 
-impl<T: ToPoint + ToOffset> SelectionExt for Selection<T> {
+impl<T: ToMultiBufferPoint + ToOffset> SelectionExt for Selection<T> {
     fn display_range(&self, map: &DisplaySnapshot) -> Range<DisplayPoint> {
         let start = self
             .start

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -20,9 +20,9 @@ use crate::{
     DisplayRow, DocumentHighlightRead, DocumentHighlightWrite, Editor, EditorMode, EditorSettings,
     EditorSnapshot, EditorStyle, ExpandExcerpts, FocusedBlock, GutterDimensions, HalfPageDown,
     HalfPageUp, HandleInput, HoveredCursor, HoveredHunk, JumpData, LineDown, LineUp, OpenExcerpts,
-    PageDown, PageUp, Point, RowExt, RowRangeExt, SelectPhase, Selection, SoftWrap, ToPoint,
-    CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN,
-    MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+    PageDown, PageUp, Point, RowExt, RowRangeExt, SelectPhase, Selection, SoftWrap,
+    ToMultiBufferPoint, CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT,
+    GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
 };
 use client::ParticipantIndex;
 use collections::{BTreeMap, HashMap, HashSet};
@@ -84,7 +84,7 @@ struct SelectionLayout {
 }
 
 impl SelectionLayout {
-    fn new<T: ToPoint + ToDisplayPoint + Clone>(
+    fn new<T: ToMultiBufferPoint + ToDisplayPoint + Clone>(
         selection: Selection<T>,
         line_mode: bool,
         cursor_shape: CursorShape,

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -4,7 +4,7 @@ use gpui::{Action, AnchorCorner, AppContext, CursorStyle, Hsla, Model, MouseButt
 use language::{Buffer, BufferId, Point};
 use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptRange, MultiBuffer, MultiBufferDiffHunk, MultiBufferRow,
-    MultiBufferSnapshot, ToPoint,
+    MultiBufferSnapshot, ToMultiBufferPoint,
 };
 use std::{ops::Range, sync::Arc};
 use text::OffsetRangeExt;

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -3,7 +3,7 @@ use crate::{
     persistence::{SerializedEditor, DB},
     scroll::ScrollAnchor,
     Anchor, Autoscroll, Editor, EditorEvent, EditorSettings, ExcerptId, ExcerptRange, MultiBuffer,
-    MultiBufferSnapshot, NavigationData, SearchWithinRange, ToPoint as _,
+    MultiBufferSnapshot, NavigationData, SearchWithinRange, ToMultiBufferPoint as _,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::HashSet;

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -2,7 +2,9 @@
 //! in editor given a given motion (e.g. it handles converting a "move left" command into coordinates in editor). It is exposed mostly for use by vim crate.
 
 use super::{Bias, DisplayPoint, DisplaySnapshot, SelectionGoal, ToDisplayPoint};
-use crate::{scroll::ScrollAnchor, CharKind, DisplayRow, EditorStyle, RowExt, ToOffset, ToPoint};
+use crate::{
+    scroll::ScrollAnchor, CharKind, DisplayRow, EditorStyle, RowExt, ToMultiBufferPoint, ToOffset,
+};
 use gpui::{Pixels, WindowTextSystem};
 use language::Point;
 use multi_buffer::{MultiBufferRow, MultiBufferSnapshot};

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -8,7 +8,7 @@ use crate::{
     hover_popover::hide_hover,
     persistence::DB,
     Anchor, DisplayPoint, DisplayRow, Editor, EditorEvent, EditorMode, EditorSettings,
-    InlayHintRefreshReason, MultiBufferSnapshot, RowExt, ToPoint,
+    InlayHintRefreshReason, MultiBufferSnapshot, RowExt, ToMultiBufferPoint,
 };
 pub use autoscroll::{Autoscroll, AutoscrollStrategy};
 use gpui::{point, px, AppContext, Entity, Global, Pixels, Task, ViewContext, WindowContext};

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -15,7 +15,7 @@ use crate::{
     display_map::{DisplayMap, DisplaySnapshot, ToDisplayPoint},
     movement::TextLayoutDetails,
     Anchor, DisplayPoint, DisplayRow, ExcerptId, MultiBuffer, MultiBufferSnapshot, SelectMode,
-    ToOffset, ToPoint,
+    ToMultiBufferPoint, ToOffset,
 };
 
 #[derive(Debug, Clone)]
@@ -502,7 +502,13 @@ impl<'a> MutableSelectionsCollection<'a> {
 
     pub fn insert_range<T>(&mut self, range: Range<T>)
     where
-        T: 'a + ToOffset + ToPoint + TextDimension + Ord + Sub<T, Output = T> + std::marker::Copy,
+        T: 'a
+            + ToOffset
+            + ToMultiBufferPoint
+            + TextDimension
+            + Ord
+            + Sub<T, Output = T>
+            + std::marker::Copy,
     {
         let mut selections = self.collection.all(self.cx);
         let mut start = range.start.to_offset(&self.buffer());
@@ -525,7 +531,7 @@ impl<'a> MutableSelectionsCollection<'a> {
 
     pub fn select<T>(&mut self, mut selections: Vec<Selection<T>>)
     where
-        T: ToOffset + ToPoint + Ord + std::marker::Copy + std::fmt::Debug,
+        T: ToOffset + ToMultiBufferPoint + Ord + std::marker::Copy + std::fmt::Debug,
     {
         let buffer = self.buffer.read(self.cx).snapshot(self.cx);
         selections.sort_unstable_by_key(|s| s.start);

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::Result;
 use serde_json::json;
 
-use crate::{Editor, ToPoint};
+use crate::{Editor, ToMultiBufferPoint};
 use collections::HashSet;
 use futures::Future;
 use gpui::{View, ViewContext, VisualTestContext};

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -11,7 +11,7 @@ use gpui::{
 };
 use itertools::Itertools;
 use language::{Buffer, BufferSnapshot, LanguageRegistry};
-use multi_buffer::{ExcerptRange, ToPoint};
+use multi_buffer::{ExcerptRange, ToMultiBufferPoint};
 use parking_lot::RwLock;
 use project::{FakeFs, Project};
 use std::{

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -1,4 +1,4 @@
-use editor::{Editor, ToPoint};
+use editor::{Editor, ToMultiBufferPoint};
 use gpui::{AppContext, FocusHandle, FocusableView, Subscription, Task, View, WeakView};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -1,5 +1,7 @@
-use super::{ExcerptId, MultiBufferSnapshot, ToOffset, ToOffsetUtf16, ToPoint};
-use language::{OffsetUtf16, Point, TextDimension};
+use crate::MultiBufferPoint;
+
+use super::{ExcerptId, MultiBufferSnapshot, ToMultiBufferPoint, ToOffset, ToOffsetUtf16};
+use language::{OffsetUtf16, TextDimension};
 use std::{
     cmp::Ordering,
     ops::{Range, Sub},
@@ -109,9 +111,9 @@ impl ToOffsetUtf16 for Anchor {
     }
 }
 
-impl ToPoint for Anchor {
-    fn to_point<'a>(&self, snapshot: &MultiBufferSnapshot) -> Point {
-        self.summary(snapshot)
+impl ToMultiBufferPoint for Anchor {
+    fn to_point<'a>(&self, snapshot: &MultiBufferSnapshot) -> MultiBufferPoint {
+        MultiBufferPoint(self.summary(snapshot))
     }
 }
 
@@ -119,7 +121,7 @@ pub trait AnchorRangeExt {
     fn cmp(&self, b: &Range<Anchor>, buffer: &MultiBufferSnapshot) -> Ordering;
     fn overlaps(&self, b: &Range<Anchor>, buffer: &MultiBufferSnapshot) -> bool;
     fn to_offset(&self, content: &MultiBufferSnapshot) -> Range<usize>;
-    fn to_point(&self, content: &MultiBufferSnapshot) -> Range<Point>;
+    fn to_point(&self, content: &MultiBufferSnapshot) -> Range<MultiBufferPoint>;
 }
 
 impl AnchorRangeExt for Range<Anchor> {
@@ -138,7 +140,7 @@ impl AnchorRangeExt for Range<Anchor> {
         self.start.to_offset(content)..self.end.to_offset(content)
     }
 
-    fn to_point(&self, content: &MultiBufferSnapshot) -> Range<Point> {
+    fn to_point(&self, content: &MultiBufferSnapshot) -> Range<MultiBufferPoint> {
         self.start.to_point(content)..self.end.to_point(content)
     }
 }

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -14,7 +14,7 @@ use editor::{
         RenderBlock,
     },
     scroll::Autoscroll,
-    Anchor, AnchorRangeExt as _, Editor, MultiBuffer, ToPoint,
+    Anchor, AnchorRangeExt as _, Editor, MultiBuffer, ToMultiBufferPoint,
 };
 use futures::FutureExt as _;
 use gpui::{

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Result};
 use command_palette_hooks::CommandInterceptResult;
 use editor::{
     actions::{SortLinesCaseInsensitive, SortLinesCaseSensitive},
-    Editor, ToPoint,
+    Editor, ToMultiBufferPoint,
 };
 use gpui::{actions, impl_actions, Action, AppContext, Global, ViewContext};
 use language::Point;

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use editor::{scroll::Autoscroll, Editor, MultiBufferSnapshot, ToOffset, ToPoint};
+use editor::{scroll::Autoscroll, Editor, MultiBufferSnapshot, ToMultiBufferPoint, ToOffset};
 use gpui::{impl_actions, ViewContext};
 use language::{Bias, Point};
 use serde::Deserialize;

--- a/crates/vim/src/replace.rs
+++ b/crates/vim/src/replace.rs
@@ -3,7 +3,7 @@ use crate::{
     state::Mode,
     Vim,
 };
-use editor::{display_map::ToDisplayPoint, Bias, Editor, ToPoint};
+use editor::{display_map::ToDisplayPoint, Bias, Editor, ToMultiBufferPoint};
 use gpui::{actions, ViewContext};
 use language::Point;
 use std::ops::Range;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 use collections::HashMap;
 use editor::{
     movement::{self, FindRange},
-    Anchor, Bias, Editor, EditorEvent, EditorMode, ToPoint,
+    Anchor, Bias, Editor, EditorEvent, EditorMode, ToMultiBufferPoint,
 };
 use gpui::{
     actions, impl_actions, Action, AppContext, Axis, Entity, EventEmitter, KeyContext,


### PR DESCRIPTION
#21511 was yet-another-panic caused by confusing these two coordinate systems.

A MultiBufferPoint is transparent with a Point so in the singleton case it's cheap to convert.


Release Notes:

- N/A
