### PR TITLE
assistant2: Change chat keybinding to just `Enter`

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -229,7 +229,7 @@
     "context": "MessageEditor > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-enter": "assistant2::Chat"
+      "enter": "assistant2::Chat"
     }
   },
   {


### PR DESCRIPTION
This PR changes the Assistant2 chat keybinding from `Cmd-Enter` to just `Enter`.

Release Notes:

- N/A
