### PR TITLE
chore: Use workspace fields for edition and publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,10 @@ members = [
 ]
 default-members = ["crates/zed"]
 
+[workspace.package]
+publish = false
+edition = "2021"
+
 [workspace.dependencies]
 
 #

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "activity_indicator"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "anthropic"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "AGPL-3.0-or-later"
 
 [features]

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assets"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lib]

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assistant"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/assistant2/Cargo.toml
+++ b/crates/assistant2/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assistant2"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/assistant_settings/Cargo.toml
+++ b/crates/assistant_settings/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assistant_settings"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/assistant_slash_command/Cargo.toml
+++ b/crates/assistant_slash_command/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assistant_slash_command"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/assistant_slash_commands/Cargo.toml
+++ b/crates/assistant_slash_commands/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assistant_slash_commands"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/assistant_tool/Cargo.toml
+++ b/crates/assistant_tool/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assistant_tool"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/assistant_tools/Cargo.toml
+++ b/crates/assistant_tools/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assistant_tools"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "audio"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "auto_update"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/auto_update_ui/Cargo.toml
+++ b/crates/auto_update_ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "auto_update_ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/breadcrumbs/Cargo.toml
+++ b/crates/breadcrumbs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "breadcrumbs"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "call"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "channel"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cli"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "client"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/clock/Cargo.toml
+++ b/crates/clock/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "clock"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 authors = ["Nathan Sobo <nathan@zed.dev>"]
 default-run = "collab"
-edition = "2021"
+edition.workspace = true
 name = "collab"
 version = "0.44.0"
-publish = false
+publish.workspace = true
 license = "AGPL-3.0-or-later"
 
 [lints]

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "collab_ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "collections"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "command_palette"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/command_palette_hooks/Cargo.toml
+++ b/crates/command_palette_hooks/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "command_palette_hooks"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/context_server/Cargo.toml
+++ b/crates/context_server/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "context_server"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/context_server_settings/Cargo.toml
+++ b/crates/context_server_settings/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "context_server_settings"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "copilot"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "db"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "diagnostics"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/docs_preprocessor/Cargo.toml
+++ b/crates/docs_preprocessor/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "docs_preprocessor"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [dependencies]

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "editor"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/evals/Cargo.toml
+++ b/crates/evals/Cargo.toml
@@ -2,8 +2,8 @@
 name = "evals"
 description = "Evaluations for Zed's AI features"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "extension"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/zed_extension_api"
 keywords = ["zed", "extension"]
 edition.workspace = true
