### PR TITLE
Fix a doc comment typo on DiagnosticEntry::to_lsp_diagnostic_stub

### DIFF
--- a/crates/language/src/diagnostic_set.rs
+++ b/crates/language/src/diagnostic_set.rs
@@ -52,7 +52,7 @@ pub struct Summary {
 }
 
 impl DiagnosticEntry<PointUtf16> {
-    /// Returns a raw LSP diagnostic ssed to provide diagnostic context to LSP
+    /// Returns a raw LSP diagnostic used to provide diagnostic context to LSP
     /// codeAction request
     pub fn to_lsp_diagnostic_stub(&self) -> lsp::Diagnostic {
         let code = self


### PR DESCRIPTION
Release Notes:

- N/A