### PR TITLE
More Git panel refinements

### DIFF
--- a/crates/git_ui/TODO.md
+++ b/crates/git_ui/TODO.md
@@ -1,0 +1,15 @@
+- [x] Disable staging and committing actions for read-only projects
+- [ ] List
+  - [ ] Git status item
+  - [ ] Directory item
+- [ ] Scrollbar (for list)
+- [ ] Context menu for list items
+  - [ ] Discard Changes
+  - ---
+  - [ ] Ignore
+  - [ ] Ignore directory
+  - ---
+  - [ ] Copy path
+  - [ ] Copy relative path
+  - ---
+  - [ ] Reveal in Finder

--- a/crates/git_ui/TODO.md
+++ b/crates/git_ui/TODO.md
@@ -1,9 +1,18 @@
+### General
+
 - [x] Disable staging and committing actions for read-only projects
-- [ ] List
-  - [ ] Git status item
-  - [ ] Directory item
-- [ ] Scrollbar (for list)
-- [ ] Context menu for list items
+
+### List
+
+- [ ] Git status item
+- [ ] Directory item
+- [ ] Scrollbar
+- [ ] Add indent size setting
+- [ ] Add tree settings
+
+### List Items
+
+- [ ] Context menu
   - [ ] Discard Changes
   - ---
   - [ ] Ignore
@@ -13,3 +22,21 @@
   - [ ] Copy relative path
   - ---
   - [ ] Reveal in Finder
+
+### Commit Editor
+
+- [ ] Add commit editor
+- [ ] Add commit message placeholder & add commit message to store
+- [ ] Add a way to get the current collaborators & automatically add them to the commit message as co-authors
+- [ ] Add action to clear commit message
+- [x] Swap commit button between "Commit" and "Commit All" based on modifier key
+
+### Component Updates
+
+- [ ] ChangedLineCount (new)
+  - takes `lines_added: usize, lines_removed: usize`, returns a added/removed badge
+- [ ] GitStatusIcon (new)
+- [ ] Checkbox
+  - update checkbox design
+- [ ] ScrollIndicator
+  - shows a gradient overlay when more content is available to be scrolled

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -41,7 +41,6 @@ pub struct GitPanel {
     project: Model<Project>,
     width: Option<Pixels>,
 
-    init_modifiers: Option<Modifiers>,
     current_modifiers: Modifiers,
 }
 
@@ -68,7 +67,6 @@ impl GitPanel {
             fs,
             pending_serialization: Task::ready(None),
             project,
-            init_modifiers: cx.modifiers().modified().then_some(cx.modifiers()),
 
             current_modifiers: cx.modifiers(),
 
@@ -141,11 +139,6 @@ impl GitPanel {
     fn all_staged(&self) -> bool {
         // todo!(): Implement all_staged
         true
-    }
-
-    fn all_unstaged(&self) -> bool {
-        // todo!(): Implement all_unstaged
-        false
     }
 }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3,14 +3,17 @@ use util::TryFutureExt;
 
 use db::kvp::KEY_VALUE_STORE;
 use gpui::*;
-use project::Fs;
+use project::{Fs, Project};
 use serde::{Deserialize, Serialize};
 use settings::Settings as _;
-use ui::{prelude::*, Checkbox, Divider, DividerColor, ElevationIndex};
+use ui::{prelude::*, Checkbox, Divider, DividerColor, ElevationIndex, Tooltip};
 use workspace::dock::{DockPosition, Panel, PanelEvent};
 use workspace::Workspace;
 
 use crate::settings::GitPanelSettings;
+use crate::{CommitAllChanges, CommitMode, CommitStagedChanges, DiscardAll, StageAll, UnstageAll};
+
+actions!(git_panel, [ToggleFocus]);
 
 const GIT_PANEL_KEY: &str = "GitPanel";
 
@@ -30,13 +33,12 @@ struct SerializedGitPanel {
     width: Option<Pixels>,
 }
 
-actions!(git_panel, [Deploy, ToggleFocus]);
-
 pub struct GitPanel {
     _workspace: WeakView<Workspace>,
-    pending_serialization: Task<Option<()>>,
-    fs: Arc<dyn Fs>,
     focus_handle: FocusHandle,
+    fs: Arc<dyn Fs>,
+    pending_serialization: Task<Option<()>>,
+    project: Model<Project>,
     width: Option<Pixels>,
 }
 
@@ -53,14 +55,16 @@ impl GitPanel {
     }
 
     pub fn new(workspace: &mut Workspace, cx: &mut ViewContext<Workspace>) -> View<Self> {
+        let project = workspace.project().clone();
         let fs = workspace.app_state().fs.clone();
         let weak_workspace = workspace.weak_handle();
 
         cx.new_view(|cx| Self {
-            fs,
             _workspace: weak_workspace,
-            pending_serialization: Task::ready(None),
             focus_handle: cx.focus_handle(),
+            fs,
+            pending_serialization: Task::ready(None),
+            project,
             width: Some(px(360.)),
         })
     }
@@ -81,7 +85,80 @@ impl GitPanel {
         );
     }
 
