### PR TITLE
Rename the `OpenFile` action to `OpenSelectedFilename`

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -311,7 +311,6 @@ gpui::actions!(
         OpenExcerpts,
         OpenExcerptsSplit,
         OpenProposedChangesEditor,
-        OpenFile,
         OpenDocs,
         OpenPermalinkToLine,
         OpenUrl,
@@ -391,3 +390,5 @@ gpui::actions!(
 action_as!(outline, ToggleOutline as Toggle);
 
 action_as!(go_to_line, ToggleGoToLine as Toggle);
+
+action_as!(editor, OpenSelectedFilename as [OpenFile]);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9479,7 +9479,7 @@ impl Editor {
         url_finder.detach();
     }
 
-    pub fn open_file(&mut self, _: &OpenFile, cx: &mut ViewContext<Self>) {
+    pub fn open_selected_filename(&mut self, _: &OpenSelectedFilename, cx: &mut ViewContext<Self>) {
         let Some(workspace) = self.workspace() else {
             return;
         };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -344,7 +344,7 @@ impl EditorElement {
                 .detach_and_log_err(cx);
         });
         register_action(view, cx, Editor::open_url);
-        register_action(view, cx, Editor::open_file);
+        register_action(view, cx, Editor::open_selected_filename);
         register_action(view, cx, Editor::fold);
         register_action(view, cx, Editor::fold_at_level);
         register_action(view, cx, Editor::fold_all);

--- a/crates/gpui_macros/src/register_action.rs
+++ b/crates/gpui_macros/src/register_action.rs
@@ -32,6 +32,7 @@ pub(crate) fn register_action(type_name: &Ident) -> proc_macro2::TokenStream {
                 fn #action_builder_fn_name() -> gpui::ActionData {
                     gpui::ActionData {
                         name: <#type_name as gpui::Action>::debug_name(),
+                        aliases: <#type_name as gpui::Action>::aliases(),
                         type_id: ::std::any::TypeId::of::<#type_name>(),
                         build: <#type_name as gpui::Action>::build,
                     }


### PR DESCRIPTION
In #22250 I floated the suggestion that `editor::OpenFile` should have a more specific name. This PR implements that; the old name remains available for keybinding purposes so this should be backward compatible, but only the new name should appear in the command palette and in suggestions when editing a keymap.

Release Notes:

- Rename `editor::OpenFile` to `editor::OpenSelectedFilename` to better reflect its purpose
