### PR TITLE
Fix older Anthropic models not supporting `-latest` tags

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -77,8 +77,8 @@ impl Model {
             Model::Claude3_5Sonnet => "claude-3-5-sonnet-latest",
             Model::Claude3_5Haiku => "claude-3-5-haiku-latest",
             Model::Claude3Opus => "claude-3-opus-latest",
-            Model::Claude3Sonnet => "claude-3-sonnet-latest",
-            Model::Claude3Haiku => "claude-3-haiku-latest",
+            Model::Claude3Sonnet => "claude-3-sonnet-20240229",
+            Model::Claude3Haiku => "claude-3-haiku-20240307",
             Self::Custom { name, .. } => name,
         }
     }


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/22322

Originally broken in:
- https://github.com/zed-industries/zed/pull/19615

Release Notes:

- Fixed older Anthropic models (Claude 3 and Haiku 3) in Zed Assistant