### PR TITLE
git_panel: Toggle stage all when clicking changes label

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -834,7 +834,17 @@ impl GitPanel {
                             false => git_panel.stage_all(&StageAll, cx),
                         })),
                     )
-                    .child(div().text_buffer(cx).text_ui_sm(cx).child(changes_string)),
+                    .child(
+                        div()
+                            .id("changes-checkbox-label")
+                            .text_buffer(cx)
+                            .text_ui_sm(cx)
+                            .child(changes_string)
+                            .on_click(cx.listener(move |git_panel, _, cx| match all_staged {
+                                true => git_panel.unstage_all(&UnstageAll, cx),
+                                false => git_panel.stage_all(&StageAll, cx),
+                            })),
+                    ),
             )
             .child(div().flex_grow())
             .child(


### PR DESCRIPTION
When clicking the checkbox label fire the toggle action.

At first I wasn't sure this is what we wanted, but after looking at a few existing implementations of checkboxes with labels it seems like this is reasonably standard.

Eventually this piece of UI will be updated to a CheckboxWithLabel, but for now it is custom due to some specific style requirements.

Release Notes:

- N/A
