### PR TITLE
Move Vim mode indicator to the left side of the status bar

### DIFF
--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -108,9 +108,13 @@ impl Render for ModeIndicator {
             .pending_keys
             .as_ref()
             .unwrap_or(&current_operators_description);
-        Label::new(format!("{} -- {} --", pending, mode))
-            .size(LabelSize::Small)
-            .line_height_style(LineHeightStyle::UiLabel)
+        div()
+            .w_20()
+            .child(
+                Label::new(format!("{} -- {} --", pending, mode))
+                    .size(LabelSize::Small)
+                    .line_height_style(LineHeightStyle::UiLabel),
+            )
             .into_any_element()
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -180,12 +180,12 @@ pub fn initialize_workspace(
         let cursor_position =
             cx.new_view(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
         workspace.status_bar().update(cx, |status_bar, cx| {
+            status_bar.add_left_item(vim_mode_indicator, cx);
             status_bar.add_left_item(diagnostic_summary, cx);
             status_bar.add_left_item(activity_indicator, cx);
             status_bar.add_right_item(inline_completion_button, cx);
             status_bar.add_right_item(active_buffer_language, cx);
             status_bar.add_right_item(active_toolchain_language, cx);
-            status_bar.add_right_item(vim_mode_indicator, cx);
             status_bar.add_right_item(cursor_position, cx);
         });
 


### PR DESCRIPTION
Addressed the first request on issue #14093, as discussed in #22048 

Release Notes:

- Improved Vim mode indicator visibility by moving it to the left of the status bar
