### PR TITLE
Adjust `TintColor` color token terminology

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -3654,7 +3654,7 @@ impl ContextEditor {
 
         let (style, tooltip) = match token_state(&self.context, cx) {
             Some(TokenState::NoTokensLeft { .. }) => (
-                ButtonStyle::Tinted(TintColor::Negative),
+                ButtonStyle::Tinted(TintColor::Error),
                 Some(Tooltip::text("Token limit reached", cx)),
             ),
             Some(TokenState::HasMoreTokens {
@@ -3711,7 +3711,7 @@ impl ContextEditor {
 
         let (style, tooltip) = match token_state(&self.context, cx) {
             Some(TokenState::NoTokensLeft { .. }) => (
-                ButtonStyle::Tinted(TintColor::Negative),
+                ButtonStyle::Tinted(TintColor::Error),
                 Some(Tooltip::text("Token limit reached", cx)),
             ),
             Some(TokenState::HasMoreTokens {

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -381,7 +381,7 @@ impl TitleBar {
                 .style(ButtonStyle::Subtle)
                 .icon_size(IconSize::Small)
                 .toggle_state(is_muted)
-                .selected_style(ButtonStyle::Tinted(TintColor::Negative))
+                .selected_style(ButtonStyle::Tinted(TintColor::Error))
                 .on_click(move |_, cx| {
                     toggle_mute(&Default::default(), cx);
                 })
@@ -398,7 +398,7 @@ impl TitleBar {
                     },
                 )
                 .style(ButtonStyle::Subtle)
-                .selected_style(ButtonStyle::Tinted(TintColor::Negative))
+                .selected_style(ButtonStyle::Tinted(TintColor::Error))
                 .icon_size(IconSize::Small)
                 .toggle_state(is_deafened)
                 .tooltip(move |cx| {

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -475,8 +475,8 @@ impl ComponentPreview for Button {
                     ),
                     single_example(
                         "Negative",
-                        Button::new("tinted_negative", "Negative")
-                            .style(ButtonStyle::Tinted(TintColor::Negative)),
+                        Button::new("tinted_negative", "Error")
+                            .style(ButtonStyle::Tinted(TintColor::Error)),
                     ),
                     single_example(
                         "Warning",
@@ -527,8 +527,8 @@ impl ComponentPreview for Button {
                     ),
                     single_example(
                         "Tinted Icons",
-                        Button::new("icon_color", "Delete")
-                            .style(ButtonStyle::Tinted(TintColor::Negative))
+                        Button::new("icon_color", "Error")
+                            .style(ButtonStyle::Tinted(TintColor::Error))
                             .color(Color::Error)
                             .icon_color(Color::Error)
                             .icon(IconName::Trash)

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -474,7 +474,7 @@ impl ComponentPreview for Button {
                             .style(ButtonStyle::Tinted(TintColor::Accent)),
                     ),
                     single_example(
-                        "Negative",
+                        "Error",
                         Button::new("tinted_negative", "Error")
                             .style(ButtonStyle::Tinted(TintColor::Error)),
                     ),

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -484,9 +484,9 @@ impl ComponentPreview for Button {
                             .style(ButtonStyle::Tinted(TintColor::Warning)),
                     ),
                     single_example(
-                        "Positive",
-                        Button::new("tinted_positive", "Positive")
-                            .style(ButtonStyle::Tinted(TintColor::Positive)),
+                        "Success",
+                        Button::new("tinted_positive", "Success")
+                            .style(ButtonStyle::Tinted(TintColor::Success)),
                     ),
                 ],
             ),

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -49,9 +49,9 @@ pub enum IconPosition {
 pub enum TintColor {
     #[default]
     Accent,
-    Negative,
+    Error,
     Warning,
-    Positive,
+    Success,
 }
 
 impl TintColor {
@@ -63,7 +63,7 @@ impl TintColor {
                 label_color: cx.theme().colors().text,
                 icon_color: cx.theme().colors().text,
             },
-            TintColor::Negative => ButtonLikeStyles {
+            TintColor::Error => ButtonLikeStyles {
                 background: cx.theme().status().error_background,
                 border_color: cx.theme().status().error_border,
                 label_color: cx.theme().colors().text,
@@ -75,7 +75,7 @@ impl TintColor {
                 label_color: cx.theme().colors().text,
                 icon_color: cx.theme().colors().text,
             },
-            TintColor::Positive => ButtonLikeStyles {
+            TintColor::Success => ButtonLikeStyles {
                 background: cx.theme().status().success_background,
                 border_color: cx.theme().status().success_border,
                 label_color: cx.theme().colors().text,
@@ -89,9 +89,9 @@ impl From<TintColor> for Color {
     fn from(tint: TintColor) -> Self {
         match tint {
             TintColor::Accent => Color::Accent,
-            TintColor::Negative => Color::Error,
+            TintColor::Error => Color::Error,
             TintColor::Warning => Color::Warning,
-            TintColor::Positive => Color::Success,
+            TintColor::Success => Color::Success,
         }
     }
 }


### PR DESCRIPTION
Previously, to use a green and red shade with `TintColor` you'd need to pass `Positive` and `Negative`, respectively. This terminology always tripped me up, because, for example, I'd often try to use something like:

```
Button::new("icon_color", "Negative")
      style(ButtonStyle::Tinted(TintColor::Negative))
      .color(Color::Error)
      .icon_color(Color::Error)
      .icon(IconName::Trash),
)
```

...and due to `icon_color` taking `Color::Error`, I'd always get `TintColor` wrong at a first try, because I would, out of muscle memory, write `TintColor::Error`, which wouldn't compile. That's exactly the change in this PR—`TintColor` now takes `Success` and `Error` instead of `Positive` and `Negative`, for more consistency.


Release Notes:

- N/A 
