### PR TITLE
lsp: Use `Path` instead of `String` for path handling

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -8330,9 +8330,7 @@ impl DiagnosticSummary {
 fn glob_literal_prefix(glob: &Path) -> PathBuf {
     glob.components()
         .take_while(|component| match component {
-            path::Component::Normal(part) => {
-                !part.to_string_lossy().contains(['*', '?', '{', '}'])
-            }
+            path::Component::Normal(part) => !part.to_string_lossy().contains(['*', '?', '{', '}']),
             _ => true,
         })
         .collect()

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2556,11 +2556,6 @@ impl LocalLspStore {
                                     let pattern = relative.to_string_lossy().to_string();
                                     let literal_prefix = glob_literal_prefix(relative).into();
 
-                                    // let literal_prefix = Arc::from(PathBuf::from(
-                                    //     literal_prefix
-                                    //         .strip_prefix(std::path::MAIN_SEPARATOR)
-                                    //         .unwrap_or(literal_prefix),
-                                    // ));
                                     PathToWatch::Worktree {
                                         literal_prefix,
                                         pattern,
@@ -2568,11 +2563,6 @@ impl LocalLspStore {
                                 }
                                 Err(_) => {
                                     let path = glob_literal_prefix(watcher_path.as_path());
-                                    // let glob = &s[path.len()..];
-                                    // let pattern = glob
-                                    //     .strip_prefix(std::path::MAIN_SEPARATOR)
-                                    //     .unwrap_or(glob)
-                                    //     .to_owned();
                                     let pattern = watcher_path
                                         .as_path()
                                         .strip_prefix(&path)
@@ -2611,11 +2601,6 @@ impl LocalLspStore {
                                 }
                                 Err(_) => {
                                     let path = glob_literal_prefix(Path::new(&rp.pattern));
-                                    // let glob = &rp.pattern[path.len()..];
-                                    // let pattern = glob
-                                    //     .strip_prefix(std::path::MAIN_SEPARATOR)
-                                    //     .unwrap_or(glob)
-                                    //     .to_owned();
                                     let pattern = Path::new(&rp.pattern)
                                         .strip_prefix(&path)
                                         .unwrap_or(path.as_path())

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2566,12 +2566,13 @@ impl LocalLspStore {
                                     let pattern = watcher_path
                                         .as_path()
                                         .strip_prefix(&path)
-                                        .context("Failed to strip prefix for string pattern")
-                                        .log_err()
                                         .map(|p| p.to_string_lossy().to_string())
-                                        .unwrap_or_else(|| {
+                                        .unwrap_or_else(|e| {
                                             debug_panic!(
-                                                "Failed to strip prefix for string pattern"
+                                                "Failed to strip prefix for string pattern: {}, with prefix: {}, with error: {}",
+                                                s,
+                                                path.display(),
+                                                e
                                             );
                                             watcher_path.as_path().to_string_lossy().to_string()
                                         });
@@ -2609,20 +2610,20 @@ impl LocalLspStore {
                                     let path = glob_literal_prefix(Path::new(&rp.pattern));
                                     let pattern = Path::new(&rp.pattern)
                                         .strip_prefix(&path)
-                                        .context("Failed to strip prefix for relative pattern")
-                                        .log_err()
                                         .map(|p| p.to_string_lossy().to_string())
-                                        .unwrap_or_else(|| {
+                                        .unwrap_or_else(|e| {
                                             debug_panic!(
-                                                "Failed to strip prefix for relative pattern"
+                                                "Failed to strip prefix for relative pattern: {}, with prefix: {}, with error: {}",
+                                                rp.pattern,
+                                                path.display(),
+                                                e
                                             );
                                             rp.pattern.clone()
                                         });
                                     base_uri.push(path);
 
                                     let path = if base_uri.components().next().is_none() {
-                                        debug_panic!("base_uri is empty!");
-                                        log::error!("base_uri is empty!");
+                                        debug_panic!("base_uri is empty, {}", base_uri.display());
                                         worktree_root_path.clone()
                                     } else {
                                         base_uri.into()

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -8331,7 +8331,7 @@ fn glob_literal_prefix(glob: &Path) -> PathBuf {
     glob.components()
         .take_while(|component| match component {
             path::Component::Normal(part) => {
-                !part.to_str().unwrap_or("").contains(['*', '?', '{', '}'])
+                !part.to_string_lossy().contains(['*', '?', '{', '}'])
             }
             _ => true,
         })

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -8316,24 +8316,14 @@ impl DiagnosticSummary {
 }
 
 fn glob_literal_prefix(glob: &Path) -> PathBuf {
-    let mut idx_end = None;
-    for (idx, component) in glob.components().enumerate() {
-        match component {
+    glob.components()
+        .take_while(|component| match component {
             path::Component::Normal(part) => {
-                let part_str = part.to_str().unwrap_or("");
-                if part_str.contains(['*', '?', '{', '}']) {
-                    idx_end = Some(idx);
-                    break;
-                }
+                !part.to_str().unwrap_or("").contains(['*', '?', '{', '}'])
             }
-            _ => {}
-        }
-    }
-    if let Some(idx_end) = idx_end {
-        glob.components().take(idx_end).collect::<PathBuf>()
-    } else {
-        glob.to_path_buf()
-    }
+            _ => true,
+        })
+        .collect()
 }
 
 pub struct SshLspAdapter {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -781,11 +781,19 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
 
 #[gpui::test]
 async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppContext) {
+    fn to_path_string(path: &str) -> String {
+        if cfg!(windows) {
+            path.replace("/the-root", "C:/the-root")
+        } else {
+            path.to_string()
+        }
+    }
+
     init_test(cx);
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree(
-        "/the-root",
+        to_path_string("/the-root"),
         json!({
             ".gitignore": "target\n",
             "src": {
@@ -813,7 +821,7 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
     )
     .await;
 
-    let project = Project::test(fs.clone(), ["/the-root".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [to_path_string("/the-root").as_ref()], cx).await;
     let language_registry = project.read_with(cx, |project, _| project.languages().clone());
     language_registry.add(rust_lang());
     let mut fake_servers = language_registry.register_fake_lsp(
@@ -829,7 +837,7 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
     // Start the language server by opening a buffer with a compatible file extension.
     let _ = project
         .update(cx, |project, cx| {
-            project.open_local_buffer_with_lsp("/the-root/src/a.rs", cx)
+            project.open_local_buffer_with_lsp(to_path_string("/the-root/src/a.rs"), cx)
         })
         .await
         .unwrap();
@@ -869,21 +877,21 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
                     lsp::DidChangeWatchedFilesRegistrationOptions {
                         watchers: vec![
                             lsp::FileSystemWatcher {
-                                glob_pattern: lsp::GlobPattern::String(
-                                    "/the-root/Cargo.toml".to_string(),
-                                ),
+                                glob_pattern: lsp::GlobPattern::String(to_path_string(
+                                    "/the-root/Cargo.toml",
+                                )),
                                 kind: None,
                             },
                             lsp::FileSystemWatcher {
-                                glob_pattern: lsp::GlobPattern::String(
-                                    "/the-root/src/*.{rs,c}".to_string(),
-                                ),
+                                glob_pattern: lsp::GlobPattern::String(to_path_string(
+                                    "/the-root/src/*.{rs,c}",
+                                )),
                                 kind: None,
                             },
                             lsp::FileSystemWatcher {
-                                glob_pattern: lsp::GlobPattern::String(
-                                    "/the-root/target/y/**/*.rs".to_string(),
-                                ),
+                                glob_pattern: lsp::GlobPattern::String(to_path_string(
+                                    "/the-root/target/y/**/*.rs",
+                                )),
                                 kind: None,
                             },
                         ],
@@ -936,21 +944,36 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
 
     // Perform some file system mutations, two of which match the watched patterns,
     // and one of which does not.
-    fs.create_file("/the-root/src/c.rs".as_ref(), Default::default())
-        .await
-        .unwrap();
-    fs.create_file("/the-root/src/d.txt".as_ref(), Default::default())
-        .await
-        .unwrap();
-    fs.remove_file("/the-root/src/b.rs".as_ref(), Default::default())
-        .await
-        .unwrap();
-    fs.create_file("/the-root/target/x/out/x2.rs".as_ref(), Default::default())
-        .await
-        .unwrap();
-    fs.create_file("/the-root/target/y/out/y2.rs".as_ref(), Default::default())
-        .await
-        .unwrap();
+    fs.create_file(
+        to_path_string("/the-root/src/c.rs").as_ref(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    fs.create_file(
+        to_path_string("/the-root/src/d.txt").as_ref(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    fs.remove_file(
+        to_path_string("/the-root/src/b.rs").as_ref(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    fs.create_file(
+        to_path_string("/the-root/target/x/out/x2.rs").as_ref(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    fs.create_file(
+        to_path_string("/the-root/target/y/out/y2.rs").as_ref(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
 
     // The language server receives events for the FS mutations that match its watch patterns.
     cx.executor().run_until_parked();
@@ -958,15 +981,16 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
         &*file_changes.lock(),
         &[
             lsp::FileEvent {
-                uri: lsp::Url::from_file_path("/the-root/src/b.rs").unwrap(),
+                uri: lsp::Url::from_file_path(to_path_string("/the-root/src/b.rs")).unwrap(),
                 typ: lsp::FileChangeType::DELETED,
             },
             lsp::FileEvent {
-                uri: lsp::Url::from_file_path("/the-root/src/c.rs").unwrap(),
+                uri: lsp::Url::from_file_path(to_path_string("/the-root/src/c.rs")).unwrap(),
                 typ: lsp::FileChangeType::CREATED,
             },
             lsp::FileEvent {
-                uri: lsp::Url::from_file_path("/the-root/target/y/out/y2.rs").unwrap(),
+                uri: lsp::Url::from_file_path(to_path_string("/the-root/target/y/out/y2.rs"))
+                    .unwrap(),
                 typ: lsp::FileChangeType::CREATED,
             },
         ]


### PR DESCRIPTION
During my work on PR #22616, while trying to fix the `test_reporting_fs_changes_to_language_servers` test case, I noticed that we are currently handling paths using `String` in some places. However, this approach causes issues on Windows.

This draft PR modifies `rebuild_watched_paths_inner` and `glob_literal_prefix`. For example, take the `glob_literal_prefix` function modified in this PR:

```rust
assert_eq!(
    glob_literal_prefix("node_modules/**/*.js"), 
    "node_modules"
);    // This works on Unix, fails on Windows

assert_eq!(
    glob_literal_prefix("node_modules\\**\\*.js"), 
    "node_modules"
);    // This works on Windows

assert_eq!(
    glob_literal_prefix("node_modules\\**/*.js"), 
    "node_modules"
);    // This fails on Windows
```

The current implementation treats path as `String` and relies on `\` as the path separator on Windows, but on Windows, both `/` and `\` can be used as separators. This means that `node_modules\**/*.js` is also a valid path representation.

There are two potential solutions to this issue:

1. **Continue handling paths with `String`**, and on Windows, replace all `/` with `\`.
2. **Use `Path` for path handling**, which is the solution implemented in this PR.

### Advantages of Solution 1:
- Simple and direct.

### Advantages of Solution 2:
- More robust, especially in handling `strip_prefix`.

Currently, the logic for removing a path prefix looks like this:

```rust
let path = "/some/path/to/file.rs";
let parent = "/some/path/to";
// remove prefix
let file = path.strip_prefix(parent).unwrap();    // which is `/file.rs`
let file = file.strip_prefix("/").unwrap();
```

However, using `Path` simplifies this process and makes it more robust:

```rust
let path = Path::new("C:/path/to/src/main.rs");
let parent = Path::new("C:/path/to/src"); 
let file = path.strip_prefix(&parent).unwrap(); // which is `main.rs`

let path = Path::new("C:\\path\\to/src/main.rs");
let parent = Path::new("C:/path/to\\src\\"); 
let file = path.strip_prefix(&parent).unwrap(); // which is `main.rs`
```

Release Notes:

- N/A