### PR TITLE
Wire up `AssistantPanelDelegate` based on `assistant2` feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16275,6 +16275,7 @@ dependencies = [
  "assets",
  "assistant",
  "assistant2",
+ "assistant_context_editor",
  "assistant_settings",
  "assistant_tools",
  "async-watch",

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -45,8 +45,6 @@ use workspace::{
 use zed_actions::assistant::{InlineAssist, ToggleFocus};
 
 pub fn init(cx: &mut AppContext) {
-    <dyn AssistantPanelDelegate>::set_global(Arc::new(ConcreteAssistantPanelDelegate), cx);
-
     workspace::FollowableViewRegistry::register::<ContextEditor>(cx);
     cx.observe_new_views(
         |workspace: &mut Workspace, _cx: &mut ViewContext<Workspace>| {
@@ -1299,7 +1297,7 @@ impl prompt_library::InlineAssistDelegate for PromptLibraryInlineAssist {
     }
 }
 
-struct ConcreteAssistantPanelDelegate;
+pub struct ConcreteAssistantPanelDelegate;
 
 impl AssistantPanelDelegate for ConcreteAssistantPanelDelegate {
     fn active_context_editor(

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -28,7 +28,7 @@ use prompt_library::{PromptBuilder, PromptLoadingParams};
 use settings::Settings as _;
 use util::ResultExt;
 
-pub use crate::assistant_panel::AssistantPanel;
+pub use crate::assistant_panel::{AssistantPanel, ConcreteAssistantPanelDelegate};
 pub use crate::inline_assistant::InlineAssistant;
 
 actions!(

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -34,7 +34,6 @@ use crate::thread_store::ThreadStore;
 use crate::{NewPromptEditor, NewThread, OpenHistory, OpenPromptEditorHistory};
 
 pub fn init(cx: &mut AppContext) {
-    <dyn AssistantPanelDelegate>::set_global(Arc::new(ConcreteAssistantPanelDelegate), cx);
     cx.observe_new_views(
         |workspace: &mut Workspace, _cx: &mut ViewContext<Workspace>| {
             workspace
@@ -811,7 +810,7 @@ impl Render for AssistantPanel {
     }
 }
 
-struct ConcreteAssistantPanelDelegate;
+pub struct ConcreteAssistantPanelDelegate;
 
 impl AssistantPanelDelegate for ConcreteAssistantPanelDelegate {
     fn active_context_editor(

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 assets.workspace = true
 assistant.workspace = true
 assistant2.workspace = true
+assistant_context_editor.workspace = true
 assistant_settings.workspace = true
 assistant_tools.workspace = true
 async-watch.workspace = true

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -12,6 +12,7 @@ pub(crate) mod windows_only_instance;
 use anyhow::Context as _;
 pub use app_menus::*;
 use assets::Assets;
+use assistant_context_editor::AssistantPanelDelegate;
 use breadcrumbs::Breadcrumbs;
 use client::{zed_urls, ZED_URL_SCHEME};
 use collections::VecDeque;
@@ -458,10 +459,20 @@ fn initialize_panels(prompt_builder: Arc<PromptBuilder>, cx: &mut ViewContext<Wo
             //
             // Once we ship `assistant2` we can push this back down into `assistant2::assistant_panel::init`.
             if is_assistant2_enabled {
+                <dyn AssistantPanelDelegate>::set_global(
+                    Arc::new(assistant2::ConcreteAssistantPanelDelegate),
+                    cx,
+                );
+
                 workspace
                     .register_action(assistant2::AssistantPanel::toggle_focus)
                     .register_action(assistant2::InlineAssistant::inline_assist);
             } else {
+                <dyn AssistantPanelDelegate>::set_global(
+                    Arc::new(assistant::assistant_panel::ConcreteAssistantPanelDelegate),
+                    cx,
+                );
+
                 workspace
                     .register_action(assistant::AssistantPanel::toggle_focus)
                     .register_action(assistant::AssistantPanel::inline_assist);


### PR DESCRIPTION
This PR adjusts how the `AssistantPanelDelegate` global is set to be based on the state of the feature flag.

This should prevent `assistant` and `assistant2` from potentially clobbering each other.

Release Notes:

- N/A
