### PR TITLE
worktree: Fix privacy check for singleton files

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -427,11 +427,6 @@ pub trait LocalFile: File {
 
     /// Loads the file's contents from disk.
     fn load_bytes(&self, cx: &AppContext) -> Task<Result<Vec<u8>>>;
-
-    /// Returns true if the file should not be shared with collaborators.
-    fn is_private(&self, _: &AppContext) -> bool {
-        false
-    }
 }
 
 /// The auto-indent behavior associated with an editing operation.

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2713,10 +2713,11 @@ async fn test_propagate_git_statuses(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_privacy(cx: &mut TestAppContext) {
+async fn test_private_single_file_worktree(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());
-    fs.insert_tree("/", json!({".env": "PRIVATE=secret"})).await;
+    fs.insert_tree("/", json!({".env": "PRIVATE=secret\n"}))
+        .await;
     let tree = Worktree::local(
         Path::new("/.env"),
         true,

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2712,6 +2712,28 @@ async fn test_propagate_git_statuses(cx: &mut TestAppContext) {
     );
 }
 
+#[gpui::test]
+async fn test_privacy(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree("/", json!({".env": "PRIVATE=secret"})).await;
+    let tree = Worktree::local(
+        Path::new("/.env"),
+        true,
+        fs.clone(),
+        Default::default(),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    tree.read_with(cx, |tree, _| {
+        let entry = tree.entry_for_path("").unwrap();
+        assert!(entry.is_private);
+    });
+}
+
 #[track_caller]
 fn check_propagated_statuses(
     snapshot: &Snapshot,


### PR DESCRIPTION
Closes #20676

Release Notes:

- Fixed private files not being redacted when not part of a larger worktree