### PR TITLE
Skip spawning task for `background_executor.timer(Duration::ZERO)`

### DIFF
--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -328,6 +328,9 @@ impl BackgroundExecutor {
     /// Depending on other concurrent tasks the elapsed duration may be longer
     /// than requested.
     pub fn timer(&self, duration: Duration) -> Task<()> {
+        if duration.is_zero() {
+            return Task::ready(());
+        }
         let (runnable, task) = async_task::spawn(async move {}, {
             let dispatcher = self.dispatcher.clone();
             move |runnable| dispatcher.dispatch_after(duration, runnable)


### PR DESCRIPTION
Release Notes:

- N/A