### PR TITLE
vim: :norm

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -94,7 +94,7 @@ impl Keystroke {
                 "alt" => alt = true,
                 "shift" => shift = true,
                 "fn" => function = true,
-                "cmd" | "super" | "win" => platform = true,
+                "cmd" | "super" | "win" | "" => platform = true,
                 _ => {
                     if let Some(next) = components.peek() {
                         if next.is_empty() && source.ends_with('-') {


### PR DESCRIPTION
Closes #ISSUE

Co-Authored-By: Thorsten <thorsten@zed.dev>

Release Notes:

- vim: Add support for `:norm` in the command palette to run a key sequence on each line

