### PR TITLE
Update some editor methods to instead take immutable references

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -40,7 +40,8 @@ pub use crease_map::*;
 pub use fold_map::{Fold, FoldId, FoldPlaceholder, FoldPoint};
 use fold_map::{FoldMap, FoldSnapshot};
 use gpui::{
-    AnyElement, Font, HighlightStyle, LineLayout, Model, ModelContext, Pixels, UnderlineStyle,
+    AnyElement, AppContext, Font, HighlightStyle, LineLayout, Model, ModelContext, Pixels,
+    UnderlineStyle,
 };
 pub use inlay_map::Inlay;
 use inlay_map::{InlayMap, InlaySnapshot};
@@ -543,7 +544,7 @@ impl DisplayMap {
         self.block_map.read(snapshot, edits);
     }
 
-    fn tab_size(buffer: &Model<MultiBuffer>, cx: &mut ModelContext<Self>) -> NonZeroU32 {
+    fn tab_size(buffer: &Model<MultiBuffer>, cx: &AppContext) -> NonZeroU32 {
         let buffer = buffer.read(cx).as_singleton().map(|buffer| buffer.read(cx));
         let language = buffer
             .and_then(|buffer| buffer.language())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1572,7 +1572,7 @@ impl Editor {
         self.buffer().read(cx).title(cx)
     }
 
-    pub fn snapshot(&mut self, cx: &mut WindowContext) -> EditorSnapshot {
+    pub fn snapshot(&self, cx: &mut WindowContext) -> EditorSnapshot {
         let git_blame_gutter_max_author_length = self
             .render_git_blame_gutter(cx)
             .then(|| {
@@ -4993,7 +4993,7 @@ impl Editor {
     }
 
     fn inline_completion_menu_hint(
-        &mut self,
+        &self,
         cx: &mut ViewContext<Self>,
     ) -> Option<InlineCompletionMenuHint> {
         let provider = self.inline_completion_provider()?;
@@ -6168,7 +6168,7 @@ impl Editor {
     }
 
     fn gather_revert_changes(
-        &mut self,
+        &self,
         selections: &[Selection<Point>],
         cx: &mut ViewContext<Editor>,
     ) -> HashMap<BufferId, Vec<(Range<text::Anchor>, Rope)>> {
@@ -6181,7 +6181,7 @@ impl Editor {
     }
 
     pub fn prepare_revert_change(
-        &mut self,
+        &self,
         revert_changes: &mut HashMap<BufferId, Vec<(Range<text::Anchor>, Rope)>>,
         hunk: &MultiBufferDiffHunk,
         cx: &AppContext,
@@ -11703,23 +11703,23 @@ impl Editor {
         self.show_git_blame_gutter
     }
 
-    pub fn render_git_blame_gutter(&mut self, cx: &mut WindowContext) -> bool {
+    pub fn render_git_blame_gutter(&self, cx: &WindowContext) -> bool {
         self.show_git_blame_gutter && self.has_blame_entries(cx)
     }
 
-    pub fn render_git_blame_inline(&mut self, cx: &mut WindowContext) -> bool {
+    pub fn render_git_blame_inline(&self, cx: &WindowContext) -> bool {
         self.show_git_blame_inline
             && self.focus_handle.is_focused(cx)
             && !self.newest_selection_head_on_empty_line(cx)
             && self.has_blame_entries(cx)
     }
 
-    fn has_blame_entries(&self, cx: &mut WindowContext) -> bool {
+    fn has_blame_entries(&self, cx: &WindowContext) -> bool {
         self.blame()
             .map_or(false, |blame| blame.read(cx).has_generated_entries())
     }
 
-    fn newest_selection_head_on_empty_line(&mut self, cx: &mut WindowContext) -> bool {
+    fn newest_selection_head_on_empty_line(&self, cx: &WindowContext) -> bool {
         let cursor_anchor = self.selections.newest_anchor().head();
 
         let snapshot = self.buffer.read(cx).snapshot(cx);
@@ -11728,7 +11728,7 @@ impl Editor {
         snapshot.line_len(buffer_row) == 0
     }
 
-    fn get_permalink_to_line(&mut self, cx: &mut ViewContext<Self>) -> Task<Result<url::Url>> {
+    fn get_permalink_to_line(&self, cx: &mut ViewContext<Self>) -> Task<Result<url::Url>> {
         let buffer_and_selection = maybe!({
             let selection = self.selections.newest::<Point>(cx);
             let selection_range = selection.range();
@@ -12012,10 +12012,7 @@ impl Editor {
     /// Merges all anchor ranges for all context types ever set, picking the last highlight added in case of a row conflict.
     /// Returns a map of display rows that are highlighted and their corresponding highlight color.
     /// Allows to ignore certain kinds of highlights.
-    pub fn highlighted_display_rows(
-        &mut self,
-        cx: &mut WindowContext,
-    ) -> BTreeMap<DisplayRow, Hsla> {
+    pub fn highlighted_display_rows(&self, cx: &mut WindowContext) -> BTreeMap<DisplayRow, Hsla> {
         let snapshot = self.snapshot(cx);
         let mut used_highlight_orders = HashMap::default();
         self.highlighted_rows
@@ -12129,7 +12126,7 @@ impl Editor {
 
     #[cfg(feature = "test-support")]
     pub fn all_text_background_highlights(
-        &mut self,
+        &self,
         cx: &mut ViewContext<Self>,
     ) -> Vec<(Range<DisplayPoint>, Hsla)> {
         let snapshot = self.snapshot(cx);
@@ -13188,7 +13185,7 @@ impl Editor {
     }
 
     pub fn to_pixel_point(
-        &mut self,
+        &self,
         source: multi_buffer::Anchor,
         editor_snapshot: &EditorSnapshot,
         cx: &mut ViewContext<Self>,

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -6,7 +6,7 @@ use git::{
     blame::{Blame, BlameEntry},
     parse_git_remote_url, GitHostingProvider, GitHostingProviderRegistry, Oid, PullRequest,
 };
-use gpui::{Model, ModelContext, Subscription, Task};
+use gpui::{AppContext, Model, ModelContext, Subscription, Task};
 use http_client::HttpClient;
 use language::{markdown, Bias, Buffer, BufferSnapshot, Edit, LanguageRegistry, ParsedMarkdown};
 use multi_buffer::MultiBufferRow;
@@ -195,7 +195,7 @@ impl GitBlame {
     pub fn blame_for_rows<'a>(
         &'a mut self,
         rows: impl 'a + IntoIterator<Item = Option<MultiBufferRow>>,
-        cx: &mut ModelContext<Self>,
+        cx: &AppContext,
     ) -> impl 'a + Iterator<Item = Option<BlameEntry>> {
         self.sync(cx);
 
@@ -207,7 +207,7 @@ impl GitBlame {
         })
     }
 
-    pub fn max_author_length(&mut self, cx: &mut ModelContext<Self>) -> usize {
+    pub fn max_author_length(&mut self, cx: &AppContext) -> usize {
         self.sync(cx);
 
         let mut max_author_length = 0;
@@ -240,7 +240,7 @@ impl GitBlame {
         }
     }
 
-    fn sync(&mut self, cx: &mut ModelContext<Self>) {
+    fn sync(&mut self, cx: &AppContext) {
         let edits = self.buffer_edits.consume();
         let new_snapshot = self.buffer.read(cx).snapshot();
 


### PR DESCRIPTION
Makes the signatures more informative and can be more convenient as multiple immutable borrows are allowed.

Release Notes:

- N/A