### PR TITLE
Show inline completions when completion menu is visible

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -468,13 +468,21 @@
   },
   {
     "context": "Editor && showing_completions",
+    "use_key_equivalents": true,
     "bindings": {
-      "enter": "editor::ConfirmCompletion",
+      "enter": "editor::ConfirmCompletion"
+    }
+  },
+  {
+    "context": "Editor && !inline_completion && showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
       "tab": "editor::ComposeCompletion"
     }
   },
   {
-    "context": "Editor && inline_completion && !showing_completions",
+    "context": "Editor && inline_completion",
+    "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptInlineCompletion"
     }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -541,12 +541,18 @@
     "context": "Editor && showing_completions",
     "use_key_equivalents": true,
     "bindings": {
-      "enter": "editor::ConfirmCompletion",
+      "enter": "editor::ConfirmCompletion"
+    }
+  },
+  {
+    "context": "Editor && !inline_completion && showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
       "tab": "editor::ComposeCompletion"
     }
   },
   {
-    "context": "Editor && inline_completion && !showing_completions",
+    "context": "Editor && inline_completion",
     "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptInlineCompletion"

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -296,7 +296,6 @@ mod tests {
             editor.set_inline_completion_provider(Some(copilot_provider), cx)
         });
 
-        // When inserting, ensure autocompletion is favored over Copilot suggestions.
         cx.set_state(indoc! {"
             oneˇ
             two
@@ -323,8 +322,9 @@ mod tests {
         );
         executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
         cx.update_editor(|editor, cx| {
+            // We want to show both: the inline completion and the completion menu
             assert!(editor.context_menu_visible());
-            assert!(!editor.has_active_inline_completion());
+            assert!(editor.has_active_inline_completion());
 
             // Confirming a completion inserts it and hides the context menu, without showing
             // the copilot suggestion afterwards.
@@ -338,40 +338,7 @@ mod tests {
             assert_eq!(editor.display_text(cx), "one.completion_a\ntwo\nthree\n");
         });
 
-        // Ensure Copilot suggestions are shown right away if no autocompletion is available.
-        cx.set_state(indoc! {"
-            oneˇ
-            two
-            three
-        "});
-        cx.simulate_keystroke(".");
-        drop(handle_completion_request(
-            &mut cx,
-            indoc! {"
-                one.|<>
-                two
-                three
-            "},
-            vec![],
-        ));
-        handle_copilot_completion_request(
-            &copilot_lsp,
-            vec![crate::request::Completion {
-                text: "one.copilot1".into(),
-                range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 4)),
-                ..Default::default()
-            }],
-            vec![],
-        );
-        executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
-        cx.update_editor(|editor, cx| {
-            assert!(!editor.context_menu_visible());
-            assert!(editor.has_active_inline_completion());
-            assert_eq!(editor.display_text(cx), "one.copilot1\ntwo\nthree\n");
-            assert_eq!(editor.text(cx), "one.\ntwo\nthree\n");
-        });
-
-        // Reset editor, and ensure autocompletion is still favored over Copilot suggestions.
+        // Reset editor and test that accepting completions works
         cx.set_state(indoc! {"
             oneˇ
             two
@@ -399,17 +366,12 @@ mod tests {
         executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
         cx.update_editor(|editor, cx| {
             assert!(editor.context_menu_visible());
-            assert!(!editor.has_active_inline_completion());
-
-            // When hiding the context menu, the Copilot suggestion becomes visible.
-            editor.cancel(&Default::default(), cx);
-            assert!(!editor.context_menu_visible());
             assert!(editor.has_active_inline_completion());
             assert_eq!(editor.display_text(cx), "one.copilot1\ntwo\nthree\n");
             assert_eq!(editor.text(cx), "one.\ntwo\nthree\n");
         });
 
-        // Ensure existing completion is interpolated when inserting again.
+        // Ensure existing inline completion is interpolated when inserting again.
         cx.simulate_keystroke("c");
         executor.run_until_parked();
         cx.update_editor(|editor, cx| {
@@ -880,7 +842,7 @@ mod tests {
         cx.update_editor(|editor, cx| editor.next_inline_completion(&Default::default(), cx));
         executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
         cx.update_editor(|editor, cx| {
-            assert!(!editor.context_menu_visible(), "Even there are some completions available, those are not triggered when active copilot suggestion is present");
+            assert!(!editor.context_menu_visible());
             assert!(editor.has_active_inline_completion());
             assert_eq!(editor.display_text(cx), "one\ntwo.foo()\nthree\n");
             assert_eq!(editor.text(cx), "one\ntw\nthree\n");
@@ -934,15 +896,9 @@ mod tests {
         );
         executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
         cx.update_editor(|editor, cx| {
-            assert!(
-                editor.context_menu_visible(),
-                "On completion trigger input, the completions should be fetched and visible"
-            );
-            assert!(
-                !editor.has_active_inline_completion(),
-                "On completion trigger input, copilot suggestion should be dismissed"
-            );
-            assert_eq!(editor.display_text(cx), "one\ntwo.\nthree\n");
+            assert!(editor.context_menu_visible());
+            assert!(editor.has_active_inline_completion(),);
+            assert_eq!(editor.display_text(cx), "one\ntwo.foo()\nthree\n");
             assert_eq!(editor.text(cx), "one\ntwo.\nthree\n");
         });
     }


### PR DESCRIPTION
This changes the behavior of how we display inline completions and non-inline completions (i.e. completion menu).

Previously we would never show inline completions if a completion menu was visible, meaning that we'd never show Copilot/Supermaven/... suggestions if the language server had a suggestion.

With this change, we now display the inline completions even if there is a completion menu visible.

In that case `<tab>` then accepts the inline completion and `<enter>` accepts the selected entry in the completion menu.

Release Notes:

- Changed how inline completions (Copilot, Supermaven, ...) and normal completions (from language servers) interact. Zed will now also show inline completions when the completion menu is visible. The user can accept the inline completion with `<tab>` and the active entry in the completion menu with `<enter>`. Previously, `<tab>` would also select the active entry in the completion menu.


Edit: superseded by https://github.com/zed-industries/zed/pull/22069