### PR TITLE
Add a case for shadows when blur_radius = 0

### DIFF
--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -203,7 +203,7 @@ vertex ShadowVertexOutput shadow_vertex(
 }
 
 fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
-                                constant Shadow *shadows 
+                                constant Shadow *shadows
                                 [[buffer(ShadowInputIndex_Shadows)]]) {
   Shadow shadow = shadows[input.shadow_id];
 
@@ -212,30 +212,40 @@ fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
   float2 half_size = size / 2.;
   float2 center = origin + half_size;
   float2 point = input.position.xy - center;
-  float corner_radius = (point.x < 0.)
-                            ? ((point.y < 0.) ? shadow.corner_radii.top_left : shadow.corner_radii.bottom_left)
-                            : ((point.y < 0.) ? shadow.corner_radii.top_right : shadow.corner_radii.bottom_right);
+  float corner_radius;
+  if (point.x < 0.) {
+    if (point.y < 0.) {
+      corner_radius = shadow.corner_radii.top_left;
+    } else {
+      corner_radius = shadow.corner_radii.bottom_left;
+    }
+  } else {
+    if (point.y < 0.) {
+      corner_radius = shadow.corner_radii.top_right;
+    } else {
+      corner_radius = shadow.corner_radii.bottom_right;
+    }
+  }
 
   float alpha;
   if (shadow.blur_radius == 0.) {
-      float distance = quad_sdf(input.position.xy, shadow.bounds, shadow.corner_radii);
-      alpha = saturate(0.5 - distance);
+    float distance = quad_sdf(input.position.xy, shadow.bounds, shadow.corner_radii);
+    alpha = saturate(0.5 - distance);
   } else {
-      // The signal is only non-zero in a limited range, so don't waste samples
-      float low = point.y - half_size.y;
-      float high = point.y + half_size.y;
-      float start = clamp(-3. * shadow.blur_radius, low, high);
-      float end = clamp(3. * shadow.blur_radius, low, high);
+    float low = point.y - half_size.y;
+    float high = point.y + half_size.y;
+    float start = clamp(-3. * shadow.blur_radius, low, high);
+    float end = clamp(3. * shadow.blur_radius, low, high);
 
-        // Accumulate samples (we can get away with surprisingly few samples)
-      float step = (end - start) / 4.;
-      float y = start + step * 0.5;
-      alpha = 0.;
-      for (int i = 0; i < 4; i++) {
-          alpha += blur_along_x(point.x, point.y - y, shadow.blur_radius, corner_radius, half_size) *
-                    gaussian(y, shadow.blur_radius) * step;
-          y += step;
-      }
+    float step = (end - start) / 4.;
+    float y = start + step * 0.5;
+    alpha = 0.;
+    for (int i = 0; i < 4; i++) {
+      alpha += blur_along_x(point.x, point.y - y, shadow.blur_radius,
+                            corner_radius, half_size) *
+               gaussian(y, shadow.blur_radius) * step;
+      y += step;
+    }
   }
 
   return input.color * float4(1., 1., 1., alpha);

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -232,11 +232,13 @@ fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
     float distance = quad_sdf(input.position.xy, shadow.bounds, shadow.corner_radii);
     alpha = saturate(0.5 - distance);
   } else {
+    // The signal is only non-zero in a limited range, so don't waste samples
     float low = point.y - half_size.y;
     float high = point.y + half_size.y;
     float start = clamp(-3. * shadow.blur_radius, low, high);
     float end = clamp(3. * shadow.blur_radius, low, high);
 
+    // Accumulate samples (we can get away with surprisingly few samples)
     float step = (end - start) / 4.;
     float y = start + step * 0.5;
     alpha = 0.;

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -227,21 +227,31 @@ fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
     }
   }
 
