### PR TITLE
extensions_ui: Show an error toast when a dev extension fails to install

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -82,13 +82,26 @@ pub fn init(cx: &mut AppContext) {
                                 }
                             };
 
-                        store
+                        let install_task = store
                             .update(&mut cx, |store, cx| {
-                                store
-                                    .install_dev_extension(extension_path, cx)
-                                    .detach_and_log_err(cx)
+                                store.install_dev_extension(extension_path, cx)
                             })
                             .ok()?;
+
+                        match install_task.await {
+                            Ok(_) => {}
+                            Err(err) => {
+                                workspace_handle
+                                    .update(&mut cx, |workspace, cx| {
+                                        workspace.show_error(
+                                            &err.context("failed to install dev extension"),
+                                            cx,
+                                        );
+                                    })
+                                    .ok();
+                            }
+                        }
+
                         Some(())
                     })
                     .detach();

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -392,7 +392,10 @@ impl Render for ErrorMessagePrompt {
                     )
                     .child(
                         div()
+                            .id("error_message")
                             .max_w_80()
+                            .max_h_40()
+                            .overflow_y_scroll()
                             .child(Label::new(self.message.clone()).size(LabelSize::Small)),
                     )
                     .when_some(self.label_and_url_button.clone(), |elm, (label, url)| {


### PR DESCRIPTION
This PR adds an error toast that will be displayed when installing a dev extension fails.

Here's what it looks like:

<img width="1310" alt="Screenshot 2025-01-09 at 11 56 42 AM" src="https://github.com/user-attachments/assets/b65eb9f9-c559-4b99-b64a-ee301fa9e443" />

<img width="1310" alt="Screenshot 2025-01-09 at 12 10 30 PM" src="https://github.com/user-attachments/assets/f4880221-2ed9-4bb0-9d48-1cb29c2b483f" />

I did have to touch the workspace `ErrorMessagePrompt` component to make it scroll for long messages. I don't anticipate this being a problem for other classes of errors (if anything, I suspect other long errors will become more usable now).

Closes #21237.

Release Notes:

- Added an error toast that is shown when a dev extension fails to install.
