### PR TITLE
vim: Fix inline completions not disappearing in normal mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1732,8 +1732,12 @@ impl Editor {
         self.input_enabled = input_enabled;
     }
 
-    pub fn set_inline_completions_enabled(&mut self, enabled: bool) {
+    pub fn set_inline_completions_enabled(&mut self, enabled: bool, cx: &mut ViewContext<Self>) {
         self.enable_inline_completions = enabled;
+        if !self.enable_inline_completions {
+            self.take_active_inline_completion(cx);
+            cx.notify();
+        }
     }
 
     pub fn set_autoindent(&mut self, autoindent: bool) {
@@ -4785,6 +4789,7 @@ impl Editor {
                 || (!self.completion_tasks.is_empty() && !self.has_active_inline_completion()));
         if completions_menu_has_precedence
             || !offset_selection.is_empty()
+            || !self.enable_inline_completions
             || self
                 .active_inline_completion
                 .as_ref()

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1240,7 +1240,7 @@ impl Vim {
                     .map_or(false, |provider| provider.show_completions_in_normal_mode()),
                 _ => false,
             };
-            editor.set_inline_completions_enabled(enable_inline_completions);
+            editor.set_inline_completions_enabled(enable_inline_completions, cx);
         });
         cx.notify()
     }


### PR DESCRIPTION
Closes #23042

Release Notes:

- Fixed inline completions (Copilot, Supermaven, ...) still being visible sometimes after leaving Vim's insert mode.
