### PR TITLE
ci: Make docs-only check a no-op in the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Check for non-docs changes
         id: check_changes
         run: |
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -qvE '^docs/'; then
-            echo "docs_only=false" >> $GITHUB_OUTPUT
-          else
-            echo "docs_only=true" >> $GITHUB_OUTPUT
-          fi
+          # The docs-only check isn't working properly when run in the merge
+          # queue, resulting in the jobs not being run. To work around this,
+          # we're always setting `docs_only` to `false` so that the necessary CI
+          # jobs run.
+          echo "docs_only=false" >> $GITHUB_OUTPUT
 
   migration_checks:
     name: Check Postgres and Protobuf migrations, mergability

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,16 @@ jobs:
       - name: Check for non-docs changes
         id: check_changes
         run: |
-          # The docs-only check isn't working properly when run in the merge
-          # queue, resulting in the jobs not being run. To work around this,
-          # we're always setting `docs_only` to `false` so that the necessary CI
-          # jobs run.
-          echo "docs_only=false" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "merge_group" ]; then
+            # When we're running in a merge queue, never assume that the changes
+            # are docs-only, as there could be other PRs in the group that
+            # contain non-docs changes.
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+          elif git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -qvE '^docs/'; then
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+          else
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+          fi
 
   migration_checks:
     name: Check Postgres and Protobuf migrations, mergability


### PR DESCRIPTION
This PR makes the docs-only check a no-op that defaults to `false` when running in the merge queue.

I noticed that the current check did not work properly in the merge queue, resulting in it always assuming a change was docs-only and not running the requisite CI jobs.

Release Notes:

- N/A
