### PR TITLE
story: Use `itertools` as a workspace dependency

### DIFF
--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -13,5 +13,5 @@ workspace = true
 
 [dependencies]
 gpui.workspace = true
-itertools = { package = "itertools", version = "0.14" }
+itertools.workspace = true
 smallvec.workspace = true


### PR DESCRIPTION
This PR makes the `story` crate depend on `itertools` as a workspace dependency.

Release Notes:

- N/A
