### PR TITLE
terminal: Check for script existence properly before activating it

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -490,7 +490,11 @@ impl Project {
             "windows" => "\r",
             _ => "\n",
         };
-        if smol::block_on(self.fs.metadata(path.as_ref())).is_err() {
+        if smol::block_on(self.fs.metadata(path.as_ref()))
+            .ok()
+            .flatten()
+            .is_none()
+        {
             return None;
         }
         Some(format!(

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -490,13 +490,10 @@ impl Project {
             "windows" => "\r",
             _ => "\n",
         };
-        if smol::block_on(self.fs.metadata(path.as_ref()))
+        smol::block_on(self.fs.metadata(path.as_ref()))
             .ok()
-            .flatten()
-            .is_none()
-        {
-            return None;
-        }
+            .flatten()?;
+
         Some(format!(
             "{} {} ; clear{}",
             activate_keyword, quoted, line_ending


### PR DESCRIPTION
We were not covering a variant where the returned metadata was Ok(None)

Closes #ISSUE

Release Notes:

- Fixed venv activation script path showing up in terminal for non-existant scripts.
