### PR TITLE
Resolve completion items once exactly

### DIFF
--- a/crates/assistant/src/slash_command.rs
+++ b/crates/assistant/src/slash_command.rs
@@ -149,6 +149,7 @@ impl SlashCommandCompletionProvider {
                             server_id: LanguageServerId(0),
                             lsp_completion: Default::default(),
                             confirm,
+                            resolved: true,
                         })
                     })
                     .collect()
@@ -242,6 +243,7 @@ impl SlashCommandCompletionProvider {
                             server_id: LanguageServerId(0),
                             lsp_completion: Default::default(),
                             confirm,
+                            resolved: true,
                         }
                     })
                     .collect())
@@ -328,16 +330,6 @@ impl CompletionProvider for SlashCommandCompletionProvider {
         _: &mut ViewContext<Editor>,
     ) -> Task<Result<bool>> {
         Task::ready(Ok(true))
-    }
-
-    fn apply_additional_edits_for_completion(
-        &self,
-        _: Model<Buffer>,
-        _: project::Completion,
-        _: bool,
-        _: &mut ViewContext<Editor>,
-    ) -> Task<Result<Option<language::Transaction>>> {
-        Task::ready(Ok(None))
     }
 
     fn is_completion_trigger(

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -79,16 +79,6 @@ impl CompletionProvider for MessageEditorCompletionProvider {
         Task::ready(Ok(false))
     }
 
-    fn apply_additional_edits_for_completion(
-        &self,
-        _buffer: Model<Buffer>,
-        _completion: Completion,
-        _push_to_history: bool,
-        _cx: &mut ViewContext<Editor>,
-    ) -> Task<Result<Option<language::Transaction>>> {
-        Task::ready(Ok(None))
-    }
-
     fn is_completion_trigger(
         &self,
         _buffer: &Model<Buffer>,
@@ -319,6 +309,7 @@ impl MessageEditor {
                     server_id: LanguageServerId(0), // TODO: Make this optional or something?
                     lsp_completion: Default::default(), // TODO: Make this optional or something?
                     confirm: None,
+                    resolved: true,
                 }
             })
             .collect()

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -224,6 +224,7 @@ impl CompletionsMenu {
                 documentation: None,
                 lsp_completion: Default::default(),
                 confirm: None,
+                resolved: true,
             })
             .collect();
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5087,7 +5087,7 @@ impl Editor {
             }))
     }
 
