### PR TITLE
ci: Cleanup for disabled Merge Queue / merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
     branches:
       - "**"
-  merge_group:
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.
@@ -114,6 +113,7 @@ jobs:
           script/generate-licenses /tmp/zed_licenses_output
 
       - name: Check for new vulnerable dependencies
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4
         with:
           license-check: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-  merge_group:
 
 jobs:
   check_formatting:


### PR DESCRIPTION
Only run actions dependency-review-action if running in a PR action.

This broke when run as part of action for commit on main and on a preview branch:
- https://github.com/zed-industries/zed/actions/runs/12793068921/job/35664998296
- https://github.com/zed-industries/zed/actions/runs/12793045639

Originally introduced in:
- https://github.com/zed-industries/zed/pull/21424

CC: @cole-miller 

But was only tested with `merge_group` which has since been reverted.

Release Notes:

- N/A
