### PR TITLE
collab: Record cancellation reason on billing subscriptions

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -438,7 +438,8 @@ CREATE TABLE IF NOT EXISTS billing_subscriptions (
     billing_customer_id INTEGER NOT NULL REFERENCES billing_customers(id),
     stripe_subscription_id TEXT NOT NULL,
     stripe_subscription_status TEXT NOT NULL,
-    stripe_cancel_at TIMESTAMP
+    stripe_cancel_at TIMESTAMP,
+    stripe_cancellation_reason TEXT
 );
 
 CREATE INDEX "ix_billing_subscriptions_on_billing_customer_id" ON billing_subscriptions (billing_customer_id);

--- a/crates/collab/migrations/20250108184547_add_stripe_cancellation_reason_to_billing_subscriptions.sql
+++ b/crates/collab/migrations/20250108184547_add_stripe_cancellation_reason_to_billing_subscriptions.sql
@@ -1,0 +1,2 @@
+alter table billing_subscriptions
+add column stripe_cancellation_reason text;

--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -1,4 +1,4 @@
-use crate::db::billing_subscription::StripeSubscriptionStatus;
+use crate::db::billing_subscription::{StripeCancellationReason, StripeSubscriptionStatus};
 
 use super::*;
 
@@ -15,6 +15,7 @@ pub struct UpdateBillingSubscriptionParams {
     pub stripe_subscription_id: ActiveValue<String>,
     pub stripe_subscription_status: ActiveValue<StripeSubscriptionStatus>,
     pub stripe_cancel_at: ActiveValue<Option<DateTime>>,
+    pub stripe_cancellation_reason: ActiveValue<Option<StripeCancellationReason>>,
 }
 
 impl Database {
@@ -51,6 +52,7 @@ impl Database {
                 stripe_subscription_id: params.stripe_subscription_id.clone(),
                 stripe_subscription_status: params.stripe_subscription_status.clone(),
                 stripe_cancel_at: params.stripe_cancel_at.clone(),
+                stripe_cancellation_reason: params.stripe_cancellation_reason.clone(),
                 ..Default::default()
             })
             .exec(&*tx)

--- a/crates/collab/src/db/tables/billing_subscription.rs
+++ b/crates/collab/src/db/tables/billing_subscription.rs
@@ -12,6 +12,7 @@ pub struct Model {
     pub stripe_subscription_id: String,
     pub stripe_subscription_status: StripeSubscriptionStatus,
     pub stripe_cancel_at: Option<DateTime>,
+    pub stripe_cancellation_reason: Option<StripeCancellationReason>,
     pub created_at: DateTime,
 }
 
@@ -72,4 +73,19 @@ impl StripeSubscriptionStatus {
             | Self::Paused => false,
         }
     }
+}
+
+/// The cancellation reason for a Stripe subscription.
+///
+/// [Stripe docs](https://docs.stripe.com/api/subscriptions/object#subscription_object-cancellation_details-reason)
+#[derive(Eq, PartialEq, Copy, Clone, Debug, EnumIter, DeriveActiveEnum, Hash, Serialize)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::None)")]
+#[serde(rename_all = "snake_case")]
+pub enum StripeCancellationReason {
+    #[sea_orm(string_value = "cancellation_requested")]
+    CancellationRequested,
+    #[sea_orm(string_value = "payment_disputed")]
+    PaymentDisputed,
+    #[sea_orm(string_value = "payment_failed")]
+    PaymentFailed,
 }


### PR DESCRIPTION
This PR updates the `billing_subscriptions` in the database to record the cancellation reason from Stripe.

We're primarily interested in this so we can check for subscriptions that were canceled for being `past_due`.

Release Notes:

- N/A
