### PR TITLE
Have Zed cli output logs path to stderr

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -257,6 +257,7 @@ fn main() -> Result<()> {
     if args.foreground {
         app.run_foreground(url)?;
     } else {
+        eprintln!("Logs are written to {:?}", paths::log_file());
         app.launch(url)?;
         sender.join().unwrap()?;
         pipe_handle.join().unwrap()?;


### PR DESCRIPTION
When switching from just running the editor directly to using the CLI I missed the logs in the terminal and started using `--foreground`.  I realized this was because there was a tiny amount of effort involved in finding out where logs were being written to.  Having the cli output it to stderr helps make this more visible.

Seems like such a minor thing not listing in release notes.

Release Notes:

- N/A
