### PR TITLE
Fix blank line cursor width

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1032,6 +1032,7 @@ impl EditorElement {
         scroll_pixel_position: gpui::Point<Pixels>,
         line_height: Pixels,
         em_width: Pixels,
+        em_advance: Pixels,
         autoscroll_containing_element: bool,
         cx: &mut WindowContext,
     ) -> Vec<CursorLayout> {
@@ -1058,7 +1059,7 @@ impl EditorElement {
                     let mut block_width =
                         cursor_row_layout.x_for_index(cursor_column + 1) - cursor_character_x;
                     if block_width == Pixels::ZERO {
-                        block_width = em_width;
+                        block_width = em_advance;
                     }
                     let block_text = if let CursorShape::Block = selection.cursor_shape {
                         snapshot
@@ -6246,6 +6247,7 @@ impl Element for EditorElement {
                         scroll_pixel_position,
                         line_height,
                         em_width,
+                        em_advance,
                         autoscroll_containing_element,
                         cx,
                     );


### PR DESCRIPTION
This PR ensures that, for fixed-width fonts, the cursor width is the same on blank lines as on non-blank lines, as well as at the end of a line. It does so by using the em advance to define the cursor width instead of the em width in these cases.

Note that this can look... bizarre on non-fixed-width fonts:
<img width="93" alt="Screenshot 2024-12-19 at 21 43 11" src="https://github.com/user-attachments/assets/a4c9b26c-98ea-4a1d-947b-51f1acd3c2f8" />
However, this is arguably reasonably consistent with how (terminal) Vim handles it:
<img width="45" alt="Screenshot 2024-12-19 at 21 46 42" src="https://github.com/user-attachments/assets/ec3ff614-7a15-4cc3-8d14-3d15ce62f2b8" />

Closes #22260.

Release Notes:

- N/A