### PR TITLE
Move task centering code closer to user input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15603,7 +15603,6 @@ dependencies = [
  "ui",
  "util",
  "uuid",
- "zed_actions",
 ]
 
 [[package]]
@@ -16108,6 +16107,7 @@ name = "zed_actions"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "schemars",
  "serde",
 ]
 

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -426,7 +426,10 @@
       "ctrl-shift-r": "task::Rerun",
       "ctrl-alt-r": "task::Rerun",
       "alt-t": "task::Rerun",
-      "alt-shift-t": "task::Spawn"
+      "alt-shift-t": "task::Spawn",
+      "alt-shift-r": ["task::Spawn", { "reveal_target": "center" }]
+      // also possible to spawn tasks by name:
+      // "foo-bar": ["task::Spawn", { "task_name": "MyTask", "reveal_target": "dock" }]
     }
   },
   // Bindings from Sublime Text

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -495,8 +495,9 @@
     "bindings": {
       "cmd-shift-r": "task::Spawn",
       "cmd-alt-r": "task::Rerun",
-      "alt-t": "task::Spawn",
-      "alt-shift-t": "task::Spawn"
+      "ctrl-alt-shift-r": ["task::Spawn", { "reveal_target": "center" }]
+      // also possible to spawn tasks by name:
+      // "foo-bar": ["task_name::Spawn", { "task_name": "MyTask", "reveal_target": "dock" }]
     }
   },
   // Bindings from Sublime Text

--- a/assets/settings/initial_tasks.json
+++ b/assets/settings/initial_tasks.json
@@ -15,10 +15,14 @@
     // Whether to allow multiple instances of the same task to be run, or rather wait for the existing ones to finish, defaults to `false`.
     "allow_concurrent_runs": false,
     // What to do with the terminal pane and tab, after the command was started:
-    // * `always` — always show the terminal pane, add and focus the corresponding task's tab in it (default)
-    // * `no_focus` — always show the terminal pane, add/reuse the task's tab there, but don't focus it
-    // * `never` — avoid changing current terminal pane focus, but still add/reuse the task's tab there
+    // * `always` — always show the task's pane, and focus the corresponding tab in it (default)
+    // * `no_focus` — always show the task's pane, add the task's tab in it, but don't focus it
+    // * `never` — do not alter focus, but still add/reuse the task's tab in its pane
     "reveal": "always",
+    // Where to place the task's terminal item after starting the task:
+    // * `dock` — in the terminal dock, "regular" terminal items' place (default)
+    // * `center` — in the central pane group, "main" editor area
+    "reveal_target": "dock",
     // What to do with the terminal pane and tab, after the command had finished:
     // * `never` — Do nothing when the command finishes (default)
     // * `always` — always hide the terminal tab, hide the pane also if it was the last tab in it

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -522,7 +522,7 @@ impl RunnableTasks {
     ) -> impl Iterator<Item = (TaskSourceKind, ResolvedTask)> + 'a {
         self.templates.iter().filter_map(|(kind, template)| {
             template
-                .resolve_task(&kind.to_id_base(), Default::default(), cx)
+                .resolve_task(&kind.to_id_base(), cx)
                 .map(|task| (kind.clone(), task))
         })
     }

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -15,14 +15,15 @@ use std::str::FromStr;
 
 pub use task_template::{HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates};
 pub use vscode_format::VsCodeTaskFile;
+pub use zed_actions::RevealTarget;
 
 /// Task identifier, unique within the application.
 /// Based on it, task reruns and terminal tabs are managed.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize)]
 pub struct TaskId(pub String);
 
 /// Contains all information needed by Zed to spawn a new terminal tab for the given task.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpawnInTerminal {
     /// Id of the task to use when determining task tab affinity.
     pub id: TaskId,
