### PR TITLE
terminal: Fix unresponsive buttons on load until center pane is clicked + Auto-focus docked terminal on load if no other item is focused

### DIFF
--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -11,8 +11,8 @@ use util::ResultExt as _;
 
 use db::{define_connection, query, sqlez::statement::Statement, sqlez_macros::sql};
 use workspace::{
-    ItemHandle, ItemId, Member, Pane, PaneAxis, PaneGroup, SerializableItem as _, Workspace,
-    WorkspaceDb, WorkspaceId,
+    ItemId, Member, Pane, PaneAxis, PaneGroup, SerializableItem as _, Workspace, WorkspaceDb,
+    WorkspaceId,
 };
 
 use crate::{
@@ -145,14 +145,14 @@ fn populate_pane_items(
     active_item: Option<u64>,
     cx: &mut ViewContext<Pane>,
 ) {
-    let mut item_index = pane.items_len();
     for item in items {
-        let activate_item = Some(item.item_id().as_u64()) == active_item;
         pane.add_item(Box::new(item), false, false, None, cx);
-        item_index += 1;
-        if activate_item {
-            pane.activate_item(item_index, false, false, cx);
-        }
+    }
+    let active_index = pane
+        .items()
+        .position(|item| Some(item.item_id().as_u64()) == active_item);
+    if let Some(index) = active_index {
+        pane.activate_item(index, false, false, cx);
     }
 }
 

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -11,8 +11,8 @@ use util::ResultExt as _;
 
 use db::{define_connection, query, sqlez::statement::Statement, sqlez_macros::sql};
 use workspace::{
-    ItemId, Member, Pane, PaneAxis, PaneGroup, SerializableItem as _, Workspace, WorkspaceDb,
-    WorkspaceId,
+    ItemHandle, ItemId, Member, Pane, PaneAxis, PaneGroup, SerializableItem as _, Workspace,
+    WorkspaceDb, WorkspaceId,
 };
 
 use crate::{
@@ -145,13 +145,16 @@ fn populate_pane_items(
     active_item: Option<u64>,
     cx: &mut ViewContext<Pane>,
 ) {
+    let mut item_index = pane.items_len();
+    let mut active_item_index = None;
     for item in items {
+        if Some(item.item_id().as_u64()) == active_item {
+            active_item_index = Some(item_index);
+        }
         pane.add_item(Box::new(item), false, false, None, cx);
+        item_index += 1;
     }
-    let active_index = pane
-        .items()
-        .position(|item| Some(item.item_id().as_u64()) == active_item);
-    if let Some(index) = active_index {
+    if let Some(index) = active_item_index {
         pane.activate_item(index, false, false, cx);
     }
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -83,7 +83,6 @@ impl TerminalPanel {
         let project = workspace.project();
         let pane = new_terminal_pane(workspace.weak_handle(), project.clone(), false, cx);
         let center = PaneGroup::new(pane.clone());
-        cx.focus_view(&pane);
         let terminal_panel = Self {
             center,
             active_pane: pane,
@@ -282,6 +281,14 @@ impl TerminalPanel {
                 task.await.log_err();
             }
         }
+
+        terminal_panel
+            .update(&mut cx, |terminal_panel, cx| {
+                terminal_panel.active_pane.update(cx, |pane, cx| {
+                    pane.focus_active_item(cx);
+                });
+            })
+            .ok();
 
         Ok(terminal_panel)
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2307,13 +2307,12 @@ impl Workspace {
         position: DockPosition,
         cx: &mut ViewContext<Self>,
     ) -> bool {
-        for dock in [&self.left_dock, &self.bottom_dock, &self.right_dock] {
-            let dock = dock.read(cx);
-            if dock.position() == position && dock.is_open() {
-                return true;
-            }
-        }
-        false
+        let dock = match position {
+            DockPosition::Left => &self.left_dock,
+            DockPosition::Bottom => &self.bottom_dock,
+            DockPosition::Right => &self.right_dock,
+        };
+        dock.read(cx).is_open()
     }
 
     pub fn toggle_dock(&mut self, dock_side: DockPosition, cx: &mut ViewContext<Self>) {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2302,6 +2302,20 @@ impl Workspace {
         }
     }
 
+    pub fn is_dock_at_position_open(
+        &self,
+        position: DockPosition,
+        cx: &mut ViewContext<Self>,
+    ) -> bool {
+        for dock in [&self.left_dock, &self.bottom_dock, &self.right_dock] {
+            let dock = dock.read(cx);
+            if dock.position() == position && dock.is_open() {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn toggle_dock(&mut self, dock_side: DockPosition, cx: &mut ViewContext<Self>) {
         let dock = match dock_side {
             DockPosition::Left => &self.left_dock,


### PR DESCRIPTION
Closes #23006

This PR should have been split into two, but since the changes are related, I merged them into one.

1. On load, the title bar actions and bottom bar toggles are unresponsive until the center pane is clicked. This happens because the terminal captures focus (even if it's closed) long after the workspace sets focus to itself during loading.

The issue was in the `focus_view` call used in the `new` method of `TerminalPanel`. Since new terminal views can be created behind the scenes (i.e., without the terminal being visible to the user), we shouldn't handle focus for the terminal in this case. Removing `focus_view` from the `new` method has no impact on the existing terminal focusing logic. I've tested scenarios such as creating new terminals, splitting terminals, zooming, etc., and everything works as expected.

2. Currently, on load, docked terminals do not automatically focus when they are only visible item to the user. This PR implements it.

Before/After:

1. When only the dock terminal is visible on load. Terminal is focused.

<img src="https://github.com/user-attachments/assets/af8848aa-ccb5-4a3b-b2c6-486e8d588f09" alt="image" height="280px" />

<img src="https://github.com/user-attachments/assets/8f76ca2e-de29-4cc0-979b-749b50a00bbd" alt="image" height="280px" />

2. When other items are visible along with the dock terminal on load. Editor is focused.

<img src="https://github.com/user-attachments/assets/d3248272-a75d-4763-9e99-defb8a369b68" alt="image" height="280px" />

<img src="https://github.com/user-attachments/assets/fba5184e-1ab2-406c-9669-b141aaf1c32f" alt="image" height="280px" />

3. Multiple tabs along with split panes. Last terminal is focused.

<img src="https://github.com/user-attachments/assets/7a10c3cf-8bb3-4b88-aacc-732b678bee19" alt="image" height="270px" />

<img src="https://github.com/user-attachments/assets/4d16e98f-9d7a-45f6-8701-d6652e411d3b" alt="image" height="270px" />

Future:

When a docked terminal is in a zoomed state and Zed is loaded, we should prioritize focusing on the terminal over the active item (e.g., an editor) behind it. This hasn't been implemented in this PR because the zoomed state during the load function is stale. The correct state is received later via the workspace. I'm still investigating where exactly this should be handled, so this will be a separate PR.

cc: @SomeoneToIgnore 

Release Notes:

- Fixed unresponsive buttons on load until the center pane is clicked.  
- Added auto-focus for the docked terminal on load when no other item is focused.
