### PR TITLE
Use warning color for live microphone

### DIFF
--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -381,6 +381,7 @@ impl TitleBar {
                 .style(ButtonStyle::Subtle)
                 .icon_size(IconSize::Small)
                 .toggle_state(is_muted)
+                .style(ButtonStyle::Tinted(TintColor::Warning))
                 .selected_style(ButtonStyle::Tinted(TintColor::Negative))
                 .on_click(move |_, cx| {
                     toggle_mute(&Default::default(), cx);


### PR DESCRIPTION
As noted in #21882, the UI/UX relating to microphone liveness is lacking.

This PR makes a small change that changes the "microphone live" icon to a warning color. This is intended to provide the user some indication of the microphone liveness status.

Release Notes:

- N/A.
