### PR TITLE
Add support for vim `Operator::AddSurrounds.target` in keymap config

### DIFF
--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -207,7 +207,10 @@ impl Vim {
                 }
                 Some(Operator::AddSurrounds { target: None }) => {
                     waiting_operator = Some(Operator::AddSurrounds {
-                        target: Some(SurroundsType::Object(object, around)),
+                        target: Some(SurroundsType::Object {
+                            target: object,
+                            around,
+                        }),
                     });
                 }
                 Some(Operator::ToggleComments) => self.toggle_comments_object(object, around, cx),

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -65,33 +65,16 @@ pub enum Operator {
     Delete,
     Yank,
     Replace,
-    Object {
-        around: bool,
-    },
-    FindForward {
-        before: bool,
-    },
-    FindBackward {
-        after: bool,
-    },
-    Sneak {
-        first_char: Option<char>,
-    },
-    SneakBackward {
-        first_char: Option<char>,
-    },
-    AddSurrounds {
-        #[serde(skip)]
-        target: Option<SurroundsType>,
-    },
-    ChangeSurrounds {
-        target: Option<Object>,
-    },
+    Object { around: bool },
+    FindForward { before: bool },
+    FindBackward { after: bool },
+    Sneak { first_char: Option<char> },
+    SneakBackward { first_char: Option<char> },
+    AddSurrounds { target: Option<SurroundsType> },
+    ChangeSurrounds { target: Option<Object> },
     DeleteSurrounds,
     Mark,
-    Jump {
-        line: bool,
-    },
+    Jump { line: bool },
     Indent,
     Outdent,
     AutoIndent,
@@ -99,12 +82,8 @@ pub enum Operator {
     Lowercase,
     Uppercase,
     OppositeCase,
-    Digraph {
-        first_char: Option<char>,
-    },
-    Literal {
-        prefix: Option<String>,
-    },
+    Digraph { first_char: Option<char> },
+    Literal { prefix: Option<String> },
     Register,
     RecordRegister,
     ReplayRegister,

--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -6,14 +6,20 @@ use crate::{
 };
 use editor::{movement, scroll::Autoscroll, Bias};
 use language::BracketPair;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use std::sync::Arc;
 use ui::ViewContext;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Eq)]
 pub enum SurroundsType {
+    #[serde(skip)]
     Motion(Motion),
-    Object(Object, bool),
+    Object {
+        target: Object,
+        around: bool,
+    },
     Selection,
 }
 
@@ -49,8 +55,8 @@ impl Vim {
 
                 for selection in &display_selections {
                     let range = match &target {
-                        SurroundsType::Object(object, around) => {
-                            object.range(&display_map, selection.clone(), *around)
+                        SurroundsType::Object { target, around } => {
+                            target.range(&display_map, selection.clone(), *around)
                         }
                         SurroundsType::Motion(motion) => {
                             motion


### PR DESCRIPTION
cc @ConradIrwin.  Found this while doing the keymap json schemas change.  Does it make sense?

Release Notes:

- N/A
