### PR TITLE
project_panel: Support multiple items in `RemoveFromProject`

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1995,8 +1995,8 @@ impl ProjectPanel {
     }
 
     fn remove_from_project(&mut self, _: &RemoveFromProject, cx: &mut ViewContext<Self>) {
-        if let Some((worktree, _)) = self.selected_sub_entry(cx) {
-            let worktree_id = worktree.read(cx).id();
+        for entry in self.effective_entries().iter() {
+            let worktree_id = entry.worktree_id;
             self.project
                 .update(cx, |project, cx| project.remove_worktree(worktree_id, cx));
         }


### PR DESCRIPTION
This makes the `RemoveFromProject` action to remove all marked entries in the project panel instead of just the selected one.

Closes #22454

Release Notes:

- Improved the `RemoveFromProject` action to remove all selected items.
