### PR TITLE
Fix permalink-to-line when Git repo root and worktree dir don't coincide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9605,6 +9605,7 @@ dependencies = [
  "tempfile",
  "terminal",
  "text",
+ "toml 0.8.19",
  "unindent",
  "url",
  "util",

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -68,6 +68,7 @@ snippet.workspace = true
 snippet_provider.workspace = true
 terminal.workspace = true
 text.workspace = true
+toml.workspace = true
 util.workspace = true
 url.workspace = true
 which.workspace = true

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1249,7 +1249,7 @@ impl BufferStore {
 
                 let path = match repo_entry.relativize(worktree, file.path()) {
                     Ok(RepoPath(path)) => path,
-                    Err(e) => return Task::ready(Err(e.into())),
+                    Err(e) => return Task::ready(Err(e)),
                 };
 
                 cx.spawn(|cx| async move {

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1231,14 +1231,14 @@ impl BufferStore {
                         .language()
                         .is_some_and(|lang| lang.name() == "Rust".into())
                     {
-                        return Task::ready(Err(anyhow!("No permalink available")));
+                        return Task::ready(Err(anyhow!("no permalink available")));
                     }
                     let file_path = worktree_path.join(file.path());
                     return cx.spawn(|cx| async move {
                         let provider_registry =
                             cx.update(GitHostingProviderRegistry::default_global)?;
                         get_permalink_in_rust_registry_src(provider_registry, file_path, selection)
-                            .map_err(|_| anyhow!("No permalink available"))
+                            .map_err(|_| anyhow!("no permalink available"))
                     });
                 };
 
@@ -1262,20 +1262,18 @@ impl BufferStore {
                             .ok_or_else(|| anyhow!("failed to parse Git remote URL"))?;
 
                     let dot_git_dir = repo.dot_git_dir();
-                    let git_dir = dot_git_dir
-                        .parent()
-                        .expect("Unexpected bare Git repository");
+                    let git_dir = dot_git_dir.parent().unwrap();
                     let path = if let Ok(segment) = worktree_path.strip_prefix(git_dir) {
                         &segment.join(path)
                     } else if let Ok(segment) = git_dir.strip_prefix(worktree_path) {
                         path.strip_prefix(segment)
-                            .expect("File is not a descendant of Git repo dir")
+                            .expect("file is not a descendant of Git repo dir")
                     } else {
-                        panic!("Worktree dir and Git repo dir are cousins")
+                        panic!("worktree dir and Git repo dir are cousins")
                     };
                     let path = path
                         .to_str()
-                        .context("Failed to convert buffer path to string")?;
+                        .context("failed to convert buffer path to string")?;
 
                     Ok(provider.build_permalink(
                         remote,

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1261,7 +1261,7 @@ impl BufferStore {
                         parse_git_remote_url(provider_registry, &origin_url)
                             .ok_or_else(|| anyhow!("failed to parse Git remote URL"))?;
 
-                    let dot_git_dir = repo.path();
+                    let dot_git_dir = repo.dot_git_dir();
                     let git_dir = dot_git_dir
                         .parent()
                         .expect("Unexpected bare Git repository");

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2396,7 +2396,6 @@ impl Snapshot {
             .map(|(path, entry)| (&path.0, entry))
     }
 
-    /// Get the repository whose work directory contains the given path.
     pub fn repository_for_work_directory(&self, path: &Path) -> Option<RepositoryEntry> {
         self.repository_entries
             .get(&RepositoryWorkDirectory(path.into()))


### PR DESCRIPTION
Closes #21505. This should work if the git dir is an ancestor of the worktree dir or vice versa.

Release Notes:

- Fixed GitHub permalink-to-line actions when worktree dir and Git dir aren't the same