### PR TITLE
assistant2: fix use with rust-analyzer `"workspace": false`

### DIFF
--- a/crates/assistant2/Cargo.toml
+++ b/crates/assistant2/Cargo.toml
@@ -12,6 +12,14 @@ workspace = true
 path = "src/assistant.rs"
 doctest = false
 
+[features]
+test-support = [
+    "editor/test-support",
+    "language/test-support",
+    "project/test-support",
+    "text/test-support",
+]
+
 [dependencies]
 anyhow.workspace = true
 assistant_settings.workspace = true


### PR DESCRIPTION
Before this was getting errors about `TestAppContext` not existing.

Release Notes:

- N/A