### PR TITLE
multi_buffer: optimize runnables layout

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -49,7 +49,7 @@ use language::{
 use lsp::DiagnosticSeverity;
 use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptId, ExpandExcerptDirection, MultiBufferPoint, MultiBufferRow,
-    MultiBufferSnapshot,
+    MultiBufferSnapshot, ToOffset,
 };
 use project::{
     project_settings::{GitGutterSetting, ProjectSettings},
@@ -1695,16 +1695,23 @@ impl EditorElement {
                     None
                 };
 
+            let offset_range_start = snapshot
+                .display_point_to_anchor(DisplayPoint::new(range.start, 0), Bias::Left)
+                .to_offset(&snapshot.buffer_snapshot);
+            let offset_range_end = snapshot
+                .display_point_to_anchor(DisplayPoint::new(range.end, 0), Bias::Right)
+                .to_offset(&snapshot.buffer_snapshot);
+
             editor
                 .tasks
                 .iter()
                 .filter_map(|(_, tasks)| {
-                    let multibuffer_point = tasks.offset.0.to_point(&snapshot.buffer_snapshot);
-                    let multibuffer_row = MultiBufferRow(multibuffer_point.row);
-                    let display_row = multibuffer_point.to_display_point(snapshot).row();
-                    if range.start > display_row || range.end < display_row {
+                    if tasks.offset.0 < offset_range_start || tasks.offset.0 >= offset_range_end {
                         return None;
                     }
+                    let multibuffer_point = tasks.offset.0.to_point(&snapshot.buffer_snapshot);
+                    let multibuffer_row = MultiBufferRow(multibuffer_point.row);
+
                     if snapshot.is_line_folded(multibuffer_row) {
                         // Skip folded indicators, unless it's the starting line of a fold.
                         if multibuffer_row
@@ -1717,6 +1724,7 @@ impl EditorElement {
                             return None;
                         }
                     }
+                    let display_row = multibuffer_point.to_display_point(snapshot).row();
                     let button = editor.render_run_indicator(
                         &self.style,
                         Some(display_row) == active_task_indicator_row,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -168,6 +168,8 @@ pub trait ToPointUtf16: 'static + fmt::Debug {
 struct BufferState {
     buffer: Model<Buffer>,
     last_version: clock::Global,
+    last_is_dirty: bool,
+    last_has_conflict: bool,
     last_non_text_state_update_count: usize,
     excerpts: Vec<Locator>,
     _subscriptions: [gpui::Subscription; 2],
@@ -416,6 +418,8 @@ impl MultiBuffer {
                 BufferState {
                     buffer: buffer_state.buffer.clone(),
                     last_version: buffer_state.last_version.clone(),
+                    last_is_dirty: buffer_state.last_is_dirty,
+                    last_has_conflict: buffer_state.last_has_conflict,
                     last_non_text_state_update_count: buffer_state.last_non_text_state_update_count,
                     excerpts: buffer_state.excerpts.clone(),
                     _subscriptions: [
@@ -1402,15 +1406,26 @@ impl MultiBuffer {
         let buffer_snapshot = buffer.read(cx).snapshot();
 
         let mut buffers = self.buffers.borrow_mut();
-        let buffer_state = buffers.entry(buffer_id).or_insert_with(|| BufferState {
-            last_version: buffer_snapshot.version().clone(),
-            last_non_text_state_update_count: buffer_snapshot.non_text_state_update_count(),
-            excerpts: Default::default(),
-            _subscriptions: [
-                cx.observe(&buffer, |_, _, cx| cx.notify()),
-                cx.subscribe(&buffer, Self::on_buffer_event),
-            ],
-            buffer: buffer.clone(),
+        let buffer_state = buffers.entry(buffer_id).or_insert_with(|| {
+            let last_is_dirty;
+            let last_has_conflict;
+            {
+                let buffer = buffer.read(cx);
+                last_is_dirty = buffer.is_dirty();
+                last_has_conflict = buffer.has_conflict();
+            }
+            BufferState {
+                last_version: buffer_snapshot.version().clone(),
+                last_non_text_state_update_count: buffer_snapshot.non_text_state_update_count(),
+                last_is_dirty,
+                last_has_conflict,
+                excerpts: Default::default(),
+                _subscriptions: [
+                    cx.observe(&buffer, |_, _, cx| cx.notify()),
+                    cx.subscribe(&buffer, Self::on_buffer_event),
+                ],
+                buffer: buffer.clone(),
+            }
         });
 
         let mut snapshot = self.snapshot.borrow_mut();
@@ -2098,7 +2113,13 @@ impl MultiBuffer {
             let buffer_edited = version.changed_since(&buffer_state.last_version);
             let buffer_non_text_state_updated =
                 non_text_state_update_count > buffer_state.last_non_text_state_update_count;
+            let buffer_is_dirty;
+            let buffer_has_conflict;
             if buffer_edited || buffer_non_text_state_updated {
+                buffer_is_dirty = buffer.is_dirty();
+                buffer_has_conflict = buffer.has_conflict();
+                buffer_state.last_has_conflict = buffer_has_conflict;
+                buffer_state.last_is_dirty = buffer_is_dirty;
                 buffer_state.last_version = version;
                 buffer_state.last_non_text_state_update_count = non_text_state_update_count;
                 excerpts_to_edit.extend(
@@ -2107,15 +2128,18 @@ impl MultiBuffer {
                         .iter()
                         .map(|locator| (locator, buffer_state.buffer.clone(), buffer_edited)),
                 );
+            } else {
+                buffer_is_dirty = buffer_state.last_is_dirty;
+                buffer_has_conflict = buffer_state.last_has_conflict;
             }
 
             edited |= buffer_edited;
             non_text_state_updated |= buffer_non_text_state_updated;
-            is_dirty |= buffer.is_dirty();
+            is_dirty |= buffer_is_dirty;
             has_deleted_file |= buffer
                 .file()
                 .map_or(false, |file| file.disk_state() == DiskState::Deleted);
-            has_conflict |= buffer.has_conflict();
+            has_conflict |= buffer_has_conflict;
         }
         if edited {
             snapshot.edit_count += 1;


### PR DESCRIPTION
Related to #21481 ; it fixes a bunch of hotspots I saw while looking at the provided profiles. MultiBuffer still takes up 100% CPU on the foreground thread for me - this time around it's on selection updates (when dragging the selected text towards an edge of a screen).

Release Notes:

- N/A
