### PR TITLE
lsp: Ignore payload of `DidChangeConfiguration` dynamic registration

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -699,6 +699,9 @@ impl LocalLspStore {
                                         anyhow::Ok(())
                                     })??;
                                 }
+                                "workspace/didChangeConfiguration" => {
+                                    // Ignore payload since we notify clients of setting changes unconditionally, relying on them pulling the latest settings.
+                                }
                                 _ => log::warn!("unhandled capability registration: {reg:?}"),
                             }
                         }


### PR DESCRIPTION
Fixes #23430

Closes #23430

Release Notes:

- N/A
