### PR TITLE
elixir: Bump to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16149,7 +16149,7 @@ dependencies = [
 
 [[package]]
 name = "zed_elixir"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zed_extension_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/extensions/elixir/Cargo.toml
+++ b/extensions/elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_elixir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extensions/elixir/extension.toml
+++ b/extensions/elixir/extension.toml
@@ -1,7 +1,7 @@
 id = "elixir"
 name = "Elixir"
 description = "Elixir support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Includes:
- https://github.com/zed-industries/zed/pull/21666
- https://github.com/zed-industries/zed/pull/20206

Release Notes:

- N/A