### PR TITLE
Make language registry optional in `parse_markdown`

### DIFF
--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -538,7 +538,7 @@ async fn parse_markdown(text: &str, language_registry: &Arc<LanguageRegistry>) -
 
     markdown::parse_markdown_block(
         text,
-        language_registry,
+        Some(language_registry),
         None,
         &mut parsed_message.text,
         &mut parsed_message.highlights,

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -189,7 +189,7 @@ impl Editor {
                     if let Some(mut signature_help) = signature_help_task.await.into_iter().next() {
                         let mut parsed_content = parse_markdown(
                             signature_help.markdown.as_str(),
-                            &language_registry,
+                            Some(&language_registry),
                             language,
                         )
                         .await;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -256,7 +256,7 @@ pub async fn prepare_completion_documentation(
             }
 
             lsp::MarkupKind::Markdown => {
-                let parsed = parse_markdown(value, language_registry, language).await;
+                let parsed = parse_markdown(value, Some(language_registry), language).await;
                 Documentation::MultiLineMarkdown(parsed)
             }
         },

--- a/crates/language/src/markdown.rs
+++ b/crates/language/src/markdown.rs
@@ -121,7 +121,7 @@ impl Link {
 /// Parses a string of Markdown.
 pub async fn parse_markdown(
     markdown: &str,
-    language_registry: &Arc<LanguageRegistry>,
+    language_registry: Option<&Arc<LanguageRegistry>>,
     language: Option<Arc<Language>>,
 ) -> ParsedMarkdown {
     let mut text = String::new();
@@ -151,7 +151,7 @@ pub async fn parse_markdown(
 /// Parses a Markdown block.
 pub async fn parse_markdown_block(
     markdown: &str,
-    language_registry: &Arc<LanguageRegistry>,
+    language_registry: Option<&Arc<LanguageRegistry>>,
     language: Option<Arc<Language>>,
     text: &mut String,
     highlights: &mut Vec<(Range<usize>, MarkdownHighlight)>,
@@ -247,10 +247,13 @@ pub async fn parse_markdown_block(
                 Tag::CodeBlock(kind) => {
                     new_paragraph(text, &mut list_stack);
                     current_language = if let CodeBlockKind::Fenced(language) = kind {
-                        language_registry
-                            .language_for_name_or_extension(language.as_ref())
-                            .await
-                            .ok()
+                        match language_registry {
+                            None => None,
+                            Some(language_registry) => language_registry
+                                .language_for_name_or_extension(language.as_ref())
+                                .await
+                                .ok(),
+                        }
                     } else {
                         language.clone()
                     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4422,7 +4422,8 @@ impl LspStore {
             Documentation::Undocumented
         } else if response.documentation_is_markdown {
             Documentation::MultiLineMarkdown(
-                markdown::parse_markdown(&response.documentation, &language_registry, None).await,
+                markdown::parse_markdown(&response.documentation, Some(&language_registry), None)
+                    .await,
             )
         } else if response.documentation.lines().count() <= 1 {
             Documentation::SingleLine(response.documentation)


### PR DESCRIPTION
Motivation for this is using markdown for keymap error notifications in #23113

Release Notes:

- N/A