### PR TITLE
Defer is_staff check for the project_diff::Deploy action

### DIFF
--- a/crates/editor/src/git/project_diff.rs
+++ b/crates/editor/src/git/project_diff.rs
@@ -62,13 +62,15 @@ struct Changes {
 }
 
 impl ProjectDiffEditor {
-    fn register(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) {
-        if cx.is_staff() {
-            workspace.register_action(Self::deploy);
-        }
+    fn register(workspace: &mut Workspace, _: &mut ViewContext<Workspace>) {
+        workspace.register_action(Self::deploy);
     }
 
     fn deploy(workspace: &mut Workspace, _: &Deploy, cx: &mut ViewContext<Workspace>) {
+        if !cx.is_staff() {
+            return;
+        }
+
         if let Some(existing) = workspace.item_of_type::<Self>(cx) {
             workspace.activate_item(&existing, true, true, cx);
         } else {


### PR DESCRIPTION
During workspace registration, it's too early to check for the `is_staff` flag due to no connection being established yet.
As a compromise, allow the action to appear and be registered, but do nothing for non-staff users.

Release Notes:

- N/A 
