### PR TITLE
Make `Project Diagnostics` icon a toggle

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -15,7 +15,7 @@ use editor::{
     Editor, EditorEvent, ExcerptId, ExcerptRange, MultiBuffer, ToOffset,
 };
 use gpui::{
-    actions, div, svg, AnyElement, AnyView, AppContext, Context, EventEmitter, FocusHandle,
+    actions, div, svg, AnyElement, AnyView, AppContext, Context, Entity, EventEmitter, FocusHandle,
     FocusableView, Global, HighlightStyle, InteractiveElement, IntoElement, Model, ParentElement,
     Render, SharedString, Styled, StyledText, Subscription, Task, View, ViewContext, VisualContext,
     WeakView, WindowContext,
@@ -30,8 +30,7 @@ use project_diagnostics_settings::ProjectDiagnosticsSettings;
 use settings::Settings;
 use std::{
     any::{Any, TypeId},
-    cmp,
-    cmp::Ordering,
+    cmp::{self, Ordering},
     mem,
     ops::{Range, RangeInclusive},
     sync::Arc,
@@ -259,6 +258,10 @@ impl ProjectDiagnosticsEditor {
     fn deploy(workspace: &mut Workspace, _: &Deploy, cx: &mut ViewContext<Workspace>) {
         if let Some(existing) = workspace.item_of_type::<ProjectDiagnosticsEditor>(cx) {
             workspace.activate_item(&existing, true, true, cx);
+            workspace.active_pane().update(cx, |p, cx| {
+                p.close_item_by_id(existing.entity_id(), workspace::SaveIntent::Skip, cx)
+                    .detach_and_log_err(cx);
+            });
         } else {
             let workspace_handle = cx.view().downgrade();
 


### PR DESCRIPTION
Closes #12886

Hi, I was looking for small issues to help with - please check if this small PR is useful.

Clicking the Project Diagnostics icon to open the tab, then clicking the icon again closes the tab.

I couldn't see how to open Project Diagnostics across multiple panes as JosephTLyons mentioned. Switching panes and clicking the icon again seems to refocus back to the Pane containing the Project Diagnostics tab - so another click is needed to toggle it closed if you switched panes.

Release Notes:

- N/A
