### PR TITLE
feature_flags: Enable `assistant2` for all staff

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -43,10 +43,6 @@ pub struct Assistant2FeatureFlag;
 
 impl FeatureFlag for Assistant2FeatureFlag {
     const NAME: &'static str = "assistant2";
-
-    fn enabled_for_staff() -> bool {
-        false
-    }
 }
 
 pub struct ToolUseFeatureFlag;


### PR DESCRIPTION
This PR makes it so the `assistant2` feature flag is automatically enabled for all staff.

Previously all the staff members had been opted in to the feature flag manually (to allow for opting out), but I think we're ready to unconditionally ship it to all staff.

Release Notes:

- N/A
