### PR TITLE
linux: Fix wrong cursor theme for arrow cursor style

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -651,7 +651,7 @@ impl CursorStyle {
         // and https://github.com/KDE/breeze (KDE). Both of them seem to be also derived from
         // Web CSS cursor names: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values
         match self {
-            CursorStyle::Arrow => "arrow",
+            CursorStyle::Arrow => "left_ptr",
             CursorStyle::IBeam => "text",
             CursorStyle::Crosshair => "crosshair",
             CursorStyle::ClosedHand => "grabbing",


### PR DESCRIPTION
Closes #22264

On Linux, the arrow cursor style currently used by Zed is `arrow`. However, this style might not be available in most themes, causing the cursor to fall back to system default theme. Note cursor style are platform (X11 and Wayland) agnostic.

Most themes use `left_ptr` as their arrow cursor style instead of `arrow`. In some cases, `left_ptr` and `arrow` are symlinks pointing to the `default` style, but the `default` style is not guaranteed to be available across all themes.  

After inspecting the available cursor themes on popular desktop environments, changing the default from `arrow` to `left_ptr` seems to be available in all of them. `left_ptr` as default cursor style is also mentioned in [Arch Wiki: Cursor themes](https://wiki.archlinux.org/title/Cursor_themes#Change_X_shaped_default_cursor). 

KDE:
```sh
tims@lemon /u/s/icons> find . -name "arrow"
./Breeze_Snow/cursors/arrow
./breeze_cursors/cursors/arrow
./Adwaita/cursors/arrow

tims@lemon /u/s/icons> find . -name "default"
./default
./Breeze_Snow/cursors/default
./breeze_cursors/cursors/default
./Adwaita/cursors/default

tims@lemon /u/s/icons> find . -name "left_ptr"
./Oxygen_White/cursors/left_ptr
./KDE_Classic/cursors/left_ptr
./Oxygen_Yellow/cursors/left_ptr
./Oxygen_Blue/cursors/left_ptr
./Oxygen_Black/cursors/left_ptr
./Breeze_Snow/cursors/left_ptr
./breeze_cursors/cursors/left_ptr
./Adwaita/cursors/left_ptr
./Oxygen_Zion/cursors/left_ptr

```

Gnome:
```sh
tims@orange:/usr/share/icons$ find . -name "arrow"
./DMZ-Black/cursors/arrow
./Adwaita/cursors/arrow
./redglass/cursors/arrow
./whiteglass/cursors/arrow
./handhelds/cursors/arrow
./Yaru/cursors/arrow
./DMZ-White/cursors/arrow

tims@orange:/usr/share/icons$ find . -name "default"
./Adwaita/cursors/default
./default
./Yaru/cursors/default

tims@orange:/usr/share/icons$ find . -name "left_ptr"
./DMZ-Black/cursors/left_ptr
./Adwaita/cursors/left_ptr
./redglass/cursors/left_ptr
./whiteglass/cursors/left_ptr
./handhelds/cursors/left_ptr
./Yaru/cursors/left_ptr
./DMZ-White/cursors/left_ptr
```

My theme is set to Oxygen Yellow here.

Before:
<img src="https://github.com/user-attachments/assets/7485f1e7-5936-45b4-96bd-399525bad95d" alt="before" width="450px" />

After:
<img src="https://github.com/user-attachments/assets/56090735-6a1f-4652-ad3e-075ff4c3f9ab" alt="after" width="450px" />


Release Notes:

- Fixed wrong cursor theme for arrow cursor style on Linux.
