### PR TITLE
Bump to livekit 1.1.6

### DIFF
--- a/crates/livekit_client_macos/LiveKitBridge/Package.resolved
+++ b/crates/livekit_client_macos/LiveKitBridge/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/livekit/client-sdk-swift.git",
         "state": {
           "branch": null,
-          "revision": "7331b813a5ab8a95cfb81fb2b4ed10519428b9ff",
-          "version": "1.0.12"
+          "revision": "8cde9e66ce9b470c3a743f5c72784f57c5a6d0c3",
+          "version": "1.1.6"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/webrtc-sdk/Specs.git",
         "state": {
           "branch": null,
-          "revision": "2f6bab30c8df0fe59ab3e58bc99097f757f85f65",
-          "version": "104.5112.17"
+          "revision": "4fa8d6d647fc759cdd0265fd413d2f28ea2e0e08",
+          "version": "114.5735.8"
         }
       },
       {

--- a/crates/livekit_client_macos/LiveKitBridge/Package.swift
+++ b/crates/livekit_client_macos/LiveKitBridge/Package.swift
@@ -12,16 +12,16 @@ let package = Package(
         .library(
             name: "LiveKitBridge",
             type: .static,
-            targets: ["LiveKitBridge"]),
+            targets: ["LiveKitBridge"])
     ],
     dependencies: [
-        .package(url: "https://github.com/livekit/client-sdk-swift.git", .exact("1.0.12")),
+        .package(url: "https://github.com/livekit/client-sdk-swift.git", .exact("1.1.6"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "LiveKitBridge",
-            dependencies: [.product(name: "LiveKit", package: "client-sdk-swift")]),
+            dependencies: [.product(name: "LiveKit", package: "client-sdk-swift")])
     ]
 )


### PR DESCRIPTION
Co-Authored-By: Mikayla <mikayla@zed.dev>

This bumps to the latest v1 version of swift SDK. We could bump to 2, but it
sounds like this will already have some race condition fixes (and a click
around locally seems less prone to deadlocking so far...)

Release Notes:

- N/A
