### PR TITLE
assistant2: Adjust empty state when there is no provider

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -3499,7 +3499,7 @@ fn size_for_image(data: &RenderImage, max_size: Size<Pixels>) -> Size<Pixels> {
     }
 }
 
-enum ConfigurationError {
+pub enum ConfigurationError {
     NoProvider,
     ProviderNotAuthenticated,
 }


### PR DESCRIPTION
This PR add a "Configure a Provider" button if the user gets to the assistant panel with no provider configured. Then, upon configuring it, they'll see a similar welcome message.

| No provider | Empty state |
|--------|--------|
| <img width="1233" alt="Screenshot 2025-01-24 at 12 25 48 PM" src="https://github.com/user-attachments/assets/2f3c602f-9e46-4c79-95cd-4bb3717f68a3" /> | <img width="1233" alt="Screenshot 2025-01-24 at 12 26 01 PM" src="https://github.com/user-attachments/assets/a4a204dd-9531-45ab-89a2-f1d84f375a7b" /> | 

Release Notes:

- N/A
