### PR TITLE
Git panel polish

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -842,11 +842,14 @@ impl GitPanel {
             .child(
                 h_flex()
                     .gap_2()
-                    .child(Checkbox::new(
-                        "all-changes",
-                        self.all_staged
-                            .map_or(ToggleState::Indeterminate, ToggleState::from),
-                    ))
+                    .child(
+                        Checkbox::new(
+                            "all-changes",
+                            self.all_staged
+                                .map_or(ToggleState::Selected, ToggleState::from),
+                        )
+                        .disabled(self.no_entries()),
+                    )
                     .child(div().text_buffer(cx).text_ui_sm(cx).child(changes_string)),
             )
             .child(div().flex_grow())

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -486,8 +486,7 @@ impl GitPanel {
             let new_selected_entry = if selected_entry > 0 {
                 selected_entry - 1
             } else {
-                self.selected_entry = Some(item_count - 1);
-                item_count - 1
+                selected_entry
             };
 
             self.selected_entry = Some(new_selected_entry);

--- a/crates/ui/src/components/toggle.rs
+++ b/crates/ui/src/components/toggle.rs
@@ -1,4 +1,4 @@
-use gpui::{div, hsla, prelude::*, ElementId, Hsla, IntoElement, Styled, WindowContext};
+use gpui::{div, hsla, prelude::*, AnyView, ElementId, Hsla, IntoElement, Styled, WindowContext};
 use std::sync::Arc;
 
 use crate::utils::is_light;
@@ -44,6 +44,7 @@ pub struct Checkbox {
     on_click: Option<Box<dyn Fn(&ToggleState, &mut WindowContext) + 'static>>,
     filled: bool,
     style: ToggleStyle,
+    tooltip: Option<Box<dyn Fn(&mut WindowContext) -> AnyView>>,
 }
 
 impl Checkbox {
@@ -56,6 +57,7 @@ impl Checkbox {
             on_click: None,
             filled: false,
             style: ToggleStyle::default(),
+            tooltip: None,
         }
     }
 
@@ -89,6 +91,12 @@ impl Checkbox {
     /// Match the style of the checkbox to the current elevation using [`ToggleStyle::ElevationBased`].
     pub fn elevation(mut self, elevation: ElevationIndex) -> Self {
         self.style = ToggleStyle::ElevationBased(elevation);
+        self
+    }
+
+    /// Sets the tooltip for the checkbox.
+    pub fn tooltip(mut self, tooltip: impl Fn(&mut WindowContext) -> AnyView + 'static) -> Self {
+        self.tooltip = Some(Box::new(tooltip));
         self
     }
 }
@@ -176,6 +184,9 @@ impl RenderOnce for Checkbox {
                     this.on_click(move |_, cx| on_click(&self.toggle_state.inverse(), cx))
                 },
             )
+            .when_some(self.tooltip, |this, tooltip| {
+                this.tooltip(move |cx| tooltip(cx))
+            })
     }
 }
 


### PR DESCRIPTION
- Clicking checkbox in the header stages or unstages all changes
- Adds tooltips to header checkbox
- Addis the ability for checkboxes to have tooltips
- Ensure an entry in the list is always selected
- Hide revert all button for now

Release Notes:

- N/A
