### PR TITLE
Set `TERM` env variable inside the terminal

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -347,6 +347,7 @@ impl TerminalBuilder {
 
         env.insert("ZED_TERM".to_string(), "true".to_string());
         env.insert("TERM_PROGRAM".to_string(), "zed".to_string());
+        env.insert("TERM".to_string(), "alacritty".to_string());
         env.insert(
             "TERM_PROGRAM_VERSION".to_string(),
             release_channel::AppVersion::global(cx).to_string(),


### PR DESCRIPTION
Closes #17991 

Release Notes:

- Set the `TERM` environment variable inside the terminal

Currently the terminal inherits the `TERM` variable from the parent process. However this can cause issues with programs that rely on this variable to make sure certain features are present. For example not supporting backspaces making the terminal almost unusable.