### PR TITLE
editor: Add "selection" key context

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1404,6 +1404,15 @@ impl Editor {
             key_context.add("inline_completion");
         }
 
+        if !self
+            .selections
+            .disjoint
+            .iter()
+            .all(|selection| selection.start == selection.end)
+        {
+            key_context.add("selection");
+        }
+
         key_context
     }
 


### PR DESCRIPTION
This change allows defining keybindings that are active when there is a text selection.

This is especially useful, as an example, for Emacs-like keybindings where movement keybindings expand the selection.

Here is a snippet from my keymap.json that implements Emacs movements when selection is active:

```json
{
    "context": "Editor && selection",
    "bindings": {
      "ctrl-f": "editor::SelectRight",
      "ctrl-b": "editor::SelectLeft",
      "ctrl-n": "editor::SelectDown",
      "ctrl-p": "editor::SelectUp",
      "ctrl-a": "editor::SelectToBeginningOfLine",
      "ctrl-e": "editor::SelectToEndOfLine",
      "alt-f": "editor::SelectToNextWordEnd",
      "alt-b": "editor::SelectToPreviousWordStart",
      "alt-<": "editor::SelectToBeginning",
      "alt->": "editor::SelectToEnd"
    }
  }
  ```

What do you think about inclusion of this feature? Should I add more granular `selection=single` `selection=multi`? 

Release Notes:

- Added "selection" context for keybindings that are active when there is a text selection.