### PR TITLE
Prevent duplicate resolution when applying additional edits

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8402,7 +8402,6 @@ async fn test_completion(cx: &mut gpui::TestAppContext) {
         additional edit
     "});
 
-    handle_resolve_completion_request(&mut cx, None).await;
     apply_additional_edits.await.unwrap();
 
     update_test_language_settings(&mut cx, |settings| {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4435,7 +4435,9 @@ impl LspStore {
                     .as_ref()
                     .and_then(|options| options.resolve_provider)
                     .unwrap_or(false);
-                let additional_text_edits = if can_resolve {
+                let additional_text_edits = if can_resolve
+                    && completion.lsp_completion.additional_text_edits.is_none()
+                {
                     lang_server
                         .request::<lsp::request::ResolveCompletionItem>(completion.lsp_completion)
                         .await?


### PR DESCRIPTION
Closes #19214

There's no reason (that I know of at least), to re-resolve the LSP completion in this code path, if we already have the additional text edits we're looking to apply.

Release Notes:

- Fixed LSP completions being unnecessarily resolved when applying additional LSP text edits. This fixes double imports for Svelte users.
