### PR TITLE
file_icons: Fall back to the default icon theme for icons

### DIFF
--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -12,7 +12,7 @@ use util::ResultExt;
 
 use crate::{
     read_user_theme, refine_theme_family, Appearance, IconTheme, Theme, ThemeFamily,
-    ThemeFamilyContent,
+    ThemeFamilyContent, DEFAULT_ICON_THEME_ID,
 };
 
 /// The metadata for a theme.
@@ -204,6 +204,11 @@ impl ThemeRegistry {
         self.insert_user_theme_families([theme]);
 
         Ok(())
+    }
+
+    /// Returns the default icon theme.
+    pub fn default_icon_theme(&self) -> Result<Arc<IconTheme>> {
+        self.get_icon_theme(DEFAULT_ICON_THEME_ID)
     }
 
     /// Returns the icon theme with the specified name.


### PR DESCRIPTION
This PR updates the various `FileIcons` methods to fall back to the default icon theme if the active icon theme does not have the desired icon.

Release Notes:

- N/A
