### PR TITLE
keybindings: Fix AcceptPartialInlineCompletion on macOS

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -158,7 +158,7 @@
     "bindings": {
       "alt-tab": "editor::NextInlineCompletion",
       "alt-shift-tab": "editor::PreviousInlineCompletion",
-      "ctrl-right": "editor::AcceptPartialInlineCompletion"
+      "ctrl-cmd-right": "editor::AcceptPartialInlineCompletion"
     }
   },
   {


### PR DESCRIPTION
Related issue: https://github.com/zed-industries/zed/issues/20167

Release Notes:

- Changed the default keybinding to accept partial inline completions from `ctrl-right` to `ctrl-cmd-right` on macOS, because `ctrl-right` is already bound to jump to the end of the line.
