### PR TITLE
gpui: Don't export named `Context` from prelude

### DIFF
--- a/crates/assistant/src/context/context_tests.rs
+++ b/crates/assistant/src/context/context_tests.rs
@@ -17,7 +17,7 @@ use futures::{
     channel::mpsc,
     stream::{self, StreamExt},
 };
-use gpui::{AppContext, Model, SharedString, Task, TestAppContext, WeakView};
+use gpui::{prelude::*, AppContext, Model, SharedString, Task, TestAppContext, WeakView};
 use language::{Buffer, BufferSnapshot, LanguageRegistry, LspAdapterDelegate};
 use language_model::{LanguageModelCacheConfiguration, LanguageModelRegistry, Role};
 use parking_lot::Mutex;
@@ -35,7 +35,7 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 use text::{network::Network, OffsetRangeExt as _, ReplicaId, ToOffset};
-use ui::{Context as _, IconName, WindowContext};
+use ui::{IconName, WindowContext};
 use unindent::Unindent;
 use util::{
     test::{generate_marked_text, marked_text_ranges},

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -6,13 +6,12 @@ use anyhow::{anyhow, Result};
 use chrono::DateTime;
 use fs::Fs;
 use futures::{io::BufReader, stream::BoxStream, AsyncBufReadExt, AsyncReadExt, StreamExt};
-use gpui::{AppContext, AsyncAppContext, Global};
+use gpui::{prelude::*, AppContext, AsyncAppContext, Global};
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use paths::home_dir;
 use serde::{Deserialize, Serialize};
 use settings::watch_config_file;
 use strum::EnumIter;
-use ui::Context;
 
 pub const COPILOT_CHAT_COMPLETION_URL: &str = "https://api.githubcopilot.com/chat/completions";
 pub const COPILOT_CHAT_AUTH_URL: &str = "https://api.github.com/copilot_internal/v2/token";

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6661,7 +6661,6 @@ mod tests {
     use language::language_settings;
     use log::info;
     use std::num::NonZeroU32;
-    use ui::Context;
     use util::test::sample_text;
 
     #[gpui::test]

--- a/crates/editor/src/git/project_diff.rs
+++ b/crates/editor/src/git/project_diff.rs
@@ -22,10 +22,7 @@ use multi_buffer::{ExcerptId, ExcerptRange, ExpandExcerptDirection, MultiBuffer}
 use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
 use text::{OffsetRangeExt, ToPoint};
 use theme::ActiveTheme;
-use ui::{
-    div, h_flex, Color, Context, FluentBuilder, Icon, IconName, IntoElement, Label, LabelCommon,
-    ParentElement, SharedString, Styled, ViewContext, VisualContext, WindowContext,
-};
+use ui::prelude::*;
 use util::{paths::compare_paths, ResultExt};
 use workspace::{
     item::{BreadcrumbText, Item, ItemEvent, ItemHandle, TabContentParams},

--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -1,10 +1,9 @@
-use gpui::Model;
+use gpui::{prelude::*, Model};
 use indoc::indoc;
 use inline_completion::InlineCompletionProvider;
 use multi_buffer::{Anchor, MultiBufferSnapshot, ToPoint};
 use std::ops::Range;
 use text::{Point, ToOffset};
-use ui::Context;
 
 use crate::{
     editor_tests::init_test, test::editor_test_context::EditorTestContext, InlineCompletion,

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -6,8 +6,8 @@ use collections::BTreeMap;
 use futures::Future;
 use git::diff::DiffHunkStatus;
 use gpui::{
-    AnyWindowHandle, AppContext, Keystroke, ModelContext, Pixels, Point, View, ViewContext,
-    VisualTestContext, WindowHandle,
+    prelude::*, AnyWindowHandle, AppContext, Keystroke, ModelContext, Pixels, Point, View,
+    ViewContext, VisualTestContext, WindowHandle,
 };
 use itertools::Itertools;
 use language::{Buffer, BufferSnapshot, LanguageRegistry};
@@ -23,8 +23,6 @@ use std::{
         Arc,
     },
 };
-
-use ui::Context;
 use util::{
     assert_set_eq,
     test::{generate_marked_text, marked_text_ranges},

--- a/crates/gpui/src/prelude.rs
+++ b/crates/gpui/src/prelude.rs
@@ -3,7 +3,7 @@
 //! application to avoid having to import each trait individually.
 
 pub use crate::{
-    util::FluentBuilder, BorrowAppContext, BorrowWindow, Context, Element, FocusableElement,
+    util::FluentBuilder, BorrowAppContext, BorrowWindow, Context as _, Element, FocusableElement,
     InteractiveElement, IntoElement, ParentElement, Refineable, Render, RenderOnce,
     StatefulInteractiveElement, Styled, StyledImage, VisualContext,
 };

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -3,9 +3,8 @@ use crate::{
     LanguageModelProviderState,
 };
 use collections::BTreeMap;
-use gpui::{AppContext, EventEmitter, Global, Model, ModelContext};
+use gpui::{prelude::*, AppContext, EventEmitter, Global, Model, ModelContext};
 use std::sync::Arc;
-use ui::Context;
 
 pub fn init(cx: &mut AppContext) {
     let registry = cx.new_model(|_cx| LanguageModelRegistry::default());

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -22,11 +22,7 @@ use language_model::{
 use settings::SettingsStore;
 use std::time::Duration;
 use strum::IntoEnumIterator;
-use ui::{
-    div, h_flex, v_flex, Button, ButtonCommon, Clickable, Color, Context, FixedWidth, Icon,
-    IconName, IconPosition, IconSize, IntoElement, Label, LabelCommon, ParentElement, Styled,
-    ViewContext, VisualContext, WindowContext,
-};
+use ui::prelude::*;
 
 use super::anthropic::count_anthropic_tokens;
 use super::open_ai::count_open_ai_tokens;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4262,7 +4262,6 @@ mod tests {
     use serde_json::json;
     use settings::SettingsStore;
     use std::path::{Path, PathBuf};
-    use ui::Context;
     use workspace::{
         item::{Item, ProjectItem},
         register_project_item, AppState,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -92,11 +92,7 @@ use task::SpawnInTerminal;
 use theme::{ActiveTheme, SystemAppearance, ThemeSettings};
 pub use toolbar::{Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
 pub use ui;
-use ui::{
-    div, h_flex, px, BorrowAppContext, Context as _, Div, FluentBuilder, InteractiveElement as _,
-    IntoElement, ParentElement as _, Pixels, SharedString, Styled as _, ViewContext,
-    VisualContext as _, WindowContext,
-};
+use ui::prelude::*;
 use util::{paths::SanitizedPath, ResultExt, TryFutureExt};
 use uuid::Uuid;
 pub use workspace_settings::{
@@ -597,7 +593,6 @@ impl AppState {
         use node_runtime::NodeRuntime;
         use session::Session;
         use settings::SettingsStore;
-        use ui::Context as _;
 
         if !cx.has_global::<SettingsStore>() {
             let settings_store = SettingsStore::test(cx);
@@ -7856,7 +7851,7 @@ mod tests {
     }
 
     mod register_project_item_tests {
-        use ui::Context as _;
+        use gpui::Context as _;
 
         use super::*;
 


### PR DESCRIPTION
This PR updates the `gpui::prelude` to not export the `Context` trait named.

This prevents some naming clashes in downstream consumers.

Release Notes:

- N/A
