### PR TITLE
Fix completion menu jumping

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -334,6 +334,9 @@ impl CompletionsMenu {
                 entries
             }
             _ => {
+                if self.selected_item != 0 {
+                    self.selected_item += 1;
+                }
                 let mut entries = Vec::with_capacity(self.entries.len() + 1);
                 entries.push(hint);
                 entries.extend_from_slice(&self.entries);
@@ -341,9 +344,6 @@ impl CompletionsMenu {
             }
         }
         .into();
-        if self.selected_item != 0 && self.selected_item + 1 < self.entries.len() {
-            self.selected_item += 1;
-        }
     }
 
     pub fn resolve_visible_completions(


### PR DESCRIPTION
Co-Authored-By: Thorsten <thorsten@zed.dev>

Release Notes:

- Fix selected suggestion updating too many times when Zeta triggers
