### PR TITLE
editor: Fix inline Git blame not visible on long lines due to overflow

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6644,11 +6644,9 @@ impl Element for EditorElement {
                             let blame = editor.blame.as_ref()?;
                             let blame_entry = blame
                                 .update(cx, |blame, cx| {
-                                    let buffer_row = snapshot
-                                        .buffer_rows(snapshot.longest_row())
-                                        .next()
-                                        .flatten()?;
-                                    blame.blame_for_rows([Some(buffer_row)], cx).next()
+                                    let row_infos =
+                                        snapshot.row_infos(snapshot.longest_row()).next()?;
+                                    blame.blame_for_rows(&[row_infos], cx).next()
                                 })
                                 .flatten()?;
                             let workspace = editor.workspace.as_ref().map(|(w, _)| w.to_owned());
@@ -6661,7 +6659,9 @@ impl Element for EditorElement {
                             );
                             let inline_blame_padding = INLINE_BLAME_PADDING_EM_WIDTHS * em_advance;
                             Some(
-                                element.layout_as_root(AvailableSpace::min_size(), cx).width
+                                element
+                                    .layout_as_root(AvailableSpace::min_size(), window, cx)
+                                    .width
                                     + inline_blame_padding,
                             )
                         })

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6639,24 +6639,16 @@ impl Element for EditorElement {
                         if !editor.show_git_blame_inline {
                             return None;
                         }
-                        let Some(blame) = editor.blame.as_ref() else {
-                            return None;
-                        };
-                        let Some(blame_entry) = blame
+                        let blame = editor.blame.as_ref()?;
+                        let blame_entry = blame
                             .update(cx, |blame, cx| {
-                                let Some(buffer_row) = snapshot
+                                let buffer_row = snapshot
                                     .buffer_rows(snapshot.longest_row())
                                     .next()
-                                    .flatten()
-                                else {
-                                    return None;
-                                };
+                                    .flatten()?;
                                 blame.blame_for_rows([Some(buffer_row)], cx).next()
                             })
-                            .flatten()
-                        else {
-                            return None;
-                        };
+                            .flatten()?;
                         let workspace = editor.workspace.as_ref().map(|(w, _)| w.to_owned());
                         let mut element =
                             render_inline_blame_entry(blame, blame_entry, &style, workspace, cx);


### PR DESCRIPTION
Closes #18702

This is take 2 of [my previous PR](https://github.com/zed-industries/zed/pull/19555), which was closed due to inactivity and merge conflicts.  

**Cause**: 

The editor's horizontal scroll width only considers the longest line in the buffer, using `layout_line` for `longest_row`. The inline blame width isn’t included in it because it is just a decoration on top of the line (think of like CSS absolute) and not part of its actual content. This causes blame to overflow.

**Solution**:

Along with `longest_row` width we also add that line's inline blame width for scroll width calculation. We also have to add some padding that is between inline blame and line's content.

**Alternate Solution**:

In my previous PR, instead of adding the inline blame width of the longest line for scroll width calculation, I used the inline blame of the current line the cursor is on (since we only see the blame for the current line). I added that to the current line's width, giving us the full width of that row. Then, we compare that row's width with the longest row width and use the max of the two for the scroll width calculation.

While this solution seems clever, it's overly complicated and could cause issues, like the scroll width changing every time you move the cursor up or down. I don't think we should go with this, but I'm open to suggestions.

**Preview**:

Before:

https://github.com/user-attachments/assets/01ef90cf-06e7-4ebb-8bd1-637a53e0654e

After:

https://github.com/user-attachments/assets/b13616de-bdea-4da4-b32d-9c4104448166


Release Notes:

- Fixed inline Git blame not visible on long lines due to overflow.
