### PR TITLE
Dedupe `PromptBuilder` construction

### DIFF
--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -25,9 +25,8 @@ use command_palette_hooks::CommandPaletteFilter;
 use feature_flags::{Assistant2FeatureFlag, FeatureFlagAppExt};
 use fs::Fs;
 use gpui::{actions, AppContext};
-use prompt_library::{PromptBuilder, PromptLoadingParams};
+use prompt_library::PromptBuilder;
 use settings::Settings as _;
-use util::ResultExt;
 
 pub use crate::assistant_panel::{AssistantPanel, ConcreteAssistantPanelDelegate};
 pub use crate::inline_assistant::InlineAssistant;
@@ -60,20 +59,15 @@ actions!(
 const NAMESPACE: &str = "assistant2";
 
 /// Initializes the `assistant2` crate.
-pub fn init(fs: Arc<dyn Fs>, client: Arc<Client>, stdout_is_a_pty: bool, cx: &mut AppContext) {
+pub fn init(
+    fs: Arc<dyn Fs>,
+    client: Arc<Client>,
+    prompt_builder: Arc<PromptBuilder>,
+    cx: &mut AppContext,
+) {
     AssistantSettings::register(cx);
     assistant_panel::init(cx);
 
-    let prompt_builder = PromptBuilder::new(Some(PromptLoadingParams {
-        fs: fs.clone(),
-        repo_path: stdout_is_a_pty
-            .then(|| std::env::current_dir().log_err())
-            .flatten(),
-        cx,
-    }))
-    .log_err()
-    .map(Arc::new)
-    .unwrap_or_else(|| Arc::new(PromptBuilder::new(None).unwrap()));
     inline_assistant::init(
         fs.clone(),
         prompt_builder.clone(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -25,6 +25,7 @@ use gpui::{
 use http_client::{read_proxy_from_env, Uri};
 use language::LanguageRegistry;
 use log::LevelFilter;
+use prompt_library::PromptBuilder;
 use reqwest_client::ReqwestClient;
 
 use assets::Assets;
@@ -443,16 +444,17 @@ fn main() {
             app_state.user_store.clone(),
             cx,
         );
-        let prompt_builder = assistant::init(
+        let prompt_builder = PromptBuilder::load(app_state.fs.clone(), stdout_is_a_pty(), cx);
+        assistant::init(
             app_state.fs.clone(),
             app_state.client.clone(),
-            stdout_is_a_pty(),
+            prompt_builder.clone(),
             cx,
         );
         assistant2::init(
             app_state.fs.clone(),
             app_state.client.clone(),
-            stdout_is_a_pty(),
+            prompt_builder.clone(),
             cx,
         );
         assistant_tools::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -3833,8 +3833,13 @@ mod tests {
                 app_state.fs.clone(),
                 cx,
             );
-            let prompt_builder =
-                assistant::init(app_state.fs.clone(), app_state.client.clone(), false, cx);
+            let prompt_builder = PromptBuilder::load(app_state.fs.clone(), false, cx);
+            assistant::init(
+                app_state.fs.clone(),
+                app_state.client.clone(),
+                prompt_builder.clone(),
+                cx,
+            );
             repl::init(app_state.fs.clone(), cx);
             repl::notebook::init(cx);
             tasks_ui::init(cx);


### PR DESCRIPTION
This PR dedupes the construction of the `PromptBuilder`.

Previously this was constructed by both `assistant` and `assistant2`, but now we construct it outside and pass it in.

Release Notes:

- N/A
