### PR TITLE
assistant2: Hide the status bar icon when disabled via the settings

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -279,7 +279,12 @@ impl Panel for AssistantPanel {
         Some(proto::PanelId::AssistantPanel)
     }
 
-    fn icon(&self, _cx: &WindowContext) -> Option<IconName> {
+    fn icon(&self, cx: &WindowContext) -> Option<IconName> {
+        let settings = AssistantSettings::get_global(cx);
+        if !settings.enabled || !settings.button {
+            return None;
+        }
+
         Some(IconName::ZedAssistant2)
     }
 


### PR DESCRIPTION
This PR makes it so the status bar icon for Assistant2 is hidden when it is disabled via the settings.

Release Notes:

- N/A
