### PR TITLE
Improve Zeta rating ergonomics

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -66,6 +66,7 @@
       "cmd-v": "editor::Paste",
       "cmd-z": "editor::Undo",
       "cmd-shift-z": "editor::Redo",
+      "ctrl-shift-z": "zeta::RateCompletions",
       "up": "editor::MoveUp",
       "ctrl-up": "editor::MoveToStartOfParagraph",
       "pageup": "editor::MovePageUp",
@@ -787,6 +788,43 @@
       "ctrl-k down": "pane::SplitDown",
       "ctrl-k left": "pane::SplitLeft",
       "ctrl-k right": "pane::SplitRight"
+    }
+  },
+  {
+    "context": "RateCompletionModal",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-enter": "zeta::ThumbsUp",
+      "cmd-delete": "zeta::ThumbsDown",
+      "shift-down": "zeta::NextEdit",
+      "shift-up": "zeta::PreviousEdit",
+      "space": "zeta::PreviewCompletion",
+
+      // These bindings are copied from menu:: to make them mutually exclusive with the editor focus
+      "up": "zeta::SelectPrev",
+      "shift-tab": "zeta::SelectPrev",
+      "home": "zeta::SelectFirst",
+      "pageup": "zeta::SelectFirst",
+      "shift-pageup": "zeta::SelectFirst",
+      "ctrl-p": "zeta::SelectPrev",
+      "down": "zeta::SelectNext",
+      "tab": "zeta::SelectNext",
+      "end": "zeta::SelectLast",
+      "pagedown": "zeta::SelectLast",
+      "shift-pagedown": "zeta::SelectFirst",
+      "ctrl-n": "zeta::SelectNext",
+      "cmd-up": "zeta::SelectFirst",
+      "cmd-down": "zeta::SelectLast",
+      "enter": "zeta::Confirm"
+    }
+  },
+  {
+    "context": "RateCompletionModal > Editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "escape": "zeta::FocusCompletions",
+      "cmd-shift-enter": "zeta::ThumbsUpActiveCompletion",
+      "cmd-shift-backspace": "zeta::ThumbsDownActiveCompletion"
     }
   }
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -798,24 +798,7 @@
       "cmd-delete": "zeta::ThumbsDown",
       "shift-down": "zeta::NextEdit",
       "shift-up": "zeta::PreviousEdit",
