### PR TITLE
vim: Don't dismiss inline completion when switching to normal mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2429,7 +2429,7 @@ impl Editor {
             cx.notify();
             return;
         }
-        if self.dismiss_menus_and_popups(true, cx) {
+        if self.dismiss_menus_and_popups(false, true, cx) {
             return;
         }
 
@@ -2444,6 +2444,7 @@ impl Editor {
 
     pub fn dismiss_menus_and_popups(
         &mut self,
+        keep_inline_completion: bool,
         should_report_inline_completion_event: bool,
         cx: &mut ViewContext<Self>,
     ) -> bool {
@@ -2467,7 +2468,9 @@ impl Editor {
             return true;
         }
 
-        if self.discard_inline_completion(should_report_inline_completion_event, cx) {
+        if !keep_inline_completion
+            && self.discard_inline_completion(should_report_inline_completion_event, cx)
+        {
             return true;
         }
 

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -22,7 +22,7 @@ impl Vim {
         if count <= 1 || Vim::globals(cx).dot_replaying {
             self.create_mark("^".into(), false, cx);
             self.update_editor(cx, |_, editor, cx| {
-                editor.dismiss_menus_and_popups(false, cx);
+                editor.dismiss_menus_and_popups(true, false, cx);
                 editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.move_cursors_with(|map, mut cursor, _| {
                         *cursor.column_mut() = cursor.column().saturating_sub(1);


### PR DESCRIPTION
I'm not sure about this yet.

On one hand: it's nice that the completion doesn't just disappear when I hit escape because I was typing and in the flow.

On the other hand: no other inline completion provider keeps the suggestion when leaving insert mode.

I'm going to merge this so we can get it into nightly and try it out for the next couple of days. cc @ConradIrwin 

Release Notes:

- vim: Do not dismiss inline completions when leaving insert/replace mode with `<esc>`.
