### PR TITLE
Decide which panel should be active for a dock based on ordering panels

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1458,6 +1458,10 @@ impl Panel for AssistantPanel {
     fn toggle_action(&self) -> Box<dyn Action> {
         Box::new(ToggleFocus)
     }
+
+    fn activation_priority(&self) -> u32 {
+        4
+    }
 }
 
 impl EventEmitter<PanelEvent> for AssistantPanel {}

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -286,6 +286,10 @@ impl Panel for AssistantPanel {
     fn toggle_action(&self) -> Box<dyn Action> {
         Box::new(ToggleFocus)
     }
+
+    fn activation_priority(&self) -> u32 {
+        3
+    }
 }
 
 impl AssistantPanel {

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -1159,6 +1159,10 @@ impl Panel for ChatPanel {
             .room()
             .is_some_and(|room| room.read(cx).contains_guests())
     }
+
+    fn activation_priority(&self) -> u32 {
+        7
+    }
 }
 
 impl EventEmitter<PanelEvent> for ChatPanel {}

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -1141,6 +1141,7 @@ impl Panel for ChatPanel {
             ChatPanelButton::WhenInCall => ActiveCall::global(cx)
                 .read(cx)
                 .room()
+                .filter(|room| room.read(cx).contains_guests())
                 .map(|_| ui::IconName::MessageBubbles),
         }
     }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2763,6 +2763,10 @@ impl Panel for CollabPanel {
     fn persistent_name() -> &'static str {
         "CollabPanel"
     }
+
+    fn activation_priority(&self) -> u32 {
+        6
+    }
 }
 
 impl FocusableView for CollabPanel {

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -731,6 +731,10 @@ impl Panel for NotificationPanel {
     fn toggle_action(&self) -> Box<dyn gpui::Action> {
         Box::new(ToggleFocus)
     }
+
+    fn activation_priority(&self) -> u32 {
+        8
+    }
 }
 
 pub struct NotificationToast {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1237,6 +1237,10 @@ impl Panel for GitPanel {
     fn toggle_action(&self) -> Box<dyn Action> {
         Box::new(ToggleFocus)
     }
+
+    fn activation_priority(&self) -> u32 {
+        2
+    }
 }
 
 fn diff_display_editor(cx: &mut WindowContext) -> View<Editor> {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4468,6 +4468,10 @@ impl Panel for OutlinePanel {
         })
         .detach()
     }
+
+    fn activation_priority(&self) -> u32 {
+        5
+    }
 }
 
 impl FocusableView for OutlinePanel {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4252,6 +4252,10 @@ impl Panel for ProjectPanel {
                 .map_or(false, |entry| entry.is_dir())
         })
     }
