### PR TITLE
Disable Prettier for C projects by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -974,7 +974,10 @@
     },
     "C": {
       "format_on_save": "off",
-      "use_on_type_format": false
+      "use_on_type_format": false,
+      "prettier": {
+        "allowed": false
+      }
     },
     "C++": {
       "format_on_save": "off",


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/23112

Same reasoning applies.

Release Notes:

- Changed default formatter for C to be the primary language server, not Prettier. Format-on-save is still disabled by default for C, but if one uses the editor: format command now, it will default to the language server. clangd can format C files, whereas prettier cannot.

