### PR TITLE
Implement bracket coloring by depth

### DIFF
--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -2,7 +2,7 @@ use super::{
     fold_map::{self, FoldChunks, FoldEdit, FoldPoint, FoldSnapshot},
     Highlights,
 };
-use language::{Chunk, Point};
+use language::{Chunk, ChunkKind, Point};
 use multi_buffer::MultiBufferSnapshot;
 use std::{cmp, mem, num::NonZeroU32, ops::Range};
 use sum_tree::Bias;
@@ -265,7 +265,7 @@ impl TabSnapshot {
             tab_size: self.tab_size,
             chunk: Chunk {
                 text: &SPACES[0..(to_next_stop as usize)],
-                is_tab: true,
+                kind: ChunkKind::Tab,
                 ..Default::default()
             },
             inside_leading_tab: to_next_stop > 0,
@@ -522,7 +522,7 @@ impl<'a> TabChunks<'a> {
         self.max_output_position = range.end.0;
         self.chunk = Chunk {
             text: &SPACES[0..(to_next_stop as usize)],
-            is_tab: true,
+            kind: ChunkKind::Tab,
             ..Default::default()
         };
         self.inside_leading_tab = to_next_stop > 0;
@@ -574,7 +574,7 @@ impl<'a> Iterator for TabChunks<'a> {
                         self.output_position = next_output_position;
                         return Some(Chunk {
                             text: &SPACES[..len as usize],
-                            is_tab: true,
+                            kind: ChunkKind::Tab,
                             ..self.chunk.clone()
                         });
                     }
@@ -718,11 +718,11 @@ mod tests {
             let mut text = String::new();
             for chunk in snapshot.chunks(start..snapshot.max_point(), false, Highlights::default())
             {
-                if chunk.is_tab != was_tab {
+                if chunk.kind.is_tab() != was_tab {
                     if !text.is_empty() {
                         chunks.push((mem::take(&mut text), was_tab));
                     }
-                    was_tab = chunk.is_tab;
+                    was_tab = chunk.kind.is_tab();
                 }
                 text.push_str(chunk.text);
             }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1437,9 +1437,12 @@ impl Language {
                 });
             let highlight_maps = vec![grammar.highlight_map()];
             let mut offset = 0;
-            for chunk in
-                BufferChunks::new(text, range, Some((captures, highlight_maps)), false, None)
-            {
+
+            let chunk_highlights =
+                Some(BufferChunkHighlights::new(captures, highlight_maps, &self));
+
+            let chunks = BufferChunks::new(text, range, chunk_highlights, false, None);
+            for chunk in chunks {
                 let end_offset = offset + chunk.text.len();
                 if let Some(highlight_id) = chunk.syntax_highlight_id {
                     if !highlight_id.is_default() {

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -52,17 +52,17 @@
 
 [
   "("
-  ")"
   "{"
-  "}"
   "["
-  "]"
-] @punctuation.bracket
+  "<"
+] @punctuation.bracket.open
 
-(_
-  .
-  "<" @punctuation.bracket
-  ">" @punctuation.bracket)
+[
+  ")"
+  "}"
+  "]"
+  ">"
+] @punctuation.bracket.close
 
 [
   "."


### PR DESCRIPTION
Implement bracket coloring by depth.

Closes #5259.

![bracket coloring preview](https://github.com/user-attachments/assets/fa1ea689-52fb-447a-a4c4-c4e12d85e00d)

---

Hi! :wave: This is my first PR.

I just hit a wall and need some feedback.

(I'm willing to pair!)

## Approach taken

In the Tree Sitter highlighting rules file `highlights.scm`, add two captures:

- `punctuation.bracket.open`
- `punctuation.bracket.close`

So we can track depth with the existing highlighting pass (no additional tree traversals).

This is backward-compatible with extensions, as `punctuation.bracket` is only used for highlighting, and `punctuation.bracket.[open,close]` are both highlighted by the `punctuation.bracket` style as a fallback.

The PR code is language-agnostic and bracket coloring doesn't work till the language's `highlights.scm` file is updated with both `open` and `close` definitions, this way, extension authors can choose what symbols should be colored by depth for the respective language.

<details>
<summary>Note about <code>brackets.scm</code> (click me).</summary>

> It's worth noting that these definitions are different from what can be found in `brackets.scm`, which is "all symbols that delimit a region", and include `||` for closures, and `""` for strings, those are used in different parts of the editor like region selection and innermost region highlight, but, they shouldn't be colored by depth (IMO).

</details>

## Problems

I'm checking Tree Sitter captures in the iteration done in `BufferChunks`, but it seems like the highlights query doesn't walk the syntax from the very start.

As a result, when I scroll down into nested scopes, I can't keep track of the context in the lines above, which makes calculating the depth impossible.

Am I missing something?

## TODO:

- [ ] Fix implementation (problems described above)
- [ ] Add docs on `punctuation.bracket.[open,close]` for extensions
- [ ] Edit `highlights.scm` of remaining languages in the repo
  - For testing purposes, I only updated Rust's for now
- [ ] Add tests
- [ ] Add setting to toggle bracket coloring
  - [ ] Update release notes line in Pull Request
- [ ] Make it look better?
  - I'm using theme accent colors
  - [ ] Maybe blend rainbow colors with `punctuation.bracket` or text color?

## Open questions:

- [ ] Should it match colors with indentation coloring?
- [ ] How to error-recover from unmatched/unclosed brackets?
  - Should a `(` match colors with the next `}` or `]`?

---

Release Notes:

 - Added bracket coloring by depth (TODO: update this with setting name).
