### PR TITLE
Add ability to perform Search with Google via Editor context menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,6 +3952,7 @@ dependencies = [
  "unicode-segmentation",
  "unindent",
  "url",
+ "urlencoding",
  "util",
  "uuid",
  "workspace",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -84,6 +84,7 @@ unicode-script.workspace = true
 unindent = { workspace = true, optional = true }
 ui.workspace = true
 url.workspace = true
+urlencoding = "2.1.2"
 util.workspace = true
 uuid.workspace = true
 workspace.workspace = true

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -335,6 +335,7 @@ gpui::actions!(
         ScrollCursorCenter,
         ScrollCursorCenterTopBottom,
         ScrollCursorTop,
+        SearchWithGoogle,
         SelectAll,
         SelectAllMatches,
         SelectDown,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6738,33 +6738,24 @@ impl Editor {
         let buffer = self.buffer.read(cx).read(cx);
         let mut query = String::new();
 
-        let mut clipboard_selections = Vec::with_capacity(selections.len());
-        {
-            let max_point = buffer.max_point();
-            let mut is_first = true;
-            for selection in selections.iter() {
-                let mut start = selection.start;
-                let mut end = selection.end;
-                let is_entire_line = selection.is_empty() || self.selections.line_mode;
-                if is_entire_line {
-                    start = Point::new(start.row, 0);
-                    end = cmp::min(max_point, Point::new(end.row + 1, 0));
-                }
-                if is_first {
-                    is_first = false;
-                } else {
-                    query += "\n";
-                }
-                let mut len = 0;
-                for chunk in buffer.text_for_range(start..end) {
-                    query.push_str(chunk);
-                    len += chunk.len();
-                }
-                clipboard_selections.push(ClipboardSelection {
-                    len,
-                    is_entire_line,
-                    first_line_indent: buffer.indent_size_for_line(MultiBufferRow(start.row)).len,
-                });
+        let max_point = buffer.max_point();
+        let mut is_first = true;
+        for selection in selections.iter() {
+            let mut start = selection.start;
+            let mut end = selection.end;
+            let is_entire_line = selection.is_empty() || self.selections.line_mode;
+            if is_entire_line {
+                start = Point::new(start.row, 0);
+                end = cmp::min(max_point, Point::new(end.row + 1, 0));
+            }
+            if is_first {
+                is_first = false;
+            } else {
+                query += "\n";
+            }
+
+            for chunk in buffer.text_for_range(start..end) {
+                query.push_str(chunk);
             }
         }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -459,6 +459,7 @@ impl EditorElement {
         register_action(view, cx, Editor::apply_all_diff_hunks);
         register_action(view, cx, Editor::apply_selected_diff_hunks);
         register_action(view, cx, Editor::open_active_item_in_terminal);
+        register_action(view, cx, Editor::search_with_google);
         register_action(view, cx, Editor::reload_file);
         register_action(view, cx, Editor::spawn_nearest_task);
         register_action(view, cx, Editor::insert_uuid_v4);

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -9,7 +9,7 @@ use gpui::prelude::FluentBuilder;
 use gpui::{DismissEvent, Pixels, Point, Subscription, View, ViewContext};
 use std::ops::Range;
 use text::PointUtf16;
-use workspace::OpenInTerminal;
+use workspace::{OpenInTerminal, SearchWithGoogle};
 
 #[derive(Debug)]
 pub enum MenuPosition {
@@ -190,7 +190,8 @@ pub fn deploy_context_menu(
                     }
                 })
                 .action("Open in Terminal", Box::new(OpenInTerminal))
-                .action("Copy Permalink", Box::new(CopyPermalinkToLine));
+                .action("Copy Permalink", Box::new(CopyPermalinkToLine))
+                .action("Search with Google", Box::new(SearchWithGoogle));
             match focus {
                 Some(focus) => builder.context(focus),
                 None => builder,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -149,6 +149,7 @@ actions!(
         ReloadActiveItem,
         SaveAs,
         SaveWithoutFormat,
+        SearchWithGoogle,
         ToggleBottomDock,
         ToggleCenteredLayout,
         ToggleLeftDock,


### PR DESCRIPTION
This PR adds the ability for users to seamlessly search for a selected snippet of code directly from Zed’s editor, streamlining the workflow by eliminating the need to manually copy text and paste it into a browser. It enhances productivity and user convenience, particularly for developers frequently referencing documentation or debugging solutions.

This is how it works:

1. The user selects text in the editor.
2. Right-click to open up the context menu.
3. The user clicks on the 'Search with Google' option.
4. Zed opens a browser and performs a search with the selected text as the query.

<img width="799" alt="Screenshot 2024-12-15 at 21 09 59" src="https://github.com/user-attachments/assets/16a0f826-64a2-4dc4-8d7f-da94da7de4d2" />
