### PR TITLE
windows: Improve foreground task dispatching on Windows (continued)

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -167,7 +167,7 @@ impl WindowsPlatform {
 
     #[inline]
     fn run_foreground_task(&self) {
-        if let Ok(runnable) = self.main_receiver.try_recv() {
+        for runnable in self.main_receiver.drain() {
             runnable.run();
         }
     }


### PR DESCRIPTION
Closes #22653 again

In PR #23283, I thought that every `runnable` dispatched to the main thread would correspond to an `EVENT_DISPATCHED` message in the message queue. However, after testing, some `runnable`s occasionally weren’t executed. 

This PR updated the code as follows:  
```rust
if let Ok(runnable) = self.main_receiver.try_recv() {    <-- before
for runnable in self.main_receiver.drain() {            <-- after
    runnable.run();
}
```

This ensures that runnables are handled more proactively on the main thread, now we handle `runnable`s with a much higher priority.

A big thanks to @MolotovCherry and @ArthurBrussee for their testing efforts!

Release Notes:

- N/A