### PR TITLE
vim: Fix deletion with sentence-motion

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -585,8 +585,6 @@ impl Motion {
             | NextLineStart
             | PreviousLineStart
             | StartOfLineDownward
-            | SentenceBackward
-            | SentenceForward
             | StartOfParagraph
             | EndOfParagraph
             | WindowTop
@@ -611,6 +609,8 @@ impl Motion {
             | Left
             | Backspace
             | Right
+            | SentenceBackward
+            | SentenceForward
             | Space
             | StartOfLine { .. }
             | EndOfLineDownward

--- a/crates/vim/test_data/test_delete_sentence.json
+++ b/crates/vim/test_data/test_delete_sentence.json
@@ -1,0 +1,22 @@
+{"Put":{"state":"Fiˇrst. Second. Third.\nFourth.\n"}}
+{"Key":"d"}
+{"Key":")"}
+{"Get":{"state":"FiˇSecond. Third.\nFourth.\n","mode":"Normal"}}
+{"Put":{"state":"First. Secˇond. Third.\nFourth.\n"}}
+{"Key":"d"}
+{"Key":")"}
+{"Get":{"state":"First. SecˇThird.\nFourth.\n","mode":"Normal"}}
+{"Put":{"state":"First. Second. Thirˇd.\nFourth.\n"}}
+{"Key":"d"}
+{"Key":")"}
+{"Key":"d"}
+{"Key":")"}
+{"Get":{"state":"First. Second. Thˇi\n","mode":"Normal"}}
+{"Put":{"state":"ˇFirst.\nFourth.\n"}}
+{"Key":"d"}
+{"Key":")"}
+{"Get":{"state":"ˇFourth.\n","mode":"Normal"}}
+{"Put":{"state":"First.\nˇSecond.\nFourth.\n"}}
+{"Key":"d"}
+{"Key":"("}
+{"Get":{"state":"ˇSecond.\nFourth.\n","mode":"Normal"}}


### PR DESCRIPTION
Fixes #22151.

Turns out Vim also has some weird behavior with sentence deletion in case it's on the first character of a line.

Release Notes:

- vim: Fixed deleting sentence-wise (i.e. `d(` and `d)`), which would previously delete the whole line instead of just a sentence.