### PR TITLE
assistant2: Add intermediate bindings to improve conditional readability

### DIFF
--- a/crates/assistant2/src/context_picker/directory_context_picker.rs
+++ b/crates/assistant2/src/context_picker/directory_context_picker.rs
@@ -188,7 +188,7 @@ impl PickerDelegate for DirectoryContextPickerDelegate {
         };
         let path = mat.path.clone();
 
-        if self
+        let already_included = self
             .context_store
             .update(cx, |context_store, _cx| {
                 if let Some(context_id) = context_store.included_directory(&path) {
@@ -198,8 +198,8 @@ impl PickerDelegate for DirectoryContextPickerDelegate {
                     false
                 }
             })
-            .unwrap_or(true)
-        {
+            .unwrap_or(true);
+        if already_included {
             return;
         }
 

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -202,7 +202,7 @@ impl PickerDelegate for FileContextPickerDelegate {
         };
         let path = mat.path.clone();
 
-        if self
+        let already_included = self
             .context_store
             .update(cx, |context_store, _cx| {
                 match context_store.included_file(&path) {
@@ -214,8 +214,8 @@ impl PickerDelegate for FileContextPickerDelegate {
                     None => false,
                 }
             })
-            .unwrap_or(true)
-        {
+            .unwrap_or(true);
+        if already_included {
             return;
         }
 


### PR DESCRIPTION
This PR adds some intermediate bindings to the checks for if a file/directory is already included to make the conditional a bit clearer.

It wasn't immediately obvious what the boolean values corresponded to when looking at it.

Release Notes:

- N/A
