### PR TITLE
linux: Fix issue with project-specific env not being found via .envrc (direnv)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -166,8 +166,11 @@ fn main() -> Result<()> {
 
     let mut env = Some(std::env::vars().collect::<HashMap<_, _>>());
 
-    // On Linux, desktop entry uses `cli` to spawn `zed`, so we need to load env vars from the shell
-    // since it doesn't inherit env vars from the terminal.
+    // On Linux, the desktop entry uses `cli` to spawn `zed`.
+    // We need to handle env vars correctly since std::env::vars() may not contain
+    // project-specific vars (e.g. those set by direnv).
+    // By setting env to None here, the LSP will use worktree env vars instead,
+    // which is what we want.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     if !std::io::stdout().is_terminal() {
         env = None;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -167,15 +167,14 @@ fn main() -> Result<()> {
         None
     };
 
+    let mut env = Some(std::env::vars().collect::<HashMap<_, _>>());
+
     // On Linux, desktop entry uses `cli` to spawn `zed`, so we need to load env vars from the shell
     // since it doesn't inherit env vars from the terminal.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     if !std::io::stdout().is_terminal() {
-        load_shell_from_passwd().log_err();
-        load_login_shell_environment().log_err();
+        env = None;
     }
-
-    let env = Some(std::env::vars().collect::<HashMap<_, _>>());
 
     let exit_status = Arc::new(Mutex::new(None));
     let mut paths = vec![];

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,10 +19,7 @@ use tempfile::NamedTempFile;
 use util::paths::PathWithPosition;
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-use {
-    std::io::IsTerminal,
-    util::{load_login_shell_environment, load_shell_from_passwd, ResultExt},
-};
+use std::io::IsTerminal;
 
 struct Detect;
 


### PR DESCRIPTION
Closes #18908

This PR started as a cleanup of redundant logic for setting up envs when Zed is launched as a desktop entry on Linux. More on this can be read [here](https://github.com/zed-industries/zed/pull/22335#issuecomment-2574726377). The TLDR is that desktop entries on Linux sometimes might not have the correct envs (as they don't `cwd` into your project directory). To address this, we initially tried to fix it by loading the default shell and its env vars. 

However, a better solution, as recommended by @mrnugget, is to pass `env` as `None`. Internally, if `env` is `None`, it falls back to the project's working dir envs. This removes the need to manually load the envs and is cleaner.

Additionally, it also fixes an issue with Zed not loading project-specific envs because now we are actually doing so (albeit unintentionally?).

I don't have macOS to test, but I believe this is not an issue on macOS since it uses the Zed binary instead of the CLI, which essentially sets the CLI `env` to `None` automatically.

Before:

Here, I have `/home/tims/go/bin` set up in `.envrc`, which only loads in that project directory.

When launching Zed via the CLI in the project directory, notice `/home/tims/go/bin` is in the `PATH`. As a result, we use the user-installed `gopls` server.

```sh
[INFO] attempting to start language server "gopls", path: "/home/tims/temp/go-proj", id: 1
[INFO] using project environment variables from CLI. PATH="/home/tims/go/bin:/usr/local/go/bin"
[INFO] found user-installed language server for gopls. path: "/home/tims/go/bin/gopls", arguments: ["-mode=stdio"]
[INFO] starting language server process. binary path: "/home/tims/go/bin/gopls", working directory: "/home/tims/temp/go-proj", args: ["-mode=stdio"]
```

However, when using the desktop entry and attempting to load envs from the default shell, notice `/home/tims/go/bin` is no longer there since it's not in the project directory. Zed cannot find the user-installed language server and starts downloading its own `gopls`.

```sh
[INFO] attempting to start language server "gopls", path: "/home/tims/temp/go-proj", id: 1
[INFO] using project environment variables from CLI. PATH="/usr/local/go/bin"
[INFO] fetching latest version of language server "gopls"
[INFO] downloading language server "gopls"
[INFO] starting language server process. binary path: "/home/tims/.local/share/zed/languages/gopls/gopls_0.17.1_go_1.23.4", working directory: "/home/tims/temp/go-proj", args: ["-mode=stdio"]
```

After: 

When using the desktop entry, we pass the CLI env as `None`. For the language server, it falls back to the project directory envs. Result, Zed finds the user-installed language server.

```sh
[INFO] attempting to start language server "gopls", path: "/home/tims/temp/go-proj", id: 1
[INFO] using project environment variables shell launched in "/home/tims/temp/go-proj". PATH="/home/tims/go/bin:/usr/local/go/bin"
[INFO] found user-installed language server for gopls. path: "/home/tims/go/bin/gopls", arguments: ["-mode=stdio"]
[INFO] starting language server process. binary path: "/home/tims/go/bin/gopls", working directory: "/home/tims/temp/go-proj", args: ["-mode=stdio"]
```

Release Notes:

- Fixed issue with project-specific env not being found via .envrc (direnv) on Linux