### PR TITLE
Stop mutating completion match state + reject fuzzy match text change

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -423,8 +423,14 @@ impl CompletionsMenu {
                             &None
                         };
 
+                        let filter_start = completion.label.filter_range.start;
                         let highlights = gpui::combine_highlights(
-                            mat.ranges().map(|range| (range, FontWeight::BOLD.into())),
+                            mat.ranges().map(|range| {
+                                (
+                                    filter_start + range.start..filter_start + range.end,
+                                    FontWeight::BOLD.into(),
+                                )
+                            }),
                             styled_runs_for_code_label(&completion.label, &style.syntax).map(
                                 |(range, mut highlight)| {
                                     // Ignore font weight for syntax highlighting, as we'll use it
@@ -593,14 +599,6 @@ impl CompletionsMenu {
                     }
                 }
             });
-        }
-
-        for mat in &mut matches {
-            let completion = &completions[mat.candidate_id];
-            mat.string.clone_from(&completion.label.text);
-            for position in &mut mat.positions {
-                *position += completion.label.filter_range.start;
-            }
         }
         drop(completions);
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4303,7 +4303,18 @@ impl LspStore {
         let mut completions = completions.write();
         let completion = &mut completions[completion_index];
         completion.lsp_completion = completion_item;
-        completion.label = new_label;
+        if completion.label.filter_text() == new_label.filter_text() {
+            completion.label = new_label;
+        } else {
+            log::error!(
+                "Resolved completion changed display label from {} to {}. \
+                 Refusing to apply this because it changes the fuzzy match text from {} to {}",
+                completion.label.text(),
+                new_label.text(),
+                completion.label.filter_text(),
+                new_label.filter_text()
+            );
+        }
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
This fixes #21837, where CompletionsMenu fuzzy match positions were desynchronized from completion label text. The solution is to not mutate `match_candidates` and instead offset the highlight positions in the rendering code.

This solution requires that the fuzzy match text not change on completion resolution. This is a property we want anyway, since fuzzy match text changing means items unexpectedly changing position in the menu.

What happened:

* #21521 updated completion resolution to modify labels on resolution.

  - This interacted poorly with the code [here](https://github.com/zed-industries/zed/blob/341e65e12289c355cbea6e91daee5493bbac921f/crates/editor/src/code_context_menus.rs#L604), where the fuzzy match results are updated to include the full label, and the fuzzy match result positions are offset to be in the correct place. The fuzzy mach positions were now invalid because they were based on the old text.

* #21705 caused completion resolution to occur more frequently. Before this only the selected item was being resolved. This caused the panic due to invalid positions to happen much more frequently.

Closes #21837

Release Notes:

- N/A