### PR TITLE
themes: Make types yellow in One Dark theme

### DIFF
--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -356,7 +356,7 @@
             "font_weight": 400
           },
           "type": {
-            "color": "#6eb4bfff",
+            "color": "#f1c232ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
Closes #21371

Before:
<img width="599" alt="image" src="https://github.com/user-attachments/assets/bca6c7c2-6fb5-4a6d-8d02-998bda645a91">
After:
<img width="607" alt="image" src="https://github.com/user-attachments/assets/11b06184-e5f6-443d-8de9-20d6433771e3">


Types are usually yellow in this theme. For example: https://plugins.jetbrains.com/plugin/11938-one-dark-theme
<img width="320" alt="image" src="https://github.com/user-attachments/assets/fa66a014-08b6-46ef-9907-873fd0b57893">

Release Notes:

- Made types in one dark theme use a yellow color instead of cyan
