### PR TITLE
zeta: Display menu entry before prediction

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -590,7 +590,9 @@ impl CompletionsMenu {
                                     )
                                     .when(state.is_none(), |element| {
                                         element.end_slot(
-                                            Label::new("No completions").size(LabelSize::XSmall),
+                                            Label::new("No completions")
+                                                .size(LabelSize::XSmall)
+                                                .color(Color::Muted),
                                         )
                                     })
                                     .on_click(cx.listener(move |editor, _event, cx| {
@@ -662,8 +664,9 @@ impl CompletionsMenu {
                         ),
                     InlineCompletionText::Move(text) => div().child(text.clone()),
                 },
-                InlineCompletionMenuState::Loading => return None,
-                InlineCompletionMenuState::None => return None,
+                InlineCompletionMenuState::Loading | InlineCompletionMenuState::None => {
+                    return None
+                }
             },
         };
 

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -321,6 +321,7 @@ pub struct Icon {
     color: Color,
     size: Rems,
     transformation: Transformation,
+    alpha: Option<f32>,
 }
 
 impl Icon {
@@ -330,6 +331,7 @@ impl Icon {
             color: Color::default(),
             size: IconSize::default().rems(),
             transformation: Transformation::default(),
+            alpha: None,
         }
     }
 
@@ -339,6 +341,7 @@ impl Icon {
             color: Color::default(),
             size: IconSize::default().rems(),
             transformation: Transformation::default(),
+            alpha: None,
         }
     }
 
@@ -362,6 +365,11 @@ impl Icon {
 
     pub fn transform(mut self, transformation: Transformation) -> Self {
         self.transformation = transformation;
+        self
+    }
+
+    pub fn alpha(mut self, alpha: f32) -> Self {
+        self.alpha = Some(alpha);
         self
     }
 }


### PR DESCRIPTION
The completion menu entry for Zeta will now be displayed even while loading and it'll be focused by default. This prevents the flickering we currently have. We decided not to show a spinner because it'd only appear for a few ms and it'd look distracting. 



https://github.com/user-attachments/assets/e1c1be55-ff93-4538-ac2d-4c6612150a57




In the rare case that Zeta produces no suggestions, but the language server does, we'll display a "No completions" label. 

<img width=400 src="https://github.com/user-attachments/assets/a3d6613e-ea1c-4879-99d0-0c391f15b1b6">

Danilo will refine the styling of the above.

Release Notes:

- N/A