### PR TITLE
Refactor multibuffer methods for multibuffer range -> buffer range

### DIFF
--- a/crates/assistant2/src/buffer_codegen.rs
+++ b/crates/assistant2/src/buffer_codegen.rs
@@ -257,9 +257,10 @@ impl CodegenAlternative {
     ) -> Self {
         let snapshot = buffer.read(cx).snapshot(cx);
 
+        // TODO: Could be more efficient by using a reverse iterator.
         let (old_excerpt, _) = snapshot
             .range_to_buffer_ranges(range.clone())
-            .pop()
+            .last()
             .unwrap();
         let old_buffer = cx.new_model(|cx| {
             let text = old_excerpt.buffer().as_rope().clone();
@@ -475,9 +476,9 @@ impl CodegenAlternative {
         let language_name = {
             let multibuffer = self.buffer.read(cx);
             let snapshot = multibuffer.snapshot(cx);
-            let ranges = snapshot.range_to_buffer_ranges(self.range.clone());
+            let mut ranges = snapshot.range_to_buffer_ranges(self.range.clone());
             ranges
-                .first()
+                .next()
                 .and_then(|(excerpt, _)| excerpt.buffer().language())
                 .map(|language| language.name())
         };

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -458,10 +458,7 @@ impl Editor {
     ) -> Option<()> {
         let multi_buffer = self.buffer.read(cx);
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
-        let (excerpt, range) = multi_buffer_snapshot
-            .range_to_buffer_ranges(range)
-            .into_iter()
-            .next()?;
+        let (excerpt, range) = multi_buffer_snapshot.range_to_buffer_ranges(range).next()?;
 
         multi_buffer
             .buffer(excerpt.buffer_id())

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1468,10 +1468,11 @@ impl SearchableItem for Editor {
                     search_within_ranges
                 };
 
-                for (excerpt_id, search_buffer, search_range) in
-                    buffer.excerpts_in_ranges(search_within_ranges)
+                for (excerpt, search_range) in
+                    buffer.disjoint_ranges_to_buffer_ranges(search_within_ranges)
                 {
                     if !search_range.is_empty() {
+                        let search_buffer = excerpt.buffer();
                         ranges.extend(
                             query
                                 .search(search_buffer, Some(search_range.clone()))
@@ -1482,8 +1483,8 @@ impl SearchableItem for Editor {
                                         .anchor_after(search_range.start + match_range.start);
                                     let end = search_buffer
                                         .anchor_before(search_range.start + match_range.end);
-                                    buffer.anchor_in_excerpt(excerpt_id, start).unwrap()
-                                        ..buffer.anchor_in_excerpt(excerpt_id, end).unwrap()
+                                    buffer.anchor_in_excerpt(excerpt.id(), start).unwrap()
+                                        ..buffer.anchor_in_excerpt(excerpt.id(), end).unwrap()
                                 }),
                         );
                     }

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -132,12 +132,14 @@ impl SyntaxTreeView {
             .editor
             .update(cx, |editor, cx| editor.snapshot(cx));
         let (excerpt, buffer, range) = editor_state.editor.update(cx, |editor, cx| {
+            let selection = editor.selections.last::<usize>(cx);
             let selection_range = editor.selections.last::<usize>(cx).range();
+            let selection_head = selection.head();
             let multi_buffer = editor.buffer().read(cx);
-            let (excerpt, range) = snapshot
+            let excerpt = snapshot
                 .buffer_snapshot
-                .range_to_buffer_ranges(selection_range)
-                .pop()?;
+                .excerpt_containing(selection_head..selection_head)?;
+            let range = excerpt.map_range_to_buffer(selection_range);
             let buffer = multi_buffer.buffer(excerpt.buffer_id()).unwrap().clone();
             Some((excerpt, buffer, range))
         })?;

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -1235,7 +1235,9 @@ fn test_random_multibuffer(cx: &mut AppContext, mut rng: StdRng) {
             );
 
             let snapshot = multibuffer.read(cx).snapshot(cx);
-            let excerpted_buffer_ranges = snapshot.range_to_buffer_ranges(start_ix..end_ix);
+            let excerpted_buffer_ranges = snapshot
+                .range_to_buffer_ranges(start_ix..end_ix)
+                .collect::<Vec<_>>();
             let excerpted_buffers_text = excerpted_buffer_ranges
                 .iter()
                 .map(|(excerpt, buffer_range)| {
@@ -1488,7 +1490,7 @@ fn test_excerpts_in_ranges_no_ranges(cx: &mut AppContext) {
 
     let snapshot = multibuffer.update(cx, |multibuffer, cx| multibuffer.snapshot(cx));
 
-    let mut excerpts = snapshot.excerpts_in_ranges(iter::from_fn(|| None));
+    let mut excerpts = snapshot.disjoint_ranges_to_buffer_ranges::<usize>(iter::from_fn(|| None));
 
     assert!(excerpts.next().is_none());
 }
@@ -1587,12 +1589,12 @@ fn test_excerpts_in_ranges_range_inside_the_excerpt(cx: &mut AppContext) {
     )];
 
     let excerpts = snapshot
-        .excerpts_in_ranges(vec![range.clone()].into_iter())
-        .map(|(excerpt_id, buffer, actual_range)| {
+        .disjoint_ranges_to_buffer_ranges(vec![range.clone()].into_iter())
+        .map(|(excerpt, actual_range)| {
             (
-                excerpt_id,
-                buffer.remote_id(),
-                map_range_from_excerpt(&snapshot, excerpt_id, buffer, actual_range),
+                excerpt.id(),
+                excerpt.buffer().remote_id(),
+                map_range_from_excerpt(&snapshot, excerpt.id(), excerpt.buffer(), actual_range),
             )
         })
         .collect_vec();
@@ -1652,12 +1654,12 @@ fn test_excerpts_in_ranges_range_crosses_excerpts_boundary(cx: &mut AppContext) 
     ];
 
     let excerpts = snapshot
-        .excerpts_in_ranges(vec![expected_range.clone()].into_iter())
-        .map(|(excerpt_id, buffer, actual_range)| {
+        .disjoint_ranges_to_buffer_ranges(vec![expected_range.clone()].into_iter())
+        .map(|(excerpt, actual_range)| {
             (
-                excerpt_id,
-                buffer.remote_id(),
-                map_range_from_excerpt(&snapshot, excerpt_id, buffer, actual_range),
+                excerpt.id(),
+                excerpt.buffer().remote_id(),
+                map_range_from_excerpt(&snapshot, excerpt.id(), excerpt.buffer(), actual_range),
             )
         })
         .collect_vec();
@@ -1728,12 +1730,12 @@ fn test_excerpts_in_ranges_range_encloses_excerpt(cx: &mut AppContext) {
     ];
 
     let excerpts = snapshot
-        .excerpts_in_ranges(vec![expected_range.clone()].into_iter())
-        .map(|(excerpt_id, buffer, actual_range)| {
+        .disjoint_ranges_to_buffer_ranges(vec![expected_range.clone()].into_iter())
+        .map(|(excerpt, actual_range)| {
             (
-                excerpt_id,
-                buffer.remote_id(),
-                map_range_from_excerpt(&snapshot, excerpt_id, buffer, actual_range),
+                excerpt.id(),
+                excerpt.buffer().remote_id(),
+                map_range_from_excerpt(&snapshot, excerpt.id(), excerpt.buffer(), actual_range),
             )
         })
         .collect_vec();
@@ -1794,12 +1796,12 @@ fn test_excerpts_in_ranges_multiple_ranges(cx: &mut AppContext) {
     });
 
     let excerpts = snapshot
-        .excerpts_in_ranges(ranges)
-        .map(|(excerpt_id, buffer, actual_range)| {
+        .disjoint_ranges_to_buffer_ranges(ranges)
+        .map(|(excerpt, actual_range)| {
             (
-                excerpt_id,
-                buffer.remote_id(),
-                map_range_from_excerpt(&snapshot, excerpt_id, buffer, actual_range),
+                excerpt.id(),
+                excerpt.buffer().remote_id(),
+                map_range_from_excerpt(&snapshot, excerpt.id(), excerpt.buffer(), actual_range),
             )
         })
         .collect_vec();
@@ -1860,12 +1862,12 @@ fn test_excerpts_in_ranges_range_ends_at_excerpt_end(cx: &mut AppContext) {
     ];
 
     let excerpts = snapshot
-        .excerpts_in_ranges(ranges.into_iter())
-        .map(|(excerpt_id, buffer, actual_range)| {
+        .disjoint_ranges_to_buffer_ranges(ranges.into_iter())
+        .map(|(excerpt, actual_range)| {
             (
-                excerpt_id,
-                buffer.remote_id(),
-                map_range_from_excerpt(&snapshot, excerpt_id, buffer, actual_range),
+                excerpt.id(),
+                excerpt.buffer().remote_id(),
+                map_range_from_excerpt(&snapshot, excerpt.id(), excerpt.buffer(), actual_range),
             )
         })
         .collect_vec();


### PR DESCRIPTION
* Renames `excerpts_for_ranges` to `disjoint_ranges_to_buffer_ranges`, and modifies it to return `MultiBufferExcerpt` since it provides more information and was already being built.

* `range_to_buffer_ranges` now returns an iterator, should improve efficiency in a few places.  Now implemented by just calling `disjoint_ranges_to_buffer_ranges`.

Release Notes:

- N/A