### PR TITLE
gpui: Add cursor style methods of nesw nwse resize

### DIFF
--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -271,6 +271,20 @@ pub fn cursor_style_methods(input: TokenStream) -> TokenStream {
             self
         }
 
+        /// Sets cursor style when hovering over an element to `nesw-resize`.
+        /// [Docs](https://tailwindcss.com/docs/cursor)
+        #visibility fn cursor_nesw_resize(mut self) -> Self {
+            self.style().mouse_cursor = Some(gpui::CursorStyle::ResizeUpRightDownLeft);
+            self
+        }
+
+        /// Sets cursor style when hovering over an element to `nwse-resize`.
+        /// [Docs](https://tailwindcss.com/docs/cursor)
+        #visibility fn cursor_nwse_resize(mut self) -> Self {
+            self.style().mouse_cursor = Some(gpui::CursorStyle::ResizeUpLeftDownRight);
+            self
+        }
+
         /// Sets cursor style when hovering over an element to `col-resize`.
         /// [Docs](https://tailwindcss.com/docs/cursor)
         #visibility fn cursor_col_resize(mut self) -> Self {


### PR DESCRIPTION
Release Notes:

- N/A

---

This change adds two new methods to the cursor_style_methods function in the gpui_macros crate (according to the Tailwind CSS documentation https://tailwindcss.com/docs/cursor):
1. `cursor_nesw_resize`: Sets the cursor style to nesw-resize when hovering over an element. This is useful for indicating resizing diagonally from top-right to bottom-left.
2. `cursor_nwse_resize`: Sets the cursor style to nwse-resize when hovering over an element. This is used for resizing diagonally from top-left to bottom-right.