### PR TITLE
Catch panic from oo7 when reading credentials

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -481,7 +481,11 @@ impl<P: LinuxClient + 'static> Platform for P {
                     let username = attributes
                         .get("username")
                         .ok_or_else(|| anyhow!("Cannot find username in stored credentials"))?;
-                    let secret = item.secret().await?;
+                    // oo7 panics if the retrieved secret can't be decrypted due to
+                    // unexpected padding.
+                    let secret = std::panic::catch_unwind(|| item.secret())
+                        .map_err(|_| anyhow!("oo7 panicked while trying to read credentials"))?
+                        .await?;
 
                     // we lose the zeroizing capabilities at this boundary,
                     // a current limitation GPUI's credentials api

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::io::Read;
 use std::ops::{Deref, DerefMut};
 use std::os::fd::{AsFd, AsRawFd, FromRawFd};
-use std::panic::Location;
+use std::panic::{AssertUnwindSafe, Location};
 use std::rc::Weak;
 use std::{
     path::{Path, PathBuf},
@@ -483,7 +483,7 @@ impl<P: LinuxClient + 'static> Platform for P {
                         .ok_or_else(|| anyhow!("Cannot find username in stored credentials"))?;
                     // oo7 panics if the retrieved secret can't be decrypted due to
                     // unexpected padding.
-                    let secret = std::panic::catch_unwind(|| item.secret())
+                    let secret = std::panic::catch_unwind(AssertUnwindSafe(|| item.secret()))
                         .map_err(|_| anyhow!("oo7 panicked while trying to read credentials"))?
                         .await?;
 


### PR DESCRIPTION
We've seen this a bunch in the reports on Slack, the panic originates here:

https://github.com/bilelmoussaoui/oo7/blob/1bba4ad5220b35a1f21aee389409ed341e14ce48/client/src/crypto/native.rs#L47

and indicates that the encrypted secret returned from DBus (or the file backend I guess) is corrupt. I don't know how it gets that way but feels like we should avoid crashing the app as a result 

Release Notes:

- Fixed panics when reading system keyring on Linux