### PR TITLE
Fix right click selection behavior in project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3496,6 +3496,9 @@ impl ProjectPanel {
                             // Stop propagation to prevent the catch-all context menu for the project
                             // panel from being deployed.
                             cx.stop_propagation();
+                            if !this.marked_entries.contains(&selection) {
+                                this.marked_entries.clear();
+                            }
                             this.deploy_context_menu(event.position, entry_id, cx);
                         },
                     ))


### PR DESCRIPTION
Closes #21605

Consider you have set of entries selected or even a single entry selected, and you right click some other entry which is **not** part of your selected set. This doesn't not clear existing entries selection (which it should clear, as how file manager right-click logic works, see more below). 

This issue might lead unexpected operation like deletion applied on those existing selected entries. This PR fixes it.

**Unintuitive Behavior for Right Click**: Doesn't not clear existing entries.

Current Zed:

https://github.com/user-attachments/assets/85838b18-7b9b-42bc-9385-8880992113fb

VSCode:

https://github.com/user-attachments/assets/ef348d9b-aa40-48aa-b720-432cfbd01875


**Expected Behavior for Right Click**: Clears existing entries.

This PR:

https://github.com/user-attachments/assets/a5b6f4d2-15cb-48d7-9a29-ab3a21885693

Thunar:

https://github.com/user-attachments/assets/095faef1-e398-4700-92ff-fa47841580ba

Gnome Files:

https://github.com/user-attachments/assets/88e8fe1f-dd0e-4118-901d-fa9830196d24


Release Notes:

- Fix right click selection behavior in project panel
