### PR TITLE
Add support for folding block/multiline comments

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -259,6 +259,7 @@ gpui::actions!(
         FoldFunctionBodies,
         FoldRecursive,
         FoldSelectedRanges,
+        FoldMultilineComments,
         ToggleFold,
         ToggleFoldRecursive,
         Format,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -353,6 +353,7 @@ impl EditorElement {
         register_action(view, cx, Editor::unfold_all);
         register_action(view, cx, Editor::unfold_at);
         register_action(view, cx, Editor::fold_selected_ranges);
+        register_action(view, cx, Editor::fold_multiline_comments);
         register_action(view, cx, Editor::show_completions);
         register_action(view, cx, Editor::toggle_code_actions);
         register_action(view, cx, Editor::open_excerpts);

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -4,6 +4,7 @@ path_suffixes = ["js", "jsx", "mjs", "cjs"]
 # [/ ] is so we match "env node" or "/node" but not "ts-node"
 first_line_pattern = '^#!.*\b(?:[/ ]node|deno run.*--ext[= ]js)\b'
 line_comments = ["// "]
+block_comment = ["/*", "*/"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -2,6 +2,7 @@ name = "TSX"
 grammar = "tsx"
 path_suffixes = ["tsx"]
 line_comments = ["// "]
+block_comment = ["/*", "*/"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -3,6 +3,7 @@ grammar = "typescript"
 path_suffixes = ["ts", "cts", "d.cts", "d.mts", "mts"]
 first_line_pattern = '^#!.*\b(?:deno run|ts-node|bun|tsx)\b'
 line_comments = ["// "]
+block_comment = ["/*", "*/"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
Closes #21349 #19957 

Release Notes:

- Added multiline comments folding
- Added JS language config for block comments (used for demonstration)


https://github.com/user-attachments/assets/8a2698af-6edc-4167-9d0b-db2c5dafc6f6

Let me know if more configs need to be added as well! Also please correct me for the wrong approaches I have taken (if any)