### PR TITLE
Use buffer font-size and font-family in inline completions menu

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -559,25 +559,22 @@ impl CompletionsMenu {
                             CompletionEntry::InlineCompletionHint(InlineCompletionMenuHint {
                                 provider_name,
                                 ..
-                            }) => div()
-                                .min_w(px(250.))
-                                .max_w(px(500.))
-                                .pb_1()
-                                .border_b_1()
-                                .border_color(cx.theme().colors().border_variant)
-                                .child(
-                                    ListItem::new("inline-completion")
-                                        .inset(true)
-                                        .toggle_state(item_ix == selected_item)
-                                        .on_click(cx.listener(move |editor, _event, cx| {
-                                            cx.stop_propagation();
-                                            editor.accept_inline_completion(
-                                                &AcceptInlineCompletion {},
-                                                cx,
-                                            );
-                                        }))
-                                        .child(Label::new(SharedString::new_static(provider_name))),
-                                ),
+                            }) => div().min_w(px(250.)).max_w(px(500.)).child(
+                                ListItem::new("inline-completion")
+                                    .inset(true)
+                                    .toggle_state(item_ix == selected_item)
+                                    .on_click(cx.listener(move |editor, _event, cx| {
+                                        cx.stop_propagation();
+                                        editor.accept_inline_completion(
+                                            &AcceptInlineCompletion {},
+                                            cx,
+                                        );
+                                    }))
+                                    .child(
+                                        StyledText::new(SharedString::new_static(provider_name))
+                                            .with_highlights(&style.text, None),
+                                    ),
+                            ),
                         }
                     })
                     .collect()


### PR DESCRIPTION
This changes how we present the provider name in the inline completions menu.

It fixes the font-family and font-size to match the buffer, so it doesn't break the list.

It also removes the padding, because with the uniform list, we can't just add padding and borders without them bleeding into other items.

Probably need to think of something else here to make this item stand out more.

Now it looks like this:

![screenshot-2024-12-17-16 59 28@2x](https://github.com/user-attachments/assets/779d58c2-00cc-4d19-8f66-9d392f167ffe)


Release Notes:

- N/A
