### PR TITLE
linux: Don't watch parent directory when target path already exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4751,6 +4751,7 @@ dependencies = [
  "git2",
  "gpui",
  "libc",
+ "log",
  "notify",
  "objc",
  "parking_lot",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -21,6 +21,7 @@ git.workspace = true
 git2.workspace = true
 gpui.workspace = true
 libc.workspace = true
+log.workspace = true
 parking_lot.workspace = true
 paths.workspace = true
 rope.workspace = true


### PR DESCRIPTION
The Linux watcher was unconditionally watching the parent directory of every watched path. This is needed in the case of config files that may not exist when the watch is set up, but not in other cases. Scoping the parent watch more narrowly cuts down on the amount of error logging from irrelevant file change notifications being sent to Zed (in my case it was picking up changes to a random file in `$HOME`). 

Release Notes:

- N/A
