### PR TITLE
Fix cursor overlap

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6558,7 +6558,10 @@ impl CursorLayout {
             let name_origin = if cursor_name.is_top_row {
                 point(bounds.right() - px(1.), bounds.top())
             } else {
-                point(bounds.left(), bounds.top() - text_size / 2. - px(1.))
+                point(
+                    bounds.right() - px(1.),
+                    bounds.top() - text_size / 2. - px(1.),
+                )
             };
             let mut name_element = div()
                 .bg(self.color)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6558,10 +6558,16 @@ impl CursorLayout {
             let name_origin = if cursor_name.is_top_row {
                 point(bounds.right() - px(1.), bounds.top())
             } else {
-                point(
-                    bounds.right() - px(1.),
-                    bounds.top() - text_size / 2. - px(1.),
-                )
+                match self.shape {
+                    CursorShape::Bar => point(
+                        bounds.right() - px(2.),
+                        bounds.top() - text_size / 2. - px(1.),
+                    ),
+                    _ => point(
+                        bounds.right() - px(1.),
+                        bounds.top() - text_size / 2. - px(1.),
+                    ),
+                }
             };
             let mut name_element = div()
                 .bg(self.color)


### PR DESCRIPTION
When the cursor has a block shape and is not on the first line, its name popup exhibits an overlap:
<img width="171" alt="Screenshot 2024-12-13 at 18 00 54" src="https://github.com/user-attachments/assets/1dc2ef93-020b-45c4-9fc6-db7d97f65c62" />

This occurs because the popup's horizontal alignment is set differently when the cursor [is](https://github.com/zed-industries/zed/blob/fff12ec1e5278e1825d912241f62179387ac8176/crates/editor/src/element.rs#L6383) or [isn't](https://github.com/zed-industries/zed/blob/fff12ec1e5278e1825d912241f62179387ac8176/crates/editor/src/element.rs#L6385) on the first line.

This PR makes the horizontal alignment the same in both cases, which removes the overlap:
<img width="176" alt="Screenshot 2024-12-13 at 17 57 20" src="https://github.com/user-attachments/assets/a3c10ed5-6a1b-4040-9408-92290e9da30b" />

Closes #21887.

Release Notes:

- Fixed an overlap that cuts off user names when a cursor has a block shape.