### PR TITLE
Do not try to activate the terminal panel twice

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -75,6 +75,7 @@ pub struct TerminalPanel {
     deferred_tasks: HashMap<TaskId, Task<()>>,
     assistant_enabled: bool,
     assistant_tab_bar_button: Option<AnyView>,
+    active: bool,
 }
 
 impl TerminalPanel {
@@ -95,6 +96,7 @@ impl TerminalPanel {
             deferred_tasks: HashMap::default(),
             assistant_enabled: false,
             assistant_tab_bar_button: None,
+            active: false,
         };
         terminal_panel.apply_tab_bar_buttons(&terminal_panel.active_pane, cx);
         terminal_panel
@@ -1339,7 +1341,9 @@ impl Panel for TerminalPanel {
     }
 
     fn set_active(&mut self, active: bool, cx: &mut ViewContext<Self>) {
-        if !active || !self.has_no_terminals(cx) {
+        let old_active = self.active;
+        self.active = active;
+        if !active || old_active == active || !self.has_no_terminals(cx) {
             return;
         }
         cx.defer(|this, cx| {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/23023

Fixes terminal pane button opening two terminals on click.

The culprit is in
https://github.com/zed-industries/zed/blob/61115bd04792d87a540558753cd01a6368baba2a/crates/workspace/src/workspace.rs#L2412-L2417

* We cannot get any panel by index from the Dock, only an active one
* Both `dock.activate_panel(panel_index, cx);` and `dock.set_open(true, cx);` do `active_panel.panel.set_active(true, cx);`

So, follow other pane's impls that have `active: bool` property for this case, e.g. https://github.com/zed-industries/zed/blob/3ec52d8451dd1178c4d036da3a71c827df422f4b/crates/assistant/src/inline_assistant.rs#L2687

Release Notes:

- Fixed terminal pane button opening two terminals on click
