### PR TITLE
windows: Fix crashing when minimizing a window on Windows 11

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -146,19 +146,18 @@ fn handle_size_msg(
     // Don't resize the renderer when the window is minimized, but record that it was minimized so
     // that on restore the swap chain can be recreated via `update_drawable_size_even_if_unchanged`.
     if wparam.0 == SIZE_MINIMIZED as usize {
-        lock.is_minimized = Some(true);
+        lock.restore_from_minimized = true;
         return Some(0);
     }
-    let may_have_been_minimized = lock.is_minimized.unwrap_or(true);
-    lock.is_minimized = Some(false);
 
     let width = lparam.loword().max(1) as i32;
     let height = lparam.hiword().max(1) as i32;
     let new_size = size(DevicePixels(width), DevicePixels(height));
     let scale_factor = lock.scale_factor;
-    if may_have_been_minimized {
+    if lock.restore_from_minimized {
         lock.renderer
             .update_drawable_size_even_if_unchanged(new_size);
+        lock.restore_from_minimized = false;
     } else {
         lock.renderer.update_drawable_size(new_size);
     }
@@ -209,7 +208,7 @@ fn handle_timer_msg(
 
 fn handle_paint_msg(handle: HWND, state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
     let mut lock = state_ptr.state.borrow_mut();
-    if let Some(is_minimized) = lock.is_minimized {
+    if let Some(is_minimized) = lock.restore_from_minimized {
         if is_minimized {
             return Some(0);
         }

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -207,12 +207,11 @@ fn handle_timer_msg(
 }
 
 fn handle_paint_msg(handle: HWND, state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
-    let mut lock = state_ptr.state.borrow_mut();
-    if let Some(is_minimized) = lock.restore_from_minimized {
-        if is_minimized {
-            return Some(0);
-        }
+    if unsafe { IsIconic(handle).as_bool() } {
+        return Some(0);
     }
+
+    let mut lock = state_ptr.state.borrow_mut();
     if let Some(mut request_frame) = lock.callbacks.request_frame.take() {
         drop(lock);
         request_frame(Default::default());

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -209,6 +209,11 @@ fn handle_timer_msg(
 
 fn handle_paint_msg(handle: HWND, state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
     let mut lock = state_ptr.state.borrow_mut();
+    if let Some(is_minimized) = lock.is_minimized {
+        if is_minimized {
+            return Some(0);
+        }
+    }
     if let Some(mut request_frame) = lock.callbacks.request_frame.take() {
         drop(lock);
         request_frame(Default::default());

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -38,7 +38,7 @@ pub struct WindowsWindowState {
     pub fullscreen_restore_bounds: Bounds<Pixels>,
     pub border_offset: WindowBorderOffset,
     pub scale_factor: f32,
-    pub restore_from_minimized: bool,
+    pub restore_from_minimized: Option<Box<dyn FnMut(RequestFrameOptions)>>,
 
     pub callbacks: Callbacks,
     pub input_handler: Option<PlatformInputHandler>,
@@ -94,7 +94,7 @@ impl WindowsWindowState {
             size: logical_size,
         };
         let border_offset = WindowBorderOffset::default();
-        let restore_from_minimized = false;
+        let restore_from_minimized = None;
         let renderer = windows_renderer::init(gpu_context, hwnd, transparent)?;
         let callbacks = Callbacks::default();
         let input_handler = None;

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -38,7 +38,7 @@ pub struct WindowsWindowState {
     pub fullscreen_restore_bounds: Bounds<Pixels>,
     pub border_offset: WindowBorderOffset,
     pub scale_factor: f32,
-    pub is_minimized: Option<bool>,
+    pub restore_from_minimized: bool,
 
     pub callbacks: Callbacks,
     pub input_handler: Option<PlatformInputHandler>,
@@ -94,7 +94,7 @@ impl WindowsWindowState {
             size: logical_size,
         };
         let border_offset = WindowBorderOffset::default();
-        let is_minimized = None;
+        let restore_from_minimized = false;
         let renderer = windows_renderer::init(gpu_context, hwnd, transparent)?;
         let callbacks = Callbacks::default();
         let input_handler = None;
@@ -112,7 +112,7 @@ impl WindowsWindowState {
             fullscreen_restore_bounds,
             border_offset,
             scale_factor,
-            is_minimized,
+            restore_from_minimized,
             callbacks,
             input_handler,
             system_key_handled,


### PR DESCRIPTION
Closes #22366

This PR fixes the issue of crashing when minimizing a window on Windows 11. And this PR supersedes #22366.

The main change in this PR is to stop rendering the window when it is minimized. Additionally, I’ve made some modifications to the code in #21756 to improve clarity (I think...).

cc @mgsloan 

Release Notes:

- N/A
