### PR TITLE
assistant2: Expose `ActiveThread::thread` via a getter

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -22,7 +22,7 @@ pub struct ActiveThread {
     workspace: WeakView<Workspace>,
     language_registry: Arc<LanguageRegistry>,
     tools: Arc<ToolWorkingSet>,
-    pub(crate) thread: Model<Thread>,
+    thread: Model<Thread>,
     messages: Vec<MessageId>,
     list_state: ListState,
     rendered_messages_by_id: HashMap<MessageId, View<Markdown>>,
@@ -66,6 +66,10 @@ impl ActiveThread {
         }
 
         this
+    }
+
+    pub fn thread(&self) -> &Model<Thread> {
+        &self.thread
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -432,7 +432,7 @@ impl AssistantPanel {
     }
 
     pub(crate) fn active_thread(&self, cx: &AppContext) -> Model<Thread> {
-        self.thread.read(cx).thread.clone()
+        self.thread.read(cx).thread().clone()
     }
 
     pub(crate) fn delete_thread(&mut self, thread_id: &ThreadId, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
This PR exposes the `thread` file on the `ActiveThread` via a getter rather than exposing the field directly.

Release Notes:

- N/A
