### PR TITLE
assistant2: Don't render the context space if there's none

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -274,13 +274,18 @@ impl ActiveThread {
                     )
                     .child(v_flex().p_2p5().text_ui(cx).child(markdown.clone()))
                     .when_some(context, |parent, context| {
-                        parent.child(
-                            h_flex().flex_wrap().gap_1().p_1p5().children(
-                                context
-                                    .iter()
-                                    .map(|context| ContextPill::new(context.clone())),
-                            ),
-                        )
+                        if !context.is_empty() {
+                            parent.child(
+                                h_flex()
+                                    .flex_wrap()
+                                    .gap_1()
+                                    .px_1p5()
+                                    .pb_1p5()
+                                    .children(context.iter().map(|c| ContextPill::new(c.clone()))),
+                            )
+                        } else {
+                            parent
+                        }
                     }),
             )
             .into_any()


### PR DESCRIPTION
Note the extra bottom space on the before version. That was because, previously, the container that holds the context pills in an active thread was being rendered even if there was no attached context.

| Before | After |
|--------|--------|
| <img width="1577" alt="Screenshot 2024-12-23 at 8 42 00 PM" src="https://github.com/user-attachments/assets/b74bdc67-0a08-4d59-b1ec-43a00a59a373" /> | <img width="1577" alt="Screenshot 2024-12-23 at 8 39 00 PM" src="https://github.com/user-attachments/assets/1cbc340d-19df-4cce-8c0b-b671703a0ff5" /> | 

Release Notes:

- N/A
