### PR TITLE
project_panel: Add precise drag-and-drop for files onto folded directories

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3720,15 +3720,24 @@ impl ProjectPanel {
                                         SharedString::new_static(std::path::MAIN_SEPARATOR_STR);
                                     for (index, component) in components.into_iter().enumerate() {
                                         if index != 0 {
+                                                let delimiter_target_index = index - 1;
+                                                let target_entry_id = folded_ancestors.ancestors.get(components_len - 1 - delimiter_target_index).cloned();
                                                 this = this.child(
                                                     div()
+                                                    .on_drop(cx.listener(move |this, selections: &DraggedSelection, cx| {
+                                                        this.hover_scroll_task.take();
+                                                        this.folded_directory_drag_target = None;
+                                                        if let Some(target_entry_id) = target_entry_id {
+                                                            this.drag_onto(selections, target_entry_id, kind.is_file(), cx);
+                                                        }
+                                                    }))
                                                     .on_drag_move(cx.listener(
                                                         move |this, event: &DragMoveEvent<DraggedSelection>, _| {
                                                             if event.bounds.contains(&event.event.position) {
                                                                 this.folded_directory_drag_target = Some(
                                                                     FoldedDirectoryDragTarget {
                                                                         entry_id,
-                                                                        index,
+                                                                        index: delimiter_target_index,
                                                                         is_delimiter_target: true,
                                                                     }
                                                                 );
@@ -3736,7 +3745,7 @@ impl ProjectPanel {
                                                                 let is_current_target = this.folded_directory_drag_target
                                                                     .map_or(false, |target|
                                                                         target.entry_id == entry_id &&
-                                                                        target.index == index &&
+                                                                        target.index == delimiter_target_index &&
                                                                         target.is_delimiter_target
                                                                     );
                                                                 if is_current_target {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -112,7 +112,7 @@ pub struct ProjectPanel {
 struct FoldedDirectoryDragTarget {
     entry_id: ProjectEntryId,
     index: usize,
-    // True if dragging over the delimiter rather than the component itself
+    /// Whether we are dragging over the delimiter rather than the component itself.
     is_delimiter_target: bool,
 }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3724,15 +3724,15 @@ impl ProjectPanel {
                                                 let target_entry_id = folded_ancestors.ancestors.get(components_len - 1 - delimiter_target_index).cloned();
                                                 this = this.child(
                                                     div()
-                                                    .on_drop(cx.listener(move |this, selections: &DraggedSelection, cx| {
+                                                    .on_drop(cx.listener(move |this, selections: &DraggedSelection, window, cx| {
                                                         this.hover_scroll_task.take();
                                                         this.folded_directory_drag_target = None;
                                                         if let Some(target_entry_id) = target_entry_id {
-                                                            this.drag_onto(selections, target_entry_id, kind.is_file(), cx);
+                                                            this.drag_onto(selections, target_entry_id, kind.is_file(), window, cx);
                                                         }
                                                     }))
                                                     .on_drag_move(cx.listener(
-                                                        move |this, event: &DragMoveEvent<DraggedSelection>, _| {
+                                                        move |this, event: &DragMoveEvent<DraggedSelection>, _, _| {
                                                             if event.bounds.contains(&event.event.position) {
                                                                 this.folded_directory_drag_target = Some(
                                                                     FoldedDirectoryDragTarget {
@@ -3783,7 +3783,7 @@ impl ProjectPanel {
                                                 let target_entry_id = folded_ancestors.ancestors.get(components_len - 1 - index).cloned();
                                                 div
                                                 .on_drag_move(cx.listener(
-                                                    move |this, event: &DragMoveEvent<DraggedSelection>, _| {
+                                                    move |this, event: &DragMoveEvent<DraggedSelection>, _, _| {
                                                     if event.bounds.contains(&event.event.position) {
                                                             this.folded_directory_drag_target = Some(
                                                                 FoldedDirectoryDragTarget {
@@ -3806,11 +3806,11 @@ impl ProjectPanel {
                                                         }
                                                     },
                                                 ))
-                                                .on_drop(cx.listener(move |this, selections: &DraggedSelection, cx| {
+                                                .on_drop(cx.listener(move |this, selections: &DraggedSelection, window,cx| {
                                                     this.hover_scroll_task.take();
                                                     this.folded_directory_drag_target = None;
                                                     if let Some(target_entry_id) = target_entry_id {
-                                                        this.drag_onto(selections, target_entry_id, kind.is_file(), cx);
+                                                        this.drag_onto(selections, target_entry_id, kind.is_file(), window, cx);
                                                     }
                                                 }))
                                                 .when(folded_directory_drag_target.map_or(false, |target|
@@ -4508,7 +4508,6 @@ impl Render for ProjectPanel {
 
 impl Render for DraggedProjectEntryView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let settings = ProjectPanelSettings::get_global(cx);
         let ui_font = ThemeSettings::get_global(cx).ui_font.clone();
         h_flex()
             .font(ui_font)

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3801,7 +3801,7 @@ impl ProjectPanel {
                                                     this.hover_scroll_task.take();
                                                     this.folded_directory_drag_target = None;
                                                     if let Some(target_entry_id) = target_entry_id {
-                                                        this.drag_onto(selections, target_entry_id.clone(), kind.is_file(), cx);
+                                                        this.drag_onto(selections, target_entry_id, kind.is_file(), cx);
                                                     }
                                                 }))
                                                 .when(folded_directory_drag_target.map_or(false, |target|


### PR DESCRIPTION
Closes #19192

1. Changed the drag overlay of entries for better visibility of where to drop.
2. Folded directories (except for the last folded one) will be highlighted as drop targets.
3. The delimiter between folded directories prevents the directory highlight from losing focus and acts as part of the directory to avoid flickering.

This works just like VS Code does.

[fold-drop.webm](https://github.com/user-attachments/assets/853f7c5e-3492-4f56-9736-6d0e3ef09325)

Release Notes:

- Added precise drag-and-drop for files onto folded directories in the Project Panel.
