### PR TITLE
Fix conversation selector popover menu offset

### DIFF
--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -10,7 +10,7 @@ use language_model::{LanguageModelRegistry, LanguageModelRequestTool};
 use language_model_selector::LanguageModelSelector;
 use rope::Point;
 use settings::Settings;
-use theme::ThemeSettings;
+use theme::{get_ui_font_size, ThemeSettings};
 use ui::{
     prelude::*, ButtonLike, ElevationIndex, KeyBinding, PopoverMenu, PopoverMenuHandle,
     SwitchWithLabel,
@@ -253,7 +253,7 @@ impl Render for MessageEditor {
                             .anchor(gpui::Corner::BottomLeft)
                             .offset(gpui::Point {
                                 x: px(0.0),
-                                y: px(-16.0),
+                                y: (-get_ui_font_size(cx) * 2) - px(4.0),
                             })
                             .with_handle(self.inline_context_picker_menu_handle.clone()),
                     )

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -254,13 +254,14 @@ impl<M: ManagedView> Element for PopoverMenu<M> {
                 let mut menu_layout_id = None;
 
                 let menu_element = element_state.menu.borrow_mut().as_mut().map(|menu| {
+                    let offset = self.resolved_offset(cx);
                     let mut anchored = anchored()
                         .snap_to_window_with_margin(px(8.))
-                        .anchor(self.anchor);
+                        .anchor(self.anchor)
+                        .offset(offset);
                     if let Some(child_bounds) = element_state.child_bounds {
-                        anchored = anchored.position(
-                            child_bounds.corner(self.resolved_attach()) + self.resolved_offset(cx),
-                        );
+                        anchored =
+                            anchored.position(child_bounds.corner(self.resolved_attach()) + offset);
                     }
                     let mut element = deferred(anchored.child(div().occlude().child(menu.clone())))
                         .with_priority(1)


### PR DESCRIPTION
Before, the conversation popover menu covered up what you were typing because it wasn't offset properly.

Now it's offset properly, using the UI font size so the amount of offset scales with the font size:

<img width="435" alt="Screenshot 2025-01-07 at 4 34 27 PM" src="https://github.com/user-attachments/assets/55e40910-8cd4-4548-b4fb-521eb2845775" />
<img width="454" alt="Screenshot 2025-01-07 at 4 33 58 PM" src="https://github.com/user-attachments/assets/30350489-09f1-4cb8-9f95-ed4ee87bc110" />
<img width="488" alt="Screenshot 2025-01-07 at 4 34 18 PM" src="https://github.com/user-attachments/assets/de60d990-2bd9-418d-a616-56beb3e4aa8a" />

Release Notes:

- N/A *or* Added/Fixed/Improved ...
