### PR TITLE
eslint: Allow configuring `workingDirectory`

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -379,6 +379,11 @@ impl LspAdapter for EsLintLspAdapter {
             }
         }
 
+        let working_directory = eslint_user_settings
+            .get("workingDirectory")
+            .cloned()
+            .unwrap_or_else(|| json!({"mode": "auto"}));
+
         let problems = eslint_user_settings
             .get("problems")
             .cloned()
@@ -400,7 +405,7 @@ impl LspAdapter for EsLintLspAdapter {
                 "rulesCustomizations": rules_customizations,
                 "run": "onType",
                 "nodePath": node_path,
-                "workingDirectory": {"mode": "auto"},
+                "workingDirectory": working_directory,
                 "workspaceFolder": {
                     "uri": workspace_root,
                     "name": workspace_root.file_name()

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -153,6 +153,24 @@ You can configure ESLint's `rulesCustomizations` setting:
 }
 ```
 
+### Configure ESLint's `workingDirectory`:
+
+You can configure ESLint's `workingDirectory` setting:
+
+```json
+{
+  "lsp": {
+    "eslint": {
+      "settings": {
+        "workingDirectory": {
+          "mode": "auto"
+        }
+      }
+    }
+  }
+}
+```
+
 ## See also
 
 - [Yarn documentation](./yarn.md) for a walkthrough of configuring your project to use Yarn.


### PR DESCRIPTION
This addresses this comment here: https://github.com/zed-industries/zed/issues/9648#issuecomment-2579246865

Release Notes:

- Added ability to configure `workingDirectory` when using ESLint. Example: `{"lsp": {"eslint": {"settings": {"workingDirectory": {"mode": "auto" }}}}}`
