### PR TITLE
Fix no whitespace displaying after an "à "

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5461,13 +5461,21 @@ impl LineWithInvisibles {
                                             let is_whitespace =
                                                 (*line_byte as char).is_whitespace();
                                             non_whitespace_added |= !is_whitespace;
-                                            is_whitespace
-                                                && (non_whitespace_added || !is_soft_wrapped)
+                                            match *line_byte as char {
+                                                '\u{a0}' => false,
+                                                _ if is_whitespace
+                                                    && (non_whitespace_added
+                                                        || !is_soft_wrapped) =>
+                                                {
+                                                    true
+                                                }
+                                                _ => false,
+                                            }
                                         })
                                         .map(|(whitespace_index, _)| Invisible::Whitespace {
                                             line_offset: line.len() + whitespace_index,
                                         }),
-                                )
+                                );
                             }
                         }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5452,20 +5452,22 @@ impl LineWithInvisibles {
                                         line_end_offset: line.len() + line_chunk.len(),
                                     });
                                 }
-                            } else {
-                                invisibles.extend(
-                                    line_chunk
-                                        .chars()
-                                        .enumerate()
-                                        .filter(|(_, c)| {
-                                            let is_whitespace = c.is_whitespace();
-                                            non_whitespace_added |= !is_whitespace;
-                                            is_whitespace
-                                                && (non_whitespace_added || !is_soft_wrapped)
-                                        })
-                                        .map(|(whitespace_index, _)| Invisible::Whitespace {
-                                            line_offset: line.len() + whitespace_index,
-                                        }),
+                            } else {                                
+                                invisibles.extend(line_chunk.char_indices().filter_map(
+                                    |(index, c)| {
+                                        let is_whitespace = c.is_whitespace();
+                                        non_whitespace_added |= !is_whitespace;
+                                        if is_whitespace
+                                            && (non_whitespace_added || !is_soft_wrapped)
+                                        {
+                                            Some(Invisible::Whitespace {
+                                                line_offset: line.len() + index,
+                                            })
+                                        } else {
+                                            None
+                                        }
+                                    },
+                                ))
                                 )
                             }
                         }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5452,7 +5452,7 @@ impl LineWithInvisibles {
                                         line_end_offset: line.len() + line_chunk.len(),
                                     });
                                 }
-                            } else {                                
+                            } else {
                                 invisibles.extend(line_chunk.char_indices().filter_map(
                                     |(index, c)| {
                                         let is_whitespace = c.is_whitespace();
@@ -5468,7 +5468,6 @@ impl LineWithInvisibles {
                                         }
                                     },
                                 ))
-                                )
                             }
                         }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5455,27 +5455,18 @@ impl LineWithInvisibles {
                             } else {
                                 invisibles.extend(
                                     line_chunk
-                                        .bytes()
+                                        .chars()
                                         .enumerate()
-                                        .filter(|(_, line_byte)| {
-                                            let is_whitespace =
-                                                (*line_byte as char).is_whitespace();
+                                        .filter(|(_, c)| {
+                                            let is_whitespace = c.is_whitespace();
                                             non_whitespace_added |= !is_whitespace;
-                                            match *line_byte as char {
-                                                '\u{a0}' => false,
-                                                _ if is_whitespace
-                                                    && (non_whitespace_added
-                                                        || !is_soft_wrapped) =>
-                                                {
-                                                    true
-                                                }
-                                                _ => false,
-                                            }
+                                            is_whitespace
+                                                && (non_whitespace_added || !is_soft_wrapped)
                                         })
                                         .map(|(whitespace_index, _)| Invisible::Whitespace {
                                             line_offset: line.len() + whitespace_index,
                                         }),
-                                );
+                                )
                             }
                         }
 


### PR DESCRIPTION
fixed a bug where with the "show_whitespaces": "boundary" option, when there was an "à" followed by a space, a white space was displayed, and when "à" was at the end of the line, a white space was added



Release Notes:

- N/A