### PR TITLE
Add fn-f keyboard shortcut for Fullscreen (mac-only)

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -37,6 +37,7 @@
       "cmd-h": "zed::Hide",
       "alt-cmd-h": "zed::HideOthers",
       "cmd-m": "zed::Minimize",
+      "fn-f": "zed::ToggleFullScreen",
       "ctrl-cmd-f": "zed::ToggleFullScreen"
     }
   },


### PR DESCRIPTION
- See: https://github.com/zed-industries/zed/issues/22674#issuecomment-2593133447

Release Notes:

- macos: Added `fn-f` keyboard shortcut for fullscreen toggle.