### PR TITLE
ci: Remove `paths-ignore` for docs, as it does not work with required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,10 @@ on:
       - "v[0-9]+.[0-9]+.x"
     tags:
       - "v*"
-    paths-ignore:
-      - "docs/**/*"
-      - ".github/workflows/community_*"
 
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - "docs/**/*"
-      - ".github/workflows/community_*"
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.


### PR DESCRIPTION
This PR removes the `paths-ignore` for docs again, as it causes docs-only PRs to be unmergable in combination with required status checks (which we need in order to support merge-when-ready).

We can put these back if and only if we come up with a solution for how to make it work with required status checks.

Release Notes:

- N/A
