### PR TITLE
assistant2: Uniquely identify remove buttons on `ContextPill`s

### DIFF
--- a/crates/assistant2/src/ui/context_pill.rs
+++ b/crates/assistant2/src/ui/context_pill.rs
@@ -39,7 +39,7 @@ impl RenderOnce for ContextPill {
             .child(Label::new(self.context.name.clone()).size(LabelSize::Small))
             .when_some(self.on_remove, |parent, on_remove| {
                 parent.child(
-                    IconButton::new("remove", IconName::Close)
+                    IconButton::new(("remove", self.context.id.0), IconName::Close)
                         .shape(IconButtonShape::Square)
                         .icon_size(IconSize::XSmall)
                         .on_click({


### PR DESCRIPTION
This PR ensures that the remove buttons on the `ContextPill`s are uniquely identified.

Release Notes:

- N/A
