### PR TITLE
Add option to activate left neighbour tab on tab close

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -561,9 +561,11 @@
     // What to do after closing the current tab.
     //
     // 1. Activate the tab that was open previously (default)
-    //     "History"
-    // 2. Activate the neighbour tab (prefers the right one, if present)
-    //     "Neighbour"
+    //     "history"
+    // 2. Activate the right neighbour tab if present
+    //     "neighbour"
+    // 3. Activate the left neighbour tab if present
+    //     "left_neighbour"
     "activate_on_close": "history",
     /// Which files containing diagnostic errors/warnings to mark in the tabs.
     /// Diagnostics are only shown when file icons are also active.

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -71,11 +71,12 @@ pub enum ShowDiagnostics {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum ActivateOnClose {
     #[default]
     History,
     Neighbour,
+    LeftNeighbour,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1506,6 +1506,7 @@ impl Pane {
             self.pinned_tab_count -= 1;
         }
         if item_index == self.active_item_index {
+            let left_neighbour_index = || item_index.min(self.items.len()).saturating_sub(1);
             let index_to_activate = match activate_on_close {
                 ActivateOnClose::History => self
                     .activation_history
@@ -1517,7 +1518,7 @@ impl Pane {
                     })
                     // We didn't have a valid activation history entry, so fallback
                     // to activating the item to the left
-                    .unwrap_or_else(|| item_index.min(self.items.len()).saturating_sub(1)),
+                    .unwrap_or_else(left_neighbour_index),
                 ActivateOnClose::Neighbour => {
                     self.activation_history.pop();
                     if item_index + 1 < self.items.len() {
@@ -1525,6 +1526,10 @@ impl Pane {
                     } else {
                         item_index.saturating_sub(1)
                     }
+                }
+                ActivateOnClose::LeftNeighbour => {
+                    self.activation_history.pop();
+                    left_neighbour_index()
                 }
             };
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -691,11 +691,19 @@ List of `string` values
 }
 ```
 
-2. Activate the neighbour tab (prefers the right one, if present):
+2. Activate the right neighbour tab if present:
 
 ```json
 {
   "activate_on_close": "neighbour"
+}
+```
+
+3. Activate the left neighbour tab if present:
+
+```json
+{
+  "activate_on_close": "left_neighbour"
 }
 ```
 


### PR DESCRIPTION
Closes #21738

Release Notes:

- Added `left_neighbour` option to the `tabs.activate_on_close` setting to activate the left adjacent tab on tab close.