### PR TITLE
Check cancel in multithreaded fuzzy matching

### DIFF
--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -8,7 +8,7 @@ use std::{
     cmp::{self, Ordering},
     iter,
     ops::Range,
-    sync::atomic::AtomicBool,
+    sync::atomic::{self, AtomicBool},
 };
 
 #[derive(Clone, Debug)]
@@ -177,6 +177,10 @@ pub async fn match_strings(
             }
         })
         .await;
+
+    if cancel_flag.load(atomic::Ordering::Relaxed) {
+        return Vec::new();
+    }
 
     let mut results = segment_results.concat();
     util::truncate_to_bottom_n_sorted_by(&mut results, max_results, &|a, b| b.cmp(a));


### PR DESCRIPTION
For both the strings and paths multithreaded matching it would still
aggregate the response even though it is unneeded. It now checks cancel.

In the paths matcher, cancel is now checked within the loop, since it
was calling `match_candidates` even though no further results would be
computed.

Release Notes:

- N/A