### PR TITLE
assistant2: Adjust "Recent" header label design in context picker

### DIFF
--- a/crates/assistant2/src/context_picker.rs
+++ b/crates/assistant2/src/context_picker.rs
@@ -92,7 +92,18 @@ impl ContextPicker {
                 .map(|(ix, entry)| self.recent_menu_item(context_picker.clone(), ix, entry));
 
             let menu = menu
-                .when(has_recent, |menu| menu.label("Recent"))
+                .when(has_recent, |menu| {
+                    menu.custom_row(|_| {
+                        div()
+                            .mb_1()
+                            .child(
+                                Label::new("Recent")
+                                    .color(Color::Muted)
+                                    .size(LabelSize::Small),
+                            )
+                            .into_any_element()
+                    })
+                })
                 .extend(recent_entries)
                 .when(has_recent, |menu| menu.separator())
                 .extend(ContextKind::all().into_iter().map(kind_entry));


### PR DESCRIPTION
Just a little design fine-tune.

| Before | After |
|--------|--------|
| <img width="454" alt="Screenshot 2025-01-20 at 12 13 10 PM" src="https://github.com/user-attachments/assets/b27372f2-00f5-40f4-927d-0d831ec4b90d" /> | <img width="454" alt="Screenshot 2025-01-20 at 12 12 17 PM" src="https://github.com/user-attachments/assets/207d08da-d75e-4c60-a6eb-cb1549b5925c" /> | 

Release Notes:

- N/A

