### PR TITLE
Map window after set_app_id() under X11

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -432,6 +432,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         Decorations::Server
     }
     fn set_app_id(&mut self, _app_id: &str) {}
+    fn map_window(&mut self) -> anyhow::Result<()> { Ok(()) } // We may want to set_app_id() first before map the window to display.
     fn window_controls(&self) -> WindowControls {
         WindowControls::default()
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -432,7 +432,9 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         Decorations::Server
     }
     fn set_app_id(&mut self, _app_id: &str) {}
-    fn map_window(&mut self) -> anyhow::Result<()> { Ok(()) } // We may want to set_app_id() first before map the window to display.
+    fn map_window(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
     fn window_controls(&self) -> WindowControls {
         WindowControls::default()
     }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -590,7 +590,6 @@ impl X11WindowState {
                 BladeRenderer::new(gpu_context, &raw_window, config)?
             };
 
-            check_reply(|| "X11 MapWindow failed.", xcb.map_window(x_window))?;
             let display = Rc::new(X11Display::new(xcb, scale_factor, x_screen_index)?);
 
             Ok(Self {
@@ -1276,6 +1275,11 @@ impl PlatformWindow for X11Window {
             ),
         )
         .unwrap();
+    }
+
+    fn map_window(&mut self) -> anyhow::Result<()> {
+        check_reply(|| "X11 MapWindow failed.", self.0.xcb.map_window(self.0.x_window))?;
+        Ok(())
     }
 
     fn set_edited(&mut self, _edited: bool) {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1278,7 +1278,10 @@ impl PlatformWindow for X11Window {
     }
 
     fn map_window(&mut self) -> anyhow::Result<()> {
-        check_reply(|| "X11 MapWindow failed.", self.0.xcb.map_window(self.0.x_window))?;
+        check_reply(
+            || "X11 MapWindow failed.",
+            self.0.xcb.map_window(self.0.x_window),
+        )?;
         Ok(())
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -783,6 +783,8 @@ impl Window {
             platform_window.set_app_id(&app_id);
         }
 
+        platform_window.map_window().unwrap();
+
         Ok(Window {
             handle,
             removed: false,


### PR DESCRIPTION
GPUI applications can set the window class by the `app_id` window option. However, GPUI will map the window first and then change the window class after the window is displayed. This doesn't work on some X11 window managers. FVWM, for example, does not track window class after a window is mapped. Because in practice, a window shouldn't change its application group on the fly.

This PR fixed this by adding a `map_window()` function `PlatformWindow`. On X11, it will `set_app_id()` first and then map the window.

Release Notes:

- N/A