### PR TITLE
assistant2: Clear all collections when clearing the `ThreadStore`

### DIFF
--- a/crates/assistant2/src/context_store.rs
+++ b/crates/assistant2/src/context_store.rs
@@ -37,11 +37,9 @@ impl ContextStore {
     }
 
     pub fn drain(&mut self) -> Vec<Context> {
-        self.files.clear();
-        self.directories.clear();
-        self.threads.clear();
-        self.fetched_urls.clear();
-        self.context.drain(..).collect()
+        let context = self.context.drain(..).collect();
+        self.clear();
+        context
     }
 
     pub fn clear(&mut self) {

--- a/crates/assistant2/src/context_store.rs
+++ b/crates/assistant2/src/context_store.rs
@@ -39,6 +39,8 @@ impl ContextStore {
     pub fn drain(&mut self) -> Vec<Context> {
         self.files.clear();
         self.directories.clear();
+        self.threads.clear();
+        self.fetched_urls.clear();
         self.context.drain(..).collect()
     }
 
@@ -46,6 +48,8 @@ impl ContextStore {
         self.context.clear();
         self.files.clear();
         self.directories.clear();
+        self.threads.clear();
+        self.fetched_urls.clear();
     }
 
     pub fn insert_file(&mut self, buffer: &Buffer) {


### PR DESCRIPTION
This PR adds some missing calls to clear the sub-collections in the `ThreadStore` when we call `ThreadStore::drain` or `ThreadStore::clear`.

Release Notes:

- N/A
