### PR TITLE
emacs: Add  as Transpose Characters (editor::Transpose)

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -29,6 +29,7 @@
       "alt-u": "editor::ConvertToUpperCase", // upcase-word
       "alt-l": "editor::ConvertToLowerCase", // downcase-word
       "alt-c": "editor::ConvertToUpperCamelCase", // capitalize-word
+      "ctrl-t": "editor::Transpose", // transpose-chars
       "alt-;": ["editor::ToggleComments", { "advance_downwards": false }],
       "ctrl-x ctrl-;": "editor::ToggleComments",
       "alt-.": "editor::GoToDefinition", // xref-find-definitions

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -29,6 +29,7 @@
       "alt-u": "editor::ConvertToUpperCase", // upcase-word
       "alt-l": "editor::ConvertToLowerCase", // downcase-word
       "alt-c": "editor::ConvertToUpperCamelCase", // capitalize-word
+      "ctrl-t": "editor::Transpose", // transpose-chars
       "alt-;": ["editor::ToggleComments", { "advance_downwards": false }],
       "ctrl-x ctrl-;": "editor::ToggleComments",
       "alt-.": "editor::GoToDefinition", // xref-find-definitions


### PR DESCRIPTION
Originally reported here:
- https://github.com/zed-industries/zed/issues/4856#issuecomment-2578468329

macOS default vscode keymap already has this:
https://github.com/zed-industries/zed/blob/8d42456b8a7c547c6760b604c24d902bd2e12b8b/assets/keymaps/default-macos.json#L55
But it's disabled on Linux default vscode keymap as VSCode has this bind instead:
https://github.com/zed-industries/zed/blob/8d42456b8a7c547c6760b604c24d902bd2e12b8b/assets/keymaps/default-linux.json#L407

Explicitly add it to both emacs keymaps so we can keep them identical between macos/linux as long as possible.

Release Notes:

- emacs: Add support for `ctrl-t` transposing characters on Linux
