### PR TITLE
assistant2: Insert default prompt into prompt editor

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -240,14 +240,16 @@ impl AssistantPanel {
             .flatten();
 
         self.context_editor = Some(cx.new_view(|cx| {
-            ContextEditor::for_context(
+            let mut editor = ContextEditor::for_context(
                 context,
                 self.fs.clone(),
                 self.workspace.clone(),
                 self.project.clone(),
                 lsp_adapter_delegate,
                 cx,
-            )
+            );
+            editor.insert_default_prompt(cx);
+            editor
         }));
 
         if let Some(context_editor) = self.context_editor.as_ref() {


### PR DESCRIPTION
This PR fixes an issue where the default prompt was not being inserted into the prompt editor in Assistant2.

Release Notes:

- N/A
