### PR TITLE
editor: Add debounce setting for triggering DocumentHighlight

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -144,6 +144,9 @@
   // 4. Highlight the full line (default):
   //    "all"
   "current_line_highlight": "all",
+  // Sets the debounce (in milliseconds) before triggering LSP DocumentHighlight
+  // to highlight references under the cursor.
+  "document_highlight_debounce": 75,
   // Whether to pop the completions menu while typing in an editor without
   // explicitly requesting it.
   "show_completions_on_input": true,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -144,9 +144,9 @@
   // 4. Highlight the full line (default):
   //    "all"
   "current_line_highlight": "all",
-  // Sets the debounce (in milliseconds) before triggering LSP DocumentHighlight
-  // to highlight references under the cursor.
-  "document_highlight_debounce": 75,
+  // The debounce delay before querying highlights from the language
+  // server based on the current cursor location.
+  "lsp_highlight_debounce": 75,
   // Whether to pop the completions menu while typing in an editor without
   // explicitly requesting it.
   "show_completions_on_input": true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5125,7 +5125,7 @@ impl Editor {
         if cursor_buffer != tail_buffer {
             return None;
         }
-        let debounce = EditorSettings::get_global(cx).document_highlight_debounce;
+        let debounce = EditorSettings::get_global(cx).lsp_highlight_debounce;
         self.document_highlights_task = Some(cx.spawn(|this, mut cx| async move {
             cx.background_executor()
                 .timer(Duration::from_millis(debounce))

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -184,8 +184,6 @@ const MAX_SELECTION_HISTORY_LEN: usize = 1024;
 pub(crate) const CURSORS_VISIBLE_FOR: Duration = Duration::from_millis(2000);
 #[doc(hidden)]
 pub const CODE_ACTIONS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(250);
-#[doc(hidden)]
-pub const DOCUMENT_HIGHLIGHTS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(75);
 
 pub(crate) const FORMAT_TIMEOUT: Duration = Duration::from_secs(2);
 pub(crate) const SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT: Duration = Duration::from_secs(1);
@@ -5127,10 +5125,10 @@ impl Editor {
         if cursor_buffer != tail_buffer {
             return None;
         }
-
+        let debounce = EditorSettings::get_global(cx).document_highlight_debounce;
         self.document_highlights_task = Some(cx.spawn(|this, mut cx| async move {
             cx.background_executor()
-                .timer(DOCUMENT_HIGHLIGHTS_DEBOUNCE_TIMEOUT)
+                .timer(Duration::from_millis(debounce))
                 .await;
 
             let highlights = if let Some(highlights) = cx

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -9,6 +9,7 @@ pub struct EditorSettings {
     pub cursor_blink: bool,
     pub cursor_shape: Option<CursorShape>,
     pub current_line_highlight: CurrentLineHighlight,
+    pub document_highlight_debounce: u64,
     pub hover_popover_enabled: bool,
     pub show_completions_on_input: bool,
     pub show_completion_documentation: bool,
@@ -188,6 +189,11 @@ pub struct EditorSettingsContent {
     ///
     /// Default: all
     pub current_line_highlight: Option<CurrentLineHighlight>,
+    /// The debounce delay to send DocumentHighlight request to LSP when
+    //  curosr moves.
+    ///
+    /// Default: 75
+    pub document_highlight_debounce: Option<u64>,
     /// Whether to show the informational hover box when moving the mouse
     /// over symbols in the editor.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -9,7 +9,7 @@ pub struct EditorSettings {
     pub cursor_blink: bool,
     pub cursor_shape: Option<CursorShape>,
     pub current_line_highlight: CurrentLineHighlight,
-    pub document_highlight_debounce: u64,
+    pub lsp_highlight_debounce: u64,
     pub hover_popover_enabled: bool,
     pub show_completions_on_input: bool,
     pub show_completion_documentation: bool,
@@ -189,11 +189,11 @@ pub struct EditorSettingsContent {
     ///
     /// Default: all
     pub current_line_highlight: Option<CurrentLineHighlight>,
-    /// The debounce delay to send DocumentHighlight request to LSP when
-    //  curosr moves.
+    /// The debounce delay before querying highlights from the language
+    /// server based on the current cursor location.
     ///
     /// Default: 75
-    pub document_highlight_debounce: Option<u64>,
+    pub lsp_highlight_debounce: Option<u64>,
     /// Whether to show the informational hover box when moving the mouse
     /// over symbols in the editor.
     ///

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -435,10 +435,10 @@ List of `string` values
 "current_line_highlight": "all"
 ```
 
-## DocumentHighlight Debounce
+## LSP Highlight Debounce
 
-- Description: Debounce (in milliseconds) before triggering LSP DocumentHighlight when moving cursor.
-- Setting: `document_highlight_debounce`
+- Description: The debounce delay before querying highlights from the language server based on the current cursor location.
+- Setting: `lsp_highlight_debounce`
 - Default: `75`
 
 ## Cursor Blink

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -435,6 +435,12 @@ List of `string` values
 "current_line_highlight": "all"
 ```
 
+## DocumentHighlight Debounce
+
+- Description: Debounce (in milliseconds) before triggering LSP DocumentHighlight when moving cursor.
+- Setting: `document_highlight_debounce`
+- Default: `75`
+
 ## Cursor Blink
 
 - Description: Whether or not the cursor blinks.


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/6843


I don't see where is the logic to remove old document highlight when new one applies,
ideally, old highlight should be cleared as soon as possible when cursor moves if the new position does not
sits in old highlight ranges to avoid linger highlights described in https://github.com/zed-industries/zed/issues/13682#issuecomment-2498368680.

So current solution is still not ideal, because only when lsp responses highlight ranges (even is a empty set) can we clear the old one.

Release Notes:

- Added a setting `lsp_highlight_debounce` to configure delay for querying highlights from language server.