### PR TITLE
Revert making keybinding display in Mac menus use standard precedence

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -290,9 +290,13 @@ impl MacPlatform {
                 action,
                 os_action,
             } => {
+                // Note that this is not the standard logic for selecting which keybinding to
+                // display. Typically the last binding takes precedence for display. However, in
+                // this case the menus are not updated on context changes. To make these bindings
+                // more likely to be correct, the first binding instead takes precedence (typically
+                // from the base keymap).
                 let keystrokes = keymap
                     .bindings_for_action(action.as_ref())
-                    .rev()
                     .next()
                     .map(|binding| binding.keystrokes());
 


### PR DESCRIPTION
Closes #23621

Change was in #23378.  Also adds a comment to clarify why this is inconsistent with all other uses of `bindings_for_action`.

Release Notes:

- N/A