### PR TITLE
docs: Improve the Getting Started page

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -50,14 +50,12 @@ Any time you see instructions that include commands of the form `zed: ...` or `e
 
 ## Configure Zed
 
-Use {#kb zed::OpenSettings} to open your custom settings to set things like fonts, formatting settings, per-language settings, and more.
+To open your custom settings to set things like fonts, formatting settings, per-language settings, and more, use the {#kb zed::OpenSettings} keybinding.
 
-On macOS, you can access the default configuration using the `Zed > Settings > Open Default Settings` menu item. See [Configuring Zed](./configuring-zed.md) for all available settings.
-
-On Linux, you can access the default configuration via the Command Palette. Open it with {#kb zed::OpenDefaultSettings} and type in `zed: open default settings` and then hit return.
+To see all available settings, open the Command Palette with {#kb command_palette::Toggle} and search for "zed: open default settings". You can also check them all out in the [Configuring Zed](./configuring-zed.md) documentation.
 
 ## Set up your key bindings
 
-On macOS, you can access the default key binding set using the `Zed > Settings > Open Default Key Bindings` menu item. Use <kbd>cmd-k cmd-s|ctrl-k ctrl-s</kbd> to open your custom keymap to add your key bindings. See Key Bindings for more info.
+To open your custom keymap to add your key bindings, use the {#kb zed::OpenKeymap} keybinding.
 
-On Linux, you can access the default key bindings via the Command Palette. Open it with <kbd>ctrl-shift-p</kbd> and type in `zed: open default keymap` and then hit return.
+To access the default key binding set, open the Command Palette with {#kb command_palette::Toggle} and search for "zed: open default keymap". See [Key Bindings](./key-bindings.md) for more info.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -6,7 +6,7 @@ Welcome to Zed! We are excited to have you. Here is a jumping-off point to getti
 
 ### macOS
 
-You can obtain the stable builds via the [download page](https://zed.dev/download). If you want to download our preview build, you can find it on its [releases page](https://zed.dev/releases/preview) After the first manual installation, Zed will periodically check for and install updates automatically for you.
+Get the latest stable builds via [the download page](https://zed.dev/download). If you want to download our preview build, you can find it on its [releases page](https://zed.dev/releases/preview). After the first manual installation, Zed will periodically check for install updates.
 
 You can also install Zed stable via Homebrew:
 
@@ -22,7 +22,7 @@ brew install --cask zed@preview
 
 ### Linux
 
-For most people, the easiest way to install Zed is through our installation script:
+For most Linux users, the easiest way to install Zed is through our installation script:
 
 ```sh
 curl -f https://zed.dev/install.sh | sh
@@ -40,15 +40,11 @@ If this script is insufficient for your use case or you run into problems runnin
 
 ## Command Palette
 
-The Command Palette is the main way to access functionality in Zed, and its keybinding is the first one you should make yourself familiar with.
-
-To open the Command Palette, use {#kb command_palette::Toggle}.
-
-The Command Palette allows you to access pretty much any functionality that's available in Zed.
+The Command Palette is the main way to access pretty much any functionality that's available in Zed. Its keybinding is the first one you should make yourself familiar with. To open it, hit: {#kb command_palette::Toggle}.
 
 ![The opened Command Palette](https://zed.dev/img/features/command-palette.jpg)
 
-Try it! Open the Command Palette and type in `new file`. You should see the list of commands being filtered down to `workspace: new file`. Hit return and you end up with a new buffer!
+Try it! Open the Command Palette and type in `new file`. You should see the list of commands being filtered down to `workspace: new file`. Hit return and you end up with a new buffer.
 
 Any time you see instructions that include commands of the form `zed: ...` or `editor: ...` and so on that means you need to execute them in the Command Palette.
 


### PR DESCRIPTION
- Little tweaks to wording and punctuation
- Remove redundancy on the Configuration and Key binding sections
- Ensure key bindings for the sections mentioned above appear

Release Notes:

- N/A
