### PR TITLE
image viewer: Allow dropping images on pane

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -94,12 +94,8 @@ impl Item for ImageView {
     }
 
     fn tab_content(&self, params: TabContentParams, cx: &WindowContext) -> AnyElement {
-        let path = self.image_item.read(cx).file.path();
-        let title = path
-            .file_name()
-            .unwrap_or_else(|| path.as_os_str())
-            .to_string_lossy()
-            .to_string();
+        let path = self.image_item.read(cx).file.file_name(cx);
+        let title = path.to_string_lossy().to_string();
         Label::new(title)
             .single_line()
             .color(params.text_color())
@@ -146,7 +142,7 @@ impl Item for ImageView {
 }
 
 fn breadcrumbs_text_for_image(project: &Project, image: &ImageItem, cx: &AppContext) -> String {
-    let path = image.path();
+    let path = image.file.file_name(cx);
     if project.visible_worktrees(cx).count() <= 1 {
         return path.to_string_lossy().to_string();
     }

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -123,13 +123,19 @@ impl ProjectItem for ImageItem {
         let path = path.clone();
         let project = project.clone();
 
-        let ext = path
-            .path
+        let worktree_abs_path = project
+            .read(cx)
+            .worktree_for_id(path.worktree_id, cx)?
+            .read(cx)
+            .abs_path();
+
+        // Resolve the file extension from either the worktree path (if it's a single file)
+        // or from the project path's subpath.
+        let ext = worktree_abs_path
             .extension()
+            .or_else(|| path.path.extension())
             .and_then(OsStr::to_str)
-            .map(str::to_lowercase)
             .unwrap_or_default();
-        let ext = ext.as_str();
 
         // Only open the item if it's a binary image (no SVGs, etc.)
         // Since we do not have a way to toggle to an editor

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -135,7 +135,9 @@ impl ProjectItem for ImageItem {
             .extension()
             .or_else(|| path.path.extension())
             .and_then(OsStr::to_str)
-            .unwrap_or_default();
+            .map(str::to_lowercase)
+            .unwrap_or_default()
+            .as_str();
 
         // Only open the item if it's a binary image (no SVGs, etc.)
         // Since we do not have a way to toggle to an editor

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -136,8 +136,8 @@ impl ProjectItem for ImageItem {
             .or_else(|| path.path.extension())
             .and_then(OsStr::to_str)
             .map(str::to_lowercase)
-            .unwrap_or_default()
-            .as_str();
+            .unwrap_or_default();
+        let ext = ext.as_str();
 
         // Only open the item if it's a binary image (no SVGs, etc.)
         // Since we do not have a way to toggle to an editor


### PR DESCRIPTION
Partially addresses #21484

https://github.com/user-attachments/assets/777da5de-15c3-4af3-a597-1835c0155326

Release Notes:

- Support opening images by dropping them onto a pane
- Support opening images from the command line