@@ -47,6 +48,8 @@ pub struct SpawnInTerminal {
     pub allow_concurrent_runs: bool,
     /// What to do with the terminal pane and tab, after the command was started.
     pub reveal: RevealStrategy,
+    /// Where to show tasks' terminal output.
+    pub reveal_target: RevealTarget,
     /// What to do with the terminal pane and tab, after the command had finished.
     pub hide: HideStrategy,
     /// Which shell to use when spawning the task.
@@ -56,15 +59,6 @@ pub struct SpawnInTerminal {
     /// Whether to show the command line in the task output.
     pub show_command: bool,
 }
-
-/// An action for spawning a specific task
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NewCenterTask {
-    /// The specification of the task to spawn.
-    pub action: SpawnInTerminal,
-}
-
-gpui::impl_actions!(tasks, [NewCenterTask]);
 
 /// A final form of the [`TaskTemplate`], that got resolved with a particualar [`TaskContext`] and now is ready to spawn the actual task.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -84,9 +78,6 @@ pub struct ResolvedTask {
     /// Further actions that need to take place after the resolved task is spawned,
     /// with all task variables resolved.
     pub resolved: Option<SpawnInTerminal>,
-
-    /// where to sawn the task in the UI, either in the terminal panel or in the center pane
-    pub target: zed_actions::TaskSpawnTarget,
 }
 
 impl ResolvedTask {

--- a/crates/tasks_ui/src/lib.rs
+++ b/crates/tasks_ui/src/lib.rs
@@ -1,9 +1,9 @@
 use ::settings::Settings;
 use editor::{tasks::task_context, Editor};
 use gpui::{AppContext, Task as AsyncTask, ViewContext, WindowContext};
-use modal::TasksModal;
+use modal::{TaskOverrides, TasksModal};
 use project::{Location, WorktreeId};
-use task::TaskId;
+use task::{RevealTarget, TaskId};
 use workspace::tasks::schedule_task;
 use workspace::{tasks::schedule_resolved_task, Workspace};
 
@@ -11,7 +11,6 @@ mod modal;
 mod settings;
 
 pub use modal::{Rerun, Spawn};
-use zed_actions::TaskSpawnTarget;
 
 pub fn init(cx: &mut AppContext) {
     settings::TaskSettings::register(cx);
@@ -54,7 +53,6 @@ pub fn init(cx: &mut AppContext) {
                                             task_source_kind,
                                             &original_task,
                                             &task_context,
-                                            Default::default(),
                                             false,
                                             cx,
                                         )
@@ -81,7 +79,7 @@ pub fn init(cx: &mut AppContext) {
                             );
                         }
                     } else {
-                        toggle_modal(workspace, cx).detach();
+                        toggle_modal(workspace, None, cx).detach();
                     };
                 });
         },
