### PR TITLE
Only debounce the cursor position in multibuffer excerpts

### DIFF
--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -48,8 +48,17 @@ impl CursorPosition {
     ) {
         let editor = editor.downgrade();
         self.update_position = cx.spawn(|cursor_position, mut cx| async move {
-            if let Some(debounce) = debounce {
-                cx.background_executor().timer(debounce).await;
+            let is_singleton = editor
+                .update(&mut cx, |editor, cx| {
+                    editor.buffer().read(cx).is_singleton()
+                })
+                .ok()
+                .unwrap_or(true);
+
+            if !is_singleton {
+                if let Some(debounce) = debounce {
+                    cx.background_executor().timer(debounce).await;
+                }
             }
 
             editor


### PR DESCRIPTION
Follow up to: https://github.com/zed-industries/zed/pull/20211

Release Notes:

- Improved the performance of the cursor position indicator in single buffers
