### PR TITLE
Revert "Log an error when there are no buffer snapshots for some LSP version (#22934)"

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2012,10 +2012,6 @@ impl LocalLspStore {
             snapshots.retain(|snapshot| snapshot.version + OLD_VERSIONS_TO_RETAIN >= version);
             Ok(found_snapshot)
         } else {
-            match buffer.read(cx).project_path(cx) {
-                Some(project_path) => log::error!("No LSP snapshots found for buffer with path {:?}", project_path.path),
-                None => log::error!("No LSP snapshots found for buffer without a project path (which is also unexpected)"),
-            }
             Ok((buffer.read(cx)).text_snapshot())
         }
     }


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/22934#issuecomment-2592239448 and myself had noted quite an increase in junk logging after that: 

https://github.com/user-attachments/assets/b678d4ec-c301-4d0e-9a12-99aa7f6da0a2


Release Notes:

- N/A
