### PR TITLE
Fix docstring for CallSettingsContent.share_on_join

### DIFF
--- a/crates/call/src/call_settings.rs
+++ b/crates/call/src/call_settings.rs
@@ -20,7 +20,7 @@ pub struct CallSettingsContent {
 
     /// Whether your current project should be shared when joining an empty channel.
     ///
-    /// Default: true
+    /// Default: false
     pub share_on_join: Option<bool>,
 }
 


### PR DESCRIPTION
The documentation for [`CallSettingsContent`](https://github.com/zed-industries/zed/blob/13a81e454a721820b7ab5a4b39ecff2b1eb6fb36/crates/call/src/call_settings.rs#L21-L24) incorrectly states that the `share_on_join` setting defaults to true. This PR fixes the documentation.

Release Notes:

- N/A
