### PR TITLE
copilot: Update Copilot Chat to o1 GA model version

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -34,7 +34,7 @@ pub enum Model {
     Gpt4,
     #[serde(alias = "gpt-3.5-turbo", rename = "gpt-3.5-turbo")]
     Gpt3_5Turbo,
-    #[serde(alias = "o1-preview", rename = "o1-preview-2024-09-12")]
+    #[serde(alias = "o1-preview", rename = "o1-2024-12-17")]
     O1Preview,
     #[serde(alias = "o1-mini", rename = "o1-mini-2024-09-12")]
     O1Mini,

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -34,9 +34,9 @@ pub enum Model {
     Gpt4,
     #[serde(alias = "gpt-3.5-turbo", rename = "gpt-3.5-turbo")]
     Gpt3_5Turbo,
-    #[serde(alias = "o1-preview", rename = "o1-2024-12-17")]
+    #[serde(alias = "o1-preview", rename = "o1")]
     O1Preview,
-    #[serde(alias = "o1-mini", rename = "o1-mini-2024-09-12")]
+    #[serde(alias = "o1-mini", rename = "o1-mini")]
     O1Mini,
     #[serde(alias = "claude-3-5-sonnet", rename = "claude-3.5-sonnet")]
     Claude3_5Sonnet,


### PR DESCRIPTION
Closes #22375

Release Notes:

- Fixed model version of o1 in GitHub Copilot Chat