-      "space": "zeta::PreviewCompletion",
-
-      // These bindings are copied from menu:: to make them mutually exclusive with the editor focus
-      "up": "zeta::SelectPrev",
-      "shift-tab": "zeta::SelectPrev",
-      "home": "zeta::SelectFirst",
-      "pageup": "zeta::SelectFirst",
-      "shift-pageup": "zeta::SelectFirst",
-      "ctrl-p": "zeta::SelectPrev",
-      "down": "zeta::SelectNext",
-      "tab": "zeta::SelectNext",
-      "end": "zeta::SelectLast",
-      "pagedown": "zeta::SelectLast",
-      "shift-pagedown": "zeta::SelectFirst",
-      "ctrl-n": "zeta::SelectNext",
-      "cmd-up": "zeta::SelectFirst",
-      "cmd-down": "zeta::SelectLast",
-      "enter": "zeta::Confirm"
+      "space": "zeta::PreviewCompletion"
     }
   },
   {

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -204,7 +204,7 @@ impl Render for InlineCompletionButton {
                 }
 
                 div().child(
-                    Button::new("zeta", "Zeta")
+                    Button::new("zeta", "ζ")
                         .label_size(LabelSize::Small)
                         .on_click(cx.listener(|this, _, cx| {
                             if let Some(workspace) = this.workspace.upgrade() {

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -39,6 +39,7 @@ pub struct ListItem {
     children: SmallVec<[AnyElement; 2]>,
     selectable: bool,
     overflow_x: bool,
+    focused: Option<bool>,
 }
 
 impl ListItem {
@@ -62,6 +63,7 @@ impl ListItem {
             children: SmallVec::new(),
             selectable: true,
             overflow_x: false,
+            focused: None,
         }
     }
 
@@ -140,6 +142,11 @@ impl ListItem {
         self.overflow_x = true;
         self
     }
+
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = Some(focused);
+        self
+    }
 }
 
 impl Disableable for ListItem {
@@ -177,9 +184,14 @@ impl RenderOnce for ListItem {
                 this
                     // TODO: Add focus state
                     // .when(self.state == InteractionState::Focused, |this| {
-                    //     this.border_1()
-                    //         .border_color(cx.theme().colors().border_focused)
-                    // })
+                    .when_some(self.focused, |this, focused| {
+                        if focused {
+                            this.border_1()
+                                .border_color(cx.theme().colors().border_focused)
+                        } else {
+                            this.border_1()
+                        }
+                    })
                     .when(self.selectable, |this| {
                         this.hover(|style| style.bg(cx.theme().colors().ghost_element_hover))
                             .active(|style| style.bg(cx.theme().colors().ghost_element_active))
@@ -204,10 +216,15 @@ impl RenderOnce for ListItem {
                     .when(self.inset && !self.disabled, |this| {
                         this
                             // TODO: Add focus state
-                            // .when(self.state == InteractionState::Focused, |this| {
-                            //     this.border_1()
-                            //         .border_color(cx.theme().colors().border_focused)
-                            // })
+                            //.when(self.state == InteractionState::Focused, |this| {
+                            .when_some(self.focused, |this, focused| {
+                                if focused {
+                                    this.border_1()
+                                        .border_color(cx.theme().colors().border_focused)
+                                } else {
+                                    this.border_1()
+                                }
+                            })
                             .when(self.selectable, |this| {
                                 this.hover(|style| {
                                     style.bg(cx.theme().colors().ghost_element_hover)

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -463,6 +463,7 @@ fn main() {
         welcome::init(cx);
         settings_ui::init(cx);
         extensions_ui::init(cx);
+        zeta::init(client, cx);
 
         cx.observe_global::<SettingsStore>({
             let languages = app_state.languages.clone();

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -463,7 +463,7 @@ fn main() {
         welcome::init(cx);
         settings_ui::init(cx);
         extensions_ui::init(cx);
-        zeta::init(client, cx);
+        zeta::init(cx);
 
         cx.observe_global::<SettingsStore>({
             let languages = app_state.languages.clone();

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -165,7 +165,7 @@ fn assign_inline_completion_provider(
             }
         }
         language::language_settings::InlineCompletionProvider::Zeta => {
-            if cx.has_flag::<ZetaFeatureFlag>() {
+            if cx.has_flag::<ZetaFeatureFlag>() || cfg!(debug_assertions) {
                 let zeta = zeta::Zeta::register(client.clone(), cx);
                 if let Some(buffer) = editor.buffer().read(cx).as_singleton() {
                     if buffer.read(cx).file().is_some() {

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -13,6 +13,11 @@ workspace = true
 path = "src/zeta.rs"
 doctest = false
 
+[features]
+# TODO: remove
+default = ["test-support"]
+test-support = []
+
 [dependencies]
 anyhow.workspace = true
 client.workspace = true
@@ -21,6 +26,7 @@ editor.workspace = true
 futures.workspace = true
 gpui.workspace = true
 http_client.workspace = true
+indoc.workspace = true
 inline_completion.workspace = true
 language.workspace = true
 language_models.workspace = true
@@ -32,8 +38,8 @@ settings.workspace = true
 similar.workspace = true
 telemetry_events.workspace = true
 theme.workspace = true
-util.workspace = true
 ui.workspace = true
+util.workspace = true
 uuid.workspace = true
 workspace.workspace = true
 

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -14,8 +14,6 @@ path = "src/zeta.rs"
 doctest = false
 
 [features]
-# TODO: remove
-default = ["test-support"]
 test-support = []
 
 [dependencies]

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -34,17 +34,10 @@ actions!(
     ]
 );
 
-pub fn init(client: Arc<Client>, cx: &mut AppContext) {
+pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(move |workspace: &mut Workspace, cx| {
         workspace.register_action(|workspace, _: &RateCompletions, cx| {
             RateCompletionModal::toggle(workspace, cx);
-        });
-
-        // TODO: remove
-        Zeta::register(client.clone(), cx);
-
-        Zeta::global(cx).unwrap().update(cx, |zeta, cx| {
-            zeta.fill_with_fake_completions(cx).detach();
         });
     })
     .detach();

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -92,8 +92,7 @@ impl RateCompletionModal {
             .skip(self.selected_index)
             .enumerate()
             .skip(1) // Skip straight to the next item
-            .skip_while(|(_, completion)| completion.edits.is_empty())
-            .next()
+            .find(|(_, completion)| !completion.edits.is_empty())
             .map(|(ix, _)| ix + self.selected_index);
 
         if let Some(next_index) = next_index {
@@ -114,8 +113,7 @@ impl RateCompletionModal {
             .skip((completions_len - 1) - self.selected_index)
             .enumerate()
             .skip(1) // Skip straight to the previous item
-            .skip_while(|(_, completion)| completion.edits.is_empty())
-            .next()
+            .find(|(_, completion)| !completion.edits.is_empty())
             .map(|(ix, _)| self.selected_index - ix);
 
         if let Some(prev_index) = prev_index {

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -1,7 +1,4 @@
-use std::sync::Arc;
-
 use crate::{InlineCompletion, InlineCompletionRating, Zeta};
-use client::Client;
 use editor::Editor;
 use gpui::{
     actions, prelude::*, AppContext, DismissEvent, EventEmitter, FocusHandle, FocusableView,
@@ -26,16 +23,11 @@ actions!(
         PreviousEdit,
         FocusCompletions,
         PreviewCompletion,
-        SelectFirst,
-        SelectLast,
-        SelectNext,
-        SelectPrev,
-        Confirm,
     ]
 );
 
 pub fn init(cx: &mut AppContext) {
-    cx.observe_new_views(move |workspace: &mut Workspace, cx| {
+    cx.observe_new_views(move |workspace: &mut Workspace, _cx| {
         workspace.register_action(|workspace, _: &RateCompletions, cx| {
             RateCompletionModal::toggle(workspace, cx);
         });
@@ -78,7 +70,7 @@ impl RateCompletionModal {
         cx.emit(DismissEvent);
     }
 
-    fn select_next(&mut self, _: &SelectNext, cx: &mut ViewContext<Self>) {
+    fn select_next(&mut self, _: &menu::SelectNext, cx: &mut ViewContext<Self>) {
         self.selected_index += 1;
         self.selected_index = usize::min(
             self.selected_index,
@@ -87,7 +79,7 @@ impl RateCompletionModal {
         cx.notify();
     }
 
-    fn select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
+    fn select_prev(&mut self, _: &menu::SelectPrev, cx: &mut ViewContext<Self>) {
         self.selected_index = self.selected_index.saturating_sub(1);
         cx.notify();
     }
@@ -133,12 +125,12 @@ impl RateCompletionModal {
         cx.notify();
     }
 
-    fn select_first(&mut self, _: &SelectFirst, cx: &mut ViewContext<Self>) {
+    fn select_first(&mut self, _: &menu::SelectFirst, cx: &mut ViewContext<Self>) {
         self.selected_index = 0;
         cx.notify();
     }
 
-    fn select_last(&mut self, _: &SelectLast, cx: &mut ViewContext<Self>) {
+    fn select_last(&mut self, _: &menu::SelectLast, cx: &mut ViewContext<Self>) {
         self.selected_index = self.zeta.read(cx).recent_completions_len() - 1;
         cx.notify();
     }
@@ -249,7 +241,7 @@ impl RateCompletionModal {
         self.select_completion(completion, false, cx);
     }
 
-    fn confirm(&mut self, _: &Confirm, cx: &mut ViewContext<Self>) {
+    fn confirm(&mut self, _: &menu::Confirm, cx: &mut ViewContext<Self>) {
         let completion = self
             .zeta
             .read(cx)

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -18,6 +18,7 @@ use std::{
     borrow::Cow,
     cmp,
     fmt::Write,
+    future::Future,
     mem,
     ops::Range,
     path::Path,
@@ -253,12 +254,17 @@ impl Zeta {
         }
     }
 
-    pub fn request_completion(
+    pub fn request_completion_impl<F, R>(
         &mut self,
         buffer: &Model<Buffer>,
         position: language::Anchor,
         cx: &mut ModelContext<Self>,
-    ) -> Task<Result<InlineCompletion>> {
+        perform_predict_edits: F,
+    ) -> Task<Result<InlineCompletion>>
+    where
+        F: FnOnce(Arc<Client>, LlmApiToken, PredictEditsParams) -> R + 'static,
+        R: Future<Output = Result<PredictEditsResponse>> + Send + 'static,
+    {
         let snapshot = self.report_changes_for_buffer(buffer, cx);
         let point = position.to_point(&snapshot);
         let offset = point.to_offset(&snapshot);
@@ -292,7 +298,7 @@ impl Zeta {
                 input_excerpt: input_excerpt.clone(),
             };
 
-            let response = Self::perform_predict_edits(&client, llm_token, body).await?;
+            let response = perform_predict_edits(client, llm_token, body).await?;
 
             let output_excerpt = response.output_excerpt;
             log::debug!("prediction took: {:?}", start.elapsed());
@@ -320,50 +326,179 @@ impl Zeta {
         })
     }
 
-    async fn perform_predict_edits(
-        client: &Arc<Client>,
+    // Generates several example completions of various states to fill the Zeta completion modal
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn fill_with_fake_completions(&mut self, cx: &mut ModelContext<Self>) -> Task<()> {
+        let test_buffer_text = indoc::indoc! {r#"a longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+            And maybe a short line
+
+            Then a few lines
+
+            and then another
+            longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+            "#};
+
+        let buffer = cx.new_model(|cx| Buffer::local(test_buffer_text, cx));
+        let position = buffer.read(cx).anchor_before(Point::new(1, 0));
+
+        let completion_tasks = vec![
+            self.fake_completion(
+                &buffer,
+                position,
+                PredictEditsResponse {
+                    output_excerpt: format!("{EDITABLE_REGION_START_MARKER}
+                        a longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+[here's a sneaky edit]
+And maybe a short line
+Then a few lines
+and then another
+longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+{EDITABLE_REGION_END_MARKER}
+                        ", ),
+                },
+                cx,
+            ),
+            self.fake_completion(
+                &buffer,
+                position,
+                PredictEditsResponse {
+                    output_excerpt: format!(r#"{EDITABLE_REGION_START_MARKER}
+a longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+And maybe a short line
+[and another sneaky edit]
+Then a few lines
+and then another
+longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+{EDITABLE_REGION_END_MARKER}
+                        "#),
+                },
+                cx,
+            ),
+            self.fake_completion(
+                &buffer,
+                position,
+                PredictEditsResponse {
+                    output_excerpt: format!(r#"{EDITABLE_REGION_START_MARKER}
+a longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+And maybe a short line
+Then a few lines
+[a third completion]
+and then another
+longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+{EDITABLE_REGION_END_MARKER}
+                        "#),
+                },
+                cx,
+            ),
+            self.fake_completion(
+                &buffer,
+                position,
+                PredictEditsResponse {
+                    output_excerpt: format!(r#"{EDITABLE_REGION_START_MARKER}
+a longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+And maybe a short line
+and then another
+[fourth completion example]
+longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+{EDITABLE_REGION_END_MARKER}
+                        "#),
+                },
+                cx,
+            ),
+            self.fake_completion(
+                &buffer,
+                position,
+                PredictEditsResponse {
+                    output_excerpt: format!(r#"{EDITABLE_REGION_START_MARKER}
+a longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+And maybe a short line
+Then a few lines
+and then another
+longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line
+[fifth and final completion]
+{EDITABLE_REGION_END_MARKER}
+                        "#),
+                },
+                cx,
+            ),
+        ];
+
+        cx.spawn(|_, _| async move {
+            for (ix, task) in completion_tasks.into_iter().enumerate() {
+                dbg!(ix);
+                task.await.unwrap();
+            }
+        })
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn fake_completion(
+        &mut self,
+        buffer: &Model<Buffer>,
+        position: language::Anchor,
+        response: PredictEditsResponse,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Result<InlineCompletion>> {
+        use std::future::ready;
+
+        self.request_completion_impl(buffer, position, cx, |_, _, _| ready(Ok(response)))
+    }
+
+    pub fn request_completion(
+        &mut self,
+        buffer: &Model<Buffer>,
+        position: language::Anchor,
+        cx: &mut ModelContext<Self>,
+    ) -> Task<Result<InlineCompletion>> {
+        self.request_completion_impl(buffer, position, cx, Self::perform_predict_edits)
+    }
+
+    fn perform_predict_edits(
+        client: Arc<Client>,
         llm_token: LlmApiToken,
         body: PredictEditsParams,
-    ) -> Result<PredictEditsResponse> {
-        let http_client = client.http_client();
-        let mut token = llm_token.acquire(client).await?;
-        let mut did_retry = false;
+    ) -> impl Future<Output = Result<PredictEditsResponse>> {
+        async move {
+            let http_client = client.http_client();
+            let mut token = llm_token.acquire(&client).await?;
+            let mut did_retry = false;
 
-        loop {
-            let request_builder = http_client::Request::builder();
-            let request = request_builder
-                .method(Method::POST)
-                .uri(
-                    http_client
-                        .build_zed_llm_url("/predict_edits", &[])?
-                        .as_ref(),
-                )
-                .header("Content-Type", "application/json")
-                .header("Authorization", format!("Bearer {}", token))
-                .body(serde_json::to_string(&body)?.into())?;
+            loop {
+                let request_builder = http_client::Request::builder();
+                let request = request_builder
+                    .method(Method::POST)
+                    .uri(
+                        http_client
+                            .build_zed_llm_url("/predict_edits", &[])?
+                            .as_ref(),
+                    )
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {}", token))
+                    .body(serde_json::to_string(&body)?.into())?;
 
-            let mut response = http_client.send(request).await?;
+                let mut response = http_client.send(request).await?;
 
-            if response.status().is_success() {
-                let mut body = String::new();
-                response.body_mut().read_to_string(&mut body).await?;
-                return Ok(serde_json::from_str(&body)?);
-            } else if !did_retry
-                && response
-                    .headers()
-                    .get(EXPIRED_LLM_TOKEN_HEADER_NAME)
-                    .is_some()
-            {
-                did_retry = true;
-                token = llm_token.refresh(client).await?;
-            } else {
-                let mut body = String::new();
-                response.body_mut().read_to_string(&mut body).await?;
-                return Err(anyhow!(
-                    "error predicting edits.\nStatus: {:?}\nBody: {}",
-                    response.status(),
-                    body
-                ));
+                if response.status().is_success() {
+                    let mut body = String::new();
+                    response.body_mut().read_to_string(&mut body).await?;
+                    return Ok(serde_json::from_str(&body)?);
+                } else if !did_retry
+                    && response
+                        .headers()
+                        .get(EXPIRED_LLM_TOKEN_HEADER_NAME)
+                        .is_some()
+                {
+                    did_retry = true;
+                    token = llm_token.refresh(&client).await?;
+                } else {
+                    let mut body = String::new();
+                    response.body_mut().read_to_string(&mut body).await?;
+                    return Err(anyhow!(
+                        "error predicting edits.\nStatus: {:?}\nBody: {}",
+                        response.status(),
+                        body
+                    ));
+                }
             }
         }
     }
@@ -409,7 +544,7 @@ impl Zeta {
         })
     }
 
-    fn compute_edits(
+    pub fn compute_edits(
         old_text: String,
         new_text: &str,
         offset: usize,


### PR DESCRIPTION
This PR adds keyboard shortcuts to common interactions you might want to do in the Zeta rating panel. 

This PR also adds a way to fake inline completion requests, as well as the test data used to create this PR, to make it easier to adjust the UI in the future.

It also changes the status bar from the text "Zeta" to "ζ", because I thought it looked cool.

Release Notes:

- N/A
