### PR TITLE
Display language server info in the server logs tab

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4143,14 +4143,6 @@ impl Project {
         self.lsp_store.read(cx).supplementary_language_servers()
     }
 
-    pub fn language_server_for_id(
-        &self,
-        id: LanguageServerId,
-        cx: &AppContext,
-    ) -> Option<Arc<LanguageServer>> {
-        self.lsp_store.read(cx).language_server_for_id(id)
-    }
-
     pub fn language_servers_for_local_buffer<'a>(
         &'a self,
         buffer: &'a Buffer,


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/19448

When dealing with issues like https://github.com/zed-industries/zed/issues/22749, it's quite tedious to ask for logs and check them out.

This PR attempts to establish a single "diagnose my language server" place in the server logs panel, where server capabilities were already displayed after https://github.com/zed-industries/zed/pull/19448

The design is pretty brutal, but seems to be on par with the previous version and it's a technical corner of Zed, so seems to be ok for now:

![image](https://github.com/user-attachments/assets/3471c83a-329e-475a-8cad-af95684da960)

Release Notes:

- Improved lsp logs view to display more language server data
