### PR TITLE
pane: Add ability to use custom tooltip content

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -92,7 +92,7 @@ use workspace::{
     DraggedSelection, Pane, Save, ShowConfiguration, Toast, ToggleZoom, ToolbarItemEvent,
     ToolbarItemLocation, ToolbarItemView, Workspace,
 };
-use workspace::{searchable::SearchableItemHandle, DraggedTab};
+use workspace::{item::TabTooltipContent, searchable::SearchableItemHandle, DraggedTab};
 use zed_actions::InlineAssist;
 
 pub fn init(cx: &mut AppContext) {
@@ -4235,7 +4235,7 @@ impl Item for ContextEditor {
         }
     }
 
-    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<workspace::item::TabTooltipContent> {
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<TabTooltipContent> {
         Some(self.title(cx).to_string().into())
     }
 

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -4235,7 +4235,7 @@ impl Item for ContextEditor {
         }
     }
 
-    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<workspace::item::TabTooltipContent> {
         Some(self.title(cx).to_string().into())
     }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -43,7 +43,7 @@ pub use toolbar_controls::ToolbarControls;
 use ui::{h_flex, prelude::*, Icon, IconName, Label};
 use util::ResultExt;
 use workspace::{
-    item::{BreadcrumbText, Item, ItemEvent, ItemHandle, TabContentParams},
+    item::{BreadcrumbText, Item, ItemEvent, ItemHandle, TabContentParams, TabTooltipContent},
     searchable::SearchableItemHandle,
     ItemNavHistory, ToolbarItemLocation, Workspace,
 };
