### PR TITLE
Do not show copy buttons in editor's hover popovers

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -590,6 +590,7 @@ async fn parse_blocks(
                 fallback_language_name,
                 cx,
             )
+            .copy_code_block_buttons(false)
         })
         .ok();
 


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/22866

Added a config option to the markdown renderer to omit code copying buttons, and used those for editor hover popovers.

Such popovers are quite frequent in language servers' hover responses, e.g. rust-analyzer on `.clone()` hover may respond with
```
{"jsonrpc":"2.0","id":119,"result":{"contents":{"kind":"markdown","value":"\n```rust\nalloc::string::String\n```\n\n```rust\nfn clone(&self) -> Self\n```\n\n---\n\nReturns a copy of the value.\n\n# Examples\n\n```rust\nlet hello = \"Hello\"; // &str implements Clone\n\nassert_eq!(\"Hello\", hello.clone());\n```"},"range":{"start":{"line":518,"character":24},"end":{"line":518,"character":29}}}}
```

(note multiple code blocks sent)

![image](https://github.com/user-attachments/assets/4c40b15e-8f53-4b3d-a809-f1e4d35a00a7)

![image](https://github.com/user-attachments/assets/77b8e13b-b665-42d3-b633-5a0375998f06)

Sounds that editor has either to use a different way to copy popover's data (so the entire text gets copied, not just its code blocks), or at least better handle hover popover's hovering to show the button.


Release Notes:

- N/A
