### PR TITLE
assistant_context_editor: Put `use`s in the right spot

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -57,6 +57,13 @@ use workspace::{
     Workspace,
 };
 
+use crate::{slash_command::SlashCommandCompletionProvider, slash_command_picker};
+use crate::{
+    AssistantPatch, AssistantPatchStatus, CacheStatus, Content, Context, ContextEvent, ContextId,
+    InvokedSlashCommandId, InvokedSlashCommandStatus, Message, MessageId, MessageMetadata,
+    MessageStatus, ParsedSlashCommand, PendingSlashCommandStatus, RequestType,
+};
+
 actions!(
     assistant,
     [
@@ -79,13 +86,6 @@ pub enum InsertDraggedFiles {
 }
 
 impl_internal_actions!(assistant, [InsertDraggedFiles]);
-
-use crate::{slash_command::SlashCommandCompletionProvider, slash_command_picker};
-use crate::{
-    AssistantPatch, AssistantPatchStatus, CacheStatus, Content, Context, ContextEvent, ContextId,
-    InvokedSlashCommandId, InvokedSlashCommandStatus, Message, MessageId, MessageMetadata,
-    MessageStatus, ParsedSlashCommand, PendingSlashCommandStatus, RequestType,
-};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 struct ScrollPosition {


### PR DESCRIPTION
This PR cleans up some `use` statements that weren't at the very top of the module.

Release Notes:

- N/A