-    #[cfg(feature = "test-support")]
+    #[cfg(any(feature = "test-support", test))]
     pub fn context_menu_visible(&self) -> bool {
         self.context_menu
             .borrow()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3830,13 +3830,11 @@ impl Editor {
         };
 
         let buffer_handle = completions_menu.buffer;
-        let completion = {
-            completions_menu
-                .completions
-                .borrow()
-                .get(mat.candidate_id)?
-                .clone()
-        };
+        let completion = completions_menu
+            .completions
+            .borrow()
+            .get(mat.candidate_id)?
+            .clone();
         cx.stop_propagation();
 
         let snippet;
@@ -3980,6 +3978,7 @@ impl Editor {
         }
 
         let provider = self.completion_provider.as_ref()?;
+        drop(completion);
         let apply_edits = provider.apply_additional_edits_for_completion(
             buffer_handle,
             completions_menu.completions.clone(),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10788,6 +10788,163 @@ async fn test_completions_resolve_updates_labels_if_filter_text_matches(
 }
 
 #[gpui::test]
+async fn test_completions_resolve_happens_once(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            completion_provider: Some(lsp::CompletionOptions {
+                trigger_characters: Some(vec![".".to_string()]),
+                resolve_provider: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state(indoc! {"fn main() { let a = 2ˇ; }"});
+    cx.simulate_keystroke(".");
+
+    let unresolved_item_1 = lsp::CompletionItem {
+        label: "id".to_string(),
+        filter_text: Some("id".to_string()),
+        detail: None,
+        documentation: None,
+        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+            range: lsp::Range::new(lsp::Position::new(0, 22), lsp::Position::new(0, 22)),
+            new_text: ".id".to_string(),
+        })),
+        ..lsp::CompletionItem::default()
+    };
+    let resolved_item_1 = lsp::CompletionItem {
+        additional_text_edits: Some(vec![lsp::TextEdit {
+            range: lsp::Range::new(lsp::Position::new(0, 23), lsp::Position::new(0, 23)),
+            new_text: "!!".to_string(),
+        }]),
+        ..unresolved_item_1.clone()
+    };
+    let unresolved_item_2 = lsp::CompletionItem {
+        label: "other".to_string(),
+        filter_text: Some("other".to_string()),
+        detail: None,
+        documentation: None,
+        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+            range: lsp::Range::new(lsp::Position::new(0, 22), lsp::Position::new(0, 22)),
+            new_text: ".other".to_string(),
+        })),
+        ..lsp::CompletionItem::default()
+    };
+    let resolved_item_2 = lsp::CompletionItem {
+        additional_text_edits: Some(vec![lsp::TextEdit {
+            range: lsp::Range::new(lsp::Position::new(0, 23), lsp::Position::new(0, 23)),
+            new_text: "??".to_string(),
+        }]),
+        ..unresolved_item_2.clone()
+    };
+
+    let resolve_requests_1 = Arc::new(AtomicUsize::new(0));
+    let resolve_requests_2 = Arc::new(AtomicUsize::new(0));
+    cx.lsp
+        .server
+        .on_request::<lsp::request::ResolveCompletionItem, _, _>({
+            let unresolved_item_1 = unresolved_item_1.clone();
+            let resolved_item_1 = resolved_item_1.clone();
+            let unresolved_item_2 = unresolved_item_2.clone();
+            let resolved_item_2 = resolved_item_2.clone();
+            let resolve_requests_1 = resolve_requests_1.clone();
+            let resolve_requests_2 = resolve_requests_2.clone();
+            move |unresolved_request, _| {
+                let unresolved_item_1 = unresolved_item_1.clone();
+                let resolved_item_1 = resolved_item_1.clone();
+                let unresolved_item_2 = unresolved_item_2.clone();
+                let resolved_item_2 = resolved_item_2.clone();
+                let resolve_requests_1 = resolve_requests_1.clone();
+                let resolve_requests_2 = resolve_requests_2.clone();
+                async move {
+                    if unresolved_request == unresolved_item_1 {
+                        resolve_requests_1.fetch_add(1, atomic::Ordering::Release);
+                        Ok(resolved_item_1.clone())
+                    } else if unresolved_request == unresolved_item_2 {
+                        resolve_requests_2.fetch_add(1, atomic::Ordering::Release);
+                        Ok(resolved_item_2.clone())
+                    } else {
+                        panic!("Unexpected completion item {unresolved_request:?}")
+                    }
+                }
+            }
+        })
+        .detach();
+
+    cx.handle_request::<lsp::request::Completion, _, _>(move |_, _, _| {
+        let unresolved_item_1 = unresolved_item_1.clone();
+        let unresolved_item_2 = unresolved_item_2.clone();
+        async move {
+            Ok(Some(lsp::CompletionResponse::Array(vec![
+                unresolved_item_1,
+                unresolved_item_2,
+            ])))
+        }
+    })
+    .next()
+    .await;
+
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+    cx.update_editor(|editor, _| {
+        let context_menu = editor.context_menu.borrow_mut();
+        let context_menu = context_menu
+            .as_ref()
+            .expect("Should have the context menu deployed");
+        match context_menu {
+            CodeContextMenu::Completions(completions_menu) => {
+                let completions = completions_menu.completions.borrow_mut();
+                assert_eq!(
+                    completions
+                        .iter()
+                        .map(|completion| &completion.label.text)
+                        .collect::<Vec<_>>(),
+                    vec!["id", "other"]
+                )
+            }
+            CodeContextMenu::CodeActions(_) => panic!("Should show the completions menu"),
+        }
+    });
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, cx| {
+        editor.context_menu_next(&ContextMenuNext, cx);
+    });
+    cx.run_until_parked();
+    cx.update_editor(|editor, cx| {
+        editor.context_menu_prev(&ContextMenuPrev, cx);
+    });
+    cx.run_until_parked();
+    cx.update_editor(|editor, cx| {
+        editor.context_menu_next(&ContextMenuNext, cx);
+    });
+    cx.run_until_parked();
+    cx.update_editor(|editor, cx| {
+        editor
+            .compose_completion(&ComposeCompletion::default(), cx)
+            .expect("No task returned")
+    })
+    .await
+    .expect("Completion failed");
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, cx| {
+        // TODO kb
+        dbg!((
+            editor.text(cx),
+            resolve_requests_1.load(atomic::Ordering::Acquire),
+            resolve_requests_2.load(atomic::Ordering::Acquire)
+        ));
+    });
+}
+
+#[gpui::test]
 async fn test_completions_default_resolve_data_handling(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10820,7 +10820,7 @@ async fn test_completions_resolve_happens_once(cx: &mut gpui::TestAppContext) {
     };
     let resolved_item_1 = lsp::CompletionItem {
         additional_text_edits: Some(vec![lsp::TextEdit {
-            range: lsp::Range::new(lsp::Position::new(0, 23), lsp::Position::new(0, 23)),
+            range: lsp::Range::new(lsp::Position::new(0, 20), lsp::Position::new(0, 22)),
             new_text: "!!".to_string(),
         }]),
         ..unresolved_item_1.clone()
@@ -10838,7 +10838,7 @@ async fn test_completions_resolve_happens_once(cx: &mut gpui::TestAppContext) {
     };
     let resolved_item_2 = lsp::CompletionItem {
         additional_text_edits: Some(vec![lsp::TextEdit {
-            range: lsp::Range::new(lsp::Position::new(0, 23), lsp::Position::new(0, 23)),
+            range: lsp::Range::new(lsp::Position::new(0, 20), lsp::Position::new(0, 22)),
             new_text: "??".to_string(),
         }]),
         ..unresolved_item_2.clone()
@@ -10935,12 +10935,21 @@ async fn test_completions_resolve_happens_once(cx: &mut gpui::TestAppContext) {
     cx.run_until_parked();
 
     cx.update_editor(|editor, cx| {
-        // TODO kb
-        dbg!((
-            editor.text(cx),
+        assert_eq!(
             resolve_requests_1.load(atomic::Ordering::Acquire),
-            resolve_requests_2.load(atomic::Ordering::Acquire)
-        ));
+            1,
+            "Should always resolve once despite multiple selections"
+        );
+        assert_eq!(
+            resolve_requests_2.load(atomic::Ordering::Acquire),
+            1,
+            "Should always resolve once after multiple selections and applying the completion"
+        );
+        assert_eq!(
+            editor.text(cx),
+            "fn main() { let a = ??.other; }",
+            "Should use resolved data when applying the completion"
+        );
     });
 }
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1918,6 +1918,7 @@ impl LspCommand for GetCompletions {
                     new_text,
                     server_id,
                     lsp_completion,
+                    resolved: false,
                 }
             })
             .collect())

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -927,6 +927,7 @@ message Completion {
     string new_text = 3;
     uint64 server_id = 4;
     bytes lsp_completion = 5;
+    bool resolved = 6;
 }
 
 message GetCodeActions {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/19214
Closes https://github.com/zed-industries/zed/pull/22443

Adds `resolved` property into Zed completion item data, to ensure we resolve every completion item exactly once.

There are 2 paths for singplayer Zed, and corresponding 2 analogues for multi player code, where resolve may happen:
* completions menu display & selection, that ends up using `resolve_completions` in `lsp_store.rs`
* applying a completion menu entry, that ends up using `apply_additional_edits_for_completion` in `lsp_store.rs`

Now, all local counterparts check `enabled` field before resolving and set it to true afterwards, and reuse the same `resolve_completion_local` method for resolving the items.

A logic for re-generating docs and item labels was moved out from the `resolve_completion_local` method into a separate method, as `apply_additional_edits_for_completion` does not need that, but needs the rest of the logic for resolving.
During the extraction, I've noted that multiplayer clients are not getting the item labels, regenerated after the resolve — as the Zed protocol-based flow is not the exact copy of the local resolving.
To improve that, `resolve_completion_remote` needs to be adjusted, but this change is omitted to avoid bloating the PR.

Release Notes:

- Fixed autocomplete inserting multiple imports
