### PR TITLE
Fix angle brackets not shown correctly in Git blame tooltip

### DIFF
--- a/crates/git/src/commit.rs
+++ b/crates/git/src/commit.rs
@@ -32,7 +32,7 @@ pub fn get_messages(working_directory: &Path, shas: &[Oid]) -> Result<HashMap<Oi
             String::from_utf8_lossy(&output.stdout)
                 .trim()
                 .split_terminator(MARKER)
-                .map(|str| str.trim().replace("<", "&lt;").replace(">", "&gt;")),
+                .map(|str| String::from(str.trim())),
         )
         .collect::<HashMap<Oid, String>>())
 }

--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -306,6 +306,10 @@ pub async fn parse_markdown_block(
 
             Event::SoftBreak => text.push(' '),
 
+            Event::InlineHtml(inline_html) => {
+                text.push_str(&inline_html);
+            }
+
             _ => {}
         }
     }


### PR DESCRIPTION
This originally broke in f633b125b9bab98bc6d73432dd6e8f352cd7fcec, this commit simply replaced `<` and `>` characters with their HTML encoded equivalents. While this worked, it was not correct for the case where `<` or `>` exist inside code blocks.

This also felt confusing that this was not happening where the markdown was being parsed, but rather where where the blame message was retrieved from git.

This commit fixes #22044, and **should not** cause a regression in \#16220, by pushing any `InlineHtml` to the resulting string after parsing the markdown.

Closes #22044

<img width="1380" alt="Screenshot 2024-12-15 at 21 23 00" src="https://github.com/user-attachments/assets/c9add978-6c14-472c-af32-3160cf7deb30" />


<img width="1380" alt="Screenshot 2024-12-15 at 21 22 43" src="https://github.com/user-attachments/assets/656206e5-a4f9-45b5-a9e0-690be8f64f82" />



Release Notes:

- Fixed an issue where angle brackes would not be rendered correctly if nested inside a codeblock in git blame