-  // The signal is only non-zero in a limited range, so don't waste samples
-  float low = point.y - half_size.y;
-  float high = point.y + half_size.y;
-  float start = clamp(-3. * shadow.blur_radius, low, high);
-  float end = clamp(3. * shadow.blur_radius, low, high);
+  float alpha;
+  if (shadow.blur_radius == 0.) {
+    // For zero blur, just check if the point is inside the shadow shape
+    float2 rounded_edge_to_point = abs(point) - half_size + corner_radius;
+    float distance = length(max(float2(0., 0.), rounded_edge_to_point)) +
+                     min(0., max(rounded_edge_to_point.x, rounded_edge_to_point.y)) -
+                     corner_radius;
+    alpha = distance <= 0. ? 1. : 0.;
+  } else {
+    // The signal is only non-zero in a limited range, so don't waste samples
+    float low = point.y - half_size.y;
+    float high = point.y + half_size.y;
+    float start = clamp(-3. * shadow.blur_radius, low, high);
+    float end = clamp(3. * shadow.blur_radius, low, high);
 
-  // Accumulate samples (we can get away with surprisingly few samples)
-  float step = (end - start) / 4.;
-  float y = start + step * 0.5;
-  float alpha = 0.;
-  for (int i = 0; i < 4; i++) {
-    alpha += blur_along_x(point.x, point.y - y, shadow.blur_radius,
-                          corner_radius, half_size) *
-             gaussian(y, shadow.blur_radius) * step;
-    y += step;
+    // Accumulate samples (we can get away with surprisingly few samples)
+    float step = (end - start) / 4.;
+    float y = start + step * 0.5;
+    alpha = 0.;
+    for (int i = 0; i < 4; i++) {
+      alpha += blur_along_x(point.x, point.y - y, shadow.blur_radius,
+                            corner_radius, half_size) *
+               gaussian(y, shadow.blur_radius) * step;
+      y += step;
+    }
   }
 
   return input.color * float4(1., 1., 1., alpha);

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -203,39 +203,42 @@ vertex ShadowVertexOutput shadow_vertex(
 }
 
 fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
-                                constant Shadow *shadows [[buffer(ShadowInputIndex_Shadows)]]) {
-    Shadow shadow = shadows[input.shadow_id];
+                                constant Shadow *shadows 
+                                [[buffer(ShadowInputIndex_Shadows)]]) {
+  Shadow shadow = shadows[input.shadow_id];
 
-    float2 origin = float2(shadow.bounds.origin.x, shadow.bounds.origin.y);
-    float2 size = float2(shadow.bounds.size.width, shadow.bounds.size.height);
-    float2 half_size = size / 2.;
-    float2 center = origin + half_size;
-    float2 point = input.position.xy - center;
+  float2 origin = float2(shadow.bounds.origin.x, shadow.bounds.origin.y);
+  float2 size = float2(shadow.bounds.size.width, shadow.bounds.size.height);
+  float2 half_size = size / 2.;
+  float2 center = origin + half_size;
+  float2 point = input.position.xy - center;
+  float corner_radius = (point.x < 0.)
+                            ? ((point.y < 0.) ? shadow.corner_radii.top_left : shadow.corner_radii.bottom_left)
+                            : ((point.y < 0.) ? shadow.corner_radii.top_right : shadow.corner_radii.bottom_right);
 
-    float corner_radius = (point.x < 0.)
-                              ? ((point.y < 0.) ? shadow.corner_radii.top_left : shadow.corner_radii.bottom_left)
-                              : ((point.y < 0.) ? shadow.corner_radii.top_right : shadow.corner_radii.bottom_right);
+  float alpha;
+  if (shadow.blur_radius == 0.) {
+      float distance = quad_sdf(input.position.xy, shadow.bounds, shadow.corner_radii);
+      alpha = saturate(0.5 - distance);
+  } else {
+      // The signal is only non-zero in a limited range, so don't waste samples
+      float low = point.y - half_size.y;
+      float high = point.y + half_size.y;
+      float start = clamp(-3. * shadow.blur_radius, low, high);
+      float end = clamp(3. * shadow.blur_radius, low, high);
 
-    float alpha;
-    if (shadow.blur_radius == 0.) {
-        float distance = quad_sdf(input.position.xy, shadow.bounds, shadow.corner_radii);
-        alpha = saturate(0.5 - distance);
-    } else {
-        float low = point.y - half_size.y;
-        float high = point.y + half_size.y;
-        float start = clamp(-3. * shadow.blur_radius, low, high);
-        float end = clamp(3. * shadow.blur_radius, low, high);
-        float step = (end - start) / 4.;
-        float y = start + step * 0.5;
-        alpha = 0.;
-        for (int i = 0; i < 4; i++) {
-            alpha += blur_along_x(point.x, point.y - y, shadow.blur_radius, corner_radius, half_size) *
-                     gaussian(y, shadow.blur_radius) * step;
-            y += step;
-        }
-    }
+        // Accumulate samples (we can get away with surprisingly few samples)
+      float step = (end - start) / 4.;
+      float y = start + step * 0.5;
+      alpha = 0.;
+      for (int i = 0; i < 4; i++) {
+          alpha += blur_along_x(point.x, point.y - y, shadow.blur_radius, corner_radius, half_size) *
+                    gaussian(y, shadow.blur_radius) * step;
+          y += step;
+      }
+  }
 
-    return input.color * float4(1., 1., 1., alpha);
+  return input.color * float4(1., 1., 1., alpha);
 }
 
 struct UnderlineVertexOutput {


### PR DESCRIPTION
Closes #22433

Before/After (macOS):

![CleanShot 2024-12-26 at 22 41 11@2x](https://github.com/user-attachments/assets/1701da2e-3db7-4dd1-a680-0f63824cbdf5)

For some reason the non-blurred one seems much lower quality, so we may need to tinker with the samples, or something else.

![CleanShot 2024-12-26 at 22 42 12@2x](https://github.com/user-attachments/assets/5a43330d-137b-4d45-a67a-fd10ef6a8ff8)

I'm unsure if this is a problem on Linux/in the Blade renderer, but since no changes were made outside of the medal shaders we can probably take this macOS-specific win for now.

Release Notes:

- gpui: Fixed an issue where shadows with a `blur_radius` of 0 would not render.
