### PR TITLE
editor: Hide horizontal scrollbar if not visible

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1206,6 +1206,7 @@ impl InlineAssistant {
                     editor.set_show_wrap_guides(false, cx);
                     editor.set_show_gutter(false, cx);
                     editor.scroll_manager.set_forbid_vertical_scroll(true);
+                    editor.set_show_scrollbars(false, cx);
                     editor.set_read_only(true);
                     editor.set_show_inline_completions(Some(false), cx);
                     editor.highlight_rows::<DeletedLines>(

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -1280,6 +1280,7 @@ impl InlineAssistant {
                     editor.set_show_wrap_guides(false, cx);
                     editor.set_show_gutter(false, cx);
                     editor.scroll_manager.set_forbid_vertical_scroll(true);
+                    editor.set_show_scrollbars(false, cx);
                     editor.set_read_only(true);
                     editor.set_show_inline_completions(Some(false), cx);
                     editor.highlight_rows::<DeletedLines>(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1335,11 +1335,15 @@ impl EditorElement {
             total_text_units
                 .horizontal
                 .zip(track_bounds.horizontal)
-                .map(|(total_text_units_x, track_bounds_x)| {
+                .and_then(|(total_text_units_x, track_bounds_x)| {
+                    if text_units_per_page.horizontal >= total_text_units_x {
+                        return None;
+                    }
+
                     let thumb_percent =
                         (text_units_per_page.horizontal / total_text_units_x).min(1.);
 
-                    track_bounds_x.size.width * thumb_percent
+                    Some(track_bounds_x.size.width * thumb_percent)
                 }),
             total_text_units.vertical.zip(track_bounds.vertical).map(
                 |(total_text_units_y, track_bounds_y)| {


### PR DESCRIPTION
This PR fixes two visual issues, that were caused by the fact that we were always painting the horizontal scrollbar even if there is no horizontal scrolling possible

Obscuring deleted lines when using the inline assistant:

https://github.com/user-attachments/assets/f8460c3f-403e-40a6-8622-65268ba2d875

Cutting off text even when horizontal scrolling is not possible (line 29):

https://github.com/user-attachments/assets/23c909f7-1c23-4693-8edc-40a2f089d4a8

This issue was only present in some themes (e.g. Nord, Catpuccin)


Closes #22716

Release Notes:

- Fixed an issue where horizontal scrollbars of editors would always be painted (even if there is no horizontal scrolling to be done)
