### PR TITLE
pane: Hide "Copy Relative Path" and "Reveal In Project Panel" actions for files outside of the projects

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2468,6 +2468,7 @@ impl Pane {
                             .and_then(|item| item.project_path(cx))
                             .map(|project_path| project_path.path)
                             .map_or(None, |path| if path.exists() { Some(path) } else { None });
+                        let has_relative_path = relative_path.is_some();
 
                         let entry_id = entry.to_proto();
                         menu = menu
@@ -2496,21 +2497,23 @@ impl Pane {
                             })
                             .map(pin_tab_entries)
                             .separator()
-                            .entry(
-                                "Reveal In Project Panel",
-                                Some(Box::new(RevealInProjectPanel {
-                                    entry_id: Some(entry_id),
-                                })),
-                                window.handler_for(&pane, move |pane, _, cx| {
-                                    pane.project
-                                        .update(cx, |_, cx| {
-                                            cx.emit(project::Event::RevealInProjectPanel(
-                                                ProjectEntryId::from_proto(entry_id),
-                                            ))
-                                        })
-                                        .ok();
-                                }),
-                            )
+                            .when(has_relative_path, |menu| {
+                                menu.entry(
+                                    "Reveal In Project Panel",
+                                    Some(Box::new(RevealInProjectPanel {
+                                        entry_id: Some(entry_id),
+                                    })),
+                                    window.handler_for(&pane, move |pane, _, cx| {
+                                        pane.project
+                                            .update(cx, |_, cx| {
+                                                cx.emit(project::Event::RevealInProjectPanel(
+                                                    ProjectEntryId::from_proto(entry_id),
+                                                ))
+                                            })
+                                            .ok();
+                                    }),
+                                )
+                            })
                             .when_some(parent_abs_path, |menu, parent_abs_path| {
                                 menu.entry(
                                     "Open in Terminal",

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2466,7 +2466,8 @@ impl Pane {
                             .read(cx)
                             .item_for_entry(entry, cx)
                             .and_then(|item| item.project_path(cx))
-                            .map(|project_path| project_path.path);
+                            .map(|project_path| project_path.path)
+                            .map_or(None, |path| if path.exists() { Some(path) } else { None });
 
                         let entry_id = entry.to_proto();
                         menu = menu


### PR DESCRIPTION
Split off from #21000.

"Copy Relative Path" action had a check for existence of relative path but it always passed because [`WorktreeStore::find_worktree()`](https://github.com/zed-industries/zed/blob/1d5499bee72f1ea57ed883b942f05d5c1e7cec89/crates/project/src/worktree_store.rs#L148) function returned empty path for these kinds of files. It feels correct to make changes there, but I don't know what else could be impacted. 

"Reveal In Project Panel" had no check whatsoever and so I made one.

Release Notes:

- N/A
