### PR TITLE
Fix LSP violation when dismissing server notifications

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -792,9 +792,8 @@ impl LocalLspStore {
                             })
                             .is_ok();
                         if did_update {
-                            let response = rx.recv().await?;
-
-                            Ok(Some(response))
+                            let response = rx.recv().await.ok();
+                            Ok(response)
                         } else {
                             Ok(None)
                         }


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/22606
Closes https://github.com/zed-industries/zed/issues/23509

When a user sees an odd notification from the language server like

<img width="508" alt="image" src="https://github.com/user-attachments/assets/6f5ef1aa-0f09-4705-a02a-aaf81dd8620c" />

they usually dismiss that.

Zed uses channels to wait and handle user interactions with such notifications, and, due to `?`, sends back 
```json
{"jsonrpc":"2.0","id":1,"error":{"message":"receiving from an empty and closed channel"}}
```

which is not spec-compliant: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest

> Response:
>
>  *  result: the selected [MessageActionItem](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#messageActionItem) | null if none got selected.
>  * error: code and message set in case an exception happens during showing a message.

Unfortunately, vtsls (and, potentially, others) crash if receive such non-compliant requests, and do not get back.

After the fix, the message is correct:
```json
{"jsonrpc":"2.0","id":1,"result":null}
```


Release Notes:

- Fixed vtsls crashing on notification dismiss
