### PR TITLE
Consolidate Assistant panels in `assistant2` feature flag

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -31,7 +31,6 @@ use crate::slash_command_settings::SlashCommandSettings;
 actions!(
     assistant,
     [
-        ToggleFocus,
         InsertActivePrompt,
         DeployHistory,
         DeployPromptLibrary,

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1342,7 +1342,6 @@ impl AssistantPanelDelegate for ConcreteAssistantPanelDelegate {
             return;
         };
 
-        // Activate the panel
         if !panel.focus_handle(cx).contains_focused(cx) {
             workspace.toggle_panel_focus::<AssistantPanel>(cx);
         }

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,6 +1,6 @@
 use crate::{
     terminal_inline_assistant::TerminalInlineAssistant, DeployHistory, DeployPromptLibrary,
-    InlineAssistant, NewContext, ToggleFocus,
+    InlineAssistant, NewContext,
 };
 use anyhow::{anyhow, Result};
 use assistant_context_editor::{
@@ -42,7 +42,7 @@ use workspace::{
     item::Item,
     pane, DraggedSelection, Pane, ShowConfiguration, ToggleZoom, Workspace,
 };
-use zed_actions::InlineAssist;
+use zed_actions::assistant::{InlineAssist, ToggleFocus};
 
 pub fn init(cx: &mut AppContext) {
     <dyn AssistantPanelDelegate>::set_global(Arc::new(ConcreteAssistantPanelDelegate), cx);
@@ -51,14 +51,6 @@ pub fn init(cx: &mut AppContext) {
     cx.observe_new_views(
         |workspace: &mut Workspace, _cx: &mut ViewContext<Workspace>| {
             workspace
-                .register_action(|workspace, _: &ToggleFocus, cx| {
-                    let settings = AssistantSettings::get_global(cx);
-                    if !settings.enabled {
-                        return;
-                    }
-
-                    workspace.toggle_panel_focus::<AssistantPanel>(cx);
-                })
                 .register_action(ContextEditor::quote_selection)
                 .register_action(ContextEditor::insert_selection)
                 .register_action(ContextEditor::copy_code)
@@ -339,6 +331,19 @@ impl AssistantPanel {
         };
         this.new_context(cx);
         this
+    }
+
+    pub fn toggle_focus(
+        workspace: &mut Workspace,
+        _: &ToggleFocus,
+        cx: &mut ViewContext<Workspace>,
+    ) {
+        let settings = AssistantSettings::get_global(cx);
+        if !settings.enabled {
+            return;
+        }
+
+        workspace.toggle_panel_focus::<Self>(cx);
     }
 
     fn watch_client_status(client: Arc<Client>, cx: &mut ViewContext<Self>) -> Task<()> {

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1728,7 +1728,7 @@ impl PromptEditor {
     }
 
     fn placeholder_text(codegen: &Codegen, cx: &WindowContext) -> String {
-        let context_keybinding = text_for_action(&crate::ToggleFocus, cx)
+        let context_keybinding = text_for_action(&zed_actions::assistant::ToggleFocus, cx)
             .map(|keybinding| format!(" • {keybinding} for context"))
             .unwrap_or_default();
 

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -740,7 +740,7 @@ impl PromptEditor {
     }
 
     fn placeholder_text(cx: &WindowContext) -> String {
-        let context_keybinding = text_for_action(&crate::ToggleFocus, cx)
+        let context_keybinding = text_for_action(&zed_actions::assistant::ToggleFocus, cx)
             .map(|keybinding| format!(" • {keybinding} for context"))
             .unwrap_or_default();
 

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -41,6 +41,7 @@ actions!(
         ToggleModelSelector,
         RemoveAllContext,
         OpenHistory,
+        OpenPromptEditorHistory,
         RemoveSelectedThread,
         Chat,
         ChatMode,

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -34,7 +34,6 @@ pub use crate::inline_assistant::InlineAssistant;
 actions!(
     assistant2,
     [
-        ToggleFocus,
         NewThread,
         NewPromptEditor,
         ToggleContextPicker,

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -825,18 +825,18 @@ impl AssistantPanelDelegate for ConcreteAssistantPanelDelegate {
 
     fn open_remote_context(
         &self,
-        workspace: &mut Workspace,
-        context_id: assistant_context_editor::ContextId,
-        cx: &mut ViewContext<Workspace>,
+        _workspace: &mut Workspace,
+        _context_id: assistant_context_editor::ContextId,
+        _cx: &mut ViewContext<Workspace>,
     ) -> Task<Result<View<ContextEditor>>> {
-        todo!()
+        Task::ready(Err(anyhow!("opening remote context not implemented")))
     }
 
     fn quote_selection(
         &self,
-        workspace: &mut Workspace,
-        creases: Vec<(String, String)>,
-        cx: &mut ViewContext<Workspace>,
+        _workspace: &mut Workspace,
+        _creases: Vec<(String, String)>,
+        _cx: &mut ViewContext<Workspace>,
     ) {
     }
 }

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -204,7 +204,7 @@ impl InlineAssistant {
 
     pub fn inline_assist(
         workspace: &mut Workspace,
-        _action: &zed_actions::InlineAssist,
+        _action: &zed_actions::assistant::InlineAssist,
         cx: &mut ViewContext<Workspace>,
     ) {
         let settings = AssistantSettings::get_global(cx);

--- a/crates/assistant2/src/inline_prompt_editor.rs
+++ b/crates/assistant2/src/inline_prompt_editor.rs
@@ -270,9 +270,10 @@ impl<T: 'static> PromptEditor<T> {
             PromptEditorMode::Terminal { .. } => "Generate",
         };
 
-        let assistant_panel_keybinding = ui::text_for_action(&crate::ToggleFocus, cx)
-            .map(|keybinding| format!("{keybinding} to chat ― "))
-            .unwrap_or_default();
+        let assistant_panel_keybinding =
+            ui::text_for_action(&zed_actions::assistant::ToggleFocus, cx)
+                .map(|keybinding| format!("{keybinding} to chat ― "))
+                .unwrap_or_default();
 
         format!("{action}… ({assistant_panel_keybinding}↓↑ for history)")
     }

--- a/crates/prompt_library/src/prompt_library.rs
+++ b/crates/prompt_library/src/prompt_library.rs
@@ -27,7 +27,7 @@ use ui::{
 };
 use util::{ResultExt, TryFutureExt};
 use workspace::Workspace;
-use zed_actions::InlineAssist;
+use zed_actions::assistant::InlineAssist;
 
 pub use crate::prompt_store::*;
 pub use crate::prompts::*;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -42,7 +42,7 @@ use workspace::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use zed_actions::InlineAssist;
+use zed_actions::assistant::InlineAssist;
 
 const TERMINAL_PANEL_KEY: &str = "TerminalPanel";
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -56,7 +56,7 @@ use anyhow::Context;
 use serde::Deserialize;
 use settings::{Settings, SettingsStore};
 use smol::Timer;
-use zed_actions::InlineAssist;
+use zed_actions::assistant::InlineAssist;
 
 use std::{
     cmp,

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -23,7 +23,7 @@ use vim_mode_setting::VimModeSetting;
 use workspace::{
     item::ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
 };
-use zed_actions::{outline::ToggleOutline, InlineAssist};
+use zed_actions::{assistant::InlineAssist, outline::ToggleOutline};
 
 pub struct QuickActionBar {
     _inlay_hints_enabled_subscription: Option<Subscription>,

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -77,12 +77,20 @@ pub mod theme_selector {
     impl_actions!(theme_selector, [Toggle]);
 }
 
-#[derive(Clone, Default, Deserialize, PartialEq, JsonSchema)]
-pub struct InlineAssist {
-    pub prompt: Option<String>,
-}
+pub mod assistant {
+    use gpui::{actions, impl_actions};
+    use schemars::JsonSchema;
+    use serde::Deserialize;
 
-impl_actions!(assistant, [InlineAssist]);
+    actions!(assistant, [ToggleFocus]);
+
+    #[derive(Clone, Default, Deserialize, PartialEq, JsonSchema)]
+    pub struct InlineAssist {
+        pub prompt: Option<String>,
+    }
+
+    impl_actions!(assistant, [InlineAssist]);
+}
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
 pub struct OpenRecent {


### PR DESCRIPTION
This PR consolidates the two Assistant panels into one for users in the `assistant2` feature flag.

Now that the Assistant1 prompt editor is accessible through the Assistant2 panel, we no longer have a need to show both panels.

Release Notes:

- N/A
