### PR TITLE
assistant2: Use a label to render the thread menu item

### DIFF
--- a/crates/assistant2/src/context_picker/thread_context_picker.rs
+++ b/crates/assistant2/src/context_picker/thread_context_picker.rs
@@ -216,7 +216,7 @@ impl PickerDelegate for ThreadContextPickerDelegate {
             ListItem::new(ix)
                 .inset(true)
                 .toggle_state(selected)
-                .child(thread.summary.clone()),
+                .child(Label::new(thread.summary.clone())),
         )
     }
 }


### PR DESCRIPTION
The thread menu items were rendering with a larger font that the file & directory counterparts. Now, they're consistent!

| Before | After | Reference |
|--------|--------|--------|
| <img width="800" alt="Screenshot 2024-12-20 at 8 39 47 PM" src="https://github.com/user-attachments/assets/d196adcb-aea6-4399-8fb1-f5b771e76c1f" /> | <img width="800" alt="Screenshot 2024-12-20 at 8 35 43 PM" src="https://github.com/user-attachments/assets/a1e22c13-fd7e-4665-b09b-f3b583e7ce24" /> | <img width="800" alt="Screenshot 2024-12-20 at 8 40 38 PM" src="https://github.com/user-attachments/assets/d509ac6f-1251-4240-a369-906faebed8c0" /> | 


Release Notes:

- N/A
