### PR TITLE
Fix a completions panic when no fuzzy matches + inline completion

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -773,7 +773,7 @@ impl CompletionsMenu {
         let mut entries = self.entries.borrow_mut();
         if let Some(CompletionEntry::InlineCompletionHint(_)) = entries.first() {
             entries.truncate(1);
-            if inline_completion_was_selected {
+            if inline_completion_was_selected || matches.is_empty() {
                 self.selected_item = 0;
             } else {
                 self.selected_item = 1;


### PR DESCRIPTION
My mistake in #22977, in the case where the inline completion was not selected it set the index to 1 assuming there would be following match entries.