### PR TITLE
linux: Add `keyboard_layout` and `on_keyboard_layout_change` support

### DIFF
--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -47,6 +47,10 @@ impl LinuxClient for HeadlessClient {
         f(&mut self.0.borrow_mut().common)
     }
 
+    fn keyboard_layout(&self) -> String {
+        "unknown".to_string()
+    }
+
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
         vec![]
     }

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -46,6 +46,7 @@ const FILE_PICKER_PORTAL_MISSING: &str =
 pub trait LinuxClient {
     fn compositor_name(&self) -> &'static str;
     fn with_common<R>(&self, f: impl FnOnce(&mut LinuxCommon) -> R) -> R;
+    fn keyboard_layout(&self) -> String;
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>>;
     #[allow(unused)]
     fn display(&self, id: DisplayId) -> Option<Rc<dyn PlatformDisplay>>;
@@ -76,6 +77,7 @@ pub(crate) struct PlatformHandlers {
     pub(crate) app_menu_action: Option<Box<dyn FnMut(&dyn Action)>>,
     pub(crate) will_open_app_menu: Option<Box<dyn FnMut()>>,
     pub(crate) validate_app_menu_command: Option<Box<dyn FnMut(&dyn Action) -> bool>>,
+    pub(crate) keyboard_layout_change: Option<Box<dyn FnMut()>>,
 }
 
 pub(crate) struct LinuxCommon {
@@ -133,11 +135,11 @@ impl<P: LinuxClient + 'static> Platform for P {
     }
 
     fn keyboard_layout(&self) -> String {
-        "unknown".into()
+        self.keyboard_layout()
     }
 
-    fn on_keyboard_layout_change(&self, _callback: Box<dyn FnMut()>) {
-        // todo(linux)
+    fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
+        self.with_common(|common| common.callbacks.keyboard_layout_change = Some(callback));
     }
 
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -589,7 +589,16 @@ impl WaylandClient {
 
 impl LinuxClient for WaylandClient {
     fn keyboard_layout(&self) -> String {
-        "unknown".to_string()
+        let state = self.0.borrow();
+        if let Some(keymap_state) = &state.keymap_state {
+            let layout_idx = keymap_state.serialize_layout(xkbcommon::xkb::STATE_LAYOUT_EFFECTIVE);
+            keymap_state
+                .get_keymap()
+                .layout_get_name(layout_idx)
+                .to_string()
+        } else {
+            "unknown".to_string()
+        }
     }
 
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
@@ -1143,6 +1152,13 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 };
                 state.keymap_state = Some(xkb::State::new(&keymap));
                 state.compose_state = get_xkb_compose_state(&xkb_context);
+
+                if let Some(mut callback) = state.common.callbacks.keyboard_layout_change.take() {
+                    drop(state);
+                    callback();
+                    state = client.borrow_mut();
+                    state.common.callbacks.keyboard_layout_change = Some(callback);
+                }
             }
             wl_keyboard::Event::Enter { surface, .. } => {
                 state.keyboard_focused_window = get_window(&mut state, &surface.id());
@@ -1180,8 +1196,20 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 let focused_window = state.keyboard_focused_window.clone();
 
                 let keymap_state = state.keymap_state.as_mut().unwrap();
+                let old_layout =
+                    keymap_state.serialize_layout(xkbcommon::xkb::STATE_LAYOUT_EFFECTIVE);
                 keymap_state.update_mask(mods_depressed, mods_latched, mods_locked, 0, 0, group);
                 state.modifiers = Modifiers::from_xkb(keymap_state);
+
+                if group != old_layout {
+                    if let Some(mut callback) = state.common.callbacks.keyboard_layout_change.take()
+                    {
+                        drop(state);
+                        callback();
+                        state = client.borrow_mut();
+                        state.common.callbacks.keyboard_layout_change = Some(callback);
+                    }
+                }
 
                 let Some(focused_window) = focused_window else {
                     return;

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -588,6 +588,10 @@ impl WaylandClient {
 }
 
 impl LinuxClient for WaylandClient {
+    fn keyboard_layout(&self) -> String {
+        "unknown".to_string()
+    }
+
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
         self.0
             .borrow()


### PR DESCRIPTION
No issue, as the functionality is currently not being used in Zed. This is more of a GPUI improvement.

Currently, `keyboard_layout` and `on_keyboard_layout_change` are already handled on macOS. This PR implements the same for X11 and Wayland.

Linux supports up to 4 keyboard layout groups (e.g., Group 0: English US, Group 1: Bulgarian, etc). On X11 and Wayland, `event` provides a new active group, which maps to the `layout_index`. We already store keymap state from where we can get the current `layout_index`. By comparing them, we determine if the layout has changed.

X11:
<img src="https://github.com/user-attachments/assets/b528db77-1ff2-4f17-aac5-7654837edeb9" alt="x11" width="300px" />

Wayland:
<img src="https://github.com/user-attachments/assets/2b4e2a30-b0f4-495c-96bb-7bca41365d56" alt="wayland" width="300px" />

Release Notes:

- N/A
