### PR TITLE
Remove main push from `bump-zed-minor-versions` script

### DIFF
--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -99,19 +99,16 @@ git checkout -q main
 cat <<MESSAGE
 Prepared new Zed versions locally. You will need to push the branches and open a PR for the change to main.
 
-# To open the PR:
-
-    git checkout ${bump_main_branch_name}
-    git push origin ${bump_main_branch_name}
-    gh pr create --fill --web
-
-# To push this:
+# To push and open a PR to update main:
 
     git push origin \\
       ${preview_tag_name} \\
       ${stable_tag_name} \\
       ${minor_branch_name} \\
-      ${prev_minor_branch_name}
+      ${prev_minor_branch_name} \\
+      ${bump_main_branch_name}
+
+    gh pr create --base main --head ${bump_main_branch_name}
 
 # To undo this push:
 

--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -28,6 +28,7 @@ minor_branch_name="v${major}.${minor}.x"
 prev_minor_branch_name="v${major}.${prev_minor}.x"
 next_minor_branch_name="v${major}.${next_minor}.x"
 preview_tag_name="v${major}.${minor}.${patch}-pre"
+bump_main_branch_name="set-minor-version-to-${major}.${next_minor}"
 
 git fetch origin ${prev_minor_branch_name}:${prev_minor_branch_name}
 git fetch origin --tags
@@ -83,29 +84,42 @@ git tag ${preview_tag_name}
 echo "Preparing main for version ${next_minor_branch_name}..."
 git checkout -q main
 git clean -q -dff
-old_main_sha=$(git rev-parse HEAD)
+git checkout -q -b ${bump_main_branch_name}
 cargo set-version --package zed --bump minor
 cargo check -q
-git commit -q --all --message "${next_minor_branch_name} dev"
+message="${next_minor_branch_name} dev
+
+Release Notes:
+
+- N/A"
+git commit -q --all --message "$message"
+
+git checkout -q main
 
 cat <<MESSAGE
-Prepared new Zed versions locally.
+Prepared new Zed versions locally. You will need to push the branches and open a PR for the change to main.
 
-To push this:
+# To open the PR:
+
+    git checkout ${bump_main_branch_name}
+    git push origin ${bump_main_branch_name}
+    gh pr create --fill --web
+
+# To push this:
 
     git push origin \\
       ${preview_tag_name} \\
       ${stable_tag_name} \\
       ${minor_branch_name} \\
-      ${prev_minor_branch_name} \\
-      main
+      ${prev_minor_branch_name}
 
-To undo this:
+# To undo this push:
 
-    git reset --hard ${old_main_sha} && git push -f . \\
+    git push -f . \\
       :${preview_tag_name} \\
       :${stable_tag_name} \\
       :${minor_branch_name} \\
+      :${bump_main_branch_name} \\
       ${old_prev_minor_sha}:${prev_minor_branch_name}
 
 MESSAGE


### PR DESCRIPTION
Motivation for this is to allow the `main` branch to be protected.  This will enable use of auto-merge and merge queue.

Release Notes:

- N/A