### PR TITLE
Autoscroll when running `editor: swap selection ends`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10679,6 +10679,7 @@ impl Editor {
                 }
             });
         });
+        self.request_autoscroll(Autoscroll::newest(), cx);
         cx.notify();
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/23512

Release Notes:

- Improved `editor: swap selection ends` by always scrolling the cursor into view
