### PR TITLE
Workspace move editor actions

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -4,12 +4,32 @@
       "ctrl-shift-[": "pane::ActivatePrevItem",
       "ctrl-shift-]": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
-      "ctrl-pagedown": "pane::ActivateNextItem"
+      "ctrl-pagedown": "pane::ActivateNextItem",
+      "ctrl-1": ["workspace::ActivatePane", 0],
+      "ctrl-2": ["workspace::ActivatePane", 1],
+      "ctrl-3": ["workspace::ActivatePane", 2],
+      "ctrl-4": ["workspace::ActivatePane", 3],
+      "ctrl-5": ["workspace::ActivatePane", 4],
+      "ctrl-6": ["workspace::ActivatePane", 5],
+      "ctrl-7": ["workspace::ActivatePane", 6],
+      "ctrl-8": ["workspace::ActivatePane", 7],
+      "ctrl-9": ["workspace::ActivatePane", 8],
+      "ctrl-shift-1": ["workspace::MoveItemToPane", 0],
+      "ctrl-shift-2": ["workspace::MoveItemToPane", 1],
+      "ctrl-shift-3": ["workspace::MoveItemToPane", 2],
+      "ctrl-shift-4": ["workspace::MoveItemToPane", 3],
+      "ctrl-shift-5": ["workspace::MoveItemToPane", 4],
+      "ctrl-shift-6": ["workspace::MoveItemToPane", 5],
+      "ctrl-shift-7": ["workspace::MoveItemToPane", 6],
+      "ctrl-shift-8": ["workspace::MoveItemToPane", 7],
+      "ctrl-shift-9": ["workspace::MoveItemToPane", 8]
     }
   },
   {
     "context": "Editor",
     "bindings": {
+      "ctrl-alt-up": "editor::AddSelectionAbove",
+      "ctrl-alt-down": "editor::AddSelectionBelow",
       "ctrl-shift-up": "editor::MoveLineUp",
       "ctrl-shift-down": "editor::MoveLineDown",
       "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
@@ -17,6 +37,8 @@
       "ctrl-shift-a": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-d": "editor::DuplicateSelection",
       "alt-f3": "editor::SelectAllMatches", // find_all_under
+      "f9": "editor::SortLinesCaseSensitive",
+      "ctrl-f9": "editor::SortLinesCaseInsensitive",
       "f12": "editor::GoToDefinition",
       "ctrl-f12": "editor::GoToDefinitionSplit",
       "shift-f12": "editor::FindAllReferences",

--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -14,15 +14,15 @@
       "ctrl-7": ["workspace::ActivatePane", 6],
       "ctrl-8": ["workspace::ActivatePane", 7],
       "ctrl-9": ["workspace::ActivatePane", 8],
-      "ctrl-shift-1": ["workspace::MoveItemToPane", 0],
-      "ctrl-shift-2": ["workspace::MoveItemToPane", 1],
-      "ctrl-shift-3": ["workspace::MoveItemToPane", 2],
-      "ctrl-shift-4": ["workspace::MoveItemToPane", 3],
-      "ctrl-shift-5": ["workspace::MoveItemToPane", 4],
-      "ctrl-shift-6": ["workspace::MoveItemToPane", 5],
-      "ctrl-shift-7": ["workspace::MoveItemToPane", 6],
-      "ctrl-shift-8": ["workspace::MoveItemToPane", 7],
-      "ctrl-shift-9": ["workspace::MoveItemToPane", 8]
+      "ctrl-shift-1": ["workspace::MoveItemToPane", { "destination": 0 }],
+      "ctrl-shift-2": ["workspace::MoveItemToPane", { "destination": 1 }],
+      "ctrl-shift-3": ["workspace::MoveItemToPane", { "destination": 2 }],
+      "ctrl-shift-4": ["workspace::MoveItemToPane", { "destination": 3 }],
+      "ctrl-shift-5": ["workspace::MoveItemToPane", { "destination": 4 }],
+      "ctrl-shift-6": ["workspace::MoveItemToPane", { "destination": 5 }],
+      "ctrl-shift-7": ["workspace::MoveItemToPane", { "destination": 6 }],
+      "ctrl-shift-8": ["workspace::MoveItemToPane", { "destination": 7 }],
+      "ctrl-shift-9": ["workspace::MoveItemToPane", { "destination": 8 }]
     }
   },
   {

--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -14,7 +14,7 @@
       "ctrl-7": ["workspace::ActivatePane", 6],
       "ctrl-8": ["workspace::ActivatePane", 7],
       "ctrl-9": ["workspace::ActivatePane", 8],
-      "ctrl-shift-1": ["workspace::MoveItemToPane", { "destination": 0 }],
+      "ctrl-shift-1": ["workspace::MoveItemToPane", { "destination": 0, "focus": true }],
       "ctrl-shift-2": ["workspace::MoveItemToPane", { "destination": 1 }],
       "ctrl-shift-3": ["workspace::MoveItemToPane", { "destination": 2 }],
       "ctrl-shift-4": ["workspace::MoveItemToPane", { "destination": 3 }],

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -4,7 +4,25 @@
       "cmd-shift-[": "pane::ActivatePrevItem",
       "cmd-shift-]": "pane::ActivateNextItem",
       "ctrl-pageup": "pane::ActivatePrevItem",
-      "ctrl-pagedown": "pane::ActivateNextItem"
+      "ctrl-pagedown": "pane::ActivateNextItem",
+      "ctrl-1": ["workspace::ActivatePane", 0],
+      "ctrl-2": ["workspace::ActivatePane", 1],
+      "ctrl-3": ["workspace::ActivatePane", 2],
+      "ctrl-4": ["workspace::ActivatePane", 3],
+      "ctrl-5": ["workspace::ActivatePane", 4],
+      "ctrl-6": ["workspace::ActivatePane", 5],
+      "ctrl-7": ["workspace::ActivatePane", 6],
+      "ctrl-8": ["workspace::ActivatePane", 7],
+      "ctrl-9": ["workspace::ActivatePane", 8],
+      "ctrl-shift-1": ["workspace::MoveItemToPane", 0],
+      "ctrl-shift-2": ["workspace::MoveItemToPane", 1],
+      "ctrl-shift-3": ["workspace::MoveItemToPane", 2],
+      "ctrl-shift-4": ["workspace::MoveItemToPane", 3],
+      "ctrl-shift-5": ["workspace::MoveItemToPane", 4],
+      "ctrl-shift-6": ["workspace::MoveItemToPane", 5],
+      "ctrl-shift-7": ["workspace::MoveItemToPane", 6],
+      "ctrl-shift-8": ["workspace::MoveItemToPane", 7],
+      "ctrl-shift-9": ["workspace::MoveItemToPane", 8]
     }
   },
   {
@@ -20,6 +38,8 @@
       "cmd-shift-a": "editor::SelectLargerSyntaxNode",
       "cmd-shift-d": "editor::DuplicateSelection",
       "ctrl-cmd-g": "editor::SelectAllMatches", // find_all_under
+      "f5": "editor::SortLinesCaseSensitive",
+      "ctrl-f5": "editor::SortLinesCaseInsensitive",
       "shift-f12": "editor::FindAllReferences",
       "alt-cmd-down": "editor::GoToDefinition",
       "ctrl-alt-cmd-down": "editor::GoToDefinitionSplit",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -14,15 +14,15 @@
       "ctrl-7": ["workspace::ActivatePane", 6],
       "ctrl-8": ["workspace::ActivatePane", 7],
       "ctrl-9": ["workspace::ActivatePane", 8],
-      "ctrl-shift-1": ["workspace::MoveItemToPane", 0],
-      "ctrl-shift-2": ["workspace::MoveItemToPane", 1],
-      "ctrl-shift-3": ["workspace::MoveItemToPane", 2],
-      "ctrl-shift-4": ["workspace::MoveItemToPane", 3],
-      "ctrl-shift-5": ["workspace::MoveItemToPane", 4],
-      "ctrl-shift-6": ["workspace::MoveItemToPane", 5],
-      "ctrl-shift-7": ["workspace::MoveItemToPane", 6],
-      "ctrl-shift-8": ["workspace::MoveItemToPane", 7],
-      "ctrl-shift-9": ["workspace::MoveItemToPane", 8]
+      "ctrl-shift-1": ["workspace::MoveItemToPane", { "destination": 0 }],
+      "ctrl-shift-2": ["workspace::MoveItemToPane", { "destination": 1 }],
+      "ctrl-shift-3": ["workspace::MoveItemToPane", { "destination": 2 }],
+      "ctrl-shift-4": ["workspace::MoveItemToPane", { "destination": 3 }],
+      "ctrl-shift-5": ["workspace::MoveItemToPane", { "destination": 4 }],
+      "ctrl-shift-6": ["workspace::MoveItemToPane", { "destination": 5 }],
+      "ctrl-shift-7": ["workspace::MoveItemToPane", { "destination": 6 }],
+      "ctrl-shift-8": ["workspace::MoveItemToPane", { "destination": 7 }],
+      "ctrl-shift-9": ["workspace::MoveItemToPane", { "destination": 8 }]
     }
   },
   {

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -14,7 +14,7 @@
       "ctrl-7": ["workspace::ActivatePane", 6],
       "ctrl-8": ["workspace::ActivatePane", 7],
       "ctrl-9": ["workspace::ActivatePane", 8],
-      "ctrl-shift-1": ["workspace::MoveItemToPane", { "destination": 0 }],
+      "ctrl-shift-1": ["workspace::MoveItemToPane", { "destination": 0, "focus": true }],
       "ctrl-shift-2": ["workspace::MoveItemToPane", { "destination": 1 }],
       "ctrl-shift-3": ["workspace::MoveItemToPane", { "destination": 2 }],
       "ctrl-shift-4": ["workspace::MoveItemToPane", { "destination": 3 }],

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1236,21 +1236,34 @@ impl Render for TerminalPanel {
                 )
                 .on_action(cx.listener(|terminal_panel, action: &MoveItemToPane, cx| {
                     let panes = terminal_panel.center.panes();
-                    let Some(target_pane) = panes.get(action.0).map(|p| (*p).clone()) else {
+                    let Some(target_pane) = panes.get(action.destination).map(|p| (*p).clone())
+                    else {
                         return;
                     };
                     let source_pane = terminal_panel.active_pane.clone();
-                    move_active_item(&source_pane, &target_pane, true, true, cx);
+                    move_active_item(
+                        &source_pane,
+                        &target_pane,
+                        action.focus_destination,
+                        true,
+                        cx,
+                    );
                 }))
                 .on_action(cx.listener(
                     |terminal_panel, action: &MoveItemToPaneInDirection, cx| {
                         let source_pane = terminal_panel.active_pane.clone();
                         if let Some(destination_pane) = terminal_panel
                             .center
-                            .find_pane_in_direction(&source_pane, action.0, cx)
+                            .find_pane_in_direction(&source_pane, action.direction, cx)
                             .cloned()
                         {
-                            move_active_item(&source_pane, &destination_pane, true, true, cx);
+                            move_active_item(
+                                &source_pane,
+                                &destination_pane,
+                                action.focus_destination,
+                                true,
+                                cx,
+                            );
                         };
                     },
                 ))

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1236,18 +1236,11 @@ impl Render for TerminalPanel {
                 )
                 .on_action(cx.listener(|terminal_panel, action: &MoveItemToPane, cx| {
                     let panes = terminal_panel.center.panes();
-                    let Some(target_pane) = panes.get(action.destination).map(|p| (*p).clone())
-                    else {
+                    let Some(&target_pane) = panes.get(action.destination) else {
                         return;
                     };
                     let source_pane = terminal_panel.active_pane.clone();
-                    move_active_item(
-                        &source_pane,
-                        &target_pane,
-                        action.focus_destination,
-                        true,
-                        cx,
-                    );
+                    move_active_item(&source_pane, target_pane, action.focus, true, cx);
                 }))
                 .on_action(cx.listener(
                     |terminal_panel, action: &MoveItemToPaneInDirection, cx| {
@@ -1260,7 +1253,7 @@ impl Render for TerminalPanel {
                             move_active_item(
                                 &source_pane,
                                 &destination_pane,
-                                action.focus_destination,
+                                action.focus,
                                 true,
                                 cx,
                             );

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -177,14 +177,14 @@ pub struct SwapPaneInDirection(pub SplitDirection);
 pub struct MoveItemToPane {
     pub destination: usize,
     #[serde(default = "default_true")]
-    pub focus_destination: bool,
+    pub focus: bool,
 }
 
 #[derive(Clone, Deserialize, PartialEq)]
 pub struct MoveItemToPaneInDirection {
     pub direction: SplitDirection,
     #[serde(default = "default_true")]
-    pub focus_destination: bool,
+    pub focus: bool,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize)]
@@ -2851,13 +2851,7 @@ impl Workspace {
         let Some(target_pane) = panes.get(action.destination).map(|p| (*p).clone()) else {
             return;
         };
-        move_active_item(
-            &source_pane,
-            &target_pane,
-            action.focus_destination,
-            true,
-            cx,
-        );
+        move_active_item(&source_pane, &target_pane, action.focus, true, cx);
     }
 
     pub fn activate_next_pane(&mut self, cx: &mut WindowContext) {
@@ -2985,7 +2979,7 @@ impl Workspace {
     ) {
         if let Some(destination) = self.find_pane_in_direction(action.direction, cx) {
             let source = self.active_pane.clone();
-            move_active_item(&source, &destination, action.focus_destination, true, cx);
+            move_active_item(&source, &destination, action.focus, true, cx);
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2846,12 +2846,10 @@ impl Workspace {
     }
 
     fn move_item_to_pane_at_index(&mut self, action: &MoveItemToPane, cx: &mut ViewContext<Self>) {
-        let panes = self.center.panes();
-        let source_pane = self.active_pane.clone();
-        let Some(target_pane) = panes.get(action.destination).map(|p| (*p).clone()) else {
+        let Some(&target_pane) = self.center.panes().get(action.destination) else {
             return;
         };
-        move_active_item(&source_pane, &target_pane, action.focus, true, cx);
+        move_active_item(&self.active_pane, target_pane, action.focus, true, cx);
     }
 
     pub fn activate_next_pane(&mut self, cx: &mut WindowContext) {
@@ -2978,8 +2976,7 @@ impl Workspace {
         cx: &mut WindowContext,
     ) {
         if let Some(destination) = self.find_pane_in_direction(action.direction, cx) {
-            let source = self.active_pane.clone();
-            move_active_item(&source, &destination, action.focus, true, cx);
+            move_active_item(&self.active_pane, &destination, action.focus, true, cx);
         }
     }
 
@@ -3003,14 +3000,14 @@ impl Workspace {
         cx: &mut ViewContext<Self>,
     ) {
         if let Some(to) = self.find_pane_in_direction(direction, cx) {
-            self.center.swap(&self.active_pane.clone(), &to);
+            self.center.swap(&self.active_pane, &to);
             cx.notify();
         }
     }
 
     pub fn resize_pane(&mut self, axis: gpui::Axis, amount: Pixels, cx: &mut ViewContext<Self>) {
         self.center
-            .resize(&self.active_pane.clone(), axis, amount, &self.bounds);
+            .resize(&self.active_pane, axis, amount, &self.bounds);
         cx.notify();
     }
 


### PR DESCRIPTION
Closes #20205

Release Notes:

- Added `MoveItemToPane` and `MoveItemToPaneInDirection` actions
