### PR TITLE
Use `send` instead of `feed` on terminal events channel

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -493,7 +493,7 @@ impl TerminalBuilder {
                 while let Some(event) = events_rx.next().await {
                     // Process the first event immediately to reduce latency
                     accumulated_events_tx
-                        .feed(EventOrAccumulator::Event(event))
+                        .send(EventOrAccumulator::Event(event))
                         .await?;
                     'outer: loop {
                         let start_time = Instant::now();
@@ -520,7 +520,7 @@ impl TerminalBuilder {
                             }
                         }
                         accumulated_events_tx
-                            .feed(EventOrAccumulator::Accumulator(event_accumulator))
+                            .send(EventOrAccumulator::Accumulator(event_accumulator))
                             .await?;
                     }
                 }


### PR DESCRIPTION
Potentially fixes a bug where tasks are not marked as finished.

Release Notes:

- N/A