### PR TITLE
Fix for extension search crash (revert #22524; revert #22525)

### DIFF
--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -3,10 +3,7 @@ use std::{
     borrow::Cow,
     cmp::{self, Ordering},
     path::Path,
-    sync::{
-        atomic::{self, AtomicBool},
-        Arc,
-    },
+    sync::{atomic::AtomicBool, Arc},
 };
 
 use crate::{
@@ -157,10 +154,6 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
 
                     let mut tree_start = 0;
                     for candidate_set in candidate_sets {
-                        if cancel_flag.load(atomic::Ordering::Relaxed) {
-                            break;
-                        }
-
                         let tree_end = tree_start + candidate_set.len();
 
                         if tree_start < segment_end && segment_start < tree_end {
@@ -208,10 +201,6 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
             }
         })
         .await;
-
-    if cancel_flag.load(atomic::Ordering::Relaxed) {
-        return Vec::new();
-    }
 
     let mut results = segment_results.concat();
     util::truncate_to_bottom_n_sorted_by(&mut results, max_results, &|a, b| b.cmp(a));

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    matcher::{MatchCandidate, Matcher},
+    matcher::{Match, MatchCandidate, Matcher},
     CharBag,
 };
 
@@ -40,6 +40,16 @@ pub trait PathMatchCandidateSet<'a>: Send + Sync {
     }
     fn prefix(&self) -> Arc<str>;
     fn candidates(&'a self, start: usize) -> Self::Candidates;
+}
+
+impl Match for PathMatch {
+    fn score(&self) -> f64 {
+        self.score
+    }
+
+    fn set_positions(&mut self, positions: Vec<usize>) {
+        self.positions = positions;
+    }
 }
 
 impl<'a> MatchCandidate for PathMatchCandidate<'a> {
@@ -92,7 +102,13 @@ pub fn match_fixed_path_set(
     let query = query.chars().collect::<Vec<_>>();
     let query_char_bag = CharBag::from(&lowercase_query[..]);
 
-    let mut matcher = Matcher::new(&query, &lowercase_query, query_char_bag, smart_case);
+    let mut matcher = Matcher::new(
+        &query,
+        &lowercase_query,
+        query_char_bag,
+        smart_case,
+        max_results,
+    );
 
     let mut results = Vec::new();
     matcher.match_candidates(
@@ -101,17 +117,16 @@ pub fn match_fixed_path_set(
         candidates.into_iter(),
         &mut results,
         &AtomicBool::new(false),
-        |candidate, score, positions| PathMatch {
+        |candidate, score| PathMatch {
             score,
             worktree_id,
-            positions: positions.clone(),
+            positions: Vec::new(),
             is_dir: candidate.is_dir,
             path: Arc::from(candidate.path),
             path_prefix: Arc::default(),
             distance_to_relative_ancestor: usize::MAX,
         },
     );
-    util::truncate_to_bottom_n_sorted_by(&mut results, max_results, &|a, b| b.cmp(a));
     results
 }
 
@@ -149,8 +164,13 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
                 scope.spawn(async move {
                     let segment_start = segment_idx * segment_size;
                     let segment_end = segment_start + segment_size;
-                    let mut matcher =
-                        Matcher::new(query, lowercase_query, query_char_bag, smart_case);
+                    let mut matcher = Matcher::new(
+                        query,
+                        lowercase_query,
+                        query_char_bag,
+                        smart_case,
+                        max_results,
+                    );
 
                     let mut tree_start = 0;
                     for candidate_set in candidate_sets {
@@ -173,10 +193,10 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
                                 candidates,
                                 results,
                                 cancel_flag,
-                                |candidate, score, positions| PathMatch {
+                                |candidate, score| PathMatch {
                                     score,
                                     worktree_id,
-                                    positions: positions.clone(),
+                                    positions: Vec::new(),
                                     path: Arc::from(candidate.path),
                                     is_dir: candidate.is_dir,
                                     path_prefix: candidate_set.prefix(),
@@ -202,8 +222,14 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
         })
         .await;
 
-    let mut results = segment_results.concat();
-    util::truncate_to_bottom_n_sorted_by(&mut results, max_results, &|a, b| b.cmp(a));
+    let mut results = Vec::new();
+    for segment_result in segment_results {
+        if results.is_empty() {
+            results = segment_result;
+        } else {
+            util::extend_sorted(&mut results, segment_result, max_results, |a, b| b.cmp(a));
+        }
+    }
     results
 }
 

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -8,7 +8,7 @@ use std::{
     cmp::{self, Ordering},
     iter,
     ops::Range,
-    sync::atomic::{self, AtomicBool},
+    sync::atomic::AtomicBool,
 };
 
 #[derive(Clone, Debug)]
@@ -177,10 +177,6 @@ pub async fn match_strings(
             }
         })
         .await;
-
-    if cancel_flag.load(atomic::Ordering::Relaxed) {
-        return Vec::new();
-    }
 
     let mut results = segment_results.concat();
     util::truncate_to_bottom_n_sorted_by(&mut results, max_results, &|a, b| b.cmp(a));

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -1,5 +1,5 @@
 use crate::{
-    matcher::{MatchCandidate, Matcher},
+    matcher::{Match, MatchCandidate, Matcher},
     CharBag,
 };
 use gpui::BackgroundExecutor;
@@ -44,6 +44,16 @@ pub struct StringMatch {
     pub score: f64,
     pub positions: Vec<usize>,
     pub string: String,
+}
+
+impl Match for StringMatch {
+    fn score(&self) -> f64 {
+        self.score
+    }
+
+    fn set_positions(&mut self, positions: Vec<usize>) {
+        self.positions = positions;
+    }
 }
 
 impl StringMatch {
@@ -157,8 +167,13 @@ pub async fn match_strings(
                 scope.spawn(async move {
                     let segment_start = cmp::min(segment_idx * segment_size, candidates.len());
                     let segment_end = cmp::min(segment_start + segment_size, candidates.len());
-                    let mut matcher =
-                        Matcher::new(query, lowercase_query, query_char_bag, smart_case);
+                    let mut matcher = Matcher::new(
+                        query,
+                        lowercase_query,
+                        query_char_bag,
+                        smart_case,
+                        max_results,
+                    );
 
                     matcher.match_candidates(
                         &[],
@@ -166,10 +181,10 @@ pub async fn match_strings(
                         candidates[segment_start..segment_end].iter(),
                         results,
                         cancel_flag,
-                        |candidate, score, positions| StringMatch {
+                        |candidate, score| StringMatch {
                             candidate_id: candidate.id,
                             score,
-                            positions: positions.clone(),
+                            positions: Vec::new(),
                             string: candidate.string.to_string(),
                         },
                     );
@@ -178,7 +193,13 @@ pub async fn match_strings(
         })
         .await;
 
-    let mut results = segment_results.concat();
-    util::truncate_to_bottom_n_sorted_by(&mut results, max_results, &|a, b| b.cmp(a));
+    let mut results = Vec::new();
+    for segment_result in segment_results {
+        if results.is_empty() {
+            results = segment_result;
+        } else {
+            util::extend_sorted(&mut results, segment_result, max_results, |a, b| b.cmp(a));
+        }
+    }
     results
 }

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -8,6 +8,7 @@ pub mod test;
 
 use anyhow::{anyhow, Context as _, Result};
 use futures::Future;
+
 use itertools::Either;
 use regex::Regex;
 use std::sync::{LazyLock, OnceLock};
@@ -108,27 +109,6 @@ where
             start_index = index;
         }
     }
-}
-
-pub fn truncate_to_bottom_n_sorted_by<T, F>(items: &mut Vec<T>, limit: usize, compare: &F)
-where
-    F: Fn(&T, &T) -> Ordering,
-{
-    if limit == 0 {
-        items.truncate(0);
-    }
-    if items.len() < limit {
-        return;
-    }
-    // When limit is near to items.len() it may be more efficient to sort the whole list and
-    // truncate, rather than always doing selection first as is done below. It's hard to analyze
-    // where the threshold for this should be since the quickselect style algorithm used by
-    // `select_nth_unstable_by` makes the prefix partially sorted, and so its work is not wasted -
-    // the expected number of comparisons needed by `sort_by` is less than it is for some arbitrary
-    // unsorted input.
-    items.select_nth_unstable_by(limit, compare);
-    items.truncate(limit);
-    items.sort_by(compare);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Revert "Improve fuzzy match performance and fix corner case that omits results (#22524)"
This reverts commit 6ef5d8f74809938f968d0ab86c7c12163c5e0940.

Revert "Check cancel in multithreaded fuzzy matching (#22525)"
This reverts commit 51ac2d366789fea42e9d1ee9294fe6065e128fe8.

Fuzzy matching implemented in:
- https://github.com/zed-industries/zed/pull/22524
- https://github.com/zed-industries/zed/pull/22525

Caused a panic in the extension store search:
- Closes: https://github.com/zed-industries/zed/issues/22541

cc: @mgsloan 

Release Notes:

- N/A