+    fn dispatch_context(&self) -> KeyContext {
+        let mut dispatch_context = KeyContext::new_with_defaults();
+        dispatch_context.add("GitPanel");
+        dispatch_context.add("menu");
+
+        dispatch_context
+    }
+}
+
+impl GitPanel {
+    fn stage_all(&mut self, _: &StageAll, _cx: &mut ViewContext<Self>) {
+        // todo!(): Implement stage all
+        println!("Stage all triggered");
+    }
+
+    fn unstage_all(&mut self, _: &UnstageAll, _cx: &mut ViewContext<Self>) {
+        // todo!(): Implement unstage all
+        println!("Unstage all triggered");
+    }
+
+    fn discard_all(&mut self, _: &DiscardAll, _cx: &mut ViewContext<Self>) {
+        // todo!(): Implement discard all
+        println!("Discard all triggered");
+    }
+
+    /// Commit all staged changes
+    fn commit_staged_changes(&mut self, _: &CommitStagedChanges, _cx: &mut ViewContext<Self>) {
+        // todo!(): Implement commit all staged
+        println!("Commit staged changes triggered");
+    }
+
+    /// Commit all changes, regardless of whether they are staged or not
+    fn commit_all_changes(&mut self, _: &CommitAllChanges, _cx: &mut ViewContext<Self>) {
+        // todo!(): Implement commit all changes
+        println!("Commit all changes triggered");
+    }
+
+    fn all_staged(&self) -> bool {
+        // todo!(): Implement all_staged
+        true
+    }
+
+    fn all_unstaged(&self) -> bool {
+        // todo!(): Implement all_unstaged
+        false
+    }
+}
+
+impl GitPanel {
+    pub fn panel_button(
+        &self,
+        id: impl Into<SharedString>,
+        label: impl Into<SharedString>,
+    ) -> Button {
+        let id = id.into().clone();
+        let label = label.into().clone();
+
+        Button::new(id, label)
+            .label_size(LabelSize::Small)
+            .layer(ElevationIndex::ElevatedSurface)
+            .size(ButtonSize::Compact)
+            .style(ButtonStyle::Filled)
+    }
+
+    pub fn render_divider(&self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+        h_flex()
+            .items_center()
+            .h(px(8.))
+            .child(Divider::horizontal_dashed().color(DividerColor::Border))
+    }
+
     pub fn render_panel_header(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let focus_handle = self.focus_handle(cx).clone();
+
         h_flex()
             .h(px(32.))
             .items_center()
@@ -99,17 +176,28 @@ impl GitPanel {
                     .gap_2()
                     .child(
                         IconButton::new("discard-changes", IconName::Undo)
+                            .tooltip(move |cx| {
+                                let focus_handle = focus_handle.clone();
+
+                                Tooltip::for_action_in(
+                                    "Discard all changes",
+                                    &DiscardAll,
+                                    &focus_handle,
+                                    cx,
+                                )
+                            })
                             .icon_size(IconSize::Small)
                             .disabled(true),
                     )
-                    .child(
-                        Button::new("stage-all", "Stage All")
-                            .label_size(LabelSize::Small)
-                            .layer(ElevationIndex::ElevatedSurface)
-                            .size(ButtonSize::Compact)
-                            .style(ButtonStyle::Filled)
-                            .disabled(true),
-                    ),
+                    .child(if self.all_staged() {
+                        self.panel_button("unstage-all", "Unstage All").on_click(
+                            cx.listener(move |_, _, cx| cx.dispatch_action(Box::new(DiscardAll))),
+                        )
+                    } else {
+                        self.panel_button("stage-all", "Stage All").on_click(
+                            cx.listener(move |_, _, cx| cx.dispatch_action(Box::new(StageAll))),
+                        )
+                    }),
             )
     }
 
@@ -128,12 +216,10 @@ impl GitPanel {
                 .child(div().flex_grow())
                 .child(
                     h_flex().child(div().gap_1().flex_grow()).child(
-                        Button::new("commit", "Commit")
-                            .label_size(LabelSize::Small)
-                            .layer(ElevationIndex::ElevatedSurface)
-                            .size(ButtonSize::Compact)
-                            .style(ButtonStyle::Filled)
-                            .disabled(true),
+                        self.panel_button("commit-staged-changes", "Commit Staged Changes")
+                            .on_click(cx.listener(|this, _: &ClickEvent, cx| {
+                                this.commit_staged_changes(&CommitStagedChanges, cx)
+                            })),
                     ),
                 )
                 .cursor(CursorStyle::OperationNotAllowed)
@@ -160,29 +246,37 @@ impl GitPanel {
 
 impl Render for GitPanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let project = self.project.read(cx);
+        let mut commit_mode = CommitMode::Staged;
+
         v_flex()
-            .key_context("GitPanel")
-            .font_buffer(cx)
-            .py_1()
             .id("git_panel")
+            .key_context(self.dispatch_context())
             .track_focus(&self.focus_handle)
+            .when(!project.is_read_only(cx), |this| {
+                this.on_action(cx.listener(|this, &StageAll, cx| this.stage_all(&StageAll, cx)))
+                    .on_action(
+                        cx.listener(|this, &UnstageAll, cx| this.unstage_all(&UnstageAll, cx)),
+                    )
+                    .on_action(
+                        cx.listener(|this, &DiscardAll, cx| this.discard_all(&DiscardAll, cx)),
+                    )
+                    .on_action(cx.listener(|this, &CommitStagedChanges, cx| {
+                        this.commit_staged_changes(&CommitStagedChanges, cx)
+                    }))
+                    .on_action(cx.listener(|this, &CommitAllChanges, cx| {
+                        this.commit_all_changes(&CommitAllChanges, cx)
+                    }))
+            })
             .size_full()
             .overflow_hidden()
+            .font_buffer(cx)
+            .py_1()
             .bg(ElevationIndex::Surface.bg(cx))
             .child(self.render_panel_header(cx))
-            .child(
-                h_flex()
-                    .items_center()
-                    .h(px(8.))
-                    .child(Divider::horizontal_dashed().color(DividerColor::Border)),
-            )
+            .child(self.render_divider(cx))
             .child(self.render_empty_state(cx))
-            .child(
-                h_flex()
-                    .items_center()
-                    .h(px(8.))
-                    .child(Divider::horizontal_dashed().color(DividerColor::Border)),
-            )
+            .child(self.render_divider(cx))
             .child(self.render_commit_editor(cx))
     }
 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -119,11 +119,13 @@ impl GitPanel {
                 .h_full()
                 .py_2p5()
                 .px_3()
+                .gap_3()
                 .bg(cx.theme().colors().editor_background)
                 .font_buffer(cx)
                 .text_ui_sm(cx)
                 .text_color(cx.theme().colors().text_muted)
                 .child("Add a message")
+                .child("Staff-only alpha. Expect non-functioal elements.")
                 .gap_1()
                 .child(div().flex_grow())
                 .child(

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -119,13 +119,11 @@ impl GitPanel {
                 .h_full()
                 .py_2p5()
                 .px_3()
-                .gap_3()
                 .bg(cx.theme().colors().editor_background)
                 .font_buffer(cx)
                 .text_ui_sm(cx)
                 .text_color(cx.theme().colors().text_muted)
                 .child("Add a message")
-                .child("Staff-only alpha. Expect non-functioal elements.")
                 .gap_1()
                 .child(div().flex_grow())
                 .child(

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -19,13 +19,3 @@ actions!(
 pub fn init(cx: &mut AppContext) {
     GitPanelSettings::register(cx);
 }
-
-/// What changes should be committed.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CommitMode {
-    /// Commit all changes, regardless of their staging status.
-    All,
-    /// Commit only staged changes.
-    #[default]
-    Staged,
-}

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -1,10 +1,31 @@
 use ::settings::Settings;
-use gpui::AppContext;
+use gpui::{actions, AppContext};
 use settings::GitPanelSettings;
 
 pub mod git_panel;
 mod settings;
 
+actions!(
+    git_ui,
+    [
+        StageAll,
+        UnstageAll,
+        DiscardAll,
+        CommitStagedChanges,
+        CommitAllChanges
+    ]
+);
+
 pub fn init(cx: &mut AppContext) {
     GitPanelSettings::register(cx);
+}
+
+/// What changes should be committed.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CommitMode {
+    /// Commit all changes, regardless of their staging status.
+    All,
+    /// Commit only staged changes.
+    #[default]
+    Staged,
 }


### PR DESCRIPTION
- Add and wire through git method stubs
- Organize render methods
- Track modifier changes
- Swap commit buttons when `option`/`alt` is held
- More TODOs

Release Notes:

- N/A