### PR TITLE
toolchains: Do not use as_json representation for PartialEq

### DIFF
--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -14,7 +14,7 @@ use settings::WorktreeId;
 use crate::LanguageName;
 
 /// Represents a single toolchain.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Toolchain {
     /// User-facing label
     pub name: SharedString,
@@ -22,6 +22,18 @@ pub struct Toolchain {
     pub language_name: LanguageName,
     /// Full toolchain data (including language-specific details)
     pub as_json: serde_json::Value,
+}
+
+impl PartialEq for Toolchain {
+    fn eq(&self, other: &Self) -> bool {
+        // Do not use as_json for comparisons; it shouldn't impact equality, as it's not user-surfaced.
+        // Thus, there could be multiple entries that look the same in the UI.
+        (&self.name, &self.path, &self.language_name).eq(&(
+            &other.name,
+            &other.path,
+            &other.language_name,
+        ))
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Closes #21679

Release Notes:

- N/A
