### PR TITLE
editor: Add actions for inserting UUIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,6 +3957,7 @@ dependencies = [
  "unindent",
  "url",
  "util",
+ "uuid",
  "workspace",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -506,7 +506,7 @@ unindent = "0.1.7"
 unicode-segmentation = "1.10"
 unicode-script = "0.5.7"
 url = "2.2"
-uuid = { version = "1.1.2", features = ["v4", "v5", "serde"] }
+uuid = { version = "1.1.2", features = ["v4", "v5", "v7", "serde"] }
 wasmparser = "0.215"
 wasm-encoder = "0.215"
 wasmtime = { version = "24", default-features = false, features = [

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -85,6 +85,7 @@ unindent = { workspace = true, optional = true }
 ui.workspace = true
 url.workspace = true
 util.workspace = true
+uuid.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -105,6 +105,7 @@ pub struct MoveDownByLines {
     #[serde(default)]
     pub(super) lines: u32,
 }
+
 #[derive(PartialEq, Clone, Deserialize, Default)]
 pub struct SelectUpByLines {
     #[serde(default)]
@@ -164,6 +165,13 @@ pub struct FoldAtLevel {
 pub struct SpawnNearestTask {
     #[serde(default)]
     pub reveal: task::RevealStrategy,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Default)]
+pub enum UuidVersion {
+    #[default]
+    V4,
+    V7,
 }
 
 impl_actions!(
@@ -271,6 +279,8 @@ gpui::actions!(
         HalfPageUp,
         Hover,
         Indent,
+        InsertUuidV4,
+        InsertUuidV7,
         JoinLines,
         KillRingCut,
         KillRingYank,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12004,6 +12004,26 @@ impl Editor {
         .detach();
     }
 
+    pub fn insert_uuid_v4(&mut self, _: &InsertUuidV4, cx: &mut ViewContext<Self>) {
+        self.insert_uuid(UuidVersion::V4, cx);
+    }
+
+    pub fn insert_uuid_v7(&mut self, _: &InsertUuidV7, cx: &mut ViewContext<Self>) {
+        self.insert_uuid(UuidVersion::V7, cx);
+    }
+
+    fn insert_uuid(&mut self, version: UuidVersion, cx: &mut ViewContext<Self>) {
+        let uuid = match version {
+            UuidVersion::V4 => uuid::Uuid::new_v4(),
+            UuidVersion::V7 => uuid::Uuid::now_v7(),
+        };
+
+        self.transact(cx, |this, cx| {
+            this.insert(&uuid.to_string(), cx);
+            this.refresh_inline_completion(true, false, cx);
+        });
+    }
+
     /// Adds a row highlight for the given range. If a row has multiple highlights, the
     /// last highlight added will be used.
     ///

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12013,13 +12013,20 @@ impl Editor {
     }
 
     fn insert_uuid(&mut self, version: UuidVersion, cx: &mut ViewContext<Self>) {
-        let uuid = match version {
-            UuidVersion::V4 => uuid::Uuid::new_v4(),
-            UuidVersion::V7 => uuid::Uuid::now_v7(),
-        };
-
         self.transact(cx, |this, cx| {
-            this.insert(&uuid.to_string(), cx);
+            let edits = this
+                .selections
+                .all::<Point>(cx)
+                .into_iter()
+                .map(|selection| {
+                    let uuid = match version {
+                        UuidVersion::V4 => uuid::Uuid::new_v4(),
+                        UuidVersion::V7 => uuid::Uuid::now_v7(),
+                    };
+
+                    (selection.range(), uuid.to_string())
+                });
+            this.edit(edits, cx);
             this.refresh_inline_completion(true, false, cx);
         });
     }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -456,6 +456,8 @@ impl EditorElement {
         register_action(view, cx, Editor::open_active_item_in_terminal);
         register_action(view, cx, Editor::reload_file);
         register_action(view, cx, Editor::spawn_nearest_task);
+        register_action(view, cx, Editor::insert_uuid_v4);
+        register_action(view, cx, Editor::insert_uuid_v7);
     }
 
     fn register_key_listeners(&self, cx: &mut WindowContext, layout: &EditorLayout) {


### PR DESCRIPTION
This PR adds two new actions for generating and inserting UUIDs into the buffer:

https://github.com/user-attachments/assets/a3445a98-07e2-40b8-9773-fd750706cbcc

Release Notes:

- Added `editor: insert uuid v4` and `editor: insert uuid v7` actions for inserting generated UUIDs into the editor.
