### PR TITLE
Adjust diagnostic in tabs behavior

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -569,7 +569,8 @@
     //     "Neighbour"
     "activate_on_close": "history",
     /// Which files containing diagnostic errors/warnings to mark in the tabs.
-    /// This setting can take the following three values:
+    /// The diagnostic are only shown when file icons are also active.
+    /// This setting only works when can take the following three values:
     ///
     /// 1. Do not mark any files:
     ///    "off"
@@ -577,7 +578,7 @@
     ///    "errors"
     /// 3. Mark files with errors and warnings:
     ///    "all"
-    "show_diagnostics": "all"
+    "show_diagnostics": "off"
   },
   // Settings related to preview tabs.
   "preview_tabs": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -569,7 +569,7 @@
     //     "Neighbour"
     "activate_on_close": "history",
     /// Which files containing diagnostic errors/warnings to mark in the tabs.
-    /// The diagnostic are only shown when file icons are also active.
+    /// Diagnostics are only shown when file icons are also active.
     /// This setting only works when can take the following three values:
     ///
     /// 1. Do not mark any files:

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -64,9 +64,9 @@ pub enum ClosePosition {
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ShowDiagnostics {
+    #[default]
     Off,
     Errors,
-    #[default]
     All,
 }
 
@@ -99,7 +99,7 @@ pub struct ItemSettingsContent {
     /// Which files containing diagnostic errors/warnings to mark in the tabs.
     /// This setting can take the following three values:
     ///
-    /// Default: all
+    /// Default: off
     show_diagnostics: Option<ShowDiagnostics>,
     /// Whether to always show the close button on tabs.
     ///

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2000,12 +2000,8 @@ impl Pane {
 
         let icon = if decorated_icon.is_none() {
             match item_diagnostic {
-                Some(&DiagnosticSeverity::ERROR) => {
-                    Some(Icon::new(IconName::X).color(Color::Error))
-                }
-                Some(&DiagnosticSeverity::WARNING) => {
-                    Some(Icon::new(IconName::Triangle).color(Color::Warning))
-                }
+                Some(&DiagnosticSeverity::ERROR) => None,
+                Some(&DiagnosticSeverity::WARNING) => None,
                 _ => item.tab_icon(cx).map(|icon| icon.color(Color::Muted)),
             }
             .map(|icon| icon.size(IconSize::Small))

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2138,13 +2138,17 @@ impl Pane {
             .child(
                 h_flex()
                     .gap_1()
-                    .child(if let Some(decorated_icon) = decorated_icon {
-                        div().child(decorated_icon.into_any_element())
-                    } else if let Some(icon) = icon {
-                        div().mt(px(2.5)).child(icon.into_any_element())
-                    } else {
-                        div()
-                    })
+                    .items_center()
+                    .children(
+                        std::iter::once(if let Some(decorated_icon) = decorated_icon {
+                            Some(div().child(decorated_icon.into_any_element()))
+                        } else if let Some(icon) = icon {
+                            Some(div().child(icon.into_any_element()))
+                        } else {
+                            None
+                        })
+                        .flatten(),
+                    )
                     .child(label),
             );
 


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/21637

After discussing about this feature with the team, we've decided that diagnostic display in tabs should be: 1) turned off by default, and 2) only shown when there are file icons. The main reason here being to keep Zed's UI uncluttered.

This means that you can technically have this setting:

```
  "tabs": {
    "show_diagnostics": "all"
  },
```

...and still don't see any diagnostics because you're missing `file_icons": true`.

| Error with file icons | Error with no file icons |
|--------|--------|
| <img width="800" alt="Screenshot 2024-12-06 at 21 05 13" src="https://github.com/user-attachments/assets/babf9cc3-b3b0-492e-9748-3e97d96ce90e"> | <img width="800" alt="Screenshot 2024-12-06 at 21 05 24" src="https://github.com/user-attachments/assets/5247a5f1-55a0-4c56-8aaf-a0cdd115464f"> | 


Release Notes:

- N/A
