### PR TITLE
Remove last few alt- bindings

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -153,8 +153,8 @@
     "context": "Editor && mode == full && inline_completion",
     "use_key_equivalents": true,
     "bindings": {
-      "alt-]": "editor::NextInlineCompletion",
-      "alt-[": "editor::PreviousInlineCompletion",
+      "alt-tab": "editor::NextInlineCompletion",
+      "alt-shift-tab": "editor::PreviousInlineCompletion",
       "ctrl-right": "editor::AcceptPartialInlineCompletion"
     }
   },
@@ -162,7 +162,7 @@
     "context": "Editor && !inline_completion",
     "use_key_equivalents": true,
     "bindings": {
-      "alt-\\": "editor::ShowInlineCompletion"
+      "alt-tab": "editor::ShowInlineCompletion"
     }
   },
   {


### PR DESCRIPTION
Although I hoped we could keep the non-ascii alt characters, it turns
out this is not the case for all keyboards.

Fixes #21175

Release Notes:

- (breaking change) editor::ShowInlineCompetion is now `option-tab` on macOS
  (not `option-/`). editor::{Next,Previous}Completion are `option-tab` and
  `option-shift-tab` (not `option-[` and `option-]`). This fixes typing
  characters generated by option-{/,[,]} on keyboards like Croatian.
