### PR TITLE
Small fixes after terminal split

### DIFF
--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -385,28 +385,20 @@ impl LineLayoutCache {
         let mut previous_frame = &mut *self.previous_frame.lock();
         let mut current_frame = &mut *self.current_frame.write();
 
-        if let Some(cached_keys) = previous_frame
-            .used_lines
-            .get(range.start.lines_index..range.end.lines_index)
-        {
-            for key in cached_keys {
-                if let Some((key, line)) = previous_frame.lines.remove_entry(key) {
-                    current_frame.lines.insert(key, line);
-                }
-                current_frame.used_lines.push(key.clone());
+        for key in &previous_frame.used_lines[range.start.lines_index..range.end.lines_index] {
+            if let Some((key, line)) = previous_frame.lines.remove_entry(key) {
+                current_frame.lines.insert(key, line);
             }
+            current_frame.used_lines.push(key.clone());
         }
 
-        if let Some(cached_keys) = previous_frame
-            .used_wrapped_lines
-            .get(range.start.wrapped_lines_index..range.end.wrapped_lines_index)
+        for key in &previous_frame.used_wrapped_lines
+            [range.start.wrapped_lines_index..range.end.wrapped_lines_index]
         {
-            for key in cached_keys {
-                if let Some((key, line)) = previous_frame.wrapped_lines.remove_entry(key) {
-                    current_frame.wrapped_lines.insert(key, line);
-                }
-                current_frame.used_wrapped_lines.push(key.clone());
+            if let Some((key, line)) = previous_frame.wrapped_lines.remove_entry(key) {
+                current_frame.wrapped_lines.insert(key, line);
             }
+            current_frame.used_wrapped_lines.push(key.clone());
         }
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1753,17 +1753,12 @@ impl<'a> WindowContext<'a> {
                 .iter_mut()
                 .map(|listener| listener.take()),
         );
-        if let Some(element_states) = window
-            .rendered_frame
-            .accessed_element_states
-            .get(range.start.accessed_element_states_index..range.end.accessed_element_states_index)
-        {
-            window.next_frame.accessed_element_states.extend(
-                element_states
-                    .iter()
-                    .map(|(id, type_id)| (GlobalElementId(id.0.clone()), *type_id)),
-            );
-        }
+        window.next_frame.accessed_element_states.extend(
+            window.rendered_frame.accessed_element_states[range.start.accessed_element_states_index
+                ..range.end.accessed_element_states_index]
+                .iter()
+                .map(|(id, type_id)| (GlobalElementId(id.0.clone()), *type_id)),
+        );
 
         window
             .text_system


### PR DESCRIPTION
* removes cache access workarounds as https://github.com/zed-industries/zed/pull/21165 is supposed to fix this
* use `WeakModel<Project>` inside `Pane` just in case 

Release Notes:

- N/A 
