### PR TITLE
Support `yaml-language-server` as formatter without `lsp` settings

### DIFF
--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -143,7 +143,11 @@ impl LspAdapter for YamlLspAdapter {
                 .language(Some(location), Some(&"YAML".into()), cx)
                 .tab_size
         })?;
-        let mut options = serde_json::json!({"[yaml]": {"editor.tabSize": tab_size}});
+
+        let mut options = serde_json::json!({
+            "[yaml]": {"editor.tabSize": tab_size},
+            "yaml": {"format": {"enable": true}}
+        });
 
         let project_options = cx.update(|cx| {
             language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -30,6 +30,57 @@ You can configure various [yaml-language-server settings](https://github.com/red
 
 Note, settings keys must be nested, so `yaml.keyOrdering` becomes `{"yaml": { "keyOrdering": true }}`.
 
+## Formatting
+
+By default Zed will use prettier for formatting YAML files.
+
+### Prettier Formatting
+
+You can customize the formatting behavior of Prettier.  For example to use single-quotes in yaml files add the following to a  `.prettierrc`:
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["*.yaml", "*.yml"]
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}
+```
+
+### yaml-language-server Formatting
+
+To use `yaml-language-server` instead of Prettier, add the following to your Zed settings.json:
+
+```json
+  "languages": {
+    "YAML": {
+      "formatter": "language_server"
+    }
+  }
+```
+
+And to instruct `yaml-language-server` to use single quotes for YAML, include this as well:
+
+```json
+  "lsp": {
+    "yaml-language-server": {
+      "settings": {
+        "yaml": {
+          "format": {
+            "singleQuote": true
+          },
+        }
+      }
+    }
+  }
+```
+
+Additional `yaml-language-server` format options can found [here](https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#language-server-settings).
+
 ## Schemas
 
 By default yaml-language-server will attempt to determine the correct schema for a given yaml file and retrieve the appropriate JSON Schema from [Json Schema Store](https://schemastore.org/).

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -36,7 +36,7 @@ By default Zed will use prettier for formatting YAML files.
 
 ### Prettier Formatting
 
-You can customize the formatting behavior of Prettier.  For example to use single-quotes in yaml files add the following to a  `.prettierrc`:
+You can customize the formatting behavior of Prettier. For example to use single-quotes in yaml files add the following to a `.prettierrc`:
 
 ```json
 {

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -53,7 +53,7 @@ You can customize the formatting behavior of Prettier. For example to use single
 
 ### yaml-language-server Formatting
 
-To use `yaml-language-server` instead of Prettier, add the following to your Zed settings.json:
+To use `yaml-language-server` instead of Prettier for YAML formatting, add the following to your Zed settings.json:
 
 ```json
   "languages": {
@@ -62,24 +62,6 @@ To use `yaml-language-server` instead of Prettier, add the following to your Zed
     }
   }
 ```
-
-And to instruct `yaml-language-server` to use single quotes for YAML, include this as well:
-
-```json
-  "lsp": {
-    "yaml-language-server": {
-      "settings": {
-        "yaml": {
-          "format": {
-            "singleQuote": true
-          },
-        }
-      }
-    }
-  }
-```
-
-Additional `yaml-language-server` format options can found [here](https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#language-server-settings).
 
 ## Schemas
 


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/20183

Release Notes:

- Improved support for `yaml-language-server` as YAML formatter.
