### PR TITLE
Fix panel.background color override

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -268,7 +268,7 @@ fn get_item_color(cx: &ViewContext<ProjectPanel>) -> ItemColors {
     let colors = cx.theme().colors();
 
     ItemColors {
-        default: colors.surface_background,
+        default: colors.panel_background,
         hover: colors.ghost_element_hover,
         drag_over: colors.drop_target_background,
         marked_active: colors.ghost_element_selected,


### PR DESCRIPTION
Closes #21266

Release Notes:

- Fixes not using the `panel.background` color in the file tree

See comments in https://github.com/zed-industries/zed/issues/21266 for more details.
