### PR TITLE
assistant2: Render placeholder thread title until summary is generated

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -301,13 +301,12 @@ impl AssistantPanel {
         let focus_handle = self.focus_handle(cx);
 
         let title = if self.thread.read(cx).is_empty() {
-            "New Thread".to_string()
+            SharedString::from("New Thread")
         } else {
             self.thread
                 .read(cx)
                 .summary(cx)
-                .map(|summary| summary.to_string())
-                .unwrap_or_else(|| "Loading Summary…".to_string())
+                .unwrap_or_else(|| SharedString::from("Loading Summary…"))
         };
 
         h_flex()
@@ -319,7 +318,7 @@ impl AssistantPanel {
             .bg(cx.theme().colors().tab_bar_background)
             .border_b_1()
             .border_color(cx.theme().colors().border)
-            .child(Label::new(title))
+            .child(h_flex().child(Label::new(title)))
             .child(
                 h_flex()
                     .h_full()

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -300,6 +300,16 @@ impl AssistantPanel {
     fn render_toolbar(&self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let focus_handle = self.focus_handle(cx);
 
+        let title = if self.thread.read(cx).is_empty() {
+            "New Thread".to_string()
+        } else {
+            self.thread
+                .read(cx)
+                .summary(cx)
+                .map(|summary| summary.to_string())
+                .unwrap_or_else(|| "Loading Summary…".to_string())
+        };
+
         h_flex()
             .id("assistant-toolbar")
             .justify_between()
@@ -309,7 +319,7 @@ impl AssistantPanel {
             .bg(cx.theme().colors().tab_bar_background)
             .border_b_1()
             .border_color(cx.theme().colors().border)
-            .child(h_flex().children(self.thread.read(cx).summary(cx).map(Label::new)))
+            .child(Label::new(title))
             .child(
                 h_flex()
                     .h_full()


### PR DESCRIPTION
This PR ensures we render a "New Thread" placeholder title until a message has been sent, and thus, a summary is generated.

https://github.com/user-attachments/assets/1c30e0ff-baaa-44ad-a1a2-42f1ce9fe0b0

Release Notes:

- N/A
