### PR TITLE
Open selections in multibuffer

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -318,6 +318,7 @@ gpui::actions!(
         OpenProposedChangesEditor,
         OpenDocs,
         OpenPermalinkToLine,
+        OpenSelectionsInMultiBuffer,
         OpenUrl,
         Outdent,
         AutoIndent,

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -318,7 +318,7 @@ gpui::actions!(
         OpenProposedChangesEditor,
         OpenDocs,
         OpenPermalinkToLine,
-        OpenSelectionsInMultiBuffer,
+        OpenSelectionsInMultibuffer,
         OpenUrl,
         Outdent,
         AutoIndent,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12002,7 +12002,9 @@ impl Editor {
         _: &OpenSelectionsInMultibuffer,
         cx: &mut ViewContext<Self>,
     ) {
-        let Some(buffer) = self.buffer.read(cx).as_singleton() else {
+        let multibuffer = self.buffer.read(cx);
+
+        let Some(buffer) = multibuffer.as_singleton() else {
             return;
         };
 
@@ -12020,12 +12022,14 @@ impl Editor {
             })
             .collect::<Vec<_>>();
 
+        let title = multibuffer.title(cx).to_string();
+
         cx.spawn(|_, mut cx| async move {
             workspace.update(&mut cx, |workspace, cx| {
                 Self::open_locations_in_multibuffer(
                     workspace,
                     locations,
-                    "Selections".into(),
+                    format!("Selections for '{title}'"),
                     false,
                     MultibufferSelectionMode::All,
                     cx,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12001,13 +12001,13 @@ impl Editor {
         &mut self,
         _: &OpenSelectionsInMultibuffer,
         cx: &mut ViewContext<Self>,
-    ) -> Option<Task<Result<()>>> {
+    ) {
         let Some(buffer) = self.buffer.read(cx).as_singleton() else {
-            return None;
+            return;
         };
 
         let Some(workspace) = self.workspace() else {
-            return None;
+            return;
         };
 
         let locations = self
@@ -12033,8 +12033,6 @@ impl Editor {
             })
         })
         .detach();
-
-        Some(Task::ready(Ok(())))
     }
 
     /// Adds a row highlight for the given range. If a row has multiple highlights, the

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1031,6 +1031,11 @@ enum JumpData {
     },
 }
 
+pub enum MultibufferSelectionMode {
+    First,
+    All,
+}
+
 impl Editor {
     pub fn single_line(cx: &mut ViewContext<Self>) -> Self {
         let buffer = cx.new_model(|cx| Buffer::local("", cx));
@@ -9836,7 +9841,14 @@ impl Editor {
                 };
                 let opened = workspace
                     .update(&mut cx, |workspace, cx| {
-                        Self::open_locations_in_multibuffer(workspace, locations, title, split, cx)
+                        Self::open_locations_in_multibuffer(
+                            workspace,
+                            locations,
+                            title,
+                            split,
+                            MultibufferSelectionMode::First,
+                            cx,
+                        )
                     })
                     .ok();
 
@@ -9971,7 +9983,14 @@ impl Editor {
                         )
                     })
                     .unwrap();
-                Self::open_locations_in_multibuffer(workspace, locations, title, false, cx);
+                Self::open_locations_in_multibuffer(
+                    workspace,
+                    locations,
+                    title,
+                    false,
+                    MultibufferSelectionMode::First,
+                    cx,
+                );
                 Navigated::Yes
             })
         }))
