### PR TITLE
Translucent/cropped menu when edit prediction is selected + no aside

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7865,6 +7865,18 @@ impl Editor {
         });
     }
 
+    pub fn context_menu_select_initial_lsp_completion(&mut self, cx: &mut Context<Self>) {
+        if let Some(context_menu) = self.context_menu.borrow_mut().as_mut() {
+            match context_menu {
+                CodeContextMenu::Completions(completions_menu) => {
+                    completions_menu
+                        .select_initial_lsp_completion(self.completion_provider.as_deref(), cx);
+                }
+                CodeContextMenu::CodeActions(_) => {}
+            }
+        }
+    }
+
     pub fn context_menu_first(
         &mut self,
         _: &ContextMenuFirst,

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -42,6 +42,7 @@ pub struct ListItem {
     outlined: bool,
     overflow_x: bool,
     focused: Option<bool>,
+    opacity: f32,
 }
 
 impl ListItem {
@@ -67,6 +68,7 @@ impl ListItem {
             outlined: false,
             overflow_x: false,
             focused: None,
+            opacity: 1.0,
         }
     }
 
@@ -158,6 +160,11 @@ impl ListItem {
         self.focused = Some(focused);
         self
     }
+
+    pub fn opacity(mut self, opacity: f32) -> Self {
+        self.opacity = opacity;
+        self
+    }
 }
 
 impl Disableable for ListItem {
@@ -186,6 +193,7 @@ impl RenderOnce for ListItem {
             .id(self.id)
             .w_full()
             .relative()
+            .opacity(self.opacity)
             // When an item is inset draw the indent spacing outside of the item
             .when(self.inset, |this| {
                 this.ml(self.indent_level as f32 * self.indent_step_size)


### PR DESCRIPTION
Displaying the edit prediction inline in the buffer is better than in an aside, as then the user doesn't need to re-locate the edit within the buffer.

Motivation for making the edit menu translucent + cropped + no content is to not obscure the displayed prediction within the buffer, while still making it clear that the menu is open and so pressing `down` will select the first LSP completion in the menu.

Release Notes:

- N/A