### PR TITLE
Prevent propagating mouse events and use button elements instead of plain text in the update notification

### DIFF
--- a/crates/auto_update_ui/src/update_notification.rs
+++ b/crates/auto_update_ui/src/update_notification.rs
@@ -1,12 +1,12 @@
 use gpui::{
-    div, DismissEvent, EventEmitter, InteractiveElement, IntoElement, ParentElement, Render,
-    SemanticVersion, StatefulInteractiveElement, Styled, ViewContext, WeakView,
+    rems, DismissEvent, EventEmitter, InteractiveElement, IntoElement, ParentElement, Render,
+    SemanticVersion, Styled, ViewContext, WeakView,
 };
 use menu::Cancel;
 use release_channel::ReleaseChannel;
 use util::ResultExt;
 use workspace::{
-    ui::{h_flex, v_flex, Icon, IconName, Label, StyledExt},
+    ui::{h_flex, v_flex, Button, Clickable, IconButton, IconName, IconSize, Label, StyledExt},
     Workspace,
 };
 
@@ -22,38 +22,34 @@ impl Render for UpdateNotification {
         let app_name = ReleaseChannel::global(cx).display_name();
 
         v_flex()
+            .occlude()
             .on_action(cx.listener(UpdateNotification::dismiss))
             .elevation_3(cx)
             .p_4()
             .child(
                 h_flex()
                     .justify_between()
-                    .child(Label::new(format!(
-                        "Updated to {app_name} {}",
-                        self.version
-                    )))
                     .child(
-                        div()
-                            .id("cancel")
-                            .child(Icon::new(IconName::Close))
-                            .cursor_pointer()
+                        Label::new(format!("Updated to {app_name} {}", self.version)).ml(rems(0.2)),
+                    )
+                    .child(
+                        IconButton::new("cancel", IconName::Close)
+                            .icon_size(IconSize::Small)
                             .on_click(cx.listener(|this, _, cx| this.dismiss(&menu::Cancel, cx))),
                     ),
             )
-            .child(
-                div()
-                    .id("notes")
-                    .child(Label::new("View the release notes"))
-                    .cursor_pointer()
-                    .on_click(cx.listener(|this, _, cx| {
+            .child(h_flex().pt(rems(0.3)).child(
+                Button::new("notes", "View the release notes").on_click(cx.listener(
+                    |this, _, cx| {
                         this.workspace
                             .update(cx, |workspace, cx| {
                                 crate::view_release_notes_locally(workspace, cx);
                             })
                             .log_err();
                         this.dismiss(&menu::Cancel, cx)
-                    })),
-            )
+                    },
+                )),
+            ))
     }
 }
 


### PR DESCRIPTION
When having project panel on the right, `update_notification` would let mouse events propagate to it, causing hover effect and opening files. I also used `Button` and `IconButton` for clickable elements inside of the notification in order to be consistent with the rest of UI.

Before:

https://github.com/user-attachments/assets/349b47bd-04bc-4295-8240-08dbb131b32c

After:

https://github.com/user-attachments/assets/5665e5ce-4b85-4837-b6fa-fd0bdfdbafb8

One thing I haven't been able to fix is pane resize event triggering (seen in both screencasts), so any help there is more than welcome.