### PR TITLE
assistant2: Change suggested file context pill label

### DIFF
--- a/crates/assistant2/src/ui/context_pill.rs
+++ b/crates/assistant2/src/ui/context_pill.rs
@@ -145,14 +145,16 @@ impl RenderOnce for ContextPill {
                         .color(Color::Muted),
                 )
                 .child(
-                    Label::new(match kind {
-                        ContextKind::File => "Open File",
-                        ContextKind::Thread | ContextKind::Directory | ContextKind::FetchedUrl => {
-                            "Active"
-                        }
-                    })
-                    .size(LabelSize::XSmall)
-                    .color(Color::Muted),
+                    div().px_0p5().child(
+                        Label::new(match kind {
+                            ContextKind::File => "Active Tab",
+                            ContextKind::Thread
+                            | ContextKind::Directory
+                            | ContextKind::FetchedUrl => "Active",
+                        })
+                        .size(LabelSize::XSmall)
+                        .color(Color::Muted),
+                    ),
                 )
                 .child(
                     Icon::new(IconName::Plus)


### PR DESCRIPTION
Changing it from "Open File" to "Active Tab" instead.

<img width="800" alt="Screenshot 2025-01-10 at 11 09 54 AM" src="https://github.com/user-attachments/assets/534e94a4-df61-41d4-ad50-514ab9a87e4e" />

Release Notes:

- N/A
