### PR TITLE
assistant: Adjust the ToS acceptance card design

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -862,21 +862,19 @@ impl ConfigurationView {
 
         let terms_button = Button::new("terms_of_service", "Terms of Service")
             .style(ButtonStyle::Subtle)
-            .icon(IconName::ExternalLink)
+            .icon(IconName::ArrowUpRight)
             .icon_color(Color::Muted)
+            .icon_size(IconSize::XSmall)
             .on_click(move |_, cx| cx.open_url("https://zed.dev/terms-of-service"));
 
-        let text =
-            "In order to use Zed AI, please read and accept our terms and conditions to continue:";
+        let text = "To start using Zed AI, please read and accept the";
 
         let form = v_flex()
-            .gap_2()
-            .child(Label::new("Terms and Conditions"))
-            .child(Label::new(text))
-            .child(h_flex().justify_center().child(terms_button))
+            .gap_1()
+            .child(h_flex().child(Label::new(text)).child(terms_button))
             .child(
-                h_flex().justify_center().child(
-                    Button::new("accept_terms", "I've read and accept the terms of service")
+                h_flex().child(
+                    Button::new("accept_terms", "I've read and accept the Terms of Service")
                         .style(ButtonStyle::Tinted(TintColor::Accent))
                         .disabled(accept_terms_disabled)
                         .on_click({


### PR DESCRIPTION
Just fine-tuning the copywriting and design here.

| Before | After |
|--------|--------|
| <img width="1233" alt="Screenshot 2025-01-24 at 9 28 30 AM" src="https://github.com/user-attachments/assets/ca91a985-8a20-4ece-b0e4-3a6779db2fda" /> | <img width="1233" alt="Screenshot 2025-01-24 at 9 27 49 AM" src="https://github.com/user-attachments/assets/edc9c2ef-4ae0-4caf-a496-9887748673c9" /> | 

Release Notes:

- N/A