### PR TITLE
Enable Assistant2 outside of development builds

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -300,7 +300,6 @@ fn show_software_emulation_warning_if_needed(
 }
 
 fn initialize_panels(prompt_builder: Arc<PromptBuilder>, cx: &mut ViewContext<Workspace>) {
-    let release_channel = ReleaseChannel::global(cx);
     let assistant2_feature_flag = cx.wait_for_flag::<feature_flags::Assistant2FeatureFlag>();
     let git_ui_feature_flag = cx.wait_for_flag::<feature_flags::GitUiFeatureFlag>();
 
@@ -361,7 +360,7 @@ fn initialize_panels(prompt_builder: Arc<PromptBuilder>, cx: &mut ViewContext<Wo
             }
         })?;
 
-        let is_assistant2_enabled = if cfg!(test) || release_channel != ReleaseChannel::Dev {
+        let is_assistant2_enabled = if cfg!(test) {
             false
         } else {
             assistant2_feature_flag.await


### PR DESCRIPTION
This PR removes the gate that limited Assistant2 to development builds, so that we can start testing it out in Nightly.

Note that currently this still requires explicit opt-in to the `assistant2` feature flag.

Release Notes:

- N/A
