### PR TITLE
Add missing argument for Flatpak desktop file

### DIFF
--- a/script/flatpak/bundle-flatpak
+++ b/script/flatpak/bundle-flatpak
@@ -11,6 +11,7 @@ channel=$(<crates/zed/RELEASE_CHANNEL)
 
 export CHANNEL="$channel"
 export ARCHIVE="$archive"
+export APP_ARGS="%U"
 if [[ "$channel" == "dev" ]]; then
     export APP_ID="dev.zed.ZedDev"
     export APP_NAME="Zed Devel"


### PR DESCRIPTION
Relates to #22235

Release Notes:

- Fixed specified project not opening via `xdg-open` when using Flatpak

## Note 

You can mitigate this issue by editing the installed `.desktop` file (usually somewhere in `/var/lib/flatpak/app/dev.zed.Zed/$ARCH/$CHANNEL/$COMMIT/export/share/applications/dev.zed.Zed.desktop` if system installed)

```diff
8c8
< Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=zed-wrapper dev.zed.Zed
---
> Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=zed-wrapper dev.zed.Zed %U
```

(Note, `branch` and `arch` might differ on your setup)

## Without this fix

`xdg-open zed://file/home/user/project` will not open `/home/user/project` but will restore that last active Zed project (if closed, empty project otherwise)

## With this fix

`xdg-open zed://file/home/user/project` will open `/home/user/project`
