### PR TITLE
git_ui: Add keybinding for focusing the git panel

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -503,6 +503,7 @@
       "cmd-shift-m": "diagnostics::Deploy",
       "cmd-shift-e": "project_panel::ToggleFocus",
       "cmd-shift-b": "outline_panel::ToggleFocus",
+      "ctrl-shift-g": "git_panel::ToggleFocus",
       "cmd-?": "assistant::ToggleFocus",
       "cmd-alt-s": "workspace::SaveAll",
       "cmd-k m": "language_selector::Toggle",


### PR DESCRIPTION
Adds a keybinding for opening/toggling focus to the git panel

Release Notes:

- N/A
