### PR TITLE
gpui: Prevent crash on macOS by adding characterIndexForPoint on GPUIView

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -17,8 +17,8 @@ use cocoa::{
     },
     base::{id, nil},
     foundation::{
-        NSArray, NSAutoreleasePool, NSDictionary, NSFastEnumeration, NSInteger, NSPoint, NSRect,
-        NSSize, NSString, NSUInteger,
+        NSArray, NSAutoreleasePool, NSDictionary, NSFastEnumeration, NSInteger, NSNotFound,
+        NSPoint, NSRect, NSSize, NSString, NSUInteger,
     },
 };
 use core_graphics::display::{CGDirectDisplayID, CGPoint, CGRect};
@@ -221,6 +221,11 @@ unsafe fn build_classes() {
         decl.add_method(
             sel!(acceptsFirstMouse:),
             accepts_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
+        );
+
+        decl.add_method(
+            sel!(characterIndexForPoint:),
+            character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> u64,
         );
 
         decl.register()
@@ -1825,6 +1830,10 @@ extern "C" fn accepts_first_mouse(this: &Object, _: Sel, _: id) -> BOOL {
     let mut lock = window_state.as_ref().lock();
     lock.first_mouse = true;
     YES
+}
+
+extern "C" fn character_index_for_point(_this: &Object, _: Sel, _position: NSPoint) -> u64 {
+    NSNotFound as u64
 }
 
 extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDragOperation {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1833,6 +1833,10 @@ extern "C" fn accepts_first_mouse(this: &Object, _: Sel, _: id) -> BOOL {
 }
 
 extern "C" fn character_index_for_point(_this: &Object, _: Sel, _position: NSPoint) -> u64 {
+    // TODO: We need to calculate if, and if so where, the user has clicked inside a text field
+    // and return the offset of the selected character inside the text buffer.
+    // This seems to be mainly used with specific input methods.
+    // See #22939 for an example on how to trigger this.
     NSNotFound as u64
 }
 


### PR DESCRIPTION
Partially resolves #22939

This PR adds the missing selector and makes it return `NSNotFound`, meaning the cursor is not within a character bounding box. This is not completely correct but it does prevent zed from crashing and doesn't cause any further bug apart from the input method selector disappearing very quickly.

A more thorough check would be to calculate if and where the user has clicked inside the editor and return the offset of the selected character. It seems like a deeper change which also requires `ViewInputHandler` to calculate Screen mouse position (x, y) to Editor (row, column) which was unclear to me.

For reference, this is the input method selector:
![Screenshot 2025-01-22 at 16 14 52](https://github.com/user-attachments/assets/b5e09abc-491a-4e05-a8a0-a7d0f83091ae)

Release Notes:

- Fix a "unrecognized selector sent to instance" crash on macOS when using different input methods
