### PR TITLE
Remember active panel after closing dock

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -339,9 +339,6 @@ impl Dock {
             self.is_open = open;
             if let Some(active_panel) = self.active_panel_entry() {
                 active_panel.panel.set_active(open, cx);
-                if !open {
-                    self.active_panel_index = None;
-                }
             }
 
             cx.notify();


### PR DESCRIPTION
A recent change in #22730 (to reduce workspace serialization) means that a dock "forgets" its active panel whenever it is closed. When opened again, the change in #22346 (which establishes a panel activation order) takes effect, always opening the highest-priority panel for that dock instead of the panel the user previously manually activated.

The result is that if you have, say, the outline panel active on the right dock, and toggle the dock closed and then back open again, the assistant panel will always appear instead.

This PR reverts part of the change in #22730 to ensure a dock remembers its active panel when it is closed.

Closes #22923.

Release Notes:

- Fixed an issue where docks did not remember the active panel.
