### PR TITLE
Trigger completions even if inline completion is visible

### DIFF
--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -373,6 +373,17 @@ mod tests {
 
         // Ensure existing inline completion is interpolated when inserting again.
         cx.simulate_keystroke("c");
+        // We still request a normal LSP completion, but we interpolate the
+        // existing inline completion.
+        drop(handle_completion_request(
+            &mut cx,
+            indoc! {"
+                one.c|<>
+                two
+                three
+            "},
+            vec!["ompletion_a", "ompletion_b"],
+        ));
         executor.run_until_parked();
         cx.update_editor(|editor, cx| {
             assert!(!editor.context_menu_visible());

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2843,7 +2843,6 @@ impl Editor {
                 );
             }
 
-            let had_active_inline_completion = this.has_active_inline_completion();
             this.change_selections_inner(Some(Autoscroll::fit()), false, cx, |s| {
                 s.select(new_selections)
             });
@@ -2864,8 +2863,7 @@ impl Editor {
                 this.show_signature_help(&ShowSignatureHelp, cx);
             }
 
-            let trigger_in_words = !had_active_inline_completion;
-            this.trigger_completion_on_input(&text, trigger_in_words, cx);
+            this.trigger_completion_on_input(&text, true, cx);
             linked_editing_ranges::refresh_linked_ranges(this, cx);
             this.refresh_inline_completion(true, false, cx);
         });


### PR DESCRIPTION
This is related to #22069 and #21858: before both of these PRs, we would only ever show inline completions OR completions, never both at the same time.

Now we show both at the same, but we still had this piece of logic here, that prevented non-inline completions from showing up if there was already an inline completion.

With this change, it's possible to get LSP completions without having to dismiss inline completions before.

Release Notes:

- Inline completions (Copilot, Supermaven, ...) don't stop other completions from showing up anymore. Both can now be visible at the same time.
