### PR TITLE
lsp: Add limited implementation of pull-based diagnostics

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -746,6 +746,10 @@ impl LanguageServer {
                         related_information: Some(true),
                         ..Default::default()
                     }),
+                    diagnostic: Some(DiagnosticClientCapabilities {
+                        related_document_support: Some(true),
+                        dynamic_registration: Some(false)
+                    }),
                     formatting: Some(DynamicRegistrationClientCapabilities {
                         dynamic_registration: Some(true),
                     }),


### PR DESCRIPTION
# Limited implementation of the diagnostic pull strategy using `textDocument/diagnostic` rpc call

Lsp server implementors are starting to support a new diagnostic pull strategy. In the case of the most recent release of rust-analyzer, this improves diagnostic reporting in the active document substantially.

Without commenting on the implementation details of #19230, I agree that using the diagnostic pull strategy is useful, but this implementation significantly reduces the complexity of the changes by utilizing existing code paths that normally handle 'textDocument/publishDiagnostics'. 

~Some work is still needed around implementing this for downstream clients, but I'm definitely open to feedback/support in the current implementation and further developing the feature set.~ My implementation is high enough above the collab buffer abstractions that I don't need to implement any new rpc features to enable it

---

I'm open to this being modified/rejected, but from my experience using this branch locally, it drastically decreases latency in diagnostic reporting when working in the zed codebase, in combination with bumping the rust toolchain channel to 1.84 (necessary since RA devs only implemented the diagnostic pull rpcs 3 months ago)

Closes #23566 

Release Notes:

- N/A
