### PR TITLE
Add key binding for `editor: open selections in multibuffer`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -122,7 +122,8 @@
       "ctrl-i": "editor::ShowSignatureHelp",
       "alt-g b": "editor::ToggleGitBlame",
       "menu": "editor::OpenContextMenu",
-      "shift-f10": "editor::OpenContextMenu"
+      "shift-f10": "editor::OpenContextMenu",
+      "alt-enter": "editor::OpenSelectionsInMultibuffer"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -132,7 +132,8 @@
       "cmd-alt-g b": "editor::ToggleGitBlame",
       "cmd-i": "editor::ShowSignatureHelp",
       "ctrl-f12": "editor::GoToDeclaration",
-      "alt-ctrl-f12": "editor::GoToDeclarationSplit"
+      "alt-ctrl-f12": "editor::GoToDeclarationSplit",
+      "alt-enter": "editor::OpenSelectionsInMultibuffer"
     }
   },
   {


### PR DESCRIPTION
Follow-up to:

- https://github.com/zed-industries/zed/pull/23644

---

- Existing: `alt-enter` to open files from multi-buffer selections
- New: `alt-enter` to open multi-buffer from file selections

I updated the original PR changelog line.

Release Notes:

- N/A
