### PR TITLE
Fix jank in LSP debug log autoscroll

### DIFF
--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -32,9 +32,15 @@ impl Autoscroll {
     pub fn focused() -> Self {
         Self::Strategy(AutoscrollStrategy::Focused)
     }
+
     /// Scrolls so that the newest cursor is roughly an n-th line from the top.
     pub fn top_relative(n: usize) -> Self {
         Self::Strategy(AutoscrollStrategy::TopRelative(n))
+    }
+
+    /// Scrolls so that the newest cursor is at the bottom.
+    pub fn bottom() -> Self {
+        Self::Strategy(AutoscrollStrategy::Bottom)
     }
 }
 

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -642,6 +642,8 @@ impl LspLogView {
                     log_view.editor.update(cx, |editor, cx| {
                         editor.set_read_only(false);
                         let last_point = editor.buffer().read(cx).len(cx);
+                        let newest_cursor_is_at_end =
+                            editor.selections.newest::<usize>(cx).start >= last_point;
                         editor.edit(
                             vec![
                                 (last_point..last_point, entry.trim()),
@@ -657,7 +659,10 @@ impl LspLogView {
                                 cx,
                             );
                         }
-                        editor.request_autoscroll(Autoscroll::fit(), cx);
+
+                        if newest_cursor_is_at_end {
+                            editor.request_autoscroll(Autoscroll::bottom(), cx);
+                        }
                         editor.set_read_only(true);
                     });
                 }


### PR DESCRIPTION
Not sure why scroll was janky with `Autoscroll::newest()`, but this appears to fix it.  Probably better to conditionally do the autoscroll requests anyway.

Release Notes:

- N/A