### PR TITLE
Fix snippet completion will be trigger, when certain symbols are pressed

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13873,6 +13873,11 @@ fn snippet_completions(
             .take_while(|c| classifier.is_word(*c))
             .collect::<String>();
         last_word = last_word.chars().rev().collect();
+
+        if last_word.is_empty() {
+            return Ok(vec![]);
+        }
+
         let as_offset = text::ToOffset::to_offset(&buffer_position, &snapshot);
         let to_lsp = |point: &text::Anchor| {
             let end = text::ToPointUtf16::to_point_utf16(point, &snapshot);


### PR DESCRIPTION
Closes #21576

This issue is caused by the fuzzy matching for snippets I added [here](https://github.com/zed-industries/zed/pull/21524). When encountering symbols such as `:`, `(`, `.`, etc., the `last_word` becomes empty, which results in an empty string being passed to `fuzzy_match`, leading to the return of all templates.

This fix adds an early return when `last_word` is empty.

Release Notes:

- N/A
