### PR TITLE
Make docs-only PRs skip CI.yml test suite (15 secs instead of 15 minutes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,16 @@ on:
       - "v[0-9]+.[0-9]+.x"
     tags:
       - "v*"
+    paths-ignore:
+      - "docs/**/*"
+      - ".github/workflows/community_*"
+
   pull_request:
     branches:
       - "**"
+    paths-ignore:
+      - "docs/**/*"
+      - ".github/workflows/community_*"
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.


### PR DESCRIPTION
These were previously in place, but removed while we evaluated Merge Queues (since reverted).

Previously:
- https://github.com/zed-industries/zed/pull/18744
- https://github.com/zed-industries/zed/pull/20170
- https://github.com/zed-industries/zed/pull/22254
- https://github.com/zed-industries/zed/pull/22261
- https://github.com/zed-industries/zed/pull/22576
- https://github.com/zed-industries/zed/pull/22724
- https://github.com/zed-industries/zed/pull/23180

Release Notes:

- N/A
