### PR TITLE
Fix script/bump-zed-minor-versions. Revert #22834 Revert #22614

### DIFF
--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -66,7 +66,7 @@ git checkout -q ${prev_minor_branch_name}
 git clean -q -dff
 stable_tag_name="v$(script/get-crate-version zed)"
 if git show-ref --quiet refs/tags/${stable_tag_name}; then
-  echo "tag ${preview_tag_name} already exists"
+  echo "tag ${stable_tag_name} already exists"
   exit 1
 fi
 old_prev_minor_sha=$(git rev-parse HEAD)
@@ -77,7 +77,6 @@ git tag ${stable_tag_name}
 echo "Creating new preview branch ${minor_branch_name}..."
 git checkout -q main
 git checkout -q -b ${minor_branch_name}
-git branch --set-upstream-to=origin/${minor_branch_name} ${minor_branch_name} --no-advice
 echo -n preview > crates/zed/RELEASE_CHANNEL
 git commit -q --all --message "${minor_branch_name} preview"
 git tag ${preview_tag_name}


### PR DESCRIPTION
Reverts #22834
Reverts #22614

Turns out it is impossible to set remote tracking to a branch that doesn't exist on the remote, so let's not even try.

Fixes an incorrect error message.

Release Notes:

- N/A
