### PR TITLE
On windows, recreate renderer swap chain on restore from minimized

### DIFF
--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -431,13 +431,25 @@ impl BladeRenderer {
     }
 
     pub fn update_drawable_size(&mut self, size: Size<DevicePixels>) {
+        self.update_drawable_size_impl(size, false);
+    }
+
+    /// Like `update_drawable_size` but skips the check that the size has changed. This is useful in
+    /// cases like restoring a window from minimization where the size is the same but the
+    /// renderer's swap chain needs to be recreated.
+    #[cfg_attr(any(target_os = "macos", target_os = "linux"), allow(dead_code))]
+    pub fn update_drawable_size_even_if_unchanged(&mut self, size: Size<DevicePixels>) {
+        self.update_drawable_size_impl(size, true);
+    }
+
+    fn update_drawable_size_impl(&mut self, size: Size<DevicePixels>, always_resize: bool) {
         let gpu_size = gpu::Extent {
             width: size.width.0 as u32,
             height: size.height.0 as u32,
             depth: 1,
         };
 
-        if gpu_size != self.surface_config.size {
+        if always_resize || gpu_size != self.surface_config.size {
             self.wait_for_gpu();
             self.surface_config.size = gpu_size;
             self.gpu.resize(self.surface_config);

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -38,6 +38,7 @@ pub struct WindowsWindowState {
     pub fullscreen_restore_bounds: Bounds<Pixels>,
     pub border_offset: WindowBorderOffset,
     pub scale_factor: f32,
+    pub is_minimized: Option<bool>,
 
     pub callbacks: Callbacks,
     pub input_handler: Option<PlatformInputHandler>,
@@ -92,6 +93,7 @@ impl WindowsWindowState {
             size: logical_size,
         };
         let border_offset = WindowBorderOffset::default();
+        let is_minimized = None;
         let renderer = windows_renderer::windows_renderer(hwnd, transparent)?;
         let callbacks = Callbacks::default();
         let input_handler = None;
@@ -109,6 +111,7 @@ impl WindowsWindowState {
             fullscreen_restore_bounds,
             border_offset,
             scale_factor,
+            is_minimized,
             callbacks,
             input_handler,
             system_key_handled,


### PR DESCRIPTION
Closes #21688

Release Notes:

- Windows: Fix freeze after window minimize and maximize
