### PR TITLE
terminal: Drain task output on completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,8 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b9241459831fee2f22fcda52ddaf9e449b6627334a0f40f13a1b3344018060"
+version = "0.25.0-dev"
+source = "git+https://github.com/alacritty/alacritty.git?rev=5e78d20c709cb1ab8d44ca7a8702cc26d779227c#5e78d20c709cb1ab8d44ca7a8702cc26d779227c"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.6.0",
@@ -102,7 +101,7 @@ dependencies = [
  "signal-hook",
  "unicode-width",
  "vte",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14275,26 +14274,15 @@ dependencies = [
 
 [[package]]
 name = "vte"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eb22ae96f050e0c0d6f7ce43feeae26c348fc4dea56928ca81537cfaa6188b"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "bitflags 2.6.0",
  "cursor-icon",
  "log",
+ "memchr",
  "serde",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,8 @@ zeta = { path = "crates/zeta" }
 #
 
 aho-corasick = "1.1"
-alacritty_terminal = "0.24"
+# TODO(#18342): Update to version 0.25 from crates.io when it is released.
+alacritty_terminal = { git = "https://github.com/alacritty/alacritty.git", rev = "5e78d20c709cb1ab8d44ca7a8702cc26d779227c" }
 any_vec = "0.14"
 anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }

--- a/crates/repl/src/outputs/plain.rs
+++ b/crates/repl/src/outputs/plain.rs
@@ -186,10 +186,10 @@ impl TerminalOutput {
         for byte in text.as_bytes() {
             if *byte == b'\n' {
                 // Dirty (?) hack to move the cursor down
-                self.parser.advance(&mut self.handler, b'\r');
-                self.parser.advance(&mut self.handler, b'\n');
+                self.parser.advance(&mut self.handler, &[b'\r']);
+                self.parser.advance(&mut self.handler, &[b'\n']);
             } else {
-                self.parser.advance(&mut self.handler, *byte);
+                self.parser.advance(&mut self.handler, &[*byte]);
             }
         }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -376,7 +376,7 @@ impl TerminalBuilder {
                 working_directory: working_directory
                     .clone()
                     .or_else(|| Some(home_dir().to_path_buf())),
-                hold: false,
+                drain_on_exit: true,
                 env: env.into_iter().collect(),
             }
         };
@@ -441,7 +441,7 @@ impl TerminalBuilder {
             term.clone(),
             ZedListener(events_tx.clone()),
             pty,
-            pty_options.hold,
+            pty_options.drain_on_exit,
             false,
         )?;
 


### PR DESCRIPTION
Now we ensure that task output is fully drained and printed to Zed terminal pane on task completion.

This change depends on a recent change to alacritty_terminal crate: https://github.com/alacritty/alacritty/commit/5e78d20c709cb1ab8d44ca7a8702cc26d779227c.

Closes https://github.com/zed-industries/zed/issues/18342

Release Notes:

- Fixed missing task terminal output on Linux for short-running commands
