### PR TITLE
nix: Update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1734324364,
-        "narHash": "sha256-omYTR59TdH0AumP1cfh49fBnWZ52HjfdNfaLzCMZBx0=",
+        "lastModified": 1736898272,
+        "narHash": "sha256-D10wlrU/HCpSRcb3a7yk+bU3ggpMD1kGbseKtO+7teo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "60d7623f1320470bf2fdb92fd2dca1e9a27b98ce",
+        "rev": "6a589f034202a7c6e10bce6c5d1d392d7bc0f340",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734316514,
-        "narHash": "sha256-0aLx44yMblcOGpfFXKCzp2GhU5JaE6OTvdU+JYrXiUc=",
+        "lastModified": 1737166965,
+        "narHash": "sha256-vlDROBAgq+7PEVM0vaS2zboY6DXs3oKK0qW/1dVuFs4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "83ee8ff74d6294a7657320f16814754c4594127b",
+        "rev": "fc839c9d5d1ebc789b4657c43c4d54838c7c01de",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -29,6 +29,7 @@ pkgs.mkShell rec {
       pkgs.libgit2
       pkgs.openssl
       pkgs.sqlite
+      pkgs.stdenv.cc.cc
       pkgs.zlib
       pkgs.zstd
       pkgs.rustToolchain
@@ -42,17 +43,14 @@ pkgs.mkShell rec {
     ]
     ++ lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.apple-sdk_15;
 
-  LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+  LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+
+  PROTOC="${pkgs.protobuf}/bin/protoc";
 
   # We set SDKROOT and DEVELOPER_DIR to the Xcode ones instead of the nixpkgs ones,
   # because we need Swift 6.0 and nixpkgs doesn't have it.
   # Xcode is required for development anyways
-  shellHook =
-    ''
-      export LD_LIBRARY_PATH="${lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH"
-      export PROTOC="${pkgs.protobuf}/bin/protoc"
-    ''
-    + lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+  shellHook = lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
       export SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
       export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer";
     '';


### PR DESCRIPTION
Closes #23342 

Ran `nix flake update` and did some cleanup in shell.nix to follow nix [best practices](https://discourse.nixos.org/t/how-to-solve-libstdc-not-found-in-shell-nix/25458/6).

Prior to running `nix flake update`
`strings "$(echo "$LD_LIBRARY_PATH" | tr : "\n" | grep "gcc")/libstdc++.so.6" | grep "CXXABI_1.3.15" CXXABI_1.3.15`
Does not find `CXXABI_1.3.15`

After running `nix flake update`

`strings "$(echo "$LD_LIBRARY_PATH" | tr : "\n" | grep "gcc")/libstdc++.so.6" | grep "CXXABI_1.3.15" CXXABI_1.3.15`
Finds `CXXABI_1.3.15`

Launching Zed 0.168.3 inside Zed's nix development shell now launches with no errors.

Release Notes:

- N/A

