### PR TITLE
Add fine-grained control for scrollbar diagnostics

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -256,8 +256,13 @@
     "search_results": true,
     // Whether to show selected symbol occurrences in the scrollbar.
     "selected_symbol": true,
-    // Whether to show diagnostic indicators in the scrollbar.
-    "diagnostics": true,
+    // Which diagnostic indicator levels to show in the scrollbar:
+    //  - "none" or false: do not show diagnostics
+    //  - "error": show only errors
+    //  - "warning": show only errors and warnings
+    //  - "information": show only errors, warnings, and information
+    //  - "all" or true: show all diagnostics
+    "diagnostics": "all",
     /// Forcefully enable or disable the scrollbar for each axis
     "axes": {
       /// When false, forcefully disables the horizontal scrollbar. Otherwise, obey other settings.


### PR DESCRIPTION
This PR updates the scrollbar diagnostic setting to provide fine-grained control over which indicators to show, based on severity level. This allows the user to hide lower-severity diagnostics that can otherwise clutter the scrollbar (for example, unused or disabled code).

The options are set such that the existing boolean setting has the same effect: when `true` all diagnostics are shown, and when `false` no diagnostics are shown.

Closes #22296.

Release Notes:

- Added fine-grained control of scrollbar diagnostic indicators.
