### PR TITLE
Fix handling of selection ranges for format selections in multibuffer

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -27,7 +27,7 @@ use language::{
 };
 use lsp::LanguageServerId;
 use parking_lot::Mutex;
-use project::lsp_store::FormatTarget;
+use project::lsp_store::FormatTargetHandles;
 use project::{
     lsp_store::FormatTrigger, search::SearchQuery, search::SearchResult, DiagnosticSummary,
     HoverBlockKind, Project, ProjectPath,
@@ -4399,10 +4399,9 @@ async fn test_formatting_buffer(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                HashSet::from_iter([buffer_b.clone()]),
+                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
                 true,
                 FormatTrigger::Save,
-                FormatTarget::Buffer,
                 cx,
             )
         })
@@ -4435,10 +4434,9 @@ async fn test_formatting_buffer(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                HashSet::from_iter([buffer_b.clone()]),
+                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
                 true,
                 FormatTrigger::Save,
-                FormatTarget::Buffer,
                 cx,
             )
         })
@@ -4545,10 +4543,9 @@ async fn test_prettier_formatting_buffer(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                HashSet::from_iter([buffer_b.clone()]),
+                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
                 true,
                 FormatTrigger::Save,
-                FormatTarget::Buffer,
                 cx,
             )
         })
@@ -4565,10 +4562,9 @@ async fn test_prettier_formatting_buffer(
     project_a
         .update(cx_a, |project, cx| {
             project.format(
-                HashSet::from_iter([buffer_a.clone()]),
+                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_a.clone()])),
                 true,
                 FormatTrigger::Manual,
-                FormatTarget::Buffer,
                 cx,
             )
         })

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -27,10 +27,10 @@ use language::{
 };
 use lsp::LanguageServerId;
 use parking_lot::Mutex;
-use project::lsp_store::FormatTargetHandles;
 use project::{
-    lsp_store::FormatTrigger, search::SearchQuery, search::SearchResult, DiagnosticSummary,
-    HoverBlockKind, Project, ProjectPath,
+    lsp_store::{FormatTrigger, LspFormatTarget},
+    search::{SearchQuery, SearchResult},
+    DiagnosticSummary, HoverBlockKind, Project, ProjectPath,
 };
 use rand::prelude::*;
 use serde_json::json;
@@ -4399,7 +4399,8 @@ async fn test_formatting_buffer(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
+                HashSet::from_iter([buffer_b.clone()]),
+                LspFormatTarget::Buffers,
                 true,
                 FormatTrigger::Save,
                 cx,
@@ -4434,7 +4435,8 @@ async fn test_formatting_buffer(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
+                HashSet::from_iter([buffer_b.clone()]),
+                LspFormatTarget::Buffers,
                 true,
                 FormatTrigger::Save,
                 cx,
@@ -4543,7 +4545,8 @@ async fn test_prettier_formatting_buffer(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
+                HashSet::from_iter([buffer_b.clone()]),
+                LspFormatTarget::Buffers,
                 true,
                 FormatTrigger::Save,
                 cx,
@@ -4562,7 +4565,8 @@ async fn test_prettier_formatting_buffer(
     project_a
         .update(cx_a, |project, cx| {
             project.format(
-                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_a.clone()])),
+                HashSet::from_iter([buffer_a.clone()]),
+                LspFormatTarget::Buffers,
                 true,
                 FormatTrigger::Manual,
                 cx,

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -16,7 +16,7 @@ use language::{
 };
 use node_runtime::NodeRuntime;
 use project::{
-    lsp_store::{FormatTarget, FormatTrigger},
+    lsp_store::{FormatTargetHandles, FormatTrigger},
     ProjectPath,
 };
 use remote::SshRemoteClient;
@@ -471,10 +471,9 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                HashSet::from_iter([buffer_b.clone()]),
+                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
                 true,
                 FormatTrigger::Save,
-                FormatTarget::Buffer,
                 cx,
             )
         })
@@ -508,10 +507,9 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     project_a
         .update(cx_a, |project, cx| {
             project.format(
-                HashSet::from_iter([buffer_a.clone()]),
+                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_a.clone()])),
                 true,
                 FormatTrigger::Manual,
-                FormatTarget::Buffer,
                 cx,
             )
         })

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -16,7 +16,7 @@ use language::{
 };
 use node_runtime::NodeRuntime;
 use project::{
-    lsp_store::{FormatTargetHandles, FormatTrigger},
+    lsp_store::{FormatTrigger, LspFormatTarget},
     ProjectPath,
 };
 use remote::SshRemoteClient;
