### PR TITLE
assistant2: Only add context if it is non-empty

### DIFF
--- a/crates/assistant2/src/context.rs
+++ b/crates/assistant2/src/context.rs
@@ -73,5 +73,7 @@ pub fn attach_context_to_message(
         context_text.push_str(&thread_context);
     }
 
-    message.content.push(MessageContent::Text(context_text));
+    if !context_text.is_empty() {
+        message.content.push(MessageContent::Text(context_text));
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where we were attaching empty message content even if there was no context.

Release Notes:

- N/A
