### PR TITLE
gpui: Remove use of `use gpui::*` in examples

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1,4 +1,16 @@
+use anyhow::Result;
 use collections::HashMap;
+use db::kvp::KEY_VALUE_STORE;
+use git::repository::GitFileStatus;
+use gpui::{
+    actions, prelude::*, uniform_list, Action, AppContext, AsyncWindowContext, ClickEvent,
+    CursorStyle, EventEmitter, FocusHandle, FocusableView, KeyContext,
+    ListHorizontalSizingBehavior, ListSizingBehavior, Model, Modifiers, ModifiersChangedEvent,
+    MouseButton, Stateful, Task, UniformListScrollHandle, View, WeakView,
+};
+use project::{Entry, EntryKind, Fs, Project, ProjectEntryId, WorktreeId};
+use serde::{Deserialize, Serialize};
+use settings::Settings as _;
 use std::{
     cell::OnceCell,
     collections::HashSet,
@@ -8,19 +20,10 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-
-use git::repository::GitFileStatus;
-
-use util::{ResultExt, TryFutureExt};
-
-use db::kvp::KEY_VALUE_STORE;
-use gpui::*;
-use project::{Entry, EntryKind, Fs, Project, ProjectEntryId, WorktreeId};
-use serde::{Deserialize, Serialize};
-use settings::Settings as _;
 use ui::{
     prelude::*, Checkbox, Divider, DividerColor, ElevationIndex, Scrollbar, ScrollbarState, Tooltip,
 };
+use util::{ResultExt, TryFutureExt};
 use workspace::dock::{DockPosition, Panel, PanelEvent};
 use workspace::Workspace;
 

--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -1,6 +1,11 @@
 use std::time::Duration;
 
-use gpui::*;
+use anyhow::Result;
+use gpui::{
+    black, bounce, div, ease_in_out, percentage, prelude::*, px, rgb, size, svg, Animation,
+    AnimationExt as _, App, AppContext, AssetSource, Bounds, SharedString, Transformation,
+    ViewContext, WindowBounds, WindowOptions,
+};
 
 struct Assets {}
 
@@ -37,7 +42,7 @@ impl Render for AnimationExample {
                 div()
                     .flex()
                     .bg(rgb(0x2e7d32))
-                    .size(Length::Definite(Pixels(300.0).into()))
+                    .size(px(300.0))
                     .justify_center()
                     .items_center()
                     .shadow_lg()

--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -1,4 +1,7 @@
-use gpui::*;
+use gpui::{
+    div, prelude::*, px, rgb, size, App, AppContext, Bounds, SharedString, ViewContext,
+    WindowBounds, WindowOptions,
+};
 
 struct HelloWorld {
     text: SharedString,
@@ -11,7 +14,7 @@ impl Render for HelloWorld {
             .flex_col()
             .gap_3()
             .bg(rgb(0x505050))
-            .size(Length::Definite(Pixels(500.0).into()))
+            .size(px(500.0))
             .justify_center()
             .items_center()
             .shadow_lg()

--- a/crates/gpui/examples/image/image.rs
+++ b/crates/gpui/examples/image/image.rs
@@ -1,9 +1,14 @@
+use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use gpui::*;
-use std::fs;
+use anyhow::Result;
+use gpui::{
+    actions, div, img, prelude::*, px, rgb, size, App, AppContext, AssetSource, Bounds,
+    ImageSource, KeyBinding, Menu, MenuItem, Point, SharedString, SharedUri, TitlebarOptions,
+    ViewContext, WindowBounds, WindowContext, WindowOptions,
+};
 
 struct Assets {
     base: PathBuf,
@@ -55,7 +60,7 @@ impl RenderOnce for ImageContainer {
                 .size_full()
                 .gap_4()
                 .child(self.text)
-                .child(img(self.src).w(px(256.0)).h(px(256.0))),
+                .child(img(self.src).size(px(256.0))),
         )
     }
 }
@@ -75,7 +80,7 @@ impl Render for ImageShowcase {
             .justify_center()
             .items_center()
             .gap_8()
-            .bg(rgb(0xFFFFFF))
+            .bg(rgb(0xffffff))
             .child(
                 div()
                     .flex()

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -1,6 +1,13 @@
 use std::ops::Range;
 
-use gpui::*;
+use gpui::{
+    actions, black, div, fill, hsla, opaque_grey, point, prelude::*, px, relative, rgb, rgba, size,
+    white, yellow, App, AppContext, Bounds, ClipboardItem, CursorStyle, ElementId,
+    ElementInputHandler, FocusHandle, FocusableView, GlobalElementId, KeyBinding, Keystroke,
+    LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
+    ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle, View, ViewContext,
+    ViewInputHandler, WindowBounds, WindowContext, WindowOptions,
+};
 use unicode_segmentation::*;
 
 actions!(
@@ -463,7 +470,7 @@ impl Element for TextElement {
                             bounds.bottom(),
                         ),
                     ),
-                    rgba(0x3311FF30),
+                    rgba(0x3311ff30),
                 )),
                 None,
             )

--- a/crates/gpui/examples/opacity.rs
+++ b/crates/gpui/examples/opacity.rs
@@ -1,6 +1,10 @@
 use std::{fs, path::PathBuf, time::Duration};
 
-use gpui::*;
+use anyhow::Result;
+use gpui::{
+    div, hsla, img, point, prelude::*, px, rgb, size, svg, App, AppContext, AssetSource, Bounds,
+    BoxShadow, ClickEvent, SharedString, Task, Timer, ViewContext, WindowBounds, WindowOptions,
+};
 
 struct Assets {
     base: PathBuf,
@@ -76,7 +80,7 @@ impl Render for HelloWorld {
             .flex()
             .flex_row()
             .size_full()
-            .bg(rgb(0xE0E0E0))
+            .bg(rgb(0xe0e0e0))
             .text_xl()
             .child(
                 div()

--- a/crates/gpui/examples/set_menus.rs
+++ b/crates/gpui/examples/set_menus.rs
@@ -1,4 +1,6 @@
-use gpui::*;
+use gpui::{
+    actions, div, prelude::*, rgb, App, AppContext, Menu, MenuItem, ViewContext, WindowOptions,
+};
 
 struct SetMenus;
 

--- a/crates/gpui/examples/shadow.rs
+++ b/crates/gpui/examples/shadow.rs
@@ -1,4 +1,7 @@
-use gpui::*;
+use gpui::{
+    div, prelude::*, px, rgb, size, App, AppContext, Bounds, ViewContext, WindowBounds,
+    WindowOptions,
+};
 
 struct Shadow {}
 

--- a/crates/gpui/examples/svg/svg.rs
+++ b/crates/gpui/examples/svg/svg.rs
@@ -1,7 +1,11 @@
+use std::fs;
 use std::path::PathBuf;
 
-use gpui::*;
-use std::fs;
+use anyhow::Result;
+use gpui::{
+    div, prelude::*, px, rgb, size, svg, App, AppContext, AssetSource, Bounds, SharedString,
+    ViewContext, WindowBounds, WindowOptions,
+};
 
 struct Assets {
     base: PathBuf,

--- a/crates/gpui/examples/text_wrapper.rs
+++ b/crates/gpui/examples/text_wrapper.rs
@@ -1,4 +1,6 @@
-use gpui::*;
+use gpui::{
+    div, prelude::*, px, size, App, AppContext, Bounds, ViewContext, WindowBounds, WindowOptions,
+};
 
 struct HelloWorld {}
 

--- a/crates/gpui/examples/uniform_list.rs
+++ b/crates/gpui/examples/uniform_list.rs
@@ -1,4 +1,7 @@
-use gpui::*;
+use gpui::{
+    div, prelude::*, px, rgb, size, uniform_list, App, AppContext, Bounds, ViewContext,
+    WindowBounds, WindowOptions,
+};
 
 struct UniformListExample {}
 

--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -1,5 +1,7 @@
-use gpui::*;
-use prelude::FluentBuilder as _;
+use gpui::{
+    div, prelude::*, px, rgb, size, App, AppContext, Bounds, SharedString, Timer, ViewContext,
+    WindowBounds, WindowContext, WindowKind, WindowOptions,
+};
 
 struct SubWindow {
     custom_titlebar: bool,

--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -1,4 +1,8 @@
-use gpui::*;
+use gpui::{
+    div, point, prelude::*, px, rgb, App, AppContext, Bounds, DisplayId, Hsla, Pixels,
+    SharedString, Size, ViewContext, WindowBackgroundAppearance, WindowBounds, WindowKind,
+    WindowOptions,
+};
 
 struct WindowContent {
     text: SharedString,

--- a/crates/gpui/examples/window_shadow.rs
+++ b/crates/gpui/examples/window_shadow.rs
@@ -1,15 +1,16 @@
-use gpui::*;
-use prelude::FluentBuilder;
+use gpui::{
+    black, canvas, div, green, point, prelude::*, px, rgb, size, transparent_black, white, App,
+    AppContext, Bounds, CursorStyle, Decorations, Hsla, MouseButton, Pixels, Point, ResizeEdge,
+    Size, ViewContext, WindowBackgroundAppearance, WindowBounds, WindowDecorations, WindowOptions,
+};
 
 struct WindowShadow {}
 
-/*
-Things to do:
-1. We need a way of calculating which edge or corner the mouse is on,
-    and then dispatch on that
-2. We need to improve the shadow rendering significantly
-3. We need to implement the techniques in here in Zed
-*/
+// Things to do:
+// 1. We need a way of calculating which edge or corner the mouse is on,
+//    and then dispatch on that
+// 2. We need to improve the shadow rendering significantly
+// 3. We need to implement the techniques in here in Zed
 
 impl Render for WindowShadow {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
@@ -128,7 +129,7 @@ impl Render for WindowShadow {
                             div()
                                 .flex()
                                 .bg(white())
-                                .size(Length::Definite(Pixels(300.0).into()))
+                                .size(px(300.0))
                                 .justify_center()
                                 .items_center()
                                 .shadow_lg()

--- a/crates/markdown/examples/markdown_as_child.rs
+++ b/crates/markdown/examples/markdown_as_child.rs
@@ -1,5 +1,5 @@
 use assets::Assets;
-use gpui::*;
+use gpui::{rgb, App, KeyBinding, Length, StyleRefinement, View, WindowOptions};
 use language::{language_settings::AllLanguageSettings, LanguageRegistry};
 use markdown::{Markdown, MarkdownStyle};
 use node_runtime::NodeRuntime;

--- a/crates/ui/src/components/tool_strip.rs
+++ b/crates/ui/src/components/tool_strip.rs
@@ -1,7 +1,8 @@
 #![allow(missing_docs)]
 
+use gpui::Axis;
+
 use crate::prelude::*;
-use gpui::*;
 
 #[derive(IntoElement)]
 pub struct ToolStrip {

--- a/crates/ui_input/src/ui_input.rs
+++ b/crates/ui_input/src/ui_input.rs
@@ -5,11 +5,11 @@
 //! It can't be located in the `ui` crate because it depends on `editor`.
 //!
 
-use editor::*;
-use gpui::*;
+use editor::{Editor, EditorElement, EditorStyle};
+use gpui::{AppContext, FocusHandle, FocusableView, FontStyle, Hsla, TextStyle, View};
 use settings::Settings;
 use theme::ThemeSettings;
-use ui::*;
+use ui::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FieldLabelLayout {


### PR DESCRIPTION
This PR removes the use of `use gpui::*` in the GPUI examples, as this is not how consumers should be importing GPUI.

Release Notes:

- N/A
