### PR TITLE
Add support for block comments in Markdown configuration

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -2,6 +2,7 @@ name = "Markdown"
 grammar = "markdown"
 path_suffixes = ["md", "mdx", "mdwn", "markdown", "MD"]
 word_characters = ["-"]
+block_comment = ["<!-- ", " -->"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
This pull request includes a small change to the `crates/languages/src/markdown/config.toml` file. The change adds block comment syntax for Markdown files.

* [`crates/languages/src/markdown/config.toml`](diffhunk://#diff-4cf73d9af0f11f2ac8929bd8113ee76aa382dc96a731f18510c09fc3d0db1f9cR5): Added block comment syntax `<!-- ` and ` -->` for Markdown files.

Closes https://github.com/zed-industries/zed/issues/19797

I have been testing it with the following:

1. create a simple markdown file containing following words

```markdown
good morning - English
Dzień dobry - polish
おはよう - japanese
صباح الخير - arabic
早安 - Chineses (Traditional)
```

2. comment using `cmd+/` and see if there are any errors



Release Notes:

- Added block comment syntax `<!-- ` and ` -->` for Markdown files.
