### PR TITLE
completions: Restore tab behavior when both visible

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -468,21 +468,24 @@
     }
   },
   {
-    "context": "Editor && showing_completions",
-    "use_key_equivalents": true,
-    "bindings": {
-      "enter": "editor::ConfirmCompletion"
-    }
-  },
-  {
     "context": "Editor && !inline_completion && showing_completions",
     "use_key_equivalents": true,
     "bindings": {
+      "enter": "editor::ConfirmCompletion",
       "tab": "editor::ComposeCompletion"
     }
   },
   {
-    "context": "Editor && inline_completion",
+    "context": "Editor && inline_completion && showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "enter": "editor::ConfirmCompletion",
+      "tab": "editor::ComposeCompletion",
+      "shift-tab": "editor::AcceptInlineCompletion"
+    }
+  },
+  {
+    "context": "Editor && inline_completion && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptInlineCompletion"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -539,21 +539,24 @@
     }
   },
   {
-    "context": "Editor && showing_completions",
-    "use_key_equivalents": true,
-    "bindings": {
-      "enter": "editor::ConfirmCompletion"
-    }
-  },
-  {
     "context": "Editor && !inline_completion && showing_completions",
     "use_key_equivalents": true,
     "bindings": {
+      "enter": "editor::ConfirmCompletion",
       "tab": "editor::ComposeCompletion"
     }
   },
   {
-    "context": "Editor && inline_completion",
+    "context": "Editor && inline_completion && showing_completions",
+    "use_key_equivalents": true,
+    "bindings": {
+      "enter": "editor::ConfirmCompletion",
+      "tab": "editor::ComposeCompletion",
+      "shift-tab": "editor::AcceptInlineCompletion"
+    }
+  },
+  {
+    "context": "Editor && inline_completion && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptInlineCompletion"


### PR DESCRIPTION
This reverts part of #21858 by changing how `tab` works again:

- If both, completions and inline completions, are visible, then `tab` accepts the completion and `shif-tab` the inline completion.
- If only one of them is shown, then `tab` accepts it.

I'm not a fan of this solution, but I think it's a short-term fix that avoids breaking people's `tab` muscle memory.

Release Notes:

- (These release notes invalidate the release notes contained in: https://github.com/zed-industries/zed/pull/21858)
- Changed how inline completions (Copilot, Supermaven, ...) and normal completions (from language servers) interact. Zed will now also show inline completions when the completion menu is visible. The user can accept the inline completion with `<shift-tab>` and the active entry in the completion menu with `<tab>`.
