### PR TITLE
Improve panic report with reentrant SlotMap use

### DIFF
--- a/crates/gpui/src/app/entity_map.rs
+++ b/crates/gpui/src/app/entity_map.rs
@@ -117,8 +117,9 @@ impl EntityMap {
 
     pub fn read<T: 'static>(&self, model: &Model<T>) -> &T {
         self.assert_valid_context(model);
-        self.entities[model.entity_id]
-            .downcast_ref()
+        self.entities
+            .get(model.entity_id)
+            .and_then(|entity| entity.downcast_ref())
             .unwrap_or_else(|| double_lease_panic::<T>("read"))
     }
 


### PR DESCRIPTION
`double_lease_panic` already does what we want, just extend it to the indexing operation as well.

Release Notes:

- N/A