### PR TITLE
windows: Make git update work

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -576,10 +576,7 @@ impl Fs for RealFs {
     }
 
     async fn canonicalize(&self, path: &Path) -> Result<PathBuf> {
-        use util::paths::SanitizedPath;
-
-        let path = smol::fs::canonicalize(path).await?;
-        Ok(SanitizedPath::from(path).as_path().to_path_buf())
+        Ok(smol::fs::canonicalize(path).await?)
     }
 
     async fn is_file(&self, path: &Path) -> bool {

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -576,7 +576,10 @@ impl Fs for RealFs {
     }
 
     async fn canonicalize(&self, path: &Path) -> Result<PathBuf> {
-        Ok(smol::fs::canonicalize(path).await?)
+        use util::paths::SanitizedPath;
+
+        let path = smol::fs::canonicalize(path).await?;
+        Ok(SanitizedPath::from(path).as_path().to_path_buf())
     }
 
     async fn is_file(&self, path: &Path) -> bool {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1242,12 +1242,6 @@ impl LocalWorktree {
         let (scan_states_tx, mut scan_states_rx) = mpsc::unbounded();
         let background_scanner = cx.background_executor().spawn({
             let abs_path = &snapshot.abs_path;
-            #[cfg(target_os = "windows")]
-            let abs_path = abs_path
-                .as_path()
-                .canonicalize()
-                .unwrap_or_else(|_| abs_path.as_path().to_path_buf());
-            #[cfg(not(target_os = "windows"))]
             let abs_path = abs_path.as_path().to_path_buf();
             let background = cx.background_executor().clone();
             async move {


### PR DESCRIPTION
According to the following log, I guess it is the UNC path that causes git to fail to open the repo. So I fix it and it passes the test.

```
2025-01-11T22:45:36.6470196+08:00 [INFO] building git repository, `.git` path in the worktree: "\\\\?\\E:\\project\\rust\\test\\.git"
2025-01-11T22:46:13.4766226+08:00 [ERROR] oneshot canceled

Stack backtrace:
   0: git_filter_source_flags
   1: git_filter_source_flags
   2: git_trace_set
   3: git_filter_source_repo
   4: git_filter_source_repo
   5: git_filter_source_repo
   6: git_filter_source_repo
   7: git_filter_source_repo
   8: git_filter_source_repo
   9: git_filter_source_repo
  10: git_odb_object_size
  11: git_odb_object_size
  12: git_odb_object_size
  13: git_odb_object_size
  14: git_filter_source_flags
  15: git_odb_object_size
  16: git_trace_set
  17: BaseThreadInitThunk
  18: RtlUserThreadStart
```

Release Notes:

- N/A