### PR TITLE
Fix upstream branch tracking error in script/bump-zed-minor-versions

### DIFF
--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -77,7 +77,7 @@ git tag ${stable_tag_name}
 echo "Creating new preview branch ${minor_branch_name}..."
 git checkout -q main
 git checkout -q -b ${minor_branch_name}
-git branch --set-upstream-to=origin/${minor_branch_name} ${minor_branch_name}
+git branch --set-upstream-to=origin/${minor_branch_name} ${minor_branch_name} --no-advice
 echo -n preview > crates/zed/RELEASE_CHANNEL
 git commit -q --all --message "${minor_branch_name} preview"
 git tag ${preview_tag_name}


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/22614

Previous change failed with:
<img width="635" alt="Screenshot 2025-01-08 at 10 37 40" src="https://github.com/user-attachments/assets/5969a9f5-9294-439c-a53d-21eedaf9ee3a" />

Release Notes:

- N/A
