### PR TITLE
Disable inline completions in Vim normal mode

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1196,10 +1196,7 @@ impl Vim {
             editor.set_input_enabled(vim.editor_input_enabled());
             editor.set_autoindent(vim.should_autoindent());
             editor.selections.line_mode = matches!(vim.mode, Mode::VisualLine);
-            editor.set_inline_completions_enabled(matches!(
-                vim.mode,
-                Mode::Insert | Mode::Normal | Mode::Replace
-            ));
+            editor.set_inline_completions_enabled(matches!(vim.mode, Mode::Insert | Mode::Replace));
         });
         cx.notify()
     }


### PR DESCRIPTION
This is harmful for user experience and at best requires a user setting. This was committed as part of https://github.com/zed-industries/zed/pull/21739 however that change had no relevant release notes and no relevant settings.

The issue #22343 shows how this can result in user experience regression: deleting a text fragment can reinsert it back, and it's thus unclear if the deletion has even worked. Maybe this can be reenabled in some very restrictive setup, and put behind a setting, but it can't be unconditional. Completions should activate when the user signals intent of entering code - for example, if instead of `de` to delete a fragment, I press `ce` to replace it, I would naturally expect inline completions to show up.

Note: The linked PR added more code in vim crate to refresh inline completions in normal mode. I'm keeping that code around in this commit, so that this can be the minimal fix to the linked issue -- with the assumption that maybe there's some way in the future to reenable this in a subset of cases that don't result in confusing / broken UX. If that is not true the code might need further cleanup. Let me know if you'd rather see removal of those changes in this PR as well.

Closes #22343.

Release Notes:

- Fixes inline completions showing up in Vim normal mode.
