### PR TITLE
Add emacs mark mode

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -16,6 +16,7 @@
       "alt-g g": "go_to_line::Toggle", // goto-line
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
       "ctrl-space": "editor::SetMark", // set-mark
+      "ctrl-@": "editor::SetMark", // set-mark
       "ctrl-x ctrl-x": "editor::ExchangeMark", // exchange-point-and-mark
       "ctrl-f": "editor::MoveRight", // forward-char
       "ctrl-b": "editor::MoveLeft", // backward-char

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -15,7 +15,8 @@
       "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
       "alt-g g": "go_to_line::Toggle", // goto-line
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
-      //"ctrl-space": "editor::SetMark",
+      "ctrl-space": "editor::SetMark", // set-mark
+      "ctrl-x ctrl-x": "editor::ExchangeMark", // exchange-point-and-mark
       "ctrl-f": "editor::MoveRight", // forward-char
       "ctrl-b": "editor::MoveLeft", // backward-char
       "ctrl-n": "editor::MoveDown", // next-line
@@ -53,6 +54,32 @@
       "ctrl-l": "editor::ScrollCursorCenterTopBottom", // recenter-top-bottom
       "ctrl-s": "buffer_search::Deploy", // isearch-forward
       "alt-^": "editor::JoinLines" // join-line
+    }
+  },
+  {
+    "context": "selection_mode",
+    "bindings": {
+      "right": "editor::SelectRight",
+      "left": "editor::SelectLeft",
+      "down": "editor::SelectDown",
+      "up": "editor::SelectUp",
+      "home": "editor::SelectToBeginningOfLine",
+      "end": "editor::SelectToEndOfLine",
+      "alt-left": "editor::SelectToPreviousWordStart",
+      "alt-right": "editor::SelectToNextWordEnd",
+      "pagedown": "editor::SelectPageDown",
+      "pageup": "editor::SelectPageUp",
+      "ctrl-f": "editor::SelectRight",
+      "ctrl-b": "editor::SelectLeft",
+      "ctrl-n": "editor::SelectDown",
+      "ctrl-p": "editor::SelectUp",
+      "ctrl-a": "editor::SelectToBeginningOfLine",
+      "ctrl-e": "editor::SelectToEndOfLine",
+      "alt-f": "editor::SelectToNextWordEnd",
+      "alt-b": "editor::SelectToPreviousSubwordStart",
+      "alt-<": "editor::SelectToBeginning",
+      "alt->": "editor::SelectToEnd",
+      "ctrl-g": "editor::Cancel"
     }
   },
   {

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -26,8 +26,6 @@
       "end": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "ctrl-a": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
       "ctrl-e": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
-      "cmd-left": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
-      "cmd-right": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
       "shift-end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "alt-f": "editor::MoveToNextSubwordEnd", // forward-word

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -26,6 +26,10 @@
       "end": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "ctrl-a": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
       "ctrl-e": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
+      "cmd-left": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
+      "cmd-right": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
+      "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
+      "shift-end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "alt-f": "editor::MoveToNextSubwordEnd", // forward-word
       "alt-b": "editor::MoveToPreviousSubwordStart", // backward-word
       "alt-u": "editor::ConvertToUpperCase", // upcase-word
@@ -58,14 +62,12 @@
     }
   },
   {
-    "context": "selection_mode",
+    "context": "Editor && selection_mode", // region selection
     "bindings": {
       "right": "editor::SelectRight",
       "left": "editor::SelectLeft",
       "down": "editor::SelectDown",
       "up": "editor::SelectUp",
-      "home": "editor::SelectToBeginningOfLine",
-      "end": "editor::SelectToEndOfLine",
       "alt-left": "editor::SelectToPreviousWordStart",
       "alt-right": "editor::SelectToNextWordEnd",
       "pagedown": "editor::SelectPageDown",
@@ -74,8 +76,10 @@
       "ctrl-b": "editor::SelectLeft",
       "ctrl-n": "editor::SelectDown",
       "ctrl-p": "editor::SelectUp",
-      "ctrl-a": "editor::SelectToBeginningOfLine",
-      "ctrl-e": "editor::SelectToEndOfLine",
+      "home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }],
+      "end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }],
+      "ctrl-a": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }],
+      "ctrl-e": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }],
       "alt-f": "editor::SelectToNextWordEnd",
       "alt-b": "editor::SelectToPreviousSubwordStart",
       "alt-<": "editor::SelectToBeginning",

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -16,6 +16,7 @@
       "alt-g g": "go_to_line::Toggle", // goto-line
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
       "ctrl-space": "editor::SetMark", // set-mark
+      "ctrl-@": "editor::SetMark", // set-mark
       "ctrl-x ctrl-x": "editor::ExchangeMark", // exchange-point-and-mark
       "ctrl-f": "editor::MoveRight", // forward-char
       "ctrl-b": "editor::MoveLeft", // backward-char

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -15,7 +15,8 @@
       "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
       "alt-g g": "go_to_line::Toggle", // goto-line
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
-      //"ctrl-space": "editor::SetMark",
+      "ctrl-space": "editor::SetMark", // set-mark
+      "ctrl-x ctrl-x": "editor::ExchangeMark", // exchange-point-and-mark
       "ctrl-f": "editor::MoveRight", // forward-char
       "ctrl-b": "editor::MoveLeft", // backward-char
       "ctrl-n": "editor::MoveDown", // next-line
