### PR TITLE
git: Implement commit creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5162,6 +5162,7 @@ dependencies = [
  "collections",
  "db",
  "editor",
+ "futures 0.3.31",
  "git",
  "gpui",
  "language",

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1560,13 +1560,14 @@ pub fn entry_diagnostic_aware_icon_decoration_and_color(
 }
 
 pub fn entry_git_aware_label_color(git_status: GitSummary, ignored: bool, selected: bool) -> Color {
+    let tracked = git_status.index + git_status.worktree;
     if ignored {
         Color::Ignored
     } else if git_status.conflict > 0 {
         Color::Conflict
-    } else if git_status.modified > 0 {
+    } else if tracked.modified > 0 {
         Color::Modified
-    } else if git_status.added > 0 || git_status.untracked > 0 {
+    } else if tracked.added > 0 {
         Color::Created
     } else {
         entry_label_color(selected)

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1567,7 +1567,7 @@ pub fn entry_git_aware_label_color(git_status: GitSummary, ignored: bool, select
         Color::Conflict
     } else if tracked.modified > 0 {
         Color::Modified
-    } else if tracked.added > 0 {
+    } else if tracked.added > 0 || git_status.untracked > 0 {
         Color::Created
     } else {
         entry_label_color(selected)

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -171,13 +171,13 @@ impl FileStatus {
             FileStatus::Tracked(TrackedStatus {
                 index_status,
                 worktree_status,
-            }) => {
-                let mut summary = index_status.to_summary() + worktree_status.to_summary();
-                if summary != GitSummary::UNCHANGED {
-                    summary.count = 1;
-                };
-                summary
-            }
+            }) => GitSummary {
+                index: index_status.to_summary(),
+                worktree: worktree_status.to_summary(),
+                conflict: 0,
+                untracked: 0,
+                count: 1,
+            },
         }
     }
 }
@@ -196,25 +196,22 @@ impl StatusCode {
         }
     }
 
