### PR TITLE
Add arrow key movements to terminal vi mode

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1183,10 +1183,10 @@ impl Terminal {
         }
 
         let motion: Option<ViMotion> = match key.as_str() {
-            "h" => Some(ViMotion::Left),
-            "j" => Some(ViMotion::Down),
-            "k" => Some(ViMotion::Up),
-            "l" => Some(ViMotion::Right),
+            "h" | "left" => Some(ViMotion::Left),
+            "j" | "down" => Some(ViMotion::Down),
+            "k" | "up" => Some(ViMotion::Up),
+            "l" | "right" => Some(ViMotion::Right),
             "w" => Some(ViMotion::WordRight),
             "b" if !keystroke.modifiers.control => Some(ViMotion::WordLeft),
             "e" => Some(ViMotion::WordRightEnd),


### PR DESCRIPTION

Expands #18715

Release Notes:

- Added arrow keys movement to the built-in terminal's [vi mode](https://github.com/alacritty/alacritty/blob/master/docs/features.md#vi-mode)  (which is using Alacritty under the hood).

Details
--
A minuscule improvement on #18715 to allow user with alternative keyboard layouts to use the terminal's vi mode with the arrow keys.  
