### PR TITLE
Randomized test of project diff view

### DIFF
--- a/crates/editor/src/git/project_diff.rs
+++ b/crates/editor/src/git/project_diff.rs
@@ -1353,7 +1353,7 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(hunks.len(), edit_hunks.len());
             for edit_hunk in edit_hunks {
-                assert!(hunks.iter().find(|hunk| hunk == &&edit_hunk).is_some());
+                assert!(hunks.iter().any(|hunk| hunk == &edit_hunk));
             }
 
             let mut hunks = hunks.into_iter().peekable();

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -9,7 +9,7 @@ use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptRange, MultiBuffer, MultiBufferDiffHunk, MultiBufferRow,
     MultiBufferSnapshot, ToOffset, ToPoint,
 };
-use project::{buffer_store::BufferChangeSet, Project};
+use project::buffer_store::BufferChangeSet;
 use std::{ops::Range, sync::Arc};
 use sum_tree::TreeMap;
 use text::OffsetRangeExt;
@@ -80,10 +80,10 @@ impl DiffMap {
         self.snapshot.clone()
     }
 
-    #[cfg(any(test, feature = "test-support"))]
+    #[cfg(test)]
     pub fn add_change_set_with_project(
         &mut self,
-        project: Model<Project>,
+        project: Model<project::Project>,
         change_set: Model<BufferChangeSet>,
         cx: &mut ViewContext<Editor>,
     ) {

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -20,6 +20,7 @@ use crate::{
     ProjectEnvironment,
 };
 
+#[expect(clippy::large_enum_variant)]
 pub enum TaskStore {
     Functional(StoreState),
     Noop,

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -20,7 +20,6 @@ use crate::{
     ProjectEnvironment,
 };
 
-#[expect(clippy::large_enum_variant)]
 pub enum TaskStore {
     Functional(StoreState),
     Noop,


### PR DESCRIPTION
Tests multiple files, editing, staging, and reverting (entire files not individual chunks). This currently fails with seed 1 due to what seems to be an actual bug in the project diff view; I can reproduce it using a file with staged text

<details>

```
JNCAOcDkp90Tx
Qq4SAJMRgUb
Mx
z4VXNGsOlvMYnswb3Hm
E3Pw9N7J
qMP6rikqmp
ltEfXbiFALOp1
hDZnR6E0
lvkb
```

</details>

and current text

<details>

```
JNCAOcDkp90Tx
Qq4SAJMRgUb
Mx
z4VXNGsOlvMYnswb3Hm
j
7qfJFCV
M
vxqT9HhGG4
thi
E3Pw9N7J
qMP6rikqmp
ltEfXbiFALOp1
hDZnR6E0
```

</details>

There are two diff hunks but no excerpts appear in the project diff view.

This PR also contains a couple of fixes that came up while developing the test:

- `MultiBufferSnapshot::excerpts_for_range` now works with empty ranges (based on the start point) and in situations where there is only a single excerpt
- `BufferDiff::build` should now return an empty range with the insertion point as start/end for `diff_base_byte_range` of pure addition hunks, instead of `0..0` as previously; this probably doesn't affect anything but I had to fix it to be able to use `Patch::compose` in my test. Due to git2 limitations I ended up refactoring the diff code to use a `Rope` in more places for the diff base, in order to have `Rope::point_to_offset` available inside `BufferDiff::process_patch_hunk`

Release Notes:

- N/A