### PR TITLE
Fix knockout icon background to match hovered entry background in project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3392,6 +3392,13 @@ impl ProjectPanel {
                             let is_warning = diagnostic_severity
                                 .map(|severity| matches!(severity, DiagnosticSeverity::WARNING))
                                 .unwrap_or(false);
+
+                            let knockout_hover_color = if !is_marked && !is_active {
+                                bg_hover_color
+                            } else {
+                                default_color
+                            };
+
                             div().child(
                                 DecoratedIcon::new(
                                     Icon::from_path(icon.clone()).color(Color::Muted),
@@ -3410,7 +3417,7 @@ impl ProjectPanel {
                                             cx,
                                         )
                                         .group_name(Some(GROUP_NAME.into()))
-                                        .knockout_hover_color(bg_hover_color)
+                                        .knockout_hover_color(knockout_hover_color)
                                         .color(decoration_color.color(cx))
                                         .position(Point {
                                             x: px(-2.),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3200,7 +3200,7 @@ impl ProjectPanel {
             item_colors.default
         };
 
-        let bg_hover_color = if self.mouse_down {
+        let bg_hover_color = if self.mouse_down || is_marked || is_active {
             item_colors.marked_active
         } else {
             item_colors.hover
@@ -3224,9 +3224,7 @@ impl ProjectPanel {
             .border_1()
             .border_r_2()
             .border_color(border_color)
-            .when(!is_marked && !is_active, |div| {
-                div.hover(|style| style.bg(bg_hover_color))
-            })
+            .hover(|style| style.bg(bg_hover_color))
             .when(is_local, |div| {
                 div.on_drag_move::<ExternalPaths>(cx.listener(
                     move |this, event: &DragMoveEvent<ExternalPaths>, cx| {
@@ -3392,13 +3390,6 @@ impl ProjectPanel {
                             let is_warning = diagnostic_severity
                                 .map(|severity| matches!(severity, DiagnosticSeverity::WARNING))
                                 .unwrap_or(false);
-
-                            let knockout_hover_color = if !is_marked && !is_active {
-                                bg_hover_color
-                            } else {
-                                default_color
-                            };
-
                             div().child(
                                 DecoratedIcon::new(
                                     Icon::from_path(icon.clone()).color(Color::Muted),
@@ -3417,7 +3408,7 @@ impl ProjectPanel {
                                             cx,
                                         )
                                         .group_name(Some(GROUP_NAME.into()))
-                                        .knockout_hover_color(knockout_hover_color)
+                                        .knockout_hover_color(bg_hover_color)
                                         .color(decoration_color.color(cx))
                                         .position(Point {
                                             x: px(-2.),


### PR DESCRIPTION
No issue attached, as this is something trivial and should have been part of my merged PR [here](https://github.com/zed-industries/zed/pull/22073).

For context, in the above-mentioned PR, I removed the hover color from selected/marked entries in the Project Panel. The reasoning behind this change is already explained in that PR, but to reiterate:

> This change was inspired by the behavior in VSCode, the Firefox sidebar, and Dolphin (KDE File Manager). When an item is selected, it doesn’t display a separate hover state to avoid confusing users about whether the item is selected or merely hovered over.

@nilskch mentioned in the comments of the above PR that I should have also changed the background of the knockout icon, which appears on entries, to match the entry background color on hover. This PR addresses that.

Before:
![Screenshot_20241219_230005](https://github.com/user-attachments/assets/fd517e01-1a1e-4e63-9320-ba24bf3d4c64)

After:
![Screenshot_20241219_225853](https://github.com/user-attachments/assets/35fb146f-83e4-409b-8061-0efbdbba5cf9)

Release Notes:

- N/A
