### PR TITLE
Deploy script: Specify remote for new Preview branch

### DIFF
--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -77,6 +77,7 @@ git tag ${stable_tag_name}
 echo "Creating new preview branch ${minor_branch_name}..."
 git checkout -q main
 git checkout -q -b ${minor_branch_name}
+git branch --set-upstream-to=origin/${minor_branch_name} ${minor_branch_name}
 echo -n preview > crates/zed/RELEASE_CHANNEL
 git commit -q --all --message "${minor_branch_name} preview"
 git tag ${preview_tag_name}


### PR DESCRIPTION
Set the git remote tracking branch when the new Preview branch is created by `script/bump-zed-minor-versions`. This only impacts the local git branch configuration of the user who runs this script.

Release Notes:

- N/A
