### PR TITLE
Fix zoomed terminal pane issues on split

### DIFF
--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -214,8 +214,13 @@ async fn deserialize_pane_group(
             .await;
 
             let pane = panel
-                .update(cx, |_, cx| {
-                    new_terminal_pane(workspace.clone(), project.clone(), cx)
+                .update(cx, |terminal_panel, cx| {
+                    new_terminal_pane(
+                        workspace.clone(),
+                        project.clone(),
+                        terminal_panel.active_pane.read(cx).is_zoomed(),
+                        cx,
+                    )
                 })
                 .log_err()?;
             let active_item = serialized_pane.active_item;

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -306,6 +306,7 @@ pub struct Pane {
     pub split_item_context_menu_handle: PopoverMenuHandle<ContextMenu>,
     pinned_tab_count: usize,
     diagnostics: HashMap<ProjectPath, DiagnosticSeverity>,
+    zoom_out_on_close: bool,
 }
 
 pub struct ActivationHistoryEntry {
@@ -507,6 +508,7 @@ impl Pane {
             new_item_context_menu_handle: Default::default(),
             pinned_tab_count: 0,
             diagnostics: Default::default(),
+            zoom_out_on_close: true,
         }
     }
 
@@ -1586,7 +1588,7 @@ impl Pane {
                 .remove(&item.item_id());
         }
 
-        if self.items.is_empty() && close_pane_if_empty && self.zoomed {
+        if self.zoom_out_on_close && self.items.is_empty() && close_pane_if_empty && self.zoomed {
             cx.emit(Event::ZoomOut);
         }
 
@@ -2786,6 +2788,10 @@ impl Pane {
 
     pub fn drag_split_direction(&self) -> Option<SplitDirection> {
         self.drag_split_direction
+    }
+
+    pub fn set_zoom_out_on_close(&mut self, zoom_out_on_close: bool) {
+        self.zoom_out_on_close = zoom_out_on_close;
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21652

* prevents zooming out the panel when any terminal pane is closed
* forces focus on new terminal panes, to prevent the workspace from getting odd pane events in the background

Release Notes:

- (Preview only) Fixed zoomed terminal pane issues on split
