### PR TITLE
terminal: Clear output after venv is activated

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -433,7 +433,10 @@ impl Project {
             "windows" => "\r",
             _ => "\n",
         };
-        Some(format!("{} {}{}", activate_keyword, quoted, line_ending))
+        Some(format!(
+            "{} {} ; clear{}",
+            activate_keyword, quoted, line_ending
+        ))
     }
 
     fn activate_python_virtual_environment(
@@ -450,7 +453,7 @@ impl Project {
     }
 }
 
-pub fn wrap_for_ssh(
+fn wrap_for_ssh(
     ssh_command: &SshCommand,
     command: Option<(&String, &Vec<String>)>,
     path: Option<&Path>,


### PR DESCRIPTION
The command used to activate the venv can still be accessed/scrolled to if needed.

Release Notes:

- The Python virtual environment activation command is no longer shown in the terminal output by default.
