### PR TITLE
Detect .NET solution file `*.sln` and project files `*.*proj` as XML

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -932,7 +932,8 @@
   "file_types": {
     "Plain Text": ["txt"],
     "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json", "**/.vscode/**/*.json"],
-    "Shell Script": [".env.*"]
+    "Shell Script": [".env.*"],
+    "XML": ["*.sln", "*.*proj"]
   },
   /// By default use a recent system version of node, or install our own.
   /// You can override this to use a version of node that is not in $PATH with:


### PR DESCRIPTION
Part of [#22080](https://github.com/zed-industries/extensions/issues/1968)
Detect .NET solution file `*.sln` and project files `*.*proj` as XML.

Release Notes:

- Improved detection of `*.sln` and `*.*proj` files as XML by default.
