### PR TITLE
ci: Enable `merge_group` for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
     paths-ignore:
       - "docs/**/*"
       - ".github/workflows/community_*"
+  merge_group:
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 jobs:
   check_formatting:


### PR DESCRIPTION
Enable the `merge_group` for CI workflows so that they work with the merge queue.

Release Notes:

- N/A
