### PR TITLE
assistant2: Disable the Submit button when missing requirements

### DIFF
--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -13,7 +13,9 @@ use rope::Point;
 use settings::Settings;
 use std::time::Duration;
 use theme::ThemeSettings;
-use ui::{prelude::*, ButtonLike, KeyBinding, PopoverMenu, PopoverMenuHandle, Switch, TintColor};
+use ui::{
+    prelude::*, ButtonLike, KeyBinding, PopoverMenu, PopoverMenuHandle, Switch, TintColor, Tooltip,
+};
 use workspace::Workspace;
 
 use crate::assistant_model_selector::AssistantModelSelector;
@@ -133,6 +135,16 @@ impl MessageEditor {
 
     fn chat(&mut self, _: &Chat, cx: &mut ViewContext<Self>) {
         self.send_to_model(RequestKind::Chat, cx);
+    }
+
+    fn is_editor_empty(&self, cx: &AppContext) -> bool {
+        self.editor.read(cx).text(cx).is_empty()
+    }
+
+    fn is_model_selected(&self, cx: &AppContext) -> bool {
+        LanguageModelRegistry::read_global(cx)
+            .active_model()
+            .is_some()
     }
 
     fn send_to_model(&mut self, request_kind: RequestKind, cx: &mut ViewContext<Self>) {
@@ -266,6 +278,13 @@ impl Render for MessageEditor {
         let bg_color = cx.theme().colors().editor_background;
         let is_streaming_completion = self.thread.read(cx).is_streaming();
         let button_width = px(64.);
+        let is_model_selected = self.is_model_selected(cx);
+        let is_editor_empty = self.is_editor_empty(cx);
+        let submit_label_color = if is_editor_empty {
+            Color::Muted
+        } else {
+            Color::Default
+        };
 
         v_flex()
             .key_context("MessageEditor")
@@ -384,11 +403,16 @@ impl Render for MessageEditor {
                                     ButtonLike::new("submit-message")
                                         .width(button_width.into())
                                         .style(ButtonStyle::Filled)
+                                        .disabled(is_editor_empty || !is_model_selected)
                                         .child(
                                             h_flex()
                                                 .w_full()
                                                 .justify_between()
-                                                .child(Label::new("Submit").size(LabelSize::Small))
+                                                .child(
+                                                    Label::new("Submit")
+                                                        .size(LabelSize::Small)
+                                                        .color(submit_label_color),
+                                                )
                                                 .children(
                                                     KeyBinding::for_action_in(
                                                         &Chat,
@@ -400,6 +424,16 @@ impl Render for MessageEditor {
                                         )
                                         .on_click(move |_event, cx| {
                                             focus_handle.dispatch_action(&Chat, cx);
+                                        })
+                                        .when(is_editor_empty, |button| {
+                                            button.tooltip(|cx| {
+                                                Tooltip::text("Type a message to submit", cx)
+                                            })
+                                        })
+                                        .when(!is_model_selected, |button| {
+                                            button.tooltip(|cx| {
+                                                Tooltip::text("Select a model to continue", cx)
+                                            })
                                         })
                                 },
                             )),


### PR DESCRIPTION
This PR disables the Assistant 2 Submit button when either there is no message written in the editor or there's no model selected. To guide the user, there will be a tooltip displayed on top of the button to indicate what to do.

Release Notes:

- N/A
