### PR TITLE
Fix app icon not showing up and dock bar icons not being merged in Gnome

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -8,6 +8,7 @@ TryExec=$APP_CLI
 StartupNotify=$DO_STARTUP_NOTIFY
 Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
+StartupWMClass=dev.zed.Zed
 Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
 MimeType=text/plain;application/x-zerosize;x-scheme-handler/zed;


### PR DESCRIPTION
Fix `.desktop` file for Gnome.