### PR TITLE
Fix incorrect language selected in language selector

### DIFF
--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -104,14 +104,15 @@ impl LanguageSelectorDelegate {
         let candidates = language_registry
             .language_names()
             .into_iter()
-            .enumerate()
-            .filter_map(|(candidate_id, name)| {
+            .filter_map(|name| {
                 language_registry
                     .available_language_for_name(&name)?
                     .hidden()
                     .not()
-                    .then(|| StringMatchCandidate::new(candidate_id, name))
+                    .then_some(name)
             })
+            .enumerate()
+            .map(|(candidate_id, name)| StringMatchCandidate::new(candidate_id, name))
             .collect::<Vec<_>>();
 
         Self {


### PR DESCRIPTION
Closes #21643

Due to filtering after enumeration, initial candidate ids are assigned incorrectly. This later causes the wrong item to be picked up when accessed via index in the vector.

Release Notes:

- Preview Only: Fix incorrect language selected in language selector