### PR TITLE
lsp: Use replace edits for completions

### DIFF
--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2121,7 +2121,7 @@ pub(crate) fn parse_completion_text_edit(
         }
 
         lsp::CompletionTextEdit::InsertAndReplace(edit) => {
-            let range = range_from_lsp(edit.insert);
+            let range = range_from_lsp(edit.replace);
 
             let start = snapshot.clip_point_utf16(range.start, Bias::Left);
             let end = snapshot.clip_point_utf16(range.end, Bias::Left);


### PR DESCRIPTION
(Late) follow up to #9634.
Fixes #23395

Release Notes:

- Accepting completions while the cursor is in the middle of suggested completion will now result in smaller edits being applied.
