### PR TITLE
Notify user about LSP errors from editor actions

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -73,7 +73,7 @@ use ui::{
 };
 use unicode_segmentation::UnicodeSegmentation;
 use util::{RangeExt, ResultExt};
-use workspace::{item::Item, Workspace};
+use workspace::{item::Item, notifications::NotifyTaskExt, Workspace};
 
 struct SelectionLayout {
     head: DisplayPoint,
@@ -314,32 +314,38 @@ impl EditorElement {
         register_action(view, cx, Editor::go_to_next_hunk);
         register_action(view, cx, Editor::go_to_prev_hunk);
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_definition(a, cx).detach_and_log_err(cx);
+            editor.go_to_definition(a, cx).detach_and_notify_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_definition_split(a, cx).detach_and_log_err(cx);
+            editor
+                .go_to_definition_split(a, cx)
+                .detach_and_notify_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_declaration(a, cx).detach_and_log_err(cx);
+            editor.go_to_declaration(a, cx).detach_and_notify_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_declaration_split(a, cx).detach_and_log_err(cx);
+            editor
+                .go_to_declaration_split(a, cx)
+                .detach_and_notify_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_implementation(a, cx).detach_and_log_err(cx);
+            editor.go_to_implementation(a, cx).detach_and_notify_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
             editor
                 .go_to_implementation_split(a, cx)
-                .detach_and_log_err(cx);
+                .detach_and_notify_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_type_definition(a, cx).detach_and_log_err(cx);
+            editor
+                .go_to_type_definition(a, cx)
+                .detach_and_notify_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
             editor
                 .go_to_type_definition_split(a, cx)
-                .detach_and_log_err(cx);
+                .detach_and_notify_err(cx);
         });
         register_action(view, cx, Editor::open_url);
         register_action(view, cx, Editor::open_selected_filename);
@@ -382,14 +388,14 @@ impl EditorElement {
         register_action(view, cx, Editor::expand_all_hunk_diffs);
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.format(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }
         });
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.format_selections(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }
@@ -399,42 +405,42 @@ impl EditorElement {
         register_action(view, cx, Editor::show_character_palette);
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.confirm_completion(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }
         });
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.compose_completion(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }
         });
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.confirm_code_action(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }
         });
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.rename(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }
         });
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.confirm_rename(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }
         });
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.find_all_references(action, cx) {
-                task.detach_and_log_err(cx);
+                task.detach_and_notify_err(cx);
             } else {
                 cx.propagate();
             }


### PR DESCRIPTION
Closes #22976

Release Notes:

* Improved visibility of errors from language servers by reporting them in the UI when the user invokes an LSP action.