### PR TITLE
Fix rust runnable is not detected if comment is after #[test] attribute

### DIFF
--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -18,7 +18,7 @@
         .
         (attribute_item) *
         .
-        (line_comment) *
+        ([line_comment block_comment]) *
         .
         (function_item
             name: (_) @run

--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -18,7 +18,7 @@
         .
         (attribute_item) *
         .
-        ([line_comment block_comment]) *
+        [(line_comment) (block_comment)] *
         .
         (function_item
             name: (_) @run

--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -18,6 +18,8 @@
         .
         (attribute_item) *
         .
+        (line_comment) *
+        .
         (function_item
             name: (_) @run
             body: _


### PR DESCRIPTION
Closes #22798

This fixes that we didn't detect the Rust runnable when there was a comment after the `#[test]` attribute.

![Screenshot 2025-01-08 at 13 22 59](https://github.com/user-attachments/assets/bd6a7ae0-93d4-4f93-9d0d-11453acb2032)


Release Notes:

- Fixed Rust runnable not detected when comment is after `#[test]` attribute.
