### PR TITLE
Fix git colors in image tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6171,6 +6171,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "db",
+ "editor",
  "file_icons",
  "gpui",
  "project",

--- a/crates/image_viewer/Cargo.toml
+++ b/crates/image_viewer/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 db.workspace = true
+editor.workspace = true
 file_icons.workspace = true
 gpui.workspace = true
 project.workspace = true

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -95,8 +95,8 @@ impl Item for ImageView {
     }
 
     fn tab_content(&self, params: TabContentParams, cx: &WindowContext) -> AnyElement {
+        let project_path = self.image_item.read(cx).project_path(cx);
         let label_color = if ItemSettings::get_global(cx).git_status {
-            let project_path = self.image_item.read(cx).project_path(cx);
             self.project
                 .read(cx)
                 .entry_for_path(&project_path, cx)
@@ -108,10 +108,10 @@ impl Item for ImageView {
             params.text_color()
         };
 
-        let path = self.image_item.read(cx).file.path();
-        let title = path
+        let title = project_path
+            .path
             .file_name()
-            .unwrap_or_else(|| path.as_os_str())
+            .unwrap_or_else(|| project_path.path.as_os_str())
             .to_string_lossy()
             .to_string();
         Label::new(title)

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Context as _;
+use editor::items::entry_git_aware_label_color;
 use gpui::{
     canvas, div, fill, img, opaque_grey, point, size, AnyElement, AppContext, Bounds, EventEmitter,
     FocusHandle, FocusableView, InteractiveElement, IntoElement, Model, ObjectFit, ParentElement,
@@ -94,6 +95,19 @@ impl Item for ImageView {
     }
 
     fn tab_content(&self, params: TabContentParams, cx: &WindowContext) -> AnyElement {
+        let label_color = if ItemSettings::get_global(cx).git_status {
+            let project_path = self.image_item.read(cx).project_path(cx);
+            self.project
+                .read(cx)
+                .entry_for_path(&project_path, cx)
+                .map(|entry| {
+                    entry_git_aware_label_color(entry.git_status, entry.is_ignored, params.selected)
+                })
+                .unwrap_or_else(|| params.text_color())
+        } else {
+            params.text_color()
+        };
+
         let path = self.image_item.read(cx).file.path();
         let title = path
             .file_name()
@@ -102,7 +116,7 @@ impl Item for ImageView {
             .to_string();
         Label::new(title)
             .single_line()
-            .color(params.text_color())
+            .color(label_color)
             .italic(params.preview)
             .into_any_element()
     }


### PR DESCRIPTION
Closes #21772

Release Notes:

- N/A

<img width="196" alt="tabs_fix" src="https://github.com/user-attachments/assets/0024d686-4f5b-4a4f-ac7a-8bc509cf161e">

Note that the git coloring of the icons got removed in https://github.com/zed-industries/zed/pull/21383
