### PR TITLE
Fix panic in linked editing ranges

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5294,7 +5294,8 @@ impl Editor {
                         if end_point == start_point {
                             let offset = text::ToOffset::to_offset(&range.start, &snapshot)
                                 .saturating_sub(1);
-                            start_point = TP::to_point(&offset, &snapshot);
+                            start_point =
+                                snapshot.clip_point(TP::to_point(&offset, &snapshot), Bias::Left);
                         };
 
                         (start_point..end_point, empty_str.clone())


### PR DESCRIPTION
We were committing the cardinal sin of subtracting one from a column
without clipping

Closes #ISSUE

Release Notes:

- Fixed a panic in linked editing ranges
