### PR TITLE
More Emacs keybinding improvements

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -57,7 +57,9 @@
   {
     "context": "Workspace && !Terminal",
     "bindings": {
-      "ctrl-x ctrl-c": "workspace::CloseWindow", // kill-emacs
+      "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
+      "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
+      "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command
       "ctrl-x o": "workspace::ActivateNextPane", // other-window
       "ctrl-x k": "pane::CloseActiveItem", // kill-buffer
       "ctrl-x 0": "pane::CloseActiveItem", // delete-window

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -5,8 +5,7 @@
 [
   {
     "bindings": {
-      "ctrl-g": "menu::Cancel",
-      "ctrl-x ctrl-c": "zed::Quit"
+      "ctrl-g": "menu::Cancel"
     }
   },
   {
@@ -58,9 +57,10 @@
   {
     "context": "Workspace && !Terminal",
     "bindings": {
-      "ctrl-x 5 0": "workspace::CloseWindow", // kill-window
-      "ctrl-x 5 2": "workspace::NewWindow", // new-window
-      "ctrl-x o": "workspace::ActivateNextPane", // other-pane
+      "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
+      "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
+      "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command
+      "ctrl-x o": "workspace::ActivateNextPane", // other-window
       "ctrl-x k": "pane::CloseActiveItem", // kill-buffer
       "ctrl-x 0": "pane::CloseActiveItem", // delete-window
       "ctrl-x 1": "pane::CloseInactiveItems", // delete-other-windows

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -5,7 +5,8 @@
 [
   {
     "bindings": {
-      "ctrl-g": "menu::Cancel"
+      "ctrl-g": "menu::Cancel",
+      "ctrl-x ctrl-c": "zed::Quit"
     }
   },
   {
@@ -57,8 +58,9 @@
   {
     "context": "Workspace && !Terminal",
     "bindings": {
-      "ctrl-x ctrl-c": "workspace::CloseWindow", // kill-emacs
-      "ctrl-x o": "workspace::ActivateNextPane", // other-window
+      "ctrl-x 5 0": "workspace::CloseWindow", // kill-window
+      "ctrl-x 5 2": "workspace::NewWindow", // new-window
+      "ctrl-x o": "workspace::ActivateNextPane", // other-pane
       "ctrl-x k": "pane::CloseActiveItem", // kill-buffer
       "ctrl-x 0": "pane::CloseActiveItem", // delete-window
       "ctrl-x 1": "pane::CloseInactiveItems", // delete-other-windows


### PR DESCRIPTION
These are more closely like default Emacs bindings.

I hope such small and minor changes didn't warrant a discussion in advance.

Release Notes:

- Added Emacs bindings for creating a new window, closing a window, and quitting zed entirely.