### PR TITLE
Solve perceptual data race between LSP completions and edit predictions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7865,6 +7865,18 @@ impl Editor {
         });
     }
 
+    pub fn context_menu_select_initial_lsp_completion(&mut self, cx: &mut Context<Self>) {
+        if let Some(context_menu) = self.context_menu.borrow_mut().as_mut() {
+            match context_menu {
+                CodeContextMenu::Completions(completions_menu) => {
+                    completions_menu
+                        .select_initial_lsp_completion(self.completion_provider.as_deref(), cx);
+                }
+                CodeContextMenu::CodeActions(_) => {}
+            }
+        }
+    }
+
     pub fn context_menu_first(
         &mut self,
         _: &ContextMenuFirst,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -15454,6 +15454,7 @@ async fn assert_highlighted_edits(
             &snapshot.as_singleton().unwrap().2,
             &edits,
             &edit_preview,
+            HighlightEditsRange::AllEdits,
             include_deletions,
             cx,
         )

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -44,7 +44,7 @@ use language::{
         IndentGuideBackgroundColoring, IndentGuideColoring, IndentGuideSettings,
         ShowWhitespaceSetting,
     },
-    ChunkRendererContext,
+    ChunkRendererContext, HighlightEditsRange,
 };
 use lsp::DiagnosticSeverity;
 use multi_buffer::{
@@ -3488,7 +3488,14 @@ impl EditorElement {
                 }
 
                 let highlighted_edits = edit_preview.as_ref().and_then(|edit_preview| {
-                    crate::inline_completion_edit_text(&snapshot, edits, edit_preview, false, cx)
+                    crate::inline_completion_edit_text(
+                        &snapshot,
+                        edits,
+                        edit_preview,
+                        HighlightEditsRange::AllEdits,
+                        false,
+                        cx,
+                    )
                 })?;
 
                 let line_count = highlighted_edits.text.lines().count() + 1;

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2687,7 +2687,15 @@ async fn test_preview_edits(cx: &mut TestAppContext) {
                 buffer.preview_edits(edits.clone().into(), cx)
             })
             .await;
-        cx.read(|cx| edit_preview.highlight_edits(&buffer.read(cx).snapshot(), &edits, true, cx))
+        cx.read(|cx| {
+            edit_preview.highlight_edits(
+                &buffer.read(cx).snapshot(),
+                &edits,
+                HighlightEditsRange::AllEdits,
+                true,
+                cx,
+            )
+        })
     }
 }
 
