### PR TITLE
Move `SlashCommandWorkingSet` to `assistant_slash_command`

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -10,15 +10,14 @@ mod prompts;
 mod slash_command;
 pub(crate) mod slash_command_picker;
 pub mod slash_command_settings;
-mod slash_command_working_set;
 mod streaming_diff;
 mod terminal_inline_assistant;
 
 use crate::slash_command::project_command::ProjectSlashCommandFeatureFlag;
-pub use crate::slash_command_working_set::{SlashCommandId, SlashCommandWorkingSet};
 pub use assistant_panel::{AssistantPanel, AssistantPanelEvent};
 use assistant_settings::AssistantSettings;
 use assistant_slash_command::SlashCommandRegistry;
+pub use assistant_slash_command::{SlashCommandId, SlashCommandWorkingSet};
 use client::{proto, Client};
 use command_palette_hooks::CommandPaletteFilter;
 pub use context::*;

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,5 +1,4 @@
 use crate::slash_command::file_command::codeblock_fence_for_path;
-use crate::slash_command_working_set::SlashCommandWorkingSet;
 use crate::{
     humanize_token_count,
     prompt_library::open_prompt_library,
@@ -21,7 +20,7 @@ use crate::{
 };
 use anyhow::Result;
 use assistant_settings::{AssistantDockPosition, AssistantSettings};
-use assistant_slash_command::{SlashCommand, SlashCommandOutputSection};
+use assistant_slash_command::{SlashCommand, SlashCommandOutputSection, SlashCommandWorkingSet};
 use assistant_tool::ToolWorkingSet;
 use client::{proto, zed_urls, Client, Status};
 use collections::{hash_map, BTreeSet, HashMap, HashSet};

--- a/crates/assistant/src/context.rs
+++ b/crates/assistant/src/context.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod context_tests;
 
-use crate::slash_command_working_set::SlashCommandWorkingSet;
 use crate::{
     prompts::PromptBuilder,
     slash_command::{file_command::FileCommandMetadata, SlashCommandLine},
@@ -10,6 +9,7 @@ use crate::{
 use anyhow::{anyhow, Context as _, Result};
 use assistant_slash_command::{
     SlashCommandContent, SlashCommandEvent, SlashCommandOutputSection, SlashCommandResult,
+    SlashCommandWorkingSet,
 };
 use assistant_tool::ToolWorkingSet;
 use client::{self, proto, telemetry::Telemetry};

--- a/crates/assistant/src/context/context_tests.rs
+++ b/crates/assistant/src/context/context_tests.rs
@@ -1,5 +1,4 @@
 use super::{AssistantEdit, MessageCacheMetadata};
-use crate::slash_command_working_set::SlashCommandWorkingSet;
 use crate::{
     assistant_panel, prompt_library, slash_command::file_command, AssistantEditKind, CacheStatus,
     Context, ContextEvent, ContextId, ContextOperation, InvokedSlashCommandId, MessageId,
@@ -8,7 +7,7 @@ use crate::{
 use anyhow::Result;
 use assistant_slash_command::{
     ArgumentCompletion, SlashCommand, SlashCommandContent, SlashCommandEvent, SlashCommandOutput,
-    SlashCommandOutputSection, SlashCommandRegistry, SlashCommandResult,
+    SlashCommandOutputSection, SlashCommandRegistry, SlashCommandResult, SlashCommandWorkingSet,
 };
 use assistant_tool::ToolWorkingSet;
 use collections::{HashMap, HashSet};

--- a/crates/assistant/src/context_store.rs
+++ b/crates/assistant/src/context_store.rs
@@ -1,10 +1,11 @@
 use crate::slash_command::context_server_command;
 use crate::SlashCommandId;
 use crate::{
-    prompts::PromptBuilder, slash_command_working_set::SlashCommandWorkingSet, Context,
-    ContextEvent, ContextId, ContextOperation, ContextVersion, SavedContext, SavedContextMetadata,
+    prompts::PromptBuilder, Context, ContextEvent, ContextId, ContextOperation, ContextVersion,
+    SavedContext, SavedContextMetadata,
 };
 use anyhow::{anyhow, Context as _, Result};
+use assistant_slash_command::SlashCommandWorkingSet;
 use assistant_tool::{ToolId, ToolWorkingSet};
 use client::{proto, telemetry::Telemetry, Client, TypedEnvelope};
 use clock::ReplicaId;

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -1,8 +1,10 @@
 mod extension_slash_command;
 mod slash_command_registry;
+mod slash_command_working_set;
 
 pub use crate::extension_slash_command::*;
 pub use crate::slash_command_registry::*;
+pub use crate::slash_command_working_set::*;
 use anyhow::Result;
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;

--- a/crates/assistant_slash_command/src/slash_command_working_set.rs
+++ b/crates/assistant_slash_command/src/slash_command_working_set.rs
@@ -1,8 +1,10 @@
-use assistant_slash_command::{SlashCommand, SlashCommandRegistry};
+use std::sync::Arc;
+
 use collections::HashMap;
 use gpui::AppContext;
 use parking_lot::Mutex;
-use std::sync::Arc;
+
+use crate::{SlashCommand, SlashCommandRegistry};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct SlashCommandId(usize);


### PR DESCRIPTION
This PR moves the `SlashCommandWorkingSet` out of the `assistant` crate and into `assistant_slash_command`.

This will unlock moving some things that depend on it out of the `assistant` crate.

Release Notes:

- N/A
