### PR TITLE
telemetry: Fix license symlink

### DIFF
--- a/crates/telemetry/LICENSE-GPL
+++ b/crates/telemetry/LICENSE-GPL
@@ -1,1 +1,1 @@
-LICENSE-GPL
+../../LICENSE-GPL


### PR DESCRIPTION
This PR fixes the `LICENSE-GPL` symlink in the `telemetry` crate.

Release Notes:

- N/A
