### PR TITLE
vim: Add any brackets to support motions like ab and ib to work with any type of brackets 

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -408,6 +408,7 @@
       "(": "vim::Parentheses",
       ")": "vim::Parentheses",
       "b": "vim::Parentheses",
+      // "b": "vim::AnyBrackets",
       "[": "vim::SquareBrackets",
       "]": "vim::SquareBrackets",
       "r": "vim::SquareBrackets",


### PR DESCRIPTION
# Add AnyBrackets text object for Vim mode

## Overview
This PR introduces a new text object `AnyBrackets` that allows operations on the closest matching pair of brackets, regardless of the bracket type. This enhances the editing experience by reducing the need to identify specific bracket types before performing text operations.

By default, this feature is NOT mapped to any key in vim.json. However, it can be enabled manually, and the recommended key for mapping is b:

If you want to add it to your zed keymap config you need to add the following config:
```json
{
	"context": "vim_operator == a || vim_operator == i || vim_operator == cs",
	"bindings": {
		"b": "vim::AnyBrackets"
	}
}
```

## Features
- New text object that works with parentheses `()`, square brackets `[]`, curly braces `{}`, they are also know as round brackets, square brackets and curly brackets in english.
- Automatically finds the closest matching pair of any bracket type
- Works with all standard Vim operators (delete, change, yank)
- Supports both "inside" and "around" variants (`i` and `a`)

## Usage Examples
```vim
# Delete inside the closest brackets
di(  # Works on (), [] or {} depending on which is closest

# Change around the closest brackets
ca[  # Works on (), [] or {}  depending on which is closest

# Visual select inside the closest brackets
vi{  # Works on (), [] or {}  depending on which is closest
```

# References:
- Based on the popular plugin https://github.com/echasnovski/mini.ai

# Important Notes
This PR also fixes a bug with nested quotes on AnyQuotes, now it works fine with any type of quotes or brackets.
Please take a look at the new tests to understand the expected behavior.

Release Notes:

- vim: Add `ab`/`ib` "AnyBrackets" text objects that are the smallest of `a(`, `a[` or `a{` or `i(`, `i[` or `i{`
- vim: Fix aq/iq "AnyQuotes" text objects when they are nested