### PR TITLE
Make building individual packages work better with LiveKit conditional compilation

### DIFF
--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -21,7 +21,6 @@ test-support = [
     "project/test-support",
     "util/test-support"
 ]
-livekit-macos = ["livekit_client_macos"]
 livekit-cross-platform = ["livekit_client"]
 
 [dependencies]
@@ -42,7 +41,7 @@ serde.workspace = true
 serde_derive.workspace = true
 settings.workspace = true
 util.workspace = true
-livekit_client_macos = { workspace = true, optional = true }
+livekit_client_macos.workspace = true
 livekit_client = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/call/src/call.rs
+++ b/crates/call/src/call.rs
@@ -1,41 +1,16 @@
 pub mod call_settings;
 
-#[cfg(any(
-    all(target_os = "macos", feature = "livekit-macos"),
-    all(
-        not(target_os = "macos"),
-        feature = "livekit-macos",
-        not(feature = "livekit-cross-platform")
-    )
-))]
+#[cfg(all(target_os = "macos", not(feature = "livekit-cross-platform")))]
 mod macos;
 
-#[cfg(any(
-    all(target_os = "macos", feature = "livekit-macos"),
-    all(
-        not(target_os = "macos"),
-        feature = "livekit-macos",
-        not(feature = "livekit-cross-platform")
-    )
-))]
+#[cfg(all(target_os = "macos", not(feature = "livekit-cross-platform")))]
 pub use macos::*;
 
-#[cfg(any(
-    all(
-        target_os = "macos",
-        feature = "livekit-cross-platform",
-        not(feature = "livekit-macos"),
-    ),
-    all(not(target_os = "macos"), feature = "livekit-cross-platform"),
-))]
+#[cfg(feature = "livekit-cross-platform")]
 mod cross_platform;
 
-#[cfg(any(
-    all(
-        target_os = "macos",
-        feature = "livekit-cross-platform",
-        not(feature = "livekit-macos"),
-    ),
-    all(not(target_os = "macos"), feature = "livekit-cross-platform"),
-))]
+#[cfg(feature = "livekit-cross-platform")]
 pub use cross_platform::*;
+
+#[cfg(all(not(target_os = "macos"), not(feature = "livekit-cross-platform")))]
+compile_error!("Linux/Windows builds require `--features call/livekit-cross-platform`");

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -24,7 +24,6 @@ test-support = [
     "gpui/test-support",
     "fs/test-support",
 ]
-livekit-macos = ["call/livekit-macos"]
 livekit-cross-platform = ["call/livekit-cross-platform"]
 
 [dependencies]

--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -1,11 +1,4 @@
-#[cfg(any(
-    all(
-        target_os = "macos",
-        feature = "livekit-cross-platform",
-        not(feature = "livekit-macos"),
-    ),
-    all(not(target_os = "macos"), feature = "livekit-cross-platform"),
-))]
+#[cfg(feature = "livekit-cross-platform")]
 mod cross_platform {
     use crate::{
         item::{Item, ItemEvent},
@@ -124,24 +117,10 @@ mod cross_platform {
     }
 }
 
-#[cfg(any(
-    all(
-        target_os = "macos",
-        feature = "livekit-cross-platform",
-        not(feature = "livekit-macos"),
-    ),
-    all(not(target_os = "macos"), feature = "livekit-cross-platform"),
-))]
+#[cfg(feature = "livekit-cross-platform")]
 pub use cross_platform::*;
 
-#[cfg(any(
-    all(target_os = "macos", feature = "livekit-macos"),
-    all(
-        not(target_os = "macos"),
-        feature = "livekit-macos",
-        not(feature = "livekit-cross-platform")
-    )
-))]
+#[cfg(all(target_os = "macos", not(feature = "livekit-cross-platform")))]
 mod macos {
     use crate::{
         item::{Item, ItemEvent},
@@ -271,12 +250,8 @@ mod macos {
     }
 }
 
-#[cfg(any(
-    all(target_os = "macos", feature = "livekit-macos"),
-    all(
-        not(target_os = "macos"),
-        feature = "livekit-macos",
-        not(feature = "livekit-cross-platform")
-    )
-))]
+#[cfg(all(target_os = "macos", not(feature = "livekit-cross-platform")))]
 pub use macos::*;
+
+#[cfg(all(not(target_os = "macos"), not(feature = "livekit-cross-platform")))]
+compile_error!("Linux/Windows builds require `--features call/livekit-cross-platform,workspace/livekit-cross-platform`");

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -126,9 +126,6 @@ welcome.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 
-[target.'cfg(target_os = "macos")'.dependencies]
-workspace = { workspace = true, features = ["livekit-macos"] }
-
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 workspace = { workspace = true, features = ["livekit-cross-platform"] }
 


### PR DESCRIPTION
This fixes an issue on MacOS where doing `cargo build -p workspace` fails due to neither the `livekit-macos` or `livekit-cross-platform` features being enabled. On Linux/Windows it is not quite as nice, there `--features
call/livekit-cross-platform,workspace/livekit-cross-platform` needs to be used.

Release Notes:

- N/A