### PR TITLE
assistant2: Change model selector keybinding and make it visible

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -175,7 +175,7 @@
       "ctrl-shift-e": "project_panel::ToggleFocus",
       "ctrl-g": "search::SelectNextMatch",
       "ctrl-shift-g": "search::SelectPrevMatch",
-      "ctrl-shift-m": "assistant::ToggleModelSelector",
+      "ctrl-alt-/": "assistant::ToggleModelSelector",
       "ctrl-k h": "assistant::DeployHistory",
       "ctrl-k l": "assistant::DeployPromptLibrary",
       "ctrl-n": "assistant::NewContext"
@@ -572,7 +572,7 @@
     "bindings": {
       "ctrl-n": "assistant2::NewThread",
       "ctrl-shift-h": "assistant2::OpenHistory",
-      "ctrl-shift-m": "assistant2::ToggleModelSelector",
+      "ctrl-alt-/": "assistant2::ToggleModelSelector",
       "ctrl-shift-a": "assistant2::ToggleContextPicker",
       "ctrl-alt-e": "assistant2::RemoveAllContext"
     }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -199,7 +199,7 @@
       "cmd-shift-e": "project_panel::ToggleFocus",
       "cmd-g": "search::SelectNextMatch",
       "cmd-shift-g": "search::SelectPrevMatch",
-      "cmd-shift-m": "assistant::ToggleModelSelector",
+      "cmd-alt-/": "assistant::ToggleModelSelector",
       "cmd-k h": "assistant::DeployHistory",
       "cmd-k l": "assistant::DeployPromptLibrary",
       "cmd-n": "assistant::NewContext"
@@ -226,7 +226,7 @@
     "bindings": {
       "cmd-n": "assistant2::NewThread",
       "cmd-shift-h": "assistant2::OpenHistory",
-      "cmd-shift-m": "assistant2::ToggleModelSelector",
+      "cmd-alt-/": "assistant2::ToggleModelSelector",
       "cmd-shift-a": "assistant2::ToggleContextPicker",
       "cmd-alt-e": "assistant2::RemoveAllContext"
     }
@@ -616,6 +616,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "cmd-shift-a": "assistant2::ToggleContextPicker",
+      "cmd-alt-/": "assistant2::ToggleModelSelector",
       "cmd-alt-e": "assistant2::RemoveAllContext",
       "ctrl-[": "assistant::CyclePreviousInlineAssist",
       "ctrl-]": "assistant::CycleNextInlineAssist"

--- a/crates/assistant2/src/assistant_model_selector.rs
+++ b/crates/assistant2/src/assistant_model_selector.rs
@@ -1,5 +1,5 @@
 use fs::Fs;
-use gpui::View;
+use gpui::{FocusHandle, View};
 use language_model::LanguageModelRegistry;
 use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use settings::update_settings_file;
@@ -11,12 +11,14 @@ use crate::{assistant_settings::AssistantSettings, ToggleModelSelector};
 pub struct AssistantModelSelector {
     selector: View<LanguageModelSelector>,
     menu_handle: PopoverMenuHandle<LanguageModelSelector>,
+    focus_handle: FocusHandle,
 }
 
 impl AssistantModelSelector {
     pub(crate) fn new(
         fs: Arc<dyn Fs>,
         menu_handle: PopoverMenuHandle<LanguageModelSelector>,
+        focus_handle: FocusHandle,
         cx: &mut WindowContext,
     ) -> Self {
         Self {
@@ -34,6 +36,7 @@ impl AssistantModelSelector {
                 )
             }),
             menu_handle,
+            focus_handle,
         }
     }
 }
@@ -41,7 +44,7 @@ impl AssistantModelSelector {
 impl Render for AssistantModelSelector {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let active_model = LanguageModelRegistry::read_global(cx).active_model();
-        let focus_handle = self.selector.focus_handle(cx).clone();
+        let focus_handle = self.focus_handle.clone();
 
         LanguageModelSelectorPopoverMenu::new(
             self.selector.clone(),
@@ -49,7 +52,6 @@ impl Render for AssistantModelSelector {
                 .style(ButtonStyle::Subtle)
                 .child(
                     h_flex()
-                        .w_full()
                         .gap_0p5()
                         .child(
                             div()

--- a/crates/assistant2/src/inline_prompt_editor.rs
+++ b/crates/assistant2/src/inline_prompt_editor.rs
@@ -842,7 +842,12 @@ impl PromptEditor<BufferCodegen> {
             context_strip,
             context_picker_menu_handle,
             model_selector: cx.new_view(|cx| {
-                AssistantModelSelector::new(fs, model_selector_menu_handle.clone(), cx)
+                AssistantModelSelector::new(
+                    fs,
+                    model_selector_menu_handle.clone(),
+                    prompt_editor.focus_handle(cx),
+                    cx,
+                )
             }),
             model_selector_menu_handle,
             edited_since_done: false,
@@ -989,7 +994,12 @@ impl PromptEditor<TerminalCodegen> {
             context_strip,
             context_picker_menu_handle,
             model_selector: cx.new_view(|cx| {
-                AssistantModelSelector::new(fs, model_selector_menu_handle.clone(), cx)
+                AssistantModelSelector::new(
+                    fs,
+                    model_selector_menu_handle.clone(),
+                    prompt_editor.focus_handle(cx),
+                    cx,
+                )
             }),
             model_selector_menu_handle,
             edited_since_done: false,

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -100,7 +100,12 @@ impl MessageEditor {
             inline_context_picker,
             inline_context_picker_menu_handle,
             model_selector: cx.new_view(|cx| {
-                AssistantModelSelector::new(fs, model_selector_menu_handle.clone(), cx)
+                AssistantModelSelector::new(
+                    fs,
+                    model_selector_menu_handle.clone(),
+                    editor.focus_handle(cx),
+                    cx,
+                )
             }),
             model_selector_menu_handle,
             use_tools: false,


### PR DESCRIPTION
We weren't showing the keybinding in none of the places where the model selector was visible. Also, I took advantage of the opportunity to change the keybinding for two reasons:

1. `cmd-shift-m` caused conflict if on an editor (inline assistant case)
2. `cmd-opt-/` is the one Cursor uses; so consistency with something that might be already consolidated sounds like a low-hanging fruit

| Editor Inline Assist | Terminal Inline Assist | Assistant Panel |
|--------|--------|--------|
| <img width="1336" alt="Screenshot 2025-01-10 at 11 01 24 AM" src="https://github.com/user-attachments/assets/0782f217-025f-4bc0-b2fa-64b3524c968b" /> | <img width="1336" alt="Screenshot 2025-01-10 at 11 01 29 AM" src="https://github.com/user-attachments/assets/d05a3b5c-33fd-4593-b1d8-aa9944de816a" /> | <img width="1336" alt="Screenshot 2025-01-10 at 11 01 33 AM" src="https://github.com/user-attachments/assets/8cb075e7-ccde-46f5-aa05-d20a9d42b286" /> | 

Release Notes:

- N/A
