### PR TITLE
Fix configuration issue in CI runners  

### DIFF
--- a/.cargo/ci-config.toml
+++ b/.cargo/ci-config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-D", "warnings"]

--- a/.cargo/ci-config.toml
+++ b/.cargo/ci-config.toml
@@ -1,2 +1,12 @@
+# This config is different from config.toml in this directory, as the latter is recognized by Cargo.
+# This file is placed in ./../.cargo/config.toml on CI runs. Cargo then merges Zeds .cargo/config.toml with ./../.cargo/config.toml
+# with preference for settings from Zeds config.toml.
+# TL;DR: If a value is set in both ci-config.toml and config.toml, config.toml value takes precedence.
+# Arrays are merged together though. See: https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+# The intent for this file is to configure CI build process with a divergance from Zed developers experience; for example, in this config file
+# we use `-D warnings` for rustflags (which makes compilation fail in presence of warnings during build process). Placing that in developers `config.toml`
+# would be incovenient.
+# The reason for not using the RUSTFLAGS environment variable is that doing so would override all the settings in the config.toml file, even if the contents of the latter are completely nonsensical. 
+# Here, we opted to use `[target.'cfg(all())']` instead of `[build]` because `[target.'**']` is guaranteed to be cumulative.
 [target.'cfg(all())']
 rustflags = ["-D", "warnings"]

--- a/.cargo/ci-config.toml
+++ b/.cargo/ci-config.toml
@@ -6,7 +6,7 @@
 # The intent for this file is to configure CI build process with a divergance from Zed developers experience; for example, in this config file
 # we use `-D warnings` for rustflags (which makes compilation fail in presence of warnings during build process). Placing that in developers `config.toml`
 # would be incovenient.
-# The reason for not using the RUSTFLAGS environment variable is that doing so would override all the settings in the config.toml file, even if the contents of the latter are completely nonsensical. 
+# The reason for not using the RUSTFLAGS environment variable is that doing so would override all the settings in the config.toml file, even if the contents of the latter are completely nonsensical. See: https://github.com/rust-lang/cargo/issues/5376
 # Here, we opted to use `[target.'cfg(all())']` instead of `[build]` because `[target.'**']` is guaranteed to be cumulative.
 [target.'cfg(all())']
 rustflags = ["-D", "warnings"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           cargo build -p zed
           cargo check -p workspace
 
-      # Event the Linux runner is not stateful, in theory there is no need to do this cleanup.
+      # Even the Linux runner is not stateful, in theory there is no need to do this cleanup.
       # But, to avoid potential issues in the future if we choose to use a stateful Linux runner and forget to add code
       # to clean up the config file, I’ve included the cleanup code here as a precaution.
       # While it’s not strictly necessary at this moment, I believe it’s better to err on the side of caution.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1
-  RUSTFLAGS: "-D warnings"
 
 jobs:
   check_docs_only:
@@ -128,6 +127,11 @@ jobs:
         with:
           clean: false
 
+      - name: Configure CI
+        run: |
+          mkdir ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+
       - name: cargo clippy
         if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/clippy
@@ -192,6 +196,11 @@ jobs:
         if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/linux
 
+      - name: Configure CI
+        run: |
+          mkdir ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+
       - name: cargo clippy
         if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/clippy
@@ -233,6 +242,11 @@ jobs:
         if: needs.check_docs_only.outputs.docs_only == 'false'
         run: ./script/remote-server && ./script/install-mold 2.34.0
 
+      - name: Configure CI
+        run: |
+          mkdir ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+
       - name: Build Remote Server
         if: needs.check_docs_only.outputs.docs_only == 'false'
         run: cargo build -p remote_server
@@ -259,6 +273,11 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-provider: "github"
+
+      - name: Configure CI
+        run: |
+          mkdir ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
 
       - name: cargo clippy
         if: needs.check_docs_only.outputs.docs_only == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
       # Since the Windows runners are stateful, so we need to remove the config file to prevent potential bug.
       - name: Clean CI config file
         if: always()
-        run: rm -rf ./../.cargo
+        run: Remove-Item -Path "./../.cargo" -Recurse -Force
 
   bundle-mac:
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Configure CI
         run: |
-          mkdir ./../.cargo
+          mkdir -p ./../.cargo
           cp ./.cargo/ci-config.toml ./../.cargo/config.toml
 
       - name: cargo clippy
@@ -169,6 +169,11 @@ jobs:
           cargo build -p remote_server
           script/check-rust-livekit-macos
 
+      # Since the macOS runners are stateful, so we need to remove the config file to prevent potential bug.
+      - name: Clean CI config file
+        if: always()
+        run: rm -rf ./../.cargo
+
   linux_tests:
     timeout-minutes: 60
     name: (Linux) Run Clippy and tests
@@ -198,7 +203,7 @@ jobs:
 
       - name: Configure CI
         run: |
-          mkdir ./../.cargo
+          mkdir -p ./../.cargo
           cp ./.cargo/ci-config.toml ./../.cargo/config.toml
 
       - name: cargo clippy
@@ -214,6 +219,14 @@ jobs:
         run: |
           cargo build -p zed
           cargo check -p workspace
+
+      # Event the Linux runner is not stateful, in theory there is no need to do this cleanup.
+      # But, to avoid potential issues in the future if we choose to use a stateful Linux runner and forget to add code
+      # to clean up the config file, I’ve included the cleanup code here as a precaution.
+      # While it’s not strictly necessary at this moment, I believe it’s better to err on the side of caution.
+      - name: Clean CI config file
+        if: always()
+        run: rm -rf ./../.cargo
 
   build_remote_server:
     timeout-minutes: 60
@@ -244,12 +257,16 @@ jobs:
 
       - name: Configure CI
         run: |
-          mkdir ./../.cargo
+          mkdir -p ./../.cargo
           cp ./.cargo/ci-config.toml ./../.cargo/config.toml
 
       - name: Build Remote Server
         if: needs.check_docs_only.outputs.docs_only == 'false'
         run: cargo build -p remote_server
+
+      - name: Clean CI config file
+        if: always()
+        run: rm -rf ./../.cargo
 
   # todo(windows): Actually run the tests
   windows_tests:
@@ -276,7 +293,7 @@ jobs:
 
       - name: Configure CI
         run: |
-          mkdir ./../.cargo
+          mkdir -p ./../.cargo
           cp ./.cargo/ci-config.toml ./../.cargo/config.toml
 
       - name: cargo clippy
@@ -287,6 +304,11 @@ jobs:
       - name: Build Zed
         if: needs.check_docs_only.outputs.docs_only == 'false'
         run: cargo build
+
+      # Since the Windows runners are stateful, so we need to remove the config file to prevent potential bug.
+      - name: Clean CI config file
+        if: always()
+        run: rm -rf ./../.cargo
 
   bundle-mac:
     timeout-minutes: 60


### PR DESCRIPTION
While working on PR #23117, I noticed that the Windows runner in our CI setup doesn't seem to respect the settings defined in `.cargo/config.toml`. With @SomeoneToIgnore ’s help, Kirill and I realized this issue isn’t limited to the Windows runner—all of our runners disregard the configurations in `.cargo/config.toml`.  

Later, @osiewicz suggested an excellent workaround. I conducted some tests on PR #23117 and found that the solution works as intended.  

Personally, I prefer using environment variables for global configuration. However, according to the documentation [here](https://doc.rust-lang.org/cargo/reference/config.html), it seems that environment variables always override the settings in `.cargo/config.toml`.

Release Notes:

- N/A
