### PR TITLE
windows: Fix fs watch when file doesn't exist or is a symlink

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -84,6 +84,7 @@ impl Watcher for FsWatcher {
 }
 
 pub struct GlobalWatcher {
+    // two mutexes because calling inotify.add triggers an inotify.event, which needs watchers.
     #[cfg(target_os = "linux")]
     pub(super) inotify: Mutex<notify::INotifyWatcher>,
     #[cfg(target_os = "freebsd")]

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -69,7 +69,7 @@ impl Watcher for FsWatcher {
         })?;
 
         global(|g| {
-            g.inotify
+            g.watcher
                 .lock()
                 .watch(path, notify::RecursiveMode::NonRecursive)
         })??;
@@ -79,18 +79,18 @@ impl Watcher for FsWatcher {
 
     fn remove(&self, path: &std::path::Path) -> gpui::Result<()> {
         use notify::Watcher;
-        Ok(global(|w| w.inotify.lock().unwatch(path))??)
+        Ok(global(|w| w.watcher.lock().unwatch(path))??)
     }
 }
 
 pub struct GlobalWatcher {
-    // two mutexes because calling inotify.add triggers an inotify.event, which needs watchers.
+    // two mutexes because calling watcher.add triggers an watcher.event, which needs watchers.
     #[cfg(target_os = "linux")]
-    pub(super) inotify: Mutex<notify::INotifyWatcher>,
+    pub(super) watcher: Mutex<notify::INotifyWatcher>,
     #[cfg(target_os = "freebsd")]
-    pub(super) inotify: Mutex<notify::KqueueWatcher>,
+    pub(super) watcher: Mutex<notify::KqueueWatcher>,
     #[cfg(target_os = "windows")]
-    pub(super) inotify: Mutex<notify::ReadDirectoryChangesWatcher>,
+    pub(super) watcher: Mutex<notify::ReadDirectoryChangesWatcher>,
     pub(super) watchers: Mutex<Vec<Box<dyn Fn(&notify::Event) + Send + Sync>>>,
 }
 
@@ -100,7 +100,8 @@ impl GlobalWatcher {
     }
 }
 
-static INOTIFY_INSTANCE: OnceLock<anyhow::Result<GlobalWatcher, notify::Error>> = OnceLock::new();
+static FS_WATCHER_INSTANCE: OnceLock<anyhow::Result<GlobalWatcher, notify::Error>> =
+    OnceLock::new();
 
 fn handle_event(event: Result<notify::Event, notify::Error>) {
     let Some(event) = event.log_err() else { return };
@@ -113,9 +114,9 @@ fn handle_event(event: Result<notify::Event, notify::Error>) {
 }
 
 pub fn global<T>(f: impl FnOnce(&GlobalWatcher) -> T) -> anyhow::Result<T> {
-    let result = INOTIFY_INSTANCE.get_or_init(|| {
+    let result = FS_WATCHER_INSTANCE.get_or_init(|| {
         notify::recommended_watcher(handle_event).map(|file_watcher| GlobalWatcher {
-            inotify: Mutex::new(file_watcher),
+            watcher: Mutex::new(file_watcher),
             watchers: Default::default(),
         })
     });

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -68,12 +68,11 @@ impl Watcher for FsWatcher {
             }
         })?;
 
-        #[cfg(target_os = "windows")]
-        let watch_mode = notify::RecursiveMode::Recursive;
-        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        let watch_mode = notify::RecursiveMode::NonRecursive;
-
-        global(|g| g.inotify.lock().watch(path, watch_mode))??;
+        global(|g| {
+            g.inotify
+                .lock()
+                .watch(path, notify::RecursiveMode::NonRecursive)
+        })??;
 
         Ok(())
     }

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -854,8 +854,8 @@ async fn test_write_file(cx: &mut TestAppContext) {
     .await
     .unwrap();
 
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-    fs::linux_watcher::global(|_| {}).unwrap();
+    #[cfg(not(target_os = "macos"))]
+    fs::fs_watcher::global(|_| {}).unwrap();
 
     cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
         .await;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -152,8 +152,8 @@ pub fn initialize_workspace(
         })
         .detach();
 
-        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        initialize_linux_file_watcher(cx);
+        #[cfg(not(target_os = "macos"))]
+        initialize_file_watcher(cx);
 
         if let Some(specs) = cx.gpu_specs() {
             log::info!("Using GPU: {:?}", specs);
@@ -234,8 +234,8 @@ fn feature_gate_zed_pro_actions(cx: &mut AppContext) {
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-fn initialize_linux_file_watcher(cx: &mut ViewContext<Workspace>) {
-    if let Err(e) = fs::linux_watcher::global(|_| {}) {
+fn initialize_file_watcher(cx: &mut ViewContext<Workspace>) {
+    if let Err(e) = fs::fs_watcher::global(|_| {}) {
         let message = format!(
             db::indoc! {r#"
             inotify_init returned {}
@@ -255,6 +255,36 @@ fn initialize_linux_file_watcher(cx: &mut ViewContext<Workspace>) {
                 cx.update(|cx| {
                     cx.open_url("https://zed.dev/docs/linux#could-not-start-inotify");
                     cx.quit();
+                })
+                .ok();
+            }
+        })
+        .detach()
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn initialize_file_watcher(cx: &mut ViewContext<Workspace>) {
+    if let Err(e) = fs::fs_watcher::global(|_| {}) {
+        let message = format!(
+            db::indoc! {r#"
+            ReadDirectoryChangesW initialization failed: {}
+
+            This may occur on network filesystems and WSL paths. For troubleshooting see: https://zed.dev/docs/windows
+            "#},
+            e
+        );
+        let prompt = cx.prompt(
+            PromptLevel::Critical,
+            "Could not start ReadDirectoryChangesW",
+            Some(&message),
+            &["Troubleshoot and Quit"],
+        );
+        cx.spawn(|_, mut cx| async move {
+            if prompt.await == Ok(0) {
+                cx.update(|cx| {
+                    cx.open_url("https://zed.dev/docs/windows");
+                    cx.quit()
                 })
                 .ok();
             }


### PR DESCRIPTION
Closes #22659

More context can be found in attached issue.

This is specific to Windows:

1. Add parent directory watching for fs watch when the file doesn't exist. For example, when Zed is first launched and `settings.json` isn't there.
2. Add proper symlink handling for fs watch. For example, when `settings.json` is a symlink.

This is exactly same as how we handle it on Linux.

Release Notes:

- Fixed an issue where items on the Welcome page could not be toggled on Windows, either on first launch or when `settings.json` is a symlink.