### PR TITLE
Remove required environment textbox for feature request issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/0_feature_request.yml
@@ -16,13 +16,6 @@ body:
     validations:
       required: true
   - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      description: Run the `copy system specs into clipboard` command palette action and paste the output in the field below. If you are unable to run the command, please include your Zed version and release channel, operating system and version, RAM amount, and architecture.
-    validations:
-      required: true
-  - type: textarea
     attributes:
       label: |
         If applicable, add mockups / screenshots to help present your vision of the feature


### PR DESCRIPTION
It doesn't seem necessary to require environment specs when requesting an issue, only for a bug report it is needed I think.

Release Notes:

- N/A