### PR TITLE
git: Make worktrees work for bare git repositories

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3166,12 +3166,11 @@ async fn is_git_dir(path: &Path, fs: &dyn Fs) -> bool {
     // bare repository, the root folder contains what would normally be in the
     // `.git` folder.
     let head_metadata = fs.metadata(&path.join("HEAD")).await;
-    let config_metadata = fs.metadata(&path.join("config")).await;
-
-    match (head_metadata, config_metadata) {
-        (Ok(Some(_)), Ok(Some(_))) => true,
-        _ => false,
+    if !matches!(head_metadata, Ok(Some(_))) {
+        return false;
     }
+    let config_metadata = fs.metadata(&path.join("config")).await;
+    matches!(config_metadata, Ok(Some(_)))
 }
 
 async fn find_git_dir(path: &Path, fs: &dyn Fs) -> Option<Arc<Path>> {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3110,12 +3110,8 @@ impl BackgroundScannerState {
         let repository = fs.open_repo(&dot_git_abs_path)?;
 
         let actual_repo_path = repository.path();
-        let actual_dot_git_dir_abs_path: Arc<Path> = Arc::from(
-            actual_repo_path
-                .ancestors()
-                .find(|ancestor| ancestor.file_name() == Some(&*DOT_GIT))?,
-        );
 
+        let actual_dot_git_dir_abs_path = smol::block_on(find_git_dir(&actual_repo_path, fs))?;
         watcher.add(&actual_repo_path).log_err()?;
 
         let dot_git_worktree_abs_path = if actual_dot_git_dir_abs_path.as_ref() == dot_git_abs_path
@@ -3159,6 +3155,32 @@ impl BackgroundScannerState {
 
         Some((work_directory, repository))
     }
+}
+
+async fn is_git_dir(path: &Path, fs: &dyn Fs) -> bool {
+    if path.file_name() == Some(&*DOT_GIT) {
+        return true;
+    }
+
+    // If we're in a bare repository, we are not inside a `.git` folder. In a
+    // bare repository, the root folder contains what would normally be in the
+    // `.git` folder.
+    let head_metadata = fs.metadata(&path.join("HEAD")).await;
+    let config_metadata = fs.metadata(&path.join("config")).await;
+
+    match (head_metadata, config_metadata) {
+        (Ok(Some(_)), Ok(Some(_))) => true,
+        _ => false,
+    }
+}
+
+async fn find_git_dir(path: &Path, fs: &dyn Fs) -> Option<Arc<Path>> {
+    for ancestor in path.ancestors() {
+        if is_git_dir(ancestor, fs).await {
+            return Some(Arc::from(ancestor));
+        }
+    }
+    None
 }
 
 async fn build_gitignore(abs_path: &Path, fs: &dyn Fs) -> Result<Gitignore> {
@@ -3967,7 +3989,7 @@ impl BackgroundScanner {
                         } else if fsmonitor_parse_state == Some(FsMonitorParseState::Cookies) && file_name == Some(*FSMONITOR_DAEMON) {
                             fsmonitor_parse_state = Some(FsMonitorParseState::FsMonitor);
                             false
-                        } else if fsmonitor_parse_state != Some(FsMonitorParseState::FsMonitor) && file_name == Some(*DOT_GIT) {
+                        } else if fsmonitor_parse_state != Some(FsMonitorParseState::FsMonitor) && smol::block_on(is_git_dir(ancestor, self.fs.as_ref())) {
                             true
                         } else {
                             fsmonitor_parse_state.take();


### PR DESCRIPTION
This fixes #21210 by ensuring that Zed can open worktrees of bare git repositories.

Closes #21210

Release Notes:

- Fixed opening git worktrees that were created from a bare repository.

