### PR TITLE
Show "tab Accept" only for zeta

### DIFF
--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -286,11 +286,7 @@ fn assert_editor_active_edit_completion(
             .as_ref()
             .expect("editor has no active completion");
 
-        if let InlineCompletion::Edit {
-            edits,
-            accept_marker: _,
-        } = &completion_state.completion
-        {
+        if let InlineCompletion::Edit { edits, .. } = &completion_state.completion {
             assert(editor.buffer().read(cx).snapshot(cx), edits);
         } else {
             panic!("expected edit completion");

--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -288,7 +288,7 @@ fn assert_editor_active_edit_completion(
 
         if let InlineCompletion::Edit {
             edits,
-            single_line: _,
+            accept_marker: _,
         } = &completion_state.completion
         {
             assert(editor.buffer().read(cx).snapshot(cx), edits);

--- a/crates/inline_completion/src/inline_completion.rs
+++ b/crates/inline_completion/src/inline_completion.rs
@@ -22,6 +22,9 @@ pub trait InlineCompletionProvider: 'static + Sized {
     fn display_name() -> &'static str;
     fn show_completions_in_menu() -> bool;
     fn show_completions_in_normal_mode() -> bool;
+    fn show_tab_accept_marker() -> bool {
+        false
+    }
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,
@@ -67,6 +70,7 @@ pub trait InlineCompletionProviderHandle {
     ) -> bool;
     fn show_completions_in_menu(&self) -> bool;
     fn show_completions_in_normal_mode(&self) -> bool;
+    fn show_tab_accept_marker(&self) -> bool;
     fn needs_terms_acceptance(&self, cx: &AppContext) -> bool;
     fn is_refreshing(&self, cx: &AppContext) -> bool;
     fn refresh(
@@ -111,6 +115,10 @@ where
 
     fn show_completions_in_normal_mode(&self) -> bool {
         T::show_completions_in_normal_mode()
+    }
+
+    fn show_tab_accept_marker(&self) -> bool {
+        T::show_tab_accept_marker()
     }
 
     fn is_enabled(

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1024,6 +1024,10 @@ impl inline_completion::InlineCompletionProvider for ZetaInlineCompletionProvide
         true
     }
 
+    fn show_tab_accept_marker() -> bool {
+        true
+    }
+
     fn is_enabled(
         &self,
         buffer: &Model<Buffer>,


### PR DESCRIPTION
#23460 brought up we are showing the new "tab Accept" marker for single line suggestions for non-zeta providers. We think this might be valid for any provider, but we only want to enable it for zeta initially so it doesn't affect an existing user base.

Release Notes:

- N/A
