### PR TITLE
Format all selections even if they are cursors

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10260,7 +10260,6 @@ impl Editor {
             .all_adjusted(cx)
             .into_iter()
             .map(|selection| selection.range())
-            .filter(|s| !s.is_empty())
             .collect_vec();
 
         Some(self.perform_format(


### PR DESCRIPTION
Closes #22816

Release Notes:

- Format selections now also applies to cursors.