### PR TITLE
Add compile_commands.json documentation for C/C++

### DIFF
--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -49,3 +49,17 @@ You can trigger formatting via {#kb editor::Format} or the `editor: format` acti
 ```
 
 See [Clang-Format Style Options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) for a complete list of options.
+
+## Compile Commands
+
+Clangd requires a `compile_commands.json` file to properly analyze your project. This file contains the compilation database that tells clangd how your project should be built.
+
+### Using CMake
+
+If you are using CMake, you can generate `compile_commands.json` automatically by adding the following line to your `CMakeLists.txt`:
+
+```cmake
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+```
+
+After building your project, CMake will generate the `compile_commands.json` file in the build directory.

--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -52,14 +52,14 @@ See [Clang-Format Style Options](https://clang.llvm.org/docs/ClangFormatStyleOpt
 
 ## Compile Commands
 
-Clangd requires a `compile_commands.json` file to properly analyze your project. This file contains the compilation database that tells clangd how your project should be built.
+For some projects Clangd requires a `compile_commands.json` file to properly analyze your project. This file contains the compilation database that tells clangd how your project should be built.
 
-### Using CMake
+### CMake Compile Commands
 
-If you are using CMake, you can generate `compile_commands.json` automatically by adding the following line to your `CMakeLists.txt`:
+With CMake, you can generate `compile_commands.json` automatically by adding the following line to your `CMakeLists.txt`:
 
 ```cmake
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 ```
 
-After building your project, CMake will generate the `compile_commands.json` file in the build directory.
+After building your project, CMake will generate the `compile_commands.json` file in the build directory and clangd will automatically pick it up.

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -98,3 +98,17 @@ Diagnostics:
 ```
 
 For more advanced usage of clangd configuration file, take a look into their [official page](https://clangd.llvm.org/config.html).
+
+## Compile Commands
+
+Clangd requires a `compile_commands.json` file to properly analyze your project. This file contains the compilation database that tells clangd how your project should be built.
+
+### Using CMake
+
+If you are using CMake, you can generate `compile_commands.json` automatically by adding the following line to your `CMakeLists.txt`:
+
+```cmake
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+```
+
+After building your project, CMake will generate the `compile_commands.json` file in the build directory.

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -101,14 +101,14 @@ For more advanced usage of clangd configuration file, take a look into their [of
 
 ## Compile Commands
 
-Clangd requires a `compile_commands.json` file to properly analyze your project. This file contains the compilation database that tells clangd how your project should be built.
+For some projects Clangd requires a `compile_commands.json` file to properly analyze your project. This file contains the compilation database that tells clangd how your project should be built.
 
-### Using CMake
+### CMake Compile Commands
 
-If you are using CMake, you can generate `compile_commands.json` automatically by adding the following line to your `CMakeLists.txt`:
+With CMake, you can generate `compile_commands.json` automatically by adding the following line to your `CMakeLists.txt`:
 
 ```cmake
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 ```
 
-After building your project, CMake will generate the `compile_commands.json` file in the build directory.
+After building your project, CMake will generate the `compile_commands.json` file in the build directory and clangd will automatically pick it up.


### PR DESCRIPTION
Added documentation explaining that clangd requires `compile_commands.json` for proper functionality in both C and C++ projects. Includes instructions for generating the file using CMake.

This is related to https://github.com/zed-industries/zed/discussions/6480

Release Notes:

- N/A