### PR TITLE
Add support for `editor::SwapSelectionEnds` everywhere (emacs exchange-point-and-mark)

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -17,7 +17,7 @@
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
       "ctrl-space": "editor::SetMark", // set-mark
       "ctrl-@": "editor::SetMark", // set-mark
-      "ctrl-x ctrl-x": "editor::ExchangeMark", // exchange-point-and-mark
+      "ctrl-x ctrl-x": "editor::SwapSelectionEnds", // exchange-point-and-mark
       "ctrl-f": "editor::MoveRight", // forward-char
       "ctrl-b": "editor::MoveLeft", // backward-char
       "ctrl-n": "editor::MoveDown", // next-line

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -17,7 +17,7 @@
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
       "ctrl-space": "editor::SetMark", // set-mark
       "ctrl-@": "editor::SetMark", // set-mark
-      "ctrl-x ctrl-x": "editor::ExchangeMark", // exchange-point-and-mark
+      "ctrl-x ctrl-x": "editor::SwapSelectionEnds", // exchange-point-and-mark
       "ctrl-f": "editor::MoveRight", // forward-char
       "ctrl-b": "editor::MoveLeft", // backward-char
       "ctrl-n": "editor::MoveDown", // next-line

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -377,7 +377,7 @@ gpui::actions!(
         ToggleInlayHints,
         ToggleInlineCompletions,
         ToggleLineNumbers,
-        ExchangeMark,
+        SwapSelectionEnds,
         SetMark,
         ToggleRelativeLineNumbers,
         ToggleSelectionMenu,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10634,16 +10634,13 @@ impl Editor {
     }
 
     pub fn exchange_mark(&mut self, _: &actions::ExchangeMark, cx: &mut ViewContext<Self>) {
-        if self.selection_mark_mode {
-            self.change_selections(None, cx, |s| {
-                s.move_with(|_, sel| {
-                    if sel.start != sel.end {
-                        sel.reversed = !sel.reversed
-                    }
-                });
-            })
-        }
-        self.selection_mark_mode = true;
+        self.change_selections(None, cx, |s| {
+            s.move_with(|_, sel| {
+                if sel.start != sel.end {
+                    sel.reversed = !sel.reversed
+                }
+            });
+        });
         cx.notify();
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10633,7 +10633,7 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn exchange_mark(&mut self, _: &actions::ExchangeMark, cx: &mut ViewContext<Self>) {
+    pub fn swap_selection_ends(&mut self, _: &actions::SwapSelectionEnds, cx: &mut ViewContext<Self>) {
         self.change_selections(None, cx, |s| {
             s.move_with(|_, sel| {
                 if sel.start != sel.end {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10633,7 +10633,11 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn swap_selection_ends(&mut self, _: &actions::SwapSelectionEnds, cx: &mut ViewContext<Self>) {
+    pub fn swap_selection_ends(
+        &mut self,
+        _: &actions::SwapSelectionEnds,
+        cx: &mut ViewContext<Self>,
+    ) {
         self.change_selections(None, cx, |s| {
             s.move_with(|_, sel| {
                 if sel.start != sel.end {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -357,7 +357,7 @@ impl EditorElement {
         register_action(view, cx, Editor::unfold_at);
         register_action(view, cx, Editor::fold_selected_ranges);
         register_action(view, cx, Editor::set_mark);
-        register_action(view, cx, Editor::exchange_mark);
+        register_action(view, cx, Editor::swap_selection_ends);
         register_action(view, cx, Editor::show_completions);
         register_action(view, cx, Editor::toggle_code_actions);
         register_action(view, cx, Editor::open_excerpts);


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/4697
- Follow-up to: https://github.com/zed-industries/zed/pull/23297

Allows using `editor:: SwapSelectionEnds ` everywhere -- reverses the direction of a selection so cursor swaps from end to beginning or vice versa.  Previously only supported in selection mode (after `editor::SetMark`). Now supported with normal selections. Works with multi-cursor as expected.  Renamed from `editor::ExchangeMark` to `editor::SwapSelectionEnds`.



Unbound by default, bound to `ctrl-x ctrl-x` in Emacs keymap.

Release Notes:

- Add `editor:: SwapSelectionEnds ` action which swaps the cursor location from the beginning/end of a given selection.