### PR TITLE
Enhance the Vim Mode toggle discoverability

### DIFF
--- a/assets/icons/info.svg
+++ b/assets/icons/info.svg
@@ -1,0 +1,12 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2131_1193)">
+<circle cx="7" cy="7" r="6" stroke="black" stroke-width="1.5"/>
+<path d="M6 10H7M8 10H7M7 10V7.1C7 7.04477 6.95523 7 6.9 7H6" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="7" cy="4.5" r="1" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_2131_1193">
+<rect width="14" height="14" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -202,6 +202,7 @@ pub enum IconName {
     HistoryRerun,
     Indicator,
     IndicatorX,
+    Info,
     InlayHint,
     Keyboard,
     Library,

--- a/crates/ui/src/components/tooltip.rs
+++ b/crates/ui/src/components/tooltip.rs
@@ -88,7 +88,7 @@ impl Render for Tooltip {
             el.child(
                 h_flex()
                     .gap_4()
-                    .child(self.title.clone())
+                    .child(div().max_w_64().child(self.title.clone()))
                     .when_some(self.key_binding.clone(), |this, key_binding| {
                         this.justify_between().child(key_binding)
                     }),

--- a/crates/ui/src/components/tooltip.rs
+++ b/crates/ui/src/components/tooltip.rs
@@ -88,7 +88,7 @@ impl Render for Tooltip {
             el.child(
                 h_flex()
                     .gap_4()
-                    .child(div().max_w_64().child(self.title.clone()))
+                    .child(div().max_w_72().child(self.title.clone()))
                     .when_some(self.key_binding.clone(), |this, key_binding| {
                         this.justify_between().child(key_binding)
                     }),

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -11,7 +11,7 @@ use gpui::{
 };
 use settings::{Settings, SettingsStore};
 use std::sync::Arc;
-use ui::{prelude::*, CheckboxWithLabel};
+use ui::{prelude::*, CheckboxWithLabel, Tooltip};
 use vim_mode_setting::VimModeSetting;
 use workspace::{
     dock::DockPosition,
@@ -266,24 +266,34 @@ impl Render for WelcomePage {
                     .child(
                         v_group()
                             .gap_2()
-                            .child(CheckboxWithLabel::new(
-                                "enable-vim",
-                                Label::new("Enable Vim Mode"),
-                                if VimModeSetting::get_global(cx).0 {
-                                    ui::Selection::Selected
-                                } else {
-                                    ui::Selection::Unselected
-                                },
-                                cx.listener(move |this, selection, cx| {
-                                    this.telemetry
-                                        .report_app_event("welcome page: toggle vim".to_string());
-                                    this.update_settings::<VimModeSetting>(
-                                        selection,
-                                        cx,
-                                        |setting, value| *setting = Some(value),
-                                    );
-                                }),
-                            ))
+                            .child(
+                                h_flex()
+                                    .justify_between()
+                                    .child(CheckboxWithLabel::new(
+                                        "enable-vim",
+                                        Label::new("Enable Vim Mode"),
+                                        if VimModeSetting::get_global(cx).0 {
+                                            ui::Selection::Selected
+                                        } else {
+                                            ui::Selection::Unselected
+                                        },
+                                        cx.listener(move |this, selection, cx| {
+                                            this.telemetry
+                                                .report_app_event("welcome page: toggle vim".to_string());
+                                            this.update_settings::<VimModeSetting>(
+                                                selection,
+                                                cx,
+                                                |setting, value| *setting = Some(value),
+                                            );
+                                        }),
+                                    ))
+                                    .child(
+                                        IconButton::new("vim-mode", IconName::Info)
+                                            .icon_size(IconSize::XSmall)
+                                            .icon_color(Color::Muted)
+                                            .tooltip(|cx| Tooltip::text("You can also toggle Vim Mode on and off via the command palette or the Editor Controls menu.", cx)),
+                                    )
+                            )
                             .child(CheckboxWithLabel::new(
                                 "enable-crash",
                                 Label::new("Send Crash Reports"),

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -291,7 +291,7 @@ impl Render for WelcomePage {
                                         IconButton::new("vim-mode", IconName::Info)
                                             .icon_size(IconSize::XSmall)
                                             .icon_color(Color::Muted)
-                                            .tooltip(|cx| Tooltip::text("You can also toggle Vim Mode on and off via the command palette or the Editor Controls menu.", cx)),
+                                            .tooltip(|cx| Tooltip::text("You can also toggle Vim Mode via the command palette or Editor Controls menu.", cx)),
                                     )
                             )
                             .child(CheckboxWithLabel::new(

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3447,6 +3447,7 @@ mod tests {
 
             app_state.languages.add(markdown_language());
 
+            vim_mode_setting::init(cx);
             theme::init(theme::LoadThemes::JustBase, cx);
             audio::init((), cx);
             channel::init(&app_state.client, app_state.user_store.clone(), cx);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21522

This PR adds an info tooltip on the Welcome screen, informing users how Vim Mode can be toggled on and off. It also adds the Vim Mode toggle in the Editor Controls menu. This is all so that folks who accidentally turn it on better know how to turn it off. We're of course already able to toggle this setting via the command palette, but that may be harder to reach for beginners. So, maybe that's enough to close the linked issue? Open to feedback.

(Note: I also added a max-width to the tooltip's label in this PR. I'm confident that this won't make any tooltip look weird/broken, but if it does, it may be because of this new property).

| Welcome Page | Editor Controls |
|--------|--------|
| <img width="800" alt="Screenshot 2024-12-05 at 11 20 04" src="https://github.com/user-attachments/assets/1229f866-6be5-45cd-a6b8-c805f72144a6"> | <img width="800" alt="Screenshot 2024-12-05 at 11 12 15" src="https://github.com/user-attachments/assets/f082d7f9-7d56-41d1-bc86-c333ad6264c7"> | 



Release Notes:

- N/A
