### PR TITLE
assistant2: Add prompt editor history

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1342,7 +1342,6 @@ impl AssistantPanelDelegate for ConcreteAssistantPanelDelegate {
             return;
         };
 
-        // Activate the panel
         if !panel.focus_handle(cx).contains_focused(cx) {
             workspace.toggle_panel_focus::<AssistantPanel>(cx);
         }

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -41,6 +41,7 @@ actions!(
         ToggleModelSelector,
         RemoveAllContext,
         OpenHistory,
+        OpenPromptEditorHistory,
         RemoveSelectedThread,
         Chat,
         ChatMode,

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -825,18 +825,18 @@ impl AssistantPanelDelegate for ConcreteAssistantPanelDelegate {
 
     fn open_remote_context(
         &self,
-        workspace: &mut Workspace,
-        context_id: assistant_context_editor::ContextId,
-        cx: &mut ViewContext<Workspace>,
+        _workspace: &mut Workspace,
+        _context_id: assistant_context_editor::ContextId,
+        _cx: &mut ViewContext<Workspace>,
     ) -> Task<Result<View<ContextEditor>>> {
-        todo!()
+        Task::ready(Err(anyhow!("opening remote context not implemented")))
     }
 
     fn quote_selection(
         &self,
-        workspace: &mut Workspace,
-        creases: Vec<(String, String)>,
-        cx: &mut ViewContext<Workspace>,
+        _workspace: &mut Workspace,
+        _creases: Vec<(String, String)>,
+        _cx: &mut ViewContext<Workspace>,
     ) {
     }
 }


### PR DESCRIPTION
This PR adds the prompt editor history to Assistant2.

<img width="1309" alt="Screenshot 2025-01-21 at 9 02 07 PM" src="https://github.com/user-attachments/assets/d79936fe-1c23-425f-b99d-43f85afd0c39" />

Release Notes:

- N/A
