### PR TITLE
assistant2: Fix panics when confirming nonexistent entries in the context picker

### DIFF
--- a/crates/assistant2/src/context_picker/directory_context_picker.rs
+++ b/crates/assistant2/src/context_picker/directory_context_picker.rs
@@ -178,7 +178,9 @@ impl PickerDelegate for DirectoryContextPickerDelegate {
     }
 
     fn confirm(&mut self, _secondary: bool, cx: &mut ViewContext<Picker<Self>>) {
-        let mat = &self.matches[self.selected_index];
+        let Some(mat) = self.matches.get(self.selected_index) else {
+            return;
+        };
 
         let workspace = self.workspace.clone();
         let Some(project) = workspace

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -192,7 +192,9 @@ impl PickerDelegate for FileContextPickerDelegate {
     }
 
     fn confirm(&mut self, _secondary: bool, cx: &mut ViewContext<Picker<Self>>) {
-        let mat = &self.matches[self.selected_index];
+        let Some(mat) = self.matches.get(self.selected_index) else {
+            return;
+        };
 
         let workspace = self.workspace.clone();
         let Some(project) = workspace

--- a/crates/assistant2/src/context_picker/thread_context_picker.rs
+++ b/crates/assistant2/src/context_picker/thread_context_picker.rs
@@ -154,7 +154,9 @@ impl PickerDelegate for ThreadContextPickerDelegate {
     }
 
     fn confirm(&mut self, _secondary: bool, cx: &mut ViewContext<Picker<Self>>) {
-        let entry = &self.matches[self.selected_index];
+        let Some(entry) = self.matches.get(self.selected_index) else {
+            return;
+        };
 
         let Some(thread_store) = self.thread_store.upgrade() else {
             return;


### PR DESCRIPTION
This PR fixes a panic that could occur when confirming when the context picker had no matching entries.

Release Notes:

- N/A
