### PR TITLE
assistant2: Add spacing between historical thread entries

### DIFF
--- a/crates/assistant2/src/thread_history.rs
+++ b/crates/assistant2/src/thread_history.rs
@@ -66,10 +66,10 @@ impl Render for ThreadHistory {
                                 threads[range]
                                     .iter()
                                     .map(|thread| {
-                                        PastThread::new(
+                                        h_flex().w_full().pb_1().child(PastThread::new(
                                             thread.clone(),
                                             history.assistant_panel.clone(),
-                                        )
+                                        ))
                                     })
                                     .collect()
                             },


### PR DESCRIPTION
This PR adds spacing between entries in the historical threads view:

<img width="1371" alt="Screenshot 2024-12-17 at 10 51 26 AM" src="https://github.com/user-attachments/assets/f66d69e9-eb59-4c76-b3b5-c4d60190c3cc" />

Release Notes:

- N/A
