### PR TITLE
settings: Rename 'zeta' to 'zed'

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -201,7 +201,7 @@ impl Render for InlineCompletionButton {
                 );
             }
 
-            InlineCompletionProvider::Zeta => {
+            InlineCompletionProvider::Zed => {
                 if !cx.has_flag::<ZetaFeatureFlag>() {
                     return div();
                 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -203,7 +203,7 @@ pub enum InlineCompletionProvider {
     #[default]
     Copilot,
     Supermaven,
-    Zeta,
+    Zed,
 }
 
 /// The settings for inline completions, such as [GitHub Copilot](https://github.com/features/copilot)

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -164,7 +164,7 @@ fn assign_inline_completion_provider(
                 editor.set_inline_completion_provider(Some(provider), cx);
             }
         }
-        language::language_settings::InlineCompletionProvider::Zeta => {
+        language::language_settings::InlineCompletionProvider::Zed => {
             if cx.has_flag::<ZetaFeatureFlag>()
                 || (cfg!(debug_assertions) && client.status().borrow().is_connected())
             {


### PR DESCRIPTION
Old:

```settings.json
{
  "features": {
    "inline_completion_provider": "zeta"
  }
}
```

New & cool:

```settings.json
{
  "features": {
    "inline_completion_provider": "zed"
  }
}
```

Release Notes:

- N/A