### PR TITLE
ui: Round hover styles for `ListItem`s with `outlined` set

### DIFF
--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -202,6 +202,7 @@ impl RenderOnce for ListItem {
                     .when(self.selectable, |this| {
                         this.hover(|style| style.bg(cx.theme().colors().ghost_element_hover))
                             .active(|style| style.bg(cx.theme().colors().ghost_element_active))
+                            .when(self.outlined, |this| this.rounded_md())
                             .when(self.selected, |this| {
                                 this.bg(cx.theme().colors().ghost_element_selected)
                             })


### PR DESCRIPTION
This PR makes `ListItem`s with `outlined` set use the same rounding for their hover state to ensure that the hover background doesn't bleed outside of the outline.

Release Notes:

- N/A
