### PR TITLE
Ensure zls is used for Zig as a primary language server

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1103,6 +1103,9 @@
       "prettier": {
         "allowed": true
       }
+    },
+    "Zig": {
+      "language_servers": ["zls", "..."]
     }
   },
   // Different settings for specific language models.

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -284,6 +284,7 @@ impl<F: Future> LspRequestFuture<F::Output> for LspRequest<F> {
 }
 
 /// Combined capabilities of the server and the adapter.
+#[derive(Debug)]
 pub struct AdapterServerCapabilities {
     // Reported capabilities by the server
     pub server_capabilities: ServerCapabilities,


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/22415

I've noticed that I cannot work with any Zig projects, as there were no "go to definition", formatting and inlay hints.

After debugging, I've discovered that `typos` was registered as a first language server, becoming the "primary" one for Zig.
That one does not have any proper capabilities, hence all corresponding LSP requests were no-op.

While this solution is not ideal (I wonder, how many other set-ups are broken due to the same thing?), we'd better fix things for now this way at least.

Release Notes:

- Fixed `zls` not working properly when `typos` extension is installed
