### PR TITLE
vim: Fix substitute command for /n and /c

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1220,7 +1220,7 @@ impl BufferSearchBar {
         }
     }
 
-    fn replace_next(&mut self, _: &ReplaceNext, cx: &mut ViewContext<Self>) {
+    pub fn replace_next(&mut self, _: &ReplaceNext, cx: &mut ViewContext<Self>) {
         let mut should_propagate = true;
         if !self.dismissed && self.active_search.is_some() {
             if let Some(searchable_item) = self.active_searchable_item.as_ref() {


### PR DESCRIPTION
Closes #23345

Release Notes:
- Fixed vim substitute command to enable override of global (replace all) default behavior using flags /n and /c