@@ -676,7 +676,7 @@ impl Item for ProjectDiagnosticsEditor {
             .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
-    fn tab_tooltip_content(&self, _: &AppContext) -> Option<workspace::item::TabTooltipContent> {
+    fn tab_tooltip_content(&self, _: &AppContext) -> Option<TabTooltipContent> {
         Some("Project Diagnostics".into())
     }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -676,7 +676,7 @@ impl Item for ProjectDiagnosticsEditor {
             .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
-    fn tab_tooltip_text(&self, _: &AppContext) -> Option<SharedString> {
+    fn tab_tooltip_content(&self, _: &AppContext) -> Option<workspace::item::TabTooltipContent> {
         Some("Project Diagnostics".into())
     }
 

--- a/crates/editor/src/git/project_diff.rs
+++ b/crates/editor/src/git/project_diff.rs
@@ -933,7 +933,7 @@ impl Item for ProjectDiffEditor {
             .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
-    fn tab_tooltip_text(&self, _: &AppContext) -> Option<SharedString> {
+    fn tab_tooltip_content(&self, _: &AppContext) -> Option<workspace::item::TabTooltipContent> {
         Some("Project Diff".into())
     }
 

--- a/crates/editor/src/git/project_diff.rs
+++ b/crates/editor/src/git/project_diff.rs
@@ -25,7 +25,7 @@ use theme::ActiveTheme;
 use ui::prelude::*;
 use util::{paths::compare_paths, ResultExt};
 use workspace::{
-    item::{BreadcrumbText, Item, ItemEvent, ItemHandle, TabContentParams},
+    item::{BreadcrumbText, Item, ItemEvent, ItemHandle, TabContentParams, TabTooltipContent},
     ItemNavHistory, ToolbarItemLocation, Workspace,
 };
 
@@ -933,7 +933,7 @@ impl Item for ProjectDiffEditor {
             .update(cx, |editor, cx| editor.navigate(data, cx))
     }
 
-    fn tab_tooltip_content(&self, _: &AppContext) -> Option<workspace::item::TabTooltipContent> {
+    fn tab_tooltip_content(&self, _: &AppContext) -> Option<TabTooltipContent> {
         Some("Project Diff".into())
     }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -27,7 +27,7 @@ use project::{
 };
 use rpc::proto::{self, update_view, PeerId};
 use settings::Settings;
-use workspace::item::{Dedup, ItemSettings, SerializableItem, TabContentParams};
+use workspace::item::{Dedup, ItemSettings, SerializableItem, TabContentParams, TabTooltipContent};
 
 use project::lsp_store::FormatTarget;
 use std::{
@@ -571,7 +571,7 @@ impl Item for Editor {
         }
     }
 
-    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<TabTooltipContent> {
         let file_path = self
             .buffer()
             .read(cx)

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -88,7 +88,7 @@ impl Item for ImageView {
         true
     }
 
-    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<workspace::item::TabTooltipContent> {
         let abs_path = self.image_item.read(cx).file.as_local()?.abs_path(cx);
         let file_path = abs_path.compact().to_string_lossy().to_string();
         Some(file_path.into())

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -16,7 +16,9 @@ use project::{image_store::ImageItemEvent, ImageItem, Project, ProjectPath};
 use settings::Settings;
 use util::paths::PathExt;
 use workspace::{
-    item::{BreadcrumbText, Item, ProjectItem, SerializableItem, TabContentParams},
+    item::{
+        BreadcrumbText, Item, ProjectItem, SerializableItem, TabContentParams, TabTooltipContent,
+    },
     ItemId, ItemSettings, ToolbarItemLocation, Workspace, WorkspaceId,
 };
 
@@ -88,7 +90,7 @@ impl Item for ImageView {
         true
     }
 
-    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<workspace::item::TabTooltipContent> {
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<TabTooltipContent> {
         let abs_path = self.image_item.read(cx).file.as_local()?.abs_path(cx);
         let file_path = abs_path.compact().to_string_lossy().to_string();
         Some(file_path.into())

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -37,7 +37,7 @@ use ui::{
 };
 use util::paths::PathMatcher;
 use workspace::{
-    item::{BreadcrumbText, Item, ItemEvent, ItemHandle},
+    item::{BreadcrumbText, Item, ItemEvent, ItemHandle, TabTooltipContent},
     searchable::{Direction, SearchableItem, SearchableItemHandle},
     DeploySearch, ItemNavHistory, NewSearch, ToolbarItemEvent, ToolbarItemLocation,
     ToolbarItemView, Workspace, WorkspaceId,
@@ -388,7 +388,8 @@ impl FocusableView for ProjectSearchView {
 
 impl Item for ProjectSearchView {
     type Event = ViewEvent;
-    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
+
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<TabTooltipContent> {
         let query_text = self.query_editor.read(cx).text(cx);
 
         query_text

--- a/crates/terminal_view/src/terminal_tab_tooltip.rs
+++ b/crates/terminal_view/src/terminal_tab_tooltip.rs
@@ -1,0 +1,27 @@
+use gpui::{IntoElement, Render, ViewContext};
+use ui::{prelude::*, tooltip_container, Divider};
+
+pub struct TerminalTooltip {
+    title: String,
+}
+
+impl TerminalTooltip {
+    pub fn new(title: String) -> Self {
+        Self { title }
+    }
+}
+
+impl Render for TerminalTooltip {
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        tooltip_container(cx, move |this, _cx| {
+            this.occlude()
+                .on_mouse_move(|_, cx| cx.stop_propagation())
+                .child(
+                    v_flex()
+                        .gap_1()
+                        .child(Label::new(self.title.clone()))
+                        .child(Divider::horizontal()),
+                )
+        })
+    }
+}

--- a/crates/terminal_view/src/terminal_tab_tooltip.rs
+++ b/crates/terminal_view/src/terminal_tab_tooltip.rs
@@ -1,12 +1,12 @@
 use gpui::{IntoElement, Render, ViewContext};
-use ui::{prelude::*, tooltip_container, Divider};
+use ui::{prelude::*, tooltip_container};
 
 pub struct TerminalTooltip {
-    title: String,
+    title: SharedString,
 }
 
 impl TerminalTooltip {
-    pub fn new(title: String) -> Self {
+    pub fn new(title: SharedString) -> Self {
         Self { title }
     }
 }
@@ -16,12 +16,7 @@ impl Render for TerminalTooltip {
         tooltip_container(cx, move |this, _cx| {
             this.occlude()
                 .on_mouse_move(|_, cx| cx.stop_propagation())
-                .child(
-                    v_flex()
-                        .gap_1()
-                        .child(Label::new(self.title.clone()))
-                        .child(Divider::horizontal()),
-                )
+                .child(v_flex().gap_1().child(Label::new(self.title.clone())))
         })
     }
 }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1004,11 +1004,9 @@ impl Item for TerminalView {
         let terminal = self.terminal().read(cx);
         let title = terminal.title(false);
 
-        Some(TabTooltipContent(Box::new(
-            move |cx: &mut WindowContext| {
-                cx.new_view(|_| TerminalTooltip::new(title.clone())).into()
-            },
-        )))
+        Some(TabTooltipContent::custom(move |cx: &mut WindowContext| {
+            cx.new_view(|_| TerminalTooltip::new(title.clone())).into()
+        }))
     }
 
     fn tab_content(&self, params: TabContentParams, cx: &WindowContext) -> AnyElement {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1002,7 +1002,7 @@ impl Item for TerminalView {
 
     fn tab_tooltip_content(&self, cx: &AppContext) -> Option<TabTooltipContent> {
         let terminal = self.terminal().read(cx);
-        let title = terminal.title(false);
+        let title: SharedString = terminal.title(false).into();
 
         Some(TabTooltipContent::custom(move |cx| {
             cx.new_view(|_| TerminalTooltip::new(title.clone())).into()

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1004,7 +1004,7 @@ impl Item for TerminalView {
         let terminal = self.terminal().read(cx);
         let title = terminal.title(false);
 
-        Some(TabTooltipContent::custom(move |cx: &mut WindowContext| {
+        Some(TabTooltipContent::custom(move |cx| {
             cx.new_view(|_| TerminalTooltip::new(title.clone())).into()
         }))
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1,6 +1,7 @@
 mod persistence;
 pub mod terminal_element;
 pub mod terminal_panel;
+pub mod terminal_tab_tooltip;
 
 use collections::HashSet;
 use editor::{actions::SelectAll, scroll::Autoscroll, Editor};
@@ -26,13 +27,16 @@ use terminal::{
 };
 use terminal_element::{is_blank, TerminalElement};
 use terminal_panel::TerminalPanel;
+use terminal_tab_tooltip::TerminalTooltip;
 use ui::{h_flex, prelude::*, ContextMenu, Icon, IconName, Label, Tooltip};
 use util::{
     paths::{PathWithPosition, SanitizedPath},
     ResultExt,
 };
 use workspace::{
-    item::{BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams},
+    item::{
+        BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams, TabTooltipContent,
+    },
     register_serializable_item,
     searchable::{SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle},
     CloseActiveItem, NewCenterTerminal, NewTerminal, OpenVisible, ToolbarItemLocation, Workspace,
@@ -996,8 +1000,15 @@ impl Render for TerminalView {
 impl Item for TerminalView {
     type Event = ItemEvent;
 
-    fn tab_tooltip_text(&self, cx: &AppContext) -> Option<SharedString> {
-        Some(self.terminal().read(cx).title(false).into())
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<TabTooltipContent> {
+        let terminal = self.terminal().read(cx);
+        let title = terminal.title(false);
+
+        Some(TabTooltipContent(Box::new(
+            move |cx: &mut WindowContext| {
+                cx.new_view(|_| TerminalTooltip::new(title.clone())).into()
+            },
+        )))
     }
 
     fn tab_content(&self, params: TabContentParams, cx: &WindowContext) -> AnyElement {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -185,15 +185,13 @@ impl TabTooltipContent {
     where
         F: for<'a> Fn(&'a mut WindowContext) -> AnyView + 'static,
     {
-        TabTooltipContent(Box::new(f))
+        Self(Box::new(f))
     }
 
     pub fn text(txt: impl Into<SharedString>) -> Self {
         let txt = txt.into();
 
-        TabTooltipContent(Box::new(move |cx: &mut WindowContext| {
-            Tooltip::text(txt.clone(), cx)
-        }))
+        Self::custom(move |cx| Tooltip::text(txt.clone(), cx))
     }
 
     pub fn view(&self, cx: &mut WindowContext) -> AnyView {
@@ -201,21 +199,9 @@ impl TabTooltipContent {
     }
 }
 
-impl Into<TabTooltipContent> for SharedString {
-    fn into(self) -> TabTooltipContent {
-        TabTooltipContent::text(self)
-    }
-}
-
-impl Into<TabTooltipContent> for String {
-    fn into(self) -> TabTooltipContent {
-        TabTooltipContent::text(self)
-    }
-}
-
-impl Into<TabTooltipContent> for &'static str {
-    fn into(self) -> TabTooltipContent {
-        TabTooltipContent::text(self)
+impl<T: Into<SharedString>> From<T> for TabTooltipContent {
+    fn from(value: T) -> Self {
+        TabTooltipContent::text(value)
     }
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -539,8 +539,8 @@ impl<T: Item> ItemHandle for View<T> {
         self.focus_handle(cx)
     }
 
-    fn tab_tooltip_content(&self, _cx: &AppContext) -> Option<TabTooltipContent> {
-        None
+    fn tab_tooltip_content(&self, cx: &AppContext) -> Option<TabTooltipContent> {
+        self.read(cx).tab_tooltip_content(cx)
     }
 
     fn telemetry_event_text(&self, cx: &WindowContext) -> Option<&'static str> {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1,7 +1,7 @@
 use crate::{
     item::{
         ActivateOnClose, ClosePosition, Item, ItemHandle, ItemSettings, PreviewTabsSettings,
-        ShowDiagnostics, TabContentParams, TabTooltipContent, WeakItemHandle,
+        ShowDiagnostics, TabContentParams, WeakItemHandle,
     },
     move_item,
     notifications::NotifyResultExt,
@@ -2147,7 +2147,7 @@ impl Pane {
                 this.handle_external_paths_drop(paths, cx)
             }))
             .when_some(item.tab_tooltip_content(cx), |tab, element_fn| {
-                tab.tooltip(move |cx| element_fn.0(cx))
+                tab.tooltip(move |cx| element_fn.view(cx))
             })
             .start_slot::<Indicator>(indicator)
             .map(|this| {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1,7 +1,7 @@
 use crate::{
     item::{
         ActivateOnClose, ClosePosition, Item, ItemHandle, ItemSettings, PreviewTabsSettings,
-        ShowDiagnostics, TabContentParams, WeakItemHandle,
+        ShowDiagnostics, TabContentParams, TabTooltipContent, WeakItemHandle,
     },
     move_item,
     notifications::NotifyResultExt,
@@ -2146,8 +2146,8 @@ impl Pane {
                 this.drag_split_direction = None;
                 this.handle_external_paths_drop(paths, cx)
             }))
-            .when_some(item.tab_tooltip_text(cx), |tab, text| {
-                tab.tooltip(move |cx| Tooltip::text(text.clone(), cx))
+            .when_some(item.tab_tooltip_content(cx), |tab, element_fn| {
+                tab.tooltip(move |cx| element_fn.0(cx))
             })
             .start_slot::<Indicator>(indicator)
             .map(|this| {

--- a/crates/workspace/src/shared_screen/cross_platform.rs
+++ b/crates/workspace/src/shared_screen/cross_platform.rs
@@ -66,8 +66,8 @@ impl Render for SharedScreen {
 impl Item for SharedScreen {
     type Event = Event;
 
-    fn tab_tooltip_text(&self, _: &AppContext) -> Option<SharedString> {
-        Some(format!("{}'s screen", self.user.github_login).into())
+    fn tab_tooltip_content(&self, _: &AppContext) -> TabTooltipContent {
+        format!("{}'s screen", self.user.github_login).into()
     }
 
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/workspace/src/shared_screen/cross_platform.rs
+++ b/crates/workspace/src/shared_screen/cross_platform.rs
@@ -66,8 +66,8 @@ impl Render for SharedScreen {
 impl Item for SharedScreen {
     type Event = Event;
 
-    fn tab_tooltip_content(&self, _: &AppContext) -> TabTooltipContent {
-        format!("{}'s screen", self.user.github_login).into()
+    fn tab_tooltip_content(&self, _: &AppContext) -> Option<TabTooltipContent> {
+        Some(format!("{}'s screen", self.user.github_login).into())
     }
 
     fn deactivated(&mut self, cx: &mut ViewContext<Self>) {

--- a/crates/workspace/src/shared_screen/macos.rs
+++ b/crates/workspace/src/shared_screen/macos.rs
@@ -1,5 +1,5 @@
 use crate::{
-    item::{Item, ItemEvent},
+    item::{Item, ItemEvent, TabTooltipContent},
     ItemNavHistory, WorkspaceId,
 };
 use anyhow::Result;
@@ -83,7 +83,7 @@ impl Render for SharedScreen {
 impl Item for SharedScreen {
     type Event = Event;
 
-    fn tab_tooltip_text(&self, _: &AppContext) -> Option<SharedString> {
+    fn tab_tooltip_content(&self, _: &AppContext) -> Option<TabTooltipContent> {
         Some(format!("{}'s screen", self.user.github_login).into())
     }
 


### PR DESCRIPTION
This PR is motivated by https://github.com/zed-industries/zed/pull/21955. We wanted to come up with an API that allowed passing custom content to a pane's tab. We replaced `tab_tooltip_text` for `tab_tooltip_content`, but it is mostly just a signature change, because we can keep constructing a tab tooltip just from a shared string. So, in this PR, visually, nothing changes.

Release Notes:

- N/A
