### PR TITLE
html: Add injections for `style` attributes and event handler attributes

### DIFF
--- a/extensions/html/languages/html/injections.scm
+++ b/extensions/html/languages/html/injections.scm
@@ -5,3 +5,13 @@
 (style_element
   (raw_text) @injection.content
   (#set! injection.language "css"))
+
+(attribute
+    (attribute_name) @_attribute_name (#match? @_attribute_name "^style$")
+    (quoted_attribute_value (attribute_value) @injection.content)
+    (#set! injection.language "css"))
+
+(attribute
+    (attribute_name) @_attribute_name (#match? @_attribute_name "^on[a-z]+$")
+    (quoted_attribute_value (attribute_value) @injection.content)
+    (#set! injection.language "javascript"))


### PR DESCRIPTION
Closes #23653 

Before:
<img width="921" alt="before" src="https://github.com/user-attachments/assets/e993df15-77a7-4b5a-b6fb-3415047914c0" />

After:
<img width="922" alt="after" src="https://github.com/user-attachments/assets/1b4bd695-2985-46e2-8b55-576d32af0583" />

Release Notes:

- N/A
