### PR TITLE
vim: Add support for ctrl-g

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -86,6 +86,7 @@
       "ctrl-[": ["vim::SwitchMode", "Normal"],
       "v": "vim::ToggleVisual",
       "shift-v": "vim::ToggleVisualLine",
+      "ctrl-g": "vim::ShowLocation",
       "ctrl-v": "vim::ToggleVisualBlock",
       "ctrl-q": "vim::ToggleVisualBlock",
       "shift-k": "editor::Hover",

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -97,18 +97,24 @@ impl Render for ModeIndicator {
         };
 
         let vim_readable = vim.read(cx);
-        let mode = if vim_readable.temp_mode {
-            format!("(insert) {}", vim_readable.mode)
+        let label = if let Some(label) = vim_readable.status_label.clone() {
+            label
         } else {
-            vim_readable.mode.to_string()
+            let mode = if vim_readable.temp_mode {
+                format!("(insert) {}", vim_readable.mode)
+            } else {
+                vim_readable.mode.to_string()
+            };
+
+            let current_operators_description = self.current_operators_description(vim.clone(), cx);
+            let pending = self
+                .pending_keys
+                .as_ref()
+                .unwrap_or(&current_operators_description);
+            format!("{} -- {} --", pending, mode).into()
         };
 
-        let current_operators_description = self.current_operators_description(vim.clone(), cx);
-        let pending = self
-            .pending_keys
-            .as_ref()
-            .unwrap_or(&current_operators_description);
-        Label::new(format!("{} -- {} --", pending, mode))
+        Label::new(label)
             .size(LabelSize::Small)
             .line_height_style(LineHeightStyle::UiLabel)
             .into_any_element()

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -42,7 +42,7 @@ use state::{Mode, Operator, RecordedSelection, SearchState, VimGlobals};
 use std::{mem, ops::Range, sync::Arc};
 use surrounds::SurroundsType;
 use theme::ThemeSettings;
-use ui::{px, IntoElement, VisualContext};
+use ui::{px, IntoElement, SharedString, VisualContext};
 use vim_mode_setting::VimModeSetting;
 use workspace::{self, Pane, ResizeIntent, Workspace};
 
@@ -201,6 +201,7 @@ pub(crate) struct Vim {
     pub(crate) mode: Mode,
     pub last_mode: Mode,
     pub temp_mode: bool,
+    pub status_label: Option<SharedString>,
     pub exit_temporary_mode: bool,
 
     operator_stack: Vec<Operator>,
@@ -262,6 +263,7 @@ impl Vim {
             current_anchor: None,
             undo_modes: HashMap::default(),
 
+            status_label: None,
             selected_register: None,
             search: SearchState::default(),
 
@@ -519,6 +521,7 @@ impl Vim {
         let last_mode = self.mode;
         let prior_mode = self.last_mode;
         let prior_tx = self.current_tx;
+        self.status_label.take();
         self.last_mode = last_mode;
         self.mode = mode;
         self.operator_stack.clear();


### PR DESCRIPTION
Co-Authored-By: Jon Walstedt <jon@walstedt.se>

Closes #22094

Release Notes:

- vim: Added support for `ctrl-g` and `{count} ctrl-g` to show the filename in the status bar
