### PR TITLE
Include generate-licenses into bundle-mac script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,9 +322,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate license file
-        run: script/generate-licenses
-
       - name: Create macOS app bundle
         run: script/bundle-mac
 

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -86,9 +86,6 @@ jobs:
           echo "Publishing version: ${version} on release channel nightly"
           echo "nightly" > crates/zed/RELEASE_CHANNEL
 
-      - name: Generate license file
-        run: script/generate-licenses
-
       - name: Create macOS app bundle
         run: script/bundle-mac
 

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -84,6 +84,9 @@ version_info=$(rustc --version --verbose)
 host_line=$(echo "$version_info" | grep host)
 local_target_triple=${host_line#*: }
 
+# Generate the licenses first, so they can be baked into the binaries
+script/generate-licenses
+
 if [ "$local_arch" = true ]; then
     echo "Building for local target only."
     cargo build ${build_flag} --package zed --package cli --package remote_server


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21613

Same as `bundle-linux`, to avoid panicking on missing licenses for homegrown-built releases when `Help -> View dependency licenses` menu action is triggered.

Release Notes:

- Altered bundle-mac script to generate licenses
