### PR TITLE
auto_update_ui: Show update notification across workspaces

### DIFF
--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -17,6 +17,7 @@ use crate::update_notification::UpdateNotification;
 actions!(auto_update, [ViewReleaseNotesLocally]);
 
 pub fn init(cx: &mut App) {
+    notify_if_app_was_updated(cx);
     cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
         workspace.register_action(|workspace, _: &ViewReleaseNotesLocally, window, cx| {
             view_release_notes_locally(workspace, window, cx);
@@ -124,10 +125,12 @@ fn view_release_notes_locally(
         .detach();
 }
 
-/// Shows a notification across all app workspaces if a new update was installed since the
-/// last time this function was called.
-pub fn notify_of_any_new_update(cx: &mut App) -> Option<()> {
-    let updater = AutoUpdater::get(cx)?;
+/// Shows a notification across all workspaces if an update was previously automatically installed
+/// and this notification had not yet been shown.
+pub fn notify_if_app_was_updated(cx: &mut App) {
+    let Some(updater) = AutoUpdater::get(cx) else {
+        return;
+    };
     let version = updater.read(cx).current_version();
     let should_show_notification = updater.read(cx).should_show_update_notification(cx);
 
@@ -153,6 +156,4 @@ pub fn notify_of_any_new_update(cx: &mut App) -> Option<()> {
         anyhow::Ok(())
     })
     .detach();
-
-    None
 }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -865,8 +865,6 @@ async fn restore_or_create_workspace(app_state: Arc<AppState>, cx: &mut AsyncApp
         .await?;
     }
 
-    cx.update(auto_update_ui::notify_of_any_new_update)?;
-
     Ok(())
 }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -865,6 +865,8 @@ async fn restore_or_create_workspace(app_state: Arc<AppState>, cx: &mut AsyncApp
         .await?;
     }
 
+    cx.update(auto_update_ui::notify_of_any_new_update)?;
+
     Ok(())
 }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -212,8 +212,6 @@ pub fn initialize_workspace(
             status_bar.add_right_item(cursor_position, window, cx);
         });
 
-        auto_update_ui::notify_of_any_new_update(window, cx);
-
         let handle = cx.entity().downgrade();
         window.on_window_should_close(cx, move |window, cx| {
             handle


### PR DESCRIPTION
When Zed reopens after an auto-update is installed, a notification was previously displayed in the first window opened. If there were multiple windows open, the notification could be hidden because Zed reopens the last session's window stack in order from back to front. Now, the notification is opened in every workspace, and dismissing the notification in any workspace will dismisses it everywhere.

Closes #23236

Release Notes:

- Improved notification after Zed is updated to be visible in all workspaces.
