### PR TITLE
For informational LSP queries log errors instead of notifying in UI

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -314,38 +314,32 @@ impl EditorElement {
         register_action(view, cx, Editor::go_to_next_hunk);
         register_action(view, cx, Editor::go_to_prev_hunk);
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_definition(a, cx).detach_and_notify_err(cx);
+            editor.go_to_definition(a, cx).detach_and_log_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor
-                .go_to_definition_split(a, cx)
-                .detach_and_notify_err(cx);
+            editor.go_to_definition_split(a, cx).detach_and_log_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_declaration(a, cx).detach_and_notify_err(cx);
+            editor.go_to_declaration(a, cx).detach_and_log_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor
-                .go_to_declaration_split(a, cx)
-                .detach_and_notify_err(cx);
+            editor.go_to_declaration_split(a, cx).detach_and_log_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor.go_to_implementation(a, cx).detach_and_notify_err(cx);
+            editor.go_to_implementation(a, cx).detach_and_log_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
             editor
                 .go_to_implementation_split(a, cx)
-                .detach_and_notify_err(cx);
+                .detach_and_log_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
-            editor
-                .go_to_type_definition(a, cx)
-                .detach_and_notify_err(cx);
+            editor.go_to_type_definition(a, cx).detach_and_log_err(cx);
         });
         register_action(view, cx, |editor, a, cx| {
             editor
                 .go_to_type_definition_split(a, cx)
-                .detach_and_notify_err(cx);
+                .detach_and_log_err(cx);
         });
         register_action(view, cx, Editor::open_url);
         register_action(view, cx, Editor::open_selected_filename);
@@ -440,7 +434,7 @@ impl EditorElement {
         });
         register_action(view, cx, |editor, action, cx| {
             if let Some(task) = editor.find_all_references(action, cx) {
-                task.detach_and_notify_err(cx);
+                task.detach_and_log_err(cx);
             } else {
                 cx.propagate();
             }


### PR DESCRIPTION
I added these notifies in #23011, but in practive have found them to be overly disruptive. It would definitely be good to do something better than logging here, but having a sticky error notification is worse. I think it is still good to notify on mutation failures, so left those in

In particular with rust-analyzer, "Go to definition" and "Find references" frequently fail with "Content modified" quite a while after sending the request.  Since users are probably used to these operations being finicky it doesn't seem useful to have a prominent display of errors for them.