### PR TITLE
Fix single line edit prediction detection

### DIFF
--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1757,7 +1757,6 @@ impl<'a> BlockChunks<'a> {
 pub struct StickyHeaderExcerpt<'a> {
     pub excerpt: &'a ExcerptInfo,
     pub next_excerpt_controls_present: bool,
-    // TODO az remove option
     pub next_buffer_row: Option<u32>,
 }
 

--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -286,7 +286,11 @@ fn assert_editor_active_edit_completion(
             .as_ref()
             .expect("editor has no active completion");
 
-        if let InlineCompletion::Edit(edits) = &completion_state.completion {
+        if let InlineCompletion::Edit {
+            edits,
+            single_line: _,
+        } = &completion_state.completion
+        {
             assert(editor.buffer().read(cx).snapshot(cx), edits);
         } else {
             panic!("expected edit completion");

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1211,7 +1211,6 @@ impl Element for Div {
             state.child_bounds = Vec::with_capacity(request_layout.child_layout_ids.len());
             state.bounds = bounds;
             let requested = state.requested_scroll_top.take();
-            // TODO az
 
             for (ix, child_layout_id) in request_layout.child_layout_ids.iter().enumerate() {
                 let child_bounds = cx.layout_bounds(*child_layout_id);


### PR DESCRIPTION
#23411 introduced an "Accept" callout for single line edits, but the logic to detect them was incorrect causing it to trigger for multiline insertions, this PR fixes that.

Release Notes:

- N/A
