### PR TITLE
gpui: Don't panic when failing to exec system opener

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context as _};
 use async_task::Runnable;
 use calloop::channel::Channel;
 use calloop::{EventLoop, LoopHandle, LoopSignal};
@@ -382,14 +382,14 @@ impl<P: LinuxClient + 'static> Platform for P {
     }
 
     fn open_with_system(&self, path: &Path) {
-        let executor = self.background_executor().clone();
         let path = path.to_owned();
-        executor
+        self.background_executor()
             .spawn(async move {
                 let _ = std::process::Command::new("xdg-open")
                     .arg(path)
                     .spawn()
-                    .expect("Failed to open file with xdg-open");
+                    .context("invoking xdg-open")
+                    .log_err();
             })
             .detach();
     }

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -10,7 +10,7 @@ use crate::{
     PlatformTextSystem, PlatformWindow, Result, ScreenCaptureSource, SemanticVersion, Task,
     WindowAppearance, WindowParams,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, Context as _};
 use block::ConcreteBlock;
 use cocoa::{
     appkit::{
@@ -779,15 +779,16 @@ impl Platform for MacPlatform {
     }
 
     fn open_with_system(&self, path: &Path) {
-        let path = path.to_path_buf();
+        let path = path.to_owned();
         self.0
             .lock()
             .background_executor
             .spawn(async move {
-                std::process::Command::new("open")
+                let _ = std::process::Command::new("open")
                     .arg(path)
                     .spawn()
-                    .expect("Failed to open file");
+                    .context("invoking open command")
+                    .log_err();
             })
             .detach();
     }

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -57,6 +57,7 @@ use std::{
     sync::Arc,
 };
 use strum::IntoEnumIterator;
+use util::ResultExt;
 
 #[allow(non_upper_case_globals)]
 const NSUTF8StringEncoding: NSUInteger = 4;


### PR DESCRIPTION
Just log the error instead. These errors only come from failing to find the binary or similar, not the subprocess's exit status. On Linux it's not unreasonable for `xdg-open` not to be present.

Release Notes:

- N/A