### PR TITLE
Add validation in `LspCommand::to_lsp` + check for inverted ranges

### DIFF
--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -1134,7 +1134,7 @@ impl RandomizedTest for ProjectCollaborationTest {
                                     let end = PointUtf16::new(end_row, end_column);
                                     let range = if start > end { end..start } else { start..end };
                                     highlights.push(lsp::DocumentHighlight {
-                                        range: range_to_lsp(range.clone()),
+                                        range: range_to_lsp(range.clone()).unwrap(),
                                         kind: Some(lsp::DocumentHighlightKind::READ),
                                     });
                                 }

--- a/crates/language/src/diagnostic_set.rs
+++ b/crates/language/src/diagnostic_set.rs
@@ -1,4 +1,5 @@
 use crate::{range_to_lsp, Diagnostic};
+use anyhow::Result;
 use collections::HashMap;
 use lsp::LanguageServerId;
 use std::{
@@ -54,16 +55,16 @@ pub struct Summary {
 impl DiagnosticEntry<PointUtf16> {
     /// Returns a raw LSP diagnostic used to provide diagnostic context to LSP
     /// codeAction request
-    pub fn to_lsp_diagnostic_stub(&self) -> lsp::Diagnostic {
+    pub fn to_lsp_diagnostic_stub(&self) -> Result<lsp::Diagnostic> {
         let code = self
             .diagnostic
             .code
             .clone()
             .map(lsp::NumberOrString::String);
 
-        let range = range_to_lsp(self.range.clone());
+        let range = range_to_lsp(self.range.clone())?;
 
-        lsp::Diagnostic {
+        Ok(lsp::Diagnostic {
             code,
             range,
             severity: Some(self.diagnostic.severity),
@@ -71,7 +72,7 @@ impl DiagnosticEntry<PointUtf16> {
             message: self.diagnostic.message.clone(),
             data: self.diagnostic.data.clone(),
             ..Default::default()
-        }
+        })
     }
 }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1849,14 +1849,19 @@ pub fn point_from_lsp(point: lsp::Position) -> Unclipped<PointUtf16> {
     Unclipped(PointUtf16::new(point.line, point.character))
 }
 
-pub fn range_to_lsp(range: Range<PointUtf16>) -> lsp::Range {
-    let mut start = point_to_lsp(range.start);
-    let mut end = point_to_lsp(range.end);
-    if start > end {
-        log::error!("range_to_lsp called with inverted range {start:?}-{end:?}");
-        mem::swap(&mut start, &mut end);
+pub fn range_to_lsp(range: Range<PointUtf16>) -> Result<lsp::Range> {
+    if range.start > range.end {
+        Err(anyhow!(
+            "Inverted range provided to an LSP request: {:?}-{:?}",
+            range.start,
+            range.end
+        ))
+    } else {
+        Ok(lsp::Range {
+            start: point_to_lsp(range.start),
+            end: point_to_lsp(range.end),
+        })
     }
-    lsp::Range { start, end }
 }
 
 pub fn range_from_lsp(range: lsp::Range) -> Range<Unclipped<PointUtf16>> {

--- a/crates/project/src/lsp_ext_command.rs
+++ b/crates/project/src/lsp_ext_command.rs
@@ -1,4 +1,4 @@
-use crate::{lsp_command::LspCommand, lsp_store::LspStore};
+use crate::{lsp_command::LspCommand, lsp_store::LspStore, make_text_document_identifier};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use gpui::{AppContext, AsyncAppContext, Model};
@@ -53,13 +53,11 @@ impl LspCommand for ExpandMacro {
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &AppContext,
-    ) -> ExpandMacroParams {
-        ExpandMacroParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: lsp::Url::from_file_path(path).unwrap(),
-            },
+    ) -> Result<ExpandMacroParams> {
+        Ok(ExpandMacroParams {
+            text_document: make_text_document_identifier(path)?,
             position: point_to_lsp(self.position),
-        }
+        })
     }
 
     async fn response_from_lsp(
@@ -179,13 +177,13 @@ impl LspCommand for OpenDocs {
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &AppContext,
-    ) -> OpenDocsParams {
-        OpenDocsParams {
+    ) -> Result<OpenDocsParams> {
+        Ok(OpenDocsParams {
             text_document: lsp::TextDocumentIdentifier {
                 uri: lsp::Url::from_file_path(path).unwrap(),
             },
             position: point_to_lsp(self.position),
-        }
+        })
     }
 
     async fn response_from_lsp(
@@ -292,10 +290,10 @@ impl LspCommand for SwitchSourceHeader {
         _: &Buffer,
         _: &Arc<LanguageServer>,
         _: &AppContext,
-    ) -> SwitchSourceHeaderParams {
-        SwitchSourceHeaderParams(lsp::TextDocumentIdentifier {
-            uri: lsp::Url::from_file_path(path).unwrap(),
-        })
+    ) -> Result<SwitchSourceHeaderParams> {
+        Ok(SwitchSourceHeaderParams(make_text_document_identifier(
+            path,
+        )?))
     }
 
     async fn response_from_lsp(

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3487,7 +3487,18 @@ impl LspStore {
         };
         let file = File::from_dyn(buffer.file()).and_then(File::as_local);
         if let (Some(file), Some(language_server)) = (file, language_server) {
-            let lsp_params = request.to_lsp(&file.abs_path(cx), buffer, &language_server, cx);
+            let lsp_params = match request.to_lsp(&file.abs_path(cx), buffer, &language_server, cx)
+            {
+                Ok(lsp_params) => lsp_params,
+                Err(err) => {
+                    log::error!(
+                        "Preparing LSP request to {} failed: {}",
+                        language_server.name(),
+                        err
+                    );
+                    return Task::ready(Err(err));
+                }
+            };
             let status = request.status();
             return cx.spawn(move |this, cx| async move {
                 if !request.check_capabilities(language_server.adapter_server_capabilities()) {
@@ -3536,11 +3547,7 @@ impl LspStore {
                 let result = lsp_request.await;
 
                 let response = result.map_err(|err| {
-                    log::warn!(
-                        "Generic lsp request to {} failed: {}",
-                        language_server.name(),
-                        err
-                    );
+                    log::warn!("LSP request to {} failed: {}", language_server.name(), err);
                     err
                 })?;
 


### PR DESCRIPTION
#22690 logged errors and flipped the range in this case.  Instead it brings more visibility to the issue to return errors.

Release Notes:

- N/A