### PR TITLE
git_ui: Capitalize co-author prefix

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -749,12 +749,13 @@ impl GitPanel {
 
         let mut existing_text = self.commit_editor.read(cx).text(cx);
         existing_text.make_ascii_lowercase();
+        let lowercase_co_author_prefix = CO_AUTHOR_PREFIX.to_lowercase();
         let mut ends_with_co_authors = false;
         let existing_co_authors = existing_text
             .lines()
             .filter_map(|line| {
                 let line = line.trim();
-                if line.starts_with(CO_AUTHOR_PREFIX) {
+                if line.starts_with(&lowercase_co_author_prefix) {
                     ends_with_co_authors = true;
                     Some(line)
                 } else {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -737,7 +737,7 @@ impl GitPanel {
     }
 
     fn fill_co_authors(&mut self, _: &FillCoAuthors, cx: &mut ViewContext<Self>) {
-        const CO_AUTHOR_PREFIX: &str = "co-authored-by: ";
+        const CO_AUTHOR_PREFIX: &str = "Co-authored-by: ";
 
         let Some(room) = self
             .workspace


### PR DESCRIPTION
This PR capitalizes the co-author prefix, as this is the way GitHub writes it in their [docs](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line).

Release Notes:

- N/A
