### PR TITLE
Invalidate tooltips when mouse leaves element's hitbox

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1417,6 +1417,19 @@ impl Interactivity {
                             None
                         };
 
+                        let invalidate_tooltip = hitbox
+                            .as_ref()
+                            .map_or(true, |hitbox| !hitbox.bounds.contains(&cx.mouse_position()));
+                        if invalidate_tooltip {
+                            if let Some(active_tooltip) = element_state
+                                .as_ref()
+                                .and_then(|state| state.active_tooltip.as_ref())
+                            {
+                                *active_tooltip.borrow_mut() = None;
+                                self.tooltip_id = None;
+                            }
+                        }
+
                         let scroll_offset = self.clamp_scroll_position(bounds, &style, cx);
                         let result = f(&style, scroll_offset, hitbox, cx);
                         (result, element_state)


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21657

In case of the task rerun button tooltip from

https://github.com/zed-industries/zed/blob/f6dabadaf79bd29c89c8d55a1e9f1d33236f736e/crates/terminal_view/src/terminal_view.rs#L1051-L1070

, the actual button element is not styled as invisible, only its parent.
Zed won't render such element since it's parent is hidden, but will consider it "visible" all the time its `paint` is called, spawning a task with the delay, that will create the tooltip:

https://github.com/zed-industries/zed/blob/f6dabadaf79bd29c89c8d55a1e9f1d33236f736e/crates/gpui/src/elements/div.rs#L1949-L1959

When the parent is hidden, the child won't be painted anymore, and no mouse listeners will be able to detect this fact and hide the tooltip.

Hence, check such cases separately, during `prepaint`, and invalidate the tooltips that are not valid anymore.
We cannot use `hitbox.is_hovered(cx)` as it's not really hovered during prepaint, so a mouse position check is used instead.

Release Notes:

- Fixed tooltips getting stuck
