### PR TITLE
Document `git.gutter_debounce` setting

### DIFF
--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -85,6 +85,11 @@ pub struct GitSettings {
     ///
     /// Default: tracked_files
     pub git_gutter: Option<GitGutterSetting>,
+    /// Sets a delay (in milliseconds) after which changes are reflected in the Git gutter.
+    ///
+    /// Delay is restarted with every diff change.
+    ///
+    /// Default: 0
     pub gutter_debounce: Option<u64>,
     /// Whether or not to show git blame data inline in
     /// the currently focused line.

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -85,11 +85,9 @@ pub struct GitSettings {
     ///
     /// Default: tracked_files
     pub git_gutter: Option<GitGutterSetting>,
-    /// Sets a delay (in milliseconds) after which changes are reflected in the Git gutter.
+    /// Sets the debounce threshold (in milliseconds) after which changes are reflected in the git gutter.
     ///
-    /// Delay is restarted with every diff change.
-    ///
-    /// Default: 0
+    /// Default: null
     pub gutter_debounce: Option<u64>,
     /// Whether or not to show git blame data inline in
     /// the currently focused line.


### PR DESCRIPTION
Closes #22588 by providing documentation to git.gutter_debounce setting

Release Notes:

- N/A 