@@ -2716,8 +2724,15 @@ async fn test_preview_edits_interpolate(cx: &mut TestAppContext) {
         .read_with(cx, |buffer, cx| buffer.preview_edits(edits.clone(), cx))
         .await;
 
-    let highlighted_edits =
-        cx.read(|cx| edit_preview.highlight_edits(&buffer.read(cx).snapshot(), &edits, false, cx));
+    let highlighted_edits = cx.read(|cx| {
+        edit_preview.highlight_edits(
+            &buffer.read(cx).snapshot(),
+            &edits,
+            HighlightEditsRange::AllEdits,
+            false,
+            cx,
+        )
+    });
 
     let created_background = cx.read(|cx| cx.theme().status().created_background);
 
@@ -2740,8 +2755,15 @@ async fn test_preview_edits_interpolate(cx: &mut TestAppContext) {
     let edit_preview = buffer
         .read_with(cx, |buffer, cx| buffer.preview_edits(edits.clone(), cx))
         .await;
-    let highlighted_edits =
-        cx.read(|cx| edit_preview.highlight_edits(&buffer.read(cx).snapshot(), &edits, false, cx));
+    let highlighted_edits = cx.read(|cx| {
+        edit_preview.highlight_edits(
+            &buffer.read(cx).snapshot(),
+            &edits,
+            HighlightEditsRange::AllEdits,
+            false,
+            cx,
+        )
+    });
 
     assert_eq!(highlighted_edits.text, "    first_name: String");
     assert_eq!(highlighted_edits.highlights.len(), 1);

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2737,6 +2737,9 @@ async fn test_preview_edits_interpolate(cx: &mut TestAppContext) {
     });
 
     let edits = construct_edits(&buffer, [(Point::new(1, 5)..Point::new(1, 5), "irst")], cx);
+    let edit_preview = buffer
+        .read_with(cx, |buffer, cx| buffer.preview_edits(edits.clone(), cx))
+        .await;
     let highlighted_edits =
         cx.read(|cx| edit_preview.highlight_edits(&buffer.read(cx).snapshot(), &edits, false, cx));
 

--- a/crates/text/src/anchor.rs
+++ b/crates/text/src/anchor.rs
@@ -99,7 +99,9 @@ impl Anchor {
         } else if self.buffer_id != Some(buffer.remote_id) {
             false
         } else {
-            let fragment_id = buffer.fragment_id_for_anchor(self);
+            let Some(fragment_id) = buffer.fragment_id_for_anchor_if_valid(self) else {
+                return false;
+            };
             let mut fragment_cursor = buffer.fragments.cursor::<(Option<&Locator>, usize)>(&None);
             fragment_cursor.seek(&Some(fragment_id), Bias::Left, &None);
             fragment_cursor

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -42,6 +42,7 @@ pub struct ListItem {
     outlined: bool,
     overflow_x: bool,
     focused: Option<bool>,
+    opacity: f32,
 }
 
 impl ListItem {
@@ -67,6 +68,7 @@ impl ListItem {
             outlined: false,
             overflow_x: false,
             focused: None,
+            opacity: 1.0,
         }
     }
 
@@ -158,6 +160,11 @@ impl ListItem {
         self.focused = Some(focused);
         self
     }
+
+    pub fn opacity(mut self, opacity: f32) -> Self {
+        self.opacity = opacity;
+        self
+    }
 }
 
 impl Disableable for ListItem {
@@ -186,6 +193,7 @@ impl RenderOnce for ListItem {
             .id(self.id)
             .w_full()
             .relative()
+            .opacity(self.opacity)
             // When an item is inset draw the indent spacing outside of the item
             .when(self.inset, |this| {
                 this.ml(self.indent_level as f32 * self.indent_step_size)

--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -64,13 +64,13 @@ impl RenderOnce for Popover {
                 .border_color(cx.theme().colors().border_variant)
                 .shadow(ElevationIndex::ElevatedSurface.shadow()),
             PopoverElision::TranslucentWithCroppedBottom => inner
-                .bg(cx.theme().colors().elevated_surface_background.opacity(0.5))
+                // .bg(cx.theme().colors().elevated_surface_background.opacity(0.5))
                 .border_color(cx.theme().colors().border_variant.opacity(0.5))
                 .rounded_bl_none()
                 .rounded_br_none()
                 .border_b(px(0.)),
             PopoverElision::TranslucentWithCroppedTop => inner
-                .bg(cx.theme().colors().elevated_surface_background.opacity(0.5))
+                // .bg(cx.theme().colors().elevated_surface_background.opacity(0.5))
                 .border_color(cx.theme().colors().border_variant.opacity(0.5))
                 .rounded_tl_none()
                 .rounded_tr_none()


### PR DESCRIPTION
Not entirely happy with this code, but quite happy with the behavior it implements:

1. When there is an edit prediction loaded and LSP completions arrive, select the edit prediction.  This handles the perceptual data race where the user sees a completion in the buffer and doesn't even notice the menu popping up.

2. When there is no edit prediction loaded and LSP completions arrive, select the LSP completion.  This makes use of LSP results more convenient, particularly when the user knows an interface well and is anticipating its presence in the LSP completion.

3. When the edit prediction entry is loaded and selected, the menu becomes transparent with no text, to show the edit prediction inline in the buffer.  No more display in an aside, so no mental overhead of re-locating the change in the buffer.  That change has its own PR (#23445) but is also included here.

4. When an LSP completion entry is selected, do not show an edit prediction in the buffer.

**Not implemented here (WIP):** Since 2 and 4 mean edit predictions are often hidden, it may be less obvious to the user that they are present.  To deal with this, show a preview of the edit prediction in the menu.  These would display the change starting at the completion menu target (e.g. character after `.`).

Release Notes:

* Improved inclusion of inline completions in language server completions menu.  When selected, the menu is made translucent with no text so that the inline completions can be fully displayed in the buffer.