### PR TITLE
assistant2: Add text_ellipsis to the `PastThread` label

### DIFF
--- a/crates/assistant2/src/thread_history.rs
+++ b/crates/assistant2/src/thread_history.rs
@@ -126,12 +126,7 @@ impl RenderOnce for PastThread {
                     .color(Color::Muted),
             )
             .spacing(ListItemSpacing::Sparse)
-            .child(
-                div()
-                    .overflow_hidden()
-                    .text_ellipsis()
-                    .child(Label::new(summary).size(LabelSize::Small)),
-            )
+            .child(Label::new(summary).size(LabelSize::Small).text_ellipsis())
             .end_slot(
                 h_flex()
                     .gap_2()

--- a/crates/assistant2/src/thread_history.rs
+++ b/crates/assistant2/src/thread_history.rs
@@ -126,7 +126,12 @@ impl RenderOnce for PastThread {
                     .color(Color::Muted),
             )
             .spacing(ListItemSpacing::Sparse)
-            .child(Label::new(summary).size(LabelSize::Small))
+            .child(
+                div()
+                    .overflow_hidden()
+                    .text_ellipsis()
+                    .child(Label::new(summary).size(LabelSize::Small)),
+            )
             .end_slot(
                 h_flex()
                     .gap_2()


### PR DESCRIPTION
To treat the case for whenever the assistant panel gets small.

<img width="360" alt="Screenshot 2024-12-16 at 20 12 34" src="https://github.com/user-attachments/assets/5426a5b9-9baf-41e3-a2c6-2f997378c994" />

Release Notes:

- N/A
