### PR TITLE
Adjust `editor: open excerpts split` key binding

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -543,7 +543,7 @@
     "bindings": {
       "alt-enter": "editor::OpenExcerpts",
       "shift-enter": "editor::ExpandExcerpts",
-      "ctrl-k enter": "editor::OpenExcerptsSplit",
+      "ctrl-alt-enter": "editor::OpenExcerptsSplit",
       "ctrl-shift-e": "pane::RevealInProjectPanel",
       "ctrl-f8": "editor::GoToHunk",
       "ctrl-shift-f8": "editor::GoToPrevHunk",
@@ -645,7 +645,7 @@
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrev",
       "alt-enter": "editor::OpenExcerpts",
-      "ctrl-k enter": "editor::OpenExcerptsSplit"
+      "ctrl-alt-enter": "editor::OpenExcerptsSplit"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -621,7 +621,7 @@
     "bindings": {
       "alt-enter": "editor::OpenExcerpts",
       "shift-enter": "editor::ExpandExcerpts",
-      "cmd-k enter": "editor::OpenExcerptsSplit",
+      "cmd-alt-enter": "editor::OpenExcerptsSplit",
       "cmd-shift-e": "pane::RevealInProjectPanel",
       "cmd-f8": "editor::GoToHunk",
       "cmd-shift-f8": "editor::GoToPrevHunk",
@@ -668,7 +668,7 @@
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrev",
       "alt-enter": "editor::OpenExcerpts",
-      "cmd-k enter": "editor::OpenExcerptsSplit"
+      "cmd-alt-enter": "editor::OpenExcerptsSplit"
     }
   },
   {


### PR DESCRIPTION
The pattern in Zed and in other editors is to use `cmd` to modify some file-opening action to open it in a split rather than in the current pane.

- In the project pane, a `click` opens a file, and a `cmd-click` opens it in a split
- In the file finder, `enter` opens the file, and a `cmd-enter` opens it in a split

It makes sense to me that if `alt-enter` opens a file from the excerpt, that `cmd-alt-enter` opens it in a split, following the pattern above.

Note: I'm not auto-merging this, as others might disagree.
Note: I didn't touch the Vim binding.

Release Notes:

- Breaking Change: Changed `editor: open excerpts split` key binding to `cmd-alt-enter` on macOS and `ctrl-alt-enter` on Linux.
