### PR TITLE
Mute microphone by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -211,8 +211,8 @@
   "show_whitespaces": "selection",
   // Settings related to calls in Zed
   "calls": {
-    // Join calls with the microphone live by default
-    "mute_on_join": false,
+    // Join calls with the microphone initially muted
+    "mute_on_join": true,
     // Share your project when you are the first to join a channel
     "share_on_join": false
   },

--- a/crates/call/src/call_settings.rs
+++ b/crates/call/src/call_settings.rs
@@ -15,7 +15,7 @@ pub struct CallSettings {
 pub struct CallSettingsContent {
     /// Whether the microphone should be muted when joining a channel or a call.
     ///
-    /// Default: false
+    /// Default: true
     pub mute_on_join: Option<bool>,
 
     /// Whether your current project should be shared when joining an empty channel.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2394,8 +2394,8 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 
 ```json
 "calls": {
-  // Join calls with the microphone live by default
-  "mute_on_join": false,
+  // Join calls with the microphone initially muted
+  "mute_on_join": true,
   // Share your project when you are the first to join a channel
   "share_on_join": false
 },


### PR DESCRIPTION
The microphone is live by default when joining channels or calls. It was muted by default when the corresponding setting was introduced in #2754, but changed in #3093 to be live by default. This PR reverts to the original approach.

Closes #21882.

Release Notes:

- Improved: microphone is now muted by default when joining a channel or call.
