### PR TITLE
Use the same label for both string and bag in tasks modal fuzzy match

### DIFF
--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -513,11 +513,7 @@ fn string_match_candidates<'a>(
 ) -> Vec<StringMatchCandidate> {
     candidates
         .enumerate()
-        .map(|(index, (_, candidate))| StringMatchCandidate {
-            id: index,
-            char_bag: candidate.resolved_label.chars().collect(),
-            string: candidate.display_label().into(),
-        })
+        .map(|(index, (_, candidate))| StringMatchCandidate::new(index, candidate.display_label()))
         .collect()
 }
 


### PR DESCRIPTION
#22592 tracks properly doing fuzzy match within the full label

Release Notes:

- N/A