### PR TITLE
util: Simplify command.rs

### DIFF
--- a/crates/util/src/command.rs
+++ b/crates/util/src/command.rs
@@ -3,30 +3,28 @@ use std::ffi::OsStr;
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000_u32;
 
-#[cfg(target_os = "windows")]
 pub fn new_std_command(program: impl AsRef<OsStr>) -> std::process::Command {
-    use std::os::windows::process::CommandExt;
-
+    #[allow(unused_mut)]
     let mut command = std::process::Command::new(program);
-    command.creation_flags(CREATE_NO_WINDOW);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
     command
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn new_std_command(program: impl AsRef<OsStr>) -> std::process::Command {
-    std::process::Command::new(program)
-}
-
-#[cfg(target_os = "windows")]
 pub fn new_smol_command(program: impl AsRef<OsStr>) -> smol::process::Command {
-    use smol::process::windows::CommandExt;
-
+    #[allow(unused_mut)]
     let mut command = smol::process::Command::new(program);
-    command.creation_flags(CREATE_NO_WINDOW);
-    command
-}
 
-#[cfg(not(target_os = "windows"))]
-pub fn new_smol_command(program: impl AsRef<OsStr>) -> smol::process::Command {
-    smol::process::Command::new(program)
+    #[cfg(target_os = "windows")]
+    {
+        use smol::process::windows::CommandExt;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    command
 }


### PR DESCRIPTION
Use a single function for all targets, but do windows-related things in separate blocks inside functions. This makes code a bit more readable for me

Release Notes:

- N/A
