### PR TITLE
title_bar: Use an `IconButton` for the user menu

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -748,15 +748,8 @@ impl TitleBar {
                     .into()
                 })
                 .trigger(
-                    ButtonLike::new("user-menu")
-                        .child(
-                            h_flex().gap_0p5().child(
-                                Icon::new(IconName::ChevronDown)
-                                    .size(IconSize::Small)
-                                    .color(Color::Muted),
-                            ),
-                        )
-                        .style(ButtonStyle::Subtle)
+                    IconButton::new("user-menu", IconName::ChevronDown)
+                        .icon_size(IconSize::Small)
                         .tooltip(move |cx| Tooltip::text("Toggle User Menu", cx)),
                 )
         }


### PR DESCRIPTION
That's specifically when we're not rendering the user menu with an Avatar. We were previously rendering a `ButtonLike` with unnecessary flex styles there. Just a little fine-tune.

Release Notes:

- N/A
