### PR TITLE
Don't abort in panic hook

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -128,8 +128,6 @@ pub fn init_panic_hook(
                 }
             }
         }
-
-        std::process::abort();
     }));
 }
 


### PR DESCRIPTION
This makes it impossible to `catch_unwind`, including in dependencies. There might be a reason I'm not thinking of to `abort` here; if so, we might want to consider building with `panic=abort` instead since this also decreases the binary size (and maybe helps compile times?). 

Release Notes:

- N/A