+publish = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -5,7 +5,7 @@ description = "APIs for creating Zed extensions in Rust"
 repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/zed_extension_api"
 keywords = ["zed", "extension"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/extension_cli/Cargo.toml
+++ b/crates/extension_cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "extension_cli"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "extension_host"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "extensions_ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/feature_flags/Cargo.toml
+++ b/crates/feature_flags/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "feature_flags"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/feedback/Cargo.toml
+++ b/crates/feedback/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "feedback"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "file_finder"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/file_icons/Cargo.toml
+++ b/crates/file_icons/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "file_icons"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/fireworks/Cargo.toml
+++ b/crates/fireworks/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fireworks"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fs"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/fsevent/Cargo.toml
+++ b/crates/fsevent/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fsevent"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/fuzzy/Cargo.toml
+++ b/crates/fuzzy/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fuzzy"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "git"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/git_hosting_providers/Cargo.toml
+++ b/crates/git_hosting_providers/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "git_hosting_providers"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "git_ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/go_to_line/Cargo.toml
+++ b/crates/go_to_line/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "go_to_line"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/google_ai/Cargo.toml
+++ b/crates/google_ai/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "google_ai"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gpui"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 authors = ["Nathan Sobo <nathan@zed.dev>"]
 description = "Zed's GPU-accelerated UI framework"
-publish = false
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/gpui_macros/Cargo.toml
+++ b/crates/gpui_macros/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gpui_macros"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/html_to_markdown/Cargo.toml
+++ b/crates/html_to_markdown/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/html_to_markdown"
 keywords = ["html", "markdown", "html-to-markdown"]
 edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/html_to_markdown/Cargo.toml
+++ b/crates/html_to_markdown/Cargo.toml
@@ -5,7 +5,7 @@ description = "Convert HTML to Markdown"
 repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/html_to_markdown"
 keywords = ["html", "markdown", "html-to-markdown"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/http_client/Cargo.toml
+++ b/crates/http_client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "http_client"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/image_viewer/Cargo.toml
+++ b/crates/image_viewer/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "image_viewer"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/indexed_docs/Cargo.toml
+++ b/crates/indexed_docs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "indexed_docs"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/inline_completion/Cargo.toml
+++ b/crates/inline_completion/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "inline_completion"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/inline_completion_button/Cargo.toml
+++ b/crates/inline_completion_button/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "inline_completion_button"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/install_cli/Cargo.toml
+++ b/crates/install_cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "install_cli"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "journal"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "language"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/language_extension/Cargo.toml
+++ b/crates/language_extension/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "language_extension"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/language_model/Cargo.toml
+++ b/crates/language_model/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "language_model"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "language_model_selector"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "language_models"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/language_selector/Cargo.toml
+++ b/crates/language_selector/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "language_selector"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/language_tools/Cargo.toml
+++ b/crates/language_tools/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "language_tools"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "languages"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/livekit_client/Cargo.toml
+++ b/crates/livekit_client/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "livekit_client"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Logic for using LiveKit with GPUI"
-publish = false
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/livekit_client_macos/Cargo.toml
+++ b/crates/livekit_client_macos/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "livekit_client_macos"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Bindings to LiveKit Swift client SDK"
-publish = false
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/livekit_server/Cargo.toml
+++ b/crates/livekit_server/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "livekit_server"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "SDK for the LiveKit server API"
-publish = false
+publish.workspace = true
 license = "AGPL-3.0-or-later"
 
 [lints]

--- a/crates/lmstudio/Cargo.toml
+++ b/crates/lmstudio/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lmstudio"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lsp"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "markdown"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "markdown_preview"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/media/Cargo.toml
+++ b/crates/media/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "media"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/menu/Cargo.toml
+++ b/crates/menu/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "menu"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/multi_buffer/Cargo.toml
+++ b/crates/multi_buffer/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "multi_buffer"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "node_runtime"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/notifications/Cargo.toml
+++ b/crates/notifications/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "notifications"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/ollama/Cargo.toml
+++ b/crates/ollama/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ollama"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/open_ai/Cargo.toml
+++ b/crates/open_ai/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "open_ai"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/outline/Cargo.toml
+++ b/crates/outline/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "outline"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/outline_panel/Cargo.toml
+++ b/crates/outline_panel/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "outline_panel"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "paths"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "picker"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/prettier/Cargo.toml
+++ b/crates/prettier/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "prettier"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "project"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "project_panel"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "project_symbols"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/prompt_library/Cargo.toml
+++ b/crates/prompt_library/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "prompt_library"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 description = "Shared protocol for communication between the Zed app and the zed.dev server"
-edition = "2021"
+edition.workspace = true
 name = "proto"
 version = "0.1.0"
-publish = false
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [features]

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "recent_projects"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/refineable/Cargo.toml
+++ b/crates/refineable/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "refineable"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/refineable/derive_refineable/Cargo.toml
+++ b/crates/refineable/derive_refineable/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "derive_refineable"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/release_channel/Cargo.toml
+++ b/crates/release_channel/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "release_channel"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "remote"
 description = "Client-side subsystem for remote editing"
-edition = "2021"
+edition.workspace = true
 version = "0.1.0"
-publish = false
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "remote_server"
 description = "Daemon used for remote editing"
-edition = "2021"
+edition.workspace = true
 version = "0.1.0"
-publish = false
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "repl"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/reqwest_client/Cargo.toml
+++ b/crates/reqwest_client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "reqwest_client"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/rich_text/Cargo.toml
+++ b/crates/rich_text/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rich_text"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rope"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 description = "Shared logic for communication between the Zed app and the zed.dev server"
-edition = "2021"
+edition.workspace = true
 name = "rpc"
 version = "0.1.0"
-publish = false
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "search"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [features]

--- a/crates/semantic_index/Cargo.toml
+++ b/crates/semantic_index/Cargo.toml
@@ -2,8 +2,8 @@
 name = "semantic_index"
 description = "Process, chunk, and embed text as vectors for semantic search."
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/semantic_version/Cargo.toml
+++ b/crates/semantic_version/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "semantic_version"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "session"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "settings"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "settings_ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/snippet/Cargo.toml
+++ b/crates/snippet/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "snippet"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/snippet_provider/Cargo.toml
+++ b/crates/snippet_provider/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "snippet_provider"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/snippets_ui/Cargo.toml
+++ b/crates/snippets_ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "snippets_ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sqlez"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/sqlez_macros/Cargo.toml
+++ b/crates/sqlez_macros/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sqlez_macros"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "story"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lib]

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "storybook"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/streaming_diff/Cargo.toml
+++ b/crates/streaming_diff/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "streaming_diff"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/sum_tree/Cargo.toml
+++ b/crates/sum_tree/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sum_tree"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/supermaven/Cargo.toml
+++ b/crates/supermaven/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "supermaven"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/supermaven_api/Cargo.toml
+++ b/crates/supermaven_api/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "supermaven_api"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/tab_switcher/Cargo.toml
+++ b/crates/tab_switcher/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tab_switcher"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "task"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/tasks_ui/Cargo.toml
+++ b/crates/tasks_ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tasks_ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "telemetry"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/telemetry_events/Cargo.toml
+++ b/crates/telemetry_events/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "telemetry_events"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "terminal"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "terminal_view"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "text"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "theme"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/theme_extension/Cargo.toml
+++ b/crates/theme_extension/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "theme_extension"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "theme_importer"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/theme_selector/Cargo.toml
+++ b/crates/theme_selector/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "theme_selector"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/time_format/Cargo.toml
+++ b/crates/time_format/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "time_format"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "title_bar"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/toolchain_selector/Cargo.toml
+++ b/crates/toolchain_selector/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "toolchain_selector"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [dependencies]

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ui"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/ui_input/Cargo.toml
+++ b/crates/ui_input/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ui_input"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/ui_macros/Cargo.toml
+++ b/crates/ui_macros/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ui_macros"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "util"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/vcs_menu/Cargo.toml
+++ b/crates/vcs_menu/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "vcs_menu"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "vim"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/vim_mode_setting/Cargo.toml
+++ b/crates/vim_mode_setting/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "vim_mode_setting"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/welcome/Cargo.toml
+++ b/crates/welcome/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "welcome"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "workspace"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "worktree"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lib]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 description = "The fast, collaborative code editor."
-edition = "2021"
+edition.workspace = true
 name = "zed"
 version = "0.171.0"
-publish = false
+publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]
 

