### PR TITLE
Make editor autoscroll put cursor to the left of scrollbar not under

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6456,7 +6456,7 @@ impl Element for EditorElement {
                         let autoscrolled = if autoscroll_horizontally {
                             editor.autoscroll_horizontally(
                                 start_row,
-                                text_hitbox.size.width,
+                                editor_width - (letter_size.width / 2.0),
                                 scroll_width,
                                 em_width,
                                 &line_layouts,
@@ -6541,7 +6541,7 @@ impl Element for EditorElement {
                         let autoscrolled = if autoscroll_horizontally {
                             editor.autoscroll_horizontally(
                                 start_row,
-                                text_hitbox.size.width,
+                                editor_width - (letter_size.width / 2.0),
                                 scroll_width,
                                 em_width,
                                 &line_layouts,


### PR DESCRIPTION
Closes #19706

Release Notes:

- Improved editor horizontal autoscroll to now place the cursor to the left of the scrollbar rather than under it.