-    /// Returns the contribution of this status code to the Git summary.
-    ///
-    /// Note that this does not include the count field, which must be set manually.
-    fn to_summary(self) -> GitSummary {
+    fn to_summary(self) -> TrackedSummary {
         match self {
-            StatusCode::Modified | StatusCode::TypeChanged => GitSummary {
+            StatusCode::Modified | StatusCode::TypeChanged => TrackedSummary {
                 modified: 1,
-                ..GitSummary::UNCHANGED
+                ..TrackedSummary::UNCHANGED
             },
-            StatusCode::Added => GitSummary {
+            StatusCode::Added => TrackedSummary {
                 added: 1,
-                ..GitSummary::UNCHANGED
+                ..TrackedSummary::UNCHANGED
             },
-            StatusCode::Deleted => GitSummary {
+            StatusCode::Deleted => TrackedSummary {
                 deleted: 1,
-                ..GitSummary::UNCHANGED
+                ..TrackedSummary::UNCHANGED
             },
             StatusCode::Renamed | StatusCode::Copied | StatusCode::Unmodified => {
-                GitSummary::UNCHANGED
+                TrackedSummary::UNCHANGED
             }
         }
     }
@@ -232,12 +229,76 @@ impl UnmergedStatusCode {
 }
 
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq)]
-pub struct GitSummary {
+pub struct TrackedSummary {
     pub added: usize,
     pub modified: usize,
+    pub deleted: usize,
+}
+
+impl TrackedSummary {
+    pub const UNCHANGED: Self = Self {
+        added: 0,
+        modified: 0,
+        deleted: 0,
+    };
+
+    pub const ADDED: Self = Self {
+        added: 1,
+        modified: 0,
+        deleted: 0,
+    };
+
+    pub const MODIFIED: Self = Self {
+        added: 0,
+        modified: 1,
+        deleted: 0,
+    };
+
+    pub const DELETED: Self = Self {
+        added: 0,
+        modified: 0,
+        deleted: 1,
+    };
+}
+
+impl std::ops::AddAssign for TrackedSummary {
+    fn add_assign(&mut self, rhs: Self) {
+        self.added += rhs.added;
+        self.modified += rhs.modified;
+        self.deleted += rhs.deleted;
+    }
+}
+
+impl std::ops::Add for TrackedSummary {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        TrackedSummary {
+            added: self.added + rhs.added,
+            modified: self.modified + rhs.modified,
+            deleted: self.deleted + rhs.deleted,
+        }
+    }
+}
+
+impl std::ops::Sub for TrackedSummary {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        TrackedSummary {
+            added: self.added - rhs.added,
+            modified: self.modified - rhs.modified,
+            deleted: self.deleted - rhs.deleted,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Copy, PartialEq, Eq)]
+pub struct GitSummary {
+    pub index: TrackedSummary,
+    pub worktree: TrackedSummary,
     pub conflict: usize,
     pub untracked: usize,
-    pub deleted: usize,
     pub count: usize,
 }
 
@@ -255,11 +316,10 @@ impl GitSummary {
     };
 
     pub const UNCHANGED: Self = Self {
-        added: 0,
-        modified: 0,
+        index: TrackedSummary::UNCHANGED,
+        worktree: TrackedSummary::UNCHANGED,
         conflict: 0,
         untracked: 0,
-        deleted: 0,
         count: 0,
     };
 }
@@ -293,11 +353,10 @@ impl std::ops::Add<Self> for GitSummary {
 
 impl std::ops::AddAssign for GitSummary {
     fn add_assign(&mut self, rhs: Self) {
-        self.added += rhs.added;
-        self.modified += rhs.modified;
+        self.index += rhs.index;
+        self.worktree += rhs.worktree;
         self.conflict += rhs.conflict;
         self.untracked += rhs.untracked;
-        self.deleted += rhs.deleted;
         self.count += rhs.count;
     }
 }
@@ -307,11 +366,10 @@ impl std::ops::Sub for GitSummary {
 
     fn sub(self, rhs: Self) -> Self::Output {
         GitSummary {
-            added: self.added - rhs.added,
-            modified: self.modified - rhs.modified,
+            index: self.index - rhs.index,
+            worktree: self.worktree - rhs.worktree,
             conflict: self.conflict - rhs.conflict,
             untracked: self.untracked - rhs.untracked,
-            deleted: self.deleted - rhs.deleted,
             count: self.count - rhs.count,
         }
     }

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -215,6 +215,20 @@ impl StatusCode {
             }
         }
     }
+
+    pub fn index(self) -> FileStatus {
+        FileStatus::Tracked(TrackedStatus {
+            index_status: self,
+            worktree_status: StatusCode::Unmodified,
+        })
+    }
+
+    pub fn worktree(self) -> FileStatus {
+        FileStatus::Tracked(TrackedStatus {
+            index_status: StatusCode::Unmodified,
+            worktree_status: self,
+        })
+    }
 }
 
 impl UnmergedStatusCode {

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 collections.workspace = true
 db.workspace = true
 editor.workspace = true
+futures.workspace = true
 git.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -956,6 +956,10 @@ impl GitPanel {
     pub fn render_commit_editor(&self, cx: &ViewContext<Self>) -> impl IntoElement {
         let editor = self.commit_editor.clone();
         let editor_focus_handle = editor.read(cx).focus_handle(cx).clone();
+        let (can_commit, can_commit_all) = self.git_state(cx).map_or((false, false), |git_state| {
+            let git_state = git_state.read(cx);
+            (git_state.can_commit(false), git_state.can_commit(true))
+        });
 
         let focus_handle_1 = self.focus_handle(cx).clone();
         let focus_handle_2 = self.focus_handle(cx).clone();
@@ -971,6 +975,7 @@ impl GitPanel {
                     cx,
                 )
             })
+            .disabled(!can_commit)
             .on_click(
                 cx.listener(|this, _: &ClickEvent, cx| this.commit_changes(&CommitChanges, cx)),
             );
@@ -986,6 +991,7 @@ impl GitPanel {
                     cx,
                 )
             })
