### PR TITLE
assistant2: Refine context pickers

### DIFF
--- a/crates/assistant2/src/context_picker/fetch_context_picker.rs
+++ b/crates/assistant2/src/context_picker/fetch_context_picker.rs
@@ -8,7 +8,7 @@ use gpui::{AppContext, DismissEvent, FocusHandle, FocusableView, Task, View, Wea
 use html_to_markdown::{convert_html_to_markdown, markdown, TagHandler};
 use http_client::{AsyncBody, HttpClientWithUrl};
 use picker::{Picker, PickerDelegate};
-use ui::{prelude::*, ListItem, ListItemSpacing, ViewContext};
+use ui::{prelude::*, ListItem, ViewContext};
 use workspace::Workspace;
 
 use crate::context::ContextKind;
@@ -150,7 +150,15 @@ impl PickerDelegate for FetchContextPickerDelegate {
     type ListItem = ListItem;
 
     fn match_count(&self) -> usize {
-        1
+        if self.url.is_empty() {
+            0
+        } else {
+            1
+        }
+    }
+
+    fn no_matches_text(&self, _cx: &mut WindowContext) -> SharedString {
+        "Enter the URL that you would like to fetch".into()
     }
 
     fn selected_index(&self) -> usize {
@@ -210,9 +218,8 @@ impl PickerDelegate for FetchContextPickerDelegate {
         Some(
             ListItem::new(ix)
                 .inset(true)
-                .spacing(ListItemSpacing::Sparse)
                 .toggle_state(selected)
-                .child(self.url.clone()),
+                .child(Label::new(self.url.clone())),
         )
     }
 }

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -8,7 +8,7 @@ use fuzzy::PathMatch;
 use gpui::{AppContext, DismissEvent, FocusHandle, FocusableView, Task, View, WeakView};
 use picker::{Picker, PickerDelegate};
 use project::{PathMatchCandidateSet, WorktreeId};
-use ui::{prelude::*, ListItem, ListItemSpacing};
+use ui::{prelude::*, ListItem};
 use util::ResultExt as _;
 use workspace::Workspace;
 
@@ -254,14 +254,29 @@ impl PickerDelegate for FileContextPickerDelegate {
         selected: bool,
         _cx: &mut ViewContext<Picker<Self>>,
     ) -> Option<Self::ListItem> {
-        let mat = &self.matches[ix];
+        let path_match = &self.matches[ix];
+        let file_name = path_match
+            .path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let directory = path_match
+            .path
+            .parent()
+            .map(|directory| format!("{}/", directory.to_string_lossy()));
 
         Some(
-            ListItem::new(ix)
-                .inset(true)
-                .spacing(ListItemSpacing::Sparse)
-                .toggle_state(selected)
-                .child(mat.path.to_string_lossy().to_string()),
+            ListItem::new(ix).inset(true).toggle_state(selected).child(
+                h_flex()
+                    .gap_2()
+                    .child(Label::new(file_name))
+                    .children(directory.map(|directory| {
+                        Label::new(directory)
+                            .size(LabelSize::Small)
+                            .color(Color::Muted)
+                    })),
+            ),
         )
     }
 }


### PR DESCRIPTION
This PR adds some visual refinements to the context pickers in Assistant2.

<img width="1159" alt="Screenshot 2024-12-13 at 5 11 24 PM" src="https://github.com/user-attachments/assets/f85ce87f-6800-4fc2-8a10-8ec3232d30e9" />

<img width="1159" alt="Screenshot 2024-12-13 at 5 11 31 PM" src="https://github.com/user-attachments/assets/9b13c76d-cb7c-4441-a855-1ec4de685e0c" />

Release Notes:

- N/A
