### PR TITLE
Add command to copy current file name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7156,7 +7156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -242,6 +242,8 @@ gpui::actions!(
         Copy,
         CopyFileLocation,
         CopyHighlightJson,
+        CopyFileName,
+        CopyFileNameWithoutExtension,
         CopyPath,
         CopyPermalinkToLine,
         CopyRelativePath,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12595,7 +12595,7 @@ impl Editor {
     pub fn copy_file_name_without_extension(
         &mut self,
         _: &CopyFileNameWithoutExtension,
-        window: &mut Window,
+        _: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let Some(file) = self.target_file(cx) {
@@ -12610,7 +12610,7 @@ impl Editor {
     pub fn copy_file_name(
         &mut self,
         _: &CopyFileName,
-        window: &mut Window,
+        _: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let Some(file) = self.target_file(cx) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12595,7 +12595,8 @@ impl Editor {
     pub fn copy_file_name_without_extension(
         &mut self,
         _: &CopyFileNameWithoutExtension,
-        cx: &mut ViewContext<Self>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
     ) {
         if let Some(file) = self.target_file(cx) {
             if let Some(file_stem) = file.path().file_stem() {
@@ -12606,7 +12607,12 @@ impl Editor {
         }
     }
 
-    pub fn copy_file_name(&mut self, _: &CopyFileName, cx: &mut ViewContext<Self>) {
+    pub fn copy_file_name(
+        &mut self,
+        _: &CopyFileName,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(file) = self.target_file(cx) {
             if let Some(file_name) = file.path().file_name() {
                 if let Some(name) = file_name.to_str() {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12607,12 +12607,7 @@ impl Editor {
         }
     }
 
-    pub fn copy_file_name(
-        &mut self,
-        _: &CopyFileName,
-        _: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    pub fn copy_file_name(&mut self, _: &CopyFileName, _: &mut Window, cx: &mut Context<Self>) {
         if let Some(file) = self.target_file(cx) {
             if let Some(file_name) = file.path().file_name() {
                 if let Some(name) = file_name.to_str() {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12592,6 +12592,30 @@ impl Editor {
         }
     }
 
+    pub fn copy_file_name_without_extension(
+        &mut self,
+        _: &CopyFileNameWithoutExtension,
+        cx: &mut ViewContext<Self>,
+    ) {
+        if let Some(file) = self.target_file(cx) {
+            if let Some(file_stem) = file.path().file_stem() {
+                if let Some(name) = file_stem.to_str() {
+                    cx.write_to_clipboard(ClipboardItem::new_string(name.to_string()));
+                }
+            }
+        }
+    }
+
+    pub fn copy_file_name(&mut self, _: &CopyFileName, cx: &mut ViewContext<Self>) {
+        if let Some(file) = self.target_file(cx) {
+            if let Some(file_name) = file.path().file_name() {
+                if let Some(name) = file_name.to_str() {
+                    cx.write_to_clipboard(ClipboardItem::new_string(name.to_string()));
+                }
+            }
+        }
+    }
+
     pub fn toggle_git_blame(
         &mut self,
         _: &ToggleGitBlame,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -407,6 +407,8 @@ impl EditorElement {
         register_action(editor, window, Editor::reveal_in_finder);
         register_action(editor, window, Editor::copy_path);
         register_action(editor, window, Editor::copy_relative_path);
+        register_action(view, cx, Editor::copy_file_name);
+        register_action(view, cx, Editor::copy_file_name_without_extension);
         register_action(editor, window, Editor::copy_highlight_json);
         register_action(editor, window, Editor::copy_permalink_to_line);
         register_action(editor, window, Editor::open_permalink_to_line);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -407,8 +407,8 @@ impl EditorElement {
         register_action(editor, window, Editor::reveal_in_finder);
         register_action(editor, window, Editor::copy_path);
         register_action(editor, window, Editor::copy_relative_path);
-        register_action(view, cx, Editor::copy_file_name);
-        register_action(view, cx, Editor::copy_file_name_without_extension);
+        register_action(editor, window, Editor::copy_file_name);
+        register_action(editor, window, Editor::copy_file_name_without_extension);
         register_action(editor, window, Editor::copy_highlight_json);
         register_action(editor, window, Editor::copy_permalink_to_line);
         register_action(editor, window, Editor::open_permalink_to_line);


### PR DESCRIPTION
Closes #21967

## Description
This PR adds commands to copy current file's name.

## Screenshots
### Editor command (command palette)
![image](https://github.com/user-attachments/assets/83f1693c-10c4-4058-b0e1-b0e166fa6bfa)

Release Notes:

- Added commands to copy current file name
