### PR TITLE
Rework go to line infrastructure

### DIFF
--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -77,12 +77,12 @@ impl CursorPosition {
                                 let buffer = editor.buffer().read(cx).snapshot(cx);
                                 if buffer.excerpts().count() > 0 {
                                     for selection in editor.selections.all::<usize>(cx) {
-                                        cursor_position.selected_count.characters += buffer
-                                            // TODO kb bad bad perf
-                                            // See `test_unicode_characters_selection`
-                                            .text_for_range(selection.start..selection.end)
-                                            .map(|t| t.chars().count())
-                                            .sum::<usize>();
+                                        let text_summary = buffer
+                                            .text_summary_for_range::<text::TextSummary, _>(
+                                                selection.start..selection.end,
+                                            );
+                                        cursor_position.selected_count.characters +=
+                                            text_summary.chars;
                                         if last_selection.as_ref().map_or(true, |last_selection| {
                                             selection.id > last_selection.id
                                         }) {

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -20,7 +20,7 @@ pub(crate) struct SelectionStats {
 }
 
 pub struct CursorPosition {
-    position: Option<(Point, bool)>,
+    position: Option<Point>,
     selected_count: SelectionStats,
     context: Option<FocusHandle>,
     workspace: WeakView<Workspace>,
@@ -176,10 +176,9 @@ impl CursorPosition {
 
 impl Render for CursorPosition {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        div().when_some(self.position, |el, (position, is_main_buffer)| {
+        div().when_some(self.position, |el, position| {
             let mut text = format!(
-                "{}{}{FILE_ROW_COLUMN_DELIMITER}{}",
-                if is_main_buffer { "" } else { "(deleted) " },
+                "{}{FILE_ROW_COLUMN_DELIMITER}{}",
                 position.row + 1,
                 position.column + 1
             );

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -78,6 +78,8 @@ impl CursorPosition {
                                 if buffer.excerpts().count() > 0 {
                                     for selection in editor.selections.all::<usize>(cx) {
                                         cursor_position.selected_count.characters += buffer
+                                            // TODO kb bad bad perf
+                                            // See `test_unicode_characters_selection`
                                             .text_for_range(selection.start..selection.end)
                                             .map(|t| t.chars().count())
                                             .sum::<usize>();
@@ -161,6 +163,11 @@ impl CursorPosition {
     #[cfg(test)]
     pub(crate) fn selection_stats(&self) -> &SelectionStats {
         &self.selected_count
+    }
+
+    #[cfg(test)]
+    pub(crate) fn position(&self) -> Option<Point> {
+        self.position
     }
 }
 

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -257,14 +257,13 @@ impl GoToLine {
 
 impl Render for GoToLine {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
-        let mut help_text = self.current_text.clone();
-        if let Some((line, character)) = self.line_and_char_from_query(cx) {
-            help_text = match character {
-                Some(column) => format!("Go to line {line}, character {column}"),
-                None => format!("Go to line {line}"),
+        let help_text = match self.line_and_char_from_query(cx) {
+            Some((line, Some(character))) => {
+                format!("Go to line {line}, character {character}").into()
             }
-            .into();
-        }
+            Some((line, None)) => format!("Go to line {line}").into(),
+            None => self.current_text.clone(),
+        };
 
         v_flex()
             .w(rems(24.))

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -194,7 +194,8 @@ impl GoToLine {
                 return;
             };
             editor.change_selections(Some(Autoscroll::center()), cx, |s| {
-                s.select_anchor_ranges([start..start])
+                // TODO kb change here, navigate to the beginning of the line, then iterate over chars to get it.
+                    s.select_anchor_ranges([start..start])
             });
             editor.focus(cx);
             cx.notify()

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -254,6 +254,7 @@ impl<'a> ChunkSlice<'a> {
             chars >>= newline_ix;
             chars >>= 1;
             row += 1;
+            *total_chars += 1;
         }
 
         let row_chars = chars.count_ones() as u8;

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -162,9 +162,11 @@ impl<'a> ChunkSlice<'a> {
 
     #[inline(always)]
     pub fn text_summary(&self) -> TextSummary {
-        let (longest_row, longest_row_chars) = self.longest_row();
+        let mut chars = 0;
+        let (longest_row, longest_row_chars) = self.longest_row(&mut chars);
         TextSummary {
             len: self.len(),
+            chars,
             len_utf16: self.len_utf16(),
             lines: self.lines(),
             first_line_chars: self.first_line_chars(),
@@ -229,16 +231,19 @@ impl<'a> ChunkSlice<'a> {
     }
 
     /// Get the longest row in the chunk and its length in characters.
+    /// Calculate the total number of characters in the chunk along the way.
     #[inline(always)]
-    pub fn longest_row(&self) -> (u32, u32) {
+    pub fn longest_row(&self, total_chars: &mut usize) -> (u32, u32) {
         let mut chars = self.chars;
         let mut newlines = self.newlines;
+        *total_chars = 0;
         let mut row = 0;
         let mut longest_row = 0;
         let mut longest_row_chars = 0;
         while newlines > 0 {
             let newline_ix = newlines.trailing_zeros();
             let row_chars = (chars & ((1 << newline_ix) - 1)).count_ones() as u8;
+            *total_chars += usize::from(row_chars);
             if row_chars > longest_row_chars {
                 longest_row = row;
                 longest_row_chars = row_chars;
@@ -252,6 +257,7 @@ impl<'a> ChunkSlice<'a> {
         }
 
         let row_chars = chars.count_ones() as u8;
+        *total_chars += usize::from(row_chars);
         if row_chars > longest_row_chars {
             (row, row_chars as u32)
         } else {
@@ -908,7 +914,7 @@ mod tests {
         }
 
         // Verify longest row
-        let (longest_row, longest_chars) = chunk.longest_row();
+        let (longest_row, longest_chars) = chunk.longest_row(&mut 0);
         let mut max_chars = 0;
         let mut current_row = 0;
         let mut current_chars = 0;

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -996,6 +996,7 @@ impl TextSummary {
     pub fn newline() -> Self {
         Self {
             len: 1,
+            chars: 1,
             len_utf16: OffsetUtf16(1),
             first_line_chars: 0,
             last_line_chars: 0,

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -965,8 +965,10 @@ impl sum_tree::Summary for ChunkSummary {
 /// Summary of a string of text.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct TextSummary {
-    /// Length in UTF-8
+    /// Length in bytes.
     pub len: usize,
+    /// Length in UTF-8.
+    pub chars: usize,
     /// Length in UTF-16 code units
     pub len_utf16: OffsetUtf16,
     /// A point representing the number of lines and the length of the last line
@@ -1022,7 +1024,9 @@ impl<'a> From<&'a str> for TextSummary {
         let mut last_line_len_utf16 = 0;
         let mut longest_row = 0;
         let mut longest_row_chars = 0;
+        let mut chars = 0;
         for c in text.chars() {
+            chars += 1;
             len_utf16.0 += c.len_utf16();
 
             if c == '\n' {
@@ -1047,6 +1051,7 @@ impl<'a> From<&'a str> for TextSummary {
 
         TextSummary {
             len: text.len(),
+            chars,
             len_utf16,
             lines,
             first_line_chars,
@@ -1103,6 +1108,7 @@ impl<'a> ops::AddAssign<&'a Self> for TextSummary {
             self.last_line_len_utf16 = other.last_line_len_utf16;
         }
 
+        self.chars += other.chars;
         self.len += other.len;
         self.len_utf16 += other.len_utf16;
         self.lines += other.lines;

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -265,6 +265,7 @@ fn test_text_summary_for_range() {
         buffer.text_summary_for_range::<TextSummary, _>(1..3),
         TextSummary {
             len: 2,
+            chars: 2,
             len_utf16: OffsetUtf16(2),
             lines: Point::new(1, 0),
             first_line_chars: 1,
@@ -278,6 +279,7 @@ fn test_text_summary_for_range() {
         buffer.text_summary_for_range::<TextSummary, _>(1..12),
         TextSummary {
             len: 11,
+            chars: 11,
             len_utf16: OffsetUtf16(11),
             lines: Point::new(3, 0),
             first_line_chars: 1,
@@ -291,6 +293,7 @@ fn test_text_summary_for_range() {
         buffer.text_summary_for_range::<TextSummary, _>(0..20),
         TextSummary {
             len: 20,
+            chars: 20,
             len_utf16: OffsetUtf16(20),
             lines: Point::new(4, 1),
             first_line_chars: 2,
@@ -304,6 +307,7 @@ fn test_text_summary_for_range() {
         buffer.text_summary_for_range::<TextSummary, _>(0..22),
         TextSummary {
             len: 22,
+            chars: 22,
             len_utf16: OffsetUtf16(22),
             lines: Point::new(4, 3),
             first_line_chars: 2,
@@ -317,6 +321,7 @@ fn test_text_summary_for_range() {
         buffer.text_summary_for_range::<TextSummary, _>(7..22),
         TextSummary {
             len: 15,
+            chars: 15,
             len_utf16: OffsetUtf16(15),
             lines: Point::new(2, 3),
             first_line_chars: 4,

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -262,6 +262,20 @@ fn test_text_summary_for_range() {
         "ab\nefg\nhklm\nnopqrs\ntuvwxyz".into(),
     );
     assert_eq!(
+        buffer.text_summary_for_range::<TextSummary, _>(0..2),
+        TextSummary {
+            len: 2,
+            chars: 2,
+            len_utf16: OffsetUtf16(2),
+            lines: Point::new(0, 2),
+            first_line_chars: 2,
+            last_line_chars: 2,
+            last_line_len_utf16: 2,
+            longest_row: 0,
+            longest_row_chars: 2,
+        }
+    );
+    assert_eq!(
         buffer.text_summary_for_range::<TextSummary, _>(1..3),
         TextSummary {
             len: 2,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/12024

https://github.com/user-attachments/assets/60ea3dbd-b594-4bf5-a44d-4bff925b815f

* Fixes incorrect line selection for certain corner cases

Before:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/35aaee6c-c120-4bf1-9355-448a29d1b9b5" />

After:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/abd97339-4594-4e8e-8605-50d74581ae86" />


* Reworks https://github.com/zed-industries/zed/pull/16420 to display selection length with less performance overhead.
Improves the performance more, doing a single selections loop instead of two.

* Fixes incorrect caret position display when text contains UTF-8 chars with size > 1
Also fixes tooltop values for this case

* Fixes go to line to treat UTF-8 chars with size > 1 properly when navigating

* Adds a way to fill go to line text editor with its tooltip on `Tab`

Release Notes:

- Fixed incorrect UTF-8 characters handling in `GoToLine` and caret position
