### PR TITLE
windows: Rename some constants and functions in GPUI

### DIFF
--- a/crates/gpui/src/platform/windows/dispatcher.rs
+++ b/crates/gpui/src/platform/windows/dispatcher.rs
@@ -21,7 +21,7 @@ use windows::{
     },
 };
 
-use crate::{PlatformDispatcher, TaskLabel, WM_ZED_EVENT_DISPATCHED_ON_MAIN_THREAD};
+use crate::{PlatformDispatcher, TaskLabel, WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD};
 
 pub(crate) struct WindowsDispatcher {
     main_sender: Sender<Runnable>,
@@ -105,7 +105,7 @@ impl PlatformDispatcher for WindowsDispatcher {
             unsafe {
                 PostThreadMessageW(
                     self.main_thread_id_win32,
-                    WM_ZED_EVENT_DISPATCHED_ON_MAIN_THREAD,
+                    WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD,
                     WPARAM(self.validation_number),
                     LPARAM(0),
                 )

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -16,9 +16,9 @@ use windows::Win32::{
 
 use crate::*;
 
-pub(crate) const WM_ZED_CURSOR_STYLE_CHANGED: u32 = WM_USER + 1;
-pub(crate) const WM_ZED_CLOSE_ONE_WINDOW: u32 = WM_USER + 2;
-pub(crate) const WM_ZED_EVENT_DISPATCHED_ON_MAIN_THREAD: u32 = WM_USER + 3;
+pub(crate) const WM_GPUI_CURSOR_STYLE_CHANGED: u32 = WM_USER + 1;
+pub(crate) const WM_GPUI_CLOSE_ONE_WINDOW: u32 = WM_USER + 2;
+pub(crate) const WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD: u32 = WM_USER + 3;
 
 const SIZE_MOVE_LOOP_TIMER_ID: usize = 1;
 const AUTO_HIDE_TASKBAR_THICKNESS_PX: i32 = 1;
@@ -90,7 +90,7 @@ pub(crate) fn handle_msg(
         WM_SETCURSOR => handle_set_cursor(lparam, state_ptr),
         WM_SETTINGCHANGE => handle_system_settings_changed(handle, state_ptr),
         WM_DWMCOLORIZATIONCOLORCHANGED => handle_system_theme_changed(state_ptr),
-        WM_ZED_CURSOR_STYLE_CHANGED => handle_cursor_changed(lparam, state_ptr),
+        WM_GPUI_CURSOR_STYLE_CHANGED => handle_cursor_changed(lparam, state_ptr),
         _ => None,
     };
     if let Some(n) = handled {
@@ -246,7 +246,7 @@ fn handle_destroy_msg(handle: HWND, state_ptr: Rc<WindowsWindowStatePtr>) -> Opt
     unsafe {
         PostThreadMessageW(
             state_ptr.main_thread_id_win32,
-            WM_ZED_CLOSE_ONE_WINDOW,
+            WM_GPUI_CLOSE_ONE_WINDOW,
             WPARAM(state_ptr.validation_number),
             LPARAM(handle.0 as isize),
         )

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -190,7 +190,7 @@ impl WindowsPlatform {
             while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
                 match msg.message {
                     WM_QUIT => return true,
-                    WM_ZED_CLOSE_ONE_WINDOW | WM_ZED_EVENT_DISPATCHED_ON_MAIN_THREAD => {
+                    WM_GPUI_CLOSE_ONE_WINDOW | WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD => {
                         if self.handle_zed_evnets(msg.message, msg.wParam, msg.lParam, &msg) {
                             return true;
                         }
@@ -219,12 +219,12 @@ impl WindowsPlatform {
             return false;
         }
         match message {
-            WM_ZED_CLOSE_ONE_WINDOW => {
+            WM_GPUI_CLOSE_ONE_WINDOW => {
                 if self.close_one_window(HWND(lparam.0 as _)) {
                     return true;
                 }
             }
-            WM_ZED_EVENT_DISPATCHED_ON_MAIN_THREAD => self.run_foreground_task(),
+            WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD => self.run_foreground_task(),
             _ => unreachable!(),
         }
         false
@@ -506,7 +506,7 @@ impl Platform for WindowsPlatform {
         let mut lock = self.state.borrow_mut();
         if lock.current_cursor.0 != hcursor.0 {
             self.post_message(
-                WM_ZED_CURSOR_STYLE_CHANGED,
+                WM_GPUI_CURSOR_STYLE_CHANGED,
                 WPARAM(0),
                 LPARAM(hcursor.0 as isize),
             );

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -184,6 +184,7 @@ impl WindowsPlatform {
         }
     }
 
+    // Returns true if the app should quit.
     fn handle_events(&self) -> bool {
         let mut msg = MSG::default();
         unsafe {
@@ -191,7 +192,7 @@ impl WindowsPlatform {
                 match msg.message {
                     WM_QUIT => return true,
                     WM_GPUI_CLOSE_ONE_WINDOW | WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD => {
-                        if self.handle_zed_evnets(msg.message, msg.wParam, msg.lParam, &msg) {
+                        if self.handle_gpui_evnets(msg.message, msg.wParam, msg.lParam, &msg) {
                             return true;
                         }
                     }
@@ -207,7 +208,8 @@ impl WindowsPlatform {
         false
     }
 
-    fn handle_zed_evnets(
+    // Returns true if the app should quit.
+    fn handle_gpui_evnets(
         &self,
         message: u32,
         wparam: WPARAM,


### PR DESCRIPTION
This PR renames the constants and functions previously introduced in PR#23283. Since the changes are within the GPUI crate, I renamed these from `**_ZED_**` to `**_GPUI_**`.


Release Notes:

- N/A