+            .disabled(!can_commit_all)
             .on_click(cx.listener(|this, _: &ClickEvent, cx| {
                 this.commit_all_changes(&CommitAllChanges, cx)
             }));

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1037,7 +1037,7 @@ impl GitPanel {
                     cx,
                 )
             })
-            .disabled(can_commit)
+            .disabled(!can_commit)
             .on_click(
                 cx.listener(|this, _: &ClickEvent, cx| this.commit_changes(&CommitChanges, cx)),
             );

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -618,7 +618,7 @@ impl GitPanel {
             }
         });
         if let Err(e) = result {
-            self.show_err_toast("toggle staged error".to_string(), e, cx);
+            self.show_err_toast("toggle staged error", e, cx);
         }
         cx.notify();
     }
@@ -658,7 +658,7 @@ impl GitPanel {
         self.all_staged = Some(true);
 
         if let Err(e) = git_state.read(cx).stage_all() {
-            self.show_err_toast("stage all error".to_string(), e, cx);
+            self.show_err_toast("stage all error", e, cx);
         };
     }
 
@@ -671,7 +671,7 @@ impl GitPanel {
         }
         self.all_staged = Some(false);
         if let Err(e) = git_state.read(cx).unstage_all() {
-            self.show_err_toast("unstage all error".to_string(), e, cx);
+            self.show_err_toast("unstage all error", e, cx);
         };
     }
 
@@ -686,7 +686,7 @@ impl GitPanel {
             return;
         };
         if let Err(e) = git_state.update(cx, |git_state, _| git_state.commit()) {
-            self.show_err_toast("commit error".to_string(), e, cx);
+            self.show_err_toast("commit error", e, cx);
         };
         self.commit_editor
             .update(cx, |editor, cx| editor.set_text("", cx));
@@ -698,7 +698,7 @@ impl GitPanel {
             return;
         };
         if let Err(e) = git_state.update(cx, |git_state, _| git_state.commit_all()) {
-            self.show_err_toast("commit all error".to_string(), e, cx);
+            self.show_err_toast("commit all error", e, cx);
         };
         self.commit_editor
             .update(cx, |editor, cx| editor.set_text("", cx));
@@ -834,23 +834,18 @@ impl GitPanel {
         }
     }
 
-    fn show_err_toast(
-        &self,
-        id: impl Into<SharedString>,
-        e: anyhow::Error,
-        cx: &mut ViewContext<Self>,
-    ) {
-        if let Some(workspace) = self.weak_workspace.upgrade() {
-            let id_string = id.into();
-            let notif_id = NotificationId::Named(id_string.into());
-            let message = e.to_string();
-            workspace.update(cx, |workspace, cx| {
-                let toast = Toast::new(notif_id, message).on_click("Open Zed Log", |cx| {
-                    cx.dispatch_action(workspace::OpenLog.boxed_clone());
-                });
-                workspace.show_toast(toast, cx);
+    fn show_err_toast(&self, id: &'static str, e: anyhow::Error, cx: &mut ViewContext<Self>) {
+        let Some(workspace) = self.weak_workspace.upgrade() else {
+            return;
+        };
+        let notif_id = NotificationId::Named(id.into());
+        let message = e.to_string();
+        workspace.update(cx, |workspace, cx| {
+            let toast = Toast::new(notif_id, message).on_click("Open Zed Log", |cx| {
+                cx.dispatch_action(workspace::OpenLog.boxed_clone());
             });
-        }
+            workspace.show_toast(toast, cx);
+        });
     }
 }
 
@@ -1264,7 +1259,7 @@ impl GitPanel {
                                 }
                             });
                             if let Err(e) = result {
-                                this.show_err_toast("toggle staged error".to_string(), e, cx);
+                                this.show_err_toast("toggle staged error", e, cx);
                             }
                         });
                     }

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -2,40 +2,43 @@ use std::sync::Arc;
 
 use futures::channel::mpsc;
 use futures::StreamExt as _;
