### PR TITLE
Restore crates/zed dependency on libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16046,6 +16046,7 @@ dependencies = [
  "language_selector",
  "language_tools",
  "languages",
+ "libc",
  "log",
  "markdown",
  "markdown_preview",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -68,6 +68,7 @@ language_models.workspace = true
 language_selector.workspace = true
 language_tools.workspace = true
 languages = { workspace = true, features = ["load-grammars"] }
+libc.workspace = true
 log.workspace = true
 markdown.workspace = true
 markdown_preview.workspace = true


### PR DESCRIPTION
This somehow got lost during or after merge of #22202.

Release Notes:

- N/A