### PR TITLE
task: Always use untruncated label if it is short

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -523,7 +523,7 @@ impl ContextProvider for RustContextProvider {
         Some(TaskTemplates(vec![
             TaskTemplate {
                 label: format!(
-                    "cargo check -p {}",
+                    "Check (package: {})",
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ),
                 command: "cargo".into(),
@@ -536,7 +536,7 @@ impl ContextProvider for RustContextProvider {
                 ..TaskTemplate::default()
             },
             TaskTemplate {
-                label: "cargo check --workspace --all-targets".into(),
+                label: "Check all targets (workspace)".into(),
                 command: "cargo".into(),
                 args: vec!["check".into(), "--workspace".into(), "--all-targets".into()],
                 cwd: Some("$ZED_DIRNAME".to_owned()),
@@ -544,9 +544,9 @@ impl ContextProvider for RustContextProvider {
             },
             TaskTemplate {
                 label: format!(
-                    "cargo test -p {} {} -- --nocapture",
-                    RUST_PACKAGE_TASK_VARIABLE.template_value(),
+                    "Test '{}' (package: {})",
                     VariableName::Symbol.template_value(),
+                    RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ),
                 command: "cargo".into(),
                 args: vec![
@@ -563,9 +563,9 @@ impl ContextProvider for RustContextProvider {
             },
             TaskTemplate {
                 label: format!(
-                    "cargo test -p {} {}",
-                    RUST_PACKAGE_TASK_VARIABLE.template_value(),
+                    "Test '{}' (package: {})",
                     VariableName::Stem.template_value(),
+                    RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ),
                 command: "cargo".into(),
                 args: vec![
@@ -580,10 +580,10 @@ impl ContextProvider for RustContextProvider {
             },
             TaskTemplate {
                 label: format!(
-                    "cargo run -p {} --{} {}",
-                    RUST_PACKAGE_TASK_VARIABLE.template_value(),
+                    "Run {} {} (package: {})",
                     RUST_BIN_KIND_TASK_VARIABLE.template_value(),
                     RUST_BIN_NAME_TASK_VARIABLE.template_value(),
+                    RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ),
                 command: "cargo".into(),
                 args: vec![
@@ -599,7 +599,7 @@ impl ContextProvider for RustContextProvider {
             },
             TaskTemplate {
                 label: format!(
-                    "cargo test -p {}",
+                    "Test (package: {})",
                     RUST_PACKAGE_TASK_VARIABLE.template_value()
                 ),
                 command: "cargo".into(),
@@ -612,14 +612,14 @@ impl ContextProvider for RustContextProvider {
                 ..TaskTemplate::default()
             },
             TaskTemplate {
-                label: "cargo run".into(),
+                label: "Run".into(),
                 command: "cargo".into(),
                 args: run_task_args,
                 cwd: Some("$ZED_DIRNAME".to_owned()),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
-                label: "cargo clean".into(),
+                label: "Clean".into(),
                 command: "cargo".into(),
                 args: vec!["clean".into()],
                 cwd: Some("$ZED_DIRNAME".to_owned()),

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -791,7 +791,7 @@ mod tests {
         assert_eq!(
             task_names(&tasks_picker, cx),
             vec![
-                "hello from …h.odd_extension:1:1".to_string(),
+                "hello from /dir/file_with.odd_extension:1:1".to_string(),
                 "opened now: /dir".to_string()
             ],
             "Second opened buffer should fill the context, labels should be trimmed if long enough"
@@ -820,7 +820,7 @@ mod tests {
         assert_eq!(
             task_names(&tasks_picker, cx),
             vec![
-                "hello from …thout_extension:2:3".to_string(),
+                "hello from /dir/file_without_extension:2:3".to_string(),
                 "opened now: /dir".to_string()
             ],
             "Opened buffer should fill the context, labels should be trimmed if long enough"


### PR DESCRIPTION
Also changed rust tasks to be less mouthful.

Release Notes:

- Shortened Rust task labels.
- Task modal will now use full task label when it does not require truncation.
