### PR TITLE
assistant2: Reduce message editor's maximum height

### DIFF
--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -52,7 +52,7 @@ impl MessageEditor {
         let inline_context_picker_menu_handle = PopoverMenuHandle::default();
 
         let editor = cx.new_view(|cx| {
-            let mut editor = Editor::auto_height(80, cx);
+            let mut editor = Editor::auto_height(10, cx);
             editor.set_placeholder_text("Ask anything, @ to add context", cx);
             editor.set_show_indent_guides(false, cx);
 


### PR DESCRIPTION
This PR reduces the message editor's maximum height to 10 lines, after which point it will scroll.

Release Notes:

- N/A
