### PR TITLE
Remove ENABLE_MATH option from pulldown_cmark to fix links which contain dollar sign

### DIFF
--- a/crates/markdown/examples/markdown.rs
+++ b/crates/markdown/examples/markdown.rs
@@ -51,6 +51,12 @@ Links are created using the format [http://zed.dev](https://zed.dev).
 
 They can also be detected automatically, for example https://zed.dev/blog.
 
+They may contain dollar signs:
+
+[https://svelte.dev/docs/svelte/$state](https://svelte.dev/docs/svelte/$state)
+
+https://svelte.dev/docs/svelte/$state
+
 ## Images
 Images are like links, but with an exclamation mark `!` in front.
 

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -8,6 +8,7 @@ pub fn parse_markdown(text: &str) -> Vec<(Range<usize>, MarkdownEvent)> {
     let mut options = Options::all();
     options.remove(pulldown_cmark::Options::ENABLE_DEFINITION_LIST);
     options.remove(pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    options.remove(pulldown_cmark::Options::ENABLE_MATH);
 
     let mut events = Vec::new();
     let mut within_link = false;


### PR DESCRIPTION
This pr closes #21466 issue by disabling math in pulldown_cmark Parser.

The dollar sign symbol is used in pulldown_cmark Math extension, see "Math in links" section for more details: https://pulldown-cmark.github.io/pulldown-cmark/specs/math.html

I've tried another approach at first, without disabling math extension: 

```
let iterator = TextMergeWithOffset::new(Parser::new_ext(text, options));
```

instead of current implementation

```
Parser::new_ext(text, options).into_offset_iter()
```

This way pulldown_cmark merges consecutive text events and this helps to correctly parse links from plain text: https://svelte.dev/docs/svelte/$state 

But in this case the dollar sign still breaks markdown links: \[https://svelte.dev/docs/svelte/$state](https://svelte.dev/docs/svelte/$state)

So in the end I disabled the math extension, it fixes both link formats. See markdown/examples/markdown.rs to reproduce.

Release Notes:
- N/A
