### PR TITLE
extension_host: Fix uploading dev extensions to the remote server

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1398,27 +1398,31 @@ impl ExtensionStore {
         };
         let fs = self.fs.clone();
         cx.background_executor().spawn(async move {
+            const EXTENSION_TOML: &str = "extension.toml";
+            const EXTENSION_WASM: &str = "extension.wasm";
+            const CONFIG_TOML: &str = "config.toml";
+
             if is_dev {
                 let manifest_toml = toml::to_string(&loaded_extension.manifest)?;
                 fs.save(
-                    &tmp_dir.join("extension.toml"),
+                    &tmp_dir.join(EXTENSION_TOML),
                     &Rope::from(manifest_toml),
                     language::LineEnding::Unix,
                 )
                 .await?;
             } else {
                 fs.copy_file(
-                    &src_dir.join("extension.toml"),
-                    &tmp_dir.join("extension.toml"),
+                    &src_dir.join(EXTENSION_TOML),
+                    &tmp_dir.join(EXTENSION_TOML),
                     fs::CopyOptions::default(),
                 )
                 .await?
             }
 
-            if fs.is_file(&src_dir.join("extension.wasm")).await {
+            if fs.is_file(&src_dir.join(EXTENSION_WASM)).await {
                 fs.copy_file(
-                    &src_dir.join("extension.wasm"),
-                    &tmp_dir.join("extension.wasm"),
+                    &src_dir.join(EXTENSION_WASM),
+                    &tmp_dir.join(EXTENSION_WASM),
                     fs::CopyOptions::default(),
                 )
                 .await?
@@ -1426,13 +1430,13 @@ impl ExtensionStore {
 
             for language_path in loaded_extension.manifest.languages.iter() {
                 if fs
-                    .is_file(&src_dir.join(language_path).join("config.toml"))
+                    .is_file(&src_dir.join(language_path).join(CONFIG_TOML))
                     .await
                 {
                     fs.create_dir(&tmp_dir.join(language_path)).await?;
                     fs.copy_file(
-                        &src_dir.join(language_path).join("config.toml"),
-                        &tmp_dir.join(language_path).join("config.toml"),
+                        &src_dir.join(language_path).join(CONFIG_TOML),
+                        &tmp_dir.join(language_path).join(CONFIG_TOML),
                         fs::CopyOptions::default(),
                     )
                     .await?


### PR DESCRIPTION
This PR fixes an issue where dev extensions were not working when uploaded to the remote server.

The `extension.toml` for dev extensions may not contain all of the information (such as the list of languages), as this is something that we derive from the filesystem at packaging time. This meant that uploading a dev extension that contained languages could have them absent from the uploaded `extension.toml`.

For dev extensions we now upload a serialized version of the in-memory extension manifest, which should have all of the information present.

Release Notes:

- SSH Remoting: Fixed an issue where some dev extensions would not work after being uploaded to the remote server.
