### PR TITLE
Show inline completions inside the completion menu if both are available

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -471,20 +471,11 @@
     }
   },
   {
-    "context": "Editor && !inline_completion && showing_completions",
+    "context": "Editor && showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "editor::ConfirmCompletion",
       "tab": "editor::ComposeCompletion"
-    }
-  },
-  {
-    "context": "Editor && inline_completion && showing_completions",
-    "use_key_equivalents": true,
-    "bindings": {
-      "enter": "editor::ConfirmCompletion",
-      "tab": "editor::ComposeCompletion",
-      "shift-tab": "editor::AcceptInlineCompletion"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -542,20 +542,11 @@
     }
   },
   {
-    "context": "Editor && !inline_completion && showing_completions",
+    "context": "Editor && showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "editor::ConfirmCompletion",
       "tab": "editor::ComposeCompletion"
-    }
-  },
-  {
-    "context": "Editor && inline_completion && showing_completions",
-    "use_key_equivalents": true,
-    "bindings": {
-      "enter": "editor::ConfirmCompletion",
-      "tab": "editor::ComposeCompletion",
-      "shift-tab": "editor::AcceptInlineCompletion"
     }
   },
   {

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -328,10 +328,15 @@ mod tests {
         cx.update_editor(|editor, cx| {
             // We want to show both: the inline completion and the completion menu
             assert!(editor.context_menu_visible());
+            assert!(editor.context_menu_contains_inline_completion());
             assert!(editor.has_active_inline_completion());
+            // Since we have both, the copilot suggestion is not shown inline
+            assert_eq!(editor.text(cx), "one.\ntwo\nthree\n");
+            assert_eq!(editor.display_text(cx), "one.\ntwo\nthree\n");
 
-            // Confirming a completion inserts it and hides the context menu, without showing
+            // Confirming a non-copilot completion inserts it and hides the context menu, without showing
             // the copilot suggestion afterwards.
+            editor.context_menu_next(&Default::default(), cx);
             editor
                 .confirm_completion(&Default::default(), cx)
                 .unwrap()
@@ -342,13 +347,14 @@ mod tests {
             assert_eq!(editor.display_text(cx), "one.completion_a\ntwo\nthree\n");
         });
 
-        // Reset editor and test that accepting completions works
+        // Reset editor and only return copilot suggestions
         cx.set_state(indoc! {"
             oneˇ
             two
             three
         "});
         cx.simulate_keystroke(".");
+
         drop(handle_completion_request(
             &mut cx,
             indoc! {"
@@ -356,7 +362,7 @@ mod tests {
                 two
                 three
             "},
-            vec!["completion_a", "completion_b"],
+            vec![],
         ));
         handle_copilot_completion_request(
             &copilot_lsp,
@@ -369,16 +375,15 @@ mod tests {
         );
         executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
         cx.update_editor(|editor, cx| {
-            assert!(editor.context_menu_visible());
+            assert!(!editor.context_menu_visible());
             assert!(editor.has_active_inline_completion());
+            // Since only the copilot is available, it's shown inline
             assert_eq!(editor.display_text(cx), "one.copilot1\ntwo\nthree\n");
             assert_eq!(editor.text(cx), "one.\ntwo\nthree\n");
         });
 
         // Ensure existing inline completion is interpolated when inserting again.
         cx.simulate_keystroke("c");
-        // We still request a normal LSP completion, but we interpolate the
-        // existing inline completion.
         drop(handle_completion_request(
             &mut cx,
             indoc! {"
@@ -386,13 +391,16 @@ mod tests {
                 two
                 three
             "},
-            vec!["ompletion_a", "ompletion_b"],
+            vec!["completion_a", "completion_b"],
         ));
         executor.run_until_parked();
         cx.update_editor(|editor, cx| {
-            assert!(!editor.context_menu_visible());
+            // Since we have an LSP completion too, the inline completion is
+            // shown in the menu now
+            assert!(editor.context_menu_visible());
+            assert!(editor.context_menu_contains_inline_completion());
             assert!(editor.has_active_inline_completion());
-            assert_eq!(editor.display_text(cx), "one.copilot1\ntwo\nthree\n");
+            assert_eq!(editor.display_text(cx), "one.c\ntwo\nthree\n");
             assert_eq!(editor.text(cx), "one.c\ntwo\nthree\n");
         });
 
@@ -408,6 +416,14 @@ mod tests {
         );
         executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
         cx.update_editor(|editor, cx| {
+            assert!(editor.context_menu_visible());
+            assert!(editor.has_active_inline_completion());
+            assert!(editor.context_menu_contains_inline_completion());
+            assert_eq!(editor.display_text(cx), "one.c\ntwo\nthree\n");
+            assert_eq!(editor.text(cx), "one.c\ntwo\nthree\n");
+
+            // Canceling should first hide the menu and make Copilot suggestion visible.
+            editor.cancel(&Default::default(), cx);
             assert!(!editor.context_menu_visible());
             assert!(editor.has_active_inline_completion());
             assert_eq!(editor.display_text(cx), "one.copilot2\ntwo\nthree\n");
@@ -912,8 +928,8 @@ mod tests {
         executor.advance_clock(COPILOT_DEBOUNCE_TIMEOUT);
         cx.update_editor(|editor, cx| {
             assert!(editor.context_menu_visible());
+            assert!(editor.context_menu_contains_inline_completion());
             assert!(editor.has_active_inline_completion(),);
-            assert_eq!(editor.display_text(cx), "one\ntwo.foo()\nthree\n");
             assert_eq!(editor.text(cx), "one\ntwo.\nthree\n");
         });
     }

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -55,6 +55,10 @@ impl InlineCompletionProvider for CopilotCompletionProvider {
         "copilot"
     }
 
+    fn display_name() -> &'static str {
+        "Copilot"
+    }
+
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -350,9 +350,7 @@ impl CompletionsMenu {
                 })
                 .detach();
             }
-            CompletionEntry::InlineCompletionHint { .. } => {
-                println!("todo: noop for now");
-            }
+            CompletionEntry::InlineCompletionHint { .. } => {}
         }
     }
 
@@ -393,8 +391,10 @@ impl CompletionsMenu {
 
                     len
                 }
-                //TODO compute this the correct way
-                CompletionEntry::InlineCompletionHint { .. } => 30,
+                CompletionEntry::InlineCompletionHint(InlineCompletionMenuHint {
+                    provider_name,
+                    ..
+                }) => provider_name.len(),
             })
             .map(|(ix, _)| ix);
 
@@ -577,13 +577,7 @@ impl CompletionsMenu {
                                                 cx,
                                             );
                                         }))
-                                        .child(Label::new(SharedString::new_static(provider_name)))
-                                        .end_slot(
-                                            Label::new("tab to accept")
-                                                .ml_4()
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted),
-                                        ),
+                                        .child(Label::new(SharedString::new_static(provider_name))),
                                 ),
                         }
                     })

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -22,6 +22,7 @@ use ui::{
 use util::ResultExt as _;
 use workspace::Workspace;
 
+use crate::AcceptInlineCompletion;
 use crate::{
     actions::{ConfirmCodeAction, ConfirmCompletion},
     display_map::DisplayPoint,
@@ -141,12 +142,18 @@ pub struct CompletionsMenu {
     pub buffer: Model<Buffer>,
     pub completions: Rc<RefCell<Box<[Completion]>>>,
     match_candidates: Rc<[StringMatchCandidate]>,
-    pub matches: Rc<[StringMatch]>,
+    pub entries: Rc<[CompletionEntry]>,
     pub selected_item: usize,
     scroll_handle: UniformListScrollHandle,
     resolve_completions: bool,
     pub aside_was_displayed: Cell<bool>,
     show_completion_documentation: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum CompletionEntry {
+    Match(StringMatch),
+    InlineCompletionHint,
 }
 
 impl CompletionsMenu {
@@ -173,7 +180,7 @@ impl CompletionsMenu {
             show_completion_documentation,
             completions: RefCell::new(completions).into(),
             match_candidates,
-            matches: Vec::new().into(),
+            entries: Vec::new().into(),
             selected_item: 0,
             scroll_handle: UniformListScrollHandle::new(),
             resolve_completions: true,
@@ -213,11 +220,13 @@ impl CompletionsMenu {
         let matches = choices
             .iter()
             .enumerate()
-            .map(|(id, completion)| StringMatch {
-                candidate_id: id,
-                score: 1.,
-                positions: vec![],
-                string: completion.clone(),
+            .map(|(id, completion)| {
+                CompletionEntry::Match(StringMatch {
+                    candidate_id: id,
+                    score: 1.,
+                    positions: vec![],
+                    string: completion.clone(),
+                })
             })
             .collect();
         Self {
@@ -227,7 +236,7 @@ impl CompletionsMenu {
             buffer,
             completions: RefCell::new(completions).into(),
             match_candidates,
-            matches,
+            entries: matches,
             selected_item: 0,
             scroll_handle: UniformListScrollHandle::new(),
             resolve_completions: false,
@@ -256,7 +265,7 @@ impl CompletionsMenu {
         if self.selected_item > 0 {
             self.selected_item -= 1;
         } else {
-            self.selected_item = self.matches.len() - 1;
+            self.selected_item = self.entries.len() - 1;
         }
         self.scroll_handle
             .scroll_to_item(self.selected_item, ScrollStrategy::Top);
@@ -269,7 +278,7 @@ impl CompletionsMenu {
         provider: Option<&dyn CompletionProvider>,
         cx: &mut ViewContext<Editor>,
     ) {
-        if self.selected_item + 1 < self.matches.len() {
+        if self.selected_item + 1 < self.entries.len() {
             self.selected_item += 1;
         } else {
             self.selected_item = 0;
@@ -285,11 +294,22 @@ impl CompletionsMenu {
         provider: Option<&dyn CompletionProvider>,
         cx: &mut ViewContext<Editor>,
     ) {
-        self.selected_item = self.matches.len() - 1;
+        self.selected_item = self.entries.len() - 1;
         self.scroll_handle
             .scroll_to_item(self.selected_item, ScrollStrategy::Top);
         self.resolve_selected_completion(provider, cx);
         cx.notify();
+    }
+
+    pub fn show_inline_completion_hint(&mut self) {
+        if let Some(CompletionEntry::InlineCompletionHint) = self.entries.first() {
+            return;
+        }
+        let mut new_entries = Vec::from(&*self.entries);
+        new_entries.insert(0, CompletionEntry::InlineCompletionHint);
+
+        self.entries = new_entries.into();
+        self.selected_item = 0;
     }
 
     pub fn resolve_selected_completion(
@@ -304,24 +324,31 @@ impl CompletionsMenu {
             return;
         };
 
-        let completion_index = self.matches[self.selected_item].candidate_id;
-        let resolve_task = provider.resolve_completions(
-            self.buffer.clone(),
-            vec![completion_index],
-            self.completions.clone(),
-            cx,
-        );
+        match &self.entries[self.selected_item] {
+            CompletionEntry::Match(entry) => {
+                let completion_index = entry.candidate_id;
+                let resolve_task = provider.resolve_completions(
+                    self.buffer.clone(),
+                    vec![completion_index],
+                    self.completions.clone(),
+                    cx,
+                );
 
-        cx.spawn(move |editor, mut cx| async move {
-            if let Some(true) = resolve_task.await.log_err() {
-                editor.update(&mut cx, |_, cx| cx.notify()).ok();
+                cx.spawn(move |editor, mut cx| async move {
+                    if let Some(true) = resolve_task.await.log_err() {
+                        editor.update(&mut cx, |_, cx| cx.notify()).ok();
+                    }
+                })
+                .detach();
             }
-        })
-        .detach();
+            CompletionEntry::InlineCompletionHint => {
+                println!("todo: noop for now");
+            }
+        }
     }
 
     fn visible(&self) -> bool {
-        !self.matches.is_empty()
+        !self.entries.is_empty()
     }
 
     fn origin(&self, cursor_position: DisplayPoint) -> ContextMenuOrigin {
@@ -340,21 +367,24 @@ impl CompletionsMenu {
         let completions = self.completions.borrow_mut();
         let show_completion_documentation = self.show_completion_documentation;
         let widest_completion_ix = self
-            .matches
+            .entries
             .iter()
             .enumerate()
-            .max_by_key(|(_, mat)| {
-                let completion = &completions[mat.candidate_id];
-                let documentation = &completion.documentation;
+            .max_by_key(|(_, mat)| match mat {
+                CompletionEntry::Match(mat) => {
+                    let completion = &completions[mat.candidate_id];
+                    let documentation = &completion.documentation;
 
-                let mut len = completion.label.text.chars().count();
-                if let Some(Documentation::SingleLine(text)) = documentation {
-                    if show_completion_documentation {
-                        len += text.chars().count();
+                    let mut len = completion.label.text.chars().count();
+                    if let Some(Documentation::SingleLine(text)) = documentation {
+                        if show_completion_documentation {
+                            len += text.chars().count();
+                        }
                     }
-                }
 
-                len
+                    len
+                }
+                CompletionEntry::InlineCompletionHint => 0,
             })
             .map(|(ix, _)| ix);
 
@@ -362,24 +392,26 @@ impl CompletionsMenu {
         let style = style.clone();
 
         let multiline_docs = if show_completion_documentation {
-            let mat = &self.matches[selected_item];
-            match &completions[mat.candidate_id].documentation {
-                Some(Documentation::MultiLinePlainText(text)) => {
-                    Some(div().child(SharedString::from(text.clone())))
-                }
-                Some(Documentation::MultiLineMarkdown(parsed)) if !parsed.text.is_empty() => {
-                    Some(div().child(render_parsed_markdown(
-                        "completions_markdown",
-                        parsed,
-                        &style,
-                        workspace,
-                        cx,
-                    )))
-                }
-                Some(Documentation::Undocumented) if self.aside_was_displayed.get() => {
-                    Some(div().child("No documentation"))
-                }
-                _ => None,
+            match &self.entries[selected_item] {
+                CompletionEntry::Match(mat) => match &completions[mat.candidate_id].documentation {
+                    Some(Documentation::MultiLinePlainText(text)) => {
+                        Some(div().child(SharedString::from(text.clone())))
+                    }
+                    Some(Documentation::MultiLineMarkdown(parsed)) if !parsed.text.is_empty() => {
+                        Some(div().child(render_parsed_markdown(
+                            "completions_markdown",
+                            parsed,
+                            &style,
+                            workspace,
+                            cx,
+                        )))
+                    }
+                    Some(Documentation::Undocumented) if self.aside_was_displayed.get() => {
+                        Some(div().child("No documentation"))
+                    }
+                    _ => None,
+                },
+                CompletionEntry::InlineCompletionHint => None,
             }
         } else {
             None
@@ -409,7 +441,7 @@ impl CompletionsMenu {
 
         drop(completions);
         let completions = self.completions.clone();
-        let matches = self.matches.clone();
+        let matches = self.entries.clone();
         let list = uniform_list(
             cx.view().clone(),
             "completions",
@@ -423,82 +455,106 @@ impl CompletionsMenu {
                     .enumerate()
                     .map(|(ix, mat)| {
                         let item_ix = start_ix + ix;
-                        let candidate_id = mat.candidate_id;
-                        let completion = &completions_guard[candidate_id];
+                        match mat {
+                            CompletionEntry::Match(mat) => {
+                                let candidate_id = mat.candidate_id;
+                                let completion = &completions_guard[candidate_id];
 
-                        let documentation = if show_completion_documentation {
-                            &completion.documentation
-                        } else {
-                            &None
-                        };
-
-                        let filter_start = completion.label.filter_range.start;
-                        let highlights = gpui::combine_highlights(
-                            mat.ranges().map(|range| {
-                                (
-                                    filter_start + range.start..filter_start + range.end,
-                                    FontWeight::BOLD.into(),
-                                )
-                            }),
-                            styled_runs_for_code_label(&completion.label, &style.syntax).map(
-                                |(range, mut highlight)| {
-                                    // Ignore font weight for syntax highlighting, as we'll use it
-                                    // for fuzzy matches.
-                                    highlight.font_weight = None;
-
-                                    if completion.lsp_completion.deprecated.unwrap_or(false) {
-                                        highlight.strikethrough = Some(StrikethroughStyle {
-                                            thickness: 1.0.into(),
-                                            ..Default::default()
-                                        });
-                                        highlight.color = Some(cx.theme().colors().text_muted);
-                                    }
-
-                                    (range, highlight)
-                                },
-                            ),
-                        );
-                        let completion_label = StyledText::new(completion.label.text.clone())
-                            .with_highlights(&style.text, highlights);
-                        let documentation_label =
-                            if let Some(Documentation::SingleLine(text)) = documentation {
-                                if text.trim().is_empty() {
-                                    None
+                                let documentation = if show_completion_documentation {
+                                    &completion.documentation
                                 } else {
-                                    Some(
-                                        Label::new(text.clone())
-                                            .ml_4()
-                                            .size(LabelSize::Small)
-                                            .color(Color::Muted),
-                                    )
-                                }
-                            } else {
-                                None
-                            };
+                                    &None
+                                };
 
-                        let color_swatch = completion
-                            .color()
-                            .map(|color| div().size_4().bg(color).rounded_sm());
+                                let filter_start = completion.label.filter_range.start;
+                                let highlights = gpui::combine_highlights(
+                                    mat.ranges().map(|range| {
+                                        (
+                                            filter_start + range.start..filter_start + range.end,
+                                            FontWeight::BOLD.into(),
+                                        )
+                                    }),
+                                    styled_runs_for_code_label(&completion.label, &style.syntax)
+                                        .map(|(range, mut highlight)| {
+                                            // Ignore font weight for syntax highlighting, as we'll use it
+                                            // for fuzzy matches.
+                                            highlight.font_weight = None;
 
-                        div().min_w(px(220.)).max_w(px(540.)).child(
-                            ListItem::new(mat.candidate_id)
-                                .inset(true)
-                                .toggle_state(item_ix == selected_item)
-                                .on_click(cx.listener(move |editor, _event, cx| {
-                                    cx.stop_propagation();
-                                    if let Some(task) = editor.confirm_completion(
-                                        &ConfirmCompletion {
-                                            item_ix: Some(item_ix),
-                                        },
-                                        cx,
-                                    ) {
-                                        task.detach_and_log_err(cx)
-                                    }
-                                }))
-                                .start_slot::<Div>(color_swatch)
-                                .child(h_flex().overflow_hidden().child(completion_label))
-                                .end_slot::<Label>(documentation_label),
-                        )
+                                            if completion.lsp_completion.deprecated.unwrap_or(false)
+                                            {
+                                                highlight.strikethrough =
+                                                    Some(StrikethroughStyle {
+                                                        thickness: 1.0.into(),
+                                                        ..Default::default()
+                                                    });
+                                                highlight.color =
+                                                    Some(cx.theme().colors().text_muted);
+                                            }
+
+                                            (range, highlight)
+                                        }),
+                                );
+                                let completion_label =
+                                    StyledText::new(completion.label.text.clone())
+                                        .with_highlights(&style.text, highlights);
+                                let documentation_label =
+                                    if let Some(Documentation::SingleLine(text)) = documentation {
+                                        if text.trim().is_empty() {
+                                            None
+                                        } else {
+                                            Some(
+                                                Label::new(text.clone())
+                                                    .ml_4()
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                            )
+                                        }
+                                    } else {
+                                        None
+                                    };
+
+                                let color_swatch = completion
+                                    .color()
+                                    .map(|color| div().size_4().bg(color).rounded_sm());
+
+                                div().min_w(px(220.)).max_w(px(540.)).child(
+                                    ListItem::new(mat.candidate_id)
+                                        .inset(true)
+                                        .toggle_state(item_ix == selected_item)
+                                        .on_click(cx.listener(move |editor, _event, cx| {
+                                            cx.stop_propagation();
+                                            if let Some(task) = editor.confirm_completion(
+                                                &ConfirmCompletion {
+                                                    item_ix: Some(item_ix),
+                                                },
+                                                cx,
+                                            ) {
+                                                task.detach_and_log_err(cx)
+                                            }
+                                        }))
+                                        .start_slot::<Div>(color_swatch)
+                                        .child(h_flex().overflow_hidden().child(completion_label))
+                                        .end_slot::<Label>(documentation_label),
+                                )
+                            }
+                            CompletionEntry::InlineCompletionHint => {
+                                div().min_w(px(220.)).max_w(px(540.)).child(
+                                    ListItem::new("inline-completion")
+                                        .inset(true)
+                                        .toggle_state(item_ix == selected_item)
+                                        .on_click(cx.listener(move |editor, _event, cx| {
+                                            cx.stop_propagation();
+                                            editor.accept_inline_completion(
+                                                &AcceptInlineCompletion {},
+                                                cx,
+                                            );
+                                        }))
+                                        .child(h_flex().overflow_hidden().child(
+                                            Label::new("Accept inline completion...").italic(true),
+                                        )),
+                                )
+                            }
+                        }
                     })
                     .collect()
             },
@@ -611,7 +667,10 @@ impl CompletionsMenu {
         }
         drop(completions);
 
-        self.matches = matches.into();
+        self.entries = matches
+            .into_iter()
+            .map(|mat| CompletionEntry::Match(mat))
+            .collect();
         self.selected_item = 0;
     }
 }

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -577,18 +577,22 @@ impl CompletionsMenu {
                                         }))
                                         .child(
                                             h_flex()
-                                                // .font(
-                                                //     theme::ThemeSettings::get_global(cx)
-                                                //         .buffer_font
-                                                //         .clone(),
-                                                // )
-                                                .text_size(ui::TextSize::XSmall.rems(cx))
-                                                .text_color(cx.theme().colors().text.opacity(0.8))
                                                 .justify_between()
                                                 .overflow_hidden()
                                                 .child(Label::new("Zed Predict"))
-                                                .child(div().child(Label::new("tab to accept")))
-                                                .child(Label::new("tab to accept")),
+                                                .child(
+                                                    div()
+                                                        // .font(
+                                                        //     theme::ThemeSettings::get_global(cx)
+                                                        //         .buffer_font
+                                                        //         .clone(),
+                                                        // )
+                                                        .text_size(ui::TextSize::XSmall.rems(cx))
+                                                        .text_color(
+                                                            cx.theme().colors().text.opacity(0.8),
+                                                        )
+                                                        .child("tab to accept"),
+                                                ),
                                         ),
                                 ),
                         }

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -582,11 +582,6 @@ impl CompletionsMenu {
                                                 .child(Label::new("Zed Predict"))
                                                 .child(
                                                     div()
-                                                        // .font(
-                                                        //     theme::ThemeSettings::get_global(cx)
-                                                        //         .buffer_font
-                                                        //         .clone(),
-                                                        // )
                                                         .text_size(ui::TextSize::XSmall.rems(cx))
                                                         .text_color(
                                                             cx.theme().colors().text.opacity(0.8),

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -3,9 +3,9 @@ use std::{cell::Cell, cmp::Reverse, ops::Range, rc::Rc};
 
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    div, px, uniform_list, AnyElement, BackgroundExecutor, Div, FontWeight, ListSizingBehavior,
-    Model, ScrollStrategy, SharedString, StrikethroughStyle, StyledText, UniformListScrollHandle,
-    ViewContext, WeakView,
+    div, px, uniform_list, AnyElement, BackgroundExecutor, Div, FontWeight, HighlightStyle,
+    ListSizingBehavior, Model, ScrollStrategy, SharedString, StrikethroughStyle, StyledText,
+    UniformListScrollHandle, ViewContext, WeakView,
 };
 use language::Buffer;
 use language::{CodeLabel, Documentation};
@@ -153,7 +153,7 @@ pub struct CompletionsMenu {
 #[derive(Clone, Debug)]
 pub(crate) enum CompletionEntry {
     Match(StringMatch),
-    InlineCompletionHint,
+    InlineCompletionHint(Option<(String, Vec<(Range<usize>, HighlightStyle)>)>),
 }
 
 impl CompletionsMenu {
@@ -301,12 +301,19 @@ impl CompletionsMenu {
         cx.notify();
     }
 
-    pub fn show_inline_completion_hint(&mut self) {
-        if let Some(CompletionEntry::InlineCompletionHint) = self.entries.first() {
-            return;
-        }
+    pub fn show_inline_completion_hint(
+        &mut self,
+        hint: Option<(String, Vec<(Range<usize>, HighlightStyle)>)>,
+    ) {
         let mut new_entries = Vec::from(&*self.entries);
-        new_entries.insert(0, CompletionEntry::InlineCompletionHint);
+        if matches!(
+            self.entries.first(),
+            Some(CompletionEntry::InlineCompletionHint { .. })
+        ) {
+            new_entries[0] = CompletionEntry::InlineCompletionHint(hint);
+        } else {
+            new_entries.insert(0, CompletionEntry::InlineCompletionHint(hint));
+        }
 
         self.entries = new_entries.into();
         self.selected_item = 0;
@@ -341,7 +348,7 @@ impl CompletionsMenu {
                 })
                 .detach();
             }
-            CompletionEntry::InlineCompletionHint => {
+            CompletionEntry::InlineCompletionHint(_) => {
                 println!("todo: noop for now");
             }
         }
@@ -384,7 +391,11 @@ impl CompletionsMenu {
 
                     len
                 }
-                CompletionEntry::InlineCompletionHint => 0,
+                //TODO compute this the correct way
+                CompletionEntry::InlineCompletionHint(hint) => hint
+                    .as_ref()
+                    .and_then(|(text, _)| text.lines().map(|line| line.chars().count()).max())
+                    .unwrap_or(0),
             })
             .map(|(ix, _)| ix);
 
@@ -411,7 +422,17 @@ impl CompletionsMenu {
                     }
                     _ => None,
                 },
-                CompletionEntry::InlineCompletionHint => None,
+                CompletionEntry::InlineCompletionHint(hint) => {
+                    hint.as_ref().map(|(text, highlights)| {
+                        div()
+                            .py_2()
+                            .bg(cx.theme().colors().editor_background)
+                            .child(
+                                gpui::StyledText::new(text)
+                                    .with_highlights(&style.text, highlights.clone()),
+                            )
+                    })
+                }
             }
         } else {
             None
@@ -537,8 +558,13 @@ impl CompletionsMenu {
                                         .end_slot::<Label>(documentation_label),
                                 )
                             }
-                            CompletionEntry::InlineCompletionHint => {
-                                div().min_w(px(220.)).max_w(px(540.)).child(
+                            CompletionEntry::InlineCompletionHint(_) => div()
+                                .min_w(px(220.))
+                                .max_w(px(540.))
+                                .pb_1()
+                                .border_b_1()
+                                .border_color(cx.theme().colors().border_variant)
+                                .child(
                                     ListItem::new("inline-completion")
                                         .inset(true)
                                         .toggle_state(item_ix == selected_item)
@@ -549,11 +575,22 @@ impl CompletionsMenu {
                                                 cx,
                                             );
                                         }))
-                                        .child(h_flex().overflow_hidden().child(
-                                            Label::new("Accept inline completion...").italic(true),
-                                        )),
-                                )
-                            }
+                                        .child(
+                                            h_flex()
+                                                // .font(
+                                                //     theme::ThemeSettings::get_global(cx)
+                                                //         .buffer_font
+                                                //         .clone(),
+                                                // )
+                                                .text_size(ui::TextSize::XSmall.rems(cx))
+                                                .text_color(cx.theme().colors().text.opacity(0.8))
+                                                .justify_between()
+                                                .overflow_hidden()
+                                                .child(Label::new("Zed Predict"))
+                                                .child(div().child(Label::new("tab to accept")))
+                                                .child(Label::new("tab to accept")),
+                                        ),
+                                ),
                         }
                     })
                     .collect()

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -28,7 +28,7 @@ use crate::{
     render_parsed_markdown, split_words, styled_runs_for_code_label, CodeActionProvider,
     CompletionId, CompletionProvider, DisplayRow, Editor, EditorStyle, ResolvedTasks,
 };
-use crate::{AcceptInlineCompletion, InlineCompletionMenuHint};
+use crate::{AcceptInlineCompletion, InlineCompletionMenuHint, InlineCompletionText};
 
 pub enum CodeContextMenu {
     Completions(CompletionsMenu),
@@ -421,15 +421,16 @@ impl CompletionsMenu {
                     }
                     _ => None,
                 },
-                CompletionEntry::InlineCompletionHint(hint) => hint.text.as_ref().map(|text| {
-                    div()
+                CompletionEntry::InlineCompletionHint(hint) => Some(match &hint.text {
+                    InlineCompletionText::Edit { text, highlights } => div()
                         .my_1()
                         .rounded_md()
                         .bg(cx.theme().colors().editor_background)
                         .child(
-                            gpui::StyledText::new(text.text.clone())
-                                .with_highlights(&style.text, text.highlights.clone()),
-                        )
+                            gpui::StyledText::new(text.clone())
+                                .with_highlights(&style.text, highlights.clone()),
+                        ),
+                    InlineCompletionText::Move(text) => div().child(text.clone()),
                 }),
             }
         } else {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -73,7 +73,7 @@ use fuzzy::StringMatchCandidate;
 
 use code_context_menus::{
     AvailableCodeAction, CodeActionContents, CodeActionsItem, CodeActionsMenu, CodeContextMenu,
-    CompletionsMenu, ContextMenuOrigin,
+    CompletionEntry, CompletionsMenu, ContextMenuOrigin,
 };
 use git::blame::GitBlame;
 use gpui::{
@@ -3707,7 +3707,7 @@ impl Editor {
                     menu.filter(query.as_deref(), cx.background_executor().clone())
                         .await;
 
-                    if menu.matches.is_empty() {
+                    if menu.entries.is_empty() {
                         None
                     } else {
                         Some(menu)
@@ -3731,6 +3731,11 @@ impl Editor {
                     if editor.focus_handle.is_focused(cx) && menu.is_some() {
                         let mut menu = menu.unwrap();
                         menu.resolve_selected_completion(editor.completion_provider.as_deref(), cx);
+
+                        if editor.has_active_inline_completion() {
+                            menu.show_inline_completion_hint();
+                        }
+
                         *context_menu = Some(CodeContextMenu::Completions(menu));
                         drop(context_menu);
                         cx.notify();
@@ -3775,7 +3780,6 @@ impl Editor {
     ) -> Option<Task<std::result::Result<(), anyhow::Error>>> {
         use language::ToOffset as _;
 
-        self.discard_inline_completion(true, cx);
         let completions_menu =
             if let CodeContextMenu::Completions(menu) = self.hide_context_menu(cx)? {
                 menu
@@ -3784,8 +3788,20 @@ impl Editor {
             };
 
         let mat = completions_menu
-            .matches
+            .entries
             .get(item_ix.unwrap_or(completions_menu.selected_item))?;
+
+        let mat = match mat {
+            CompletionEntry::InlineCompletionHint => {
+                self.accept_inline_completion(&AcceptInlineCompletion, cx);
+                return None;
+            }
+            CompletionEntry::Match(mat) => {
+                self.discard_inline_completion(true, cx);
+                mat
+            }
+        };
+
         let buffer_handle = completions_menu.buffer;
         let completions = completions_menu.completions.borrow_mut();
         let completion = completions.get(mat.candidate_id)?;
@@ -4783,6 +4799,13 @@ impl Editor {
             completion,
             invalidation_range,
         });
+
+        match self.context_menu.borrow_mut().as_mut() {
+            Some(CodeContextMenu::Completions(menu)) => {
+                menu.show_inline_completion_hint();
+            }
+            _ => {}
+        }
         cx.notify();
 
         Some(())

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8470,10 +8470,7 @@ async fn test_completion_page_up_down_keys(cx: &mut gpui::TestAppContext) {
     cx.update_editor(|editor, _| {
         if let Some(CodeContextMenu::Completions(menu)) = editor.context_menu.borrow_mut().as_ref()
         {
-            assert_eq!(
-                menu.matches.iter().map(|m| &m.string).collect::<Vec<_>>(),
-                &["first", "last"]
-            );
+            assert_eq!(completion_menu_entries(&menu.entries), &["first", "last"]);
         } else {
             panic!("expected completion menu to be open");
         }
@@ -8566,7 +8563,7 @@ async fn test_completion_sort(cx: &mut gpui::TestAppContext) {
         if let Some(CodeContextMenu::Completions(menu)) = editor.context_menu.borrow_mut().as_ref()
         {
             assert_eq!(
-                menu.matches.iter().map(|m| &m.string).collect::<Vec<_>>(),
+                completion_menu_entries(&menu.entries),
                 &["r", "ret", "Range", "return"]
             );
         } else {
@@ -10962,11 +10959,7 @@ async fn test_completions_default_resolve_data_handling(cx: &mut gpui::TestAppCo
         match menu.as_ref().expect("should have the completions menu") {
             CodeContextMenu::Completions(completions_menu) => {
                 assert_eq!(
-                    completions_menu
-                        .matches
-                        .iter()
-                        .map(|c| c.string.as_str())
-                        .collect::<Vec<_>>(),
+                    completion_menu_entries(&completions_menu.entries),
                     vec!["Some(2)", "vec![2]"]
                 );
             }
@@ -11066,7 +11059,7 @@ async fn test_completions_in_languages_with_extra_word_characters(cx: &mut gpui:
         if let Some(CodeContextMenu::Completions(menu)) = editor.context_menu.borrow_mut().as_ref()
         {
             assert_eq!(
-                menu.matches.iter().map(|m| &m.string).collect::<Vec<_>>(),
+                completion_menu_entries(&menu.entries),
                 &["bg-red", "bg-blue", "bg-yellow"]
             );
         } else {
@@ -11080,7 +11073,7 @@ async fn test_completions_in_languages_with_extra_word_characters(cx: &mut gpui:
         if let Some(CodeContextMenu::Completions(menu)) = editor.context_menu.borrow_mut().as_ref()
         {
             assert_eq!(
-                menu.matches.iter().map(|m| &m.string).collect::<Vec<_>>(),
+                completion_menu_entries(&menu.entries),
                 &["bg-blue", "bg-yellow"]
             );
         } else {
@@ -11096,14 +11089,21 @@ async fn test_completions_in_languages_with_extra_word_characters(cx: &mut gpui:
     cx.update_editor(|editor, _| {
         if let Some(CodeContextMenu::Completions(menu)) = editor.context_menu.borrow_mut().as_ref()
         {
-            assert_eq!(
-                menu.matches.iter().map(|m| &m.string).collect::<Vec<_>>(),
-                &["bg-yellow"]
-            );
+            assert_eq!(completion_menu_entries(&menu.entries), &["bg-yellow"]);
         } else {
             panic!("expected completion menu to be open");
         }
     });
+}
+
+fn completion_menu_entries(entries: &[CompletionEntry]) -> Vec<&str> {
+    entries
+        .iter()
+        .flat_map(|e| match e {
+            CompletionEntry::Match(mat) => Some(mat.string.as_str()),
+            _ => None,
+        })
+        .collect()
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14382,8 +14382,11 @@ fn test_inline_completion_text(cx: &mut TestAppContext) {
                     ..snapshot.buffer_snapshot.anchor_before(Point::new(0, 6));
                 let edits = vec![(edit_range, " beautiful".to_string())];
 
-                let InlineCompletionText { text, highlights } =
-                    inline_completion_text(&snapshot, &edits, cx);
+                let InlineCompletionText::Edit { text, highlights } =
+                    inline_completion_edit_text(&snapshot, &edits, cx)
+                else {
+                    panic!("Failed to generate inline completion text");
+                };
 
                 assert_eq!(text, "Hello, beautiful world!");
                 assert_eq!(highlights.len(), 1);
@@ -14413,8 +14416,11 @@ fn test_inline_completion_text(cx: &mut TestAppContext) {
                     "That".to_string(),
                 )];
 
-                let InlineCompletionText { text, highlights } =
-                    inline_completion_text(&snapshot, &edits, cx);
+                let InlineCompletionText::Edit { text, highlights } =
+                    inline_completion_edit_text(&snapshot, &edits, cx)
+                else {
+                    panic!("Failed to generate inline completion text");
+                };
 
                 assert_eq!(text, "That is a test.");
                 assert_eq!(highlights.len(), 1);
@@ -14451,8 +14457,11 @@ fn test_inline_completion_text(cx: &mut TestAppContext) {
                     ),
                 ];
 
-                let InlineCompletionText { text, highlights } =
-                    inline_completion_text(&snapshot, &edits, cx);
+                let InlineCompletionText::Edit { text, highlights } =
+                    inline_completion_edit_text(&snapshot, &edits, cx)
+                else {
+                    panic!("Failed to generate inline completion text");
+                };
 
                 assert_eq!(text, "Greetings, world and universe!");
                 assert_eq!(highlights.len(), 2);
@@ -14500,8 +14509,11 @@ fn test_inline_completion_text(cx: &mut TestAppContext) {
                     ),
                 ];
 
-                let InlineCompletionText { text, highlights } =
-                    inline_completion_text(&snapshot, &edits, cx);
+                let InlineCompletionText::Edit { text, highlights } =
+                    inline_completion_edit_text(&snapshot, &edits, cx)
+                else {
+                    panic!("Failed to generate inline completion text");
+                };
 
                 assert_eq!(text, "Second modified\nNew third line\nFourth updated line");
                 assert_eq!(highlights.len(), 3);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2891,6 +2891,10 @@ impl EditorElement {
         const PADDING_X: Pixels = Pixels(24.);
         const PADDING_Y: Pixels = Pixels(2.);
 
+        if self.editor.read(cx).has_active_completions_menu() {
+            return None;
+        }
+
         let active_inline_completion = self.editor.read(cx).active_inline_completion.as_ref()?;
 
         match &active_inline_completion.completion {
@@ -4519,7 +4523,7 @@ fn jump_data(
     }
 }
 
-fn inline_completion_popover_text(
+pub(crate) fn inline_completion_popover_text(
     editor_snapshot: &EditorSnapshot,
     edits: &Vec<(Range<Anchor>, String)>,
     cx: &WindowContext,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2994,7 +2994,7 @@ impl EditorElement {
                     return None;
                 }
 
-                let hint = crate::inline_completion_hint(editor_snapshot, edits, cx);
+                let hint = crate::inline_completion_text(editor_snapshot, edits, cx);
                 let line_count = hint.text.lines().count() + 1;
 
                 let longest_row =
@@ -6819,7 +6819,7 @@ mod tests {
     use crate::{
         display_map::{BlockPlacement, BlockProperties},
         editor_tests::{init_test, update_test_language_settings},
-        Editor, InlineCompletionHint, MultiBuffer,
+        Editor, MultiBuffer,
     };
     use gpui::{TestAppContext, VisualTestContext};
     use language::language_settings;
@@ -7269,165 +7269,6 @@ mod tests {
 
                 editor_width += resize_step;
             }
-        }
-    }
-
-    #[gpui::test]
-    fn test_inline_completion_popover_text(cx: &mut TestAppContext) {
-        init_test(cx, |_| {});
-
-        // Test case 1: Simple insertion
-        {
-            let window = cx.add_window(|cx| {
-                let buffer = MultiBuffer::build_simple("Hello, world!", cx);
-                Editor::new(EditorMode::Full, buffer, None, true, cx)
-            });
-            let cx = &mut VisualTestContext::from_window(*window, cx);
-
-            window
-                .update(cx, |editor, cx| {
-                    let snapshot = editor.snapshot(cx);
-                    let edit_range = snapshot.buffer_snapshot.anchor_after(Point::new(0, 6))
-                        ..snapshot.buffer_snapshot.anchor_before(Point::new(0, 6));
-                    let edits = vec![(edit_range, " beautiful".to_string())];
-
-                    let InlineCompletionHint { text, highlights } =
-                        crate::inline_completion_hint(&snapshot, &edits, cx);
-
-                    assert_eq!(text, "Hello, beautiful world!");
-                    assert_eq!(highlights.len(), 1);
-                    assert_eq!(highlights[0].0, 6..16);
-                    assert_eq!(
-                        highlights[0].1.background_color,
-                        Some(cx.theme().status().created_background)
-                    );
-                })
-                .unwrap();
-        }
-
-        // Test case 2: Replacement
-        {
-            let window = cx.add_window(|cx| {
-                let buffer = MultiBuffer::build_simple("This is a test.", cx);
-                Editor::new(EditorMode::Full, buffer, None, true, cx)
-            });
-            let cx = &mut VisualTestContext::from_window(*window, cx);
-
-            window
-                .update(cx, |editor, cx| {
-                    let snapshot = editor.snapshot(cx);
-                    let edits = vec![(
-                        snapshot.buffer_snapshot.anchor_after(Point::new(0, 0))
-                            ..snapshot.buffer_snapshot.anchor_before(Point::new(0, 4)),
-                        "That".to_string(),
-                    )];
-
-                    let InlineCompletionHint { text, highlights } =
-                        crate::inline_completion_hint(&snapshot, &edits, cx);
-
-                    assert_eq!(text, "That is a test.");
-                    assert_eq!(highlights.len(), 1);
-                    assert_eq!(highlights[0].0, 0..4);
-                    assert_eq!(
-                        highlights[0].1.background_color,
-                        Some(cx.theme().status().created_background)
-                    );
-                })
-                .unwrap();
-        }
-
-        // Test case 3: Multiple edits
-        {
-            let window = cx.add_window(|cx| {
-                let buffer = MultiBuffer::build_simple("Hello, world!", cx);
-                Editor::new(EditorMode::Full, buffer, None, true, cx)
-            });
-            let cx = &mut VisualTestContext::from_window(*window, cx);
-
-            window
-                .update(cx, |editor, cx| {
-                    let snapshot = editor.snapshot(cx);
-                    let edits = vec![
-                        (
-                            snapshot.buffer_snapshot.anchor_after(Point::new(0, 0))
-                                ..snapshot.buffer_snapshot.anchor_before(Point::new(0, 5)),
-                            "Greetings".into(),
-                        ),
-                        (
-                            snapshot.buffer_snapshot.anchor_after(Point::new(0, 12))
-                                ..snapshot.buffer_snapshot.anchor_before(Point::new(0, 12)),
-                            " and universe".into(),
-                        ),
-                    ];
-
-                    let InlineCompletionHint { text, highlights } =
-                        crate::inline_completion_hint(&snapshot, &edits, cx);
-
-                    assert_eq!(text, "Greetings, world and universe!");
-                    assert_eq!(highlights.len(), 2);
-                    assert_eq!(highlights[0].0, 0..9);
-                    assert_eq!(highlights[1].0, 16..29);
-                    assert_eq!(
-                        highlights[0].1.background_color,
-                        Some(cx.theme().status().created_background)
-                    );
-                    assert_eq!(
-                        highlights[1].1.background_color,
-                        Some(cx.theme().status().created_background)
-                    );
-                })
-                .unwrap();
-        }
-
-        // Test case 4: Multiple lines with edits
-        {
-            let window = cx.add_window(|cx| {
-                let buffer = MultiBuffer::build_simple(
-                    "First line\nSecond line\nThird line\nFourth line",
-                    cx,
-                );
-                Editor::new(EditorMode::Full, buffer, None, true, cx)
-            });
-            let cx = &mut VisualTestContext::from_window(*window, cx);
-
-            window
-                .update(cx, |editor, cx| {
-                    let snapshot = editor.snapshot(cx);
-                    let edits = vec![
-                        (
-                            snapshot.buffer_snapshot.anchor_before(Point::new(1, 7))
-                                ..snapshot.buffer_snapshot.anchor_before(Point::new(1, 11)),
-                            "modified".to_string(),
-                        ),
-                        (
-                            snapshot.buffer_snapshot.anchor_before(Point::new(2, 0))
-                                ..snapshot.buffer_snapshot.anchor_before(Point::new(2, 10)),
-                            "New third line".to_string(),
-                        ),
-                        (
-                            snapshot.buffer_snapshot.anchor_before(Point::new(3, 6))
-                                ..snapshot.buffer_snapshot.anchor_before(Point::new(3, 6)),
-                            " updated".to_string(),
-                        ),
-                    ];
-
-                    let InlineCompletionHint { text, highlights } =
-                        crate::inline_completion_hint(&snapshot, &edits, cx);
-
-                    assert_eq!(text, "Second modified\nNew third line\nFourth updated line");
-                    assert_eq!(highlights.len(), 3);
-                    assert_eq!(highlights[0].0, 7..15); // "modified"
-                    assert_eq!(highlights[1].0, 16..30); // "New third line"
-                    assert_eq!(highlights[2].0, 37..45); // " updated"
-
-                    for highlight in &highlights {
-                        assert_eq!(
-                            highlight.1.background_color,
-                            Some(cx.theme().status().created_background)
-                        );
-                    }
-                })
-                .unwrap();
         }
     }
 

--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -317,6 +317,10 @@ impl InlineCompletionProvider for FakeInlineCompletionProvider {
         "fake-completion-provider"
     }
 
+    fn display_name() -> &'static str {
+        "Fake Completion Provider"
+    }
+
     fn is_enabled(
         &self,
         _buffer: &gpui::Model<language::Buffer>,

--- a/crates/inline_completion/src/inline_completion.rs
+++ b/crates/inline_completion/src/inline_completion.rs
@@ -19,6 +19,7 @@ pub struct InlineCompletion {
 
 pub trait InlineCompletionProvider: 'static + Sized {
     fn name() -> &'static str;
+    fn display_name() -> &'static str;
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,
@@ -51,6 +52,7 @@ pub trait InlineCompletionProvider: 'static + Sized {
 
 pub trait InlineCompletionProviderHandle {
     fn name(&self) -> &'static str;
+    fn display_name(&self) -> &'static str;
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,
@@ -87,6 +89,10 @@ where
 {
     fn name(&self) -> &'static str {
         T::name()
+    }
+
+    fn display_name(&self) -> &'static str {
+        T::display_name()
     }
 
     fn is_enabled(

--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -98,6 +98,10 @@ impl InlineCompletionProvider for SupermavenCompletionProvider {
         "supermaven"
     }
 
+    fn display_name() -> &'static str {
+        "Supermaven"
+    }
+
     fn is_enabled(&self, buffer: &Model<Buffer>, cursor_position: Anchor, cx: &AppContext) -> bool {
         if !self.supermaven.read(cx).is_enabled() {
             return false;

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -930,6 +930,10 @@ impl inline_completion::InlineCompletionProvider for ZetaInlineCompletionProvide
         "zeta"
     }
 
+    fn display_name() -> &'static str {
+        "Zeta"
+    }
+
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,


### PR DESCRIPTION
Screenshot:

![screenshot-2024-12-17-11 53 41@2x](https://github.com/user-attachments/assets/bace3d20-7175-4833-9326-7b859166c0e8)

Demo:

https://github.com/user-attachments/assets/70197042-4785-4e45-80fd-29d12e68333f



(Note for Joseph/Peter: this supersedes https://github.com/zed-industries/zed/pull/22069)

Release Notes:
- Changed inline completions to show up inside the normal completions in case LSP and inline-completions are available. In that case, the inline completion will be the first entry in the menu and can be selected with `<tab>`.