### PR TITLE
Remove unwrap in GitTraversal::synchronize_statuses

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5725,7 +5725,8 @@ impl<'a> GitTraversal<'a> {
         } else if entry.is_file() {
             // For a file entry, park the cursor on the corresponding status
             if statuses.seek_forward(&PathTarget::Path(repo_path.as_ref()), Bias::Left, &()) {
-                self.current_entry_summary = Some(statuses.item().unwrap().status.into());
+                // TODO: Investigate statuses.item() being None here.
+                self.current_entry_summary = statuses.item().map(|item| item.status.into());
             } else {
                 self.current_entry_summary = Some(GitSummary::UNCHANGED);
             }


### PR DESCRIPTION
Release Notes:

- Fixed a potential panic in handling of Git statuses.
