### PR TITLE
Allow folding buffers inside multi buffers

### DIFF
--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -1052,7 +1052,7 @@ fn editor_blocks(
 
                             Block::ExcerptBoundary { kind, .. } => match kind {
                                 ExcerptBoundaryKind::FoldedBufferBoundary => FILE_HEADER.into(),
-                                ExcerptBoundaryKind::UnfoldedBufferBoundary => FILE_HEADER.into(),
+                                ExcerptBoundaryKind::BufferBoundary => FILE_HEADER.into(),
                                 ExcerptBoundaryKind::ExcerptSeparator => EXCERPT_HEADER.into(),
                             },
                         };

--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use collections::HashMap;
 use editor::{
-    display_map::{Block, BlockContext, DisplayRow},
+    display_map::{Block, BlockContext, DisplayRow, ExcerptBoundaryKind},
     DisplayPoint, GutterDimensions,
 };
 use gpui::{px, AvailableSpace, Stateful, TestAppContext, VisualTestContext};
@@ -1050,15 +1050,11 @@ fn editor_blocks(
                                     .ok()?
                             }
 
-                            Block::ExcerptBoundary {
-                                starts_new_buffer, ..
-                            } => {
-                                if *starts_new_buffer {
-                                    FILE_HEADER.into()
-                                } else {
-                                    EXCERPT_HEADER.into()
-                                }
-                            }
+                            Block::ExcerptBoundary { kind, .. } => match kind {
+                                ExcerptBoundaryKind::FoldedBufferBoundary => FILE_HEADER.into(),
+                                ExcerptBoundaryKind::UnfoldedBufferBoundary => FILE_HEADER.into(),
+                                ExcerptBoundaryKind::ExcerptSeparator => EXCERPT_HEADER.into(),
+                            },
                         };
 
                         Some((row, name))

--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use collections::HashMap;
 use editor::{
-    display_map::{Block, BlockContext, DisplayRow, ExcerptBoundaryKind},
+    display_map::{Block, BlockContext, DisplayRow},
     DisplayPoint, GutterDimensions,
 };
 use gpui::{px, AvailableSpace, Stateful, TestAppContext, VisualTestContext};
@@ -1050,11 +1050,16 @@ fn editor_blocks(
                                     .ok()?
                             }
 
