### PR TITLE
project_panel: Refine selection, copying, and deletion behavior

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3271,8 +3271,10 @@ impl ProjectPanel {
 
         let bg_hover_color = if self.mouse_down || is_marked {
             item_colors.marked_active
-        } else {
+        } else if !is_active {
             item_colors.hover
+        } else {
+            item_colors.default
         };
 
         let border_color =


### PR DESCRIPTION
Closes #22655

A more detailed write-up for this change can be found in the issue itself. Here, I'm just providing previews after the change. The preview before the change can be found in the attached issue.

1. While selecting multiple entries, the last clicked entry should be selected.

[a.webm](https://github.com/user-attachments/assets/2add69c3-82a9-4e45-92e8-366aaf9b298a)

2. When holding `Ctrl`/`Cmd` on an entry, there should be clear visual feedback to indicate whether the entry is selected or marked.

[b.webm](https://github.com/user-attachments/assets/2cefb8aa-e7d0-4929-9efa-89a4329f428b)


3. When only one entry is marked, but it’s different from the selection, operations should prioritize the selected entry. This let's you do quick one-off actions without disrupting the marked state.

[c.webm](https://github.com/user-attachments/assets/8e7ae0c0-4387-49b9-9761-5d02a1c21a84)


4. When more than one entries are marked, operations should prioritize the marked entries. If the selection differs from the marked entries, it should not interfere with operations on the marked entries. This let's you do actions on multiple marked entries without needing to adjust the selection.

[d.webm](https://github.com/user-attachments/assets/165a74be-cbe9-48ac-b558-2562485ea224)

Release Notes:

- Improved project panel selection, copying, and deletion behavior, to be more predictable.