### PR TITLE
Update completions fuzzy match state on resolve

### DIFF
--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -8,7 +8,7 @@ use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{AppContext, Model, Task, ViewContext, WeakView, WindowContext};
 use language::{Anchor, Buffer, CodeLabel, Documentation, HighlightId, LanguageServerId, ToPoint};
 use parking_lot::{Mutex, RwLock};
-use project::CompletionIntent;
+use project::{lsp_store::CompletionsMatchState, CompletionIntent};
 use rope::Point;
 use std::{
     ops::Range,
@@ -322,7 +322,7 @@ impl CompletionProvider for SlashCommandCompletionProvider {
         &self,
         _: Model<Buffer>,
         _: Vec<usize>,
-        _: Arc<RwLock<Box<[project::Completion]>>>,
+        _: Arc<RwLock<CompletionsMatchState>>,
         _: &mut ViewContext<Editor>,
     ) -> Task<Result<bool>> {
         Task::ready(Ok(true))

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -13,7 +13,7 @@ use language::{
     LanguageServerId, ToOffset,
 };
 use parking_lot::RwLock;
-use project::{search::SearchQuery, Completion};
+use project::{lsp_store::CompletionsMatchState, search::SearchQuery, Completion};
 use settings::Settings;
 use std::{ops::Range, sync::Arc, sync::LazyLock, time::Duration};
 use theme::ThemeSettings;
@@ -68,7 +68,7 @@ impl CompletionProvider for MessageEditorCompletionProvider {
         &self,
         _buffer: Model<Buffer>,
         _completion_indices: Vec<usize>,
-        _completions: Arc<RwLock<Box<[Completion]>>>,
+        _completions_match_state: Arc<RwLock<CompletionsMatchState>>,
         _cx: &mut ViewContext<Editor>,
     ) -> Task<anyhow::Result<bool>> {
         Task::ready(Ok(false))

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10694,7 +10694,8 @@ async fn test_completions_resolve_updates_labels(cx: &mut gpui::TestAppContext) 
             .expect("Should have the context menu deployed");
         match context_menu {
             CodeContextMenu::Completions(completions_menu) => {
-                let completions = completions_menu.completions.read();
+                let state_guard = completions_menu.completions_state.read();
+                let completions = &state_guard.completions;
                 assert_eq!(completions.len(), 1, "Should have one completion");
                 assert_eq!(completions.get(0).unwrap().label.text, "unresolved");
             }
@@ -10725,7 +10726,8 @@ async fn test_completions_resolve_updates_labels(cx: &mut gpui::TestAppContext) 
             .expect("Should have the context menu deployed");
         match context_menu {
             CodeContextMenu::Completions(completions_menu) => {
-                let completions = completions_menu.completions.read();
+                let state_guard = completions_menu.completions_state.read();
+                let completions = &state_guard.completions;
                 assert_eq!(completions.len(), 1, "Should have one completion");
                 assert_eq!(
                     completions.get(0).unwrap().label.text,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1678,6 +1678,10 @@ impl CodeLabel {
     pub fn text(&self) -> &str {
         self.text.as_str()
     }
+
+    pub fn filter_text(&self) -> &str {
+        &self.text[self.filter_range.clone()]
+    }
 }
 
 impl From<String> for CodeLabel {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -56,6 +56,7 @@ use lsp::{
     LanguageServerId, LanguageServerName, MessageActionItem,
 };
 use lsp_command::*;
+use lsp_store::CompletionsMatchState;
 use node_runtime::NodeRuntime;
 use parking_lot::{Mutex, RwLock};
 pub use prettier_store::PrettierStore;
@@ -2872,7 +2873,7 @@ impl Project {
         &self,
         buffer: Model<Buffer>,
         completion_indices: Vec<usize>,
-        completions: Arc<RwLock<Box<[Completion]>>>,
+        completions: Arc<RwLock<CompletionsMatchState>>,
         cx: &mut ModelContext<Self>,
     ) -> Task<Result<bool>> {
         self.lsp_store.update(cx, |lsp_store, cx| {


### PR DESCRIPTION
Closes #21837

The fix is to update fuzzy match state of the completions menu when resolving documentation. This update is only allowed to change display text - fuzzy text must be identical to prevent items moving in the menu.

What happened:

* #21521 updated completion resolution to update labels.

  - This interacted poorly with the code [here](https://github.com/zed-industries/zed/blob/341e65e12289c355cbea6e91daee5493bbac921f/crates/editor/src/code_context_menus.rs#L604), where the fuzzy match results are updated to include the full label, and the fuzzy match result positions are offset to be in the correct place. The fuzzy mach positions were now invalid because they were based on the old text.

* #21705 caused completion resolution to occur more frequently. Before this only the selected item was being resolved. This caused the panic due to invalid positions to happen much more frequently.

Release Notes:

- N/A