### PR TITLE
ci: Remove zero-width whitespace in job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       # To support writing comments that they will certainly be revisited.
-      - name: Check for todo​! and FIX​ME comments
+      - name: Check for todo! and FIXME comments
         run: script/check-todos
 
       - name: Run style checks

--- a/script/check-todos
+++ b/script/check-todos
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Brackets are used around characters so these don't show up in normal search.
 pattern='tod[o]!|FIXM[E]'
-result=$(git grep --no-color --ignore-case --line-number --extended-regexp -e $pattern || true)
+result=$(git grep --no-color --ignore-case --line-number --extended-regexp -e $pattern -- ':(exclude).github/workflows/ci.yml' || true)
 echo "${result}"
 if [[ -n "${result}" ]]; then
   exit 1


### PR DESCRIPTION
This PR removes some zero-width whitespace characters from one of the CI job names.

Release Notes:

- N/A
