### PR TITLE
ui: Add background color property to label

### DIFF
--- a/crates/ui/src/components/label/highlighted_label.rs
+++ b/crates/ui/src/components/label/highlighted_label.rs
@@ -46,6 +46,11 @@ impl LabelCommon for HighlightedLabel {
         self
     }
 
+    fn background(mut self, color: Color) -> Self {
+        self.base = self.base.background(color);
+        self
+    }
+
     fn strikethrough(mut self, strikethrough: bool) -> Self {
         self.base = self.base.strikethrough(strikethrough);
         self

--- a/crates/ui/src/components/label/label.rs
+++ b/crates/ui/src/components/label/label.rs
@@ -117,6 +117,20 @@ impl LabelCommon for Label {
         self
     }
 
+    /// Sets the background color of the label using a [`Color`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ui::prelude::*;
+    ///
+    /// let my_label = Label::new("Hello, World!").background(Color::Accent);
+    /// ```
+    fn background(mut self, color: Color) -> Self {
+        self.base = self.base.background(color);
+        self
+    }
+
     /// Sets the strikethrough property of the label.
     ///
     /// # Examples

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -176,12 +176,14 @@ impl RenderOnce for LabelLike {
             color.fade_out(1.0 - alpha);
         }
 
-        let background = self.background.map(|bg| bg.color(cx));
-        if let Some(mut background) = background {
+        let background = self.background.map(|background| {
+            let mut background = background.color(cx);
             if let Some(alpha) = self.alpha {
                 background.fade_out(1.0 - alpha);
             }
-        }
+
+            background
+        });
 
         self.base
             .map(|this| match self.size {

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -207,9 +207,7 @@ impl RenderOnce for LabelLike {
             .when(self.strikethrough, |this| this.line_through())
             .when(self.single_line, |this| this.whitespace_nowrap())
             .text_color(color)
-            .when(background.is_some(), |this| {
-                this.text_bg(background.unwrap())
-            })
+            .when_some(background, |this, background| this.text_bg(background))
             .font_weight(self.weight.unwrap_or(settings.ui_font.weight))
             .children(self.children)
     }


### PR DESCRIPTION
For issue #14093 I need to be able to specify a background color on the label used for the vim mode indicator.

Release Notes:

- N/A
