### PR TITLE
Revert "Have Zed cli output logs path to stderr"

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -257,7 +257,6 @@ fn main() -> Result<()> {
     if args.foreground {
         app.run_foreground(url)?;
     } else {
-        eprintln!("Logs are written to {:?}", paths::log_file());
         app.launch(url)?;
         sender.join().unwrap()?;
         pipe_handle.join().unwrap()?;


### PR DESCRIPTION
Removes noisy log location stderr output on every `zed` cli invocation.

Reverts zed-industries/zed#22509

Release Notes:

- N/A