### PR TITLE
toolbar: Add gap between the Kernel and REPL button

### DIFF
--- a/crates/zed/src/zed/quick_action_bar/repl_menu.rs
+++ b/crates/zed/src/zed/quick_action_bar/repl_menu.rs
@@ -353,6 +353,7 @@ impl QuickActionBar {
         let tooltip: SharedString = SharedString::from(format!("Setup Zed REPL for {}", language));
         Some(
             h_flex()
+                .gap(DynamicSpacing::Base06.rems(cx))
                 .child(self.render_kernel_selector(cx))
                 .child(
                     IconButton::new("toggle_repl_icon", IconName::ReplNeutral)


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/dbc382a8-2ba5-4639-964f-35c934875e88)

After:
![image](https://github.com/user-attachments/assets/5faf2144-63c3-41d4-b1b8-fcd6f6fd7b7e)

Also works with dark themes:
![image](https://github.com/user-attachments/assets/1f3e9bfb-94f8-44f2-9727-e46fddccb153)

Release Notes:

- N/A