### PR TITLE
Update collab local development instructions

### DIFF
--- a/crates/collab/README.md
+++ b/crates/collab/README.md
@@ -8,7 +8,12 @@ It contains our back-end logic for collaboration, to which we connect from the Z
 
 ## Database setup
 
-Before you can run the collab server locally, you'll need to set up a zed Postgres database.
+Before you can run the collab server locally, you'll need to set up a zed Postgres database. Follow the steps sequentially:
+
+1. Ensure you have postgres installed. If not, install with `brew install postgresql@15`.
+2. Follow the steps on Brew's formula and verify your `$PATH` contains `/opt/homebrew/opt/postgresql@15/bin`.
+3. If you hadn't done it before, create the `postgres` user with `createuser -s postgres`.
+4. You are now ready to run the `bootstrap` script:
 
 ```sh
 script/bootstrap


### PR DESCRIPTION
When running the collab server locally on a new machine, I found there were some instructions missing for setting up the Postgres database. Namely, the user mentioned on the `.env.toml` is not created by default.

Ref: https://github.com/zed-industries/zed/issues/8260

Release Notes:

- N/A
