### PR TITLE
assistant2: Background load of context + prep for refresh + efficiency

### DIFF
--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -201,7 +201,7 @@ impl PickerDelegate for FileContextPickerDelegate {
         let Some(task) = self
             .context_store
             .update(cx, |context_store, cx| {
-                context_store.add_file(project_path, cx)
+                context_store.add_file_from_path(project_path, cx)
             })
             .ok()
         else {


### PR DESCRIPTION
* Now loads context on background threads.

    - For file and directory context, buffer ropes can be shared between threads as they are immutable. This allows for traversal and accumulation of buffer text on a background thread.

    - For url context, the request, parsing, and rendering is now done on a background thread.

* Prepares for support of buffer reload by individually storing the text of directory buffers.

* Avoids some string copying / redundant strings.

    - When attaching message context, no longer builds a string for each context type.

    - For directory context, does not build a `SharedString` for the full text, instead has a slice of `SharedString` chunks which are then directly appended to the message context.

    - Building a fenced codeblock for a buffer now computes a precise capacity in advance.

Release Notes:

- N/A