### PR TITLE
Use proper path separator for multi buffer headers

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2611,9 +2611,9 @@ impl EditorElement {
         let filename = path
             .as_ref()
             .and_then(|path| Some(path.file_name()?.to_string_lossy().to_string()));
-        let parent_path = path
-            .as_ref()
-            .and_then(|path| Some(path.parent()?.to_string_lossy().to_string() + "/"));
+        let parent_path = path.as_ref().and_then(|path| {
+            Some(path.parent()?.to_string_lossy().to_string() + std::path::MAIN_SEPARATOR_STR)
+        });
         let focus_handle = self.editor.focus_handle(cx);
         let colors = cx.theme().colors();
 


### PR DESCRIPTION
Before: 

![bad](https://github.com/user-attachments/assets/ab20836a-b3bb-4b33-8ce4-eecc79d5f02f)


After:

![good](https://github.com/user-attachments/assets/40c328d1-2ef1-4a9b-9de9-9be9bba26756)


Release Notes:

- N/A
