### PR TITLE
collab: Fix compilation error by removing dependency on livekit_client

### DIFF
--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -77,12 +77,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "re
 util.workspace = true
 uuid.workspace = true
 
-[target.'cfg(target_os = "macos")'.dependencies]
-livekit_client_macos = { workspace = true, features = ["test-support"] }
-
-[target.'cfg(not(target_os = "macos"))'.dependencies]
-livekit_client = { workspace = true, features = ["test-support"] }
-
 [dev-dependencies]
 assistant = { workspace = true, features = ["test-support"] }
 assistant_tool.workspace = true


### PR DESCRIPTION
This fixes collab not being able to compile anymore for Linux:

https://github.com/zed-industries/zed/actions/runs/12236650046/job/34130962682

Release Notes:

- N/A
