### PR TITLE
docs: Fix "copy" being used instead of "paste" in vim mode documentation

### DIFF
--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -424,7 +424,7 @@ The [Sneak motion](https://github.com/justinmk/vim-sneak) feature allows for qui
 
 ### Restoring common text editing keybindings
 
-If you're using vim mode on Linux or Windows, you may find it overrides keybindings you can't live without: `ctrl+v` to copy, `ctrl+f` to search, etc. You can restore them by copying this data into your keymap:
+If you're using vim mode on Linux or Windows, you may find it overrides keybindings you can't live without: `ctrl+v` to paste, `ctrl+f` to search, etc. You can restore them by copying this data into your keymap:
 
 ```json
 {


### PR DESCRIPTION
It seems the original author intended to write either "`ctrl+c` to copy" or "`ctrl+v` to paste". Updated to be "`ctrl+v` to paste".

Release Notes:

- N/A