### PR TITLE
docs: Fix missing } in multiple formatters example

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1000,7 +1000,7 @@ WARNING: `{buffer_path}` should not be used to direct your formatter to read fro
     {"external": {
       "command": "sed",
       "arguments": ["-e", "s/ *$//"]
-    }
+    }}
   ]
 }
 ```

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -996,11 +996,13 @@ WARNING: `{buffer_path}` should not be used to direct your formatter to read fro
 ```json
 {
   "formatter": [
-    {"language_server": {"name": "rust-analyzer"}},
-    {"external": {
-      "command": "sed",
-      "arguments": ["-e", "s/ *$//"]
-    }}
+    { "language_server": { "name": "rust-analyzer" } },
+    {
+      "external": {
+        "command": "sed",
+        "arguments": ["-e", "s/ *$//"]
+      }
+    }
   ]
 }
 ```


### PR DESCRIPTION
Add a missing } in the multiple formatters example in the configuring Zed section of the manual.

Release Notes:

- Fixed a missing } in the multiple formatters doc example
