### PR TITLE
Use the same `InlineAssist` action between both `assistant` and `assistant2`

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -108,7 +108,6 @@ pub fn init(cx: &mut AppContext) {
 
                     workspace.toggle_panel_focus::<AssistantPanel>(cx);
                 })
-                .register_action(AssistantPanel::inline_assist)
                 .register_action(ContextEditor::quote_selection)
                 .register_action(ContextEditor::insert_selection)
                 .register_action(ContextEditor::copy_code)

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -15,9 +15,9 @@ mod thread_history;
 mod thread_store;
 mod ui;
 
+use std::any::TypeId;
 use std::sync::Arc;
 
-use assistant_settings::AssistantSettings;
 use client::Client;
 use command_palette_hooks::CommandPaletteFilter;
 use feature_flags::{Assistant2FeatureFlag, FeatureFlagAppExt};
@@ -28,6 +28,8 @@ use settings::Settings as _;
 use util::ResultExt;
 
 pub use crate::assistant_panel::AssistantPanel;
+use crate::assistant_settings::AssistantSettings;
+pub use crate::inline_assistant::InlineAssistant;
 
 actions!(
     assistant2,
@@ -37,7 +39,6 @@ actions!(
         ToggleModelSelector,
         OpenHistory,
         Chat,
-        ToggleInlineAssist,
         CycleNextInlineAssist,
         CyclePreviousInlineAssist
     ]
@@ -79,6 +80,8 @@ pub fn init(fs: Arc<dyn Fs>, client: Arc<Client>, stdout_is_a_pty: bool, cx: &mu
 fn feature_gate_assistant2_actions(cx: &mut AppContext) {
     const ASSISTANT1_NAMESPACE: &str = "assistant";
 
+    let inline_assist_actions = [TypeId::of::<zed_actions::InlineAssist>()];
+
     CommandPaletteFilter::update_global(cx, |filter, _cx| {
         filter.hide_namespace(NAMESPACE);
     });
@@ -88,6 +91,11 @@ fn feature_gate_assistant2_actions(cx: &mut AppContext) {
             CommandPaletteFilter::update_global(cx, |filter, _cx| {
                 filter.show_namespace(NAMESPACE);
                 filter.hide_namespace(ASSISTANT1_NAMESPACE);
+
+                // We're hiding all of the `assistant: ` actions, but we want to
+                // keep the inline assist action around so we can use the same
+                // one in Assistant2.
+                filter.show_action_types(inline_assist_actions.iter());
             });
         } else {
             CommandPaletteFilter::update_global(cx, |filter, _cx| {

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -8,7 +8,7 @@ use crate::{
     prompts::PromptBuilder,
     streaming_diff::{CharOperation, LineDiff, LineOperation, StreamingDiff},
     terminal_inline_assistant::TerminalInlineAssistant,
-    CycleNextInlineAssist, CyclePreviousInlineAssist, ToggleInlineAssist,
+    CycleNextInlineAssist, CyclePreviousInlineAssist,
 };
 use anyhow::{Context as _, Result};
 use client::{telemetry::Telemetry, ErrorExt};
@@ -72,9 +72,7 @@ pub fn init(
     cx: &mut AppContext,
 ) {
     cx.set_global(InlineAssistant::new(fs, prompt_builder, telemetry));
-    cx.observe_new_views(|workspace: &mut Workspace, cx| {
-        workspace.register_action(InlineAssistant::toggle_inline_assist);
-
+    cx.observe_new_views(|_workspace: &mut Workspace, cx| {
         let workspace = cx.view().clone();
         InlineAssistant::update_global(cx, |inline_assistant, cx| {
             inline_assistant.register_workspace(&workspace, cx)
@@ -201,9 +199,9 @@ impl InlineAssistant {
         }
     }
 
-    pub fn toggle_inline_assist(
+    pub fn inline_assist(
         workspace: &mut Workspace,
-        _action: &ToggleInlineAssist,
+        _action: &zed_actions::InlineAssist,
         cx: &mut ViewContext<Workspace>,
     ) {
         let settings = AssistantSettings::get_global(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -314,12 +314,13 @@ pub fn initialize_workspace(
             workspace_handle.update(&mut cx, |workspace, cx| {
                 if let Some(assistant_panel) = assistant_panel {
                     workspace.add_panel(assistant_panel, cx);
+                    workspace.register_action(assistant::AssistantPanel::inline_assist);
                 }
 
                 if let Some(assistant2_panel) = assistant2_panel {
                     workspace.add_panel(assistant2_panel, cx);
+                    workspace.register_action(assistant2::InlineAssistant::inline_assist);
                 }
-
             })
         })
         .detach();


### PR DESCRIPTION
This PR makes it so `assistant` and `assistant2` both use the same action for inline assist (`zed_actions::InlineAssist`).

This makes it so the keybindings to deploy the inline assist seamlessly swap based on the feature flag without needing to rebind them.

One minor caveat: if you're using `assistant2` the action name in the command palette will be `assistant: inline assist`.

Release Notes:

- N/A
