### PR TITLE
Show error alert when there's an error opening file with native OS picker

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5561,15 +5561,22 @@ pub fn open_paths(
         }
 
         if let Some(existing) = existing {
-            Ok((
-                existing,
-                existing
-                    .update(&mut cx, |workspace, cx| {
-                        cx.activate_window();
-                        workspace.open_paths(abs_paths, open_visible, None, cx)
-                    })?
-                    .await,
-            ))
+            let open_task = existing
+                .update(&mut cx, |workspace, cx| {
+                    cx.activate_window();
+                    workspace.open_paths(abs_paths, open_visible, None, cx)
+                })?
+                .await;
+
+            _ = existing.update(&mut cx, |workspace, cx| {
+                for item in open_task.iter().flatten() {
+                    if let Err(e) = item {
+                        workspace.show_error(&e, cx);
+                    }
+                }
+            });
+
+            Ok((existing, open_task))
         } else {
             cx.update(move |cx| {
                 Workspace::new_local(


### PR DESCRIPTION
Closes #20814 by showing error alert if there's some error after OS native File -> Open 


https://github.com/user-attachments/assets/ce092831-4b55-4e20-8ffa-8e60eaf6364d



The implementation here is the same as in handle_external_paths_drop function (when users uses drag and drop to open the file): https://github.com/zed-industries/zed/blob/de08e47e5bc94afdee81fd99f838100fc577a98c/crates/workspace/src/pane.rs#L2810

Release Notes:

- Added an error alert when there's an error opening file with native OS picker.


