### PR TITLE
assistant2: Add check icon for included context

### DIFF
--- a/crates/assistant2/src/context_picker/directory_context_picker.rs
+++ b/crates/assistant2/src/context_picker/directory_context_picker.rs
@@ -304,7 +304,16 @@ impl PickerDelegate for DirectoryContextPickerDelegate {
                 .toggle_state(selected)
                 .child(h_flex().gap_2().child(Label::new(directory_name)))
                 .when(added, |el| {
-                    el.end_slot(Label::new("Added").size(LabelSize::XSmall))
+                    el.end_slot(
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Check)
+                                    .size(IconSize::Small)
+                                    .color(Color::Success),
+                            )
+                            .child(Label::new("Added").size(LabelSize::Small)),
+                    )
                 }),
         )
     }

--- a/crates/assistant2/src/context_picker/fetch_context_picker.rs
+++ b/crates/assistant2/src/context_picker/fetch_context_picker.rs
@@ -243,9 +243,16 @@ impl PickerDelegate for FetchContextPickerDelegate {
                 .toggle_state(selected)
                 .child(Label::new(self.url.clone()))
                 .when(added, |child| {
-                    child
-                        .disabled(true)
-                        .end_slot(Label::new("Added").size(LabelSize::XSmall))
+                    child.disabled(true).end_slot(
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Check)
+                                    .size(IconSize::Small)
+                                    .color(Color::Success),
+                            )
+                            .child(Label::new("Added").size(LabelSize::Small)),
+                    )
                 }),
         )
     }

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -322,14 +322,30 @@ impl PickerDelegate for FileContextPickerDelegate {
                         })),
                 )
                 .when_some(added, |el, added| match added {
-                    IncludedFile::Direct(_) => {
-                        el.end_slot(Label::new("Added").size(LabelSize::XSmall))
-                    }
+                    IncludedFile::Direct(_) => el.end_slot(
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Check)
+                                    .size(IconSize::Small)
+                                    .color(Color::Success),
+                            )
+                            .child(Label::new("Added").size(LabelSize::Small)),
+                    ),
                     IncludedFile::InDirectory(dir_name) => {
                         let dir_name = dir_name.to_string_lossy().into_owned();
 
-                        el.end_slot(Label::new("Included").size(LabelSize::XSmall))
-                            .tooltip(move |cx| Tooltip::text(format!("in {dir_name}"), cx))
+                        el.end_slot(
+                            h_flex()
+                                .gap_1()
+                                .child(
+                                    Icon::new(IconName::Check)
+                                        .size(IconSize::Small)
+                                        .color(Color::Success),
+                                )
+                                .child(Label::new("Included").size(LabelSize::Small)),
+                        )
+                        .tooltip(move |cx| Tooltip::text(format!("in {dir_name}"), cx))
                     }
                 }),
         )

--- a/crates/assistant2/src/context_picker/thread_context_picker.rs
+++ b/crates/assistant2/src/context_picker/thread_context_picker.rs
@@ -209,7 +209,16 @@ impl PickerDelegate for ThreadContextPickerDelegate {
                 .toggle_state(selected)
                 .child(Label::new(thread.summary.clone()))
                 .when(added, |el| {
-                    el.end_slot(Label::new("Added").size(LabelSize::XSmall))
+                    el.end_slot(
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Check)
+                                    .size(IconSize::Small)
+                                    .color(Color::Success),
+                            )
+                            .child(Label::new("Added").size(LabelSize::Small)),
+                    )
                 }),
         )
     }


### PR DESCRIPTION
Quick follow-up to: https://github.com/zed-industries/zed/pull/22712 — just to make it more visually easier to understand.

<img width="800" alt="Screenshot 2025-01-07 at 11 48 06 AM" src="https://github.com/user-attachments/assets/92f0523b-eb85-4929-a825-2e1e524b3ad7" />

Release Notes:

- N/A
