### PR TITLE
assistant2: Remove single-letter variable name

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -283,12 +283,11 @@ impl ActiveThread {
                     .when_some(context, |parent, context| {
                         if !context.is_empty() {
                             parent.child(
-                                h_flex()
-                                    .flex_wrap()
-                                    .gap_1()
-                                    .px_1p5()
-                                    .pb_1p5()
-                                    .children(context.iter().map(|c| ContextPill::new(c.clone()))),
+                                h_flex().flex_wrap().gap_1().px_1p5().pb_1p5().children(
+                                    context
+                                        .iter()
+                                        .map(|context| ContextPill::new(context.clone())),
+                                ),
                             )
                         } else {
                             parent


### PR DESCRIPTION
This PR removes a single-letter variable name in place of a full one, for readability.

Release Notes:

- N/A
