### PR TITLE
terminal: Set TERM to xterm-256color

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -347,7 +347,7 @@ impl TerminalBuilder {
 
         env.insert("ZED_TERM".to_string(), "true".to_string());
         env.insert("TERM_PROGRAM".to_string(), "zed".to_string());
-        env.insert("TERM".to_string(), "alacritty".to_string());
+        env.insert("TERM".to_string(), "xterm-256color".to_string());
         env.insert(
             "TERM_PROGRAM_VERSION".to_string(),
             release_channel::AppVersion::global(cx).to_string(),


### PR DESCRIPTION
This is a follow-up to #22615 and fixes the issue of `alacritty` resulting in broken shell/CLI apps if `alacritty` is not in the terminfo database.

Closes #ISSUE

Release Notes:

- Set `TERM` to `xterm-256color` in Zed's built-in terminal