@@ -90,14 +88,25 @@ pub fn init(cx: &mut AppContext) {
 }
 
 fn spawn_task_or_modal(workspace: &mut Workspace, action: &Spawn, cx: &mut ViewContext<Workspace>) {
-    match &action.task_name {
-        Some(name) => spawn_task_with_name(name.clone(), action.target.unwrap_or_default(), cx)
-            .detach_and_log_err(cx),
-        None => toggle_modal(workspace, cx).detach(),
+    match action {
+        Spawn::ByName {
+            task_name,
+            reveal_target,
+        } => {
+            let overrides = reveal_target.map(|reveal_target| TaskOverrides {
+                reveal_target: Some(reveal_target),
+            });
+            spawn_task_with_name(task_name.clone(), overrides, cx).detach_and_log_err(cx)
+        }
+        Spawn::ViaModal { reveal_target } => toggle_modal(workspace, *reveal_target, cx).detach(),
     }
 }
 
-fn toggle_modal(workspace: &mut Workspace, cx: &mut ViewContext<'_, Workspace>) -> AsyncTask<()> {
+fn toggle_modal(
+    workspace: &mut Workspace,
+    reveal_target: Option<RevealTarget>,
+    cx: &mut ViewContext<'_, Workspace>,
+) -> AsyncTask<()> {
     let task_store = workspace.project().read(cx).task_store().clone();
     let workspace_handle = workspace.weak_handle();
     let can_open_modal = workspace.project().update(cx, |project, cx| {
@@ -110,7 +119,15 @@ fn toggle_modal(workspace: &mut Workspace, cx: &mut ViewContext<'_, Workspace>) 
             workspace
                 .update(&mut cx, |workspace, cx| {
                     workspace.toggle_modal(cx, |cx| {
-                        TasksModal::new(task_store.clone(), task_context, workspace_handle, cx)
+                        TasksModal::new(
+                            task_store.clone(),
+                            task_context,
+                            reveal_target.map(|target| TaskOverrides {
+                                reveal_target: Some(target),
+                            }),
+                            workspace_handle,
+                            cx,
+                        )
                     })
                 })
                 .ok();
@@ -122,7 +139,7 @@ fn toggle_modal(workspace: &mut Workspace, cx: &mut ViewContext<'_, Workspace>) 
 
 fn spawn_task_with_name(
     name: String,
-    task_target: TaskSpawnTarget,
+    overrides: Option<TaskOverrides>,
     cx: &mut ViewContext<Workspace>,
 ) -> AsyncTask<anyhow::Result<()>> {
     cx.spawn(|workspace, mut cx| async move {
@@ -157,14 +174,18 @@ fn spawn_task_with_name(
 
         let did_spawn = workspace
             .update(&mut cx, |workspace, cx| {
-                let (task_source_kind, target_task) =
+                let (task_source_kind, mut target_task) =
                     tasks.into_iter().find(|(_, task)| task.label == name)?;
+                if let Some(overrides) = &overrides {
+                    if let Some(target_override) = overrides.reveal_target {
+                        target_task.reveal_target = target_override;
+                    }
+                }
                 schedule_task(
                     workspace,
                     task_source_kind,
                     &target_task,
                     &task_context,
-                    task_target,
                     false,
                     cx,
                 );
@@ -174,7 +195,13 @@ fn spawn_task_with_name(
         if !did_spawn {
             workspace
                 .update(&mut cx, |workspace, cx| {
-                    spawn_task_or_modal(workspace, &Spawn::default(), cx);
+                    spawn_task_or_modal(
+                        workspace,
+                        &Spawn::ViaModal {
+                            reveal_target: overrides.and_then(|overrides| overrides.reveal_target),
+                        },
+                        cx,
+                    );
                 })
                 .ok();
         }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -14,7 +14,6 @@ use gpui::{
 use language::Bias;
 use persistence::TERMINAL_DB;
 use project::{search::SearchQuery, terminals::TerminalKind, Fs, Metadata, Project};
-use task::{NewCenterTask, RevealStrategy};
 use terminal::{
     alacritty_terminal::{
         index::Point,
@@ -31,7 +30,6 @@ use ui::{h_flex, prelude::*, ContextMenu, Icon, IconName, Label, Tooltip};
 use util::{paths::PathWithPosition, ResultExt};
 use workspace::{
     item::{BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams},
-    notifications::NotifyResultExt,
     register_serializable_item,
     searchable::{SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle},
     CloseActiveItem, NewCenterTerminal, NewTerminal, OpenVisible, ToolbarItemLocation, Workspace,
@@ -46,7 +44,7 @@ use zed_actions::InlineAssist;
 
 use std::{
     cmp,
-    ops::{ControlFlow, RangeInclusive},
+    ops::RangeInclusive,
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
@@ -81,7 +79,6 @@ pub fn init(cx: &mut AppContext) {
 
     cx.observe_new_views(|workspace: &mut Workspace, _cx| {
         workspace.register_action(TerminalView::deploy);
-        workspace.register_action(TerminalView::deploy_center_task);
     })
     .detach();
 }
@@ -129,61 +126,6 @@ impl FocusableView for TerminalView {
 }
 
 impl TerminalView {
-    pub fn deploy_center_task(
-        workspace: &mut Workspace,
-        task: &NewCenterTask,
-        cx: &mut ViewContext<Workspace>,
-    ) {
-        let reveal_strategy: RevealStrategy = task.action.reveal;
-        let mut spawn_task = task.action.clone();
-
-        let is_local = workspace.project().read(cx).is_local();
-
-        if let ControlFlow::Break(_) =
-            TerminalPanel::fill_command(is_local, &task.action, &mut spawn_task)
-        {
-            return;
-        }
-
-        let kind = TerminalKind::Task(spawn_task);
-
-        let project = workspace.project().clone();
-        let database_id = workspace.database_id();
-        cx.spawn(|workspace, mut cx| async move {
-            let terminal = cx
-                .update(|cx| {
-                    let window = cx.window_handle();
-                    project.update(cx, |project, cx| project.create_terminal(kind, window, cx))
-                })?
-                .await?;
-
-            let terminal_view = cx.new_view(|cx| {
-                TerminalView::new(terminal.clone(), workspace.clone(), database_id, cx)
-            })?;
-
-            cx.update(|cx| {
-                let focus_item = match reveal_strategy {
-                    RevealStrategy::Always => true,
-                    RevealStrategy::Never | RevealStrategy::NoFocus => false,
-                };
-
-                workspace.update(cx, |workspace, cx| {
-                    workspace.add_item_to_active_pane(
-                        Box::new(terminal_view),
-                        None,
-                        focus_item,
-                        cx,
-                    );
-                })?;
-
-                anyhow::Ok(())
-            })??;
-
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
-    }
-
     ///Create a new Terminal in the current working directory or the user's home directory
     pub fn deploy(
         workspace: &mut Workspace,
@@ -191,38 +133,8 @@ impl TerminalView {
         cx: &mut ViewContext<Workspace>,
     ) {
         let working_directory = default_working_directory(workspace, cx);
-
-        let window = cx.window_handle();
-        let project = workspace.project().downgrade();
-        cx.spawn(move |workspace, mut cx| async move {
-            let terminal = project
-                .update(&mut cx, |project, cx| {
-                    project.create_terminal(TerminalKind::Shell(working_directory), window, cx)
-                })
-                .ok()?
-                .await;
-            let terminal = workspace
-                .update(&mut cx, |workspace, cx| terminal.notify_err(workspace, cx))
-                .ok()
-                .flatten()?;
-
-            workspace
-                .update(&mut cx, |workspace, cx| {
-                    let view = cx.new_view(|cx| {
-                        TerminalView::new(
-                            terminal,
-                            workspace.weak_handle(),
-                            workspace.database_id(),
-                            cx,
-                        )
-                    });
-                    workspace.add_item_to_active_pane(Box::new(view), None, true, cx);
-                })
-                .ok();
-
-            Some(())
-        })
-        .detach()
+        TerminalPanel::add_center_terminal(workspace, TerminalKind::Shell(working_directory), cx)
+            .detach_and_log_err(cx);
     }
 
     pub fn new(

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -61,7 +61,6 @@ ui.workspace = true
 util.workspace = true
 uuid.workspace = true
 strum.workspace = true
-zed_actions.workspace = true
 
 [dev-dependencies]
 call = { workspace = true, features = ["test-support"] }

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -1,8 +1,7 @@
 use project::TaskSourceKind;
 use remote::ConnectionState;
-use task::{NewCenterTask, ResolvedTask, TaskContext, TaskTemplate};
+use task::{ResolvedTask, TaskContext, TaskTemplate};
 use ui::ViewContext;
-use zed_actions::TaskSpawnTarget;
 
 use crate::Workspace;
 
@@ -11,7 +10,6 @@ pub fn schedule_task(
     task_source_kind: TaskSourceKind,
     task_to_resolve: &TaskTemplate,
     task_cx: &TaskContext,
-    task_target: zed_actions::TaskSpawnTarget,
     omit_history: bool,
     cx: &mut ViewContext<'_, Workspace>,
 ) {
@@ -29,7 +27,7 @@ pub fn schedule_task(
     }
 
     if let Some(spawn_in_terminal) =
-        task_to_resolve.resolve_task(&task_source_kind.to_id_base(), task_target, task_cx)
+        task_to_resolve.resolve_task(&task_source_kind.to_id_base(), task_cx)
     {
         schedule_resolved_task(
             workspace,
@@ -48,7 +46,6 @@ pub fn schedule_resolved_task(
     omit_history: bool,
     cx: &mut ViewContext<'_, Workspace>,
 ) {
-    let target = resolved_task.target;
     if let Some(spawn_in_terminal) = resolved_task.resolved.take() {
         if !omit_history {
             resolved_task.resolved = Some(spawn_in_terminal.clone());
@@ -63,17 +60,8 @@ pub fn schedule_resolved_task(
             });
         }
 
-        match target {
-            TaskSpawnTarget::Center => {
-                cx.dispatch_action(Box::new(NewCenterTask {
-                    action: spawn_in_terminal,
-                }));
-            }
-            TaskSpawnTarget::Dock => {
-                cx.emit(crate::Event::SpawnTask {
-                    action: Box::new(spawn_in_terminal),
-                });
-            }
-        }
+        cx.emit(crate::Event::SpawnTask {
+            action: Box::new(spawn_in_terminal),
+        });
     }
 }

--- a/crates/zed_actions/Cargo.toml
+++ b/crates/zed_actions/Cargo.toml
@@ -10,4 +10,5 @@ workspace = true
 
 [dependencies]
 gpui.workspace = true
+schemars.workspace = true
 serde.workspace = true

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -1,5 +1,6 @@
 use gpui::{actions, impl_actions};
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 // If the zed binary doesn't use anything in this crate, it will be optimized away
 // and the actions won't initialize. So we just provide an empty initialization function
@@ -90,33 +91,39 @@ pub struct OpenRecent {
 gpui::impl_actions!(projects, [OpenRecent]);
 gpui::actions!(projects, [OpenRemote]);
 
-#[derive(PartialEq, Eq, Clone, Copy, Deserialize, Default, Debug)]
+/// Where to spawn the task in the UI.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum TaskSpawnTarget {
+pub enum RevealTarget {
+    /// In the central pane group, "main" editor area.
     Center,
+    /// In the terminal dock, "regular" terminal items' place.
     #[default]
     Dock,
 }
 
 /// Spawn a task with name or open tasks modal
-#[derive(PartialEq, Clone, Deserialize, Default)]
-pub struct Spawn {
-    #[serde(default)]
-    /// Name of the task to spawn.
-    /// If it is not set, a modal with a list of available tasks is opened instead.
-    /// Defaults to None.
-    pub task_name: Option<String>,
-    /// Which part of the UI the task should be spawned in.
-    /// Defaults to Dock.
-    #[serde(default)]
-    pub target: Option<TaskSpawnTarget>,
+#[derive(Debug, PartialEq, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum Spawn {
+    /// Spawns a task by the name given.
+    ByName {
+        task_name: String,
+        #[serde(default)]
+        reveal_target: Option<RevealTarget>,
+    },
+    /// Spawns a task via modal's selection.
+    ViaModal {
+        /// Selected task's `reveal_target` property override.
+        #[serde(default)]
+        reveal_target: Option<RevealTarget>,
+    },
 }
 
 impl Spawn {
     pub fn modal() -> Self {
-        Self {
-            task_name: None,
-            target: None,
+        Self::ViaModal {
+            reveal_target: None,
         }
     }
 }

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -17,9 +17,9 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     // Whether to allow multiple instances of the same task to be run, or rather wait for the existing ones to finish, defaults to `false`.
     "allow_concurrent_runs": false,
     // What to do with the terminal pane and tab, after the command was started:
-    // * `always` — always show the terminal pane, add and focus the corresponding task's tab in it (default)
-    // * `no_focus` — always show the terminal pane, add/reuse the task's tab there, but don't focus it
-    // * `never` — avoid changing current terminal pane focus, but still add/reuse the task's tab there
+    // * `always` — always show the task's pane, and focus the corresponding tab in it (default)
+    // * `no_focus` — always show the task's pane, add the task's tab in it, but don't focus it
+    // * `never` — do not alter focus, but still add/reuse the task's tab in its pane
     "reveal": "always",
     // What to do with the terminal pane and tab, after the command had finished:
     // * `never` — Do nothing when the command finishes (default)


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/22004 

* Reuse center terminals for tasks, when requested
* Extend task templates with `RevealTarget`, moving it from `TaskSpawnTarget` into the core library
* Use `reveal_target` instead of `target` to avoid misinterpretations in the task template context
* Do not expose `SpawnInTerminal` to user interface, avoid it implementing `Serialize` and `Deserialize`
* Remove `NewCenterTask` action, extending `task::Spawn` interface instead
* Do not require any extra unrelated parameters during task resolution, instead, use task overrides on the resolved tasks on the modal side
* Add keybindings for opening the task modal in the `RevealTarget::Center` mode

Release Notes:

- N/A
