### PR TITLE
pane: Turn off preview mode when pinning a tab

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1955,14 +1955,15 @@ impl Pane {
     }
 
     fn pin_tab_at(&mut self, ix: usize, cx: &mut ViewContext<Self>) {
-        if self.is_active_preview_item(self.items[ix].item_id()) {
-            self.set_preview_item_id(None, cx);
-        }
         maybe!({
             let pane = cx.view().clone();
             let destination_index = self.pinned_tab_count.min(ix);
             self.pinned_tab_count += 1;
             let id = self.item_for_index(ix)?.item_id();
+
+            if self.is_active_preview_item(id) {
+                self.set_preview_item_id(None, cx);
+            }
 
             self.workspace
                 .update(cx, |_, cx| {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1955,6 +1955,9 @@ impl Pane {
     }
 
     fn pin_tab_at(&mut self, ix: usize, cx: &mut ViewContext<Self>) {
+        if self.is_active_preview_item(self.items[ix].item_id()) {
+            self.set_preview_item_id(None, cx);
+        }
         maybe!({
             let pane = cx.view().clone();
             let destination_index = self.pinned_tab_count.min(ix);


### PR DESCRIPTION
I opened the tab in preview mode, pinned it, then I opened another file, but its tab unexpectedly closed.

https://github.com/user-attachments/assets/b857382e-f0ad-4d5a-9036-19de01663c97

Pinning a tab now turns off preview mode.


https://github.com/user-attachments/assets/e34b7c7f-452b-4f36-99c1-e0c68429225c


Release Notes:

- Pinning a preview tab will now turn off preview mode
