### PR TITLE
Add setting for hover delay

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -101,6 +101,8 @@
   // Whether to show the informational hover box when moving the mouse
   // over symbols in the editor.
   "hover_popover_enabled": true,
+  // Time to wait before showing the informational hover box
+  "hover_popover_delay": 350,
   // Whether to confirm before quitting Zed.
   "confirm_quit": false,
   // Whether to restore last closed project when fresh Zed instance is opened.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -11,6 +11,7 @@ pub struct EditorSettings {
     pub current_line_highlight: CurrentLineHighlight,
     pub lsp_highlight_debounce: u64,
     pub hover_popover_enabled: bool,
+    pub hover_popover_delay: u64,
     pub toolbar: Toolbar,
     pub scrollbar: Scrollbar,
     pub gutter: Gutter,
@@ -196,7 +197,10 @@ pub struct EditorSettingsContent {
     ///
     /// Default: true
     pub hover_popover_enabled: Option<bool>,
-
+    /// Time to wait before showing the informational hover box
+    ///
+    /// Default: 350
+    pub hover_popover_delay: Option<u64>,
     /// Toolbar related settings
     pub toolbar: Option<ToolbarContent>,
     /// Scrollbar related settings


### PR DESCRIPTION
This PR adds a new `hover_popover_delay` setting that allows the user to specify how long to wait before showing informational hover boxes. It defaults to the existing delay.

Release Notes:

- Added a setting to control the delay for informational hover boxes
