### PR TITLE
Revert "Open folds containing selections when jumping from multibuffer (#21433)"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12925,7 +12925,6 @@ impl Editor {
                             None => Autoscroll::newest(),
                         };
                         let nav_history = editor.nav_history.take();
-                        editor.unfold_ranges(&ranges, false, true, cx);
                         editor.change_selections(Some(autoscroll), cx, |s| {
                             s.select_ranges(ranges);
                         });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11651,7 +11651,7 @@ async fn test_multibuffer_reverts(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_multibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
+async fn test_mutlibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
     let cols = 4;
@@ -11938,74 +11938,6 @@ async fn test_multibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
             assert!(!active_item.is_singleton(cx));
         })
         .unwrap();
-}
-
-#[gpui::test]
-async fn test_multibuffer_unfold_on_jump(cx: &mut gpui::TestAppContext) {
-    init_test(cx, |_| {});
-
-    let texts = ["{\n\tx\n}".to_owned(), "y".to_owned()];
-    let buffers = texts
-        .clone()
-        .map(|txt| cx.new_model(|cx| Buffer::local(txt, cx)));
-    let multi_buffer = cx.new_model(|cx| {
-        let mut multi_buffer = MultiBuffer::new(ReadWrite);
-        for i in 0..2 {
-            multi_buffer.push_excerpts(
-                buffers[i].clone(),
-                [ExcerptRange {
-                    context: 0..texts[i].len(),
-                    primary: None,
-                }],
-                cx,
-            );
-        }
-        multi_buffer
-    });
-
-    let fs = FakeFs::new(cx.executor());
-    fs.insert_tree(
-        "/project",
-        json!({
-            "x": &texts[0],
-            "y": &texts[1],
-        }),
-    )
-    .await;
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
-    let workspace = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
-    let cx = &mut VisualTestContext::from_window(*workspace.deref(), cx);
-
-    let multi_buffer_editor = cx.new_view(|cx| {
-        Editor::for_multibuffer(multi_buffer.clone(), Some(project.clone()), true, cx)
-    });
-    let buffer_editor =
-        cx.new_view(|cx| Editor::for_buffer(buffers[0].clone(), Some(project.clone()), cx));
-    workspace
-        .update(cx, |workspace, cx| {
-            workspace.add_item_to_active_pane(
-                Box::new(multi_buffer_editor.clone()),
-                None,
-                true,
-                cx,
-            );
-            workspace.add_item_to_active_pane(Box::new(buffer_editor.clone()), None, false, cx);
-        })
-        .unwrap();
-    cx.executor().run_until_parked();
-    buffer_editor.update(cx, |buffer_editor, cx| {
-        buffer_editor.fold_at_level(&FoldAtLevel { level: 1 }, cx);
-        assert!(buffer_editor.snapshot(cx).fold_count() == 1);
-    });
-    cx.executor().run_until_parked();
-    multi_buffer_editor.update(cx, |multi_buffer_editor, cx| {
-        multi_buffer_editor.change_selections(None, cx, |s| s.select_ranges([3..4]));
-        multi_buffer_editor.open_excerpts(&OpenExcerpts, cx);
-    });
-    cx.executor().run_until_parked();
-    buffer_editor.update(cx, |buffer_editor, cx| {
-        assert!(buffer_editor.snapshot(cx).fold_count() == 0);
-    });
 }
 
 #[gpui::test]


### PR DESCRIPTION
This reverts commit dc32ab25a0f76280ff0f1485333a729523840e27.

This has been causing panics, backing it out while figuring out what's up.

Release Notes:

- N/A