### PR TITLE
assistant2: Show the popover keybinding when context is empty

### DIFF
--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -54,7 +54,7 @@ impl MessageEditor {
 
         let editor = cx.new_view(|cx| {
             let mut editor = Editor::auto_height(10, cx);
-            editor.set_placeholder_text("Ask anything, @ to add context", cx);
+            editor.set_placeholder_text("Ask anything…", cx);
             editor.set_show_indent_guides(false, cx);
 
             editor


### PR DESCRIPTION
This PR makes it so we always show the "Add Context {keybinding}" text when there's no context pills attached. Also, while we haven't fully implemented the mention system (triggered by typing `@`), we removed the instruction on the message editor placeholder. Once that's fully in place, we should return with it!

<img width="800" alt="Screenshot 2024-12-27 at 1 35 56 PM" src="https://github.com/user-attachments/assets/201cf784-e7ac-420a-adf2-51b6e075c2b6" />

Release Notes:

- N/A
