### PR TITLE
haskell: Bump to v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16479,7 +16479,7 @@ dependencies = [
 
 [[package]]
 name = "zed_haskell"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/haskell/Cargo.toml
+++ b/extensions/haskell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_haskell"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/haskell/extension.toml
+++ b/extensions/haskell/extension.toml
@@ -1,7 +1,7 @@
 id = "haskell"
 name = "Haskell"
 description = "Haskell support."
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = [
     "Pocæus <github@pocaeus.com>",


### PR DESCRIPTION
Includes:
- https://github.com/zed-industries/zed/pull/22609

Release Notes:

- N/A
