### PR TITLE
racket: Bump Extension to v0.0.2

### DIFF
--- a/extensions/racket/extension.toml
+++ b/extensions/racket/extension.toml
@@ -1,7 +1,7 @@
 id = "racket"
 name = "Racket"
 description = "Racket support."
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Mikayla Maki <mikayla@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Includes:
- https://github.com/zed-industries/zed/pull/18728

Release Notes:

- N/A
