### PR TITLE
html_to_markdown: Restore ability to publish

### DIFF
--- a/crates/html_to_markdown/Cargo.toml
+++ b/crates/html_to_markdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/html_to_markdown"
 keywords = ["html", "markdown", "html-to-markdown"]
 edition.workspace = true
-publish.workspace = true
+publish = true
 license = "Apache-2.0"
 
 [lints]


### PR DESCRIPTION
This PR restores the ability to publish the `html_to_markdown` crate after #23291.

This crate is [published](https://crates.io/crates/html_to_markdown) to crates.io so that it can be consumed by extensions.

Release Notes:

- N/A
