### PR TITLE
assistant2: Fix context strip context popover position in relation to trigger

### DIFF
--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -190,7 +190,7 @@ impl Render for ContextStrip {
                     .anchor(gpui::Corner::BottomLeft)
                     .offset(gpui::Point {
                         x: px(0.0),
-                        y: px(-16.0),
+                        y: px(-2.0),
                     })
                     .with_handle(self.context_picker_menu_handle.clone()),
             )


### PR DESCRIPTION
Little visual adjustment here.

| Before | After |
|--------|--------|
| <img width="1336" alt="Screenshot 2025-01-10 at 11 08 06 AM" src="https://github.com/user-attachments/assets/268c6df6-fdb2-4a1c-b3b8-d6a39b93b206" /> | <img width="1336" alt="Screenshot 2025-01-10 at 11 06 17 AM" src="https://github.com/user-attachments/assets/fb53feef-9ae4-489b-9d12-bd50b349afc1" /> | 

Release Notes:

- N/A
