### PR TITLE
Revert accidental change to Rust outline files

### DIFF
--- a/crates/languages/src/rust/outline.scm
+++ b/crates/languages/src/rust/outline.scm
@@ -15,7 +15,11 @@
     (visibility_modifier)? @context
     name: (_) @name) @item
 
-(function_item
+(impl_item
+    "impl" @context
+    trait: (_)? @name
+    "for"? @context
+    type: (_) @name
     body: (_ "{" @open (_)* "}" @close)) @item
 
 (trait_item


### PR DESCRIPTION
Release Notes:

- Preview only: Fixed impl blocks in the rust outline view

