### PR TITLE
Fix panic when calculating inline completion

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4737,16 +4737,10 @@ impl Editor {
         let edits = completion
             .edits
             .into_iter()
-            .map(|(range, new_text)| {
-                (
-                    multibuffer
-                        .anchor_in_excerpt(excerpt_id, range.start)
-                        .unwrap()
-                        ..multibuffer
-                            .anchor_in_excerpt(excerpt_id, range.end)
-                            .unwrap(),
-                    new_text,
-                )
+            .flat_map(|(range, new_text)| {
+                let start = multibuffer.anchor_in_excerpt(excerpt_id, range.start)?;
+                let end = multibuffer.anchor_in_excerpt(excerpt_id, range.end)?;
+                Some((start..end, new_text))
             })
             .collect::<Vec<_>>();
         if edits.is_empty() {


### PR DESCRIPTION
Possible panic here in case we can't find the excerpt in the multibuffer.

I thought this could happen when the inline completion references an excerpt that disappeared from the multibuffer, but looking at the code I'm not sure anymore - we use the same multibuffer snapshot in this whole function and the `anchor_in_excerpt` method clips the anchors.

Still, let's be safe here.

Release Notes:

- N/A
