### PR TITLE
zeta: Show deletions when inline completion is shown in menu

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3221,7 +3221,7 @@ impl EditorElement {
                 }
 
                 let crate::InlineCompletionText::Edit { text, highlights } =
-                    crate::inline_completion_edit_text(editor_snapshot, edits, cx)
+                    crate::inline_completion_edit_text(editor_snapshot, edits, false, cx)
                 else {
                     return None;
                 };


### PR DESCRIPTION
If an inline completion isn't shown in a menu, we highlight text in the editor as deleted.

But if it's shown in the menu, we didn't even show deleted text, which makes it hard to understand what's going on.

This fixes it.
![screenshot-2024-12-18-14 34 55@2x](https://github.com/user-attachments/assets/579639e4-5ed9-4fe6-8e21-65166d192432)


Release Notes:

- N/A
