### PR TITLE
assistant2: Cancel pending completion when an error occurs

### DIFF
--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -361,7 +361,7 @@ impl Thread {
             let result = stream_completion.await;
 
             thread
-                .update(&mut cx, |_thread, cx| match result.as_ref() {
+                .update(&mut cx, |thread, cx| match result.as_ref() {
                     Ok(stop_reason) => match stop_reason {
                         StopReason::ToolUse => {
                             cx.emit(ThreadEvent::UsePendingTools);
@@ -384,6 +384,8 @@ impl Thread {
                                 SharedString::from(error_message.clone()),
                             )));
                         }
+
+                        thread.cancel_last_completion();
                     }
                 })
                 .ok();


### PR DESCRIPTION
This PR makes it so the pending completion is cleared when an error occurs.

This makes it so `Thread::is_streaming()` will return `false` in the error case (and thus hide the streaming indicator in the UI).

Release Notes:

- N/A
