### PR TITLE
assistant2: Add thread history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assistant_tool",
+ "chrono",
  "client",
  "collections",
  "command_palette_hooks",
@@ -478,6 +479,8 @@ dependencies = [
  "settings",
  "smol",
  "theme",
+ "time",
+ "time_format",
  "ui",
  "unindent",
  "util",

--- a/crates/assistant2/Cargo.toml
+++ b/crates/assistant2/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 assistant_tool.workspace = true
+chrono.workspace = true
 client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
@@ -37,6 +38,8 @@ serde_json.workspace = true
 settings.workspace = true
 smol.workspace = true
 theme.workspace = true
+time.workspace = true
+time_format.workspace = true
 ui.workspace = true
 unindent.workspace = true
 util.workspace = true

--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use assistant_tool::ToolWorkingSet;
 use collections::HashMap;
 use gpui::{
-    list, AnyElement, Empty, ListAlignment, ListState, Model, StyleRefinement, Subscription,
-    TextStyleRefinement, View, WeakView,
+    list, AnyElement, AppContext, Empty, ListAlignment, ListState, Model, StyleRefinement,
+    Subscription, TextStyleRefinement, View, WeakView,
 };
 use language::LanguageRegistry;
 use language_model::Role;
@@ -68,6 +68,10 @@ impl ActiveThread {
 
     pub fn is_empty(&self) -> bool {
         self.messages.is_empty()
+    }
+
+    pub fn summary(&self, cx: &AppContext) -> Option<SharedString> {
+        self.thread.read(cx).summary()
     }
 
     pub fn last_error(&self) -> Option<ThreadError> {
@@ -139,6 +143,7 @@ impl ActiveThread {
                 self.last_error = Some(error.clone());
             }
             ThreadEvent::StreamedCompletion => {}
+            ThreadEvent::SummaryChanged => {}
             ThreadEvent::StreamedAssistantText(message_id, text) => {
                 if let Some(markdown) = self.rendered_messages_by_id.get_mut(&message_id) {
                     markdown.update(cx, |markdown, cx| {

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -3,6 +3,7 @@ mod assistant_panel;
 mod context_picker;
 mod message_editor;
 mod thread;
+mod thread_history;
 mod thread_store;
 
 use command_palette_hooks::CommandPaletteFilter;

--- a/crates/assistant2/src/thread_history.rs
+++ b/crates/assistant2/src/thread_history.rs
@@ -1,0 +1,144 @@
+use gpui::{
+    uniform_list, AppContext, FocusHandle, FocusableView, Model, UniformListScrollHandle, WeakView,
+};
+use time::{OffsetDateTime, UtcOffset};
+use ui::{prelude::*, IconButtonShape, ListItem};
+
+use crate::thread::Thread;
+use crate::thread_store::ThreadStore;
+use crate::AssistantPanel;
+
+pub struct ThreadHistory {
+    focus_handle: FocusHandle,
+    assistant_panel: WeakView<AssistantPanel>,
+    thread_store: Model<ThreadStore>,
+    scroll_handle: UniformListScrollHandle,
+}
+
+impl ThreadHistory {
+    pub(crate) fn new(
+        assistant_panel: WeakView<AssistantPanel>,
+        thread_store: Model<ThreadStore>,
+        cx: &mut ViewContext<Self>,
+    ) -> Self {
+        Self {
+            focus_handle: cx.focus_handle(),
+            assistant_panel,
+            thread_store,
+            scroll_handle: UniformListScrollHandle::default(),
+        }
+    }
+}
+
+impl FocusableView for ThreadHistory {
+    fn focus_handle(&self, _cx: &AppContext) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for ThreadHistory {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let threads = self.thread_store.update(cx, |this, cx| this.threads(cx));
+
+        v_flex()
+            .id("thread-history-container")
+            .track_focus(&self.focus_handle)
+            .overflow_y_scroll()
+            .size_full()
+            .p_1()
+            .map(|history| {
+                if threads.is_empty() {
+                    history
+                        .justify_center()
+                        .child(
+                            h_flex().w_full().justify_center().child(
+                                Label::new("You don't have any past threads yet.")
+                                    .size(LabelSize::Small),
+                            ),
+                        )
+                } else {
+                    history.child(
+                        uniform_list(
+                            cx.view().clone(),
+                            "thread-history",
+                            threads.len(),
+                            move |history, range, _cx| {
+                                threads[range]
+                                    .iter()
+                                    .map(|thread| {
+                                        PastThread::new(
+                                            thread.clone(),
+                                            history.assistant_panel.clone(),
+                                        )
+                                    })
+                                    .collect()
+                            },
+                        )
+                        .track_scroll(self.scroll_handle.clone())
+                        .flex_grow(),
+                    )
+                }
+            })
+    }
+}
+
+#[derive(IntoElement)]
+pub struct PastThread {
+    thread: Model<Thread>,
+    assistant_panel: WeakView<AssistantPanel>,
+}
+
+impl PastThread {
+    pub fn new(thread: Model<Thread>, assistant_panel: WeakView<AssistantPanel>) -> Self {
+        Self {
+            thread,
+            assistant_panel,
+        }
+    }
+}
+
+impl RenderOnce for PastThread {
+    fn render(self, cx: &mut WindowContext) -> impl IntoElement {
+        let (id, summary) = {
+            const DEFAULT_SUMMARY: SharedString = SharedString::new_static("New Thread");
+            let thread = self.thread.read(cx);
+            (
+                thread.id().clone(),
+                thread.summary().unwrap_or(DEFAULT_SUMMARY),
+            )
+        };
+
+        let thread_timestamp = time_format::format_localized_timestamp(
+            OffsetDateTime::from_unix_timestamp(self.thread.read(cx).updated_at().timestamp())
+                .unwrap(),
+            OffsetDateTime::now_utc(),
+            self.assistant_panel
+                .update(cx, |this, _cx| this.local_timezone())
+                .unwrap_or(UtcOffset::UTC),
+            time_format::TimestampFormat::EnhancedAbsolute,
+        );
+        ListItem::new(("past-thread", self.thread.entity_id()))
+            .start_slot(Icon::new(IconName::MessageBubbles))
+            .child(Label::new(summary))
+            .end_slot(
+                h_flex()
+                    .gap_2()
+                    .child(Label::new(thread_timestamp).color(Color::Disabled))
+                    .child(
+                        IconButton::new("delete", IconName::TrashAlt)
+                            .shape(IconButtonShape::Square)
+                            .icon_size(IconSize::Small),
+                    ),
+            )
+            .on_click({
+                let assistant_panel = self.assistant_panel.clone();
+                move |_event, cx| {
+                    assistant_panel
+                        .update(cx, |this, cx| {
+                            this.open_thread(&id, cx);
+                        })
+                        .ok();
+                }
+            })
+    }
+}

--- a/crates/assistant2/src/thread_store.rs
+++ b/crates/assistant2/src/thread_store.rs
@@ -148,6 +148,7 @@ impl ThreadStore {
 
         self.threads.push(cx.new_model(|cx| {
             let mut thread = Thread::new(self.tools.clone(), cx);
+            thread.set_summary("Introduction to quantum computing", cx);
             thread.insert_user_message("Hello! Can you help me understand quantum computing?", cx);
             thread.insert_message(Role::Assistant, "Of course! I'd be happy to help you understand quantum computing. Quantum computing is a fascinating field that uses the principles of quantum mechanics to process information. Unlike classical computers that use bits (0s and 1s), quantum computers use quantum bits or 'qubits'. These qubits can exist in multiple states simultaneously, a property called superposition. This allows quantum computers to perform certain calculations much faster than classical computers. What specific aspect of quantum computing would you like to know more about?", cx);
             thread.insert_user_message("That's interesting! Can you explain how quantum entanglement is used in quantum computing?", cx);
@@ -157,6 +158,7 @@ impl ThreadStore {
 
         self.threads.push(cx.new_model(|cx| {
             let mut thread = Thread::new(self.tools.clone(), cx);
+            thread.set_summary("Rust web development and async programming", cx);
             thread.insert_user_message("Can you show me an example of Rust code for a simple web server?", cx);
             thread.insert_message(Role::Assistant, "Certainly! Here's an example of a simple web server in Rust using the `actix-web` framework:
 

--- a/crates/assistant2/src/thread_store.rs
+++ b/crates/assistant2/src/thread_store.rs
@@ -52,14 +52,19 @@ impl ThreadStore {
         })
     }
 
-    pub fn recent_threads(&self, limit: usize, cx: &ModelContext<Self>) -> Vec<Model<Thread>> {
+    pub fn threads(&self, cx: &ModelContext<Self>) -> Vec<Model<Thread>> {
         let mut threads = self
             .threads
             .iter()
             .filter(|thread| !thread.read(cx).is_empty())
+            .cloned()
             .collect::<Vec<_>>();
-        threads.sort_unstable_by(|a, b| b.read(cx).updated_at().cmp(&a.read(cx).updated_at()));
-        threads.into_iter().take(limit).cloned().collect()
+        threads.sort_unstable_by_key(|thread| std::cmp::Reverse(thread.read(cx).updated_at()));
+        threads
+    }
+
+    pub fn recent_threads(&self, limit: usize, cx: &ModelContext<Self>) -> Vec<Model<Thread>> {
+        self.threads(cx).into_iter().take(limit).collect()
     }
 
     pub fn create_thread(&mut self, cx: &mut ModelContext<Self>) -> Model<Thread> {

--- a/crates/assistant2/src/thread_store.rs
+++ b/crates/assistant2/src/thread_store.rs
@@ -53,12 +53,13 @@ impl ThreadStore {
     }
 
     pub fn recent_threads(&self, limit: usize, cx: &ModelContext<Self>) -> Vec<Model<Thread>> {
-        self.threads
+        let mut threads = self
+            .threads
             .iter()
             .filter(|thread| !thread.read(cx).is_empty())
-            .take(limit)
-            .cloned()
-            .collect()
+            .collect::<Vec<_>>();
+        threads.sort_unstable_by(|a, b| b.read(cx).updated_at().cmp(&a.read(cx).updated_at()));
+        threads.into_iter().take(limit).cloned().collect()
     }
 
     pub fn create_thread(&mut self, cx: &mut ModelContext<Self>) -> Model<Thread> {


### PR DESCRIPTION
This PR adds support for thread history to the Assistant 2 panel.

We also now generate summaries for the threads.

<img width="986" alt="Screenshot 2024-12-05 at 12 56 53 PM" src="https://github.com/user-attachments/assets/46cb1309-38a2-4ab9-9fcc-c1275d4b5f2c">

<img width="986" alt="Screenshot 2024-12-05 at 12 56 58 PM" src="https://github.com/user-attachments/assets/8c91ba57-a6c5-4b88-be05-b22fb615ece5">

Release Notes:

- N/A
