### PR TITLE
ruby: Make `ruby-lsp` the default LSP for Ruby

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1047,7 +1047,7 @@
       }
     },
     "Ruby": {
-      "language_servers": ["solargraph", "!ruby-lsp", "!rubocop", "..."]
+      "language_servers": ["ruby-lsp", "!solargraph", "!rubocop", "..."]
     },
     "SCSS": {
       "prettier": {


### PR DESCRIPTION
Make `ruby-lsp` the default LSP for Ruby. I believe `ruby-lsp` is now mature enough to become the default LSP for the Ruby language. Despite all my love for `solargraph`, its development has stalled (last commit 10 months ago), and perhaps it's time to replace it with `ruby-lsp`.

Release Notes:

- N/A
