### PR TITLE
assistant2: Make `Esc` cancel current completion

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -80,6 +80,12 @@ impl ActiveThread {
         self.thread.read(cx).summary_or_default()
     }
 
+    pub fn cancel_last_completion(&mut self, cx: &mut AppContext) -> bool {
+        self.last_error.take();
+        self.thread
+            .update(cx, |thread, _cx| thread.cancel_last_completion())
+    }
+
     pub fn last_error(&self) -> Option<ThreadError> {
         self.last_error.clone()
     }

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -143,6 +143,11 @@ impl AssistantPanel {
         &self.thread_store
     }
 
+    fn cancel(&mut self, _: &editor::actions::Cancel, cx: &mut ViewContext<Self>) {
+        self.thread
+            .update(cx, |thread, cx| thread.cancel_last_completion(cx));
+    }
+
     fn new_thread(&mut self, cx: &mut ViewContext<Self>) {
         let thread = self
             .thread_store
@@ -611,6 +616,7 @@ impl Render for AssistantPanel {
             .key_context("AssistantPanel2")
             .justify_between()
             .size_full()
+            .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(|this, _: &NewThread, cx| {
                 this.new_thread(cx);
             }))

--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -502,6 +502,17 @@ impl Thread {
             };
         }
     }
+
+    /// Cancels the last pending completion, if there are any pending.
+    ///
+    /// Returns whether a completion was canceled.
+    pub fn cancel_last_completion(&mut self) -> bool {
+        if let Some(_last_completion) = self.pending_completions.pop() {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR makes it so pressing `Esc` in Assistant2 will cancel the current completion.

Release Notes:

- N/A
