### PR TITLE
cpp: Enable language server as formatter by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -978,7 +978,10 @@
     },
     "C++": {
       "format_on_save": "off",
-      "use_on_type_format": false
+      "use_on_type_format": false,
+      "prettier": {
+        "allowed": false
+      }
     },
     "CSS": {
       "prettier": {


### PR DESCRIPTION
As @hferreiro points out in [this
comment](https://github.com/zed-industries/zed/pull/18752#issuecomment-2589340565): C++ and prettier don't work well together, so let's make the default formatter for C++ the primary language server. We get that by disabling prettier.

Release Notes:

- Changed default formatter for C++ to be the primary language server, not Prettier. Format-on-save is still disabled by default for C++, but if one uses the `editor: format` command now, it will default to the language server. `clangd` can format C++ files, whereas prettier cannot.
