### PR TITLE
Increase timeout for macos release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
         run: cargo build
 
   bundle-mac:
-    timeout-minutes: 60
+    timeout-minutes: 120
     name: Create a macOS bundle
     runs-on:
       - self-hosted


### PR DESCRIPTION
Today's Preview hotfix timed out during notarization:
- https://github.com/zed-industries/zed/actions/runs/12790602047/job/35656767355

Release Notes:

- N/A