### PR TITLE
Remove usage of `use gpui::*`

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1,4 +1,16 @@
+use anyhow::Result;
 use collections::HashMap;
+use db::kvp::KEY_VALUE_STORE;
+use git::repository::GitFileStatus;
+use gpui::{
+    actions, prelude::*, uniform_list, Action, AppContext, AsyncWindowContext, ClickEvent,
+    CursorStyle, EventEmitter, FocusHandle, FocusableView, KeyContext,
+    ListHorizontalSizingBehavior, ListSizingBehavior, Model, Modifiers, ModifiersChangedEvent,
+    MouseButton, Stateful, Task, UniformListScrollHandle, View, WeakView,
+};
+use project::{Entry, EntryKind, Fs, Project, ProjectEntryId, WorktreeId};
+use serde::{Deserialize, Serialize};
+use settings::Settings as _;
 use std::{
     cell::OnceCell,
     collections::HashSet,
@@ -8,19 +20,10 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-
-use git::repository::GitFileStatus;
-
-use util::{ResultExt, TryFutureExt};
-
-use db::kvp::KEY_VALUE_STORE;
-use gpui::*;
-use project::{Entry, EntryKind, Fs, Project, ProjectEntryId, WorktreeId};
-use serde::{Deserialize, Serialize};
-use settings::Settings as _;
 use ui::{
     prelude::*, Checkbox, Divider, DividerColor, ElevationIndex, Scrollbar, ScrollbarState, Tooltip,
 };
+use util::{ResultExt, TryFutureExt};
 use workspace::dock::{DockPosition, Panel, PanelEvent};
 use workspace::Workspace;
 

--- a/crates/ui/src/components/tool_strip.rs
+++ b/crates/ui/src/components/tool_strip.rs
@@ -1,7 +1,8 @@
 #![allow(missing_docs)]
 
+use gpui::Axis;
+
 use crate::prelude::*;
-use gpui::*;
 
 #[derive(IntoElement)]
 pub struct ToolStrip {

--- a/crates/ui_input/src/ui_input.rs
+++ b/crates/ui_input/src/ui_input.rs
@@ -5,11 +5,11 @@
 //! It can't be located in the `ui` crate because it depends on `editor`.
 //!
 
-use editor::*;
-use gpui::*;
+use editor::{Editor, EditorElement, EditorStyle};
+use gpui::{AppContext, FocusHandle, FocusableView, FontStyle, Hsla, TextStyle, View};
 use settings::Settings;
 use theme::ThemeSettings;
-use ui::*;
+use ui::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FieldLabelLayout {


### PR DESCRIPTION
This PR removes usages of `use gpui::*;` in the codebase (excluding examples).

We should only use glob imports for `gpui::prelude`, and then import everything else individually.

Release Notes:

- N/A
