### PR TITLE
Revert docs-only test-skipping with Merge Queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,31 +24,6 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  check_docs_only:
-    runs-on: ubuntu-latest
-    outputs:
-      docs_only: ${{ steps.check_changes.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
-      - name: Check for non-docs changes
-        id: check_changes
-        run: |
-          if [ "${{ github.event_name }}" == "merge_group" ]; then
-            # When we're running in a merge queue, never assume that the changes
-            # are docs-only, as there could be other PRs in the group that
-            # contain non-docs changes.
-            echo "Running in the merge queue"
-            echo "docs_only=false" >> $GITHUB_OUTPUT
-          elif git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -qvE '^docs/'; then
-            echo "Detected non-docs changes"
-            echo "docs_only=false" >> $GITHUB_OUTPUT
-          else
-            echo "Docs-only change"
-            echo "docs_only=true" >> $GITHUB_OUTPUT
-          fi
-
   migration_checks:
     name: Check Postgres and Protobuf migrations, mergability
     if: github.repository_owner == 'zed-industries'
@@ -116,12 +91,11 @@ jobs:
 
   macos_tests:
     timeout-minutes: 60
-    name: (macOS) Run Clippy and tests
+    name: macOS Tests and Clippy
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
       - test
-    needs: check_docs_only
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -129,35 +103,28 @@ jobs:
           clean: false
 
       - name: cargo clippy
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/clippy
 
       - name: Check unused dependencies
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         uses: bnjbvr/cargo-machete@main
 
       - name: Check licenses
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: |
           script/check-licenses
           script/generate-licenses /tmp/zed_licenses_output
 
       - name: Check for new vulnerable dependencies
-        if: github.event_name == 'pull_request' && needs.check_docs_only.outputs.docs_only == 'false'
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4
         with:
           license-check: false
 
       - name: Run tests
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         uses: ./.github/actions/run_tests
 
       - name: Build collab
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: cargo build -p collab
 
       - name: Build other binaries and features
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: |
           cargo build --workspace --bins --all-features
           cargo check -p gpui --features "macos-blade"
@@ -167,11 +134,10 @@ jobs:
 
   linux_tests:
     timeout-minutes: 60
-    name: (Linux) Run Clippy and tests
+    name: Linux Tests and Clippy
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
-    needs: check_docs_only
     steps:
       - name: Add Rust to the PATH
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -182,26 +148,21 @@ jobs:
           clean: false
 
       - name: Cache dependencies
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         uses: swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-provider: "buildjet"
 
       - name: Install Linux dependencies
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/linux
 
       - name: cargo clippy
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/clippy
 
       - name: Run tests
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         uses: ./.github/actions/run_tests
 
       - name: Build other binaries and features
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: |
           cargo build -p zed
           cargo check -p workspace
@@ -212,7 +173,6 @@ jobs:
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
-    needs: check_docs_only
     steps:
       - name: Add Rust to the PATH
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -223,27 +183,23 @@ jobs:
           clean: false
 
       - name: Cache dependencies
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         uses: swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-provider: "buildjet"
 
       - name: Install Clang & Mold
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/remote-server && ./script/install-mold 2.34.0
 
       - name: Build Remote Server
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: cargo build -p remote_server
 
   # todo(windows): Actually run the tests
   windows_tests:
     timeout-minutes: 60
-    name: (Windows) Run Clippy and tests
+    name: Windows Tests and Clippy
     if: github.repository_owner == 'zed-industries'
     runs-on: hosted-windows-1
-    needs: check_docs_only
     steps:
       # more info here:- https://github.com/rust-lang/cargo/issues/13020
       - name: Enable longer pathnames for git
@@ -254,19 +210,16 @@ jobs:
           clean: false
 
       - name: Cache dependencies
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         uses: swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-provider: "github"
 
       - name: cargo clippy
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         # Windows can't run shell scripts, so we need to use `cargo xtask`.
         run: cargo xtask clippy
 
       - name: Build Zed
-        if: needs.check_docs_only.outputs.docs_only == 'false'
         run: cargo build
 
   bundle-mac:
@@ -359,9 +312,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  bundle-linux:
+  bundle-linux-x86_x64:
     timeout-minutes: 60
-    name: Create a Linux bundle
+    name: Linux x86_x64 release bundle
     runs-on:
       - buildjet-16vcpu-ubuntu-2004
     if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling') }}
@@ -409,7 +362,7 @@ jobs:
 
   bundle-linux-aarch64: # this runs on ubuntu22.04
     timeout-minutes: 60
-    name: Create arm64 Linux bundle
+    name: Linux arm64 release bundle
     runs-on:
       - buildjet-16vcpu-ubuntu-2204-arm
     if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling') }}
@@ -458,7 +411,7 @@ jobs:
   auto-release-preview:
     name: Auto release preview
     if: ${{ startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-pre') && !endsWith(github.ref, '.0-pre') }}
-    needs: [bundle-mac, bundle-linux, bundle-linux-aarch64]
+    needs: [bundle-mac, bundle-linux-x86_x64, bundle-linux-aarch64]
     runs-on:
       - self-hosted
       - bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
   macos_tests:
     timeout-minutes: 60
-    name: macOS Tests and Clippy
+    name: (macOS) Run Clippy and tests
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
@@ -134,7 +134,7 @@ jobs:
 
   linux_tests:
     timeout-minutes: 60
-    name: Linux Tests and Clippy
+    name: (Linux) Run Clippy and tests
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
@@ -197,7 +197,7 @@ jobs:
   # todo(windows): Actually run the tests
   windows_tests:
     timeout-minutes: 60
-    name: Windows Tests and Clippy
+    name: (Windows) Run Clippy and tests
     if: github.repository_owner == 'zed-industries'
     runs-on: hosted-windows-1
     steps:


### PR DESCRIPTION
These checks were not functioning as intended.  Notably tests were skipped for today's hotfix release of Preview [v0.169.2-pre](https://github.com/zed-industries/zed/actions/runs/12790602047): 

<img width="802" alt="Screenshot 2025-01-15 at 10 42 35" src="https://github.com/user-attachments/assets/0ca9a07a-5e5e-48c1-a21e-05f308481cc7" />

Separately these checks were flawed as they would only be considered "docs only" if the diff between the PR branch base and main also did not have any subsequent non-docs changes.

Reverting until we can figure out something better.

Previously:
- https://github.com/zed-industries/zed/pull/22261
- https://github.com/zed-industries/zed/pull/22254

CC: @maxdeviant 

Release Notes:

- N/A