@@ -53,6 +54,32 @@
       "ctrl-l": "editor::ScrollCursorCenterTopBottom", // recenter-top-bottom
       "ctrl-s": "buffer_search::Deploy", // isearch-forward
       "alt-^": "editor::JoinLines" // join-line
+    }
+  },
+  {
+    "context": "selection_mode",
+    "bindings": {
+      "right": "editor::SelectRight",
+      "left": "editor::SelectLeft",
+      "down": "editor::SelectDown",
+      "up": "editor::SelectUp",
+      "home": "editor::SelectToBeginningOfLine",
+      "end": "editor::SelectToEndOfLine",
+      "alt-left": "editor::SelectToPreviousWordStart",
+      "alt-right": "editor::SelectToNextWordEnd",
+      "pagedown": "editor::SelectPageDown",
+      "pageup": "editor::SelectPageUp",
+      "ctrl-f": "editor::SelectRight",
+      "ctrl-b": "editor::SelectLeft",
+      "ctrl-n": "editor::SelectDown",
+      "ctrl-p": "editor::SelectUp",
+      "ctrl-a": "editor::SelectToBeginningOfLine",
+      "ctrl-e": "editor::SelectToEndOfLine",
+      "alt-f": "editor::SelectToNextWordEnd",
+      "alt-b": "editor::SelectToPreviousSubwordStart",
+      "alt-<": "editor::SelectToBeginning",
+      "alt->": "editor::SelectToEnd",
+      "ctrl-g": "editor::Cancel"
     }
   },
   {

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -26,8 +26,6 @@
       "end": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "ctrl-a": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
       "ctrl-e": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
-      "cmd-left": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
-      "cmd-right": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
       "shift-end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "alt-f": "editor::MoveToNextSubwordEnd", // forward-word

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -26,6 +26,10 @@
       "end": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "ctrl-a": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
       "ctrl-e": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
+      "cmd-left": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
+      "cmd-right": ["editor::MoveToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
+      "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }], // move-beginning-of-line
+      "shift-end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }], // move-end-of-line
       "alt-f": "editor::MoveToNextSubwordEnd", // forward-word
       "alt-b": "editor::MoveToPreviousSubwordStart", // backward-word
       "alt-u": "editor::ConvertToUpperCase", // upcase-word
@@ -58,14 +62,12 @@
     }
   },
   {
-    "context": "selection_mode",
+    "context": "Editor && selection_mode", // region selection
     "bindings": {
       "right": "editor::SelectRight",
       "left": "editor::SelectLeft",
       "down": "editor::SelectDown",
       "up": "editor::SelectUp",
-      "home": "editor::SelectToBeginningOfLine",
-      "end": "editor::SelectToEndOfLine",
       "alt-left": "editor::SelectToPreviousWordStart",
       "alt-right": "editor::SelectToNextWordEnd",
       "pagedown": "editor::SelectPageDown",
@@ -74,8 +76,10 @@
       "ctrl-b": "editor::SelectLeft",
       "ctrl-n": "editor::SelectDown",
       "ctrl-p": "editor::SelectUp",
-      "ctrl-a": "editor::SelectToBeginningOfLine",
-      "ctrl-e": "editor::SelectToEndOfLine",
+      "home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }],
+      "end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }],
+      "ctrl-a": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false }],
+      "ctrl-e": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }],
       "alt-f": "editor::SelectToNextWordEnd",
       "alt-b": "editor::SelectToPreviousSubwordStart",
       "alt-<": "editor::SelectToBeginning",

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -377,6 +377,8 @@ gpui::actions!(
         ToggleInlayHints,
         ToggleInlineCompletions,
         ToggleLineNumbers,
+        ExchangeMark,
+        SetMark,
         ToggleRelativeLineNumbers,
         ToggleSelectionMenu,
         ToggleSoftWrap,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -356,6 +356,8 @@ impl EditorElement {
         register_action(view, cx, Editor::unfold_all);
         register_action(view, cx, Editor::unfold_at);
         register_action(view, cx, Editor::fold_selected_ranges);
+        register_action(view, cx, Editor::set_mark);
+        register_action(view, cx, Editor::exchange_mark);
         register_action(view, cx, Editor::show_completions);
         register_action(view, cx, Editor::toggle_code_actions);
         register_action(view, cx, Editor::open_excerpts);


### PR DESCRIPTION
Updates #21927
Replaces https://github.com/zed-industries/zed/pull/22904
Closes #8580

Adds actions (default keybinds with emacs keymap):
- editor::SetMark (`ctrl-space` and `ctrl-@`)
- editor::ExchangeMark (`ctrl-x ctrl-x`)

Co-Authored-By: Peter <peter@zed.dev>

Release Notes:

- Add Emacs mark mode (`ctrl-space` / `ctrl-@` to set mark; `ctrl-x ctrl-x` to swap mark/cursor)
- Breaking change: `selection` keyboard context has been replaced with `selection_mode`