### PR TITLE
Revert "Invalidate tooltips when mouse leaves element's hitbox (#22488)"

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1417,19 +1417,6 @@ impl Interactivity {
                             None
                         };
 
-                        let invalidate_tooltip = hitbox
-                            .as_ref()
-                            .map_or(true, |hitbox| !hitbox.bounds.contains(&cx.mouse_position()));
-                        if invalidate_tooltip {
-                            if let Some(active_tooltip) = element_state
-                                .as_ref()
-                                .and_then(|state| state.active_tooltip.as_ref())
-                            {
-                                *active_tooltip.borrow_mut() = None;
-                                self.tooltip_id = None;
-                            }
-                        }
-
                         let scroll_offset = self.clamp_scroll_position(bounds, &style, cx);
                         let result = f(&style, scroll_offset, hitbox, cx);
                         (result, element_state)


### PR DESCRIPTION
This reverts commit 344284e01331667c018e6ade5d791a20598a3a5c.

That change broke git blame tooltips, as Zed should also show tooltips which are hovered, even though the mouse had left the origin element's bounds.

Release Notes:

- N/A
