### PR TITLE
assistant2: Respect panel dock position

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -397,8 +397,12 @@ impl Panel for AssistantPanel {
         "AssistantPanel2"
     }
 
-    fn position(&self, _cx: &WindowContext) -> DockPosition {
-        DockPosition::Right
+    fn position(&self, cx: &WindowContext) -> DockPosition {
+        match AssistantSettings::get_global(cx).dock {
+            AssistantDockPosition::Left => DockPosition::Left,
+            AssistantDockPosition::Bottom => DockPosition::Bottom,
+            AssistantDockPosition::Right => DockPosition::Right,
+        }
     }
 
     fn position_is_valid(&self, _: DockPosition) -> bool {


### PR DESCRIPTION
This PR fixes an issue where Assistant2 was not respecting the panel dock position.

Release Notes:

- N/A
