### PR TITLE
assistant2: Only show thread context in picker when we have a `ThreadStore`

### DIFF
--- a/crates/assistant2/src/context.rs
+++ b/crates/assistant2/src/context.rs
@@ -43,15 +43,6 @@ pub enum ContextKind {
 }
 
 impl ContextKind {
-    pub fn all() -> &'static [ContextKind] {
-        &[
-            ContextKind::File,
-            ContextKind::Directory,
-            ContextKind::FetchedUrl,
-            ContextKind::Thread,
-        ]
-    }
-
     pub fn label(&self) -> &'static str {
         match self {
             ContextKind::File => "File",


### PR DESCRIPTION
This PR fixes an issue with the context picker where it would show thread context as an option even if there was no `ThreadStore` available.

Release Notes:

- N/A
