### PR TITLE
Fix panic on diagnostic hover

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -3,7 +3,7 @@ use crate::{
     hover_links::{InlayHighlight, RangeInEditor},
     scroll::ScrollAmount,
     Anchor, AnchorRangeExt, DisplayPoint, DisplayRow, Editor, EditorSettings, EditorSnapshot,
-    Hover, RangeToAnchorExt,
+    Hover,
 };
 use gpui::{
     div, px, AnyElement, AsyncWindowContext, FontWeight, Hsla, InteractiveElement, IntoElement,
@@ -277,12 +277,8 @@ fn show_hover(
             let primary_diagnostic = local_diagnostic.as_ref().and_then(|local_diagnostic| {
                 snapshot
                     .buffer_snapshot
-                    .diagnostic_group::<usize>(local_diagnostic.diagnostic.group_id)
+                    .diagnostic_group(local_diagnostic.diagnostic.group_id)
                     .find(|diagnostic| diagnostic.diagnostic.is_primary)
-                    .map(|entry| DiagnosticEntry {
-                        diagnostic: entry.diagnostic,
-                        range: entry.range.to_anchors(&snapshot.buffer_snapshot),
-                    })
             });
             if let Some(invisible) = snapshot
                 .buffer_snapshot


### PR DESCRIPTION
In #22620 `diagnostic_group` was modified to return results for multibuffers, but was returning singleton buffer points. `hover_popover` uses it to find the jump target for clicking the popup - which doesn't seem to be working right now but that's a separate issue. Now that `diagnostic_group` is returning values in multibuffers converting these to anchors was crashing.

Also resolves a potential bug - if folding in multibuffers was supported then "Go To Diagnostics" would not properly skip diagnostics from folded regions.

Release Notes:

- N/A