### PR TITLE
Improve LSP notification design

### DIFF
--- a/assets/icons/copy.svg
+++ b/assets/icons/copy.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.4286 9H10.5714C9.70355 9 9 9.70355 9 10.5714V18.4286C9 19.2964 9.70355 20 10.5714 20H18.4286C19.2964 20 20 19.2964 20 18.4286V10.5714C20 9.70355 19.2964 9 18.4286 9Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.57143 15C4.70714 15 4 14.2929 4 13.4286V5.57143C4 4.70714 4.70714 4 5.57143 4H13.4286C14.2929 4 15 4.70714 15 5.57143" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Mostly just fine-tuning the styles and modernizing some of the component usage. Visually, it doesn't change that _much_, but it still polishes it up a bit.

| Before | After |
|--------|--------|
| <img width="1426" alt="Screenshot 2025-01-08 at 11 25 01 AM" src="https://github.com/user-attachments/assets/df074f88-08c0-47c2-bd98-1a8b6dbadc99" /> | <img width="1426" alt="Screenshot 2025-01-08 at 11 23 24 AM" src="https://github.com/user-attachments/assets/250e3aee-fd1b-4b32-b305-e58b4fede75a" /> | 

Release Notes:

- N/A
