### PR TITLE
Bump x11rb version to v0.13.1

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -181,7 +181,7 @@ wayland-protocols-plasma = { version = "0.2.0", features = [
 
 # X11
 as-raw-xcb-connection = { version = "1", optional = true }
-x11rb = { version = "0.13.0", features = [
+x11rb = { version = "0.13.1", features = [
     "allow-unsafe-code",
     "xkb",
     "randr",
@@ -198,7 +198,7 @@ xim = { git = "https://github.com/XDeme1/xim-rs", rev = "d50d461764c2213655cd9cf
     "x11rb-xcb",
     "x11rb-client",
 ], optional = true }
-x11-clipboard = { version = "0.9.2", optional = true }
+x11-clipboard = { version = "0.9.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 blade-util.workspace = true


### PR DESCRIPTION
From diff looks like no material differences.  With a local checkout of `v0.13.0` I get build errors due to warning checking when I use a `path = ...` dependency, but it is fixed with `v0.13.1`.

I see mention of this in the [renovate configuration PR](https://github.com/zed-industries/zed/pull/15132) but doesn't seem like that initial batch of renovation happened.

Release Notes:

- N/A