### PR TITLE
python: Check for activate script existence before running it

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -433,7 +433,7 @@ impl Project {
             "windows" => "\r",
             _ => "\n",
         };
-        if smol::block_on(self.fs.load_bytes(path.as_ref())).is_err() {
+        if smol::block_on(self.fs.metadata(path.as_ref())).is_err() {
             return None;
         }
         Some(format!(

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -433,6 +433,9 @@ impl Project {
             "windows" => "\r",
             _ => "\n",
         };
+        if smol::block_on(self.fs.load_bytes(path.as_ref())).is_err() {
+            return None;
+        }
         Some(format!(
             "{} {} ; clear{}",
             activate_keyword, quoted, line_ending


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Python auto-venv activation in terminal now checks for path existence before executing the activate script.