@@ -471,7 +471,8 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     project_b
         .update(cx_b, |project, cx| {
             project.format(
-                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_b.clone()])),
+                HashSet::from_iter([buffer_b.clone()]),
+                LspFormatTarget::Buffers,
                 true,
                 FormatTrigger::Save,
                 cx,
@@ -507,7 +508,8 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     project_a
         .update(cx_a, |project, cx| {
             project.format(
-                FormatTargetHandles::Buffers(HashSet::from_iter([buffer_a.clone()])),
+                HashSet::from_iter([buffer_a.clone()]),
+                LspFormatTarget::Buffers,
                 true,
                 FormatTrigger::Manual,
                 cx,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -129,7 +129,7 @@ use multi_buffer::{
 };
 use project::{
     buffer_store::BufferChangeSet,
-    lsp_store::{FormatTarget, FormatTrigger, OpenLspBufferHandle},
+    lsp_store::{FormatTarget, FormatTargetHandles, FormatTrigger, OpenLspBufferHandle},
     project_settings::{GitGutterSetting, ProjectSettings},
     CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, Location, LocationLink,
     LspStore, Project, ProjectItem, ProjectTransaction, TaskSourceKind,
@@ -10237,7 +10237,7 @@ impl Editor {
             None => return None,
         };
 
-        Some(self.perform_format(project, FormatTrigger::Manual, FormatTarget::Buffer, cx))
+        Some(self.perform_format(project, FormatTrigger::Manual, FormatTarget::Buffers, cx))
     }
 
     fn format_selections(
@@ -10279,9 +10279,7 @@ impl Editor {
         }
 
         let mut timeout = cx.background_executor().timer(FORMAT_TIMEOUT).fuse();
-        let format = project.update(cx, |project, cx| {
-            project.format(buffers, true, trigger, target, cx)
-        });
+        let format = project.update(cx, |project, cx| project.format(target, true, trigger, cx));
 
         cx.spawn(|_, mut cx| async move {
             let transaction = futures::select_biased! {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -129,7 +129,7 @@ use multi_buffer::{
 };
 use project::{
     buffer_store::BufferChangeSet,
-    lsp_store::{FormatTarget, FormatTargetHandles, FormatTrigger, OpenLspBufferHandle},
+    lsp_store::{FormatTrigger, LspFormatTarget, OpenLspBufferHandle},
     project_settings::{GitGutterSetting, ProjectSettings},
     CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, Location, LocationLink,
     LspStore, Project, ProjectItem, ProjectTransaction, TaskSourceKind,
@@ -984,6 +984,11 @@ impl InlayHintRefreshReason {
             Self::ExcerptsRemoved(_) => "excerpts removed",
         }
     }
+}
+
+pub enum FormatTarget {
+    Buffers,
+    Ranges(Vec<Range<MultiBufferPoint>>),
 }
 
 pub(crate) struct FocusedBlock {
@@ -10250,17 +10255,18 @@ impl Editor {
             None => return None,
         };
 
-        let selections = self
+        let ranges = self
             .selections
             .all_adjusted(cx)
             .into_iter()
+            .map(|selection| selection.range())
             .filter(|s| !s.is_empty())
             .collect_vec();
 
         Some(self.perform_format(
             project,
             FormatTrigger::Manual,
-            FormatTarget::Ranges(selections),
+            FormatTarget::Ranges(ranges),
             cx,
         ))
     }
@@ -10272,14 +10278,42 @@ impl Editor {
         target: FormatTarget,
         cx: &mut ViewContext<Self>,
     ) -> Task<Result<()>> {
-        let buffer = self.buffer().clone();
-        let mut buffers = buffer.read(cx).all_buffers();
-        if trigger == FormatTrigger::Save {
-            buffers.retain(|buffer| buffer.read(cx).is_dirty());
-        }
+        let buffer = self.buffer.clone();
+        let (buffers, target) = match target {
+            FormatTarget::Buffers => {
+                let mut buffers = buffer.read(cx).all_buffers();
+                if trigger == FormatTrigger::Save {
+                    buffers.retain(|buffer| buffer.read(cx).is_dirty());
+                }
+                (buffers, LspFormatTarget::Buffers)
+            }
+            FormatTarget::Ranges(selection_ranges) => {
+                let multi_buffer = buffer.read(cx);
+                let snapshot = multi_buffer.read(cx);
+                let mut buffers = HashSet::default();
+                let mut buffer_id_to_ranges: BTreeMap<BufferId, Vec<Range<text::Anchor>>> =
+                    BTreeMap::new();
+                for selection_range in selection_ranges {
+                    for (excerpt, buffer_range) in snapshot.range_to_buffer_ranges(selection_range)
+                    {
+                        let buffer_id = excerpt.buffer_id();
+                        let start = excerpt.buffer().anchor_before(buffer_range.start);
+                        let end = excerpt.buffer().anchor_after(buffer_range.end);
+                        buffers.insert(multi_buffer.buffer(buffer_id).unwrap());
+                        buffer_id_to_ranges
+                            .entry(buffer_id)
+                            .and_modify(|buffer_ranges| buffer_ranges.push(start..end))
+                            .or_insert_with(|| vec![start..end]);
+                    }
+                }
+                (buffers, LspFormatTarget::Ranges(buffer_id_to_ranges))
+            }
+        };
 
         let mut timeout = cx.background_executor().timer(FORMAT_TIMEOUT).fuse();
-        let format = project.update(cx, |project, cx| project.format(target, true, trigger, cx));
+        let format = project.update(cx, |project, cx| {
+            project.format(buffers, target, true, trigger, cx)
+        });
 
         cx.spawn(|_, mut cx| async move {
             let transaction = futures::select_biased! {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7380,7 +7380,7 @@ async fn test_document_format_manual_trigger(cx: &mut gpui::TestAppContext) {
             editor.perform_format(
                 project.clone(),
                 FormatTrigger::Manual,
-                FormatTarget::Buffer,
+                FormatTarget::Buffers,
                 cx,
             )
         })
@@ -7418,7 +7418,7 @@ async fn test_document_format_manual_trigger(cx: &mut gpui::TestAppContext) {
     });
     let format = editor
         .update(cx, |editor, cx| {
-            editor.perform_format(project, FormatTrigger::Manual, FormatTarget::Buffer, cx)
+            editor.perform_format(project, FormatTrigger::Manual, FormatTarget::Buffers, cx)
         })
         .unwrap();
     cx.executor().advance_clock(super::FORMAT_TIMEOUT);
@@ -11293,7 +11293,7 @@ async fn test_document_format_with_prettier(cx: &mut gpui::TestAppContext) {
             editor.perform_format(
                 project.clone(),
                 FormatTrigger::Manual,
-                FormatTarget::Buffer,
+                FormatTarget::Buffers,
                 cx,
             )
         })
@@ -11312,7 +11312,7 @@ async fn test_document_format_with_prettier(cx: &mut gpui::TestAppContext) {
         editor.perform_format(
             project.clone(),
             FormatTrigger::Manual,
-            FormatTarget::Buffer,
+            FormatTarget::Buffers,
             cx,
         )
     });

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -29,7 +29,7 @@ use rpc::proto::{self, update_view, PeerId};
 use settings::Settings;
 use workspace::item::{Dedup, ItemSettings, SerializableItem, TabContentParams};
 
-use project::lsp_store::FormatTarget;
+use project::lsp_store::FormatTargetHandles;
 use std::{
     any::TypeId,
     borrow::Cow,
@@ -753,10 +753,13 @@ impl Item for Editor {
         cx.spawn(|this, mut cx| async move {
             if format {
                 this.update(&mut cx, |editor, cx| {
+                    let buffer = self.buffer().clone();
+                    let mut buffers = buffer.read(cx).all_buffers();
+                    buffers.retain(|buffer| buffer.read(cx).is_dirty());
                     editor.perform_format(
                         project.clone(),
                         FormatTrigger::Save,
-                        FormatTarget::Buffer,
+                        FormatTarget::Buffer(buffers),
                         cx,
                     )
                 })?

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -2,8 +2,8 @@ use crate::{
     editor_settings::SeedQuerySetting,
     persistence::{SerializedEditor, DB},
     scroll::ScrollAnchor,
-    Anchor, Autoscroll, Editor, EditorEvent, EditorSettings, ExcerptId, ExcerptRange, MultiBuffer,
-    MultiBufferSnapshot, NavigationData, SearchWithinRange, ToPoint as _,
+    Anchor, Autoscroll, Editor, EditorEvent, EditorSettings, ExcerptId, ExcerptRange, FormatTarget,
+    MultiBuffer, MultiBufferSnapshot, NavigationData, SearchWithinRange, ToPoint as _,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::HashSet;
@@ -29,7 +29,6 @@ use rpc::proto::{self, update_view, PeerId};
 use settings::Settings;
 use workspace::item::{Dedup, ItemSettings, SerializableItem, TabContentParams};
 
-use project::lsp_store::FormatTargetHandles;
 use std::{
     any::TypeId,
     borrow::Cow,
@@ -753,13 +752,10 @@ impl Item for Editor {
         cx.spawn(|this, mut cx| async move {
             if format {
                 this.update(&mut cx, |editor, cx| {
-                    let buffer = self.buffer().clone();
-                    let mut buffers = buffer.read(cx).all_buffers();
-                    buffers.retain(|buffer| buffer.read(cx).is_dirty());
                     editor.perform_format(
                         project.clone(),
                         FormatTrigger::Save,
-                        FormatTarget::Buffer(buffers),
+                        FormatTarget::Buffers,
                         cx,
                     )
                 })?

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2631,14 +2631,13 @@ impl Project {
 
     pub fn format(
         &mut self,
-        buffers: HashSet<Model<Buffer>>,
+        target: lsp_store::FormatTargetHandles,
         push_to_history: bool,
         trigger: lsp_store::FormatTrigger,
-        target: lsp_store::FormatTarget,
         cx: &mut ModelContext<Project>,
     ) -> Task<anyhow::Result<ProjectTransaction>> {
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.format(buffers, push_to_history, trigger, target, cx)
+            lsp_store.format(target, push_to_history, trigger, cx)
         })
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -59,6 +59,7 @@ use lsp::{
     LanguageServerId, LanguageServerName, MessageActionItem,
 };
 use lsp_command::*;
+use lsp_store::LspFormatTarget;
 use node_runtime::NodeRuntime;
 use parking_lot::Mutex;
 pub use prettier_store::PrettierStore;
@@ -2631,13 +2632,14 @@ impl Project {
 
     pub fn format(
         &mut self,
-        target: lsp_store::FormatTargetHandles,
+        buffers: HashSet<Model<Buffer>>,
+        target: LspFormatTarget,
         push_to_history: bool,
         trigger: lsp_store::FormatTrigger,
         cx: &mut ModelContext<Project>,
     ) -> Task<anyhow::Result<ProjectTransaction>> {
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.format(target, push_to_history, trigger, cx)
+            lsp_store.format(buffers, target, push_to_history, trigger, cx)
         })
     }
 


### PR DESCRIPTION
Before this change it was using the same multibuffer point ranges in every buffer, which only worked correctly for singleton buffers.

Release Notes:

- Fixed handling of selection ranges when formatting selections within a multibuffer.