### PR TITLE
ruby: Document `use_bundler` configuration option

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -106,14 +106,14 @@ Solargraph has formatting and diagnostics disabled by default. We can tell Zed t
 }
 ```
 
-To use Solargraph in the context of the bundle, you can use [folder-specific settings](../configuring-zed.md#settings-files) and specify the absolute path to the [`binstub`](https://bundler.io/v2.5/man/bundle-binstubs.1.html) of Solargraph:
+By default, Solargraph uses `bundle exec` to run in the context of the bundle. To disable that, you can use the `use_bundler` configuration option:
 
 ```json
 {
   "lsp": {
     "solargraph": {
-      "binary": {
-        "path": "<path_to_your_project>/bin/solargraph"
+      "settings": {
+        "use_bundler": false
       }
     }
   }
@@ -150,6 +150,20 @@ Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell 
           // This disables diagnostics
           "diagnostics": false
         }
+      }
+    }
+  }
+}
+```
+
+By default, Ruby LSP does not use `bundle exec` to run in the context of the bundle. To enable that, you can use the `use_bundler` configuration option:
+
+```json
+{
+  "lsp": {
+    "ruby-lsp": {
+      "settings": {
+        "use_bundler": true
       }
     }
   }
@@ -193,14 +207,14 @@ Rubocop has unsafe autocorrection disabled by default. We can tell Zed to enable
 }
 ```
 
-To use Rubocop in the context of the bundle, you can use [folder-specific settings](../configuring-zed.md#settings-files) and specify the absolute path to the [`binstub`](https://bundler.io/v2.5/man/bundle-binstubs.1.html) of Rubocop:
+By default, `rubocop` uses `bundle exec` to run in the context of the bundle. To disable that, you can use the `use_bundler` configuration option:
 
 ```json
 {
   "lsp": {
     "rubocop": {
-      "binary": {
-        "path": "<path_to_your_project>/bin/rubocop"
+      "settings": {
+        "use_bundler": false
       }
     }
   }


### PR DESCRIPTION
Hello,

This PR documents the `use_bundler` configuration option that was added in https://github.com/zed-extensions/ruby/releases/tag/v0.3.3

**What it does?**

This option allows users to run `solargraph` and `rubocop` within the context of Bundler, which is the most commonly used scenario in the Ruby ecosystem. Ruby LSP is not configured to run in the context of Bundler because it is recommended not to add it to the project dependencies (https://shopify.github.io/ruby-lsp/composed-bundle.html). However, if this is the case, the Ruby LSP can still be configured to run in the context of Bundler via the same configuration option.

This configuration option has the following default values:

- `rubocop` - `use_bundler` is `true`.
- `solargraph` - `use_bundler` is `true`.
- `ruby-lsp` - `use_bundler` is `false`.

Release Notes:

- N/A
