### PR TITLE
Fix project and buffer search input width

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -209,6 +209,7 @@ impl Render for BufferSearchBar {
 
         let input_base_styles = || {
             h_flex()
+                .min_w_32()
                 .w(input_width)
                 .h_8()
                 .px_2()

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1595,6 +1595,7 @@ impl Render for ProjectSearchBar {
 
         let input_base_styles = || {
             h_flex()
+                .min_w_32()
                 .w(input_width)
                 .h_8()
                 .px_2()


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21922

Now, both the project and buffer search inputs have a min-width set so that text inside it, as well as the additional controls, are always visible even at the window's smallest possible size, which looks like this:

<img width="407" alt="Screenshot 2024-12-13 at 00 35 46" src="https://github.com/user-attachments/assets/e6e2c4c6-4f75-4663-8c65-590e02141a5d" />


Release Notes:

- N/A
