### PR TITLE
Fix terminal pane tabs arrangement and closing

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1468,7 +1468,7 @@ impl Pane {
                     // Always propose to save singleton files without any project paths: those cannot be saved via multibuffer, as require a file path selection modal.
                     || cx
                         .update(|cx| {
-                            item_to_close.is_dirty(cx)
+                            item_to_close.can_save(cx) && item_to_close.is_dirty(cx)
                                 && item_to_close.is_singleton(cx)
                                 && item_to_close.project_path(cx).is_none()
                         })

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4025,11 +4025,8 @@ mod tests {
 
         cx.executor().run_until_parked();
         cx.simulate_prompt_answer(2);
-        cx.executor().run_until_parked();
-        cx.simulate_prompt_answer(2);
-        cx.executor().run_until_parked();
         save.await.unwrap();
-        assert_item_labels(&pane, ["A*^", "B^", "C^"], cx);
+        assert_item_labels(&pane, [], cx);
     }
 
     #[gpui::test]


### PR DESCRIPTION
* Fixes the inability to drag and drop terminal tabs to reorder them; fixed incorrect terminal tab move on drag and drop into existing pane (follow-up of https://github.com/zed-industries/zed/pull/21238)
* Fixes save dialogue appearing when on closing terminal tabs with running tasks (follow-up of https://github.com/zed-industries/zed/pull/21374)

Release Notes:

- Fixed terminal pane tabs arrangement and closing
