### PR TITLE
Fix project entry rename in Remote Development

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2864,6 +2864,7 @@ impl LspStore {
         client.add_model_request_handler(Self::handle_on_type_formatting);
         client.add_model_request_handler(Self::handle_apply_additional_edits_for_completion);
         client.add_model_request_handler(Self::handle_register_buffer_with_language_servers);
+        client.add_model_request_handler(Self::handle_rename_project_entry);
         client.add_model_request_handler(Self::handle_lsp_command::<GetCodeActions>);
         client.add_model_request_handler(Self::handle_lsp_command::<GetCompletions>);
         client.add_model_request_handler(Self::handle_lsp_command::<GetHover>);
@@ -5918,6 +5919,52 @@ impl LspStore {
             Ok(())
         })??;
         Ok(proto::Ack {})
+    }
+
+    async fn handle_rename_project_entry(
+        this: Model<Self>,
+        envelope: TypedEnvelope<proto::RenameProjectEntry>,
+        mut cx: AsyncAppContext,
+    ) -> Result<proto::ProjectEntryResponse> {
+        let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
+        let (worktree_id, worktree, old_path, is_dir) = this
+            .update(&mut cx, |this, cx| {
+                this.worktree_store
+                    .read(cx)
+                    .worktree_and_entry_for_id(entry_id, cx)
+                    .map(|(worktree, entry)| {
+                        (
+                            worktree.read(cx).id(),
+                            worktree,
+                            entry.path.clone(),
+                            entry.is_dir(),
+                        )
+                    })
+            })?
+            .ok_or_else(|| anyhow!("worktree not found"))?;
+        let (old_abs_path, new_abs_path) = {
+            let root_path = worktree.update(&mut cx, |this, _| this.abs_path())?;
+            (
+                root_path.join(&old_path),
+                root_path.join(&envelope.payload.new_path),
+            )
+        };
+
+        Self::will_rename_entry(
+            this.downgrade(),
+            worktree_id,
+            &old_abs_path,
+            &new_abs_path,
+            is_dir,
+            cx.clone(),
+        )
+        .await;
+        let response = Worktree::handle_rename_entry(worktree, envelope.payload, cx.clone()).await;
+        this.update(&mut cx, |this, _| {
+            this.did_rename_entry(worktree_id, &old_abs_path, &new_abs_path, is_dir);
+        })
+        .ok();
+        response
     }
 
     async fn handle_update_diagnostic_summary(

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6246,7 +6246,7 @@ impl LspStore {
             .map(|(key, value)| (*key, value))
     }
 
-    pub fn did_rename_entry(
+    pub(super) fn did_rename_entry(
         &self,
         worktree_id: WorktreeId,
         old_path: &Path,
@@ -6282,7 +6282,7 @@ impl LspStore {
         });
     }
 
-    pub fn will_rename_entry(
+    pub(super) fn will_rename_entry(
         this: WeakModel<Self>,
         worktree_id: WorktreeId,
         old_path: &Path,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6199,7 +6199,7 @@ impl LspStore {
             .map(|(key, value)| (*key, value))
     }
 
-    pub(super) fn did_rename_entry(
+    pub fn did_rename_entry(
         &self,
         worktree_id: WorktreeId,
         old_path: &Path,
@@ -6235,7 +6235,7 @@ impl LspStore {
         });
     }
 
-    pub(super) fn will_rename_entry(
+    pub fn will_rename_entry(
         this: WeakModel<Self>,
         worktree_id: WorktreeId,
         old_path: &Path,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -602,6 +602,7 @@ impl Project {
         client.add_model_request_handler(Self::handle_open_new_buffer);
         client.add_model_message_handler(Self::handle_create_buffer_for_peer);
 
+        // Uses the Project to coordinate the rename between LSP and Worktree.
         client.add_model_request_handler(WorktreeStore::handle_rename_project_entry);
 
         WorktreeStore::init(&client);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -602,9 +602,6 @@ impl Project {
         client.add_model_request_handler(Self::handle_open_new_buffer);
         client.add_model_message_handler(Self::handle_create_buffer_for_peer);
 
-        // Uses the Project to coordinate the rename between LSP and Worktree.
-        client.add_model_request_handler(WorktreeStore::handle_rename_project_entry);
-
         WorktreeStore::init(&client);
         BufferStore::init(&client);
         LspStore::init(&client);

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -12,8 +12,7 @@ use project::{
     search::SearchQuery,
     task_store::TaskStore,
     worktree_store::WorktreeStore,
-    LspStore, LspStoreEvent, PrettierStore, ProjectEntryId, ProjectPath, ToolchainStore,
-    WorktreeId,
+    LspStore, LspStoreEvent, PrettierStore, ProjectPath, ToolchainStore, WorktreeId,
 };
 use remote::ssh_session::ChannelClient;
 use rpc::{

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -12,7 +12,8 @@ use project::{
     search::SearchQuery,
     task_store::TaskStore,
     worktree_store::WorktreeStore,
-    LspStore, LspStoreEvent, PrettierStore, ProjectPath, ToolchainStore, WorktreeId,
+    LspStore, LspStoreEvent, PrettierStore, ProjectEntryId, ProjectPath, ToolchainStore,
+    WorktreeId,
 };
 use remote::ssh_session::ChannelClient;
 use rpc::{
@@ -184,6 +185,7 @@ impl HeadlessProject {
         client.add_model_request_handler(Self::handle_open_new_buffer);
         client.add_model_request_handler(Self::handle_find_search_candidates);
         client.add_model_request_handler(Self::handle_open_server_settings);
+        client.add_model_request_handler(Self::handle_rename_project_entry);
 
         client.add_model_request_handler(BufferStore::handle_update_buffer);
         client.add_model_message_handler(BufferStore::handle_close_buffer);
@@ -376,6 +378,60 @@ impl HeadlessProject {
         .detach();
 
         Ok(response)
+    }
+
+    pub async fn handle_rename_project_entry(
+        this: Model<Self>,
+        envelope: TypedEnvelope<proto::RenameProjectEntry>,
+        mut cx: AsyncAppContext,
+    ) -> Result<proto::ProjectEntryResponse> {
+        let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
+        let (worktree_id, worktree, old_path, is_dir) = this
+            .update(&mut cx, |this, cx| {
+                this.worktree_store
+                    .read(cx)
+                    .worktree_and_entry_for_id(entry_id, cx)
+                    .map(|(worktree, entry)| {
+                        (
+                            worktree.read(cx).id(),
+                            worktree,
+                            entry.path.clone(),
+                            entry.is_dir(),
+                        )
+                    })
+            })?
+            .ok_or_else(|| anyhow!("worktree not found"))?;
+        let (old_abs_path, new_abs_path) = {
+            let root_path = worktree.update(&mut cx, |this, _| this.abs_path())?;
+            (
+                root_path.join(&old_path),
+                root_path.join(&envelope.payload.new_path),
+            )
+        };
+
+        let lsp_store = this
+            .update(&mut cx, |this, _| this.lsp_store.clone())?
+            .downgrade();
+        LspStore::will_rename_entry(
+            lsp_store,
+            worktree_id,
+            &old_abs_path,
+            &new_abs_path,
+            is_dir,
+            cx.clone(),
+        )
+        .await;
+        let response = Worktree::handle_rename_entry(worktree, envelope.payload, cx.clone()).await;
+        this.update(&mut cx, |this, cx| {
+            this.lsp_store.clone().read(cx).did_rename_entry(
+                worktree_id,
+                &old_abs_path,
+                &new_abs_path,
+                is_dir,
+            );
+        })
+        .ok();
+        response
     }
 
     pub async fn handle_remove_worktree(


### PR DESCRIPTION
Closes #22883

To fix the problem, we move `handle_rename_project_entry` from `Worktree` to `LspStore` and register it there. This way it becomes available both in local and headless projects and this avoids the duplication.

Release Notes:

- Fixed renaming project entries in Remote Development
