### PR TITLE
Add "tool" support to go.mod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13775,8 +13775,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-gomod"
-version = "1.1.0"
-source = "git+https://github.com/ConradIrwin/tree-sitter-go-mod?rev=a5414c6789c00a7f7807e4229fbc3a5b0f0f668a#a5414c6789c00a7f7807e4229fbc3a5b0f0f668a"
+version = "1.1.1"
+source = "git+https://github.com/camdencheek/tree-sitter-go-mod?rev=6efb59652d30e0e9cd5f3b3a669afd6f1a926d3c#6efb59652d30e0e9cd5f3b3a669afd6f1a926d3c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13775,8 +13775,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-gomod"
-version = "1.0.2"
-source = "git+https://github.com/zed-industries/tree-sitter-go-mod?rev=a9aea5e358cde4d0f8ff20b7bc4fa311e359c7ca#a9aea5e358cde4d0f8ff20b7bc4fa311e359c7ca"
+version = "1.1.0"
+source = "git+https://github.com/ConradIrwin/tree-sitter-go-mod?rev=a5414c6789c00a7f7807e4229fbc3a5b0f0f668a#a5414c6789c00a7f7807e4229fbc3a5b0f0f668a"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,7 +490,7 @@ tree-sitter-css = "0.23"
 tree-sitter-elixir = "0.3"
 tree-sitter-embedded-template = "0.23.0"
 tree-sitter-go = "0.23"
-tree-sitter-go-mod = { git = "https://github.com/ConradIrwin/tree-sitter-go-mod", rev = "a5414c6789c00a7f7807e4229fbc3a5b0f0f668a", package = "tree-sitter-gomod" }
+tree-sitter-go-mod = { git = "https://github.com/camdencheek/tree-sitter-go-mod", rev = "6efb59652d30e0e9cd5f3b3a669afd6f1a926d3c", package = "tree-sitter-gomod" }
 tree-sitter-gowork = { git = "https://github.com/zed-industries/tree-sitter-go-work", rev = "acb0617bf7f4fda02c6217676cc64acb89536dc7" }
 tree-sitter-heex = { git = "https://github.com/zed-industries/tree-sitter-heex", rev = "1dd45142fbb05562e35b2040c6129c9bca346592" }
 tree-sitter-diff = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,7 +490,7 @@ tree-sitter-css = "0.23"
 tree-sitter-elixir = "0.3"
 tree-sitter-embedded-template = "0.23.0"
 tree-sitter-go = "0.23"
-tree-sitter-go-mod = { git = "https://github.com/zed-industries/tree-sitter-go-mod", rev = "a9aea5e358cde4d0f8ff20b7bc4fa311e359c7ca", package = "tree-sitter-gomod" }
+tree-sitter-go-mod = { git = "https://github.com/ConradIrwin/tree-sitter-go-mod", rev = "a5414c6789c00a7f7807e4229fbc3a5b0f0f668a", package = "tree-sitter-gomod" }
 tree-sitter-gowork = { git = "https://github.com/zed-industries/tree-sitter-go-work", rev = "acb0617bf7f4fda02c6217676cc64acb89536dc7" }
 tree-sitter-heex = { git = "https://github.com/zed-industries/tree-sitter-heex", rev = "1dd45142fbb05562e35b2040c6129c9bca346592" }
 tree-sitter-diff = "0.1.0"

--- a/crates/languages/src/gomod/highlights.scm
+++ b/crates/languages/src/gomod/highlights.scm
@@ -3,6 +3,7 @@
   "replace"
   "go"
   "toolchain"
+  "tool"
   "exclude"
   "retract"
   "module"


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixed highlighting of ["tool" directives](https://tip.golang.org/doc/go1.24#tools) in go.mod
