### PR TITLE
vim: Fix `NextSubwordEnd` crash

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1653,6 +1653,7 @@ pub(crate) fn next_subword_end(
         if need_backtrack {
             *new_point.column_mut() -= 1;
         }
+        let new_point = map.clip_point(new_point, Bias::Left);
         if point == new_point {
             break;
         }


### PR DESCRIPTION
Closes #23550 

Release Notes:

- N/A 