### PR TITLE
Provide helpful message when Zed accesses Symlinks

### DIFF
--- a/crates/collab/README.md
+++ b/crates/collab/README.md
@@ -8,7 +8,12 @@ It contains our back-end logic for collaboration, to which we connect from the Z
 
 ## Database setup
 
-Before you can run the collab server locally, you'll need to set up a zed Postgres database.
+Before you can run the collab server locally, you'll need to set up a zed Postgres database. Follow the steps sequentially:
+
+1. Ensure you have postgres installed. If not, install with `brew install postgresql@15`.
+2. Follow the steps on Brew's formula and verify your `$PATH` contains `/opt/homebrew/opt/postgresql@15/bin`.
+3. If you hadn't done it before, create the `postgres` user with `createuser -s postgres`.
+4. You are now ready to run the `bootstrap` script:
 
 ```sh
 script/bootstrap

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -4,7 +4,7 @@ mod mac_watcher;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub mod linux_watcher;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use git::GitHostingProviderRegistry;
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -585,7 +585,9 @@ impl Fs for RealFs {
 
         let is_symlink = symlink_metadata.file_type().is_symlink();
         let metadata = if is_symlink {
-            smol::fs::metadata(path).await?
+            smol::fs::metadata(path)
+                .await
+                .with_context(|| "accessing symlink for path {path}")?
         } else {
             symlink_metadata
         };


### PR DESCRIPTION
When developing extensions, it's common that you start throwing code in a specific directory for your extension. As times goes by, it's likely that the Extension is moved across directories.

When you install a "dev extension", a symlink is created for the initial directory you installed the extension in. If you continue developing in a different directory, Zed will fail with an unhelpful error:

```
2024-12-22T14:29:43.70337+01:00 [INFO] finished compiling extension /Users/enrikes/Documents/BrazilConfigZedExtension
2024-12-22T14:29:43.703545+01:00 [ERROR] No such file or directory (os error 2)
```

With this change, we add context to the error, to ensure the reader knows the issue is symlink related.

Release Notes:

- N/A
