### PR TITLE
nix: Build using nixpkgs package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,25 @@
-(
-  import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
-      fetchTarball {
-        url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-  )
-  {src = ./.;}
-)
-.defaultNix
+{
+  system ? builtins.currentSystem,
+}:
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  root = lock.nodes.${lock.root};
+  inherit (lock.nodes.${root.inputs.flake-compat}.locked)
+    owner
+    repo
+    rev
+    narHash
+    ;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat {
+    inherit system;
+    src = ./.;
+  };
+in
+flake.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,42 +1,27 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1734324364,
-        "narHash": "sha256-omYTR59TdH0AumP1cfh49fBnWZ52HjfdNfaLzCMZBx0=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "60d7623f1320470bf2fdb92fd2dca1e9a27b98ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
+        "lastModified": 1717312683,
+        "narHash": "sha256-FrlieJH50AuvagamEvWMIE6D2OAnERuDboFDYAED/dE=",
+        "owner": "nix-community",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "38fd3954cf65ce6faf3d0d45cd26059e059f07ea",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "nix-community",
         "repo": "flake-compat",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {
@@ -48,7 +33,6 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
@@ -61,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734316514,
-        "narHash": "sha256-0aLx44yMblcOGpfFXKCzp2GhU5JaE6OTvdU+JYrXiUc=",
+        "lastModified": 1736303309,
+        "narHash": "sha256-IKrk7RL+Q/2NC6+Ql6dwwCNZI6T6JH2grTdJaVWHF0A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "83ee8ff74d6294a7657320f16814754c4594127b",
+        "rev": "a0b81d4fa349d9af1765b0f0b4a899c13776f706",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
   };
 
   outputs =
