### PR TITLE
assistant2: Fix toolbar layout shift

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -311,10 +311,11 @@ impl AssistantPanel {
 
         h_flex()
             .id("assistant-toolbar")
+            .px(DynamicSpacing::Base08.rems(cx))
+            .h(Tab::container_height(cx))
+            .flex_none()
             .justify_between()
             .gap(DynamicSpacing::Base08.rems(cx))
-            .h(Tab::container_height(cx))
-            .px(DynamicSpacing::Base08.rems(cx))
             .bg(cx.theme().colors().tab_bar_background)
             .border_b_1()
             .border_color(cx.theme().colors().border)
@@ -322,7 +323,7 @@ impl AssistantPanel {
             .child(
                 h_flex()
                     .h_full()
-                    .pl_1()
+                    .pl_1p5()
                     .border_l_1()
                     .border_color(cx.theme().colors().border)
                     .gap(DynamicSpacing::Base02.rems(cx))


### PR DESCRIPTION
Note how, previously, switching between the thread view and the history caused a slightly reduction of the toolbar height. Super subtle stuff, but doesn't happen anymore.

### Before

https://github.com/user-attachments/assets/712ff34e-a638-484d-8415-16011b10ae63

### After

https://github.com/user-attachments/assets/7ccff7a3-45a4-445c-9638-8445733e0ffc

Release Notes:

- N/A
