### PR TITLE
vim: Fix vim delete to line

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -435,12 +435,6 @@
     }
   },
   {
-    "context": "vim_operator == d && VimCount",
-    "bindings": {
-      "shift-g": "vim::StartOfDocument" // "d x G"
-    }
-  },
-  {
     "context": "vim_operator == gu",
     "bindings": {
       "g u": "vim::CurrentLine",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -435,6 +435,12 @@
     }
   },
   {
+    "context": "vim_operator == d && VimCount",
+    "bindings": {
+      "shift-g": "vim::StartOfDocument" // "d x G"
+    }
+  },
+  {
     "context": "vim_operator == gu",
     "bindings": {
       "g u": "vim::CurrentLine",

--- a/crates/vim/src/normal/delete.rs
+++ b/crates/vim/src/normal/delete.rs
@@ -50,7 +50,7 @@ impl Vim {
                             {
                                 selection.end = next_line
                             }
-                            Motion::EndOfDocument {} => {
+                            Motion::EndOfDocument {} if times.is_none() => {
                                 // Deleting until the end of the document includes the last line, including
                                 // soft-wrapped lines.
                                 selection.end = map.max_point()

--- a/crates/vim/src/normal/delete.rs
+++ b/crates/vim/src/normal/delete.rs
@@ -487,6 +487,41 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_delete_to_line(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.simulate(
+            "d 3 shift-g",
+            indoc! {"
+            The quick
+            brownˇ fox
+            jumps over
+            the lazy"},
+        )
+        .await
+        .assert_matches();
+        cx.simulate(
+            "d 3 shift-g",
+            indoc! {"
+            The quick
+            brown fox
+            jumps over
+            the lˇazy"},
+        )
+        .await
+        .assert_matches();
+        cx.simulate(
+            "d 2 shift-g",
+            indoc! {"
+            The quick
+            brown fox
+            jumps over
+            ˇ"},
+        )
+        .await
+        .assert_matches();
+    }
+
+    #[gpui::test]
     async fn test_delete_gg(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
         cx.simulate(

--- a/crates/vim/test_data/test_delete_to_line.json
+++ b/crates/vim/test_data/test_delete_to_line.json
@@ -1,0 +1,15 @@
+{"Put":{"state":"The quick\nbrownˇ fox\njumps over\nthe lazy"}}
+{"Key":"d"}
+{"Key":"3"}
+{"Key":"shift-g"}
+{"Get":{"state":"The quick\nthe lˇazy","mode":"Normal"}}
+{"Put":{"state":"The quick\nbrown fox\njumps over\nthe lˇazy"}}
+{"Key":"d"}
+{"Key":"3"}
+{"Key":"shift-g"}
+{"Get":{"state":"The quick\nbrownˇ fox","mode":"Normal"}}
+{"Put":{"state":"The quick\nbrown fox\njumps over\nˇ"}}
+{"Key":"d"}
+{"Key":"2"}
+{"Key":"shift-g"}
+{"Get":{"state":"ˇThe quick","mode":"Normal"}}


### PR DESCRIPTION
Closes #23024

Release Notes:

- Fixed Vim `dxG` delete to line
