### PR TITLE
Reuse vtsls logic for completion details display

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -212,9 +212,18 @@ impl LspAdapter for TypeScriptLspAdapter {
             _ => None,
         }?;
 
-        let text = match &item.detail {
-            Some(detail) => format!("{} {}", item.label, detail),
-            None => item.label.clone(),
+        let one_line = |s: &str| s.replace("    ", "").replace('\n', " ");
+
+        let text = if let Some(description) = item
+            .label_details
+            .as_ref()
+            .and_then(|label_details| label_details.description.as_ref())
+        {
+            format!("{} {}", item.label, one_line(description))
+        } else if let Some(detail) = &item.detail {
+            format!("{} {}", item.label, one_line(detail))
+        } else {
+            item.label.clone()
         };
 
         Some(language::CodeLabel {


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/22833, https://github.com/zed-industries/zed/issues/22267, https://github.com/zed-industries/zed/issues/22503

Before:
![image](https://github.com/user-attachments/assets/b6abd3dc-b5d7-4d6a-91e2-92361a519adb)
![image](https://github.com/user-attachments/assets/e3a9e766-efbe-4f4d-b4f9-e6b019e165a5)

After:
![image](https://github.com/user-attachments/assets/d29414d5-4fcc-4d2f-adb2-48304cbafdf6)

Copies https://github.com/zed-industries/zed/pull/15087 change into `typescript-language-server`-related label details rendering code.

Release Notes:

- Improved typescript-language-server's completion details rendering
