### PR TITLE
Make ZED_WORKTREE_ROOT always point to a directory or is not set

### DIFF
--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -489,7 +489,7 @@ impl ContextProvider for BasicContextProvider {
         if !selected_text.trim().is_empty() {
             task_variables.insert(VariableName::SelectedText, selected_text);
         }
-        let worktree_abs_path =
+        let worktree_root_dir =
             buffer
                 .file()
                 .map(|file| file.worktree_id(cx))
@@ -497,9 +497,9 @@ impl ContextProvider for BasicContextProvider {
                     self.worktree_store
                         .read(cx)
                         .worktree_for_id(worktree_id, cx)
-                        .map(|worktree| worktree.read(cx).abs_path())
+                        .map(|worktree| worktree.read(cx).root_dir())
                 });
-        if let Some(worktree_path) = worktree_abs_path {
+        if let Some(Some(worktree_path)) = worktree_root_dir {
             task_variables.insert(
                 VariableName::WorktreeRoot,
                 worktree_path.to_string_lossy().to_string(),


### PR DESCRIPTION
See: https://github.com/zed-industries/zed/issues/22912

When the out-of-tree file like `tasks.json` is selected, the `ZED_WORKTREE_ROOT` is now unset.

This fixes the immediate problem with `ZED_WORKTREE_ROOT` pointing to the file, but the desired long-term behavior is still under discussion.

At the moment, `BasicContextProvider::build_context` does not have any information about the active project, so there is no way to get the root directory of the active project without plumbing in more context.

Release Notes:

- Fixed `ZED_WORKTREE_ROOT` incorrectly pointing to a file. Now points to a directory when current file is a project or unset when in out-of-project files (settings.json, tasks.json, etc).