### PR TITLE
workspace: Add actions for cycling between windows

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4688,13 +4688,12 @@ impl Workspace {
         let Some(current_window_id) = cx.active_window().map(|a| a.window_id()) else {
             return;
         };
-        let Some(next_window) = cx
-            .windows()
+        let windows = cx.windows();
+        let Some(next_window) = windows
             .iter()
             .cycle()
             .skip_while(|window| window.window_id() != current_window_id)
             .nth(1)
-            .cloned()
         else {
             return;
         };
@@ -4705,14 +4704,13 @@ impl Workspace {
         let Some(current_window_id) = cx.active_window().map(|a| a.window_id()) else {
             return;
         };
-        let Some(prev_window) = cx
-            .windows()
+        let windows = cx.windows();
+        let Some(prev_window) = windows
             .iter()
             .rev()
             .cycle()
             .skip_while(|window| window.window_id() != current_window_id)
             .nth(1)
-            .cloned()
         else {
             return;
         };


### PR DESCRIPTION
Closes #22740

I haven't assigned any default keybindings to these actions because it might conflict with existing OS bindings.

Preview:

https://github.com/user-attachments/assets/7c62cb34-2747-4674-a278-f0998e7d17f9

Release Notes:

- Added `workspace::ActivateNextWindow` and `workspace::ActivatePreviousWindow` actions for cycling between windows.

