### PR TITLE
Refine diagnostic icons in tabs

### DIFF
--- a/assets/icons/triangle.svg
+++ b/assets/icons/triangle.svg
@@ -1,3 +1,3 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M8 4L4 12H12L8 4Z" fill="currentColor"/>
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 3L3 12H14L8.5 3Z" fill="black"/>
 </svg>

--- a/assets/icons/x.svg
+++ b/assets/icons/x.svg
@@ -1,3 +1,3 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" stroke-width="2"/>
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 4.5L12 11.5M12 4.5L5 11.5" stroke="black" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2145,7 +2145,7 @@ impl Pane {
                     .child(if let Some(decorated_icon) = decorated_icon {
                         div().child(decorated_icon.into_any_element())
                     } else if let Some(icon) = icon {
-                        div().child(icon.into_any_element())
+                        div().mt(px(2.5)).child(icon.into_any_element())
                     } else {
                         div()
                     })


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/21383

Mostly adjusting the alignment when there are no file icons.

<img width="800" alt="Screenshot 2024-12-06 at 08 35 48" src="https://github.com/user-attachments/assets/6a4206cc-2af5-4317-a92e-49dffa37de99">

Release Notes:

- N/A
