### PR TITLE
Only count existing branches in picker search

### DIFF
--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -129,9 +129,7 @@ impl BranchListDelegate {
         })
     }
 
-    /// Get the number of matches that should be included in displayed counts
-    fn displayed_match_count(&self) -> usize {
-        // We only care about existing branches
+    fn branch_count(&self) -> usize {
         self.matches
             .iter()
             .filter(|item| matches!(item, BranchEntry::Branch(_)))
@@ -316,15 +314,9 @@ impl PickerDelegate for BranchListDelegate {
                 .ml_3()
                 .into_any_element()
         } else {
-            // We use the "nominal" match count (which includes the new branch option) to determine if any label should be shown
             let match_label = self.matches.is_empty().not().then(|| {
-                // We use the displayed match count (which excludes the new branch option) to determine the suffix and number
-                let suffix = if self.displayed_match_count() == 1 {
-                    ""
-                } else {
-                    "es"
-                };
-                Label::new(format!("{} match{}", self.displayed_match_count(), suffix))
+                let suffix = if self.branch_count() == 1 { "" } else { "es" };
+                Label::new(format!("{} match{}", self.branch_count(), suffix))
                     .color(Color::Muted)
                     .size(LabelSize::Small)
             });

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -128,6 +128,15 @@ impl BranchListDelegate {
             branch_name_trailoff_after,
         })
     }
+
+    /// Get the number of matches that should be included in displayed counts
+    fn displayed_match_count(&self) -> usize {
+        // We only care about existing branches
+        self.matches
+            .iter()
+            .filter(|item| matches!(item, BranchEntry::Branch(_)))
+            .count()
+    }
 }
 
 impl PickerDelegate for BranchListDelegate {
@@ -307,9 +316,15 @@ impl PickerDelegate for BranchListDelegate {
                 .ml_3()
                 .into_any_element()
         } else {
+            // We use the "nominal" match count (which includes the new branch option) to determine if any label should be shown
             let match_label = self.matches.is_empty().not().then(|| {
-                let suffix = if self.matches.len() == 1 { "" } else { "es" };
-                Label::new(format!("{} match{}", self.matches.len(), suffix))
+                // We use the displayed match count (which excludes the new branch option) to determine the suffix and number
+                let suffix = if self.displayed_match_count() == 1 {
+                    ""
+                } else {
+                    "es"
+                };
+                Label::new(format!("{} match{}", self.displayed_match_count(), suffix))
                     .color(Color::Muted)
                     .size(LabelSize::Small)
             });


### PR DESCRIPTION
When displaying the number of matches in the branch picker during a search, don't count the "create new branch" option as a match, since it only appears when _no_ existing branches are found.

<img width="530" alt="Screenshot 2025-01-09 at 12 17 30" src="https://github.com/user-attachments/assets/c4e6ac6f-d842-4b2f-a3af-ec28c9d90f0a" />

Closes #22905.

Release Notes:

- Fixed result count in branch picker searches.