### PR TITLE
Improve truncate efficiency and fix OBOE in truncate_and_remove_front

### DIFF
--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -570,7 +570,7 @@ mod tests {
                 spawn_in_terminal.label,
                 format!(
                     "test label for 1234 and …{}",
-                    &long_value[..=MAX_DISPLAY_VARIABLE_LENGTH]
+                    &long_value[long_value.len() - MAX_DISPLAY_VARIABLE_LENGTH..]
                 ),
                 "Human-readable label should have long substitutions trimmed"
             );

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -795,7 +795,7 @@ mod tests {
         assert_eq!(
             task_names(&tasks_picker, cx),
             vec![
-                "hello from …th.odd_extension:1:1".to_string(),
+                "hello from …h.odd_extension:1:1".to_string(),
                 "opened now: /dir".to_string()
             ],
             "Second opened buffer should fill the context, labels should be trimmed if long enough"
@@ -824,7 +824,7 @@ mod tests {
         assert_eq!(
             task_names(&tasks_picker, cx),
             vec![
-                "hello from …ithout_extension:2:3".to_string(),
+                "hello from …thout_extension:2:3".to_string(),
                 "opened now: /dir".to_string()
             ],
             "Opened buffer should fill the context, labels should be trimmed if long enough"


### PR DESCRIPTION
* Skip walking string for truncate when byte len is <= char limit

* Fix `truncate_and_remove_front` returning string that is `max_chars + 1` in length. Now more consistent with `truncate_and_trailoff` behavior.

* Fix `truncate_and_remove_front` adding ellipsis when max_chars == char length

Release Notes:

- N/A