### PR TITLE
cli: Fix support for older macOS versions

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -2,4 +2,9 @@ fn main() {
     if std::env::var("ZED_UPDATE_EXPLANATION").is_ok() {
         println!(r#"cargo:rustc-cfg=feature="no-bundled-uninstall""#);
     }
+
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.15.7");
+        println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
+    }
 }

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -5,6 +5,7 @@ fn main() {
 
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.15.7");
+        // Weakly link ScreenCaptureKit to ensure can be used on macOS 10.15+.
         println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
     }
 }

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -51,6 +51,8 @@ mod macos {
     fn generate_dispatch_bindings() {
         println!("cargo:rustc-link-lib=framework=System");
         println!("cargo:rustc-link-lib=framework=ScreenCaptureKit");
+        // Weakly link ScreenCaptureKit to ensure can be used on macOS 10.15+.
+        println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
         println!("cargo:rerun-if-changed=src/platform/mac/dispatch.h");
 
         let bindings = bindgen::Builder::default()

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -51,8 +51,6 @@ mod macos {
     fn generate_dispatch_bindings() {
         println!("cargo:rustc-link-lib=framework=System");
         println!("cargo:rustc-link-lib=framework=ScreenCaptureKit");
-        // Weakly link ScreenCaptureKit to ensure can be used on macOS 10.15+.
-        println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
         println!("cargo:rerun-if-changed=src/platform/mac/dispatch.h");
 
         let bindings = bindgen::Builder::default()


### PR DESCRIPTION
Close #22419

Release Notes:

- Fixed `zed` cli crash by `ScreenCaptureKit` library not loaded error on macOS lower versions.

<img width="843" alt="image" src="https://github.com/user-attachments/assets/9e0b615e-933f-4808-bf20-3e37e9e8bc6d" />

--- 

The main reason is the `cli` depends on `release_channel`, and it depends on `gpui`.

```
$ cargo tree -p cli
├── release_channel v0.1.0 (/Users/jason/github/zed/crates/release_channel)
│   └── gpui v0.1.0 (/Users/jason/github/zed/crates/gpui)
│       ├── anyhow v1.0.95
│       ├── async-task v4.7.1
│       ├── block v0.1.6
│       ├── cocoa v0.26.0
```