### PR TITLE
docs: Add "bounded" mode to soft_wrap documentation

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1637,6 +1637,7 @@ Or to set a `socks5` proxy:
 2. `prefer_line` (deprecated, same as `none`)
 3. `editor_width` to wrap lines that overflow the editor width
 4. `preferred_line_length` to wrap lines that overflow `preferred_line_length` config value
+5. `bounded` to wrap lines at the minimum of `editor_width` and `preferred_line_length`
 
 ## Wrap Guides (Vertical Rulers)
 


### PR DESCRIPTION
Closes #22272

Release Notes:

- Added documentation for the new "bounded" mode in the soft_wrap configuration