-                            Block::ExcerptBoundary { kind, .. } => match kind {
-                                ExcerptBoundaryKind::FoldedBufferBoundary => FILE_HEADER.into(),
-                                ExcerptBoundaryKind::BufferBoundary => FILE_HEADER.into(),
-                                ExcerptBoundaryKind::ExcerptSeparator => EXCERPT_HEADER.into(),
-                            },
+                            Block::FoldedBuffer { .. } => FILE_HEADER.into(),
+                            Block::ExcerptBoundary {
+                                starts_new_buffer, ..
+                            } => {
+                                if *starts_new_buffer {
+                                    FILE_HEADER.into()
+                                } else {
+                                    EXCERPT_HEADER.into()
+                                }
+                            }
                         };
 
                         Some((row, name))

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -269,7 +269,7 @@ impl DisplayMap {
                     let start = buffer_snapshot.anchor_before(range.start);
                     let end = buffer_snapshot.anchor_after(range.end);
                     BlockProperties {
-                        placement: BlockPlacement::Replace(start..end),
+                        placement: BlockPlacement::Replace(start..=end),
                         render,
                         height,
                         style,
@@ -2259,7 +2259,7 @@ pub mod tests {
                 [BlockProperties {
                     placement: BlockPlacement::Replace(
                         buffer_snapshot.anchor_before(Point::new(1, 2))
-                            ..buffer_snapshot.anchor_after(Point::new(2, 3)),
+                            ..=buffer_snapshot.anchor_after(Point::new(2, 3)),
                     ),
                     height: 4,
                     style: BlockStyle::Fixed,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -364,6 +364,10 @@ impl DisplayMap {
         block_map.unfold_buffer(buffer_id, self.buffer.read(cx), cx)
     }
 
+    pub(crate) fn buffer_folded(&self, buffer_id: language::BufferId) -> bool {
+        self.block_map.folded_buffers.contains(&buffer_id)
+    }
+
     pub fn insert_creases(
         &mut self,
         creases: impl IntoIterator<Item = Crease<Anchor>>,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -756,7 +756,6 @@ impl DisplaySnapshot {
             let mut display_point = self.point_to_display_point(point, Bias::Right);
             *display_point.column_mut() = self.line_len(display_point.row());
             let next_point = self.display_point_to_point(display_point, Bias::Right);
-            // TODO kb why is it a fix?
             if next_point == point || original_point == point || original_point == next_point {
                 return (point, display_point);
             }
@@ -1111,12 +1110,8 @@ impl DisplaySnapshot {
     }
 
     pub fn is_line_folded(&self, buffer_row: MultiBufferRow) -> bool {
-        self.block_snapshot.is_line_replaced(buffer_row)
+        self.block_snapshot.is_line_replaced_or_folded(buffer_row)
             || self.fold_snapshot.is_line_folded(buffer_row)
-    }
-
-    pub fn is_line_replaced(&self, buffer_row: MultiBufferRow) -> bool {
-        self.block_snapshot.is_line_replaced(buffer_row)
     }
 
     pub fn is_block_line(&self, display_row: DisplayRow) -> bool {

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -741,7 +741,11 @@ impl DisplaySnapshot {
         }
     }
 
-    pub fn next_line_boundary(&self, mut point: MultiBufferPoint) -> (Point, DisplayPoint) {
+    pub fn next_line_boundary(
+        &self,
+        mut point: MultiBufferPoint,
+    ) -> (MultiBufferPoint, DisplayPoint) {
+        let original_point = point;
         loop {
             let mut inlay_point = self.inlay_snapshot.to_inlay_point(point);
             let mut fold_point = self.fold_snapshot.to_fold_point(inlay_point, Bias::Right);
@@ -752,7 +756,8 @@ impl DisplaySnapshot {
             let mut display_point = self.point_to_display_point(point, Bias::Right);
             *display_point.column_mut() = self.line_len(display_point.row());
             let next_point = self.display_point_to_point(display_point, Bias::Right);
-            if next_point == point {
+            // TODO kb why is it a fix?
+            if next_point == point || original_point == point || original_point == next_point {
                 return (point, display_point);
             }
             point = next_point;

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1109,7 +1109,7 @@ impl DisplaySnapshot {
     }
 
     pub fn is_line_folded(&self, buffer_row: MultiBufferRow) -> bool {
-        self.block_snapshot.is_line_replaced_or_folded(buffer_row)
+        self.block_snapshot.is_line_replaced(buffer_row)
             || self.fold_snapshot.is_line_folded(buffer_row)
     }
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -30,8 +30,7 @@ use crate::{
 };
 pub use block_map::{
     Block, BlockBufferRows, BlockChunks as DisplayChunks, BlockContext, BlockId, BlockMap,
-    BlockPlacement, BlockPoint, BlockProperties, BlockStyle, CustomBlockId, ExcerptBoundaryKind,
-    RenderBlock,
+    BlockPlacement, BlockPoint, BlockProperties, BlockStyle, CustomBlockId, RenderBlock,
 };
 use block_map::{BlockRow, BlockSnapshot};
 use collections::{HashMap, HashSet};

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -795,6 +795,7 @@ impl BlockMap {
 
                         if let Some(next_excerpt) = &next_boundary.next {
                             if next_excerpt.buffer_id != new_buffer_id {
+                                wrap_end_row = wrap_end_row.saturating_sub(1);
                                 break;
                             }
                         }

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1206,8 +1206,7 @@ impl<'a> BlockMapWriter<'a> {
 
     // TODO kb the last buffer folded disappears
     // TODO kb custom blocks (e.g. diagnostics in the tab) are not removed on fold
-    // TODO kb folding a single excerpt (when no others are in the multi buffer) panics
-    // TODO kb indent guids and gutter buttons for folded blocks are pushed upwards, and can be seen between the blocks
+    // TODO kb indent guides and gutter buttons for folded blocks are pushed upwards, and can be seen between the blocks
     // TODO kb folding multiple buffers and unfolding one in the middle makes its next neighbour look unfolded
     pub fn fold_buffer(
         &mut self,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1204,6 +1204,11 @@ impl<'a> BlockMapWriter<'a> {
         self.remove(blocks_to_remove);
     }
 
+    // TODO kb the last buffer folded disappears
+    // TODO kb custom blocks (e.g. diagnostics in the tab) are not removed on fold
+    // TODO kb folding a single excerpt (when no others are in the multi buffer) panics
+    // TODO kb indent guids and gutter buttons for folded blocks are pushed upwards, and can be seen between the blocks
+    // TODO kb folding multiple buffers and unfolding one in the middle makes its next neighbour look unfolded
     pub fn fold_buffer(
         &mut self,
         buffer_id: BufferId,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -979,7 +979,6 @@ impl<'a> BlockMapWriter<'a> {
             if let BlockPlacement::Replace(_) = &block.placement {
                 debug_assert!(block.height > 0);
             }
-
             let id = CustomBlockId(self.0.next_block_id.fetch_add(1, SeqCst));
             ids.push(id);
 

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -748,22 +748,18 @@ impl BlockMap {
 
         std::iter::from_fn(move || {
             let excerpt_boundary = boundaries.next()?;
-            let wrap_row;
-            if excerpt_boundary.next.is_some() {
-                wrap_row = wrap_snapshot
-                    .make_wrap_point(Point::new(excerpt_boundary.row.0, 0), Bias::Left)
-                    .row();
+            let wrap_row = if excerpt_boundary.next.is_some() {
+                wrap_snapshot.make_wrap_point(Point::new(excerpt_boundary.row.0, 0), Bias::Left)
             } else {
-                wrap_row = wrap_snapshot
-                    .make_wrap_point(
-                        Point::new(
-                            excerpt_boundary.row.0,
-                            buffer.line_len(excerpt_boundary.row),
-                        ),
-                        Bias::Left,
-                    )
-                    .row();
+                wrap_snapshot.make_wrap_point(
+                    Point::new(
+                        excerpt_boundary.row.0,
+                        buffer.line_len(excerpt_boundary.row),
+                    ),
+                    Bias::Left,
+                )
             }
+            .row();
 
             let new_buffer_id = match (&excerpt_boundary.prev, &excerpt_boundary.next) {
                 (_, None) => None,
@@ -2622,7 +2618,7 @@ mod tests {
                 buffer_start_header_height,
                 excerpt_header_height,
                 &buffer_snapshot,
-                &folded_buffers,
+                &HashSet::default(),
                 0..,
                 &wraps_snapshot,
             ));

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -719,6 +719,7 @@ impl BlockMap {
         self.show_excerpt_controls
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn header_and_footer_blocks<'a, R, T>(
         show_excerpt_controls: bool,
         excerpt_footer_height: u32,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -503,7 +503,6 @@ impl BlockMap {
         if edits.is_empty() {
             return;
         }
-        dbg!(&edits);
 
         let mut transforms = self.transforms.borrow_mut();
         let mut new_transforms = SumTree::default();
@@ -669,7 +668,6 @@ impl BlockMap {
                 ));
             }
 
-            dbg!(new_start..new_end, &blocks_in_edit);
             BlockMap::sort_blocks(&mut blocks_in_edit);
 
             // For each of these blocks, insert a new isomorphic transform preceding the block,
@@ -720,7 +718,6 @@ impl BlockMap {
         }
 
         new_transforms.append(cursor.suffix(&()), &());
-        dbg!(new_transforms.items(&()));
         debug_assert_eq!(
             new_transforms.summary().input_rows,
             wrap_snapshot.max_point().row() + 1
@@ -1259,7 +1256,9 @@ impl<'a> BlockMapWriter<'a> {
                 + 1;
             let last_edit_row = wrap_snapshot
                 .clip_point(WrapPoint(Point::new(last_edit_row, 0)), Bias::Right)
-                .row();
+                .row()
+                // make range exclusive, as it got clipped
+                + 1;
             let range = wrap_snapshot.make_wrap_point(range.start, Bias::Left).row()..last_edit_row;
             edits.push(Edit {
                 old: range.clone(),

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -41,7 +41,7 @@ pub struct BlockMap {
     buffer_header_height: u32,
     excerpt_header_height: u32,
     excerpt_footer_height: u32,
-    folded_buffers: HashSet<BufferId>,
+    pub(super) folded_buffers: HashSet<BufferId>,
 }
 
 pub struct BlockMapReader<'a> {

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -913,12 +913,8 @@ impl BlockMap {
             })
         });
         blocks.dedup_by(|right, left| match (left.0.clone(), right.0.clone()) {
-            (BlockPlacement::Replace(range), BlockPlacement::Above(row)) => {
-                *range.start() <= row && *range.end() >= row
-            }
-            (BlockPlacement::Replace(range), BlockPlacement::Below(row)) => {
-                *range.start() <= row && *range.end() >= row
-            }
+            (BlockPlacement::Replace(range), BlockPlacement::Above(row))
+            | (BlockPlacement::Replace(range), BlockPlacement::Below(row)) => range.contains(&row),
             (BlockPlacement::Replace(range_a), BlockPlacement::Replace(range_b)) => {
                 if range_a.end() >= range_b.start() && range_a.start() <= range_b.end() {
                     left.0 = BlockPlacement::Replace(

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1561,7 +1561,7 @@ impl BlockSnapshot {
         cursor.item().map_or(false, |t| t.block.is_some())
     }
 
-    pub(super) fn is_line_replaced_or_folded(&self, row: MultiBufferRow) -> bool {
+    pub(super) fn is_line_replaced(&self, row: MultiBufferRow) -> bool {
         let wrap_point = self
             .wrap_snapshot
             .make_wrap_point(Point::new(row.0, 0), Bias::Left);
@@ -3379,7 +3379,7 @@ mod tests {
             for buffer_row in 0..=buffer_snapshot.max_point().row {
                 let buffer_row = MultiBufferRow(buffer_row);
                 assert_eq!(
-                    blocks_snapshot.is_line_replaced_or_folded(buffer_row),
+                    blocks_snapshot.is_line_replaced(buffer_row),
                     expected_replaced_buffer_rows.contains(&buffer_row),
                     "incorrect is_line_replaced({buffer_row:?}), expected replaced rows: {expected_replaced_buffer_rows:?}",
                 );

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -678,6 +678,7 @@ pub struct Editor {
     next_scroll_position: NextScrollCursorCenterTopBottom,
     addons: HashMap<TypeId, Box<dyn Addon>>,
     registered_buffers: HashMap<BufferId, OpenLspBufferHandle>,
+    folded_excerpts: HashMap<Anchor, CustomBlockId>,
     _scroll_cursor_center_top_bottom_task: Task<()>,
 }
 
@@ -1326,6 +1327,8 @@ impl Editor {
             registered_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
             text_style_refinement: None,
+            folded_excerpts: HashMap::default(),
+            _scroll_cursor_center_top_bottom_task: Task::ready(()),
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));
         this._subscriptions.extend(project_subscriptions);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -678,7 +678,6 @@ pub struct Editor {
     next_scroll_position: NextScrollCursorCenterTopBottom,
     addons: HashMap<TypeId, Box<dyn Addon>>,
     registered_buffers: HashMap<BufferId, OpenLspBufferHandle>,
-    folded_buffers: HashMap<BufferId, CustomBlockId>,
     _scroll_cursor_center_top_bottom_task: Task<()>,
 }
 
@@ -1327,7 +1326,6 @@ impl Editor {
             registered_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
             text_style_refinement: None,
-            folded_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));
@@ -10663,6 +10661,17 @@ impl Editor {
         self.remove_folds_with(ranges, auto_scroll, cx, |map, cx| {
             map.unfold_intersecting(ranges.iter().cloned(), inclusive, cx)
         });
+    }
+
+    pub fn fold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
+        self.display_map
+            .update(cx, |display_map, cx| display_map.fold_buffer(buffer_id, cx))
+    }
+
+    pub fn unfold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
+        self.display_map.update(cx, |display_map, cx| {
+            display_map.unfold_buffer(buffer_id, cx);
+        })
     }
 
     /// Removes any folds with the given ranges.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -678,7 +678,7 @@ pub struct Editor {
     next_scroll_position: NextScrollCursorCenterTopBottom,
     addons: HashMap<TypeId, Box<dyn Addon>>,
     registered_buffers: HashMap<BufferId, OpenLspBufferHandle>,
-    folded_excerpts: HashMap<Anchor, CustomBlockId>,
+    folded_buffers: HashMap<BufferId, CustomBlockId>,
     _scroll_cursor_center_top_bottom_task: Task<()>,
 }
 
@@ -1327,7 +1327,7 @@ impl Editor {
             registered_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
             text_style_refinement: None,
-            folded_excerpts: HashMap::default(),
+            folded_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10663,11 +10663,17 @@ impl Editor {
     }
 
     pub fn fold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
+        if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
+            return;
+        }
         self.display_map
             .update(cx, |display_map, cx| display_map.fold_buffer(buffer_id, cx))
     }
 
     pub fn unfold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
+        if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
+            return;
+        }
         self.display_map.update(cx, |display_map, cx| {
             display_map.unfold_buffer(buffer_id, cx);
         })

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10663,17 +10663,18 @@ impl Editor {
     }
 
     pub fn fold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
-        if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
-            return;
-        }
+        // if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
+        //     return;
+        // }
+        //
         self.display_map
             .update(cx, |display_map, cx| display_map.fold_buffer(buffer_id, cx))
     }
 
     pub fn unfold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
-        if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
-            return;
-        }
+        // if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
+        //     return;
+        // }
         self.display_map.update(cx, |display_map, cx| {
             display_map.unfold_buffer(buffer_id, cx);
         })

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1326,7 +1326,6 @@ impl Editor {
             registered_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
             text_style_refinement: None,
-            _scroll_cursor_center_top_bottom_task: Task::ready(()),
         };
         this.tasks_update_task = Some(this.refresh_runnables(cx));
         this._subscriptions.extend(project_subscriptions);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10311,22 +10311,53 @@ impl Editor {
     }
 
     pub fn toggle_fold(&mut self, _: &actions::ToggleFold, cx: &mut ViewContext<Self>) {
-        let selection = self.selections.newest::<Point>(cx);
+        if self.is_singleton(cx) {
+            let selection = self.selections.newest::<Point>(cx);
 
-        let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
-        let range = if selection.is_empty() {
-            let point = selection.head().to_display_point(&display_map);
-            let start = DisplayPoint::new(point.row(), 0).to_point(&display_map);
-            let end = DisplayPoint::new(point.row(), display_map.line_len(point.row()))
-                .to_point(&display_map);
-            start..end
+            let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+            let range = if selection.is_empty() {
+                let point = selection.head().to_display_point(&display_map);
+                let start = DisplayPoint::new(point.row(), 0).to_point(&display_map);
+                let end = DisplayPoint::new(point.row(), display_map.line_len(point.row()))
+                    .to_point(&display_map);
+                start..end
+            } else {
+                selection.range()
+            };
+            if display_map.folds_in_range(range).next().is_some() {
+                self.unfold_lines(&Default::default(), cx)
+            } else {
+                self.fold(&Default::default(), cx)
+            }
         } else {
-            selection.range()
-        };
-        if display_map.folds_in_range(range).next().is_some() {
-            self.unfold_lines(&Default::default(), cx)
-        } else {
-            self.fold(&Default::default(), cx)
+            let (display_snapshot, selections) = self.selections.all_adjusted_display(cx);
+            let mut toggled_buffers = HashSet::default();
+            for selection in selections {
+                if let Some(buffer_id) = display_snapshot
+                    .display_point_to_anchor(selection.head(), Bias::Right)
+                    .buffer_id
+                {
+                    if toggled_buffers.insert(buffer_id) {
+                        if self.buffer_folded(buffer_id, cx) {
+                            self.unfold_buffer(buffer_id, cx);
+                        } else {
+                            self.fold_buffer(buffer_id, cx);
+                        }
+                    }
+                }
+                if let Some(buffer_id) = display_snapshot
+                    .display_point_to_anchor(selection.tail(), Bias::Left)
+                    .buffer_id
+                {
+                    if toggled_buffers.insert(buffer_id) {
+                        if self.buffer_folded(buffer_id, cx) {
+                            self.unfold_buffer(buffer_id, cx);
+                        } else {
+                            self.fold_buffer(buffer_id, cx);
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -10355,44 +10386,68 @@ impl Editor {
     }
 
     pub fn fold(&mut self, _: &actions::Fold, cx: &mut ViewContext<Self>) {
-        let mut to_fold = Vec::new();
-        let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
-        let selections = self.selections.all_adjusted(cx);
+        if self.is_singleton(cx) {
+            let mut to_fold = Vec::new();
+            let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+            let selections = self.selections.all_adjusted(cx);
 
-        for selection in selections {
-            let range = selection.range().sorted();
-            let buffer_start_row = range.start.row;
+            for selection in selections {
+                let range = selection.range().sorted();
+                let buffer_start_row = range.start.row;
 
-            if range.start.row != range.end.row {
-                let mut found = false;
-                let mut row = range.start.row;
-                while row <= range.end.row {
-                    if let Some(crease) = display_map.crease_for_buffer_row(MultiBufferRow(row)) {
-                        found = true;
-                        row = crease.range().end.row + 1;
-                        to_fold.push(crease);
-                    } else {
-                        row += 1
+                if range.start.row != range.end.row {
+                    let mut found = false;
+                    let mut row = range.start.row;
+                    while row <= range.end.row {
+                        if let Some(crease) = display_map.crease_for_buffer_row(MultiBufferRow(row))
+                        {
+                            found = true;
+                            row = crease.range().end.row + 1;
+                            to_fold.push(crease);
+                        } else {
+                            row += 1
+                        }
+                    }
+                    if found {
+                        continue;
                     }
                 }
-                if found {
-                    continue;
-                }
-            }
 
-            for row in (0..=range.start.row).rev() {
-                if let Some(crease) = display_map.crease_for_buffer_row(MultiBufferRow(row)) {
-                    if crease.range().end.row >= buffer_start_row {
-                        to_fold.push(crease);
-                        if row <= range.start.row {
-                            break;
+                for row in (0..=range.start.row).rev() {
+                    if let Some(crease) = display_map.crease_for_buffer_row(MultiBufferRow(row)) {
+                        if crease.range().end.row >= buffer_start_row {
+                            to_fold.push(crease);
+                            if row <= range.start.row {
+                                break;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        self.fold_creases(to_fold, true, cx);
+            self.fold_creases(to_fold, true, cx);
+        } else {
+            let (display_snapshot, selections) = self.selections.all_adjusted_display(cx);
+            let mut folded_buffers = HashSet::default();
+            for selection in selections {
+                if let Some(buffer_id) = display_snapshot
+                    .display_point_to_anchor(selection.head(), Bias::Right)
+                    .buffer_id
+                {
+                    if folded_buffers.insert(buffer_id) {
+                        self.fold_buffer(buffer_id, cx);
+                    }
+                }
+                if let Some(buffer_id) = display_snapshot
+                    .display_point_to_anchor(selection.tail(), Bias::Left)
+                    .buffer_id
+                {
+                    if folded_buffers.insert(buffer_id) {
+                        self.fold_buffer(buffer_id, cx);
+                    }
+                }
+            }
+        }
     }
 
     fn fold_at_level(&mut self, fold_at: &FoldAtLevel, cx: &mut ViewContext<Self>) {
@@ -10519,22 +10574,45 @@ impl Editor {
     }
 
     pub fn unfold_lines(&mut self, _: &UnfoldLines, cx: &mut ViewContext<Self>) {
-        let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
-        let buffer = &display_map.buffer_snapshot;
-        let selections = self.selections.all::<Point>(cx);
-        let ranges = selections
-            .iter()
-            .map(|s| {
-                let range = s.display_range(&display_map).sorted();
-                let mut start = range.start.to_point(&display_map);
-                let mut end = range.end.to_point(&display_map);
-                start.column = 0;
-                end.column = buffer.line_len(MultiBufferRow(end.row));
-                start..end
-            })
-            .collect::<Vec<_>>();
+        if self.is_singleton(cx) {
+            let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+            let buffer = &display_map.buffer_snapshot;
+            let selections = self.selections.all::<Point>(cx);
+            let ranges = selections
+                .iter()
+                .map(|s| {
+                    let range = s.display_range(&display_map).sorted();
+                    let mut start = range.start.to_point(&display_map);
+                    let mut end = range.end.to_point(&display_map);
+                    start.column = 0;
+                    end.column = buffer.line_len(MultiBufferRow(end.row));
+                    start..end
+                })
+                .collect::<Vec<_>>();
 
-        self.unfold_ranges(&ranges, true, true, cx);
+            self.unfold_ranges(&ranges, true, true, cx);
+        } else {
+            let (display_snapshot, selections) = self.selections.all_adjusted_display(cx);
+            let mut unfolded_buffers = HashSet::default();
+            for selection in selections {
+                if let Some(buffer_id) = display_snapshot
+                    .display_point_to_anchor(selection.head(), Bias::Right)
+                    .buffer_id
+                {
+                    if unfolded_buffers.insert(buffer_id) {
+                        self.unfold_buffer(buffer_id, cx);
+                    }
+                }
+                if let Some(buffer_id) = display_snapshot
+                    .display_point_to_anchor(selection.tail(), Bias::Left)
+                    .buffer_id
+                {
+                    if unfolded_buffers.insert(buffer_id) {
+                        self.unfold_buffer(buffer_id, cx);
+                    }
+                }
+            }
+        }
     }
 
     pub fn unfold_recursive(&mut self, _: &UnfoldRecursive, cx: &mut ViewContext<Self>) {
@@ -10663,7 +10741,7 @@ impl Editor {
     }
 
     pub fn fold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
-        if self.buffer().read(cx).is_singleton() {
+        if self.buffer().read(cx).is_singleton() || self.buffer_folded(buffer_id, cx) {
             return;
         }
         let Some(buffer) = self.buffer().read(cx).buffer(buffer_id) else {
@@ -10676,10 +10754,11 @@ impl Editor {
             ids: folded_excerpts.iter().map(|&(id, _)| id).collect(),
             folded: true,
         });
+        cx.notify();
     }
 
     pub fn unfold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
-        if self.buffer().read(cx).is_singleton() {
+        if self.buffer().read(cx).is_singleton() || !self.buffer_folded(buffer_id, cx) {
             return;
         }
         let Some(buffer) = self.buffer().read(cx).buffer(buffer_id) else {
@@ -10693,6 +10772,7 @@ impl Editor {
             ids: unfolded_excerpts.iter().map(|&(id, _)| id).collect(),
             folded: false,
         });
+        cx.notify();
     }
 
     pub fn buffer_folded(&self, buffer: BufferId, cx: &AppContext) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10663,18 +10663,17 @@ impl Editor {
     }
 
     pub fn fold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
-        // if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
-        //     return;
-        // }
-        //
+        if self.buffer().read(cx).is_singleton() {
+            return;
+        }
         self.display_map
             .update(cx, |display_map, cx| display_map.fold_buffer(buffer_id, cx))
     }
 
     pub fn unfold_buffer(&mut self, buffer_id: BufferId, cx: &mut ViewContext<Self>) {
-        // if self.buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
-        //     return;
-        // }
+        if self.buffer().read(cx).is_singleton() {
+            return;
+        }
         self.display_map.update(cx, |display_map, cx| {
             display_map.unfold_buffer(buffer_id, cx);
         })

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14179,7 +14179,6 @@ async fn test_multi_buffer_folding_with_fewer_excerpts(cx: &mut gpui::TestAppCon
         full_text,
     );
 
-    dbg!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
     multi_buffer_editor.update(cx, |editor, cx| {
         editor.fold_buffer(buffer_1.read(cx).remote_id(), cx)
     });
@@ -14189,14 +14188,10 @@ async fn test_multi_buffer_folding_with_fewer_excerpts(cx: &mut gpui::TestAppCon
         "After folding the first buffer, its text should not be displayed"
     );
 
-    // TODO kb remove
-    if true {
-        return;
-    }
-
     multi_buffer_editor.update(cx, |editor, cx| {
         editor.fold_buffer(buffer_2.read(cx).remote_id(), cx)
     });
+
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
         "\n\n\n\n\n\n\n7777\n8888\n9999\n",
@@ -14212,37 +14207,32 @@ async fn test_multi_buffer_folding_with_fewer_excerpts(cx: &mut gpui::TestAppCon
         "After folding the third buffer, its text should not be displayed"
     );
 
-    // Emulate selection inside the fold logic, that should work
-    multi_buffer_editor.update(cx, |editor, cx| {
-        editor.snapshot(cx).next_line_boundary(Point::new(0, 4));
-    });
-
     multi_buffer_editor.update(cx, |editor, cx| {
         editor.unfold_buffer(buffer_2.read(cx).remote_id(), cx)
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
         "\n\n\n\n\n4444\n5555\n6666\n\n\n",
+        "After unfolding the second buffer, its text should be displayed"
     );
 
-    // TODO kb
-    // multi_buffer_editor.update(cx, |editor, cx| {
-    //     editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
-    // });
-    // assert_eq!(
-    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-    //     "\n\n\naaaa\nbbbb\ncccc\n\n\n\nffff\ngggg\n\n\n\njjjj\n\n\n",
-    //     "After unfolding the first buffer, its text should be displayed"
-    // );
-    //
-    // // multi_buffer_editor.update(cx, |editor, cx| {
-    //     editor.unfold_buffer(buffer_2.read(cx).remote_id(), cx)
-    // });
-    // assert_eq!(
-    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-    //     "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n",
-    //     "After unfolding the second buffer, all original text should be displayed"
-    // );
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n\n\n1111\n2222\n3333\n\n\n\n\n4444\n5555\n6666\n\n\n",
+        "After unfolding the first buffer, its text should be displayed"
+    );
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.unfold_buffer(buffer_3.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        full_text,
+        "After unfolding all buffers, all original text should be displayed"
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6987,7 +6987,7 @@ async fn test_multibuffer_format_during_save(cx: &mut gpui::TestAppContext) {
         json!({
             "main.rs": sample_text_1,
             "other.rs": sample_text_2,
-            "lisecond.rs": sample_text_3,
+            "lib.rs": sample_text_3,
         }),
     )
     .await;
@@ -7030,7 +7030,7 @@ async fn test_multibuffer_format_during_save(cx: &mut gpui::TestAppContext) {
         .unwrap();
     let buffer_3 = project
         .update(cx, |project, cx| {
-            project.open_buffer((worktree_id, "lisecond.rs"), cx)
+            project.open_buffer((worktree_id, "lib.rs"), cx)
         })
         .await
         .unwrap();
@@ -11764,7 +11764,7 @@ async fn test_mutlibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
         json!({
             "main.rs": sample_text_1,
             "other.rs": sample_text_2,
-            "lisecond.rs": sample_text_3,
+            "lib.rs": sample_text_3,
         }),
     )
     .await;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14057,6 +14057,137 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     multi_buffer_editor.update(cx, |editor, cx| {
         editor.snapshot(cx).next_line_boundary(Point::new(0, 4));
     });
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.unfold_buffer(buffer_3.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n\n\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
+        "After unfolding the third buffer, its text should be displayed"
+    );
+
+    // multi_buffer_editor.update(cx, |editor, cx| {
+    //     editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
+    // });
+    // assert_eq!(
+    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+    //     "\n\n\naaaa\nbbbb\ncccc\n\n\n\nffff\ngggg\n\n\n\njjjj\n\n\n",
+    //     "After unfolding the first buffer, its text should be displayed"
+    // );
+    //
+    // // multi_buffer_editor.update(cx, |editor, cx| {
+    //     editor.unfold_buffer(buffer_2.read(cx).remote_id(), cx)
+    // });
+    // assert_eq!(
+    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+    //     "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n",
+    //     "After unfolding the second buffer, all original text should be displayed"
+    // );
+}
+
+#[gpui::test]
+async fn test_multi_buffer_with_single_excerpt_folding(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let sample_text = "aaaa\nbbbb\ncccc\ndddd\neeee\nffff\ngggg\nhhhh\niiii\njjjj".to_string();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/a",
+        json!({
+            "main.rs": sample_text,
+        }),
+    )
+    .await;
+    let project = Project::test(fs, ["/a".as_ref()], cx).await;
+    let workspace = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+    let cx = &mut VisualTestContext::from_window(*workspace.deref(), cx);
+    let worktree = project.update(cx, |project, cx| {
+        let mut worktrees = project.worktrees(cx).collect::<Vec<_>>();
+        assert_eq!(worktrees.len(), 1);
+        worktrees.pop().unwrap()
+    });
+    let worktree_id = worktree.update(cx, |worktree, _| worktree.id());
+
+    let buffer_1 = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, "main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let multi_buffer = cx.new_model(|cx| {
+        let mut multi_buffer = MultiBuffer::new(ReadWrite);
+        multi_buffer.push_excerpts(
+            buffer_1.clone(),
+            [ExcerptRange {
+                context: Point::new(0, 0)
+                    ..Point::new(
+                        sample_text.chars().filter(|&c| c == '\n').count() as u32 + 1,
+                        0,
+                    ),
+                primary: None,
+            }],
+            cx,
+        );
+        multi_buffer
+    });
+    let multi_buffer_editor = cx.new_view(|cx| {
+        Editor::new(
+            EditorMode::Full,
+            multi_buffer,
+            Some(project.clone()),
+            true,
+            cx,
+        )
+    });
+
+    let selection_range = Point::new(1, 0)..Point::new(2, 0);
+    multi_buffer_editor.update(cx, |editor, cx| {
+        enum TestHighlight {}
+        let multi_buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
+        let highlight_range = selection_range.clone().to_anchors(&multi_buffer_snapshot);
+        editor.highlight_text::<TestHighlight>(
+            vec![highlight_range.clone()],
+            HighlightStyle::color(Hsla::green()),
+            cx,
+        );
+        editor.change_selections(None, cx, |s| s.select_ranges(Some(highlight_range)));
+    });
+
+    let full_text = format!("\n\n\n{sample_text}\n");
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        full_text,
+    );
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.fold_buffer(buffer_1.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n",
+    );
+
+    // Simulate element rendering, where selections are resolved
+    multi_buffer_editor.update(cx, |editor, cx| {
+        let selections = editor
+            .selections
+            .disjoint_in_range::<Point>(Anchor::min()..Anchor::max(), cx)
+            .into_iter()
+            .map(|s| s.range())
+            .collect::<Vec<_>>();
+        assert_eq!(selections, vec![selection_range]);
+    });
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        full_text,
+    );
 }
 
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14027,17 +14027,6 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     );
 
     multi_buffer_editor.update(cx, |editor, cx| {
-        editor.change_selections(None, cx, |s| {
-            s.select_display_ranges([
-                DisplayPoint::new(DisplayRow(1), 1)..DisplayPoint::new(DisplayRow(1), 5),
-                DisplayPoint::new(DisplayRow(8), 1)..DisplayPoint::new(DisplayRow(8), 5),
-                DisplayPoint::new(DisplayRow(15), 1)..DisplayPoint::new(DisplayRow(15), 5),
-                DisplayPoint::new(DisplayRow(32), 1)..DisplayPoint::new(DisplayRow(32), 5),
-            ]);
-        });
-    });
-
-    multi_buffer_editor.update(cx, |editor, cx| {
         editor.fold_buffer(buffer_1.read(cx).remote_id(), cx)
     });
     assert_eq!(
@@ -14063,6 +14052,11 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
         "\n\n\n\n\n",
         "After folding the third buffer, its text should not be displayed"
     );
+
+    // Emulate selection inside the fold logic, that should work
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.snapshot(cx).next_line_boundary(Point::new(0, 4));
+    });
 }
 
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4064,7 +4064,7 @@ async fn test_selections_and_replace_blocks(cx: &mut TestAppContext) {
         let snapshot = editor.snapshot(cx);
         let snapshot = &snapshot.buffer_snapshot;
         let placement = BlockPlacement::Replace(
-            snapshot.anchor_after(Point::new(1, 0))..snapshot.anchor_after(Point::new(3, 0)),
+            snapshot.anchor_after(Point::new(1, 0))..=snapshot.anchor_after(Point::new(3, 0)),
         );
         editor.insert_blocks(
             [BlockProperties {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14309,24 +14309,6 @@ async fn test_multi_buffer_with_single_excerpt_folding(cx: &mut gpui::TestAppCon
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
         full_text,
     );
-
-    multi_buffer_editor.update(cx, |editor, cx| {
-        editor.fold_buffer(buffer_1.read(cx).remote_id(), cx)
-    });
-    assert_eq!(
-        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        full_text,
-        "Folding a single buffer is a noop"
-    );
-
-    multi_buffer_editor.update(cx, |editor, cx| {
-        editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
-    });
-    assert_eq!(
-        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        full_text,
-        "Unfolding a not folded buffer is a noop"
-    );
 }
 
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6987,7 +6987,7 @@ async fn test_multibuffer_format_during_save(cx: &mut gpui::TestAppContext) {
         json!({
             "main.rs": sample_text_1,
             "other.rs": sample_text_2,
-            "lib.rs": sample_text_3,
+            "lisecond.rs": sample_text_3,
         }),
     )
     .await;
@@ -7030,7 +7030,7 @@ async fn test_multibuffer_format_during_save(cx: &mut gpui::TestAppContext) {
         .unwrap();
     let buffer_3 = project
         .update(cx, |project, cx| {
-            project.open_buffer((worktree_id, "lib.rs"), cx)
+            project.open_buffer((worktree_id, "lisecond.rs"), cx)
         })
         .await
         .unwrap();
@@ -11764,7 +11764,7 @@ async fn test_mutlibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
         json!({
             "main.rs": sample_text_1,
             "other.rs": sample_text_2,
-            "lib.rs": sample_text_3,
+            "lisecond.rs": sample_text_3,
         }),
     )
     .await;
@@ -13917,9 +13917,9 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     fs.insert_tree(
         "/a",
         json!({
-            "main.rs": sample_text_1,
-            "other.rs": sample_text_2,
-            "lib.rs": sample_text_3,
+            "first.rs": sample_text_1,
+            "second.rs": sample_text_2,
+            "third.rs": sample_text_3,
         }),
     )
     .await;
@@ -13935,19 +13935,19 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
 
     let buffer_1 = project
         .update(cx, |project, cx| {
-            project.open_buffer((worktree_id, "main.rs"), cx)
+            project.open_buffer((worktree_id, "first.rs"), cx)
         })
         .await
         .unwrap();
     let buffer_2 = project
         .update(cx, |project, cx| {
-            project.open_buffer((worktree_id, "other.rs"), cx)
+            project.open_buffer((worktree_id, "second.rs"), cx)
         })
         .await
         .unwrap();
     let buffer_3 = project
         .update(cx, |project, cx| {
-            project.open_buffer((worktree_id, "lib.rs"), cx)
+            project.open_buffer((worktree_id, "third.rs"), cx)
         })
         .await
         .unwrap();
@@ -14031,7 +14031,7 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
+        "\n\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
         "After folding the first buffer, its text should not be displayed"
     );
 
@@ -14040,7 +14040,7 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        "\n\n\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
+        "\n\n\n\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
         "After folding the second buffer, its text should not be displayed"
     );
 
@@ -14059,12 +14059,170 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     });
 
     multi_buffer_editor.update(cx, |editor, cx| {
-        editor.unfold_buffer(buffer_3.read(cx).remote_id(), cx)
+        editor.unfold_buffer(buffer_2.read(cx).remote_id(), cx)
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        "\n\n\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
-        "After unfolding the third buffer, its text should be displayed"
+        "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n",
+        "After unfolding the second buffer, its text should be displayed"
+    );
+
+    // TODO kb
+    // multi_buffer_editor.update(cx, |editor, cx| {
+    //     editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
+    // });
+    // assert_eq!(
+    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+    //     "\n\n\naaaa\nbbbb\ncccc\n\n\n\nffff\ngggg\n\n\n\njjjj\n\n\n",
+    //     "After unfolding the first buffer, its text should be displayed"
+    // );
+    //
+    // // multi_buffer_editor.update(cx, |editor, cx| {
+    //     editor.unfold_buffer(buffer_2.read(cx).remote_id(), cx)
+    // });
+    // assert_eq!(
+    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+    //     "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n",
+    //     "After unfolding the second buffer, all original text should be displayed"
+    // );
+}
+
+#[gpui::test]
+async fn test_multi_buffer_folding_with_fewer_excerpts(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let sample_text_1 = "1111\n2222\n3333".to_string();
+    let sample_text_2 = "4444\n5555\n6666".to_string();
+    let sample_text_3 = "7777\n8888\n9999".to_string();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/a",
+        json!({
+            "first.rs": sample_text_1,
+            "second.rs": sample_text_2,
+            "third.rs": sample_text_3,
+        }),
+    )
+    .await;
+    let project = Project::test(fs, ["/a".as_ref()], cx).await;
+    let workspace = cx.add_window(|cx| Workspace::test_new(project.clone(), cx));
+    let cx = &mut VisualTestContext::from_window(*workspace.deref(), cx);
+    let worktree = project.update(cx, |project, cx| {
+        let mut worktrees = project.worktrees(cx).collect::<Vec<_>>();
+        assert_eq!(worktrees.len(), 1);
+        worktrees.pop().unwrap()
+    });
+    let worktree_id = worktree.update(cx, |worktree, _| worktree.id());
+
+    let buffer_1 = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, "first.rs"), cx)
+        })
+        .await
+        .unwrap();
+    let buffer_2 = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, "second.rs"), cx)
+        })
+        .await
+        .unwrap();
+    let buffer_3 = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, "third.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let multi_buffer = cx.new_model(|cx| {
+        let mut multi_buffer = MultiBuffer::new(ReadWrite);
+        multi_buffer.push_excerpts(
+            buffer_1.clone(),
+            [ExcerptRange {
+                context: Point::new(0, 0)..Point::new(3, 0),
+                primary: None,
+            }],
+            cx,
+        );
+        multi_buffer.push_excerpts(
+            buffer_2.clone(),
+            [ExcerptRange {
+                context: Point::new(0, 0)..Point::new(3, 0),
+                primary: None,
+            }],
+            cx,
+        );
+        multi_buffer.push_excerpts(
+            buffer_3.clone(),
+            [ExcerptRange {
+                context: Point::new(0, 0)..Point::new(3, 0),
+                primary: None,
+            }],
+            cx,
+        );
+        multi_buffer
+    });
+
+    let multi_buffer_editor = cx.new_view(|cx| {
+        Editor::new(
+            EditorMode::Full,
+            multi_buffer,
+            Some(project.clone()),
+            true,
+            cx,
+        )
+    });
+
+    let full_text = "\n\n\n1111\n2222\n3333\n\n\n\n\n4444\n5555\n6666\n\n\n\n\n7777\n8888\n9999\n";
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        full_text,
+    );
+
+    dbg!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.fold_buffer(buffer_1.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n\n\n\n\n4444\n5555\n6666\n\n\n\n\n7777\n8888\n9999\n",
+        "After folding the first buffer, its text should not be displayed"
+    );
+
+    // TODO kb remove
+    if true {
+        return;
+    }
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.fold_buffer(buffer_2.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n\n\n\n\n\n\n7777\n8888\n9999\n",
+        "After folding the second buffer, its text should not be displayed"
+    );
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.fold_buffer(buffer_3.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n\n\n\n\n",
+        "After folding the third buffer, its text should not be displayed"
+    );
+
+    // Emulate selection inside the fold logic, that should work
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.snapshot(cx).next_line_boundary(Point::new(0, 4));
+    });
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.unfold_buffer(buffer_2.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n\n\n\n\n4444\n5555\n6666\n\n\n",
     );
 
     // TODO kb

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14031,7 +14031,7 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        "\n\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
+        "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
         "After folding the first buffer, its text should not be displayed"
     );
 
@@ -14040,7 +14040,7 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        "\n\n\n\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
+        "\n\n\n\n\n\n\nvvvv\nwwww\nxxxx\n\n\n\n1111\n2222\n\n\n\n5555\n",
         "After folding the second buffer, its text should not be displayed"
     );
 
@@ -14063,32 +14063,31 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n",
+        "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n",
         "After unfolding the second buffer, its text should be displayed"
     );
 
-    // TODO kb
-    // multi_buffer_editor.update(cx, |editor, cx| {
-    //     editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
-    // });
-    // assert_eq!(
-    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-    //     "\n\n\naaaa\nbbbb\ncccc\n\n\n\nffff\ngggg\n\n\n\njjjj\n\n\n",
-    //     "After unfolding the first buffer, its text should be displayed"
-    // );
-    //
-    // // multi_buffer_editor.update(cx, |editor, cx| {
-    //     editor.unfold_buffer(buffer_2.read(cx).remote_id(), cx)
-    // });
-    // assert_eq!(
-    //     multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-    //     "\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n",
-    //     "After unfolding the second buffer, all original text should be displayed"
-    // );
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        "\n\n\naaaa\nbbbb\ncccc\n\n\n\nffff\ngggg\n\n\n\njjjj\n\n\n\n\nllll\nmmmm\nnnnn\n\n\n\nqqqq\nrrrr\n\n\n\nuuuu\n\n\n",
+        "After unfolding the first buffer, its and 2nd buffer's text should be displayed"
+    );
+
+    multi_buffer_editor.update(cx, |editor, cx| {
+        editor.unfold_buffer(buffer_3.read(cx).remote_id(), cx)
+    });
+    assert_eq!(
+        multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
+        full_text,
+        "After unfolding the all buffers, all original text should be displayed"
+    );
 }
 
 #[gpui::test]
-async fn test_multi_buffer_folding_with_fewer_excerpts(cx: &mut gpui::TestAppContext) {
+async fn test_multi_buffer_single_excerpts_folding(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
     let sample_text_1 = "1111\n2222\n3333".to_string();

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14067,6 +14067,7 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
         "After unfolding the third buffer, its text should be displayed"
     );
 
+    // TODO kb
     // multi_buffer_editor.update(cx, |editor, cx| {
     //     editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
     // });
@@ -14167,19 +14168,9 @@ async fn test_multi_buffer_with_single_excerpt_folding(cx: &mut gpui::TestAppCon
     });
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
-        "\n",
+        full_text,
+        "Folding a single buffer is a noop"
     );
-
-    // Simulate element rendering, where selections are resolved
-    multi_buffer_editor.update(cx, |editor, cx| {
-        let selections = editor
-            .selections
-            .disjoint_in_range::<Point>(Anchor::min()..Anchor::max(), cx)
-            .into_iter()
-            .map(|s| s.range())
-            .collect::<Vec<_>>();
-        assert_eq!(selections, vec![selection_range]);
-    });
 
     multi_buffer_editor.update(cx, |editor, cx| {
         editor.unfold_buffer(buffer_1.read(cx).remote_id(), cx)
@@ -14187,6 +14178,7 @@ async fn test_multi_buffer_with_single_excerpt_folding(cx: &mut gpui::TestAppCon
     assert_eq!(
         multi_buffer_editor.update(cx, |editor, cx| editor.display_text(cx)),
         full_text,
+        "Unfolding a not folded buffer is a noop"
     );
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1897,9 +1897,6 @@ impl EditorElement {
             .enumerate()
             .map(|(ix, multibuffer_row)| {
                 let multibuffer_row = multibuffer_row?;
-                if snapshot.is_line_folded(multibuffer_row) {
-                    return None;
-                }
                 let display_row = DisplayRow(rows.start.0 + ix as u32);
                 let color = if active_rows.contains_key(&display_row) {
                     cx.theme().colors().editor_active_line_number

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2254,6 +2254,10 @@ impl EditorElement {
                                             h_flex()
                                                 .gap_3()
                                                 .map(|header| {
+                                                    if self.editor.read(cx).buffer().read(cx).excerpt_buffer_ids().len() <= 1 {
+                                                        return header;
+                                                    }
+
                                                     let kind = *kind;
                                                     let editor = self.editor.clone();
                                                     let buffer_id = next_excerpt.buffer_id;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2091,7 +2091,7 @@ impl EditorElement {
         cx: &mut WindowContext,
     ) -> (AnyElement, Size<Pixels>) {
         let header_padding = px(6.0);
-        let mut element = match dbg!(block) {
+        let mut element = match block {
             Block::Custom(block) => {
                 let block_start = block.start().to_point(&snapshot.buffer_snapshot);
                 let block_end = block.end().to_point(&snapshot.buffer_snapshot);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -18,16 +18,13 @@ use crate::{
     items::BufferSearchHighlights,
     mouse_context_menu::{self, MenuPosition, MouseContextMenu},
     scroll::scroll_amount::ScrollAmount,
-    BlockId, ChunkReplacement, CursorShape, CustomBlockId, DisplayPoint,
-    DisplayRow,
+    BlockId, ChunkReplacement, CursorShape, CustomBlockId, DisplayPoint, DisplayRow,
     DocumentHighlightRead, DocumentHighlightWrite, Editor, EditorMode, EditorSettings,
     EditorSnapshot, EditorStyle, ExpandExcerpts, FocusedBlock, GutterDimensions, HalfPageDown,
     HalfPageUp, HandleInput, HoveredCursor, HoveredHunk, InlineCompletion, JumpData, LineDown,
-    LineUp, OpenExcerpts,
-    PageDown, PageUp, Point, RowExt, RowRangeExt, SelectPhase, Selection,
-    SoftWrap, ToPoint,
-    CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN,
-    MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+    LineUp, OpenExcerpts, PageDown, PageUp, Point, RowExt, RowRangeExt, SelectPhase, Selection,
+    SoftWrap, ToPoint, CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT,
+    GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
 };
 use client::ParticipantIndex;
 use collections::{BTreeMap, HashMap, HashSet};
@@ -37,11 +34,11 @@ use gpui::{
     anchored, deferred, div, fill, outline, point, px, quad, relative, size, svg,
     transparent_black, Action, AnchorCorner, AnyElement, AvailableSpace, Bounds, ClickEvent,
     ClipboardItem, ContentMask, Corners, CursorStyle, DispatchPhase, Edges, Element,
-    ElementInputHandler, Entity, FontId, GlobalElementId, HighlightStyle, Hitbox, Hsla, InteractiveElement,
-    IntoElement, Length, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, PaintQuad, ParentElement, Pixels, ScrollDelta, ScrollWheelEvent, ShapedLine,
-    SharedString, Size, StatefulInteractiveElement, Style, Styled, Subscription, TextRun,
-    TextStyleRefinement, View, ViewContext, WeakView, WindowContext,
+    ElementInputHandler, Entity, FontId, GlobalElementId, HighlightStyle, Hitbox, Hsla,
+    InteractiveElement, IntoElement, Length, ModifiersChangedEvent, MouseButton, MouseDownEvent,
+    MouseMoveEvent, MouseUpEvent, PaintQuad, ParentElement, Pixels, ScrollDelta, ScrollWheelEvent,
+    ShapedLine, SharedString, Size, StatefulInteractiveElement, Style, Styled, Subscription,
+    TextRun, TextStyleRefinement, View, ViewContext, WeakView, WindowContext,
 };
 use itertools::Itertools;
 use language::{
@@ -1901,6 +1898,9 @@ impl EditorElement {
             .enumerate()
             .map(|(ix, multibuffer_row)| {
                 let multibuffer_row = multibuffer_row?;
+                if snapshot.is_line_folded(multibuffer_row) {
+                    return None;
+                }
                 let display_row = DisplayRow(rows.start.0 + ix as u32);
                 let color = if active_rows.contains_key(&display_row) {
                     cx.theme().colors().editor_active_line_number

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -172,13 +172,7 @@ pub fn indent_guides_in_range(
             let start =
                 MultiBufferRow(indent_guide.multibuffer_row_range.start.0.saturating_sub(1));
             // Filter out indent guides that are inside a fold
-            let is_folded = snapshot.is_line_folded(start);
-            let line_indent = snapshot.line_indent_for_buffer_row(start);
-
-            let contained_in_fold =
-                line_indent.len(indent_guide.tab_size) <= indent_guide.indent_level();
-
-            !(is_folded && contained_in_fold)
+            !snapshot.is_line_folded(start)
         })
         .collect()
 }

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -881,8 +881,10 @@ fn resolve_selections_display<'a>(
         .buffer_snapshot
         .summaries_for_anchors::<Point, _>(to_summarize.flat_map(|s| [&s.start, &s.end]))
         .into_iter();
+    // s.start.buffer_id
+    // let aa = map.blo
     let mut selections = selections
-        .map(move |s| {
+        .filter_map(move |s| {
             let start = summaries.next().unwrap();
             let end = summaries.next().unwrap();
 
@@ -893,13 +895,13 @@ fn resolve_selections_display<'a>(
                 map.point_to_display_point(end, Bias::Left)
             };
 
-            Selection {
+            Some(Selection {
                 id: s.id,
                 start: display_start,
                 end: display_end,
                 reversed: s.reversed,
                 goal: s.goal,
-            }
+            })
         })
         .peekable();
     iter::from_fn(move || {

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -881,10 +881,8 @@ fn resolve_selections_display<'a>(
         .buffer_snapshot
         .summaries_for_anchors::<Point, _>(to_summarize.flat_map(|s| [&s.start, &s.end]))
         .into_iter();
-    // s.start.buffer_id
-    // let aa = map.blo
     let mut selections = selections
-        .filter_map(move |s| {
+        .map(move |s| {
             let start = summaries.next().unwrap();
             let end = summaries.next().unwrap();
 
@@ -895,13 +893,13 @@ fn resolve_selections_display<'a>(
                 map.point_to_display_point(end, Bias::Left)
             };
 
-            Some(Selection {
+            Selection {
                 id: s.id,
                 start: display_start,
                 end: display_end,
                 reversed: s.reversed,
                 goal: s.goal,
-            })
+            }
         })
         .peekable();
     iter::from_fn(move || {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1546,6 +1546,31 @@ impl MultiBuffer {
         excerpts
     }
 
+    pub fn excerpt_ranges_for_buffer(
+        &self,
+        buffer_id: BufferId,
+        cx: &AppContext,
+    ) -> Vec<Range<Point>> {
+        let snapshot = self.read(cx);
+        let buffers = self.buffers.borrow();
+        let mut cursor = snapshot.excerpts.cursor::<(Option<&Locator>, Point)>(&());
+        buffers
+            .get(&buffer_id)
+            .into_iter()
+            .flat_map(|state| &state.excerpts)
+            .filter_map(move |locator| {
+                cursor.seek_forward(&Some(locator), Bias::Left, &());
+                cursor.item().and_then(|excerpt| {
+                    if excerpt.locator == *locator {
+                        Some(cursor.start().1..cursor.end(&()).1)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect()
+    }
+
     pub fn excerpt_buffer_ids(&self) -> Vec<BufferId> {
         self.snapshot
             .borrow()

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1562,7 +1562,11 @@ impl MultiBuffer {
                 cursor.seek_forward(&Some(locator), Bias::Left, &());
                 cursor.item().and_then(|excerpt| {
                     if excerpt.locator == *locator {
-                        Some(cursor.start().1..cursor.end(&()).1)
+                        let excerpt_start = cursor.start().1;
+                        let excerpt_end = excerpt_start + excerpt.text_summary.lines;
+                        Some(excerpt_start..excerpt_end)
+                        // TODO kb
+                        // Some(cursor.start().1..cursor.end(&()).1)
                     } else {
                         None
                     }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -195,6 +195,7 @@ pub struct ExcerptInfo {
     pub buffer: BufferSnapshot,
     pub buffer_id: BufferId,
     pub range: ExcerptRange<text::Anchor>,
+    pub text_summary: TextSummary,
 }
 
 impl std::fmt::Debug for ExcerptInfo {
@@ -1565,8 +1566,6 @@ impl MultiBuffer {
                         let excerpt_start = cursor.start().1;
                         let excerpt_end = excerpt_start + excerpt.text_summary.lines;
                         Some(excerpt_start..excerpt_end)
-                        // TODO kb
-                        // Some(cursor.start().1..cursor.end(&()).1)
                     } else {
                         None
                     }
@@ -3588,6 +3587,7 @@ impl MultiBufferSnapshot {
                     buffer: excerpt.buffer.clone(),
                     buffer_id: excerpt.buffer_id,
                     range: excerpt.range.clone(),
+                    text_summary: excerpt.text_summary.clone(),
                 });
 
                 if next.is_none() {
@@ -3603,6 +3603,7 @@ impl MultiBufferSnapshot {
                     buffer: prev_excerpt.buffer.clone(),
                     buffer_id: prev_excerpt.buffer_id,
                     range: prev_excerpt.range.clone(),
+                    text_summary: prev_excerpt.text_summary.clone(),
                 });
                 let row = MultiBufferRow(cursor.start().1.row);
 

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -1274,7 +1274,6 @@ impl OutlinePanel {
             if let Some(buffer_id) = buffer_id_to_unfold {
                 active_editor.update(cx, |editor, cx| {
                     editor.unfold_buffer(buffer_id, cx);
-                    cx.notify();
                 });
             }
             self.update_cached_entries(None, cx);
@@ -1344,7 +1343,6 @@ impl OutlinePanel {
         if let Some(buffer_id) = buffer_id_to_fold {
             active_editor.update(cx, |editor, cx| {
                 editor.fold_buffer(buffer_id, cx);
-                cx.notify();
             });
         }
     }
@@ -1483,7 +1481,6 @@ impl OutlinePanel {
                 } else {
                     editor.unfold_buffer(buffer_id, cx);
                 }
-                cx.notify();
             });
         }
     }

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -1329,7 +1329,7 @@ impl OutlinePanel {
         };
 
         let mut buffers_to_fold = HashSet::default();
-        let folded = match &selected_entry {
+        let collapsed = match &selected_entry {
             PanelEntry::Fs(FsEntry::Directory(worktree_id, selected_dir_entry)) => {
                 if self
                     .collapsed_entries
@@ -1381,10 +1381,10 @@ impl OutlinePanel {
             PanelEntry::Outline(OutlineEntry::Excerpt(buffer_id, excerpt_id, _)) => self
                 .collapsed_entries
                 .insert(CollapsedEntry::Excerpt(*buffer_id, *excerpt_id)),
-            PanelEntry::Search(_) | PanelEntry::Outline(..) => return,
+            PanelEntry::Search(_) | PanelEntry::Outline(..) => false,
         };
 
-        if folded {
+        if collapsed {
             active_editor.update(cx, |editor, cx| {
                 buffers_to_fold.retain(|buffer_id| !editor.buffer_folded(*buffer_id, cx));
             });
@@ -1394,6 +1394,8 @@ impl OutlinePanel {
             } else {
                 self.toggle_buffers_fold(buffers_to_fold, true, cx).detach();
             }
+        } else {
+            self.select_parent(&SelectParent, cx);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/4925

https://github.com/user-attachments/assets/e7b87375-893f-41ae-a2d9-d501499e40d1


Allows to fold any buffer inside multi buffers, either by clicking the chevron icon on the header, or by using `editor::Fold`/`editor::UnfoldLines`/`editor::ToggleFold`/`editor::FoldAll` and `editor::UnfoldAll` actions inside the multi buffer (those were noop there before).

Every fold has a fake line inside it, so it's possible to navigate into that via the keyboard and unfold it with the corresponding editor action.

The state is synchronized with the outline panel state: any fold inside multi buffer folds the corresponding file entry; any file entry fold inside the outline panel folds the corresponding buffer inside the multi buffer, any directory fold inside the outline panel folds the corresponding buffers inside the multi buffer for each nested file entry in the panel.


Release Notes:

- Added a possibility to fold buffers inside multi buffers
