### PR TITLE
vim: Fix clipping when navigating over inlay hints

### DIFF
--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -63,6 +63,10 @@ impl InlineCompletionProvider for CopilotCompletionProvider {
         false
     }
 
+    fn show_completions_in_normal_mode() -> bool {
+        false
+    }
+
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -42,7 +42,7 @@ use fold_map::{FoldMap, FoldSnapshot};
 use gpui::{
     AnyElement, Font, HighlightStyle, LineLayout, Model, ModelContext, Pixels, UnderlineStyle,
 };
-pub(crate) use inlay_map::Inlay;
+pub use inlay_map::Inlay;
 use inlay_map::{InlayMap, InlaySnapshot};
 pub use inlay_map::{InlayOffset, InlayPoint};
 use invisibles::{is_invisible, replacement};

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -33,7 +33,7 @@ enum Transform {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct Inlay {
+pub struct Inlay {
     pub(crate) id: InlayId,
     pub position: Anchor,
     pub text: text::Rope,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -258,7 +258,7 @@ pub fn render_parsed_markdown(
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum InlayId {
+pub enum InlayId {
     InlineCompletion(usize),
     Hint(usize),
 }
@@ -3592,7 +3592,7 @@ impl Editor {
         }
     }
 
-    fn splice_inlays(
+    pub fn splice_inlays(
         &self,
         to_remove: Vec<InlayId>,
         to_insert: Vec<Inlay>,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4883,7 +4883,7 @@ impl Editor {
         }
     }
 
-    fn inline_completion_provider(&self) -> Option<Arc<dyn InlineCompletionProviderHandle>> {
+    pub fn inline_completion_provider(&self) -> Option<Arc<dyn InlineCompletionProviderHandle>> {
         Some(self.inline_completion_provider.as_ref()?.provider.clone())
     }
 

--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -325,6 +325,10 @@ impl InlineCompletionProvider for FakeInlineCompletionProvider {
         false
     }
 
+    fn show_completions_in_normal_mode() -> bool {
+        false
+    }
+
     fn is_enabled(
         &self,
         _buffer: &gpui::Model<language::Buffer>,

--- a/crates/inline_completion/src/inline_completion.rs
+++ b/crates/inline_completion/src/inline_completion.rs
@@ -21,6 +21,7 @@ pub trait InlineCompletionProvider: 'static + Sized {
     fn name() -> &'static str;
     fn display_name() -> &'static str;
     fn show_completions_in_menu() -> bool;
+    fn show_completions_in_normal_mode() -> bool;
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,
@@ -61,6 +62,7 @@ pub trait InlineCompletionProviderHandle {
         cx: &AppContext,
     ) -> bool;
     fn show_completions_in_menu(&self) -> bool;
+    fn show_completions_in_normal_mode(&self) -> bool;
     fn refresh(
         &self,
         buffer: Model<Buffer>,
@@ -99,6 +101,10 @@ where
 
     fn show_completions_in_menu(&self) -> bool {
         T::show_completions_in_menu()
+    }
+
+    fn show_completions_in_normal_mode(&self) -> bool {
+        T::show_completions_in_normal_mode()
     }
 
     fn is_enabled(

--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -106,6 +106,10 @@ impl InlineCompletionProvider for SupermavenCompletionProvider {
         false
     }
 
+    fn show_completions_in_normal_mode() -> bool {
+        false
+    }
+
     fn is_enabled(&self, buffer: &Model<Buffer>, cursor_position: Anchor, cx: &AppContext) -> bool {
         if !self.supermaven.read(cx).is_enabled() {
             return false;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1196,10 +1196,15 @@ impl Vim {
             editor.set_input_enabled(vim.editor_input_enabled());
             editor.set_autoindent(vim.should_autoindent());
             editor.selections.line_mode = matches!(vim.mode, Mode::VisualLine);
-            editor.set_inline_completions_enabled(matches!(
-                vim.mode,
-                Mode::Insert | Mode::Normal | Mode::Replace
-            ));
+
+            let enable_inline_completions = match vim.mode {
+                Mode::Insert | Mode::Replace => true,
+                Mode::Normal => editor
+                    .inline_completion_provider()
+                    .map_or(false, |provider| provider.show_completions_in_normal_mode()),
+                _ => false,
+            };
+            editor.set_inline_completions_enabled(enable_inline_completions);
         });
         cx.notify()
     }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1196,7 +1196,10 @@ impl Vim {
             editor.set_input_enabled(vim.editor_input_enabled());
             editor.set_autoindent(vim.should_autoindent());
             editor.selections.line_mode = matches!(vim.mode, Mode::VisualLine);
-            editor.set_inline_completions_enabled(matches!(vim.mode, Mode::Insert | Mode::Replace));
+            editor.set_inline_completions_enabled(matches!(
+                vim.mode,
+                Mode::Insert | Mode::Normal | Mode::Replace
+            ));
         });
         cx.notify()
     }

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -979,6 +979,10 @@ impl inline_completion::InlineCompletionProvider for ZetaInlineCompletionProvide
         true
     }
 
+    fn show_completions_in_normal_mode() -> bool {
+        true
+    }
+
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,


### PR DESCRIPTION
This fixes the issue described in this comment: https://github.com/zed-industries/zed/pull/22439#issuecomment-2563896422

Essentially, we'd clip in the wrong direction when there were multi-line inlay hints.

It also fixes inline completions for non-Zeta-providers showing up in normal mode.

Release Notes:

- N/A
