### PR TITLE
LSP debug logs: Default to soft wrap + fold long lines + autoscroll 

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10910,6 +10910,20 @@ impl Editor {
         self.fold_creases(ranges, true, cx);
     }
 
+    pub fn fold_ranges<T: ToOffset + Clone>(
+        &mut self,
+        ranges: Vec<Range<T>>,
+        auto_scroll: bool,
+        cx: &mut ViewContext<Self>,
+    ) {
+        let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+        let ranges = ranges
+            .into_iter()
+            .map(|r| Crease::simple(r, display_map.fold_placeholder.clone()))
+            .collect::<Vec<_>>();
+        self.fold_creases(ranges, auto_scroll, cx);
+    }
+
     pub fn fold_creases<T: ToOffset + Clone>(
         &mut self,
         creases: Vec<Crease<T>>,

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -1,13 +1,13 @@
 use collections::{HashMap, VecDeque};
 use copilot::Copilot;
-use editor::{actions::MoveToEnd, Editor, EditorEvent};
+use editor::{actions::MoveToEnd, scroll::Autoscroll, Editor, EditorEvent};
 use futures::{channel::mpsc, StreamExt};
 use gpui::{
     actions, div, AppContext, Context, Corner, EventEmitter, FocusHandle, FocusableView,
     IntoElement, Model, ModelContext, ParentElement, Render, Styled, Subscription, View,
     ViewContext, VisualContext, WeakModel, WindowContext,
 };
-use language::LanguageServerId;
+use language::{language_settings::SoftWrap, LanguageServerId};
 use lsp::{
     notification::SetTrace, IoKind, LanguageServer, LanguageServerName, MessageType,
     SetTraceParams, TraceValue,
@@ -649,6 +649,15 @@ impl LspLogView {
                             ],
                             cx,
                         );
+                        let entry_length = entry.len();
+                        if entry_length > 1024 {
+                            editor.fold_ranges(
+                                vec![last_point + 1024..last_point + entry_length],
+                                false,
+                                cx,
+                            );
+                        }
+                        editor.request_autoscroll(Autoscroll::fit(), cx);
                         editor.set_read_only(true);
                     });
                 }
@@ -691,6 +700,7 @@ impl LspLogView {
             editor.move_to_end(&MoveToEnd, cx);
             editor.set_read_only(true);
             editor.set_show_inline_completions(Some(false), cx);
+            editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
             editor
         });
         let editor_subscription = cx.subscribe(
@@ -728,6 +738,7 @@ impl LspLogView {
             editor.set_text(server_info, cx);
             editor.set_read_only(true);
             editor.set_show_inline_completions(Some(false), cx);
+            editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
             editor
         });
         let editor_subscription = cx.subscribe(


### PR DESCRIPTION
Closes #18737

Release notes:

- Improved LSP debug logs by defaulting to soft wrap and folding a suffix of long lines. Also adds autoscroll, so if the cursor is on the last line of the logs they will scroll like `tail`.