+
+    fn activation_priority(&self) -> u32 {
+        0
+    }
 }
 
 impl FocusableView for ProjectPanel {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1393,6 +1393,10 @@ impl Panel for TerminalPanel {
     fn pane(&self) -> Option<View<Pane>> {
         Some(self.active_pane.clone())
     }
+
+    fn activation_priority(&self) -> u32 {
+        1
+    }
 }
 
 struct InlineAssistTabBarButton {

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -165,7 +165,7 @@ pub struct Dock {
     position: DockPosition,
     panel_entries: Vec<PanelEntry>,
     is_open: bool,
-    active_panel_index: usize,
+    active_panel_index: Option<usize>,
     focus_handle: FocusHandle,
     pub(crate) serialized_dock: Option<DockData>,
     resizeable: bool,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1286,7 +1286,7 @@ impl Workspace {
 
         dock.update(cx, |dock, cx| {
             dock.add_panel(panel, self.weak_self.clone(), cx)
-        })
+        });
     }
 
     pub fn status_bar(&self) -> &View<StatusBar> {
@@ -7271,14 +7271,10 @@ mod tests {
         let (panel_1, panel_2) = workspace.update(cx, |workspace, cx| {
             let panel_1 = cx.new_view(|cx| TestPanel::new(DockPosition::Left, cx));
             workspace.add_panel(panel_1.clone(), cx);
-            workspace
-                .left_dock()
-                .update(cx, |left_dock, cx| left_dock.set_open(true, cx));
+            workspace.toggle_dock(DockPosition::Left, cx);
             let panel_2 = cx.new_view(|cx| TestPanel::new(DockPosition::Right, cx));
             workspace.add_panel(panel_2.clone(), cx);
-            workspace
-                .right_dock()
-                .update(cx, |right_dock, cx| right_dock.set_open(true, cx));
+            workspace.toggle_dock(DockPosition::Right, cx);
 
             let left_dock = workspace.left_dock();
             assert_eq!(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1273,7 +1273,7 @@ impl Workspace {
         self.window_edited
     }
 
-    pub fn add_panel<T: Panel>(&mut self, panel: View<T>, cx: &mut ViewContext<Self>) -> usize {
+    pub fn add_panel<T: Panel>(&mut self, panel: View<T>, cx: &mut ViewContext<Self>) {
         let focus_handle = panel.focus_handle(cx);
         cx.on_focus_in(&focus_handle, Self::handle_panel_focused)
             .detach();
@@ -2296,6 +2296,10 @@ impl Workspace {
             let other_is_zoomed = self.zoomed.is_some() && self.zoomed_position != Some(dock_side);
             let was_visible = dock.is_open() && !other_is_zoomed;
             dock.set_open(!was_visible, cx);
+
+            if dock.active_panel().is_none() && dock.panels_len() > 0 {
+                dock.activate_panel(0, cx);
+            }
 
             if let Some(active_panel) = dock.active_panel() {
                 if was_visible {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1273,7 +1273,7 @@ impl Workspace {
         self.window_edited
     }
 
-    pub fn add_panel<T: Panel>(&mut self, panel: View<T>, cx: &mut ViewContext<Self>) {
+    pub fn add_panel<T: Panel>(&mut self, panel: View<T>, cx: &mut ViewContext<Self>) -> usize {
         let focus_handle = panel.focus_handle(cx);
         cx.on_focus_in(&focus_handle, Self::handle_panel_focused)
             .detach();
@@ -1286,7 +1286,7 @@ impl Workspace {
 
         dock.update(cx, |dock, cx| {
             dock.add_panel(panel, self.weak_self.clone(), cx)
-        });
+        })
     }
 
     pub fn status_bar(&self) -> &View<StatusBar> {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -338,7 +338,7 @@ fn initialize_panels(prompt_builder: Arc<PromptBuilder>, cx: &mut ViewContext<Wo
             assistant_panel,
         )?;
 
-        let mut index = workspace_handle.update(&mut cx, |workspace, cx| {
+        workspace_handle.update(&mut cx, |workspace, cx| {
             workspace.add_panel(project_panel, cx);
             workspace.add_panel(outline_panel, cx);
             workspace.add_panel(terminal_panel, cx);
@@ -347,7 +347,6 @@ fn initialize_panels(prompt_builder: Arc<PromptBuilder>, cx: &mut ViewContext<Wo
             workspace.add_panel(notification_panel, cx);
             workspace.add_panel(assistant_panel, cx)
         })?;
-        let index = &mut index;
 
         let git_ui_enabled = git_ui_feature_flag.await;
         let git_panel = if git_ui_enabled {
@@ -373,7 +372,7 @@ fn initialize_panels(prompt_builder: Arc<PromptBuilder>, cx: &mut ViewContext<Wo
         };
         workspace_handle.update(&mut cx, |workspace, cx| {
             if let Some(assistant2_panel) = assistant2_panel {
-                *index = workspace.add_panel(assistant2_panel, cx);
+                workspace.add_panel(assistant2_panel, cx);
             }
 
             if is_assistant2_enabled {
@@ -383,11 +382,6 @@ fn initialize_panels(prompt_builder: Arc<PromptBuilder>, cx: &mut ViewContext<Wo
             }
         })?;
 
-        workspace_handle.update(&mut cx, |workspace, cx| {
-            workspace.right_dock().update(cx, |dock, cx| {
-                dock.activate_panel(*index, cx);
-            });
-        })?;
         anyhow::Ok(())
     })
     .detach();


### PR DESCRIPTION
This means that `workspace::ToggleRightDock` will open the assistant if no right-dock panel has been manually activated, instead of the chat as before. Also cleans up the `active_panel_index` logic a bit.

cc @nathansobo 

Release Notes:

- Make `workspace::ToggleRightDock` open the assistant panel if no right-dock panel has yet been activated