### PR TITLE
Fix tooltips too eager to disappear when there's a gap between the tooltip source and the tooltip itself

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1557,19 +1557,6 @@ impl<'a> WindowContext<'a> {
         let tooltip_size = element.layout_as_root(AvailableSpace::min_size(), self);
 
         let mut tooltip_bounds = Bounds::new(mouse_position + point(px(1.), px(1.)), tooltip_size);
-        // Element's parent can get hidden (e.g. via the `visible_on_hover` method),
-        // and element's `paint` won't be called (ergo, mouse listeners also won't be active) to detect that the tooltip has to be removed.
-        // Ensure it's not stuck around in such cases.
-        let invalidate_tooltip = !tooltip_request
-            .tooltip
-            .origin_bounds
-            .contains(&self.mouse_position())
-            && (!tooltip_request.tooltip.hoverable
-                || !tooltip_bounds.contains(&self.mouse_position()));
-        if invalidate_tooltip {
-            return None;
-        }
-
         let window_bounds = Bounds {
             origin: Point::default(),
             size: self.viewport_size(),
@@ -1597,6 +1584,19 @@ impl<'a> WindowContext<'a> {
                     tooltip_bounds.origin.y - tooltip_bounds.bottom() - window_bounds.bottom(),
                 );
             }
+        }
+
+        // Element's parent can get hidden (e.g. via the `visible_on_hover` method),
+        // and element's `paint` won't be called (ergo, mouse listeners also won't be active) to detect that the tooltip has to be removed.
+        // Ensure it's not stuck around in such cases.
+        let invalidate_tooltip = !tooltip_request
+            .tooltip
+            .origin_bounds
+            .contains(&self.mouse_position())
+            && (!tooltip_request.tooltip.hoverable
+                || !tooltip_bounds.contains(&self.mouse_position()));
+        if invalidate_tooltip {
+            return None;
         }
 
         self.with_absolute_element_offset(tooltip_bounds.origin, |cx| element.prepaint(cx));


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/22548

Release Notes:

- N/A