-use git::repository::{GitRepository, RepoPath};
+use git::{
+    repository::{GitRepository, RepoPath},
+    status::GitSummary,
+};
 use gpui::{AppContext, SharedString};
 use settings::WorktreeId;
 use util::ResultExt as _;
 use worktree::RepositoryEntry;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum StatusAction {
-    Stage,
-    Unstage,
-}
-
 pub struct GitState {
     /// The current commit message being composed.
-    pub commit_message: Option<SharedString>,
+    pub commit_message: SharedString,
 
     /// When a git repository is selected, this is used to track which repository's changes
     /// are currently being viewed or modified in the UI.
     pub active_repository: Option<(WorktreeId, RepositoryEntry, Arc<dyn GitRepository>)>,
 
-    pub update_sender: mpsc::UnboundedSender<(Arc<dyn GitRepository>, Vec<RepoPath>, StatusAction)>,
+    update_sender: mpsc::UnboundedSender<Message>,
+}
+
+enum Message {
+    Commit(Arc<dyn GitRepository>, SharedString),
+    Stage(Arc<dyn GitRepository>, Vec<RepoPath>),
+    Unstage(Arc<dyn GitRepository>, Vec<RepoPath>),
 }
 
 impl GitState {
     pub fn new(cx: &AppContext) -> Self {
-        let (tx, mut rx) =
-            mpsc::unbounded::<(Arc<dyn GitRepository>, Vec<RepoPath>, StatusAction)>();
+        let (tx, mut rx) = mpsc::unbounded();
         cx.spawn(|cx| async move {
-            while let Some((git_repo, paths, action)) = rx.next().await {
+            while let Some(msg) = rx.next().await {
                 cx.background_executor()
                     .spawn(async move {
-                        match action {
-                            StatusAction::Stage => git_repo.stage_paths(&paths),
-                            StatusAction::Unstage => git_repo.unstage_paths(&paths),
+                        match msg {
+                            Message::Stage(repo, paths) => repo.stage_paths(&paths),
+                            Message::Unstage(repo, paths) => repo.unstage_paths(&paths),
+                            Message::Commit(repo, message) => repo.commit(&message),
                         }
                     })
                     .await
@@ -44,7 +47,7 @@ impl GitState {
         })
         .detach();
         GitState {
-            commit_message: None,
+            commit_message: SharedString::default(),
             active_repository: None,
             update_sender: tx,
         }
@@ -65,31 +68,28 @@ impl GitState {
         self.active_repository.as_ref()
     }
 
-    pub fn commit_message(&mut self, message: Option<SharedString>) {
-        self.commit_message = message;
-    }
-
-    pub fn clear_commit_message(&mut self) {
-        self.commit_message = None;
-    }
-
-    fn act_on_entries(&self, entries: Vec<RepoPath>, action: StatusAction) {
+    pub fn stage_entries(&self, entries: Vec<RepoPath>) {
         if entries.is_empty() {
             return;
         }
-        if let Some((_, _, git_repo)) = self.active_repository.as_ref() {
-            let _ = self
-                .update_sender
-                .unbounded_send((git_repo.clone(), entries, action));
-        }
-    }
-
-    pub fn stage_entries(&self, entries: Vec<RepoPath>) {
-        self.act_on_entries(entries, StatusAction::Stage);
+        let Some((_, _, git_repo)) = self.active_repository.as_ref() else {
+            return;
+        };
+        let _ = self
+            .update_sender
+            .unbounded_send(Message::Stage(git_repo.clone(), entries));
     }
 
     pub fn unstage_entries(&self, entries: Vec<RepoPath>) {
-        self.act_on_entries(entries, StatusAction::Unstage);
+        if entries.is_empty() {
+            return;
+        }
+        let Some((_, _, git_repo)) = self.active_repository.as_ref() else {
+            return;
+        };
+        let _ = self
+            .update_sender
+            .unbounded_send(Message::Unstage(git_repo.clone(), entries));
     }
 
     pub fn stage_all(&self) {
@@ -122,5 +122,37 @@ impl GitState {
         self.active_repository
             .as_ref()
             .map_or(0, |(_, entry, _)| entry.status_len())
+    }
+
+    fn have_changes(&self) -> bool {
+        let Some((_, entry, _)) = self.active_repository.as_ref() else {
+            return false;
+        };
+        entry.status_summary() != GitSummary::UNCHANGED
+    }
+
+    fn have_staged_changes(&self) -> bool {
+        // FIXME need to make the GitSummary more complex...
+        true
+    }
+
+    pub fn can_commit(&self, commit_all: bool) -> bool {
+        return !self.commit_message.trim().is_empty()
+            && self.have_changes()
+            && (commit_all || self.have_staged_changes());
+    }
+
+    pub fn commit(&mut self) {
+        if !self.can_commit(false) {
+            return;
+        }
+        let Some((_, _, git_repo)) = self.active_repository() else {
+            return;
+        };
+        let git_repo = git_repo.clone();
+        let message = std::mem::take(&mut self.commit_message);
+        let _ = self
+            .update_sender
+            .unbounded_send(Message::Commit(git_repo, message));
     }
 }

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -168,7 +168,7 @@ impl GitState {
 
     pub fn commit(&mut self, err_sender: mpsc::Sender<anyhow::Error>) -> anyhow::Result<()> {
         if !self.can_commit(false) {
-            return Err(anyhow!("No staged changes to commit"));
+            return Err(anyhow!("Unable to commit"));
         }
         let Some((_, _, git_repo)) = self.active_repository() else {
             return Err(anyhow!("No active repository"));
@@ -183,7 +183,7 @@ impl GitState {
 
     pub fn commit_all(&mut self, err_sender: mpsc::Sender<anyhow::Error>) -> anyhow::Result<()> {
         if !self.can_commit(true) {
-            return Err(anyhow!("No changes to commit"));
+            return Err(anyhow!("Unable to commit"));
         }
         let Some((_, entry, git_repo)) = self.active_repository.as_ref() else {
             return Err(anyhow!("No active repository"));

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -4,7 +4,7 @@ use futures::channel::mpsc;
 use futures::StreamExt as _;
 use git::{
     repository::{GitRepository, RepoPath},
-    status::GitSummary,
+    status::{GitSummary, TrackedSummary},
 };
 use gpui::{AppContext, SharedString};
 use settings::WorktreeId;
@@ -132,8 +132,10 @@ impl GitState {
     }
 
     fn have_staged_changes(&self) -> bool {
-        // FIXME need to make the GitSummary more complex...
-        true
+        let Some((_, entry, _)) = self.active_repository.as_ref() else {
+            return false;
+        };
+        entry.status_summary().index != TrackedSummary::UNCHANGED
     }
 
     pub fn can_commit(&self, commit_all: bool) -> bool {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1584,7 +1584,7 @@ impl ProjectPanel {
                         }
                     }))
                     && entry.is_file()
-                    && entry.git_summary.modified > 0
+                    && entry.git_summary.index.modified + entry.git_summary.worktree.modified > 0
             },
             cx,
         );
@@ -1662,7 +1662,7 @@ impl ProjectPanel {
                         }
                     }))
                     && entry.is_file()
-                    && entry.git_summary.modified > 0
+                    && entry.git_summary.index.modified + entry.git_summary.worktree.modified > 0
             },
             cx,
         );

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -231,6 +231,10 @@ impl RepositoryEntry {
         self.statuses_by_path.summary().item_summary.count
     }
 
+    pub fn status_summary(&self) -> GitSummary {
+        self.statuses_by_path.summary().item_summary
+    }
+
     pub fn status_for_path(&self, path: &RepoPath) -> Option<StatusEntry> {
         self.statuses_by_path
             .get(&PathKey(path.0.clone()), &())

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -746,7 +746,7 @@ async fn test_rescan_with_gitignore(cx: &mut TestAppContext) {
         Path::new("/root/tree/.git"),
         &[(
             Path::new("tracked-dir/tracked-file2"),
-            FileStatus::worktree(StatusCode::Added),
+            StatusCode::Added.index(),
         )],
     );
 
@@ -831,7 +831,7 @@ async fn test_update_gitignore(cx: &mut TestAppContext) {
 
     fs.set_status_for_repo_via_working_copy_change(
         Path::new("/root/.git"),
-        &[(Path::new("b.txt"), FileStatus::worktree(StatusCode::Added))],
+        &[(Path::new("b.txt"), StatusCode::Added.index())],
     );
 
     cx.executor().run_until_parked();
@@ -1501,10 +1501,7 @@ async fn test_bump_mtime_of_git_repo_workdir(cx: &mut TestAppContext) {
     // detected.
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/.git"),
-        &[(
-            Path::new("b/c.txt"),
-            FileStatus::worktree(StatusCode::Modified),
-        )],
+        &[(Path::new("b/c.txt"), StatusCode::Modified.index())],
     );
     cx.executor().run_until_parked();
 
@@ -2200,7 +2197,7 @@ async fn test_rename_work_directory(cx: &mut TestAppContext) {
         assert_eq!(repo.path.as_ref(), Path::new("projects/project1"));
         assert_eq!(
             tree.status_for_file(Path::new("projects/project1/a")),
-            Some(FileStatus::worktree(StatusCode::Modified)),
+            Some(StatusCode::Modified.worktree()),
         );
         assert_eq!(
             tree.status_for_file(Path::new("projects/project1/b")),
@@ -2221,7 +2218,7 @@ async fn test_rename_work_directory(cx: &mut TestAppContext) {
         assert_eq!(repo.path.as_ref(), Path::new("projects/project2"));
         assert_eq!(
             tree.status_for_file(Path::new("projects/project2/a")),
-            Some(FileStatus::worktree(StatusCode::Modified)),
+            Some(StatusCode::Modified.worktree()),
         );
         assert_eq!(
             tree.status_for_file(Path::new("projects/project2/b")),
@@ -2422,7 +2419,7 @@ async fn test_file_status(cx: &mut TestAppContext) {
         let snapshot = tree.snapshot();
         assert_eq!(
             snapshot.status_for_file(project_path.join(A_TXT)),
-            Some(FileStatus::worktree(StatusCode::Modified)),
+            Some(StatusCode::Modified.worktree()),
         );
     });
 
@@ -2464,7 +2461,7 @@ async fn test_file_status(cx: &mut TestAppContext) {
         );
         assert_eq!(
             snapshot.status_for_file(project_path.join(E_TXT)),
-            Some(FileStatus::worktree(StatusCode::Modified)),
+            Some(StatusCode::Modified.worktree()),
         );
     });
 
@@ -2576,14 +2573,11 @@ async fn test_git_repository_status(cx: &mut TestAppContext) {
 
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[0].repo_path.as_ref(), Path::new("a.txt"));
-        assert_eq!(
-            entries[0].status,
-            FileStatus::worktree(StatusCode::Modified)
-        );
+        assert_eq!(entries[0].status, StatusCode::Modified.worktree());
         assert_eq!(entries[1].repo_path.as_ref(), Path::new("b.txt"));
         assert_eq!(entries[1].status, FileStatus::Untracked);
         assert_eq!(entries[2].repo_path.as_ref(), Path::new("d.txt"));
-        assert_eq!(entries[2].status, FileStatus::worktree(StatusCode::Deleted));
+        assert_eq!(entries[2].status, StatusCode::Deleted.worktree());
     });
 
     std::fs::write(work_dir.join("c.txt"), "some changes").unwrap();
@@ -2601,20 +2595,14 @@ async fn test_git_repository_status(cx: &mut TestAppContext) {
 
         std::assert_eq!(entries.len(), 4, "entries: {entries:?}");
         assert_eq!(entries[0].repo_path.as_ref(), Path::new("a.txt"));
-        assert_eq!(
-            entries[0].status,
-            FileStatus::worktree(StatusCode::Modified)
-        );
+        assert_eq!(entries[0].status, StatusCode::Modified.worktree());
         assert_eq!(entries[1].repo_path.as_ref(), Path::new("b.txt"));
         assert_eq!(entries[1].status, FileStatus::Untracked);
         // Status updated
         assert_eq!(entries[2].repo_path.as_ref(), Path::new("c.txt"));
-        assert_eq!(
-            entries[2].status,
-            FileStatus::worktree(StatusCode::Modified)
-        );
+        assert_eq!(entries[2].status, StatusCode::Modified.worktree());
         assert_eq!(entries[3].repo_path.as_ref(), Path::new("d.txt"));
-        assert_eq!(entries[3].status, FileStatus::worktree(StatusCode::Deleted));
+        assert_eq!(entries[3].status, StatusCode::Deleted.worktree());
     });
 
     git_add("a.txt", &repo);
@@ -2647,7 +2635,7 @@ async fn test_git_repository_status(cx: &mut TestAppContext) {
             &entries
         );
         assert_eq!(entries[0].repo_path.as_ref(), Path::new("a.txt"));
-        assert_eq!(entries[0].status, FileStatus::worktree(StatusCode::Deleted));
+        assert_eq!(entries[0].status, StatusCode::Deleted.worktree());
     });
 }
 
@@ -2770,11 +2758,8 @@ async fn test_traverse_with_git_status(cx: &mut TestAppContext) {
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/x/.git"),
         &[
-            (
-                Path::new("x2.txt"),
-                FileStatus::worktree(StatusCode::Modified),
-            ),
-            (Path::new("z.txt"), FileStatus::worktree(StatusCode::Added)),
+            (Path::new("x2.txt"), StatusCode::Modified.index()),
+            (Path::new("z.txt"), StatusCode::Added.index()),
         ],
     );
     fs.set_status_for_repo_via_git_operation(
@@ -2783,7 +2768,7 @@ async fn test_traverse_with_git_status(cx: &mut TestAppContext) {
     );
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/z/.git"),
-        &[(Path::new("z2.txt"), FileStatus::worktree(StatusCode::Added))],
+        &[(Path::new("z2.txt"), StatusCode::Added.index())],
     );
 
     let tree = Worktree::local(
@@ -2863,14 +2848,8 @@ async fn test_propagate_git_statuses(cx: &mut TestAppContext) {
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/.git"),
         &[
-            (
-                Path::new("a/b/c1.txt"),
-                FileStatus::worktree(StatusCode::Added),
-            ),
-            (
-                Path::new("a/d/e2.txt"),
-                FileStatus::worktree(StatusCode::Modified),
-            ),
+            (Path::new("a/b/c1.txt"), StatusCode::Added.index()),
+            (Path::new("a/d/e2.txt"), StatusCode::Modified.index()),
             (Path::new("g/h2.txt"), CONFLICT),
         ],
     );
@@ -2972,24 +2951,18 @@ async fn test_propagate_statuses_for_repos_under_project(cx: &mut TestAppContext
 
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/x/.git"),
-        &[(Path::new("x1.txt"), FileStatus::worktree(StatusCode::Added))],
+        &[(Path::new("x1.txt"), StatusCode::Added.index())],
     );
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/y/.git"),
         &[
             (Path::new("y1.txt"), CONFLICT),
-            (
-                Path::new("y2.txt"),
-                FileStatus::worktree(StatusCode::Modified),
-            ),
+            (Path::new("y2.txt"), StatusCode::Modified.index()),
         ],
     );
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/z/.git"),
-        &[(
-            Path::new("z2.txt"),
-            FileStatus::worktree(StatusCode::Modified),
-        )],
+        &[(Path::new("z2.txt"), StatusCode::Modified.index())],
     );
 
     let tree = Worktree::local(
@@ -3082,11 +3055,8 @@ async fn test_propagate_statuses_for_nested_repos(cx: &mut TestAppContext) {
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/x/.git"),
         &[
-            (
-                Path::new("x2.txt"),
-                FileStatus::worktree(StatusCode::Modified),
-            ),
-            (Path::new("z.txt"), FileStatus::worktree(StatusCode::Added)),
+            (Path::new("x2.txt"), StatusCode::Modified.index()),
+            (Path::new("z.txt"), StatusCode::Added.index()),
         ],
     );
     fs.set_status_for_repo_via_git_operation(
@@ -3096,7 +3066,7 @@ async fn test_propagate_statuses_for_nested_repos(cx: &mut TestAppContext) {
 
     fs.set_status_for_repo_via_git_operation(
         Path::new("/root/z/.git"),
-        &[(Path::new("z2.txt"), FileStatus::worktree(StatusCode::Added))],
+        &[(Path::new("z2.txt"), StatusCode::Added.index())],
     );
 
     let tree = Worktree::local(
@@ -3379,15 +3349,15 @@ fn init_test(cx: &mut gpui::TestAppContext) {
 fn assert_entry_git_state(
     tree: &Worktree,
     path: &str,
-    worktree_status: Option<StatusCode>,
+    index_status: Option<StatusCode>,
     is_ignored: bool,
 ) {
     let entry = tree.entry_for_path(path).expect("entry {path} not found");
     let status = tree.status_for_file(Path::new(path));
-    let expected = worktree_status.map(|worktree_status| {
+    let expected = index_status.map(|index_status| {
         TrackedStatus {
-            worktree_status,
-            index_status: StatusCode::Unmodified,
+            index_status,
+            worktree_status: StatusCode::Unmodified,
         }
         .into()
     });

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -6,7 +6,8 @@ use anyhow::Result;
 use fs::{FakeFs, Fs, RealFs, RemoveOptions};
 use git::{
     status::{
-        FileStatus, GitSummary, StatusCode, TrackedStatus, UnmergedStatus, UnmergedStatusCode,
+        FileStatus, GitSummary, StatusCode, TrackedStatus, TrackedSummary, UnmergedStatus,
+        UnmergedStatusCode,
     },
     GITIGNORE,
 };
@@ -3227,12 +3228,12 @@ fn check_git_statuses(snapshot: &Snapshot, expected_statuses: &[(&Path, GitSumma
 }
 
 const ADDED: GitSummary = GitSummary {
-    added: 1,
+    index: TrackedSummary::ADDED,
     count: 1,
     ..GitSummary::UNCHANGED
 };
 const MODIFIED: GitSummary = GitSummary {
-    modified: 1,
+    index: TrackedSummary::MODIFIED,
     count: 1,
     ..GitSummary::UNCHANGED
 };


### PR DESCRIPTION
- [x] Basic implementation
- [x] Disable commit buttons when committing is not possible (empty message, no changes)
- [x] Upgrade GitSummary to efficiently figure out whether there are any staged changes
- [x] Make CommitAll work
- [x] Surface errors with toasts
  - [x] Channel shutdown
  - [x] Empty commit message or no changes
  - [x] Failed git operations
- [x] Fix added files no longer appearing correctly in the project panel (GitSummary breakage)
- [x] Fix handling of commit message

Release Notes:

- N/A
