### PR TITLE
Reduce amount of workspace serialization happening

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -1813,7 +1813,7 @@ impl OutlinePanel {
     }
 
     fn reveal_entry_for_selection(&mut self, editor: View<Editor>, cx: &mut ViewContext<Self>) {
-        if self.hidden() || !OutlinePanelSettings::get_global(cx).auto_reveal_entries {
+        if !self.active || !OutlinePanelSettings::get_global(cx).auto_reveal_entries {
             return;
         }
         let project = self.project.clone();
@@ -2439,7 +2439,7 @@ impl OutlinePanel {
         debounce: Option<Duration>,
         cx: &mut ViewContext<Self>,
     ) {
-        if self.hidden() {
+        if !self.active {
             return;
         }
 
@@ -3261,7 +3261,7 @@ impl OutlinePanel {
         debounce: Option<Duration>,
         cx: &mut ViewContext<OutlinePanel>,
     ) {
-        if self.hidden() {
+        if !self.active {
             return;
         }
 
@@ -3807,7 +3807,7 @@ impl OutlinePanel {
     }
 
     fn update_non_fs_items(&mut self, cx: &mut ViewContext<OutlinePanel>) {
-        if self.hidden() {
+        if !self.active {
             return;
         }
 
@@ -3817,7 +3817,7 @@ impl OutlinePanel {
     }
 
     fn update_search_matches(&mut self, cx: &mut ViewContext<OutlinePanel>) {
-        if self.hidden() {
+        if !self.active {
             return;
         }
 
@@ -4544,10 +4544,6 @@ impl OutlinePanel {
             })
             .collect()
     }
-
-    fn hidden(&self) -> bool {
-        !self.active
-    }
 }
 
 fn workspace_active_editor(
@@ -4828,7 +4824,7 @@ fn subscribe_for_editor_events(
 ) -> Subscription {
     let debounce = Some(UPDATE_DEBOUNCE);
     cx.subscribe(editor, move |outline_panel, editor, e: &EditorEvent, cx| {
-        if outline_panel.hidden() {
+        if !outline_panel.active {
             return;
         }
         match e {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4655,9 +4655,6 @@ impl Panel for OutlinePanel {
     }
 
     fn set_active(&mut self, active: bool, cx: &mut ViewContext<Self>) {
-        if active {
-            eprintln!("{}", std::backtrace::Backtrace::force_capture());
-        }
         cx.spawn(|outline_panel, mut cx| async move {
             outline_panel
                 .update(&mut cx, |outline_panel, cx| {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1339,7 +1339,6 @@ impl Panel for TerminalPanel {
     }
 
     fn set_active(&mut self, active: bool, cx: &mut ViewContext<Self>) {
-        dbg!(("???", active));
         if !active || !self.has_no_terminals(cx) {
             return;
         }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1339,6 +1339,7 @@ impl Panel for TerminalPanel {
     }
 
     fn set_active(&mut self, active: bool, cx: &mut ViewContext<Self>) {
+        dbg!(("???", active));
         if !active || !self.has_no_terminals(cx) {
             return;
         }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -337,6 +337,9 @@ impl Dock {
             self.is_open = open;
             if let Some(active_panel) = self.active_panel_entry() {
                 active_panel.panel.set_active(open, cx);
+                if !open {
+                    self.active_panel_index = None;
+                }
             }
 
             cx.notify();
@@ -487,7 +490,7 @@ impl Dock {
 
         self.restore_state(cx);
         if panel.read(cx).starts_open(cx) {
-            self.activate_panel(dbg!(index), cx);
+            self.activate_panel(index, cx);
             self.set_open(true, cx);
         }
 
@@ -549,7 +552,6 @@ impl Dock {
 
             self.active_panel_index = Some(panel_ix);
             if let Some(active_panel) = self.active_panel_entry() {
-                dbg!(panel_ix);
                 active_panel.panel.set_active(true, cx);
             }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -354,6 +354,7 @@ impl Dock {
             }
         }
 
+        // TODO kb notify workspace?
         cx.notify();
     }
 
@@ -484,8 +485,9 @@ impl Dock {
             },
         );
 
-        if !self.restore_state(cx) && panel.read(cx).starts_open(cx) {
-            self.activate_panel(index, cx);
+        self.restore_state(cx);
+        if panel.read(cx).starts_open(cx) {
+            self.activate_panel(dbg!(index), cx);
             self.set_open(true, cx);
         }
 
@@ -547,6 +549,7 @@ impl Dock {
 
             self.active_panel_index = Some(panel_ix);
             if let Some(active_panel) = self.active_panel_entry() {
+                dbg!(panel_ix);
                 active_panel.panel.set_active(true, cx);
             }
 
@@ -603,6 +606,7 @@ impl Dock {
             entry.panel.set_size(size, cx);
             cx.notify();
         }
+        // TODO kb notify workspace
     }
 
     pub fn toggle_action(&self) -> Box<dyn Action> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1020,17 +1020,14 @@ impl Workspace {
 
                 ThemeSettings::reload_current_theme(cx);
             }),
-            cx.observe(&left_dock, |this, _, cx| {
-                this.serialize_workspace(cx);
-                cx.notify();
+            cx.observe(&left_dock, |_, _, _| {
+                dbg!("left dock observed");
             }),
-            cx.observe(&bottom_dock, |this, _, cx| {
-                this.serialize_workspace(cx);
-                cx.notify();
+            cx.observe(&bottom_dock, |_, _, _| {
+                dbg!("bottom dock observed");
             }),
-            cx.observe(&right_dock, |this, _, cx| {
-                this.serialize_workspace(cx);
-                cx.notify();
+            cx.observe(&right_dock, |_, _, _| {
+                dbg!("right dock observed");
             }),
             cx.on_release(|this, window, cx| {
                 this.app_state.workspace_store.update(cx, |store, _| {
@@ -4125,6 +4122,7 @@ impl Workspace {
                     .timer(Duration::from_millis(100))
                     .await;
                 this.update(&mut cx, |this, cx| {
+                    dbg!("serializing worktree");
                     this.serialize_workspace_internal(cx).detach();
                     this._schedule_serialize.take();
                 })
@@ -4934,7 +4932,8 @@ impl Render for Workspace {
                                                         cx,
                                                     );
                                                 }
-                                            }
+                                            };
+                                            workspace.serialize_workspace(cx);
                                         },
                                     ))
                                 })

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1021,15 +1021,6 @@ impl Workspace {
 
                 ThemeSettings::reload_current_theme(cx);
             }),
-            cx.observe(&left_dock, |_, _, _| {
-                dbg!("left dock observed");
-            }),
-            cx.observe(&bottom_dock, |_, _, _| {
-                dbg!("bottom dock observed");
-            }),
-            cx.observe(&right_dock, |_, _, _| {
-                dbg!("right dock observed");
-            }),
             cx.on_release(|this, window, cx| {
                 this.app_state.workspace_store.update(cx, |store, _| {
                     let window = window.downcast::<Self>().unwrap();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4126,7 +4126,6 @@ impl Workspace {
                     .timer(Duration::from_millis(100))
                     .await;
                 this.update(&mut cx, |this, cx| {
-                    dbg!("serializing worktree");
                     this.serialize_workspace_internal(cx).detach();
                     this._schedule_serialize.take();
                 })


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/16472

Reduces amount of workspace serialization happening by:
* fixing the deserialization logic: now it does not set panels that are hidden to active
* cleaning up `active_panel_index` for docks that are closed, to avoid emitting extra events for such closed docks
* adjusting outline panel to drop active editor subscriptions on deactivation — this way, `cx.observe` on the dock with outline panel is not triggered (used to be triggered on every selection change before)
* adjusting workspace dock drag listener to remember previous coordinates and only resize the dock if those had changed
* adjusting workspace pane event listener to ignore `pane::Event::UserSavedItem` and `pane::Event::ChangeItemTitle` that seem to happen relatively frequently but not influence values that are serialized for the workspace
* not using `cx.observe` on docks, instead explicitly serializing on panel zoom and size changes

Release Notes:

- Reduced amount of workspace serialization happening
