### PR TITLE
Fix `closest_index_for_x` to get correct offset when only 1 char

### DIFF
--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -90,6 +90,14 @@ impl LineLayout {
             }
         }
 
+        if self.len == 1 {
+            if x > self.width / 2. {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+
         self.len
     }
 


### PR DESCRIPTION
Release Notes:

- N/A

----------

This bug can easy to replay by `input` example, just enter 1 char and click on the middle of the char, we can't move cursor to 0, it is always be 1.

```bash
cargo run -p gpui --example input
```

## Before

https://github.com/user-attachments/assets/3239dd47-278e-4311-9757-5165d1ccd796

## After

https://github.com/user-attachments/assets/4e2c1500-0142-4e28-bf34-7ef1f4929925


