### PR TITLE
Add `musl`  package for Arch Linux

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -167,6 +167,7 @@ if [[ -n $pacman ]]; then
   deps=(
     gcc
     clang
+    musl
     cmake
     alsa-lib
     fontconfig

--- a/script/linux
+++ b/script/linux
@@ -167,7 +167,6 @@ if [[ -n $pacman ]]; then
   deps=(
     gcc
     clang
-    musl
     cmake
     alsa-lib
     fontconfig
@@ -183,6 +182,8 @@ if [[ -n $pacman ]]; then
     jq
     git
   )
+  $maysudo "$pacman" -Sy
+  $maysudo "$pacman" -Q glibc || $maysudo "$pacman" -Q musl || { echo "Please install 'glibc' or 'musl' and try again."; exit 1; }
   $maysudo "$pacman" -Syu --needed --noconfirm "${deps[@]}"
   finalize
   exit 0

--- a/script/linux
+++ b/script/linux
@@ -167,6 +167,7 @@ if [[ -n $pacman ]]; then
   deps=(
     gcc
     clang
+    musl
     cmake
     alsa-lib
     fontconfig
@@ -182,8 +183,6 @@ if [[ -n $pacman ]]; then
     jq
     git
   )
-  $maysudo "$pacman" -Sy
-  $maysudo "$pacman" -Q glibc || $maysudo "$pacman" -Q musl || { echo "Please install 'glibc' or 'musl' and try again."; exit 1; }
   $maysudo "$pacman" -Syu --needed --noconfirm "${deps[@]}"
   finalize
   exit 0

--- a/script/linux
+++ b/script/linux
@@ -183,7 +183,7 @@ if [[ -n $pacman ]]; then
     git
   )
   $maysudo "$pacman" -Sy
-  $maysudo "$pacman" -Q glibc || $maysudo "$pacman" -Q musl || { echo "Please install 'glibc' or 'musl' and try again."; exit 1; }
+  "$pacman" -Q glibc || "$pacman" -Q musl || { echo "Please install 'glibc' or 'musl' and try again."; exit 1; }
   $maysudo "$pacman" -Syu --needed --noconfirm "${deps[@]}"
   finalize
   exit 0

--- a/script/linux
+++ b/script/linux
@@ -183,7 +183,7 @@ if [[ -n $pacman ]]; then
     git
   )
   $maysudo "$pacman" -Sy
-  "$pacman" -Q glibc || "$pacman" -Q musl || { echo "Please install 'glibc' or 'musl' and try again."; exit 1; }
+  $maysudo "$pacman" -Q glibc || $maysudo "$pacman" -Q musl || { echo "Please install 'glibc' or 'musl' and try again."; exit 1; }
   $maysudo "$pacman" -Syu --needed --noconfirm "${deps[@]}"
   finalize
   exit 0


### PR DESCRIPTION
It seems like `musl` is required to build on Arch Linux, but it is not included in the dependencies list. I think adding it here will fix this?

<details>

```
+ [[ x86_64-unknown-linux-musl == \x\8\6\_\6\4\-\u\n\k\n\o\w\n\-\l\i\n\u\x\-\m\u\s\l ]]
+ export 'RUSTFLAGS= -C link-args=-Wl,--disable-new-dtags,-rpath,$ORIGIN/../lib -C target-feature=+crt-static'
+ RUSTFLAGS=' -C link-args=-Wl,--disable-new-dtags,-rpath,$ORIGIN/../lib -C target-feature=+crt-static'
+ cargo build --release --target x86_64-unknown-linux-musl --package remote_server

<-- snip -->

The following warnings were emitted during compilation:

warning: ring@0.17.8: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `musl-gcc` installed?
warning: ring@0.17.8: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `musl-gcc` installed?

error: failed to run custom build command for `ring v0.17.8`

Caused by:
  process didn't exit successfully: `???/zed/target/release/build/ring-e6a4c8b1838d35d7/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=RING_PREGENERATE_ASM
  cargo:rustc-env=RING_CORE_PREFIX=ring_core_0_17_8_
  OPT_LEVEL = Some(3)
  OUT_DIR = Some(???/zed/target/x86_64-unknown-linux-musl/release/build/ring-98c5093b40c533c3/out)
  TARGET = Some(x86_64-unknown-linux-musl)
  HOST = Some(x86_64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-musl
  CC_x86_64-unknown-linux-musl = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_musl
  CC_x86_64_unknown_linux_musl = None
  cargo:rerun-if-env-changed=TARGET_CC
  TARGET_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CROSS_COMPILE
  CROSS_COMPILE = None
  RUSTC_LINKER = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:warning=Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `musl-gcc` installed?
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  CARGO_CFG_TARGET_FEATURE = Some(crt-static,fxsr,sse,sse2)
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-musl
  CFLAGS_x86_64-unknown-linux-musl = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_musl
  CFLAGS_x86_64_unknown_linux_musl = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:warning=Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `musl-gcc` installed?

  --- stderr


  error occurred: Failed to find tool. Is `musl-gcc` installed?


warning: build failed, waiting for other jobs to finish...
```

</details>

Release Notes:

- Fixed missing `musl` dependency required to build from source on ArchLinux