### PR TITLE
Extract `ContextHistory` to `assistant_context_editor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,6 @@ dependencies = [
  "multi_buffer",
  "parking_lot",
  "paths",
- "picker",
  "pretty_assertions",
  "project",
  "prompt_library",

--- a/crates/assistant/Cargo.toml
+++ b/crates/assistant/Cargo.toml
@@ -50,7 +50,6 @@ menu.workspace = true
 multi_buffer.workspace = true
 parking_lot.workspace = true
 paths.workspace = true
-picker.workspace = true
 project.workspace = true
 prompt_library.workspace = true
 proto.workspace = true

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(target_os = "windows", allow(unused, dead_code))]
 
 pub mod assistant_panel;
-mod context_history;
 mod inline_assistant;
 pub mod slash_command_settings;
 mod terminal_inline_assistant;

--- a/crates/assistant_context_editor/src/assistant_context_editor.rs
+++ b/crates/assistant_context_editor/src/assistant_context_editor.rs
@@ -1,5 +1,6 @@
 mod context;
 mod context_editor;
+mod context_history;
 mod context_store;
 mod patch;
 mod slash_command;
@@ -12,6 +13,7 @@ use gpui::AppContext;
 
 pub use crate::context::*;
 pub use crate::context_editor::*;
+pub use crate::context_history::*;
 pub use crate::context_store::*;
 pub use crate::patch::*;
 pub use crate::slash_command::*;

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -121,6 +121,13 @@ pub trait AssistantPanelDelegate {
         cx: &mut ViewContext<Workspace>,
     ) -> Option<View<ContextEditor>>;
 
+    fn open_saved_context(
+        &self,
+        workspace: &mut Workspace,
+        path: PathBuf,
+        cx: &mut ViewContext<Workspace>,
+    ) -> Task<Result<()>>;
+
     fn open_remote_context(
         &self,
         workspace: &mut Workspace,


### PR DESCRIPTION
This PR extracts the `ContextHistory` to the `assistant_context_editor` crate.

Release Notes:

- N/A
