### PR TITLE
git: Restore basic jump-to-file functionality

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -333,7 +333,9 @@ impl GitPanel {
                 Event::OpenedEntry { path } => {
                     workspace
                         .open_path_preview(path, None, false, false, cx)
-                        .detach_and_prompt_err("Couldn't open file", cx, |_, _| None);
+                        .detach_and_prompt_err("Failed to open file", cx, |e, _| {
+                            Some(format!("{e}"))
+                        });
                 }
                 Event::Focus => { /* TODO */ }
             }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -327,8 +327,8 @@ impl GitPanel {
             git_panel
         });
 
-        cx.subscribe(&git_panel, {
-            let git_panel = git_panel.downgrade();
+        cx.subscribe(
+            &git_panel,
             move |workspace, _, event: &Event, cx| match event.clone() {
                 Event::OpenedEntry { path } => {
                     workspace
@@ -338,8 +338,8 @@ impl GitPanel {
                         });
                 }
                 Event::Focus => { /* TODO */ }
-            }
-        })
+            },
+        )
         .detach();
 
         git_panel
@@ -574,7 +574,7 @@ impl GitPanel {
     }
 
     fn open_entry(&self, entry: &GitListEntry, cx: &mut ViewContext<Self>) {
-        let Some((worktree_id, path)) = GitState::get_global(cx).update(cx, |state, cx| {
+        let Some((worktree_id, path)) = GitState::get_global(cx).update(cx, |state, _| {
             state.active_repository.as_ref().and_then(|(id, repo, _)| {
                 Some((*id, repo.work_directory.unrelativize(&entry.repo_path)?))
             })

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -332,7 +332,7 @@ impl GitPanel {
             move |workspace, _, event: &Event, cx| match event.clone() {
                 Event::OpenedEntry { path } => {
                     workspace
-                        .open_path_preview(path, None, true, true, cx)
+                        .open_path_preview(path, None, false, false, cx)
                         .detach_and_prompt_err("Couldn't open file", cx, |_, _| None);
                 }
                 Event::Focus => { /* TODO */ }
@@ -580,6 +580,12 @@ impl GitPanel {
             return;
         };
         let path = (worktree_id, path).into();
+        let path_exists = self.project.update(cx, |project, cx| {
+            project.entry_for_path(&path, cx).is_some()
+        });
+        if !path_exists {
+            return;
+        }
         cx.emit(Event::OpenedEntry { path });
     }
 


### PR DESCRIPTION
This just opens the file for the selected `GitListEntry` right now; we'll add back integration with the project diff view later.

Release Notes:

- N/A
