### PR TITLE
Fix false-positive from Danger on release notes

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -8,7 +8,7 @@ prHygiene({
   },
 });
 
-const RELEASE_NOTES_PATTERN = /Release Notes:\r?\n\s+-/gm;
+const RELEASE_NOTES_PATTERN = /Release Notes:\r?\n\s*-/gm;
 const body = danger.github.pr.body;
 
 const hasReleaseNotes = RELEASE_NOTES_PATTERN.test(body);


### PR DESCRIPTION
Got a false-positive at #21875, apparently for removing some extra whitespace.

Release Notes:

- N/A