### PR TITLE
ci: Install `cargo-nextest` with `--locked`

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Rust
       shell: bash -euxo pipefail {0}
       run: |
-        cargo install cargo-nextest
+        cargo install cargo-nextest --locked
 
     - name: Install Node
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo nextest
         shell: bash -euxo pipefail {0}
         run: |
-          cargo install cargo-nextest
+          cargo install cargo-nextest --locked
 
       - name: Limit target directory size
         shell: bash -euxo pipefail {0}


### PR DESCRIPTION
This PR makes it so we install `cargo-nextest` with `cargo install cargo-nextest --locked` in CI.

According to the [docs](https://nexte.st/docs/installation/from-source/), this is the **only** supported way to install `cargo-nextest` when building from source.

Release Notes:

- N/A
