### PR TITLE
assistant2: Scroll to the bottom when you submit a new message

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -4,8 +4,8 @@ use assistant_tool::ToolWorkingSet;
 use collections::HashMap;
 use gpui::{
     list, AbsoluteLength, AnyElement, AppContext, DefiniteLength, EdgesRefinement, Empty, Length,
-    ListAlignment, ListState, Model, StyleRefinement, Subscription, TextStyleRefinement, View,
-    WeakView,
+    ListAlignment, ListOffset, ListState, Model, StyleRefinement, Subscription,
+    TextStyleRefinement, View, WeakView,
 };
 use language::LanguageRegistry;
 use language_model::Role;
@@ -153,6 +153,10 @@ impl ActiveThread {
             )
         });
         self.rendered_messages_by_id.insert(*id, markdown);
+        self.list_state.scroll_to(ListOffset {
+            item_ix: old_len,
+            offset_in_item: Pixels(0.0),
+        });
     }
 
     fn handle_thread_event(


### PR DESCRIPTION
Up until now, in the assistant 2, if you scrolled up either while a message was being generated or after it's been generated, then submitted a new message, you'd keep your scroll position. Now, with this PR, if your scroll position is somewhere else that's not the bottom, as you submit a new message, you'll be back at the bottom.

https://github.com/user-attachments/assets/8b111c10-27ff-4d7b-9b10-4c31093c6457

Release Notes:

- N/A
