### PR TITLE
assistant2: Add floating indicator when a response is streaming

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -344,7 +344,30 @@ impl ActiveThread {
 }
 
 impl Render for ActiveThread {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
-        list(self.list_state.clone()).flex_1().py_1()
+    fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
+        let is_streaming_completion = self.thread.read(cx).is_streaming();
+
+        v_flex()
+            .size_full()
+            .child(list(self.list_state.clone()).flex_grow())
+            .child(
+                h_flex()
+                    .absolute()
+                    .bottom_1()
+                    .flex_shrink()
+                    .justify_center()
+                    .w_full()
+                    .when(is_streaming_completion, |parent| {
+                        parent.child(
+                            h_flex()
+                                .gap_2()
+                                .p_1p5()
+                                .rounded_md()
+                                .bg(cx.theme().colors().elevated_surface_background)
+                                .child(Label::new("Generating…").size(LabelSize::Small))
+                                .child(Label::new("esc to cancel").size(LabelSize::Small)),
+                        )
+                    }),
+            )
     }
 }


### PR DESCRIPTION
This PR adds a separate indicator at the bottom of the thread that shows when a response is being streamed (as well as how to cancel it):

<img width="1309" alt="Screenshot 2025-01-13 at 4 19 07 PM" src="https://github.com/user-attachments/assets/b64f785b-d522-458d-b915-3f604890597f" />

Release Notes:

- N/A
