### PR TITLE
Wire up `@mention`ed files in assistant2

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1969,6 +1969,8 @@ impl ContextEditor {
                                 );
                             });
 
+                            dbg!(&start, &end);
+
                             Crease::inline(
                                 start..end,
                                 placeholder,
@@ -2067,6 +2069,8 @@ impl ContextEditor {
                             let end = buffer
                                 .anchor_in_excerpt(excerpt_id, command.source_range.end)
                                 .unwrap();
+
+                            dbg!(&start, &end);
                             Crease::inline(start..end, placeholder, render_toggle, render_trailer)
                         }),
                         cx,

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1969,8 +1969,6 @@ impl ContextEditor {
                                 );
                             });
 
-                            dbg!(&start, &end);
-
                             Crease::inline(
                                 start..end,
                                 placeholder,
@@ -2069,8 +2067,6 @@ impl ContextEditor {
                             let end = buffer
                                 .anchor_in_excerpt(excerpt_id, command.source_range.end)
                                 .unwrap();
-
-                            dbg!(&start, &end);
                             Crease::inline(start..end, placeholder, render_toggle, render_trailer)
                         }),
                         cx,

--- a/crates/assistant2/src/context_picker.rs
+++ b/crates/assistant2/src/context_picker.rs
@@ -43,6 +43,7 @@ enum ContextPickerMode {
 pub(super) struct ContextPicker {
     mode: ContextPickerMode,
     workspace: WeakView<Workspace>,
+    editor: WeakView<Editor>,
     context_store: WeakModel<ContextStore>,
     thread_store: Option<WeakModel<ThreadStore>>,
     confirm_behavior: ConfirmBehavior,
@@ -53,6 +54,7 @@ impl ContextPicker {
         workspace: WeakView<Workspace>,
         thread_store: Option<WeakModel<ThreadStore>>,
         context_store: WeakModel<ContextStore>,
+        editor: WeakView<Editor>,
         confirm_behavior: ConfirmBehavior,
         cx: &mut ViewContext<Self>,
     ) -> Self {
@@ -61,6 +63,7 @@ impl ContextPicker {
             workspace,
             context_store,
             thread_store,
+            editor,
             confirm_behavior,
         }
     }
@@ -131,6 +134,7 @@ impl ContextPicker {
                     FileContextPicker::new(
                         context_picker.clone(),
                         self.workspace.clone(),
+                        self.editor.clone(),
                         self.context_store.clone(),
                         self.confirm_behavior,
                         cx,

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -265,14 +265,24 @@ impl PickerDelegate for FileContextPickerDelegate {
                         .selections
                         .all::<Point>(cx)
                         .into_iter()
-                        .map(|selection| snapshot.anchor_at(selection.head(), Bias::Left))
+                        .map(|selection| snapshot.anchor_after(selection.end))
                         .collect::<Vec<_>>()
                 };
+
+                editor.insert("\n", cx); // Needed to end the fold
+
+                // let snapshot = &editor.snapshot(cx).buffer_snapshot;
+                // for anchor in &start_anchors {
+                //     dbg!(anchor.to_point(&snapshot));
+                // }
+                // for anchor in &end_anchors {
+                //     dbg!(anchor.to_point(&snapshot));
+                // }
 
                 let placeholder = FoldPlaceholder {
                     render: render_fold_icon_button(
                         cx.view().downgrade(),
-                        IconName::PocketKnife,
+                        IconName::File,
                         file_name.into(),
                     ),
                     ..Default::default()

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -283,21 +283,19 @@ impl PickerDelegate for FileContextPickerDelegate {
 
                 let buffer = editor.buffer().read(cx).snapshot(cx);
                 let mut rows_to_fold = BTreeSet::new();
-                let crease_iter =
-                    start_anchors
-                        .into_iter()
-                        .zip(end_anchors.into_iter())
-                        .map(|(start, end)| {
-                            dbg!(&start, &end);
-                            rows_to_fold.insert(MultiBufferRow(start.to_point(&buffer).row));
+                let crease_iter = start_anchors
+                    .into_iter()
+                    .zip(end_anchors)
+                    .map(|(start, end)| {
+                        rows_to_fold.insert(MultiBufferRow(start.to_point(&buffer).row));
 
-                            Crease::inline(
-                                start..end,
-                                placeholder.clone(),
-                                fold_toggle("tool-use"),
-                                render_trailer,
-                            )
-                        });
+                        Crease::inline(
+                            start..end,
+                            placeholder.clone(),
+                            fold_toggle("tool-use"),
+                            render_trailer,
+                        )
+                    });
 
                 editor.insert_creases(crease_iter, cx);
 

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use editor::actions::{Backspace, FoldAt};
+use editor::actions::FoldAt;
 use editor::display_map::{Crease, FoldId};
 use editor::scroll::Autoscroll;
 use editor::{Anchor, Editor, FoldPlaceholder, ToPoint};
@@ -275,11 +275,7 @@ impl PickerDelegate for FileContextPickerDelegate {
                 editor.insert("\n", cx); // Needed to end the fold
 
                 let placeholder = FoldPlaceholder {
-                    render: render_fold_icon_button(
-                        cx.view().downgrade(),
-                        IconName::File,
-                        file_name.into(),
-                    ),
+                    render: render_fold_icon_button(IconName::File, file_name.into()),
                     ..Default::default()
                 };
 
@@ -303,7 +299,7 @@ impl PickerDelegate for FileContextPickerDelegate {
                             )
                         });
 
-                let crease_ids = editor.insert_creases(crease_iter, cx);
+                editor.insert_creases(crease_iter, cx);
 
                 for buffer_row in rows_to_fold {
                     editor.fold_at(&FoldAt { buffer_row }, cx);
@@ -446,28 +442,15 @@ pub fn render_file_context_entry(
 }
 
 fn render_fold_icon_button(
-    editor: WeakView<Editor>,
     icon: IconName,
     label: SharedString,
 ) -> Arc<dyn Send + Sync + Fn(FoldId, Range<Anchor>, &mut WindowContext) -> AnyElement> {
-    Arc::new(move |fold_id, fold_range, _cx| {
-        let editor = editor.clone();
+    Arc::new(move |fold_id, _fold_range, _cx| {
         ButtonLike::new(fold_id)
             .style(ButtonStyle::Filled)
             .layer(ElevationIndex::ElevatedSurface)
             .child(Icon::new(icon))
             .child(Label::new(label.clone()).single_line())
-            // .on_click(move |_, cx| {
-            //     editor
-            //         .update(cx, |editor, cx| {
-            //             let buffer_start = fold_range
-            //                 .start
-            //                 .to_point(&editor.buffer().read(cx).read(cx));
-            //             let buffer_row = MultiBufferRow(buffer_start.row);
-            //             editor.unfold_at(&UnfoldAt { buffer_row }, cx);
-            //         })
-            //         .ok();
-            // })
             .into_any_element()
     })
 }

--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 pub struct ContextStrip {
+    editor: WeakView<Editor>,
     context_store: Model<ContextStore>,
     pub context_picker: View<ContextPicker>,
     context_picker_menu_handle: PopoverMenuHandle<ContextPicker>,
@@ -39,6 +40,7 @@ impl ContextStrip {
     pub fn new(
         context_store: Model<ContextStore>,
         workspace: WeakView<Workspace>,
+        editor: WeakView<Editor>,
         thread_store: Option<WeakModel<ThreadStore>>,
         context_picker_menu_handle: PopoverMenuHandle<ContextPicker>,
         suggest_context_kind: SuggestContextKind,
@@ -49,6 +51,7 @@ impl ContextStrip {
                 workspace.clone(),
                 thread_store.clone(),
                 context_store.downgrade(),
+                editor.clone(),
                 ConfirmBehavior::KeepOpen,
                 cx,
             )
@@ -63,6 +66,7 @@ impl ContextStrip {
         ];
 
         Self {
+            editor,
             context_store: context_store.clone(),
             context_picker,
             context_picker_menu_handle,

--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 
 pub struct ContextStrip {
-    editor: WeakView<Editor>,
     context_store: Model<ContextStore>,
     pub context_picker: View<ContextPicker>,
     context_picker_menu_handle: PopoverMenuHandle<ContextPicker>,
@@ -66,7 +65,6 @@ impl ContextStrip {
         ];
 
         Self {
-            editor,
             context_store: context_store.clone(),
             context_picker,
             context_picker_menu_handle,

--- a/crates/assistant2/src/inline_prompt_editor.rs
+++ b/crates/assistant2/src/inline_prompt_editor.rs
@@ -834,6 +834,7 @@ impl PromptEditor<BufferCodegen> {
             ContextStrip::new(
                 context_store.clone(),
                 workspace.clone(),
+                prompt_editor.downgrade(),
                 thread_store.clone(),
                 context_picker_menu_handle.clone(),
                 SuggestContextKind::Thread,
@@ -985,6 +986,7 @@ impl PromptEditor<TerminalCodegen> {
             ContextStrip::new(
                 context_store.clone(),
                 workspace.clone(),
+                prompt_editor.downgrade(),
                 thread_store.clone(),
                 context_picker_menu_handle.clone(),
                 SuggestContextKind::Thread,

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -64,6 +64,7 @@ impl MessageEditor {
                 workspace.clone(),
                 Some(thread_store.clone()),
                 context_store.downgrade(),
+                editor.downgrade(),
                 ConfirmBehavior::Close,
                 cx,
             )
@@ -73,6 +74,7 @@ impl MessageEditor {
             ContextStrip::new(
                 context_store.clone(),
                 workspace.clone(),
+                editor.downgrade(),
                 Some(thread_store.clone()),
                 context_picker_menu_handle.clone(),
                 SuggestContextKind::File,

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -8,7 +8,7 @@ pub use crate::slash_command_working_set::*;
 use anyhow::Result;
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
-use gpui::{AnyElement, AppContext, ElementId, SharedString, Task, WeakView, WindowContext};
+use gpui::{AppContext, SharedString, Task, WeakView, WindowContext};
 use language::{BufferSnapshot, CodeLabel, LspAdapterDelegate, OffsetRangeExt};
 pub use language_model::Role;
 use serde::{Deserialize, Serialize};
@@ -103,11 +103,6 @@ pub trait SlashCommand: 'static + Send + Sync {
     ) -> Task<SlashCommandResult>;
 }
 
-pub type RenderFoldPlaceholder = Arc<
-    dyn Send
-        + Sync
-        + Fn(ElementId, Arc<dyn Fn(&mut WindowContext)>, &mut WindowContext) -> AnyElement,
->;
 
 #[derive(Debug, PartialEq)]
 pub enum SlashCommandContent {

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -103,7 +103,6 @@ pub trait SlashCommand: 'static + Send + Sync {
     ) -> Task<SlashCommandResult>;
 }
 
-
 #[derive(Debug, PartialEq)]
 pub enum SlashCommandContent {
     Text {


### PR DESCRIPTION
`@mention`ed files in assistant2 now get replaced by the full path of the file in what gets sent to the model, while rendering visually as just the filename (in a crease, so they can only be selected/deleted as a whole unit, not character by character).

https://github.com/user-attachments/assets/a5867a93-d656-4a17-aced-58424c6e8cf6

Release Notes:

- N/A
