### PR TITLE
call: Add `test-support` feature for `livekit_client_macos`

### DIFF
--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -18,6 +18,7 @@ test-support = [
     "collections/test-support",
     "gpui/test-support",
     "livekit_client/test-support",
+    "livekit_client_macos/test-support",
     "project/test-support",
     "util/test-support"
 ]


### PR DESCRIPTION
This PR updates the `call` crate to include the `test-support` feature for `livekit_client_macos` when `call` is used with `test-support`.

This fixes running `cargo test -p copilot` and `cargo test -p editor` (and perhaps some other crates).

Release Notes:

- N/A
