### PR TITLE
extension: Fix manifest filename in error message

### DIFF
--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -175,7 +175,7 @@ impl ExtensionManifest {
                 .await
                 .with_context(|| format!("failed to load {extension_name} extension.toml"))?;
             toml::from_str(&manifest_content)
-                .with_context(|| format!("invalid extension.json for extension {extension_name}"))
+                .with_context(|| format!("invalid extension.toml for extension {extension_name}"))
         }
     }
 }


### PR DESCRIPTION
This PR fixes the incorrect filename for the extension manifest being used in an error message.

It should be `extension.toml` and not `extension.json`.

Release Notes:

- N/A
