### PR TITLE
title_bar: Add show_user_picture setting to let users hide their profile picture

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1186,6 +1186,8 @@
   //   "W": "workspace::Save"
   // }
   "command_aliases": {},
+  // Whether to show user picture in titlebar.
+  "show_user_picture": true,
   // ssh_connections is an array of ssh connections.
   // You can configure these from `project: Open Remote` in the command palette.
   // Zed's ssh support will pull configuration from your ~/.ssh too.

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -37,6 +37,7 @@ project.workspace = true
 remote.workspace = true
 rpc.workspace = true
 serde.workspace = true
+settings.workspace = true
 smallvec.workspace = true
 story = { workspace = true, optional = true }
 theme.workspace = true

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -19,6 +19,7 @@ use gpui::{
 };
 use project::{Project, RepositoryEntry};
 use rpc::proto;
+use settings::Settings as _;
 use smallvec::SmallVec;
 use std::sync::Arc;
 use theme::ActiveTheme;
@@ -600,7 +601,11 @@ impl TitleBar {
                         .child(
                             h_flex()
                                 .gap_0p5()
-                                .child(Avatar::new(user.avatar_uri.clone()))
+                                .children(
+                                    workspace::WorkspaceSettings::get_global(cx)
+                                        .show_user_picture
+                                        .then(|| Avatar::new(user.avatar_uri.clone())),
+                                )
                                 .child(
                                     Icon::new(IconName::ChevronDown)
                                         .size(IconSize::Small)

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -19,6 +19,7 @@ pub struct WorkspaceSettings {
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub use_system_path_prompts: bool,
     pub command_aliases: HashMap<String, String>,
+    pub show_user_picture: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -128,6 +129,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: true
     pub command_aliases: Option<HashMap<String, String>>,
+    /// Whether to show user avatar in the title bar.
+    ///
+    /// Default: true
+    pub show_user_picture: Option<bool>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Fixes #21464

Closes #21464

Release Notes:

- Added `show_user_picture` setting (default: true) to allow users to hide their profile picture in titlebar.
