### PR TITLE
Refine interaction in foldable multibuffer header

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -22,7 +22,7 @@ use crate::{
     EditorSnapshot, EditorStyle, ExpandExcerpts, FocusedBlock, GutterDimensions, HalfPageDown,
     HalfPageUp, HandleInput, HoveredCursor, HoveredHunk, InlineCompletion, JumpData, LineDown,
     LineUp, OpenExcerpts, PageDown, PageUp, Point, RowExt, RowRangeExt, SelectPhase, Selection,
-    SoftWrap, ToPoint, CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT,
+    SoftWrap, ToPoint, ToggleFold, CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT,
     GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
 };
 use client::ParticipantIndex;
@@ -2435,6 +2435,17 @@ impl EditorElement {
                                 .size(ButtonSize::Large)
                                 .width(px(30.).into())
                                 .children(toggle_chevron_icon)
+                                .tooltip({
+                                    let focus_handle = focus_handle.clone();
+                                    move |cx| {
+                                        Tooltip::for_action_in(
+                                            "Toggle Excerpt Fold",
+                                            &ToggleFold,
+                                            &focus_handle,
+                                            cx,
+                                        )
+                                    }
+                                })
                                 .on_click(move |_, cx| {
                                     if is_folded {
                                         editor.update(cx, |editor, cx| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2424,39 +2424,38 @@ impl EditorElement {
                         let toggle_chevron_icon =
                             FileIcons::get_chevron_icon(!is_folded, cx).map(Icon::from_path);
                         header.child(
-                            ButtonLike::new("toggle-buffer-fold")
-                                .tooltip(move |cx| {
-                                    if is_folded {
-                                        Tooltip::text("Unfold Excerpt", cx)
-                                    } else {
-                                        Tooltip::text("Fold Excerpt", cx)
-                                    }
-                                })
-                                .size(ButtonSize::Large)
-                                .width(px(30.).into())
-                                .children(toggle_chevron_icon)
-                                .tooltip({
-                                    let focus_handle = focus_handle.clone();
-                                    move |cx| {
-                                        Tooltip::for_action_in(
-                                            "Toggle Excerpt Fold",
-                                            &ToggleFold,
-                                            &focus_handle,
-                                            cx,
-                                        )
-                                    }
-                                })
-                                .on_click(move |_, cx| {
-                                    if is_folded {
-                                        editor.update(cx, |editor, cx| {
-                                            editor.unfold_buffer(buffer_id, cx);
-                                        });
-                                    } else {
-                                        editor.update(cx, |editor, cx| {
-                                            editor.fold_buffer(buffer_id, cx);
-                                        });
-                                    }
-                                }),
+                            div()
+                                .hover(|style| style.bg(cx.theme().colors().element_selected))
+                                .rounded_sm()
+                                .child(
+                                    ButtonLike::new("toggle-buffer-fold")
+                                        .style(ui::ButtonStyle::Transparent)
+                                        .size(ButtonSize::Large)
+                                        .width(px(30.).into())
+                                        .children(toggle_chevron_icon)
+                                        .tooltip({
+                                            let focus_handle = focus_handle.clone();
+                                            move |cx| {
+                                                Tooltip::for_action_in(
+                                                    "Toggle Excerpt Fold",
+                                                    &ToggleFold,
+                                                    &focus_handle,
+                                                    cx,
+                                                )
+                                            }
+                                        })
+                                        .on_click(move |_, cx| {
+                                            if is_folded {
+                                                editor.update(cx, |editor, cx| {
+                                                    editor.unfold_buffer(buffer_id, cx);
+                                                });
+                                            } else {
+                                                editor.update(cx, |editor, cx| {
+                                                    editor.fold_buffer(buffer_id, cx);
+                                                });
+                                            }
+                                        }),
+                                ),
                         )
                     })
                     .child(


### PR DESCRIPTION
- Ensuring that the fold button is big enough to avoid clicking on the header as a whole (and then moving to the actual file)
- Adding tooltips to the fold button
- Refining the container structure so that the tooltip for the folder button and the header click don't overlap
- Adding keybindings to tooltips

https://github.com/user-attachments/assets/82284b59-3025-4d6d-b916-ad4d1ecdb119

Release Notes:

- N/A
