### PR TITLE
gpui: Fix image paths in examples

### DIFF
--- a/crates/gpui/examples/gif_viewer.rs
+++ b/crates/gpui/examples/gif_viewer.rs
@@ -26,7 +26,7 @@ fn main() {
     env_logger::init();
     App::new().run(|cx: &mut AppContext| {
         let cwd = std::env::current_dir().expect("Failed to get current working directory");
-        let gif_path = cwd.join("crates/gpui/examples/image/black-cat-typing.gif");
+        let gif_path = cwd.join("examples/image/black-cat-typing.gif");
 
         if !gif_path.exists() {
             eprintln!("Image file not found at {:?}", gif_path);

--- a/crates/gpui/examples/svg/svg.rs
+++ b/crates/gpui/examples/svg/svg.rs
@@ -70,7 +70,7 @@ impl Render for SvgExample {
 fn main() {
     App::new()
         .with_assets(Assets {
-            base: PathBuf::from("crates/gpui/examples"),
+            base: PathBuf::from("examples"),
         })
         .run(|cx: &mut AppContext| {
             let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);


### PR DESCRIPTION
Release Notes:

- N/A


## Before

```sh
cargo run --example svg
cargo run --example gif_viewer

Image file not found at "~/zed/crates/gpui/crates/gpui/examples/image/black-cat-typing.gif"
Make sure you're running this example from the root of the gpui crate
```
![Screenshot 2025-01-23 at 9 23 40 AM](https://github.com/user-attachments/assets/945f498f-f025-4897-a29a-d71770b0ec8e)



## After

![Screenshot 2025-01-23 at 9 24 28 AM](https://github.com/user-attachments/assets/863efc11-28af-447b-a804-ed808e31a5d7)

![Screenshot 2025-01-23 at 9 25 50 AM](https://github.com/user-attachments/assets/54293301-5f54-4568-9ceb-1821d8630e18)

