### PR TITLE
php: Add nowdoc language injection

### DIFF
--- a/extensions/php/languages/php/injections.scm
+++ b/extensions/php/languages/php/injections.scm
@@ -7,3 +7,5 @@
   (#set! injection.language "phpdoc"))
 
 ((heredoc_body) (heredoc_end) @injection.language) @injection.content
+
+((nowdoc_body) (heredoc_end) @injection.language) @injection.content


### PR DESCRIPTION
We already have heredoc injection support, so this just extends it to also cover [nowdoc](https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.nowdoc).

Before:
![Screenshot 2025-01-23 at 13 07 20](https://github.com/user-attachments/assets/c26a7690-8960-42da-a74b-74974369c514)

After:
![Screenshot 2025-01-23 at 13 07 28](https://github.com/user-attachments/assets/5c392f6e-e24f-42a1-8dec-0d328b87a00a)

Release Notes:

- N/A