@@ -9983,12 +10002,13 @@ impl Editor {
         mut locations: Vec<Location>,
         title: String,
         split: bool,
+        multibuffer_selection_mode: MultibufferSelectionMode,
         cx: &mut ViewContext<Workspace>,
     ) {
         // If there are multiple definitions, open them in a multibuffer
         locations.sort_by_key(|location| location.buffer.read(cx).remote_id());
         let mut locations = locations.into_iter().peekable();
-        let mut ranges_to_highlight = Vec::new();
+        let mut ranges = Vec::new();
         let capability = workspace.project().read(cx).capability();
 
         let excerpt_buffer = cx.new_model(|cx| {
@@ -10009,7 +10029,7 @@ impl Editor {
                 }
 
                 ranges_for_buffer.sort_by_key(|range| (range.start, Reverse(range.end)));
-                ranges_to_highlight.extend(multibuffer.push_excerpts_with_context_lines(
+                ranges.extend(multibuffer.push_excerpts_with_context_lines(
                     location.buffer.clone(),
                     ranges_for_buffer,
                     DEFAULT_MULTIBUFFER_CONTEXT,
@@ -10024,17 +10044,27 @@ impl Editor {
             Editor::for_multibuffer(excerpt_buffer, Some(workspace.project().clone()), true, cx)
         });
         editor.update(cx, |editor, cx| {
-            if let Some(first_range) = ranges_to_highlight.first() {
-                editor.change_selections(None, cx, |selections| {
-                    selections.clear_disjoint();
-                    selections.select_anchor_ranges(std::iter::once(first_range.clone()));
-                });
+            match multibuffer_selection_mode {
+                MultibufferSelectionMode::First => {
+                    if let Some(first_range) = ranges.first() {
+                        editor.change_selections(None, cx, |selections| {
+                            selections.clear_disjoint();
+                            selections.select_anchor_ranges(std::iter::once(first_range.clone()));
+                        });
+                    }
+                    editor.highlight_background::<Self>(
+                        &ranges,
+                        |theme| theme.editor_highlighted_line_background,
+                        cx,
+                    );
+                }
+                MultibufferSelectionMode::All => {
+                    editor.change_selections(None, cx, |selections| {
+                        selections.clear_disjoint();
+                        selections.select_anchor_ranges(ranges);
+                    });
+                }
             }
-            editor.highlight_background::<Self>(
-                &ranges_to_highlight,
-                |theme| theme.editor_highlighted_line_background,
-                cx,
-            );
             editor.register_buffers_with_language_servers(cx);
         });
 
@@ -11997,6 +12027,7 @@ impl Editor {
                     locations,
                     "Selections".into(),
                     false,
+                    MultibufferSelectionMode::All,
                     cx,
                 );
             })

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11999,7 +11999,7 @@ impl Editor {
 
     pub fn open_selections_in_multibuffer(
         &mut self,
-        _: &OpenSelectionsInMultiBuffer,
+        _: &OpenSelectionsInMultibuffer,
         cx: &mut ViewContext<Self>,
     ) -> Option<Task<Result<()>>> {
         let Some(buffer) = self.buffer.read(cx).as_singleton() else {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -455,13 +455,6 @@ impl EditorElement {
                 cx.propagate();
             }
         });
-        register_action(view, cx, |editor, action, cx| {
-            if let Some(task) = editor.open_selections_in_multibuffer(action, cx) {
-                task.detach_and_log_err(cx);
-            } else {
-                cx.propagate();
-            }
-        });
         register_action(view, cx, Editor::show_signature_help);
         register_action(view, cx, Editor::next_inline_completion);
         register_action(view, cx, Editor::previous_inline_completion);
@@ -484,6 +477,7 @@ impl EditorElement {
         register_action(view, cx, Editor::spawn_nearest_task);
         register_action(view, cx, Editor::insert_uuid_v4);
         register_action(view, cx, Editor::insert_uuid_v7);
+        register_action(view, cx, Editor::open_selections_in_multibuffer);
     }
 
     fn register_key_listeners(&self, cx: &mut WindowContext, layout: &EditorLayout) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -455,6 +455,13 @@ impl EditorElement {
                 cx.propagate();
             }
         });
+        register_action(view, cx, |editor, action, cx| {
+            if let Some(task) = editor.open_selections_in_multibuffer(action, cx) {
+                task.detach_and_log_err(cx);
+            } else {
+                cx.propagate();
+            }
+        });
         register_action(view, cx, Editor::show_signature_help);
         register_action(view, cx, Editor::next_inline_completion);
         register_action(view, cx, Editor::previous_inline_completion);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/5126

https://github.com/user-attachments/assets/a9a68196-7c3f-486f-be6a-3132b6a02057

Note: This PR doesn't allow opening selections across multiple panes; I'd like to have that, but I think it'll require some pairing. It also requires some decisions about what should be included, like only active editors in each pane, or all editors with selections in each pane.

~I also didn't add a key binding - if anyone wants to use it, people can assign it themselves, for now.~ (https://github.com/zed-industries/zed/pull/23648)

Release Notes:

- Added an `editor: open selections in multibuffer` (`alt-enter`) command.
