### PR TITLE
Improve diff syntax highlighting queries

### DIFF
--- a/crates/languages/src/diff/highlights.scm
+++ b/crates/languages/src/diff/highlights.scm
@@ -1,3 +1,5 @@
+(comment) @comment
+
 [
   (addition)
   (new_file)
@@ -12,4 +14,35 @@
 
 (location) @attribute
 
-(command) @function
+(command
+  "diff" @function
+  (argument) @variable.parameter)
+
+(filename) @string.special.path
+
+(mode) @number
+
+([
+  ".."
+  "+"
+  "++"
+  "+++"
+  "++++"
+  "-"
+  "--"
+  "---"
+  "----"
+] @punctuation.special)
+
+[
+  (binary_change)
+  (similarity)
+  (file_change)
+] @label
+
+(index
+  "index" @keyword)
+
+(similarity
+  (score) @number
+  "%" @number)


### PR DESCRIPTION
Brings over the improvements made for the same grammar: https://github.com/nvim-treesitter/nvim-treesitter/pull/6619.

Related to #19986 but not really- the problem brought up there is an issue of themes not supporting the `diff.plus` and `diff.minus` captures (already used before this PR).

<details><summary>Theme previews (before/after)</summary>

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-09 at 07 33 31](https://github.com/user-attachments/assets/698122df-fb63-4d7c-95aa-9559c7dcc684) | ![CleanShot 2024-12-09 at 07 31 08](https://github.com/user-attachments/assets/ef927c0d-6c77-4fd4-b513-8359fb2442f7) | 

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-09 at 07 34 15](https://github.com/user-attachments/assets/53b825ec-2987-4122-837d-1ebce334f153) | ![CleanShot 2024-12-09 at 07 31 36](https://github.com/user-attachments/assets/079f19fb-4cc4-4256-b390-868f33e775c5) |

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-09 at 07 34 27](https://github.com/user-attachments/assets/4e3a80da-edff-4a53-bbf8-abc17cd49c5e) | ![CleanShot 2024-12-09 at 07 31 53](https://github.com/user-attachments/assets/c6e12d79-5e59-4ebf-9fb9-ef3b0f8c9a81) |

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-09 at 07 33 44](https://github.com/user-attachments/assets/a007df22-7012-4de7-a71e-0ce5b523b561) | ![CleanShot 2024-12-09 at 07 32 13](https://github.com/user-attachments/assets/c8c63292-5a64-4560-ad7c-9235b8b98ca3) |

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-09 at 07 33 57](https://github.com/user-attachments/assets/1a9c3656-3805-45a6-97af-747ef50e3b6c) | ![CleanShot 2024-12-09 at 07 32 25](https://github.com/user-attachments/assets/76bac31c-8786-4907-8570-bf3c2888823e) |

</details>

Release Notes:

- Improved diff syntax highlighting
