### PR TITLE
Log an error when there are no buffer snapshots for some LSP version

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1997,6 +1997,10 @@ impl LocalLspStore {
             snapshots.retain(|snapshot| snapshot.version + OLD_VERSIONS_TO_RETAIN >= version);
             Ok(found_snapshot)
         } else {
+            match buffer.read(cx).project_path(cx) {
+                Some(project_path) => log::error!("No LSP snapshots found for buffer with path {:?}", project_path.path),
+                None => log::error!("No LSP snapshots found for buffer without a project path (which is also unexpected)"),
+            }
             Ok((buffer.read(cx)).text_snapshot())
         }
     }


### PR DESCRIPTION
I'm hoping this will bring more visibility to issues related to keeping track of what version of code the LSP has:

* I've seen diagnostic ranges not appearing in the correct places.

* There have also been reports of edits from language servers misapplying.  This might bring more visibility to the issue - it doesn't seem good to silently use the current version of the buffer.

Release Notes:

- N/A