### PR TITLE
Recognize .C and .H as supported cpp extensions

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "cu", "cuh"]
+path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "cu", "cuh", "C", "H"]
 line_comments = ["// ", "/// ", "//! "]
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -14,6 +14,16 @@ CompileFlags:
   Add: [-xc]
 ```
 
+By default clang and gcc by will recognize `*.C` and `*.H` (uppercase extensions) as C++ and not C and so Zed too follows this convention. If you are working with a C-only project (perhaps one with legacy uppercase pathing like `FILENAME.C`) you can override this behavior by adding this to your settings:
+
+```json
+{
+  "file_types": {
+    "C": ["C", "H"]
+  }
+}
+```
+
 ## Formatting
 
 By default Zed will use the `clangd` language server for formatting C code. The Clangd is the same as the `clang-format` CLI tool. To configure this you can add a `.clang-format` file. For example:


### PR DESCRIPTION
Closes #20996

Release Notes:

- Add support for `*.C` and `*.H` (uppercase) to be recognized as C++