### PR TITLE
extensions_ui: Add Cython as a suggested extension

### DIFF
--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -19,6 +19,7 @@ const SUGGESTIONS_BY_EXTENSION_ID: &[(&str, &[&str])] = &[
     ("clojure", &["bb", "clj", "cljc", "cljs", "edn"]),
     ("neocmake", &["CMakeLists.txt", "cmake"]),
     ("csharp", &["cs"]),
+    ("cython", &["pyx", "pxd", "pxi"]),
     ("dart", &["dart"]),
     ("dockerfile", &["Dockerfile"]),
     ("elisp", &["el"]),


### PR DESCRIPTION
This suggest the [Cython extension](https://github.com/lgeiger/zed-cython) for syntax highlighting of Cython files.

Release Notes:

- Suggest Cython extension for syntax highlighting  of `.pyx`, `.pxd` and `.pxi` files
