### PR TITLE
Revert "vim: Don't dismiss inline completion when switching to normal mode (#22075)"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2427,7 +2427,7 @@ impl Editor {
             cx.notify();
             return;
         }
-        if self.dismiss_menus_and_popups(false, true, cx) {
+        if self.dismiss_menus_and_popups(true, cx) {
             return;
         }
 
@@ -2442,7 +2442,6 @@ impl Editor {
 
     pub fn dismiss_menus_and_popups(
         &mut self,
-        keep_inline_completion: bool,
         should_report_inline_completion_event: bool,
         cx: &mut ViewContext<Self>,
     ) -> bool {
@@ -2466,9 +2465,7 @@ impl Editor {
             return true;
         }
 
-        if !keep_inline_completion
-            && self.discard_inline_completion(should_report_inline_completion_event, cx)
-        {
+        if self.discard_inline_completion(should_report_inline_completion_event, cx) {
             return true;
         }
 

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -22,7 +22,7 @@ impl Vim {
         if count <= 1 || Vim::globals(cx).dot_replaying {
             self.create_mark("^".into(), false, cx);
             self.update_editor(cx, |_, editor, cx| {
-                editor.dismiss_menus_and_popups(true, false, cx);
+                editor.dismiss_menus_and_popups(false, cx);
                 editor.change_selections(Some(Autoscroll::fit()), cx, |s| {
                     s.move_cursors_with(|map, mut cursor, _| {
                         *cursor.column_mut() = cursor.column().saturating_sub(1);


### PR DESCRIPTION
This reverts commit 38c0aa303e8c58238bceea9ee719ef2716158e81 from #22075.

Release Notes:

- N/A