-    { nixpkgs, ... }:
+    { nixpkgs, ... }@inputs:
     let
       systems = [
         "x86_64-linux"
@@ -21,6 +21,10 @@
       ];
 
       overlays = {
+        rust-overlay = inputs.rust-overlay.overlays.default;
+        rust-toolchain = final: prev: {
+          rustToolchain = final.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        };
         zed-editor = final: prev: {
           zed-editor = final.callPackage ./nix/build.nix {
             inherit (import nixpkgs { inherit (final) system; }) zed-editor;

--- a/flake.nix
+++ b/flake.nix
@@ -7,17 +7,11 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    crane.url = "github:ipetkov/crane";
-    flake-compat.url = "github:edolstra/flake-compat";
+    flake-compat.url = "github:nix-community/flake-compat";
   };
 
   outputs =
-    {
-      nixpkgs,
-      rust-overlay,
-      crane,
-      ...
-    }:
+    { nixpkgs, ... }:
     let
       systems = [
         "x86_64-linux"
@@ -27,14 +21,9 @@
       ];
 
       overlays = {
-        rust-overlay = rust-overlay.overlays.default;
-        rust-toolchain = final: prev: {
-          rustToolchain = final.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-        };
         zed-editor = final: prev: {
           zed-editor = final.callPackage ./nix/build.nix {
-            crane = crane.mkLib final;
-            rustToolchain = final.rustToolchain;
+            inherit (import nixpkgs { inherit (final) system; }) zed-editor;
           };
         };
       };

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,248 +1,50 @@
 {
   lib,
-  crane,
-  rustToolchain,
-  fetchpatch,
-  clang,
-  cmake,
-  copyDesktopItems,
-  curl,
-  perl,
-  pkg-config,
-  protobuf,
-  fontconfig,
-  freetype,
-  libgit2,
-  openssl,
-  sqlite,
-  zlib,
-  zstd,
-  alsa-lib,
-  libxkbcommon,
-  wayland,
-  libglvnd,
-  xorg,
   stdenv,
-  makeFontsConf,
-  vulkan-loader,
-  envsubst,
-  cargo-about,
-  cargo-bundle,
-  git,
-  apple-sdk_15,
-  darwinMinVersionHook,
-  makeWrapper,
-  nodejs_22,
+  rustPlatform,
+  zed-editor,
   nix-gitignore,
-
-  withGLES ? false,
 }:
-
-assert withGLES -> stdenv.hostPlatform.isLinux;
-
 let
   includeFilter =
     path: type:
-    let
-      baseName = baseNameOf (toString path);
-      parentDir = dirOf path;
-      inRootDir = type == "directory" && parentDir == ../.;
-    in
     !(
-      inRootDir
-      && (baseName == "docs" || baseName == ".github" || baseName == ".git" || baseName == "target")
+      (type == "directory" && (dirOf path) == ../.)
+      && (builtins.elem (baseNameOf (toString path)) [
+        "docs"
+        ".github"
+        ".git"
+        "target"
+      ])
     );
-  craneLib = crane.overrideToolchain rustToolchain;
-  commonSrc = lib.cleanSourceWith {
-    src = nix-gitignore.gitignoreSource [ ] ../.;
-    filter = includeFilter;
-    name = "source";
-  };
-  commonArgs = rec {
-    pname = "zed-editor";
-    version = "nightly";
-
-    src = commonSrc;
-
-    nativeBuildInputs =
-      [
-        clang
-        cmake
-        copyDesktopItems
-        curl
-        perl
-        pkg-config
-        protobuf
-        cargo-about
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ cargo-bundle ];
-
-    buildInputs =
-      [
-        curl
-        fontconfig
-        freetype
-        libgit2
-        openssl
-        sqlite
-        zlib
-        zstd
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isLinux [
-        alsa-lib
-        libxkbcommon
-        wayland
-        xorg.libxcb
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        apple-sdk_15
-        (darwinMinVersionHook "10.15")
-      ];
-
-    env = {
-      ZSTD_SYS_USE_PKG_CONFIG = true;
-      FONTCONFIG_FILE = makeFontsConf {
-        fontDirectories = [
-          "${src}/assets/fonts/plex-mono"
-          "${src}/assets/fonts/plex-sans"
-        ];
-      };
-      ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
-      RELEASE_VERSION = version;
-    };
-  };
-  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  disableSandboxDarwin =
+    drv:
+    drv.overrideAttrs (
+      lib.optionalAttrs stdenv.buildPlatform.isDarwin {
+        __noChroot = true;
+      }
+    );
 in
-craneLib.buildPackage (
-  commonArgs
-  // rec {
-    inherit cargoArtifacts;
-
-    patches =
-      [
-        # Zed uses cargo-install to install cargo-about during the script execution.
-        # We provide cargo-about ourselves and can skip this step.
-        # Until https://github.com/zed-industries/zed/issues/19971 is fixed,
-        # we also skip any crate for which the license cannot be determined.
-        (fetchpatch {
-          url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fd02d90c6c097f91349df35da62d36c19359ba7/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch";
-          hash = "sha256-cLgqLDXW1JtQ2OQFLd5UolAjfy7bMoTw40lEx2jA2pk=";
-        })
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        # Livekit requires Swift 6
-        # We need this until livekit-rust sdk is used
-        (fetchpatch {
-          url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fd02d90c6c097f91349df35da62d36c19359ba7/pkgs/by-name/ze/zed-editor/0002-disable-livekit-darwin.patch";
-          hash = "sha256-whZ7RaXv8hrVzWAveU3qiBnZSrvGNEHTuyNhxgMIo5w=";
-        })
-      ];
-
-    cargoExtraArgs = "--package=zed --package=cli --features=gpui/runtime_shaders";
-
-    dontUseCmakeConfigure = true;
-    preBuild = ''
-      bash script/generate-licenses
-    '';
-
-    postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-      patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*
-      patchelf --add-rpath ${wayland}/lib $out/libexec/*
-      wrapProgram $out/libexec/zed-editor --suffix PATH : ${lib.makeBinPath [ nodejs_22 ]}
-    '';
-
-    RUSTFLAGS = if withGLES then "--cfg gles" else "";
-    gpu-lib = if withGLES then libglvnd else vulkan-loader;
-
-    preCheck = ''
-      export HOME=$(mktemp -d);
-    '';
-
-    cargoTestExtraArgs =
-      "-- "
-      + lib.concatStringsSep " " (
-        [
-          # Flaky: unreliably fails on certain hosts (including Hydra)
-          "--skip=zed::tests::test_window_edit_state_restoring_enabled"
-        ]
-        ++ lib.optionals stdenv.hostPlatform.isLinux [
-          # Fails on certain hosts (including Hydra) for unclear reason
-          "--skip=test_open_paths_action"
-        ]
-      );
-
-    installPhase =
-      if stdenv.hostPlatform.isDarwin then
-        ''
-          runHook preInstall
-
-          # cargo-bundle expects the binary in target/release
-          mv target/release/zed target/release/zed
-
-          pushd crates/zed
-
-          # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
-          sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
-          export CARGO_BUNDLE_SKIP_BUILD=true
-          app_path=$(cargo bundle --release | xargs)
-
-          # We're not using the fork of cargo-bundle, so we must manually append plist extensions
-          # Remove closing tags from Info.plist (last two lines)
-          head -n -2 $app_path/Contents/Info.plist > Info.plist
-          # Append extensions
-          cat resources/info/*.plist >> Info.plist
-          # Add closing tags
-          printf "</dict>\n</plist>\n" >> Info.plist
-          mv Info.plist $app_path/Contents/Info.plist
-
-          popd
-
-          mkdir -p $out/Applications $out/bin
-          # Zed expects git next to its own binary
-          ln -s ${git}/bin/git $app_path/Contents/MacOS/git
-          mv target/release/cli $app_path/Contents/MacOS/cli
-          mv $app_path $out/Applications/
-
-          # Physical location of the CLI must be inside the app bundle as this is used
-          # to determine which app to start
-          ln -s $out/Applications/Zed.app/Contents/MacOS/cli $out/bin/zed
-
-          runHook postInstall
-        ''
-      else
-        ''
-          runHook preInstall
-
-          mkdir -p $out/bin $out/libexec
-          cp target/release/zed $out/libexec/zed-editor
-          cp target/release/cli $out/bin/zed
-
-          install -D ${commonSrc}/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
-          install -D ${commonSrc}/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
-
-          # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
-          # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
-          (
-            export DO_STARTUP_NOTIFY="true"
-            export APP_CLI="zed"
-            export APP_ICON="zed"
-            export APP_NAME="Zed"
-            export APP_ARGS="%U"
-            mkdir -p "$out/share/applications"
-            ${lib.getExe envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
-          )
-
-          runHook postInstall
-        '';
-
-    meta = {
-      description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
-      homepage = "https://zed.dev";
-      changelog = "https://zed.dev/releases/preview";
-      license = lib.licenses.gpl3Only;
-      mainProgram = "zed";
-      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+disableSandboxDarwin (
+  zed-editor.overrideAttrs (old: {
+    version = "nightly";
+    src = lib.cleanSourceWith {
+      src = nix-gitignore.gitignoreSource [ ] ../.;
+      filter = includeFilter;
+      name = "source";
     };
-  }
+
+    postPatch = ''
+      substituteInPlace ../cargo-vendor-dir/webrtc-sys-*/build.rs \
+        --replace-fail "cargo:rustc-link-lib=static=webrtc" "cargo:rustc-link-lib=dylib=webrtc"
+    '';
+
+    cargoDeps = disableSandboxDarwin (
+      rustPlatform.importCargoLock {
+        lockFile = ../Cargo.lock;
+        allowBuiltinFetchGit = true;
+      }
+    );
+    doInstallCheck = false;
+  })
 )


### PR DESCRIPTION
This changes the build to use the package definition from nixpkgs with a number of overrides, namely allowing the usage of `builtins.fetchGit` and using the sources from the repo. While this technically makes zed a downstream of nixpkgs in this regard, the build process is fairly stable and the current situation is a lot worse anyways

- [x] Build on macOS
- [ ] Build on Linux 

Release Notes:

- N/A
