### PR TITLE
zeta: Fix completions not being marked as rated

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -733,6 +733,7 @@ and then another
         feedback: String,
         cx: &mut ModelContext<Self>,
     ) {
+        self.rated_completions.insert(completion.id);
         telemetry::event!(
             "Inline Completion Rated",
             rating,


### PR DESCRIPTION
Seems like #22171 accidentally removed this line.

Now it's back and completions are marked as rated again.

![screenshot-2025-01-10-10 56 32@2x](https://github.com/user-attachments/assets/c68bff1b-5b97-493e-9062-390876fd757c)

Release Notes:

- N/A
