### PR TITLE
Revert "Avoid endless loop of the diagnostic updates (#21209)"

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2950,21 +2950,6 @@ impl LspStore {
             })
     }
 
-    pub fn diagnostics_for_buffer(
-        &self,
-        path: &ProjectPath,
-    ) -> Option<
-        &[(
-            LanguageServerId,
-            Vec<DiagnosticEntry<Unclipped<PointUtf16>>>,
-        )],
-    > {
-        self.diagnostics
-            .get(&path.worktree_id)?
-            .get(&path.path)
-            .map(|diagnostics| diagnostics.as_slice())
-    }
-
     pub fn started_language_servers(&self) -> Vec<(WorktreeId, LanguageServerName)> {
         self.language_server_ids.keys().cloned().collect()
     }


### PR DESCRIPTION
This reverts commit 9999c31859210654dd572d54dfa42b67c00b33b0.

Release Notes:

- Fixes diagnostics not updating in some circumstances
