### PR TITLE
zeta: Rework displaying paths in completion rating modal

### DIFF
--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -494,6 +494,9 @@ impl Render for RateCompletionModal {
                                                 (false, true) => (IconName::File, Color::Muted, "No Edits Produced"),
                                                 (false, false) => (IconName::FileDiff, Color::Accent, "Edits Available"),
                                             };
+                                            
+                                            let file_name = completion.path.file_name().map(|f| f.to_string_lossy().to_string()).unwrap_or("untitled".to_string());
+                                            let file_path = completion.path.parent().map(|p| p.to_string_lossy().to_string());
 
                                             ListItem::new(completion.id)
                                                 .inset(true)
@@ -511,7 +514,11 @@ impl Render for RateCompletionModal {
                                                         )
                                                         .child(
                                                             v_flex()
-                                                                .child(Label::new(completion.path.to_string_lossy().to_string()).size(LabelSize::Small))
+                                                                .child(
+                                                                    h_flex().gap_2()
+                                                                        .child(Label::new(file_name).size(LabelSize::Small))
+                                                                        .when_some(file_path, |this, p| this.child(Label::new(p).size(LabelSize::Small).color(Color::Muted)))
+                                                                )
                                                                 .child(Label::new(format!("{} ago, {:.2?}", format_time_ago(completion.response_received_at.elapsed()), completion.latency()))
                                                                     .color(Color::Muted)
                                                                     .size(LabelSize::XSmall)

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -494,7 +494,7 @@ impl Render for RateCompletionModal {
                                                 (false, true) => (IconName::File, Color::Muted, "No Edits Produced"),
                                                 (false, false) => (IconName::FileDiff, Color::Accent, "Edits Available"),
                                             };
-                                            
+
                                             let file_name = completion.path.file_name().map(|f| f.to_string_lossy().to_string()).unwrap_or("untitled".to_string());
                                             let file_path = completion.path.parent().map(|p| p.to_string_lossy().to_string());
 

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -293,7 +293,7 @@ impl Zeta {
         let events = self.events.clone();
         let path = snapshot
             .file()
-            .map(|f| f.path().clone())
+            .map(|f| Arc::from(f.full_path(cx).as_path()))
             .unwrap_or_else(|| Arc::from(Path::new("untitled")));
 
         let client = self.client.clone();


### PR DESCRIPTION
Two issues i ran into while looking at the completion rating modal
- Single-file worktrees file names are not displayed at all
- Hard to see the filename when the path is long (lots of directories)

This PR fixes this by displaying the filename on the left, followed by the full path (including the worktree name), similar to how we do it in the file finder/assistant panel /file command
| Before | After |
|--------|--------|
| <img width="1067" alt="Screenshot 2025-01-14 at 16 09 05" src="https://github.com/user-attachments/assets/628fde18-da9a-4d98-8ddf-ed0ab0cd8d35" /> | <img width="1161" alt="Screenshot 2025-01-14 at 16 17 52" src="https://github.com/user-attachments/assets/80c6a4e1-065d-4b0a-b9c0-5f3391af4557" /> | 





Release Notes:

- N/A
