### PR TITLE
windows: Don't load login shell environment

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -6,7 +6,7 @@ pub mod serde;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test;
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::Result;
 use futures::Future;
 use itertools::Either;
 use regex::Regex;
@@ -22,6 +22,9 @@ use std::{
     time::Instant,
 };
 use unicase::UniCase;
+
+#[cfg(unix)]
+use anyhow::{anyhow, Context as _};
 
 pub use take_until::*;
 
@@ -195,6 +198,7 @@ pub fn load_shell_from_passwd() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 pub fn load_login_shell_environment() -> Result<()> {
     let marker = "ZED_LOGIN_SHELL_START";
     let shell = env::var("SHELL").context(

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -48,7 +48,7 @@ use std::{
 };
 use theme::{ActiveTheme, SystemAppearance, ThemeRegistry, ThemeSettings};
 use time::UtcOffset;
-use util::{load_login_shell_environment, maybe, ResultExt, TryFutureExt};
+use util::{maybe, ResultExt, TryFutureExt};
 use uuid::Uuid;
 use welcome::{show_welcome_view, BaseKeymap, FIRST_OPEN};
 use workspace::{
@@ -64,7 +64,7 @@ use zed::{
 use crate::zed::inline_completion_registry;
 
 #[cfg(unix)]
-use util::load_shell_from_passwd;
+use util::{load_login_shell_environment, load_shell_from_passwd};
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
@@ -255,13 +255,11 @@ fn main() {
         paths::keymap_file().clone(),
     );
 
+    #[cfg(unix)]
     if !stdout_is_a_pty() {
         app.background_executor()
             .spawn(async {
-                #[cfg(unix)]
-                {
-                    load_shell_from_passwd().log_err();
-                }
+                load_shell_from_passwd().log_err();
                 load_login_shell_environment().log_err();
             })
             .detach()


### PR DESCRIPTION
I'm consistently getting the following error on startup:

```
2025-01-05T14:45:43.4602865+01:00 [ERROR] SHELL environment variable is not assigned so we can't source login environment variables

Caused by:
    environment variable not found
```

The source function, `load_login_shell_environment`, assumes a UNIX environment and should therefore not be called on Windows. (Unless you are using git bash?)

Release Notes:

* N/A