### PR TITLE
Add "newline above" and "newline below" to Sublime Text keymap

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -50,6 +50,8 @@
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
       "ctrl-delete": "editor::DeleteToNextWordEnd"
+    	"ctrl-enter": "editor::NewlineBelow",
+    	"ctrl-shift-enter": "editor::NewlineAbove"
     }
   },
   {


### PR DESCRIPTION
This seems inconsequential enough that I don't think the overhead of a separate Discussion would be worth it.

Release Notes:

- Added two more bindings to the Sublime Text keymap
