### PR TITLE
Syntax highlight the JavaScript keyword `using`

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -194,6 +194,7 @@
   "throw"
   "try"
   "typeof"
+  "using"
   "var"
   "void"
   "while"


### PR DESCRIPTION
The ECMAScript Explicit Resource Management proposal (stage 3) that specifies the  keyword `using`:

https://github.com/tc39/proposal-explicit-resource-management

This has already been done for the TypeScript and TSX languages:

- https://github.com/zed-industries/zed/issues/14762
- https://github.com/zed-industries/zed/pull/14772

Release Notes:

- Syntax highlight the JavaScript keyword `using` ([#22479](https://github.com/zed-industries/zed/pull/22479); thanks [jaydenseric](https://github.com/jaydenseric)).