--- a/crates/zed_actions/Cargo.toml
+++ b/crates/zed_actions/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_actions"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zeta"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 exclude = ["fixtures"]
 

--- a/extensions/csharp/Cargo.toml
+++ b/extensions/csharp/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_csharp"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/deno/Cargo.toml
+++ b/extensions/deno/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_deno"
 version = "0.0.2"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/elixir/Cargo.toml
+++ b/extensions/elixir/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_elixir"
 version = "0.1.2"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/emmet/Cargo.toml
+++ b/extensions/emmet/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_emmet"
 version = "0.0.3"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/erlang/Cargo.toml
+++ b/extensions/erlang/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_erlang"
 version = "0.1.1"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/glsl/Cargo.toml
+++ b/extensions/glsl/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_glsl"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_haskell"
 version = "0.1.2"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/html/Cargo.toml
+++ b/extensions/html/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_html"
 version = "0.1.4"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/lua/Cargo.toml
+++ b/extensions/lua/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_lua"
 version = "0.1.1"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/perplexity/Cargo.toml
+++ b/extensions/perplexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "perplexity"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [lib]

--- a/extensions/perplexity/Cargo.toml
+++ b/extensions/perplexity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "perplexity"
 version = "0.1.0"
 edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lib]

--- a/extensions/php/Cargo.toml
+++ b/extensions/php/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_php"
 version = "0.2.3"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/prisma/Cargo.toml
+++ b/extensions/prisma/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_prisma"
 version = "0.0.4"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/proto/Cargo.toml
+++ b/extensions/proto/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_proto"
 version = "0.2.1"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/purescript/Cargo.toml
+++ b/extensions/purescript/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_purescript"
 version = "0.0.1"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/ruff/Cargo.toml
+++ b/extensions/ruff/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_ruff"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/slash-commands-example/Cargo.toml
+++ b/extensions/slash-commands-example/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "slash_commands_example"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/snippets/Cargo.toml
+++ b/extensions/snippets/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_snippets"
 version = "0.0.5"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/terraform/Cargo.toml
+++ b/extensions/terraform/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_terraform"
 version = "0.1.1"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/test-extension/Cargo.toml
+++ b/extensions/test-extension/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_test_extension"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/toml/Cargo.toml
+++ b/extensions/toml/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_toml"
 version = "0.1.2"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/uiua/Cargo.toml
+++ b/extensions/uiua/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_uiua"
 version = "0.0.1"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/extensions/zig/Cargo.toml
+++ b/extensions/zig/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zed_zig"
 version = "0.3.2"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "Apache-2.0"
 
 [lints]

--- a/tooling/xtask/Cargo.toml
+++ b/tooling/xtask/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [lints]


### PR DESCRIPTION
This prepares us for an upcoming bump to Rust 2024 edition.

Release Notes:

- N/A
