### PR TITLE
assistant2: Don't suggest thread context for inline assist without a `ThreadStore`

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -259,7 +259,7 @@ impl ActiveThread {
                         h_flex().flex_wrap().gap_1().px_1p5().pb_1p5().children(
                             context
                                 .into_iter()
-                                .map(|context| ContextPill::new_added(context, false, false, None)),
+                                .map(|context| ContextPill::added(context, false, false, None)),
                         ),
                     )
                 } else {

--- a/crates/assistant2/src/context_picker.rs
+++ b/crates/assistant2/src/context_picker.rs
@@ -89,7 +89,7 @@ impl ContextPicker {
                 ContextKind::Directory,
                 ContextKind::FetchedUrl,
             ];
-            if self.thread_store.is_some() {
+            if self.allow_threads() {
                 context_kinds.push(ContextKind::Thread);
             }
 
@@ -130,6 +130,11 @@ impl ContextPicker {
         .detach();
 
         menu
+    }
+
+    /// Whether threads are allowed as context.
+    pub fn allow_threads(&self) -> bool {
+        self.thread_store.is_some()
     }
 
     fn select_kind(&mut self, kind: ContextKind, cx: &mut ViewContext<Self>) {

--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -432,7 +432,7 @@ impl Render for ContextStrip {
                 }
             })
             .children(context.iter().enumerate().map(|(i, context)| {
-                ContextPill::new_added(
+                ContextPill::added(
                     context.clone(),
                     dupe_names.contains(&context.name),
                     self.focused_index == Some(i),
@@ -454,7 +454,7 @@ impl Render for ContextStrip {
             }))
             .when_some(suggested_context, |el, suggested| {
                 el.child(
-                    ContextPill::new_suggested(
+                    ContextPill::suggested(
                         suggested.name().clone(),
                         suggested.icon_path(),
                         suggested.kind(),

--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -118,6 +118,10 @@ impl ContextStrip {
     }
 
     fn suggested_thread(&self, cx: &ViewContext<Self>) -> Option<SuggestedContext> {
+        if !self.context_picker.read(cx).allow_threads() {
+            return None;
+        }
+
         let workspace = self.workspace.upgrade()?;
         let active_thread = workspace
             .read(cx)

--- a/crates/assistant2/src/ui/context_pill.rs
+++ b/crates/assistant2/src/ui/context_pill.rs
@@ -24,7 +24,7 @@ pub enum ContextPill {
 }
 
 impl ContextPill {
-    pub fn new_added(
+    pub fn added(
         context: ContextSnapshot,
         dupe_name: bool,
         focused: bool,
@@ -39,7 +39,7 @@ impl ContextPill {
         }
     }
 
-    pub fn new_suggested(
+    pub fn suggested(
         name: SharedString,
         icon_path: Option<SharedString>,
         kind: ContextKind,


### PR DESCRIPTION
This PR makes it so we don't suggest threads as context in the inline assist when we don't have a `ThreadStore` to pull from.

Release Notes:

- N/A
