### PR TITLE
Extend filtering of backtrace frames a bit

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -85,7 +85,7 @@ pub fn init_panic_hook(
         // Strip out leading stack frames for rust panic-handling.
         if let Some(ix) = backtrace
             .iter()
-            .position(|name| name == "rust_begin_unwind")
+            .position(|name| name == "rust_begin_unwind" || name == "_rust_begin_unwind")
         {
             backtrace.drain(0..=ix);
         }


### PR DESCRIPTION
This adds a filename and line and column numbers to each frame of the backtrace that's sent with panic reports. The full source file path is not sent, both for brevity and because this path might be considered sensitive information.

I also tweaked the condition for dropping uninformative frames related to panic handling at the top of the trace to reflect that we see both `rust_begin_unwind` and `_rust_begin_unwind` in practice (I don't know why).

Release Notes:

- N/A