### PR TITLE
gpui: Don't panic on failing to set X11 cursor style

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use calloop::generic::{FdWrapper, Generic};
 use calloop::{EventLoop, LoopHandle, RegistrationToken};
 
+use anyhow::Context as _;
 use collections::HashMap;
 use http_client::Url;
 use smallvec::SmallVec;
@@ -1417,9 +1418,10 @@ impl LinuxClient for X11Client {
                     ..Default::default()
                 },
             )
-            .expect("failed to change window cursor")
-            .check()
-            .unwrap();
+            .anyhow()
+            .and_then(|cookie| cookie.check().anyhow())
+            .context("setting cursor style")
+            .log_err();
     }
 
     fn open_uri(&self, uri: &str) {

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -206,6 +206,9 @@ pub trait ResultExt<E> {
     /// Assert that this result should never be an error in development or tests.
     fn debug_assert_ok(self, reason: &str) -> Self;
     fn warn_on_err(self) -> Option<Self::Ok>;
+    fn anyhow(self) -> anyhow::Result<Self::Ok>
+    where
+        E: Into<anyhow::Error>;
 }
 
 impl<T, E> ResultExt<E> for Result<T, E>
@@ -242,6 +245,13 @@ where
                 None
             }
         }
+    }
+
+    fn anyhow(self) -> anyhow::Result<T>
+    where
+        E: Into<anyhow::Error>,
+    {
+        self.map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
One more panic (well, two) that should be a `log_err`.

Release Notes:

- N/A