### PR TITLE
Fix panics on opening repositories with empty remotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,9 +5204,8 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+version = "0.20.0"
+source = "git+https://github.com/rust-lang/git2-rs?rev=a3b90cb3756c1bb63e2317bf9cfa57838178de5c#a3b90cb3756c1bb63e2317bf9cfa57838178de5c"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
@@ -7029,9 +7028,8 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+version = "0.18.0+1.9.0"
+source = "git+https://github.com/rust-lang/git2-rs?rev=a3b90cb3756c1bb63e2317bf9cfa57838178de5c#a3b90cb3756c1bb63e2317bf9cfa57838178de5c"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,7 +400,8 @@ fork = "0.2.0"
 futures = "0.3"
 futures-batch = "0.6.1"
 futures-lite = "1.13"
-git2 = { version = "0.19", default-features = false }
+# TODO: get back to regular versions when https://github.com/rust-lang/git2-rs/pull/1120 is released
+git2 = { git = "https://github.com/rust-lang/git2-rs", rev = "a3b90cb3756c1bb63e2317bf9cfa57838178de5c", default-features = false }
 globset = "0.4"
 handlebars = "4.3"
 heed = { version = "0.21.0", features = ["read-txn-no-tls"] }


### PR DESCRIPTION
Uses a newer `git2` version with https://github.com/rust-lang/git2-rs/pull/1120 fix

Closes https://github.com/zed-industries/zed/issues/23453

Release Notes:

- Fixed panics on opening repositories with empty remotes
