### PR TITLE
Update reference to editor::OpenFile in keymap

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -110,7 +110,7 @@
       "g y": "editor::GoToTypeDefinition",
       "g shift-i": "editor::GoToImplementation",
       "g x": "editor::OpenUrl",
-      "g f": "editor::OpenFile",
+      "g f": "editor::OpenSelectedFilename",
       "g n": "vim::SelectNextMatch",
       "g shift-n": "vim::SelectPreviousMatch",
       "g l": "vim::SelectNext",


### PR DESCRIPTION
Follow-up to #22494

Release Notes:

- Preview Only: Fix for "g f" (Open File) in Vim-mode
