### PR TITLE
language_model_selector: Don't recreate the `Picker` view each render

### DIFF
--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -20,7 +20,7 @@ use language::Buffer;
 use language_model::{
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
-use language_model_selector::LanguageModelSelector;
+use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use language_models::report_assistant_event;
 use settings::{update_settings_file, Settings};
 use std::{
@@ -476,9 +476,9 @@ enum PromptEditorEvent {
 
 struct PromptEditor {
     id: TerminalInlineAssistId,
-    fs: Arc<dyn Fs>,
     height_in_lines: u8,
     editor: View<Editor>,
+    language_model_selector: View<LanguageModelSelector>,
     edited_since_done: bool,
     prompt_history: VecDeque<String>,
     prompt_history_ix: Option<usize>,
@@ -614,17 +614,8 @@ impl Render for PromptEditor {
                     .w_12()
                     .justify_center()
                     .gap_2()
-                    .child(LanguageModelSelector::new(
-                        {
-                            let fs = self.fs.clone();
-                            move |model, cx| {
-                                update_settings_file::<AssistantSettings>(
-                                    fs.clone(),
-                                    cx,
-                                    move |settings, _| settings.set_model(model.clone()),
-                                );
-                            }
-                        },
+                    .child(LanguageModelSelectorPopoverMenu::new(
+                        self.language_model_selector.clone(),
                         IconButton::new("context", IconName::SettingsAlt)
                             .shape(IconButtonShape::Square)
                             .icon_size(IconSize::Small)
@@ -718,6 +709,19 @@ impl PromptEditor {
             id,
             height_in_lines: 1,
             editor: prompt_editor,
+            language_model_selector: cx.new_view(|cx| {
+                let fs = fs.clone();
+                LanguageModelSelector::new(
+                    move |model, cx| {
+                        update_settings_file::<AssistantSettings>(
+                            fs.clone(),
+                            cx,
+                            move |settings, _| settings.set_model(model.clone()),
+                        );
+                    },
+                    cx,
+                )
+            }),
             edited_since_done: false,
             prompt_history,
             prompt_history_ix: None,
@@ -725,7 +729,6 @@ impl PromptEditor {
             _codegen_subscription: cx.observe(&codegen, Self::handle_codegen_changed),
             editor_subscriptions: Vec::new(),
             codegen,
-            fs,
             pending_token_count: Task::ready(Ok(())),
             token_count: None,
             _token_count_subscriptions: token_count_subscriptions,

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -31,7 +31,7 @@ use language_model::{
     LanguageModel, LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage,
     LanguageModelTextStream, Role,
 };
-use language_model_selector::LanguageModelSelector;
+use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use language_models::report_assistant_event;
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
@@ -1454,8 +1454,8 @@ enum PromptEditorEvent {
 
 struct PromptEditor {
     id: InlineAssistId,
-    fs: Arc<dyn Fs>,
     editor: View<Editor>,
+    language_model_selector: View<LanguageModelSelector>,
     edited_since_done: bool,
     gutter_dimensions: Arc<Mutex<GutterDimensions>>,
     prompt_history: VecDeque<String>,
@@ -1589,43 +1589,27 @@ impl Render for PromptEditor {
                     .w(gutter_dimensions.full_width() + (gutter_dimensions.margin / 2.0))
                     .justify_center()
                     .gap_2()
-                    .child(
-                        LanguageModelSelector::new(
-                            {
-                                let fs = self.fs.clone();
-                                move |model, cx| {
-                                    update_settings_file::<AssistantSettings>(
-                                        fs.clone(),
-                                        cx,
-                                        move |settings, _| settings.set_model(model.clone()),
-                                    );
-                                }
-                            },
-                            IconButton::new("context", IconName::SettingsAlt)
-                                .shape(IconButtonShape::Square)
-                                .icon_size(IconSize::Small)
-                                .icon_color(Color::Muted)
-                                .tooltip(move |cx| {
-                                    Tooltip::with_meta(
-                                        format!(
-                                            "Using {}",
-                                            LanguageModelRegistry::read_global(cx)
-                                                .active_model()
-                                                .map(|model| model.name().0)
-                                                .unwrap_or_else(|| "No model selected".into()),
-                                        ),
-                                        None,
-                                        "Change Model",
-                                        cx,
-                                    )
-                                }),
-                        )
-                        .info_text(
-                            "Inline edits use context\n\
-                            from the currently selected\n\
-                            assistant panel tab.",
-                        ),
-                    )
+                    .child(LanguageModelSelectorPopoverMenu::new(
+                        self.language_model_selector.clone(),
+                        IconButton::new("context", IconName::SettingsAlt)
+                            .shape(IconButtonShape::Square)
+                            .icon_size(IconSize::Small)
+                            .icon_color(Color::Muted)
+                            .tooltip(move |cx| {
+                                Tooltip::with_meta(
+                                    format!(
+                                        "Using {}",
+                                        LanguageModelRegistry::read_global(cx)
+                                            .active_model()
+                                            .map(|model| model.name().0)
+                                            .unwrap_or_else(|| "No model selected".into()),
+                                    ),
+                                    None,
+                                    "Change Model",
+                                    cx,
+                                )
+                            }),
+                    ))
                     .map(|el| {
                         let CodegenStatus::Error(error) = self.codegen.read(cx).status(cx) else {
                             return el;
@@ -1714,6 +1698,19 @@ impl PromptEditor {
         let mut this = Self {
             id,
             editor: prompt_editor,
+            language_model_selector: cx.new_view(|cx| {
+                let fs = fs.clone();
+                LanguageModelSelector::new(
+                    move |model, cx| {
+                        update_settings_file::<AssistantSettings>(
+                            fs.clone(),
+                            cx,
+                            move |settings, _| settings.set_model(model.clone()),
+                        );
+                    },
+                    cx,
+                )
+            }),
             edited_since_done: false,
             gutter_dimensions,
             prompt_history,
@@ -1722,7 +1719,6 @@ impl PromptEditor {
             _codegen_subscription: cx.observe(&codegen, Self::handle_codegen_changed),
             editor_subscriptions: Vec::new(),
             codegen,
-            fs,
             show_rate_limit_notice: false,
         };
         this.subscribe_to_editor(cx);

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use editor::{Editor, EditorElement, EditorStyle};
 use gpui::{AppContext, FocusableView, Model, TextStyle, View, WeakView};
 use language_model::{LanguageModelRegistry, LanguageModelRequestTool};
-use language_model_selector::LanguageModelSelector;
+use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use settings::Settings;
 use theme::ThemeSettings;
 use ui::{
@@ -25,6 +25,7 @@ pub struct MessageEditor {
     next_context_id: ContextId,
     context_picker: View<ContextPicker>,
     pub(crate) context_picker_handle: PopoverMenuHandle<ContextPicker>,
+    language_model_selector: View<LanguageModelSelector>,
     use_tools: bool,
 }
 
@@ -47,6 +48,14 @@ impl MessageEditor {
             next_context_id: ContextId(0),
             context_picker: cx.new_view(|cx| ContextPicker::new(workspace.clone(), weak_self, cx)),
             context_picker_handle: PopoverMenuHandle::default(),
+            language_model_selector: cx.new_view(|cx| {
+                LanguageModelSelector::new(
+                    |model, _cx| {
+                        println!("Selected {:?}", model.name());
+                    },
+                    cx,
+                )
+            }),
             use_tools: false,
         }
     }
@@ -120,10 +129,8 @@ impl MessageEditor {
         let active_provider = LanguageModelRegistry::read_global(cx).active_provider();
         let active_model = LanguageModelRegistry::read_global(cx).active_model();
 
-        LanguageModelSelector::new(
-            |model, _cx| {
-                println!("Selected {:?}", model.name());
-            },
+        LanguageModelSelectorPopoverMenu::new(
+            self.language_model_selector.clone(),
             ButtonLike::new("active-model")
                 .style(ButtonStyle::Subtle)
                 .child(

--- a/crates/assistant2/src/terminal_inline_assistant.rs
+++ b/crates/assistant2/src/terminal_inline_assistant.rs
@@ -17,7 +17,7 @@ use language::Buffer;
 use language_model::{
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
-use language_model_selector::LanguageModelSelector;
+use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use language_models::report_assistant_event;
 use settings::{update_settings_file, Settings};
 use std::{cmp, sync::Arc, time::Instant};
@@ -439,9 +439,9 @@ enum PromptEditorEvent {
 
 struct PromptEditor {
     id: TerminalInlineAssistId,
-    fs: Arc<dyn Fs>,
     height_in_lines: u8,
     editor: View<Editor>,
+    language_model_selector: View<LanguageModelSelector>,
     edited_since_done: bool,
     prompt_history: VecDeque<String>,
     prompt_history_ix: Option<usize>,
@@ -575,17 +575,8 @@ impl Render for PromptEditor {
                     .w_12()
                     .justify_center()
                     .gap_2()
-                    .child(LanguageModelSelector::new(
-                        {
-                            let fs = self.fs.clone();
-                            move |model, cx| {
-                                update_settings_file::<AssistantSettings>(
-                                    fs.clone(),
-                                    cx,
-                                    move |settings, _| settings.set_model(model.clone()),
-                                );
-                            }
-                        },
+                    .child(LanguageModelSelectorPopoverMenu::new(
+                        self.language_model_selector.clone(),
                         IconButton::new("context", IconName::SettingsAlt)
                             .shape(IconButtonShape::Square)
                             .icon_size(IconSize::Small)
@@ -665,6 +656,19 @@ impl PromptEditor {
             id,
             height_in_lines: 1,
             editor: prompt_editor,
+            language_model_selector: cx.new_view(|cx| {
+                let fs = fs.clone();
+                LanguageModelSelector::new(
+                    move |model, cx| {
+                        update_settings_file::<AssistantSettings>(
+                            fs.clone(),
+                            cx,
+                            move |settings, _| settings.set_model(model.clone()),
+                        );
+                    },
+                    cx,
+                )
+            }),
             edited_since_done: false,
             prompt_history,
             prompt_history_ix: None,
@@ -672,7 +676,6 @@ impl PromptEditor {
             _codegen_subscription: cx.observe(&codegen, Self::handle_codegen_changed),
             editor_subscriptions: Vec::new(),
             codegen,
-            fs,
         };
         this.count_lines(cx);
         this.subscribe_to_editor(cx);


### PR DESCRIPTION
While working on Assistant2, I noticed that the `LanguageModelSelector` was recreating its `Picker` view on every single render.

This PR makes it so we create the view once and hold onto it in the parent view.

Release Notes:

- N/A
