### PR TITLE
Add file filter to buffer search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11390,6 +11390,7 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "language",
+ "log",
  "menu",
  "project",
  "serde",

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -1091,6 +1091,7 @@ impl SearchableItem for LspLogView {
             // LSP log is read-only.
             replacement: false,
             selection: false,
+            filters: false,
         }
     }
     fn active_match_index(

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -29,6 +29,7 @@ editor.workspace = true
 futures.workspace = true
 gpui.workspace = true
 language.workspace = true
+log.workspace = true
 menu.workspace = true
 project.workspace = true
 serde.workspace = true

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -29,6 +29,7 @@ actions!(
         ToggleRegex,
         ToggleReplace,
         ToggleSelection,
+        ToggleFilters,
         SelectNextMatch,
         SelectPrevMatch,
         SelectAllMatches,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1259,6 +1259,7 @@ impl SearchableItem for TerminalView {
             regex: true,
             replacement: false,
             selection: false,
+            filters: false,
         }
     }
 

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -42,6 +42,7 @@ pub struct SearchOptions {
     /// Specifies whether the  supports search & replace.
     pub replacement: bool,
     pub selection: bool,
+    pub filters: bool,
 }
 
 pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
@@ -54,6 +55,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
             regex: true,
             replacement: true,
             selection: true,
+            filters: true, // TODO: should only be true for multi-buffers
         }
     }
 


### PR DESCRIPTION


When dealing with multi-file buffers this can be immensely helpful.
My main use-case is filtering out test files when finding all
references.

## TODO

- [ ] Figure out why updating the file search bar has no effect on the matches
- [ ] Make sure we only allow this filter for multi-file buffers


Release Notes:

- Added file filters to multi-buffer search