### PR TITLE
Fix button demo in the component preview

### DIFF
--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -527,7 +527,7 @@ impl ComponentPreview for Button {
                     ),
                     single_example(
                         "Tinted Icons",
-                        Button::new("icon_color", "Error")
+                        Button::new("tinted_icons", "Error")
                             .style(ButtonStyle::Tinted(TintColor::Error))
                             .color(Color::Error)
                             .icon_color(Color::Error)


### PR DESCRIPTION
Problem: If you click on "Tinted Icons", "Icon Color" is also activated.

Release Notes:

- N/A