### PR TITLE
Show configuration in language server debug logs

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -460,7 +460,14 @@ impl Copilot {
             server
                 .on_notification::<StatusNotification, _>(|_, _| { /* Silence the notification */ })
                 .detach();
-            let server = cx.update(|cx| server.initialize(None, cx))?.await?;
+
+            let initialize_params = None;
+            let configuration = lsp::DidChangeConfigurationParams {
+                settings: Default::default(),
+            };
+            let server = cx
+                .update(|cx| server.initialize(initialize_params, configuration.into(), cx))?
+                .await?;
 
             let status = server
                 .request::<request::CheckStatus>(request::CheckStatusParams {

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -732,13 +732,17 @@ impl LspLogView {
 
 * Running in project: {PATH:?}
 
-* Capabilities: {CAPABILITIES}",
+* Capabilities: {CAPABILITIES}
+
+* Configuration: {CONFIGURATION}",
                 NAME = server.name(),
                 ID = server.server_id(),
                 BINARY = server.binary(),
                 PATH = server.root_path(),
                 CAPABILITIES = serde_json::to_string_pretty(&server.capabilities())
                     .unwrap_or_else(|e| format!("Failed to serialize capabilities: {e}")),
+                CONFIGURATION = serde_json::to_string_pretty(server.configuration())
+                    .unwrap_or_else(|e| format!("Failed to serialize configuration: {e}")),
             );
             editor.set_text(server_info, cx);
             editor.set_read_only(true);

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -88,6 +88,8 @@ impl JsonLspAdapter {
         let tsconfig_schema = serde_json::Value::from_str(TSCONFIG_SCHEMA).unwrap();
         let package_json_schema = serde_json::Value::from_str(PACKAGE_JSON_SCHEMA).unwrap();
 
+        // This can be viewed via `debug: open language server logs` -> `json-language-server` ->
+        // `Server Info`
         serde_json::json!({
             "json": {
                 "format": {

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -282,8 +282,15 @@ impl Prettier {
             cx.clone(),
         )
         .context("prettier server creation")?;
+
+        let initialize_params = None;
+        let configuration = lsp::DidChangeConfigurationParams {
+            settings: Default::default(),
+        };
         let server = cx
-            .update(|cx| executor.spawn(server.initialize(None, cx)))?
+            .update(|cx| {
+                executor.spawn(server.initialize(initialize_params, configuration.into(), cx))
+            })?
             .await
             .context("prettier server initialization")?;
         Ok(Self::Real(RealPrettier {

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -255,6 +255,8 @@ impl KeymapFile {
             .definitions
             .insert("KeymapAction".to_owned(), action_schema);
 
+        // This and other json schemas can be viewed via `debug: open language server logs` ->
+        // `json-language-server` -> `Server Info`.
         serde_json::to_value(root_schema).unwrap()
     }
 


### PR DESCRIPTION
Release Notes:

- Added configuration sent on initialization to the `Server Info` section of the language server logs.