### PR TITLE
Add table for files with manual selections

### DIFF
--- a/crates/editor/src/persistence.rs
+++ b/crates/editor/src/persistence.rs
@@ -134,6 +134,12 @@ define_connection!(
             ALTER TABLE editors ADD COLUMN mtime_seconds INTEGER DEFAULT NULL;
             ALTER TABLE editors ADD COLUMN mtime_nanos INTEGER DEFAULT NULL;
         ),
+        sql! (
+            CREATE TABLE manual_language_selections(
+                path BLOB NOT NULL PRIMARY KEY,
+                language TEXT NOT NULL
+            ) STRICT;
+        ),
         ];
 );
 
@@ -212,6 +218,27 @@ impl EditorDb {
             statement.exec()
         })
         .await
+    }
+
+    query! {
+        pub fn get_manual_language_selection(path: &Path) -> Result<Option<String>> {
+            SELECT language FROM manual_language_selections
+            WHERE path = ?
+        }
+    }
+
+    query! {
+        pub fn set_manual_language_selection(path: &Path, language: &str) -> Result<()> {
+            INSERT OR REPLACE INTO manual_language_selections (path, language)
+            VALUES (?, ?)
+        }
+    }
+
+    query! {
+        pub fn remove_manual_language_selection(path: &Path) -> Result<()> {
+            DELETE FROM manual_language_selections
+            WHERE path = ?
+        }
     }
 }
 

--- a/crates/editor/src/persistence.rs
+++ b/crates/editor/src/persistence.rs
@@ -221,21 +221,21 @@ impl EditorDb {
     }
 
     query! {
-        pub fn get_manual_language_selection(path: &Path) -> Result<Option<String>> {
+        pub fn get_manual_language_selection(path: &str) -> Result<Option<String>> {
             SELECT language FROM manual_language_selections
             WHERE path = ?
         }
     }
 
     query! {
-        pub fn set_manual_language_selection(path: &Path, language: &str) -> Result<()> {
+        pub fn set_manual_language_selection(path: &str, language: &str) -> Result<()> {
             INSERT OR REPLACE INTO manual_language_selections (path, language)
             VALUES (?, ?)
         }
     }
 
     query! {
-        pub fn remove_manual_language_selection(path: &Path) -> Result<()> {
+        pub fn remove_manual_language_selection(path: &str) -> Result<()> {
             DELETE FROM manual_language_selections
             WHERE path = ?
         }


### PR DESCRIPTION
Closes #19982

Release Notes:

Added table in EditorsDb for files with manually selected languages.

TODO:
fix dependencies for db to access language in detect_language_for_buffer and update language on LanguageChanged event.
