### PR TITLE
Project panel: Deselect entries on remaining blank space click + Remove hover color for selected entries

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3224,7 +3224,9 @@ impl ProjectPanel {
             .border_1()
             .border_r_2()
             .border_color(border_color)
-            .hover(|style| style.bg(bg_hover_color))
+            .when(!is_marked && !is_active, |div| {
+                div.hover(|style| style.bg(bg_hover_color))
+            })
             .when(is_local, |div| {
                 div.on_drag_move::<ExternalPaths>(cx.listener(
                     move |this, event: &DragMoveEvent<ExternalPaths>, cx| {
@@ -3896,6 +3898,11 @@ impl Render for ProjectPanel {
                     } else if !this.focus_handle.contains_focused(cx) {
                         this.hide_scrollbar(cx);
                     }
+                }))
+                .on_click(cx.listener(|this, _event, cx| {
+                    cx.stop_propagation();
+                    this.selection = None;
+                    this.marked_entries.clear();
                 }))
                 .key_context(self.dispatch_context(cx))
                 .on_action(cx.listener(Self::select_next))


### PR DESCRIPTION
Closes #22072

Clicking on the remaining space now allows a single click to deselect all selected items. Check the issue for a preview of the current state and how it works in VSCode.

Bonus: I found the hover color on selected items to be distracting. When I have many entries selected and hover over them, it becomes hard to tell if a particular entry is selected while the mouse pointer is on it. This PR removes hover coloring for selected entries, mimicking how VSCode handles it.

This PR:
<img src="https://github.com/user-attachments/assets/9c4b20fc-df93-4868-b7fe-4045433e85b2" alt="zed" width="450px" />

Release Notes:

- Clicking on empty space in the Project Panel now deselects all selected items.
