### PR TITLE
ui: Don't add an `on_click` handler for disabled `ListItem`s

### DIFF
--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -245,9 +245,10 @@ impl RenderOnce for ListItem {
                                 })
                             })
                     })
-                    .when_some(self.on_click, |this, on_click| {
-                        this.cursor_pointer().on_click(on_click)
-                    })
+                    .when_some(
+                        self.on_click.filter(|_| !self.disabled),
+                        |this, on_click| this.cursor_pointer().on_click(on_click),
+                    )
                     .when(self.outlined, |this| {
                         this.border_1()
                             .border_color(cx.theme().colors().border)


### PR DESCRIPTION
This PR updates the `ListItem` component to not register an `on_click` handler for `ListItem`s that are disabled.

When working on #23350 I noticed that even when the context menu entry was disabled you could still click on the entry to fire the action.

Release Notes:

- Fixed some instances of disabled list items still registering clicks.
