### PR TITLE
Fix missed renames in #22632

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5464,6 +5464,7 @@ dependencies = [
 name = "gpui_macros"
 version = "0.1.0"
 dependencies = [
+ "gpui",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/crates/assistant2/src/context_store.rs
+++ b/crates/assistant2/src/context_store.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Result};
 use collections::{BTreeMap, HashMap, HashSet};
 use futures::{self, future, Future, FutureExt};
-use gpui::{App, AsyncAppContext, Context, Entity, SharedString, Task, WeakEntity};
+use gpui::{App, AsyncApp, Context, Entity, SharedString, Task, WeakEntity};
 use language::Buffer;
 use project::{ProjectPath, Worktree};
 use rope::Rope;
@@ -447,7 +447,7 @@ fn collect_buffer_info_and_text(
     path: Arc<Path>,
     buffer_model: Entity<Buffer>,
     buffer: &Buffer,
-    cx: AsyncAppContext,
+    cx: AsyncApp,
 ) -> (BufferInfo, Task<SharedString>) {
     let buffer_info = BufferInfo {
         id: buffer.remote_id(),

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -1217,7 +1217,7 @@ impl ContextEditor {
         let project = this.update(&mut cx, |this, _| this.project.clone())?;
         let resolved_patch = patch.resolve(project.clone(), &mut cx).await;
 
-        let editor = cx.new_window_model(|window, cx| {
+        let editor = cx.new_window_entity(|window, cx| {
             let editor = ProposedChangesEditor::new(
                 patch.title.clone(),
                 resolved_patch

--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -13,9 +13,7 @@ use context_server::{ContextServerFactoryRegistry, ContextServerTool};
 use fs::Fs;
 use futures::StreamExt;
 use fuzzy::StringMatchCandidate;
-use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Task, WeakEntity,
-};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use language::LanguageRegistry;
 use paths::contexts_dir;
 use project::Project;
@@ -165,7 +163,7 @@ impl ContextStore {
     async fn handle_advertise_contexts(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::AdvertiseContexts>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             this.host_contexts = envelope
@@ -184,7 +182,7 @@ impl ContextStore {
     async fn handle_open_context(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::OpenContext>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::OpenContextResponse> {
         let context_id = ContextId::from_proto(envelope.payload.context_id);
         let operations = this.update(&mut cx, |this, cx| {
@@ -214,7 +212,7 @@ impl ContextStore {
     async fn handle_create_context(
         this: Entity<Self>,
         _: TypedEnvelope<proto::CreateContext>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::CreateContextResponse> {
         let (context_id, operations) = this.update(&mut cx, |this, cx| {
             if this.project.read(cx).is_via_collab() {
@@ -242,7 +240,7 @@ impl ContextStore {
     async fn handle_update_context(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateContext>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             let context_id = ContextId::from_proto(envelope.payload.context_id);
@@ -258,7 +256,7 @@ impl ContextStore {
     async fn handle_synchronize_contexts(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::SynchronizeContexts>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::SynchronizeContextsResponse> {
         this.update(&mut cx, |this, cx| {
             if this.project.read(cx).is_via_collab() {
@@ -791,7 +789,7 @@ impl ContextStore {
     }
 
     pub fn restart_context_servers(&mut self, cx: &mut Context<Self>) {
-        cx.update_model(
+        cx.update_entity(
             &self.context_server_manager,
             |context_server_manager, cx| {
                 for server in context_server_manager.servers() {

--- a/crates/assistant_context_editor/src/patch.rs
+++ b/crates/assistant_context_editor/src/patch.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context as _, Result};
 use collections::HashMap;
 use editor::ProposedChangesEditor;
 use futures::{future, TryFutureExt as _};
-use gpui::{App, AsyncAppContext, Entity, SharedString};
+use gpui::{App, AsyncApp, Entity, SharedString};
 use language::{AutoindentMode, Buffer, BufferSnapshot};
 use project::{Project, ProjectPath};
 use std::{cmp, ops::Range, path::Path, sync::Arc};
@@ -229,7 +229,7 @@ impl AssistantEdit {
     pub async fn resolve(
         &self,
         project: Entity<Project>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<(Entity<Buffer>, ResolvedEdit)> {
         let path = self.path.clone();
         let kind = self.kind.clone();
@@ -424,7 +424,7 @@ impl AssistantPatch {
     pub async fn resolve(
         &self,
         project: Entity<Project>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> ResolvedPatch {
         let mut resolve_tasks = Vec::new();
         for (ix, edit) in self.edits.iter().enumerate() {

--- a/crates/assistant_context_editor/src/patch.rs
+++ b/crates/assistant_context_editor/src/patch.rs
@@ -421,11 +421,7 @@ impl AssistantEditKind {
 }
 
 impl AssistantPatch {
-    pub async fn resolve(
-        &self,
-        project: Entity<Project>,
-        cx: &mut AsyncApp,
-    ) -> ResolvedPatch {
+    pub async fn resolve(&self, project: Entity<Project>, cx: &mut AsyncApp) -> ResolvedPatch {
         let mut resolve_tasks = Vec::new();
         for (ix, edit) in self.edits.iter().enumerate() {
             if let Ok(edit) = edit.as_ref() {

--- a/crates/assistant_slash_commands/src/auto_command.rs
+++ b/crates/assistant_slash_commands/src/auto_command.rs
@@ -5,7 +5,7 @@ use assistant_slash_command::{
 };
 use feature_flags::FeatureFlag;
 use futures::StreamExt;
-use gpui::{App, AsyncAppContext, Task, WeakEntity, Window};
+use gpui::{App, AsyncApp, Task, WeakEntity, Window};
 use language::{CodeLabel, LspAdapterDelegate};
 use language_model::{
     LanguageModelCompletionEvent, LanguageModelRegistry, LanguageModelRequest,
@@ -77,7 +77,7 @@ impl SlashCommand for AutoCommand {
 
         let cx: &mut App = cx;
 
-        cx.spawn(|cx: gpui::AsyncAppContext| async move {
+        cx.spawn(|cx: gpui::AsyncApp| async move {
             let task = project_index.read_with(&cx, |project_index, cx| {
                 project_index.flush_summary_backlogs(cx)
             })?;
@@ -189,7 +189,7 @@ struct CommandToRun {
 async fn commands_for_summaries(
     summaries: &[FileSummary],
     original_prompt: &str,
-    cx: &AsyncAppContext,
+    cx: &AsyncApp,
 ) -> Result<Vec<CommandToRun>> {
     if summaries.is_empty() {
         log::warn!("Inferring no context because there were no summaries available.");

--- a/crates/assistant_slash_commands/src/diagnostics_command.rs
+++ b/crates/assistant_slash_commands/src/diagnostics_command.rs
@@ -303,7 +303,7 @@ fn collect_diagnostics(
                 .await
                 .log_err()
             {
-                let snapshot = cx.read_model(&buffer, |buffer, _| buffer.snapshot())?;
+                let snapshot = cx.read_entity(&buffer, |buffer, _| buffer.snapshot())?;
                 collect_buffer_diagnostics(&mut output, &snapshot, options.include_warnings);
             }
 

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -3,8 +3,7 @@ use client::{Client, TelemetrySettings};
 use db::kvp::KEY_VALUE_STORE;
 use db::RELEASE_CHANNEL;
 use gpui::{
-    actions, App, AppContext as _, AsyncApp, Context, Entity, Global, SemanticVersion, Task,
-    Window,
+    actions, App, AppContext as _, AsyncApp, Context, Entity, Global, SemanticVersion, Task, Window,
 };
 use http_client::{AsyncBody, HttpClient, HttpClientWithUrl};
 use paths::remote_servers_dir;

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -3,7 +3,7 @@ use client::{Client, TelemetrySettings};
 use db::kvp::KEY_VALUE_STORE;
 use db::RELEASE_CHANNEL;
 use gpui::{
-    actions, App, AppContext as _, AsyncAppContext, Context, Entity, Global, SemanticVersion, Task,
+    actions, App, AppContext as _, AsyncApp, Context, Entity, Global, SemanticVersion, Task,
     Window,
 };
 use http_client::{AsyncBody, HttpClient, HttpClientWithUrl};
@@ -303,7 +303,7 @@ impl AutoUpdater {
         arch: &str,
         release_channel: ReleaseChannel,
         version: Option<SemanticVersion>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<PathBuf> {
         let this = cx.update(|cx| {
             cx.default_global::<GlobalAutoUpdate>()
@@ -347,7 +347,7 @@ impl AutoUpdater {
         arch: &str,
         release_channel: ReleaseChannel,
         version: Option<SemanticVersion>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Option<(String, String)>> {
         let this = cx.update(|cx| {
             cx.default_global::<GlobalAutoUpdate>()
@@ -380,7 +380,7 @@ impl AutoUpdater {
         arch: &str,
         version: Option<SemanticVersion>,
         release_channel: Option<ReleaseChannel>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<JsonRelease> {
         let client = this.read_with(cx, |this, _| this.http_client.clone())?;
 
@@ -429,12 +429,12 @@ impl AutoUpdater {
         os: &str,
         arch: &str,
         release_channel: Option<ReleaseChannel>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<JsonRelease> {
         Self::get_release(this, asset, os, arch, None, release_channel, cx).await
     }
 
-    async fn update(this: Entity<Self>, mut cx: AsyncAppContext) -> Result<()> {
+    async fn update(this: Entity<Self>, mut cx: AsyncApp) -> Result<()> {
         let (client, current_version, release_channel) = this.update(&mut cx, |this, cx| {
             this.status = AutoUpdateStatus::Checking;
             cx.notify();
@@ -544,7 +544,7 @@ async fn download_remote_server_binary(
     target_path: &PathBuf,
     release: JsonRelease,
     client: Arc<HttpClientWithUrl>,
-    cx: &AsyncAppContext,
+    cx: &AsyncApp,
 ) -> Result<()> {
     let temp = tempfile::Builder::new().tempfile_in(remote_servers_dir())?;
     let mut temp_file = File::create(&temp).await?;
@@ -564,7 +564,7 @@ async fn download_remote_server_binary(
     Ok(())
 }
 
-fn build_remote_server_update_request_body(cx: &AsyncAppContext) -> Result<UpdateRequestBody> {
+fn build_remote_server_update_request_body(cx: &AsyncApp) -> Result<UpdateRequestBody> {
     let (installation_id, release_channel, telemetry_enabled, is_staff) = cx.update(|cx| {
         let telemetry = Client::global(cx).telemetry().clone();
         let is_staff = telemetry.is_staff();
@@ -594,7 +594,7 @@ async fn download_release(
     target_path: &Path,
     release: JsonRelease,
     client: Arc<HttpClientWithUrl>,
-    cx: &AsyncAppContext,
+    cx: &AsyncApp,
 ) -> Result<()> {
     let mut target_file = File::create(&target_path).await?;
 
@@ -632,7 +632,7 @@ async fn download_release(
 async fn install_release_linux(
     temp_dir: &tempfile::TempDir,
     downloaded_tar_gz: PathBuf,
-    cx: &AsyncAppContext,
+    cx: &AsyncApp,
 ) -> Result<PathBuf> {
     let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name())?;
     let home_dir = PathBuf::from(env::var("HOME").context("no HOME env var set")?);
@@ -699,7 +699,7 @@ async fn install_release_linux(
 async fn install_release_macos(
     temp_dir: &tempfile::TempDir,
     downloaded_dmg: PathBuf,
-    cx: &AsyncAppContext,
+    cx: &AsyncApp,
 ) -> Result<PathBuf> {
     let running_app_path = cx.update(|cx| cx.app_path())??;
     let running_app_filename = running_app_path

--- a/crates/call/src/cross_platform/mod.rs
+++ b/crates/call/src/cross_platform/mod.rs
@@ -8,8 +8,8 @@ use client::{proto, ChannelId, Client, TypedEnvelope, User, UserStore, ZED_ALWAY
 use collections::HashSet;
 use futures::{channel::oneshot, future::Shared, Future, FutureExt};
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Global, Subscription,
-    Task, WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Global, Subscription, Task,
+    WeakEntity,
 };
 use postage::watch;
 use project::Project;
@@ -48,7 +48,7 @@ impl OneAtATime {
     /// otherwise you'll see the result of the task.
     fn spawn<F, Fut, R>(&mut self, cx: &mut App, f: F) -> Task<Result<Option<R>>>
     where
-        F: 'static + FnOnce(AsyncAppContext) -> Fut,
+        F: 'static + FnOnce(AsyncApp) -> Fut,
         Fut: Future<Output = Result<R>>,
         R: 'static,
     {
@@ -120,7 +120,7 @@ impl ActiveCall {
     async fn handle_incoming_call(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::IncomingCall>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let user_store = this.update(&mut cx, |this, _| this.user_store.clone())?;
         let call = IncomingCall {
@@ -147,7 +147,7 @@ impl ActiveCall {
     async fn handle_call_canceled(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::CallCanceled>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {
             let mut incoming_call = this.incoming_call.0.borrow_mut();

--- a/crates/call/src/cross_platform/room.rs
+++ b/crates/call/src/cross_platform/room.rs
@@ -13,7 +13,7 @@ use client::{
 use collections::{BTreeMap, HashMap, HashSet};
 use fs::Fs;
 use futures::{FutureExt, StreamExt};
-use gpui::{App, AppContext, AsyncAppContext, Context, Entity, EventEmitter, Task, WeakEntity};
+use gpui::{App, AppContext, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use language::LanguageRegistry;
 #[cfg(not(all(target_os = "windows", target_env = "gnu")))]
 use livekit::{
@@ -218,7 +218,7 @@ impl Room {
         channel_id: ChannelId,
         client: Arc<Client>,
         user_store: Entity<UserStore>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         Self::from_join_response(
             client
@@ -236,7 +236,7 @@ impl Room {
         room_id: u64,
         client: Arc<Client>,
         user_store: Entity<UserStore>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         Self::from_join_response(
             client.request(proto::JoinRoom { id: room_id }).await?,
@@ -277,7 +277,7 @@ impl Room {
         response: proto::JoinRoomResponse,
         client: Arc<Client>,
         user_store: Entity<UserStore>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         let room_proto = response.room.ok_or_else(|| anyhow!("invalid room"))?;
         let room = cx.new(|cx| {
@@ -358,7 +358,7 @@ impl Room {
     async fn maintain_connection(
         this: WeakEntity<Self>,
         client: Arc<Client>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let mut client_status = client.status();
         loop {
@@ -639,7 +639,7 @@ impl Room {
     async fn handle_room_updated(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::RoomUpdated>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let room = envelope
             .payload

--- a/crates/call/src/cross_platform/room.rs
+++ b/crates/call/src/cross_platform/room.rs
@@ -1318,7 +1318,7 @@ impl Room {
     }
 
     #[cfg(all(target_os = "windows", target_env = "gnu"))]
-    pub fn share_microphone(&mut self, cx: &mut ModelContext<Self>) -> Task<Result<()>> {
+    pub fn share_microphone(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
         Task::ready(Err(anyhow!("MinGW is not supported yet")))
     }
 
@@ -1626,7 +1626,7 @@ impl Room {
 #[cfg(all(target_os = "windows", target_env = "gnu"))]
 fn spawn_room_connection(
     livekit_connection_info: Option<proto::LiveKitConnectionInfo>,
-    cx: &mut ModelContext<'_, Room>,
+    cx: &mut Context<'_, Room>,
 ) {
 }
 

--- a/crates/call/src/macos/mod.rs
+++ b/crates/call/src/macos/mod.rs
@@ -8,8 +8,8 @@ use client::{proto, ChannelId, Client, TypedEnvelope, User, UserStore, ZED_ALWAY
 use collections::HashSet;
 use futures::{channel::oneshot, future::Shared, Future, FutureExt};
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Global, Subscription,
-    Task, WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Global, Subscription, Task,
+    WeakEntity,
 };
 use postage::watch;
 use project::Project;
@@ -41,7 +41,7 @@ impl OneAtATime {
     /// otherwise you'll see the result of the task.
     fn spawn<F, Fut, R>(&mut self, cx: &mut App, f: F) -> Task<Result<Option<R>>>
     where
-        F: 'static + FnOnce(AsyncAppContext) -> Fut,
+        F: 'static + FnOnce(AsyncApp) -> Fut,
         Fut: Future<Output = Result<R>>,
         R: 'static,
     {
@@ -113,7 +113,7 @@ impl ActiveCall {
     async fn handle_incoming_call(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::IncomingCall>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let user_store = this.update(&mut cx, |this, _| this.user_store.clone())?;
         let call = IncomingCall {
@@ -140,7 +140,7 @@ impl ActiveCall {
     async fn handle_call_canceled(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::CallCanceled>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {
             let mut incoming_call = this.incoming_call.0.borrow_mut();

--- a/crates/call/src/macos/room.rs
+++ b/crates/call/src/macos/room.rs
@@ -11,9 +11,7 @@ use client::{
 use collections::{BTreeMap, HashMap, HashSet};
 use fs::Fs;
 use futures::{FutureExt, StreamExt};
-use gpui::{
-    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity,
-};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use language::LanguageRegistry;
 use livekit_client_macos::{LocalAudioTrack, LocalTrackPublication, LocalVideoTrack, RoomUpdate};
 use postage::{sink::Sink, stream::Stream, watch};

--- a/crates/call/src/macos/room.rs
+++ b/crates/call/src/macos/room.rs
@@ -12,7 +12,7 @@ use collections::{BTreeMap, HashMap, HashSet};
 use fs::Fs;
 use futures::{FutureExt, StreamExt};
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Task, WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity,
 };
 use language::LanguageRegistry;
 use livekit_client_macos::{LocalAudioTrack, LocalTrackPublication, LocalVideoTrack, RoomUpdate};
@@ -276,7 +276,7 @@ impl Room {
         channel_id: ChannelId,
         client: Arc<Client>,
         user_store: Entity<UserStore>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         Self::from_join_response(
             client
@@ -294,7 +294,7 @@ impl Room {
         room_id: u64,
         client: Arc<Client>,
         user_store: Entity<UserStore>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         Self::from_join_response(
             client.request(proto::JoinRoom { id: room_id }).await?,
@@ -335,7 +335,7 @@ impl Room {
         response: proto::JoinRoomResponse,
         client: Arc<Client>,
         user_store: Entity<UserStore>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         let room_proto = response.room.ok_or_else(|| anyhow!("invalid room"))?;
         let room = cx.new(|cx| {
@@ -416,7 +416,7 @@ impl Room {
     async fn maintain_connection(
         this: WeakEntity<Self>,
         client: Arc<Client>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let mut client_status = client.status();
         loop {
@@ -697,7 +697,7 @@ impl Room {
     async fn handle_room_updated(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::RoomUpdated>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let room = envelope
             .payload

--- a/crates/channel/src/channel_buffer.rs
+++ b/crates/channel/src/channel_buffer.rs
@@ -2,7 +2,7 @@ use crate::{Channel, ChannelStore};
 use anyhow::Result;
 use client::{ChannelId, Client, Collaborator, UserStore, ZED_ALWAYS_ACTIVE};
 use collections::HashMap;
-use gpui::{App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Task};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task};
 use language::proto::serialize_version;
 use rpc::{
     proto::{self, PeerId},
@@ -47,7 +47,7 @@ impl ChannelBuffer {
         client: Arc<Client>,
         user_store: Entity<UserStore>,
         channel_store: Entity<ChannelStore>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         let response = client
             .request(proto::JoinChannelBuffer {
@@ -138,7 +138,7 @@ impl ChannelBuffer {
     async fn handle_update_channel_buffer(
         this: Entity<Self>,
         update_channel_buffer: TypedEnvelope<proto::UpdateChannelBuffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let ops = update_channel_buffer
             .payload
@@ -159,7 +159,7 @@ impl ChannelBuffer {
     async fn handle_update_channel_buffer_collaborators(
         this: Entity<Self>,
         message: TypedEnvelope<proto::UpdateChannelBufferCollaborators>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             this.replace_collaborators(message.payload.collaborators, cx);

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -7,9 +7,7 @@ use client::{
 };
 use collections::HashSet;
 use futures::lock::Mutex;
-use gpui::{
-    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity,
-};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use rand::prelude::*;
 use rpc::AnyProtoClient;
 use std::{

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -7,8 +7,8 @@ use client::{ChannelId, Client, ClientSettings, Subscription, User, UserId, User
 use collections::{hash_map, HashMap, HashSet};
 use futures::{channel::mpsc, future::Shared, Future, FutureExt, StreamExt};
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Global, SharedString,
-    Task, WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Global, SharedString, Task,
+    WeakEntity,
 };
 use language::Capability;
 use rpc::{
@@ -458,7 +458,7 @@ impl ChannelStore {
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<T>>>
     where
-        F: 'static + FnOnce(Arc<Channel>, AsyncAppContext) -> Fut,
+        F: 'static + FnOnce(Arc<Channel>, AsyncApp) -> Fut,
         Fut: Future<Output = Result<Entity<T>>>,
         T: 'static,
     {
@@ -848,7 +848,7 @@ impl ChannelStore {
     async fn handle_update_channels(
         this: Entity<Self>,
         message: TypedEnvelope<proto::UpdateChannels>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {
             this.update_channels_tx
@@ -861,7 +861,7 @@ impl ChannelStore {
     async fn handle_update_user_channels(
         this: Entity<Self>,
         message: TypedEnvelope<proto::UpdateUserChannels>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             for buffer_version in message.payload.observed_channel_buffer_version {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -199,9 +199,8 @@ pub struct Client {
 
     #[allow(clippy::type_complexity)]
     #[cfg(any(test, feature = "test-support"))]
-    authenticate: RwLock<
-        Option<Box<dyn 'static + Send + Sync + Fn(&AsyncApp) -> Task<Result<Credentials>>>>,
-    >,
+    authenticate:
+        RwLock<Option<Box<dyn 'static + Send + Sync + Fn(&AsyncApp) -> Task<Result<Credentials>>>>>,
 
     #[allow(clippy::type_complexity)]
     #[cfg(any(test, feature = "test-support"))]
@@ -883,11 +882,7 @@ impl Client {
         }
     }
 
-    async fn set_connection(
-        self: &Arc<Self>,
-        conn: Connection,
-        cx: &AsyncApp,
-    ) -> Result<()> {
+    async fn set_connection(self: &Arc<Self>, conn: Connection, cx: &AsyncApp) -> Result<()> {
         let executor = cx.background_executor();
         log::debug!("add connection to peer");
         let (connection_id, handle_io, mut incoming) = self.peer.add_connection(conn, {
@@ -1174,10 +1169,7 @@ impl Client {
         })
     }
 
-    pub fn authenticate_with_browser(
-        self: &Arc<Self>,
-        cx: &AsyncApp,
-    ) -> Task<Result<Credentials>> {
+    pub fn authenticate_with_browser(self: &Arc<Self>, cx: &AsyncApp) -> Task<Result<Credentials>> {
         let http = self.http.clone();
         let this = self.clone();
         cx.spawn(|cx| async move {
@@ -1528,11 +1520,7 @@ impl Client {
         }
     }
 
-    fn handle_message(
-        self: &Arc<Client>,
-        message: Box<dyn AnyTypedEnvelope>,
-        cx: &AsyncApp,
-    ) {
+    fn handle_message(self: &Arc<Client>, message: Box<dyn AnyTypedEnvelope>, cx: &AsyncApp) {
         let sender_id = message.sender_id();
         let request_id = message.message_id();
         let type_name = message.payload_type_name();

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -19,7 +19,7 @@ use futures::{
     channel::oneshot, future::BoxFuture, AsyncReadExt, FutureExt, SinkExt, Stream, StreamExt,
     TryFutureExt as _, TryStreamExt,
 };
-use gpui::{actions, App, AsyncAppContext, Entity, Global, Task, WeakEntity};
+use gpui::{actions, App, AsyncApp, Entity, Global, Task, WeakEntity};
 use http_client::{AsyncBody, HttpClient, HttpClientWithUrl};
 use parking_lot::RwLock;
 use postage::watch;
@@ -200,7 +200,7 @@ pub struct Client {
     #[allow(clippy::type_complexity)]
     #[cfg(any(test, feature = "test-support"))]
     authenticate: RwLock<
-        Option<Box<dyn 'static + Send + Sync + Fn(&AsyncAppContext) -> Task<Result<Credentials>>>>,
+        Option<Box<dyn 'static + Send + Sync + Fn(&AsyncApp) -> Task<Result<Credentials>>>>,
     >,
 
     #[allow(clippy::type_complexity)]
@@ -213,7 +213,7 @@ pub struct Client {
                     + Sync
                     + Fn(
                         &Credentials,
-                        &AsyncAppContext,
+                        &AsyncApp,
                     ) -> Task<Result<Connection, EstablishConnectionError>>,
             >,
         >,
@@ -313,7 +313,7 @@ trait CredentialsProvider {
     /// Reads the credentials from the provider.
     fn read_credentials<'a>(
         &'a self,
-        cx: &'a AsyncAppContext,
+        cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Option<Credentials>> + 'a>>;
 
     /// Writes the credentials to the provider.
@@ -321,13 +321,13 @@ trait CredentialsProvider {
         &'a self,
         user_id: u64,
         access_token: String,
-        cx: &'a AsyncAppContext,
+        cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>>;
 
     /// Deletes the credentials from the provider.
     fn delete_credentials<'a>(
         &'a self,
-        cx: &'a AsyncAppContext,
+        cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>>;
 }
 
@@ -380,7 +380,7 @@ pub struct PendingEntitySubscription<T: 'static> {
 }
 
 impl<T: 'static> PendingEntitySubscription<T> {
-    pub fn set_model(mut self, model: &Entity<T>, cx: &AsyncAppContext) -> Subscription {
+    pub fn set_model(mut self, model: &Entity<T>, cx: &AsyncApp) -> Subscription {
         self.consumed = true;
         let mut handlers = self.client.handler_set.lock();
         let id = (TypeId::of::<T>(), self.remote_id);
@@ -552,7 +552,7 @@ impl Client {
     #[cfg(any(test, feature = "test-support"))]
     pub fn override_authenticate<F>(&self, authenticate: F) -> &Self
     where
-        F: 'static + Send + Sync + Fn(&AsyncAppContext) -> Task<Result<Credentials>>,
+        F: 'static + Send + Sync + Fn(&AsyncApp) -> Task<Result<Credentials>>,
     {
         *self.authenticate.write() = Some(Box::new(authenticate));
         self
@@ -564,7 +564,7 @@ impl Client {
         F: 'static
             + Send
             + Sync
-            + Fn(&Credentials, &AsyncAppContext) -> Task<Result<Connection, EstablishConnectionError>>,
+            + Fn(&Credentials, &AsyncApp) -> Task<Result<Connection, EstablishConnectionError>>,
     {
         *self.establish_connection.write() = Some(Box::new(connect));
         self
@@ -603,7 +603,7 @@ impl Client {
         self.state.read().status.1.clone()
     }
 
-    fn set_status(self: &Arc<Self>, status: Status, cx: &AsyncAppContext) {
+    fn set_status(self: &Arc<Self>, status: Status, cx: &AsyncApp) {
         log::info!("set status on client {}: {:?}", self.id(), status);
         let mut state = self.state.write();
         *state.status.0.borrow_mut() = status;
@@ -684,7 +684,7 @@ impl Client {
     where
         M: EnvelopedMessage,
         E: 'static,
-        H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncAppContext) -> F + Send + Sync,
+        H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncApp) -> F + Send + Sync,
         F: 'static + Future<Output = Result<()>>,
     {
         self.add_message_handler_impl(entity, move |model, message, _, cx| {
@@ -702,7 +702,7 @@ impl Client {
         E: 'static,
         H: 'static
             + Sync
-            + Fn(Entity<E>, TypedEnvelope<M>, AnyProtoClient, AsyncAppContext) -> F
+            + Fn(Entity<E>, TypedEnvelope<M>, AnyProtoClient, AsyncApp) -> F
             + Send
             + Sync,
         F: 'static + Future<Output = Result<()>>,
@@ -745,7 +745,7 @@ impl Client {
     where
         M: RequestMessage,
         E: 'static,
-        H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncAppContext) -> F + Send + Sync,
+        H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncApp) -> F + Send + Sync,
         F: 'static + Future<Output = Result<M::Response>>,
     {
         self.add_message_handler_impl(model, move |handle, envelope, this, cx| {
@@ -770,7 +770,7 @@ impl Client {
         }
     }
 
-    pub async fn has_credentials(&self, cx: &AsyncAppContext) -> bool {
+    pub async fn has_credentials(&self, cx: &AsyncApp) -> bool {
         self.credentials_provider
             .read_credentials(cx)
             .await
@@ -781,7 +781,7 @@ impl Client {
     pub async fn authenticate_and_connect(
         self: &Arc<Self>,
         try_provider: bool,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> anyhow::Result<()> {
         let was_disconnected = match *self.status().borrow() {
             Status::SignedOut => true,
@@ -886,7 +886,7 @@ impl Client {
     async fn set_connection(
         self: &Arc<Self>,
         conn: Connection,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Result<()> {
         let executor = cx.background_executor();
         log::debug!("add connection to peer");
@@ -981,7 +981,7 @@ impl Client {
         Ok(())
     }
 
-    fn authenticate(self: &Arc<Self>, cx: &AsyncAppContext) -> Task<Result<Credentials>> {
+    fn authenticate(self: &Arc<Self>, cx: &AsyncApp) -> Task<Result<Credentials>> {
         #[cfg(any(test, feature = "test-support"))]
         if let Some(callback) = self.authenticate.read().as_ref() {
             return callback(cx);
@@ -993,7 +993,7 @@ impl Client {
     fn establish_connection(
         self: &Arc<Self>,
         credentials: &Credentials,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Task<Result<Connection, EstablishConnectionError>> {
         #[cfg(any(test, feature = "test-support"))]
         if let Some(callback) = self.establish_connection.read().as_ref() {
@@ -1052,7 +1052,7 @@ impl Client {
     fn establish_websocket_connection(
         self: &Arc<Self>,
         credentials: &Credentials,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Task<Result<Connection, EstablishConnectionError>> {
         let release_channel = cx
             .update(|cx| ReleaseChannel::try_global(cx))
@@ -1176,7 +1176,7 @@ impl Client {
 
     pub fn authenticate_with_browser(
         self: &Arc<Self>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Task<Result<Credentials>> {
         let http = self.http.clone();
         let this = self.clone();
@@ -1412,7 +1412,7 @@ impl Client {
         })
     }
 
-    pub async fn sign_out(self: &Arc<Self>, cx: &AsyncAppContext) {
+    pub async fn sign_out(self: &Arc<Self>, cx: &AsyncApp) {
         self.state.write().credentials = None;
         self.disconnect(cx);
 
@@ -1424,12 +1424,12 @@ impl Client {
         }
     }
 
-    pub fn disconnect(self: &Arc<Self>, cx: &AsyncAppContext) {
+    pub fn disconnect(self: &Arc<Self>, cx: &AsyncApp) {
         self.peer.teardown();
         self.set_status(Status::SignedOut, cx);
     }
 
-    pub fn reconnect(self: &Arc<Self>, cx: &AsyncAppContext) {
+    pub fn reconnect(self: &Arc<Self>, cx: &AsyncApp) {
         self.peer.teardown();
         self.set_status(Status::ConnectionLost, cx);
     }
@@ -1531,7 +1531,7 @@ impl Client {
     fn handle_message(
         self: &Arc<Client>,
         message: Box<dyn AnyTypedEnvelope>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) {
         let sender_id = message.sender_id();
         let request_id = message.message_id();
@@ -1640,7 +1640,7 @@ struct DevelopmentCredentialsProvider {
 impl CredentialsProvider for DevelopmentCredentialsProvider {
     fn read_credentials<'a>(
         &'a self,
-        _cx: &'a AsyncAppContext,
+        _cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Option<Credentials>> + 'a>> {
         async move {
             if IMPERSONATE_LOGIN.is_some() {
@@ -1663,7 +1663,7 @@ impl CredentialsProvider for DevelopmentCredentialsProvider {
         &'a self,
         user_id: u64,
         access_token: String,
-        _cx: &'a AsyncAppContext,
+        _cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
         async move {
             let json = serde_json::to_string(&DevelopmentCredentials {
@@ -1680,7 +1680,7 @@ impl CredentialsProvider for DevelopmentCredentialsProvider {
 
     fn delete_credentials<'a>(
         &'a self,
-        _cx: &'a AsyncAppContext,
+        _cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
         async move { Ok(std::fs::remove_file(&self.path)?) }.boxed_local()
     }
@@ -1692,7 +1692,7 @@ struct KeychainCredentialsProvider;
 impl CredentialsProvider for KeychainCredentialsProvider {
     fn read_credentials<'a>(
         &'a self,
-        cx: &'a AsyncAppContext,
+        cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Option<Credentials>> + 'a>> {
         async move {
             if IMPERSONATE_LOGIN.is_some() {
@@ -1717,7 +1717,7 @@ impl CredentialsProvider for KeychainCredentialsProvider {
         &'a self,
         user_id: u64,
         access_token: String,
-        cx: &'a AsyncAppContext,
+        cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
         async move {
             cx.update(move |cx| {
@@ -1734,7 +1734,7 @@ impl CredentialsProvider for KeychainCredentialsProvider {
 
     fn delete_credentials<'a>(
         &'a self,
-        cx: &'a AsyncAppContext,
+        cx: &'a AsyncApp,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
         async move {
             cx.update(move |cx| cx.delete_credentials(&ClientSettings::get_global(cx).server_url))?

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -5,7 +5,7 @@ use collections::{hash_map::Entry, HashMap, HashSet};
 use feature_flags::FeatureFlagAppExt;
 use futures::{channel::mpsc, Future, StreamExt};
 use gpui::{
-    App, AsyncAppContext, Context, Entity, EventEmitter, SharedString, SharedUri, Task, WeakEntity,
+    App, AsyncApp, Context, Entity, EventEmitter, SharedString, SharedUri, Task, WeakEntity,
 };
 use postage::{sink::Sink, watch};
 use rpc::proto::{RequestMessage, UsersResponse};
@@ -275,7 +275,7 @@ impl UserStore {
     async fn handle_update_invite_info(
         this: Entity<Self>,
         message: TypedEnvelope<proto::UpdateInviteInfo>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             this.invite_info = Some(InviteInfo {
@@ -290,7 +290,7 @@ impl UserStore {
     async fn handle_show_contacts(
         this: Entity<Self>,
         _: TypedEnvelope<proto::ShowContacts>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |_, cx| cx.emit(Event::ShowContacts))?;
         Ok(())
@@ -303,7 +303,7 @@ impl UserStore {
     async fn handle_update_contacts(
         this: Entity<Self>,
         message: TypedEnvelope<proto::UpdateContacts>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, _| {
             this.update_contacts_tx
@@ -316,7 +316,7 @@ impl UserStore {
     async fn handle_update_plan(
         this: Entity<Self>,
         message: TypedEnvelope<proto::UpdateUserPlan>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             this.current_plan = Some(message.payload.plan());
@@ -819,7 +819,7 @@ impl Contact {
     async fn from_proto(
         contact: proto::Contact,
         user_store: &Entity<UserStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Self> {
         let user = user_store
             .update(cx, |user_store, cx| {

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -104,7 +104,7 @@ async fn test_host_disconnect(
         .unwrap();
 
     //TODO: focus
-    assert!(cx_b.update_window_model(&editor_b, |editor, window, _| editor.is_focused(window)));
+    assert!(cx_b.update_window_entity(&editor_b, |editor, window, _| editor.is_focused(window)));
     editor_b.update_in(cx_b, |editor, window, cx| editor.insert("X", window, cx));
 
     cx_b.update(|_, cx| {
@@ -208,7 +208,7 @@ async fn test_newline_above_or_below_does_not_move_guest_cursor(
         .unwrap();
     let cx_a = cx_a.add_empty_window();
     let editor_a = cx_a
-        .new_window_model(|window, cx| Editor::for_buffer(buffer_a, Some(project_a), window, cx));
+        .new_window_entity(|window, cx| Editor::for_buffer(buffer_a, Some(project_a), window, cx));
 
     let mut editor_cx_a = EditorTestContext {
         cx: cx_a.clone(),
@@ -224,7 +224,7 @@ async fn test_newline_above_or_below_does_not_move_guest_cursor(
         .await
         .unwrap();
     let editor_b = cx_b
-        .new_window_model(|window, cx| Editor::for_buffer(buffer_b, Some(project_b), window, cx));
+        .new_window_entity(|window, cx| Editor::for_buffer(buffer_b, Some(project_b), window, cx));
 
     let mut editor_cx_b = EditorTestContext {
         cx: cx_b.clone(),
@@ -327,7 +327,7 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
         .await
         .unwrap();
     let cx_b = cx_b.add_empty_window();
-    let editor_b = cx_b.new_window_model(|window, cx| {
+    let editor_b = cx_b.new_window_entity(|window, cx| {
         Editor::for_buffer(buffer_b.clone(), Some(project_b.clone()), window, cx)
     });
 
@@ -1206,7 +1206,7 @@ async fn test_share_project(
         .unwrap();
 
     let editor_b =
-        cx_b.new_window_model(|window, cx| Editor::for_buffer(buffer_b, None, window, cx));
+        cx_b.new_window_entity(|window, cx| Editor::for_buffer(buffer_b, None, window, cx));
 
     // Client A sees client B's selection
     executor.run_until_parked();
@@ -1313,7 +1313,7 @@ async fn test_on_input_format_from_host_to_guest(
         .await
         .unwrap();
     let cx_a = cx_a.add_empty_window();
-    let editor_a = cx_a.new_window_model(|window, cx| {
+    let editor_a = cx_a.new_window_entity(|window, cx| {
         Editor::for_buffer(buffer_a, Some(project_a.clone()), window, cx)
     });
 
@@ -1435,7 +1435,7 @@ async fn test_on_input_format_from_guest_to_host(
         .await
         .unwrap();
     let cx_b = cx_b.add_empty_window();
-    let editor_b = cx_b.new_window_model(|window, cx| {
+    let editor_b = cx_b.new_window_entity(|window, cx| {
         Editor::for_buffer(buffer_b, Some(project_b.clone()), window, cx)
     });
 
@@ -2195,10 +2195,10 @@ async fn test_collaborating_with_editorconfig(
         .await
         .unwrap();
     let cx_a = cx_a.add_empty_window();
-    let main_editor_a = cx_a.new_window_model(|window, cx| {
+    let main_editor_a = cx_a.new_window_entity(|window, cx| {
         Editor::for_buffer(main_buffer_a, Some(project_a.clone()), window, cx)
     });
-    let other_editor_a = cx_a.new_window_model(|window, cx| {
+    let other_editor_a = cx_a.new_window_entity(|window, cx| {
         Editor::for_buffer(other_buffer_a, Some(project_a), window, cx)
     });
     let mut main_editor_cx_a = EditorTestContext {
@@ -2229,10 +2229,10 @@ async fn test_collaborating_with_editorconfig(
         .await
         .unwrap();
     let cx_b = cx_b.add_empty_window();
-    let main_editor_b = cx_b.new_window_model(|window, cx| {
+    let main_editor_b = cx_b.new_window_entity(|window, cx| {
         Editor::for_buffer(main_buffer_b, Some(project_b.clone()), window, cx)
     });
-    let other_editor_b = cx_b.new_window_model(|window, cx| {
+    let other_editor_b = cx_b.new_window_entity(|window, cx| {
         Editor::for_buffer(other_buffer_b, Some(project_b.clone()), window, cx)
     });
     let mut main_editor_cx_b = EditorTestContext {

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -180,7 +180,7 @@ impl ChannelView {
                 })
             })?;
 
-            cx.new_window_model(|window, cx| {
+            cx.new_window_entity(|window, cx| {
                 let mut this = Self::new(
                     project,
                     weak_workspace,

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -5,7 +5,7 @@ use collections::HashSet;
 use editor::{AnchorRangeExt, CompletionProvider, Editor, EditorElement, EditorStyle};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    AsyncAppContext, AsyncWindowContext, Context, Entity, Focusable, FontStyle, FontWeight,
+    AsyncApp, AsyncWindowContext, Context, Entity, Focusable, FontStyle, FontWeight,
     HighlightStyle, IntoElement, Render, Task, TextStyle, WeakEntity, Window,
 };
 use language::{
@@ -285,7 +285,7 @@ impl MessageEditor {
     }
 
     async fn resolve_completions_for_candidates(
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
         query: &str,
         candidates: &[StringMatchCandidate],
         range: Range<Anchor>,

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -516,7 +516,7 @@ mod tests {
         let (workspace, cx) =
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
-        let editor = cx.new_window_model(|window, cx| {
+        let editor = cx.new_window_entity(|window, cx| {
             let mut editor = Editor::single_line(window, cx);
             editor.set_text("abc", window, cx);
             editor
@@ -587,7 +587,7 @@ mod tests {
         let (workspace, cx) =
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
-        let editor = cx.new_window_model(|window, cx| {
+        let editor = cx.new_window_entity(|window, cx| {
             let mut editor = Editor::single_line(window, cx);
             editor.set_text("abc", window, cx);
             editor

--- a/crates/context_server/src/manager.rs
+++ b/crates/context_server/src/manager.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use anyhow::{bail, Result};
 use collections::HashMap;
 use command_palette_hooks::CommandPaletteFilter;
-use gpui::{AsyncAppContext, Context, Entity, EventEmitter, Subscription, Task, WeakEntity};
+use gpui::{AsyncApp, Context, Entity, EventEmitter, Subscription, Task, WeakEntity};
 use log;
 use parking_lot::RwLock;
 use project::Project;
@@ -61,7 +61,7 @@ impl ContextServer {
         self.client.read().clone()
     }
 
-    pub async fn start(self: Arc<Self>, cx: &AsyncAppContext) -> Result<()> {
+    pub async fn start(self: Arc<Self>, cx: &AsyncApp) -> Result<()> {
         log::info!("starting context server {}", self.id);
         let Some(command) = &self.config.command else {
             bail!("no command specified for server {}", self.id);
@@ -214,7 +214,7 @@ impl ContextServerManager {
             .collect()
     }
 
-    async fn maintain_servers(this: WeakEntity<Self>, mut cx: AsyncAppContext) -> Result<()> {
+    async fn maintain_servers(this: WeakEntity<Self>, mut cx: AsyncApp) -> Result<()> {
         let mut desired_servers = HashMap::default();
 
         let (registry, project) = this.update(&mut cx, |this, cx| {

--- a/crates/context_server/src/registry.rs
+++ b/crates/context_server/src/registry.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use collections::HashMap;
-use gpui::{App, AppContext as _, AsyncAppContext, Entity, Global, ReadGlobal, Task};
+use gpui::{App, AppContext as _, AsyncApp, Entity, Global, ReadGlobal, Task};
 use project::Project;
 
 use crate::ServerCommand;
 
 pub type ContextServerFactory = Arc<
-    dyn Fn(Entity<Project>, &AsyncAppContext) -> Task<Result<ServerCommand>>
+    dyn Fn(Entity<Project>, &AsyncApp) -> Task<Result<ServerCommand>>
         + Send
         + Sync
         + 'static,

--- a/crates/context_server/src/registry.rs
+++ b/crates/context_server/src/registry.rs
@@ -7,12 +7,8 @@ use project::Project;
 
 use crate::ServerCommand;
 
-pub type ContextServerFactory = Arc<
-    dyn Fn(Entity<Project>, &AsyncApp) -> Task<Result<ServerCommand>>
-        + Send
-        + Sync
-        + 'static,
->;
+pub type ContextServerFactory =
+    Arc<dyn Fn(Entity<Project>, &AsyncApp) -> Task<Result<ServerCommand>> + Send + Sync + 'static>;
 
 struct GlobalContextServerFactoryRegistry(Entity<ContextServerFactoryRegistry>);
 

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -11,8 +11,8 @@ use collections::{HashMap, HashSet};
 use command_palette_hooks::CommandPaletteFilter;
 use futures::{channel::oneshot, future::Shared, Future, FutureExt, TryFutureExt};
 use gpui::{
-    actions, App, AppContext as _, AsyncAppContext, Context, Entity, EntityId, EventEmitter,
-    Global, Task, WeakEntity,
+    actions, App, AppContext as _, AsyncApp, Context, Entity, EntityId, EventEmitter, Global, Task,
+    WeakEntity,
 };
 use http_client::github::get_release_by_tag_name;
 use http_client::HttpClient;
@@ -424,7 +424,7 @@ impl Copilot {
         http: Arc<dyn HttpClient>,
         node_runtime: NodeRuntime,
         this: WeakEntity<Self>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) {
         let start_language_server = async {
             let server_path = get_copilot_lsp(http).await?;

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use chrono::DateTime;
 use fs::Fs;
 use futures::{io::BufReader, stream::BoxStream, AsyncBufReadExt, AsyncReadExt, StreamExt};
-use gpui::{prelude::*, App, AsyncAppContext, Global};
+use gpui::{prelude::*, App, AsyncApp, Global};
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use paths::home_dir;
 use serde::{Deserialize, Serialize};
@@ -268,7 +268,7 @@ impl CopilotChat {
 
     pub async fn stream_completion(
         request: Request,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<BoxStream<'static, Result<ResponseEvent>>> {
         let Some(this) = cx.update(|cx| Self::global(cx)).ok().flatten() else {
             return Err(anyhow!("Copilot chat is not enabled"));

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -79,11 +79,11 @@ use git::blame::GitBlame;
 use gpui::{
     div, impl_actions, point, prelude::*, px, relative, size, Action, AnyElement, App,
     AsyncWindowContext, AvailableSpace, Bounds, ClipboardEntry, ClipboardItem, Context,
-    DispatchPhase, ElementId, Entity, EventEmitter, FocusHandle, FocusOutEvent, Focusable, FontId,
-    FontWeight, Global, HighlightStyle, Hsla, InteractiveText, KeyContext, MouseButton, PaintQuad,
-    ParentElement, Pixels, Render, SharedString, Size, Styled, StyledText, Subscription, Task,
-    TextStyle, TextStyleRefinement, UTF16Selection, UnderlineStyle, UniformListScrollHandle,
-    ViewInputHandler, WeakEntity, WeakFocusHandle, Window,
+    DispatchPhase, ElementId, Entity, EntityInputHandler, EventEmitter, FocusHandle, FocusOutEvent,
+    Focusable, FontId, FontWeight, Global, HighlightStyle, Hsla, InteractiveText, KeyContext,
+    MouseButton, PaintQuad, ParentElement, Pixels, Render, SharedString, Size, Styled, StyledText,
+    Subscription, Task, TextStyle, TextStyleRefinement, UTF16Selection, UnderlineStyle,
+    UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window,
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_popover::{hide_hover, HoverState};
@@ -15355,7 +15355,7 @@ impl Render for Editor {
     }
 }
 
-impl ViewInputHandler for Editor {
+impl EntityInputHandler for Editor {
     fn text_for_range(
         &mut self,
         range_utf16: Range<usize>,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7331,7 +7331,7 @@ async fn test_multibuffer_format_during_save(cx: &mut gpui::TestAppContext) {
         );
         multi_buffer
     });
-    let multi_buffer_editor = cx.new_window_model(|window, cx| {
+    let multi_buffer_editor = cx.new_window_entity(|window, cx| {
         Editor::new(
             EditorMode::Full,
             multi_buffer,
@@ -12595,7 +12595,7 @@ async fn test_mutlibuffer_in_navigation_history(cx: &mut gpui::TestAppContext) {
     let project = Project::test(fs, ["/a".as_ref()], cx).await;
     let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
     let cx = &mut VisualTestContext::from_window(*workspace.deref(), cx);
-    let multi_buffer_editor = cx.new_window_model(|window, cx| {
+    let multi_buffer_editor = cx.new_window_entity(|window, cx| {
         Editor::new(
             EditorMode::Full,
             multi_buffer,
@@ -14800,7 +14800,7 @@ async fn test_find_enclosing_node_with_task(cx: &mut gpui::TestAppContext) {
     let buffer = cx.new(|cx| Buffer::local(text, cx).with_language(language, cx));
     let multi_buffer = cx.new(|cx| MultiBuffer::singleton(buffer.clone(), cx));
 
-    let editor = cx.new_window_model(|window, cx| {
+    let editor = cx.new_window_entity(|window, cx| {
         Editor::new(
             EditorMode::Full,
             multi_buffer,
@@ -14954,7 +14954,7 @@ async fn test_multi_buffer_folding(cx: &mut gpui::TestAppContext) {
         );
         multi_buffer
     });
-    let multi_buffer_editor = cx.new_window_model(|window, cx| {
+    let multi_buffer_editor = cx.new_window_entity(|window, cx| {
         Editor::new(
             EditorMode::Full,
             multi_buffer,
@@ -15109,7 +15109,7 @@ async fn test_multi_buffer_single_excerpts_folding(cx: &mut gpui::TestAppContext
         multi_buffer
     });
 
-    let multi_buffer_editor = cx.new_window_model(|window, cx| {
+    let multi_buffer_editor = cx.new_window_entity(|window, cx| {
         Editor::new(
             EditorMode::Full,
             multi_buffer,
@@ -15229,7 +15229,7 @@ async fn test_multi_buffer_with_single_excerpt_folding(cx: &mut gpui::TestAppCon
         );
         multi_buffer
     });
-    let multi_buffer_editor = cx.new_window_model(|window, cx| {
+    let multi_buffer_editor = cx.new_window_entity(|window, cx| {
         Editor::new(
             EditorMode::Full,
             multi_buffer,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -306,7 +306,7 @@ fn show_hover(
                 let mut background_color: Option<Hsla> = None;
 
                 let parsed_content = cx
-                    .new_window_model(|window, cx| {
+                    .new_window_entity(|window, cx| {
                         let status_colors = cx.theme().status();
 
                         match local_diagnostic.diagnostic.severity {
@@ -556,7 +556,7 @@ async fn parse_blocks(
         .join("\n\n");
 
     let rendered_block = cx
-        .new_window_model(|window, cx| {
+        .new_window_entity(|window, cx| {
             let settings = ThemeSettings::get_global(cx);
             let ui_font_family = settings.ui_font.family.clone();
             let ui_font_fallbacks = settings.ui_font.fallbacks.clone();

--- a/crates/editor/src/hunk_diff.rs
+++ b/crates/editor/src/hunk_diff.rs
@@ -14,8 +14,8 @@ use std::{ops::Range, sync::Arc};
 use sum_tree::TreeMap;
 use text::OffsetRangeExt;
 use ui::{
-    prelude::*, ActiveTheme, ContextMenu, IconButtonShape, InteractiveElement, IntoElement,
-    ModelContext, ParentElement, PopoverMenu, Styled, Tooltip, Window,
+    prelude::*, ActiveTheme, Context, Context, ContextMenu, IconButtonShape, InteractiveElement,
+    IntoElement, ParentElement, PopoverMenu, Styled, Tooltip, Window,
 };
 use util::RangeExt;
 use workspace::Item;
@@ -84,7 +84,7 @@ impl DiffMap {
         &mut self,
         change_set: Model<BufferChangeSet>,
         window: &mut Window,
-        cx: &mut ModelContext<Editor>,
+        cx: &mut Context<Editor>,
     ) {
         let buffer_id = change_set.read(cx).buffer_id;
         self.snapshot
@@ -216,7 +216,7 @@ impl Editor {
         &mut self,
         hovered_hunk: &HoveredHunk,
         window: &mut Window,
-        cx: &mut ModelContext<Editor>,
+        cx: &mut Context<Editor>,
     ) {
         let editor_snapshot = self.snapshot(window, cx);
         if let Some(diff_hunk) = to_diff_hunk(hovered_hunk, &editor_snapshot.buffer_snapshot) {
@@ -229,7 +229,7 @@ impl Editor {
         &mut self,
         _: &ToggleHunkDiff,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         let snapshot = self.snapshot(window, cx);
         let selections = self.selections.all(cx);
@@ -240,7 +240,7 @@ impl Editor {
         &mut self,
         _: &ExpandAllHunkDiffs,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         let snapshot = self.snapshot(window, cx);
         let display_rows_with_expanded_hunks = self
@@ -280,7 +280,7 @@ impl Editor {
         &mut self,
         hunks_to_toggle: Vec<MultiBufferDiffHunk>,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         if self.diff_map.expand_all {
             return;
@@ -389,7 +389,7 @@ impl Editor {
         diff_base_buffer: Option<Model<Buffer>>,
         hunk: &HoveredHunk,
         window: &mut Window,
-        cx: &mut ModelContext<Editor>,
+        cx: &mut Context<Editor>,
     ) -> Option<()> {
         let buffer = self.buffer.clone();
         let multi_buffer_snapshot = buffer.read(cx).snapshot(cx);
@@ -491,7 +491,7 @@ impl Editor {
         &mut self,
         range: Range<Anchor>,
         window: &mut Window,
-        cx: &mut ModelContext<Editor>,
+        cx: &mut Context<Editor>,
     ) -> Option<()> {
         let multi_buffer = self.buffer.read(cx);
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
@@ -518,7 +518,7 @@ impl Editor {
         &mut self,
         _: &ApplyAllDiffHunks,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         let buffers = self.buffer.read(cx).all_buffers();
         for branch_buffer in buffers {
@@ -536,7 +536,7 @@ impl Editor {
         &mut self,
         _: &ApplyDiffHunk,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         let snapshot = self.snapshot(window, cx);
         let hunks = hunks_for_selections(&snapshot, &self.selections.all(cx));
@@ -572,7 +572,7 @@ impl Editor {
     fn hunk_header_block(
         &self,
         hunk: &HoveredHunk,
-        cx: &mut ModelContext<Editor>,
+        cx: &mut Context<Editor>,
     ) -> BlockProperties<Anchor> {
         let is_branch_buffer = self
             .buffer
@@ -860,7 +860,7 @@ impl Editor {
         diff_base_buffer: Model<Buffer>,
         deleted_text_height: u32,
         window: &mut Window,
-        cx: &mut ModelContext<Editor>,
+        cx: &mut Context<Editor>,
     ) -> BlockProperties<Anchor> {
         let gutter_color = match hunk.status {
             DiffHunkStatus::Added => unreachable!(),
@@ -923,7 +923,7 @@ impl Editor {
         }
     }
 
-    pub(super) fn clear_expanded_diff_hunks(&mut self, cx: &mut ModelContext<Editor>) -> bool {
+    pub(super) fn clear_expanded_diff_hunks(&mut self, cx: &mut Context<Editor>) -> bool {
         if self.diff_map.expand_all {
             return false;
         }
@@ -947,7 +947,7 @@ impl Editor {
         diff_map: &mut DiffMap,
         buffer_id: BufferId,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         let diff_base_state = diff_map.diff_bases.get_mut(&buffer_id);
         let mut diff_base_buffer = None;
@@ -1119,7 +1119,7 @@ impl Editor {
         &mut self,
         position: Anchor,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         let snapshot = self.snapshot(window, cx);
         let position = position.to_point(&snapshot.buffer_snapshot);
@@ -1147,7 +1147,7 @@ impl Editor {
         &mut self,
         position: Anchor,
         window: &mut Window,
-        cx: &mut ModelContext<Self>,
+        cx: &mut Context<Self>,
     ) {
         let snapshot = self.snapshot(window, cx);
         let position = position.to_point(&snapshot.buffer_snapshot);
@@ -1212,7 +1212,7 @@ fn editor_with_deleted_text(
     deleted_color: Hsla,
     hunk: &HoveredHunk,
     window: &mut Window,
-    cx: &mut ModelContext<Editor>,
+    cx: &mut Context<Editor>,
 ) -> (u32, Model<Editor>) {
     let parent_editor = cx.model().downgrade();
     let editor = cx.new(|cx| {

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -19,7 +19,7 @@ use crate::{
 use anyhow::Context as _;
 use clock::Global;
 use futures::future;
-use gpui::{AsyncAppContext, Context, Entity, Task, Window};
+use gpui::{AsyncApp, Context, Entity, Task, Window};
 use language::{language_settings::InlayHintKind, Buffer, BufferSnapshot};
 use parking_lot::RwLock;
 use project::{InlayHint, ResolveState};
@@ -840,7 +840,7 @@ fn new_update_task(
         ));
 
         let query_range_failed =
-            |range: &Range<language::Anchor>, e: anyhow::Error, cx: &mut AsyncAppContext| {
+            |range: &Range<language::Anchor>, e: anyhow::Error, cx: &mut AsyncApp| {
                 log::error!("inlay hint update task for range failed: {e:#?}");
                 editor
                     .update(cx, |editor, cx| {

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -329,7 +329,7 @@ impl EditorLspTestContext {
     where
         T: 'static + request::Request,
         T::Params: 'static + Send,
-        F: 'static + Send + FnMut(lsp::Url, T::Params, gpui::AsyncAppContext) -> Fut,
+        F: 'static + Send + FnMut(lsp::Url, T::Params, gpui::AsyncApp) -> Fut,
         Fut: 'static + Send + Future<Output = Result<T::Result>>,
     {
         let url = self.buffer_lsp_url.clone();

--- a/crates/evals/src/eval.rs
+++ b/crates/evals/src/eval.rs
@@ -6,7 +6,7 @@ use clock::RealSystemClock;
 use collections::BTreeMap;
 use feature_flags::FeatureFlagAppExt as _;
 use git::GitHostingProviderRegistry;
-use gpui::{AppContext as _, AsyncAppContext, BackgroundExecutor, Entity};
+use gpui::{AppContext as _, AsyncApp, BackgroundExecutor, Entity};
 use http_client::{HttpClient, Method};
 use language::LanguageRegistry;
 use node_runtime::NodeRuntime;
@@ -252,7 +252,7 @@ struct Counts {
 async fn run_evaluation(
     only_repo: Option<String>,
     executor: &BackgroundExecutor,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<()> {
     let mut http_client = None;
     cx.update(|cx| {
@@ -409,7 +409,7 @@ async fn run_eval_project(
     project: Entity<Project>,
     embedding_provider: Arc<dyn EmbeddingProvider>,
     fs: Arc<dyn Fs>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<(), anyhow::Error> {
     let mut semantic_index = SemanticDb::new(repo_db_path, embedding_provider, cx).await?;
 
@@ -546,7 +546,7 @@ async fn run_eval_project(
 
 async fn wait_for_indexing_complete(
     project_index: &Entity<ProjectIndex>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
     timeout: Option<Duration>,
 ) {
     let (tx, rx) = bounded(1);

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -27,7 +27,7 @@ use futures::{
     select_biased, AsyncReadExt as _, Future, FutureExt as _, StreamExt as _,
 };
 use gpui::{
-    actions, App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Global, Task,
+    actions, App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Global, Task,
     WeakEntity,
 };
 use http_client::{AsyncBody, HttpClient, HttpClientWithUrl};
@@ -556,7 +556,7 @@ impl ExtensionStore {
     async fn upgrade_extensions(
         this: WeakEntity<Self>,
         extensions: Vec<ExtensionMetadata>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         for extension in extensions {
             let task = this.update(cx, |this, cx| {
@@ -1516,7 +1516,7 @@ impl ExtensionStore {
     async fn sync_extensions_over_ssh(
         this: &WeakEntity<Self>,
         client: WeakEntity<SshRemoteClient>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         let extensions = this.update(cx, |this, _cx| {
             this.extension_index
@@ -1583,7 +1583,7 @@ impl ExtensionStore {
 
     pub async fn update_ssh_clients(
         this: &WeakEntity<Self>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         let clients = this.update(cx, |this, _cx| {
             this.ssh_clients.retain(|_k, v| v.upgrade().is_some());

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1581,10 +1581,7 @@ impl ExtensionStore {
         anyhow::Ok(())
     }
 
-    pub async fn update_ssh_clients(
-        this: &WeakEntity<Self>,
-        cx: &mut AsyncApp,
-    ) -> Result<()> {
+    pub async fn update_ssh_clients(this: &WeakEntity<Self>, cx: &mut AsyncApp) -> Result<()> {
         let clients = this.update(cx, |this, _cx| {
             this.ssh_clients.retain(|_k, v| v.upgrade().is_some());
             this.ssh_clients.values().cloned().collect::<Vec<_>>()

--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -8,7 +8,7 @@ use extension::{
     ExtensionManifest,
 };
 use fs::{Fs, RemoveOptions, RenameOptions};
-use gpui::{App, AppContext as _, AsyncAppContext, Context, Entity, Task, WeakEntity};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, Task, WeakEntity};
 use http_client::HttpClient;
 use language::{LanguageConfig, LanguageName, LanguageQueries, LoadedLanguage};
 use lsp::LanguageServerName;
@@ -113,7 +113,7 @@ impl HeadlessExtensionStore {
     pub async fn load_extension(
         this: WeakEntity<Self>,
         extension: ExtensionVersion,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         let (fs, wasm_host, extension_dir) = this.update(cx, |this, _cx| {
             this.loaded_extensions.insert(
@@ -258,7 +258,7 @@ impl HeadlessExtensionStore {
     pub async fn handle_sync_extensions(
         extension_store: Entity<HeadlessExtensionStore>,
         envelope: TypedEnvelope<proto::SyncExtensions>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::SyncExtensionsResponse> {
         let requested_extensions =
             envelope
@@ -294,7 +294,7 @@ impl HeadlessExtensionStore {
     pub async fn handle_install_extension(
         extensions: Entity<HeadlessExtensionStore>,
         envelope: TypedEnvelope<proto::InstallExtension>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let extension = envelope
             .payload

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -305,8 +305,7 @@ pub struct WasmState {
     pub host: Arc<WasmHost>,
 }
 
-type MainThreadCall =
-    Box<dyn Send + for<'a> FnOnce(&'a mut AsyncApp) -> LocalBoxFuture<'a, ()>>;
+type MainThreadCall = Box<dyn Send + for<'a> FnOnce(&'a mut AsyncApp) -> LocalBoxFuture<'a, ()>>;
 
 type ExtensionCall = Box<
     dyn Send + for<'a> FnOnce(&'a mut Extension, &'a mut Store<WasmState>) -> BoxFuture<'a, ()>,

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -17,7 +17,7 @@ use futures::{
     future::BoxFuture,
     Future, FutureExt, StreamExt as _,
 };
-use gpui::{App, AsyncAppContext, BackgroundExecutor, Task};
+use gpui::{App, AsyncApp, BackgroundExecutor, Task};
 use http_client::HttpClient;
 use language::LanguageName;
 use lsp::LanguageServerName;
@@ -306,7 +306,7 @@ pub struct WasmState {
 }
 
 type MainThreadCall =
-    Box<dyn Send + for<'a> FnOnce(&'a mut AsyncAppContext) -> LocalBoxFuture<'a, ()>>;
+    Box<dyn Send + for<'a> FnOnce(&'a mut AsyncApp) -> LocalBoxFuture<'a, ()>>;
 
 type ExtensionCall = Box<
     dyn Send + for<'a> FnOnce(&'a mut Extension, &'a mut Store<WasmState>) -> BoxFuture<'a, ()>,
@@ -491,7 +491,7 @@ impl WasmExtension {
         extension_dir: PathBuf,
         manifest: &Arc<ExtensionManifest>,
         wasm_host: Arc<WasmHost>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Result<Self> {
         let path = extension_dir.join("extension.wasm");
 
@@ -538,7 +538,7 @@ impl WasmState {
     fn on_main_thread<T, Fn>(&self, f: Fn) -> impl 'static + Future<Output = T>
     where
         T: 'static + Send,
-        Fn: 'static + Send + for<'a> FnOnce(&'a mut AsyncAppContext) -> LocalBoxFuture<'a, T>,
+        Fn: 'static + Send + for<'a> FnOnce(&'a mut AsyncApp) -> LocalBoxFuture<'a, T>,
     {
         let (return_tx, return_rx) = oneshot::channel();
         self.host

--- a/crates/gpui/docs/contexts.md
+++ b/crates/gpui/docs/contexts.md
@@ -24,7 +24,7 @@ Provides access to the global application state. All other kinds of contexts ult
 
 Provides access to the state of an application window, and also derefs to an `AppContext`, so you can pass a window context reference to any method taking an app context. Obtain this context by calling `WindowHandle::update`.
 
-## `ModelContext<T>`
+## `Context<T>`
 
 Available when you create or update a `Model<T>`. It derefs to an `AppContext`, but also contains methods specific to the particular model, such as the ability to notify change observers or emit events.
 

--- a/crates/gpui/docs/contexts.md
+++ b/crates/gpui/docs/contexts.md
@@ -32,7 +32,7 @@ Available when you create or update a `Model<T>`. It derefs to an `AppContext`, 
 
 Available when you create or update a `View<V>`. It derefs to a `WindowContext`, but also contains methods specific to the particular view, such as the ability to notify change observers or emit events.
 
-## `AsyncAppContext` and `AsyncWindowContext`
+## `AsyncApp` and `AsyncWindowContext`
 
 Whereas the above contexts are always passed to your code as references, you can call `to_async` on the reference to create an async context, which has a static lifetime and can be held across `await` points in async code. When you interact with `Model`s or `View`s with an async context, the calls become fallible, because the context may outlive the window or even the app itself.
 

--- a/crates/gpui/docs/key_dispatch.md
+++ b/crates/gpui/docs/key_dispatch.md
@@ -42,9 +42,9 @@ To bind actions, chain `on_action` on to your element:
 
 ```rust
 impl Render for Menu {
-    fn render(&mut self, window: &mut Window, cx: &mut ModelContext<Self>) -> impl Component {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl Component {
         div()
-            .on_action(|this: &mut Menu, move: &MoveUp, window: &mut Window, cx: &mut ModelContext<Menu>| {
+            .on_action(|this: &mut Menu, move: &MoveUp, window: &mut Window, cx: &mut Context<Menu>| {
                 // ...
             })
             .on_action(|this, move: &MoveDown, cx| {
@@ -59,10 +59,10 @@ In order to bind keys to actions, you need to declare a _key context_ for part o
 
 ```rust
 impl Render for Menu {
-    fn render(&mut self, window: &mut Window, cx: &mut ModelContext<Self>) -> impl Component {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl Component {
         div()
             .key_context("menu")
-            .on_action(|this: &mut Menu, move: &MoveUp, window: &mut Window, cx: &mut ModelContext<Menu>| {
+            .on_action(|this: &mut Menu, move: &MoveUp, window: &mut Window, cx: &mut Context<Menu>| {
                 // ...
             })
             .on_action(|this, move: &MoveDown, cx| {

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -3,10 +3,10 @@ use std::ops::Range;
 use gpui::{
     actions, black, div, fill, hsla, opaque_grey, point, prelude::*, px, relative, rgb, rgba, size,
     white, yellow, App, Application, Bounds, ClipboardItem, Context, CursorStyle, ElementId,
-    ElementInputHandler, Entity, FocusHandle, Focusable, GlobalElementId, KeyBinding, Keystroke,
-    LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
-    ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle, ViewInputHandler,
-    Window, WindowBounds, WindowOptions,
+    ElementInputHandler, Entity, EntityInputHandler, FocusHandle, Focusable, GlobalElementId,
+    KeyBinding, Keystroke, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    PaintQuad, Pixels, Point, ShapedLine, SharedString, Style, TextRun, UTF16Selection,
+    UnderlineStyle, Window, WindowBounds, WindowOptions,
 };
 use unicode_segmentation::*;
 
@@ -257,7 +257,7 @@ impl TextInput {
     }
 }
 
-impl ViewInputHandler for TextInput {
+impl EntityInputHandler for TextInput {
     fn text_for_range(
         &mut self,
         range_utf16: Range<usize>,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1018,7 +1018,7 @@ impl App {
             Ok(result)
         })
     }
-    /// Creates an `AsyncAppContext`, which can be cloned and has a static lifetime
+    /// Creates an `AsyncApp`, which can be cloned and has a static lifetime
     /// so it can be held across `await` points.
     pub fn to_async(&self) -> AsyncApp {
         AsyncApp {
@@ -1039,7 +1039,7 @@ impl App {
     }
 
     /// Spawns the future returned by the given function on the thread pool. The closure will be invoked
-    /// with [AsyncAppContext], which allows the application state to be accessed across await points.
+    /// with [AsyncApp], which allows the application state to be accessed across await points.
     pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncApp) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1020,8 +1020,8 @@ impl App {
     }
     /// Creates an `AsyncAppContext`, which can be cloned and has a static lifetime
     /// so it can be held across `await` points.
-    pub fn to_async(&self) -> AsyncAppContext {
-        AsyncAppContext {
+    pub fn to_async(&self) -> AsyncApp {
+        AsyncApp {
             app: self.this.clone(),
             background_executor: self.background_executor.clone(),
             foreground_executor: self.foreground_executor.clone(),
@@ -1040,7 +1040,7 @@ impl App {
 
     /// Spawns the future returned by the given function on the thread pool. The closure will be invoked
     /// with [AsyncAppContext], which allows the application state to be accessed across await points.
-    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncAppContext) -> Fut) -> Task<R>
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncApp) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,
         R: 'static,
@@ -1598,11 +1598,11 @@ impl AppContext for App {
         })
     }
 
-    fn reserve_model<T: 'static>(&mut self) -> Self::Result<Reservation<T>> {
+    fn reserve_entity<T: 'static>(&mut self) -> Self::Result<Reservation<T>> {
         Reservation(self.entities.reserve())
     }
 
-    fn insert_model<T: 'static>(
+    fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
         build_model: impl FnOnce(&mut Context<'_, T>) -> T,
@@ -1616,7 +1616,7 @@ impl AppContext for App {
 
     /// Updates the entity referenced by the given model. The function is passed a mutable reference to the
     /// entity along with a `ModelContext` for the entity.
-    fn update_model<T: 'static, R>(
+    fn update_entity<T: 'static, R>(
         &mut self,
         model: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
@@ -1632,7 +1632,7 @@ impl AppContext for App {
         })
     }
 
-    fn read_model<T, R>(
+    fn read_entity<T, R>(
         &self,
         handle: &Entity<T>,
         read: impl FnOnce(&T, &App) -> R,

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -14,13 +14,13 @@ use super::Context;
 /// You're provided with an instance when calling [AppContext::spawn], and you can also create one with [AppContext::to_async].
 /// Internally, this holds a weak reference to an `AppContext`, so its methods are fallible to protect against cases where the [AppContext] is dropped.
 #[derive(Clone)]
-pub struct AsyncAppContext {
+pub struct AsyncApp {
     pub(crate) app: Weak<AppCell>,
     pub(crate) background_executor: BackgroundExecutor,
     pub(crate) foreground_executor: ForegroundExecutor,
 }
 
-impl AppContext for AsyncAppContext {
+impl AppContext for AsyncApp {
     type Result<T> = Result<T>;
 
     fn new<T: 'static>(
@@ -35,16 +35,16 @@ impl AppContext for AsyncAppContext {
         Ok(app.new(build_model))
     }
 
-    fn reserve_model<T: 'static>(&mut self) -> Result<Reservation<T>> {
+    fn reserve_entity<T: 'static>(&mut self) -> Result<Reservation<T>> {
         let app = self
             .app
             .upgrade()
             .ok_or_else(|| anyhow!("app was released"))?;
         let mut app = app.borrow_mut();
-        Ok(app.reserve_model())
+        Ok(app.reserve_entity())
     }
 
-    fn insert_model<T: 'static>(
+    fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
         build_model: impl FnOnce(&mut Context<'_, T>) -> T,
@@ -54,10 +54,10 @@ impl AppContext for AsyncAppContext {
             .upgrade()
             .ok_or_else(|| anyhow!("app was released"))?;
         let mut app = app.borrow_mut();
-        Ok(app.insert_model(reservation, build_model))
+        Ok(app.insert_entity(reservation, build_model))
     }
 
-    fn update_model<T: 'static, R>(
+    fn update_entity<T: 'static, R>(
         &mut self,
         handle: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
@@ -67,10 +67,10 @@ impl AppContext for AsyncAppContext {
             .upgrade()
             .ok_or_else(|| anyhow!("app was released"))?;
         let mut app = app.borrow_mut();
-        Ok(app.update_model(handle, update))
+        Ok(app.update_entity(handle, update))
     }
 
-    fn read_model<T, R>(
+    fn read_entity<T, R>(
         &self,
         handle: &Entity<T>,
         callback: impl FnOnce(&T, &App) -> R,
@@ -80,7 +80,7 @@ impl AppContext for AsyncAppContext {
     {
         let app = self.app.upgrade().context("app was released")?;
         let lock = app.borrow();
-        Ok(lock.read_model(handle, callback))
+        Ok(lock.read_entity(handle, callback))
     }
 
     fn update_window<T, F>(&mut self, window: AnyWindowHandle, f: F) -> Result<T>
@@ -106,7 +106,7 @@ impl AppContext for AsyncAppContext {
     }
 }
 
-impl AsyncAppContext {
+impl AsyncApp {
     /// Schedules all windows in the application to be redrawn.
     pub fn refresh(&self) -> Result<()> {
         let app = self
@@ -156,7 +156,7 @@ impl AsyncAppContext {
     }
 
     /// Schedule a future to be polled in the background.
-    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncAppContext) -> Fut) -> Task<R>
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncApp) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,
         R: 'static,
@@ -221,12 +221,12 @@ impl AsyncAppContext {
 pub struct AsyncWindowContext {
     #[deref]
     #[deref_mut]
-    app: AsyncAppContext,
+    app: AsyncApp,
     window: AnyWindowHandle,
 }
 
 impl AsyncWindowContext {
-    pub(crate) fn new_context(app: AsyncAppContext, window: AnyWindowHandle) -> Self {
+    pub(crate) fn new_context(app: AsyncApp, window: AnyWindowHandle) -> Self {
         Self { app, window }
     }
 
@@ -317,29 +317,29 @@ impl AppContext for AsyncWindowContext {
         self.window.update(self, |_, _, cx| cx.new(build_model))
     }
 
-    fn reserve_model<T: 'static>(&mut self) -> Result<Reservation<T>> {
-        self.window.update(self, |_, _, cx| cx.reserve_model())
+    fn reserve_entity<T: 'static>(&mut self) -> Result<Reservation<T>> {
+        self.window.update(self, |_, _, cx| cx.reserve_entity())
     }
 
-    fn insert_model<T: 'static>(
+    fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
         build_model: impl FnOnce(&mut Context<'_, T>) -> T,
     ) -> Self::Result<Entity<T>> {
         self.window
-            .update(self, |_, _, cx| cx.insert_model(reservation, build_model))
+            .update(self, |_, _, cx| cx.insert_entity(reservation, build_model))
     }
 
-    fn update_model<T: 'static, R>(
+    fn update_entity<T: 'static, R>(
         &mut self,
         handle: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
     ) -> Result<R> {
         self.window
-            .update(self, |_, _, cx| cx.update_model(handle, update))
+            .update(self, |_, _, cx| cx.update_entity(handle, update))
     }
 
-    fn read_model<T, R>(
+    fn read_entity<T, R>(
         &self,
         handle: &Entity<T>,
         read: impl FnOnce(&T, &App) -> R,
@@ -347,7 +347,7 @@ impl AppContext for AsyncWindowContext {
     where
         T: 'static,
     {
-        self.app.read_model(handle, read)
+        self.app.read_entity(handle, read)
     }
 
     fn update_window<T, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<T>
@@ -374,7 +374,7 @@ impl VisualContext for AsyncWindowContext {
         self.window
     }
 
-    fn new_window_model<T: 'static>(
+    fn new_window_entity<T: 'static>(
         &mut self,
         build_model: impl FnOnce(&mut Window, &mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
@@ -382,7 +382,7 @@ impl VisualContext for AsyncWindowContext {
             .update(self, |_, window, cx| cx.new(|cx| build_model(window, cx)))
     }
 
-    fn update_window_model<T: 'static, R>(
+    fn update_window_entity<T: 'static, R>(
         &mut self,
         view: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Window, &mut Context<T>) -> R,

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -190,7 +190,7 @@ impl AsyncApp {
 
     /// Reads the global state of the specified type, passing it to the given callback.
     ///
-    /// Similar to [`AsyncAppContext::read_global`], but returns an error instead of panicking
+    /// Similar to [`AsyncApp::read_global`], but returns an error instead of panicking
     /// if no state of the specified type has been assigned.
     ///
     /// Returns an error if no state of the specified type has been assigned the `AppContext` has been dropped.

--- a/crates/gpui/src/app/entity_map.rs
+++ b/crates/gpui/src/app/entity_map.rs
@@ -422,7 +422,7 @@ impl<T: 'static> Entity<T> {
         cx: &C,
         f: impl FnOnce(&T, &App) -> R,
     ) -> C::Result<R> {
-        cx.read_model(self, f)
+        cx.read_entity(self, f)
     }
 
     /// Updates the entity referenced by this model with the given function.
@@ -438,7 +438,7 @@ impl<T: 'static> Entity<T> {
     where
         C: AppContext,
     {
-        cx.update_model(self, update)
+        cx.update_entity(self, update)
     }
 
     /// Updates the entity referenced by this model with the given function if
@@ -452,7 +452,7 @@ impl<T: 'static> Entity<T> {
     where
         C: VisualContext,
     {
-        cx.update_window_model(self, update)
+        cx.update_window_entity(self, update)
     }
 }
 
@@ -650,7 +650,7 @@ impl<T: 'static> WeakEntity<T> {
         crate::Flatten::flatten(
             self.upgrade()
                 .ok_or_else(|| anyhow!("entity released"))
-                .map(|this| cx.update_model(&this, update)),
+                .map(|this| cx.update_entity(&this, update)),
         )
     }
 
@@ -685,7 +685,7 @@ impl<T: 'static> WeakEntity<T> {
         crate::Flatten::flatten(
             self.upgrade()
                 .ok_or_else(|| anyhow!("entity release"))
-                .map(|this| cx.read_model(&this, read)),
+                .map(|this| cx.read_entity(&this, read)),
         )
     }
 }

--- a/crates/gpui/src/app/model_context.rs
+++ b/crates/gpui/src/app/model_context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnyView, AnyWindowHandle, App, AppContext, AsyncAppContext, DispatchPhase, Effect, EntityId,
+    AnyView, AnyWindowHandle, App, AppContext, AsyncApp, DispatchPhase, Effect, EntityId,
     EventEmitter, FocusHandle, FocusOutEvent, Focusable, Global, KeystrokeObserver, Reservation,
     SubscriberSet, Subscription, Task, WeakEntity, WeakFocusHandle, Window, WindowHandle,
 };
@@ -183,7 +183,7 @@ impl<'a, T: 'static> Context<'a, T> {
     /// Spawn the future returned by the given function.
     /// The function is provided a weak handle to the model owned by this context and a context that can be held across await points.
     /// The returned task must be held or detached.
-    pub fn spawn<Fut, R>(&self, f: impl FnOnce(WeakEntity<T>, AsyncAppContext) -> Fut) -> Task<R>
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(WeakEntity<T>, AsyncApp) -> Fut) -> Task<R>
     where
         T: 'static,
         Fut: Future<Output = R> + 'static,
@@ -683,27 +683,27 @@ impl<'a, T> AppContext for Context<'a, T> {
         self.app.new(build_model)
     }
 
-    fn reserve_model<U: 'static>(&mut self) -> Reservation<U> {
-        self.app.reserve_model()
+    fn reserve_entity<U: 'static>(&mut self) -> Reservation<U> {
+        self.app.reserve_entity()
     }
 
-    fn insert_model<U: 'static>(
+    fn insert_entity<U: 'static>(
         &mut self,
         reservation: Reservation<U>,
         build_model: impl FnOnce(&mut Context<'_, U>) -> U,
     ) -> Self::Result<Entity<U>> {
-        self.app.insert_model(reservation, build_model)
+        self.app.insert_entity(reservation, build_model)
     }
 
-    fn update_model<U: 'static, R>(
+    fn update_entity<U: 'static, R>(
         &mut self,
         handle: &Entity<U>,
         update: impl FnOnce(&mut U, &mut Context<'_, U>) -> R,
     ) -> R {
-        self.app.update_model(handle, update)
+        self.app.update_entity(handle, update)
     }
 
-    fn read_model<U, R>(
+    fn read_entity<U, R>(
         &self,
         handle: &Entity<U>,
         read: impl FnOnce(&U, &App) -> R,
@@ -711,7 +711,7 @@ impl<'a, T> AppContext for Context<'a, T> {
     where
         U: 'static,
     {
-        self.app.read_model(handle, read)
+        self.app.read_entity(handle, read)
     }
 
     fn update_window<R, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<R>

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -341,7 +341,7 @@ impl TestAppContext {
         lock.update(|cx| cx.update_global(update))
     }
 
-    /// Returns an `AsyncAppContext` which can be used to run tasks that expect to be on a background
+    /// Returns an `AsyncApp` which can be used to run tasks that expect to be on a background
     /// thread on the current thread in tests.
     pub fn to_async(&self) -> AsyncApp {
         AsyncApp {

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Action, AnyView, AnyWindowHandle, App, AppCell, AppContext, AsyncAppContext, AvailableSpace,
+    Action, AnyView, AnyWindowHandle, App, AppCell, AppContext, AsyncApp, AvailableSpace,
     BackgroundExecutor, BorrowAppContext, Bounds, ClipboardItem, DrawPhase, Drawable, Element,
     Empty, EventEmitter, ForegroundExecutor, Global, InputEvent, Keystroke, Modifiers,
     ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
@@ -40,30 +40,30 @@ impl AppContext for TestAppContext {
         app.new(build_model)
     }
 
-    fn reserve_model<T: 'static>(&mut self) -> Self::Result<crate::Reservation<T>> {
+    fn reserve_entity<T: 'static>(&mut self) -> Self::Result<crate::Reservation<T>> {
         let mut app = self.app.borrow_mut();
-        app.reserve_model()
+        app.reserve_entity()
     }
 
-    fn insert_model<T: 'static>(
+    fn insert_entity<T: 'static>(
         &mut self,
         reservation: crate::Reservation<T>,
         build_model: impl FnOnce(&mut Context<'_, T>) -> T,
     ) -> Self::Result<Entity<T>> {
         let mut app = self.app.borrow_mut();
-        app.insert_model(reservation, build_model)
+        app.insert_entity(reservation, build_model)
     }
 
-    fn update_model<T: 'static, R>(
+    fn update_entity<T: 'static, R>(
         &mut self,
         handle: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
     ) -> Self::Result<R> {
         let mut app = self.app.borrow_mut();
-        app.update_model(handle, update)
+        app.update_entity(handle, update)
     }
 
-    fn read_model<T, R>(
+    fn read_entity<T, R>(
         &self,
         handle: &Entity<T>,
         read: impl FnOnce(&T, &App) -> R,
@@ -72,7 +72,7 @@ impl AppContext for TestAppContext {
         T: 'static,
     {
         let app = self.app.borrow();
-        app.read_model(handle, read)
+        app.read_entity(handle, read)
     }
 
     fn update_window<T, F>(&mut self, window: AnyWindowHandle, f: F) -> Result<T>
@@ -302,7 +302,7 @@ impl TestAppContext {
     }
 
     /// Run the given task on the main thread.
-    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncAppContext) -> Fut) -> Task<R>
+    pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncApp) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,
         R: 'static,
@@ -343,8 +343,8 @@ impl TestAppContext {
 
     /// Returns an `AsyncAppContext` which can be used to run tasks that expect to be on a background
     /// thread on the current thread in tests.
-    pub fn to_async(&self) -> AsyncAppContext {
-        AsyncAppContext {
+    pub fn to_async(&self) -> AsyncApp {
+        AsyncApp {
             app: Rc::downgrade(&self.app),
             background_executor: self.background_executor.clone(),
             foreground_executor: self.foreground_executor.clone(),
@@ -855,19 +855,19 @@ impl AppContext for VisualTestContext {
         self.cx.new(build_model)
     }
 
-    fn reserve_model<T: 'static>(&mut self) -> Self::Result<crate::Reservation<T>> {
-        self.cx.reserve_model()
+    fn reserve_entity<T: 'static>(&mut self) -> Self::Result<crate::Reservation<T>> {
+        self.cx.reserve_entity()
     }
 
-    fn insert_model<T: 'static>(
+    fn insert_entity<T: 'static>(
         &mut self,
         reservation: crate::Reservation<T>,
         build_model: impl FnOnce(&mut Context<'_, T>) -> T,
     ) -> Self::Result<Entity<T>> {
-        self.cx.insert_model(reservation, build_model)
+        self.cx.insert_entity(reservation, build_model)
     }
 
-    fn update_model<T, R>(
+    fn update_entity<T, R>(
         &mut self,
         handle: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
@@ -875,10 +875,10 @@ impl AppContext for VisualTestContext {
     where
         T: 'static,
     {
-        self.cx.update_model(handle, update)
+        self.cx.update_entity(handle, update)
     }
 
-    fn read_model<T, R>(
+    fn read_entity<T, R>(
         &self,
         handle: &Entity<T>,
         read: impl FnOnce(&T, &App) -> R,
@@ -886,7 +886,7 @@ impl AppContext for VisualTestContext {
     where
         T: 'static,
     {
-        self.cx.read_model(handle, read)
+        self.cx.read_entity(handle, read)
     }
 
     fn update_window<T, F>(&mut self, window: AnyWindowHandle, f: F) -> Result<T>
@@ -914,7 +914,7 @@ impl VisualContext for VisualTestContext {
         self.window
     }
 
-    fn new_window_model<T: 'static>(
+    fn new_window_entity<T: 'static>(
         &mut self,
         build_model: impl FnOnce(&mut Window, &mut Context<'_, T>) -> T,
     ) -> Self::Result<Entity<T>> {
@@ -925,7 +925,7 @@ impl VisualContext for VisualTestContext {
             .unwrap()
     }
 
-    fn update_window_model<V: 'static, R>(
+    fn update_window_entity<V: 'static, R>(
         &mut self,
         view: &Entity<V>,
         update: impl FnOnce(&mut V, &mut Window, &mut Context<V>) -> R,

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -171,19 +171,19 @@ pub trait AppContext {
 
     /// Reserve a slot for a model to be inserted later.
     /// The returned [Reservation] allows you to obtain the [EntityId] for the future model.
-    fn reserve_model<T: 'static>(&mut self) -> Self::Result<Reservation<T>>;
+    fn reserve_entity<T: 'static>(&mut self) -> Self::Result<Reservation<T>>;
 
-    /// Insert a new model in the app context based on a [Reservation] previously obtained from [`reserve_model`].
+    /// Insert a new model in the app context based on a [Reservation] previously obtained from [`reserve_entity`].
     ///
-    /// [`reserve_model`]: Self::reserve_model
-    fn insert_model<T: 'static>(
+    /// [`reserve_entity`]: Self::reserve_entity
+    fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
         build_model: impl FnOnce(&mut Context<'_, T>) -> T,
     ) -> Self::Result<Entity<T>>;
 
     /// Update a model in the app context.
-    fn update_model<T, R>(
+    fn update_entity<T, R>(
         &mut self,
         handle: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
@@ -192,7 +192,7 @@ pub trait AppContext {
         T: 'static;
 
     /// Read a model from the app context.
-    fn read_model<T, R>(
+    fn read_entity<T, R>(
         &self,
         handle: &Entity<T>,
         read: impl FnOnce(&T, &App) -> R,
@@ -215,7 +215,7 @@ pub trait AppContext {
         T: 'static;
 }
 
-/// Returned by [Context::reserve_model] to later be passed to [Context::insert_model].
+/// Returned by [Context::reserve_entity] to later be passed to [Context::insert_model].
 /// Allows you to obtain the [EntityId] for a model before it is created.
 pub struct Reservation<T>(pub(crate) Slot<T>);
 
@@ -233,14 +233,14 @@ pub trait VisualContext: AppContext {
     fn window_handle(&self) -> AnyWindowHandle;
 
     /// Update a view with the given callback
-    fn update_window_model<T: 'static, R>(
+    fn update_window_entity<T: 'static, R>(
         &mut self,
         model: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Window, &mut Context<T>) -> R,
     ) -> Self::Result<R>;
 
     /// Update a view with the given callback
-    fn new_window_model<T: 'static>(
+    fn new_window_entity<T: 'static>(
         &mut self,
         build_model: impl FnOnce(&mut Window, &mut Context<'_, T>) -> T,
     ) -> Self::Result<Entity<T>>;

--- a/crates/gpui/src/input.rs
+++ b/crates/gpui/src/input.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 /// This input handler can then be assigned during paint by calling [`WindowContext::handle_input`].
 ///
 /// See [`InputHandler`] for details on how to implement each method.
-pub trait ViewInputHandler: 'static + Sized {
+pub trait EntityInputHandler: 'static + Sized {
     /// See [`InputHandler::text_for_range`] for details
     fn text_for_range(
         &mut self,
@@ -84,7 +84,7 @@ impl<V: 'static> ElementInputHandler<V> {
     }
 }
 
-impl<V: ViewInputHandler> InputHandler for ElementInputHandler<V> {
+impl<V: EntityInputHandler> InputHandler for ElementInputHandler<V> {
     fn selected_text_range(
         &mut self,
         ignore_disabled_input: bool,

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -9,12 +9,12 @@
 /// actions!(editor,[Undo, Redo]);;
 ///
 /// impl Editor {
-///   fn undo(&mut self, _: &Undo, _window: &mut Window, _cx: &mut ModelContext<Self>) { ... }
-///   fn redo(&mut self, _: &Redo, _window: &mut Window, _cx: &mut ModelContext<Self>) { ... }
+///   fn undo(&mut self, _: &Undo, _window: &mut Window, _cx: &mut Context<Self>) { ... }
+///   fn redo(&mut self, _: &Redo, _window: &mut Window, _cx: &mut Context<Self>) { ... }
 /// }
 ///
 /// impl Render for Editor {
-///   fn render(&mut self, window: &mut Window, cx: &mut ModelContext<Self>) -> impl IntoElement {
+///   fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 ///     div()
 ///       .track_focus(&self.focus_handle(cx))
 ///       .keymap_context("Editor")

--- a/crates/gpui_macros/Cargo.toml
+++ b/crates/gpui_macros/Cargo.toml
@@ -17,3 +17,6 @@ doctest = false
 proc-macro2 = "1.0.66"
 quote = "1.0.9"
 syn = { version = "1.0.72", features = ["full", "extra-traits"] }
+
+[dev-dependencies]
+gpui.workspace = true

--- a/crates/gpui_macros/src/derive_render.rs
+++ b/crates/gpui_macros/src/derive_render.rs
@@ -11,7 +11,7 @@ pub fn derive_render(input: TokenStream) -> TokenStream {
         impl #impl_generics gpui::Render for #type_name #type_generics
         #where_clause
         {
-            fn render(&mut self, _window: &mut Window, _cx: &mut ModelContext<Self>) -> impl gpui::Element {
+            fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl gpui::Element {
                 gpui::Empty
             }
         }

--- a/crates/gpui_macros/src/derive_render.rs
+++ b/crates/gpui_macros/src/derive_render.rs
@@ -11,7 +11,7 @@ pub fn derive_render(input: TokenStream) -> TokenStream {
         impl #impl_generics gpui::Render for #type_name #type_generics
         #where_clause
         {
-            fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl gpui::Element {
+            fn render(&mut self, _window: &mut gpui::Window, _cx: &mut gpui::Context<Self>) -> impl gpui::Element {
                 gpui::Empty
             }
         }

--- a/crates/gpui_macros/tests/render_test.rs
+++ b/crates/gpui_macros/tests/render_test.rs
@@ -1,0 +1,7 @@
+#[test]
+fn test_derive_render() {
+    use gpui_macros::Render;
+
+    #[derive(Render)]
+    struct _Element;
+}

--- a/crates/install_cli/src/install_cli.rs
+++ b/crates/install_cli/src/install_cli.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, Result};
-use gpui::{actions, AsyncAppContext};
+use gpui::{actions, AsyncApp};
 use std::path::{Path, PathBuf};
 use util::ResultExt;
 
 actions!(cli, [Install, RegisterZedScheme]);
 
-pub async fn install_cli(cx: &AsyncAppContext) -> Result<PathBuf> {
+pub async fn install_cli(cx: &AsyncApp) -> Result<PathBuf> {
     let cli_path = cx.update(|cx| cx.path_for_auxiliary_executable("cli"))??;
     let link_path = Path::new("/usr/local/bin/zed");
     let bin_dir_path = link_path.parent().unwrap();

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -928,7 +928,7 @@ impl Buffer {
         language_registry: Option<Arc<LanguageRegistry>>,
         cx: &mut App,
     ) -> impl Future<Output = BufferSnapshot> {
-        let entity_id = cx.reserve_model::<Self>().entity_id();
+        let entity_id = cx.reserve_entity::<Self>().entity_id();
         let buffer_id = entity_id.as_non_zero_u64().into();
         async move {
             let text =

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use collections::{HashMap, HashSet};
 use fs::Fs;
 use futures::Future;
-use gpui::{App, AsyncAppContext, Entity, SharedString, Task};
+use gpui::{App, AsyncApp, Entity, SharedString, Task};
 pub use highlight_map::HighlightMap;
 use http_client::HttpClient;
 pub use language_registry::{LanguageName, LoadedLanguage};
@@ -211,7 +211,7 @@ impl CachedLspAdapter {
         delegate: Arc<dyn LspAdapterDelegate>,
         toolchains: Arc<dyn LanguageToolchainStore>,
         binary_options: LanguageServerBinaryOptions,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<LanguageServerBinary> {
         let cached_binary = self.cached_binary.lock().await;
         self.adapter
@@ -293,7 +293,7 @@ pub trait LspAdapter: 'static + Send + Sync {
         toolchains: Arc<dyn LanguageToolchainStore>,
         binary_options: LanguageServerBinaryOptions,
         mut cached_binary: futures::lock::MutexGuard<'a, Option<LanguageServerBinary>>,
-        cx: &'a mut AsyncAppContext,
+        cx: &'a mut AsyncApp,
     ) -> Pin<Box<dyn 'a + Future<Output = Result<LanguageServerBinary>>>> {
         async move {
             // First we check whether the adapter can give us a user-installed binary.
@@ -368,7 +368,7 @@ pub trait LspAdapter: 'static + Send + Sync {
         &self,
         _: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         None
     }
@@ -381,7 +381,7 @@ pub trait LspAdapter: 'static + Send + Sync {
     fn will_fetch_server(
         &self,
         _: &Arc<dyn LspAdapterDelegate>,
-        _: &mut AsyncAppContext,
+        _: &mut AsyncApp,
     ) -> Option<Task<Result<()>>> {
         None
     }
@@ -476,7 +476,7 @@ pub trait LspAdapter: 'static + Send + Sync {
         _: &dyn Fs,
         _: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        _cx: &mut AsyncAppContext,
+        _cx: &mut AsyncApp,
     ) -> Result<Value> {
         Ok(serde_json::json!({}))
     }
@@ -514,7 +514,7 @@ async fn try_fetch_server_binary<L: LspAdapter + 'static + Send + Sync + ?Sized>
     adapter: &L,
     delegate: &Arc<dyn LspAdapterDelegate>,
     container_dir: PathBuf,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<LanguageServerBinary> {
     if let Some(task) = adapter.will_fetch_server(delegate, cx) {
         task.await?;
@@ -1805,7 +1805,7 @@ impl LspAdapter for FakeLspAdapter {
         &self,
         _: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         Some(self.language_server_binary.clone())
     }
@@ -1816,7 +1816,7 @@ impl LspAdapter for FakeLspAdapter {
         _: Arc<dyn LanguageToolchainStore>,
         _: LanguageServerBinaryOptions,
         _: futures::lock::MutexGuard<'a, Option<LanguageServerBinary>>,
-        _: &'a mut AsyncAppContext,
+        _: &'a mut AsyncApp,
     ) -> Pin<Box<dyn 'a + Future<Output = Result<LanguageServerBinary>>>> {
         async move { Ok(self.language_server_binary.clone()) }.boxed_local()
     }

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -904,7 +904,7 @@ impl LanguageRegistry {
         server_id: LanguageServerId,
         name: &LanguageServerName,
         binary: lsp::LanguageServerBinary,
-        cx: gpui::AsyncAppContext,
+        cx: gpui::AsyncApp,
     ) -> Option<lsp::LanguageServer> {
         let mut state = self.state.write();
         let fake_entry = state.fake_server_entries.get_mut(&name)?;

--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -8,7 +8,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
 use collections::HashMap;
-use gpui::{AsyncAppContext, SharedString};
+use gpui::{AsyncApp, SharedString};
 use settings::WorktreeId;
 
 use crate::LanguageName;
@@ -53,7 +53,7 @@ pub trait LanguageToolchainStore {
         self: Arc<Self>,
         worktree_id: WorktreeId,
         language_name: LanguageName,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Option<Toolchain>;
 }
 

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -10,7 +10,7 @@ use collections::HashMap;
 use extension::{Extension, ExtensionLanguageServerProxy, WorktreeDelegate};
 use fs::Fs;
 use futures::{Future, FutureExt};
-use gpui::AsyncAppContext;
+use gpui::AsyncApp;
 use language::{
     CodeLabel, HighlightId, Language, LanguageName, LanguageServerBinaryStatus,
     LanguageToolchainStore, LspAdapter, LspAdapterDelegate,
@@ -119,7 +119,7 @@ impl LspAdapter for ExtensionLspAdapter {
         _: Arc<dyn LanguageToolchainStore>,
         _: LanguageServerBinaryOptions,
         _: futures::lock::MutexGuard<'a, Option<LanguageServerBinary>>,
-        _: &'a mut AsyncAppContext,
+        _: &'a mut AsyncApp,
     ) -> Pin<Box<dyn 'a + Future<Output = Result<LanguageServerBinary>>>> {
         async move {
             let delegate = Arc::new(WorktreeDelegateAdapter(delegate.clone())) as _;
@@ -251,7 +251,7 @@ impl LspAdapter for ExtensionLspAdapter {
         _: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        _cx: &mut AsyncAppContext,
+        _cx: &mut AsyncApp,
     ) -> Result<Value> {
         let delegate = Arc::new(WorktreeDelegateAdapter(delegate.clone())) as _;
         let json_options: Option<String> = self

--- a/crates/language_model/src/fake_provider.rs
+++ b/crates/language_model/src/fake_provider.rs
@@ -4,7 +4,7 @@ use crate::{
     LanguageModelProviderState, LanguageModelRequest,
 };
 use futures::{channel::mpsc, future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
-use gpui::{AnyView, App, AsyncAppContext, Entity, Task, Window};
+use gpui::{AnyView, App, AsyncApp, Entity, Task, Window};
 use http_client::Result;
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -164,7 +164,7 @@ impl LanguageModel for FakeLanguageModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<LanguageModelCompletionEvent>>>> {
         let (tx, rx) = mpsc::unbounded();
         self.current_completion_txs.lock().push((request, tx));
@@ -182,7 +182,7 @@ impl LanguageModel for FakeLanguageModel {
         name: String,
         description: String,
         schema: serde_json::Value,
-        _cx: &AsyncAppContext,
+        _cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
         let (tx, rx) = mpsc::unbounded();
         let tool_call = ToolUseRequest {

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -10,7 +10,7 @@ pub mod fake_provider;
 use anyhow::Result;
 use futures::FutureExt;
 use futures::{future::BoxFuture, stream::BoxStream, StreamExt, TryStreamExt as _};
-use gpui::{AnyElement, AnyView, App, AsyncAppContext, SharedString, Task, Window};
+use gpui::{AnyElement, AnyView, App, AsyncApp, SharedString, Task, Window};
 pub use model::*;
 use proto::Plan;
 pub use rate_limiter::*;
@@ -136,13 +136,13 @@ pub trait LanguageModel: Send + Sync {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<LanguageModelCompletionEvent>>>>;
 
     fn stream_completion_text(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<LanguageModelTextStream>> {
         let events = self.stream_completion(request, cx);
 
@@ -186,7 +186,7 @@ pub trait LanguageModel: Send + Sync {
         name: String,
         description: String,
         schema: serde_json::Value,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>>;
 
     fn cache_configuration(&self) -> Option<LanguageModelCacheConfiguration> {
@@ -203,7 +203,7 @@ impl dyn LanguageModel {
     pub fn use_tool<T: LanguageModelTool>(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> impl 'static + Future<Output = Result<T>> {
         let schema = schemars::schema_for!(T);
         let schema_json = serde_json::to_value(&schema).unwrap();
@@ -218,7 +218,7 @@ impl dyn LanguageModel {
     pub fn use_tool_stream<T: LanguageModelTool>(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
         let schema = schemars::schema_for!(T);
         let schema_json = serde_json::to_value(&schema).unwrap();

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -6,8 +6,7 @@ use editor::{Editor, EditorElement, EditorStyle};
 use futures::Stream;
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt, TryStreamExt as _};
 use gpui::{
-    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle,
-    WhiteSpace,
+    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle, WhiteSpace,
 };
 use http_client::HttpClient;
 use language_model::{

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -6,7 +6,7 @@ use editor::{Editor, EditorElement, EditorStyle};
 use futures::Stream;
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt, TryStreamExt as _};
 use gpui::{
-    AnyView, App, AsyncAppContext, Context, Entity, FontStyle, Subscription, Task, TextStyle,
+    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle,
     WhiteSpace,
 };
 use http_client::HttpClient;
@@ -307,12 +307,12 @@ impl AnthropicModel {
     fn stream_completion(
         &self,
         request: anthropic::Request,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<anthropic::Event, AnthropicError>>>>
     {
         let http_client = self.http_client.clone();
 
-        let Ok((api_key, api_url)) = cx.read_model(&self.state, |state, cx| {
+        let Ok((api_key, api_url)) = cx.read_entity(&self.state, |state, cx| {
             let settings = &AllLanguageModelSettings::get_global(cx).anthropic;
             (state.api_key.clone(), settings.api_url.clone())
         }) else {
@@ -373,7 +373,7 @@ impl LanguageModel for AnthropicModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<LanguageModelCompletionEvent>>>> {
         let request = request.into_anthropic(
             self.model.id().into(),
@@ -404,7 +404,7 @@ impl LanguageModel for AnthropicModel {
         tool_name: String,
         tool_description: String,
         input_schema: serde_json::Value,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
         let mut request = request.into_anthropic(
             self.model.tool_model_id().into(),

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -12,7 +12,7 @@ use futures::{
     TryStreamExt as _,
 };
 use gpui::{
-    AnyElement, AnyView, App, AsyncAppContext, Context, Entity, EventEmitter, Global, ReadGlobal,
+    AnyElement, AnyView, App, AsyncApp, Context, Entity, EventEmitter, Global, ReadGlobal,
     Subscription, Task,
 };
 use http_client::{AsyncBody, HttpClient, Method, Response, StatusCode};
@@ -131,7 +131,7 @@ impl RefreshLlmTokenListener {
     async fn handle_refresh_llm_token(
         this: Entity<Self>,
         _: TypedEnvelope<proto::RefreshLlmToken>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |_this, cx| cx.emit(RefreshLlmTokenEvent))
     }
@@ -621,7 +621,7 @@ impl LanguageModel for CloudLanguageModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        _cx: &AsyncAppContext,
+        _cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<LanguageModelCompletionEvent>>>> {
         match &self.model {
             CloudModel::Anthropic(model) => {
@@ -716,7 +716,7 @@ impl LanguageModel for CloudLanguageModel {
         tool_name: String,
         tool_description: String,
         input_schema: serde_json::Value,
-        _cx: &AsyncAppContext,
+        _cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
         let client = self.client.clone();
         let llm_api_token = self.llm_api_token.clone();

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -11,8 +11,8 @@ use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt};
 use gpui::{
-    percentage, svg, Animation, AnimationExt, AnyView, App, AsyncApp, Entity, Render,
-    Subscription, Task, Transformation,
+    percentage, svg, Animation, AnimationExt, AnyView, App, AsyncApp, Entity, Render, Subscription,
+    Task, Transformation,
 };
 use language_model::{
     LanguageModel, LanguageModelCompletionEvent, LanguageModelId, LanguageModelName,

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -11,7 +11,7 @@ use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt};
 use gpui::{
-    percentage, svg, Animation, AnimationExt, AnyView, App, AsyncAppContext, Entity, Render,
+    percentage, svg, Animation, AnimationExt, AnyView, App, AsyncApp, Entity, Render,
     Subscription, Task, Transformation,
 };
 use language_model::{
@@ -190,7 +190,7 @@ impl LanguageModel for CopilotChatLanguageModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<LanguageModelCompletionEvent>>>> {
         if let Some(message) = request.messages.last() {
             if message.contents_empty() {
@@ -266,7 +266,7 @@ impl LanguageModel for CopilotChatLanguageModel {
         _name: String,
         _description: String,
         _schema: serde_json::Value,
-        _cx: &AsyncAppContext,
+        _cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
         future::ready(Err(anyhow!("not implemented"))).boxed()
     }

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -4,8 +4,7 @@ use editor::{Editor, EditorElement, EditorStyle};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use google_ai::stream_generate_content;
 use gpui::{
-    AnyView, App, AsyncAppContext, Context, Entity, FontStyle, Subscription, Task, TextStyle,
-    WhiteSpace,
+    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle, WhiteSpace,
 };
 use http_client::HttpClient;
 use language_model::LanguageModelCompletionEvent;
@@ -282,7 +281,7 @@ impl LanguageModel for GoogleLanguageModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
         Result<futures::stream::BoxStream<'static, Result<LanguageModelCompletionEvent>>>,
@@ -290,7 +289,7 @@ impl LanguageModel for GoogleLanguageModel {
         let request = request.into_google(self.model.id().to_string());
 
         let http_client = self.http_client.clone();
-        let Ok((api_key, api_url)) = cx.read_model(&self.state, |state, cx| {
+        let Ok((api_key, api_url)) = cx.read_entity(&self.state, |state, cx| {
             let settings = &AllLanguageModelSettings::get_global(cx).google;
             (state.api_key.clone(), settings.api_url.clone())
         }) else {
@@ -319,7 +318,7 @@ impl LanguageModel for GoogleLanguageModel {
         _name: String,
         _description: String,
         _schema: serde_json::Value,
-        _cx: &AsyncAppContext,
+        _cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<String>>>> {
         future::ready(Err(anyhow!("not implemented"))).boxed()
     }

--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
-use gpui::{AnyView, App, AsyncAppContext, Context, Subscription, Task};
+use gpui::{AnyView, App, AsyncApp, Context, Subscription, Task};
 use http_client::HttpClient;
 use language_model::LanguageModelCompletionEvent;
 use language_model::{
@@ -295,7 +295,7 @@ impl LanguageModel for LmStudioLanguageModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<LanguageModelCompletionEvent>>>> {
         let request = self.to_lmstudio_request(request);
 
@@ -362,7 +362,7 @@ impl LanguageModel for LmStudioLanguageModel {
         _tool_name: String,
         _tool_description: String,
         _schema: serde_json::Value,
-        _cx: &AsyncAppContext,
+        _cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
         async move { Ok(futures::stream::empty().boxed()) }.boxed()
     }

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Result};
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
-use gpui::{AnyView, App, AsyncAppContext, Context, Subscription, Task};
+use gpui::{AnyView, App, AsyncApp, Context, Subscription, Task};
 use http_client::HttpClient;
 use language_model::LanguageModelCompletionEvent;
 use language_model::{
@@ -263,7 +263,7 @@ impl OllamaLanguageModel {
     fn request_completion(
         &self,
         request: ChatRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<ChatResponseDelta>> {
         let http_client = self.http_client.clone();
 
@@ -323,7 +323,7 @@ impl LanguageModel for OllamaLanguageModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<LanguageModelCompletionEvent>>>> {
         let request = self.to_ollama_request(request);
 
@@ -370,7 +370,7 @@ impl LanguageModel for OllamaLanguageModel {
         tool_name: String,
         tool_description: String,
         schema: serde_json::Value,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
         use ollama::{OllamaFunctionTool, OllamaTool};
         let function = OllamaFunctionTool {

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -3,8 +3,7 @@ use collections::BTreeMap;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use gpui::{
-    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle,
-    WhiteSpace,
+    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle, WhiteSpace,
 };
 use http_client::HttpClient;
 use language_model::{

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -3,7 +3,7 @@ use collections::BTreeMap;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use gpui::{
-    AnyView, App, AsyncAppContext, Context, Entity, FontStyle, Subscription, Task, TextStyle,
+    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle,
     WhiteSpace,
 };
 use http_client::HttpClient;
@@ -224,11 +224,11 @@ impl OpenAiLanguageModel {
     fn stream_completion(
         &self,
         request: open_ai::Request,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<ResponseStreamEvent>>>>
     {
         let http_client = self.http_client.clone();
-        let Ok((api_key, api_url)) = cx.read_model(&self.state, |state, cx| {
+        let Ok((api_key, api_url)) = cx.read_entity(&self.state, |state, cx| {
             let settings = &AllLanguageModelSettings::get_global(cx).openai;
             (state.api_key.clone(), settings.api_url.clone())
         }) else {
@@ -286,7 +286,7 @@ impl LanguageModel for OpenAiLanguageModel {
     fn stream_completion(
         &self,
         request: LanguageModelRequest,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
         Result<futures::stream::BoxStream<'static, Result<LanguageModelCompletionEvent>>>,
@@ -307,7 +307,7 @@ impl LanguageModel for OpenAiLanguageModel {
         tool_name: String,
         tool_description: String,
         schema: serde_json::Value,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<String>>>> {
         let mut request = request.into_open_ai(self.model.id().into(), self.max_output_tokens());
         request.tool_choice = Some(ToolChoice::Other(ToolDefinition::Function {

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use futures::StreamExt;
-use gpui::AsyncAppContext;
+use gpui::AsyncApp;
 use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 pub use language::*;
 use lsp::{InitializeParams, LanguageServerBinary, LanguageServerName};
@@ -26,7 +26,7 @@ impl super::LspAdapter for CLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
         Some(LanguageServerBinary {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
-use gpui::{App, AsyncAppContext, Task};
+use gpui::{App, AsyncApp, Task};
 use http_client::github::latest_github_release;
 pub use language::*;
 use lsp::{LanguageServerBinary, LanguageServerName};
@@ -76,7 +76,7 @@ impl super::LspAdapter for GoLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
         Some(LanguageServerBinary {
@@ -89,7 +89,7 @@ impl super::LspAdapter for GoLspAdapter {
     fn will_fetch_server(
         &self,
         delegate: &Arc<dyn LspAdapterDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Option<Task<Result<()>>> {
         static DID_SHOW_NOTIFICATION: AtomicBool = AtomicBool::new(false);
 

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -4,7 +4,7 @@ use async_tar::Archive;
 use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
-use gpui::{App, AsyncAppContext};
+use gpui::{App, AsyncApp};
 use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 use language::{LanguageRegistry, LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
 use lsp::{LanguageServerBinary, LanguageServerName};
@@ -221,7 +221,7 @@ impl LspAdapter for JsonLspAdapter {
         _: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let mut config = cx.update(|cx| {
             self.workspace_config

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use collections::HashMap;
 use gpui::{App, Task};
-use gpui::{AsyncAppContext, SharedString};
+use gpui::{AsyncApp, SharedString};
 use language::language_settings::language_settings;
 use language::LanguageName;
 use language::LanguageToolchainStore;
@@ -81,7 +81,7 @@ impl LspAdapter for PythonLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         let node = delegate.which("node".as_ref()).await?;
         let (node_modules_path, _) = delegate
@@ -254,7 +254,7 @@ impl LspAdapter for PythonLspAdapter {
         _: &dyn Fs,
         adapter: &Arc<dyn LspAdapterDelegate>,
         toolchains: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let toolchain = toolchains
             .active_toolchain(adapter.worktree_id(), LanguageName::new("Python"), cx)
@@ -789,7 +789,7 @@ impl LspAdapter for PyLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
         toolchains: Arc<dyn LanguageToolchainStore>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         let venv = toolchains
             .active_toolchain(
@@ -936,7 +936,7 @@ impl LspAdapter for PyLspAdapter {
         _: &dyn Fs,
         adapter: &Arc<dyn LspAdapterDelegate>,
         toolchains: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let toolchain = toolchains
             .active_toolchain(adapter.worktree_id(), LanguageName::new("Python"), cx)

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -3,7 +3,7 @@ use async_compression::futures::bufread::GzipDecoder;
 use async_trait::async_trait;
 use collections::HashMap;
 use futures::{io::BufReader, StreamExt};
-use gpui::{App, AsyncAppContext, Task};
+use gpui::{App, AsyncApp, Task};
 use http_client::github::AssetKind;
 use http_client::github::{latest_github_release, GitHubLspBinaryVersion};
 pub use language::*;
@@ -78,7 +78,7 @@ impl LspAdapter for RustLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         let path = delegate.which("rust-analyzer".as_ref()).await?;
         let env = delegate.shell_env().await;

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
-use gpui::AsyncAppContext;
+use gpui::AsyncApp;
 use language::{LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
 use lsp::{LanguageServerBinary, LanguageServerName};
 use node_runtime::NodeRuntime;
@@ -135,7 +135,7 @@ impl LspAdapter for TailwindLspAdapter {
         _: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let mut tailwind_user_settings = cx.update(|cx| {
             language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -3,7 +3,7 @@ use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
 use async_trait::async_trait;
 use collections::HashMap;
-use gpui::AsyncAppContext;
+use gpui::AsyncApp;
 use http_client::github::{build_asset_url, AssetKind, GitHubLspBinaryVersion};
 use language::{LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
@@ -270,7 +270,7 @@ impl LspAdapter for TypeScriptLspAdapter {
         _: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let override_options = cx.update(|cx| {
             language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
@@ -367,7 +367,7 @@ impl LspAdapter for EsLintLspAdapter {
         _: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let workspace_root = delegate.worktree_root_path();
 

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use collections::HashMap;
-use gpui::AsyncAppContext;
+use gpui::AsyncApp;
 use language::{LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
 use node_runtime::NodeRuntime;
@@ -87,7 +87,7 @@ impl LspAdapter for VtslsLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         let env = delegate.shell_env().await;
         let path = delegate.which(SERVER_NAME.as_ref()).await?;
@@ -208,7 +208,7 @@ impl LspAdapter for VtslsLspAdapter {
         fs: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let tsdk_path = Self::tsdk_path(fs, delegate).await;
         let config = serde_json::json!({

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::StreamExt;
-use gpui::AsyncAppContext;
+use gpui::AsyncApp;
 use language::{
     language_settings::AllLanguageSettings, LanguageToolchainStore, LspAdapter, LspAdapterDelegate,
 };
@@ -58,7 +58,7 @@ impl LspAdapter for YamlLspAdapter {
         &self,
         delegate: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         let path = delegate.which(Self::SERVER_NAME.as_ref()).await?;
         let env = delegate.shell_env().await;
@@ -131,7 +131,7 @@ impl LspAdapter for YamlLspAdapter {
         _: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Value> {
         let location = SettingsLocation {
             worktree_id: delegate.worktree_id(),

--- a/crates/livekit_client/examples/test_app.rs
+++ b/crates/livekit_client/examples/test_app.rs
@@ -6,7 +6,7 @@
 use gpui::{
     actions, bounds, div, point,
     prelude::{FluentBuilder as _, IntoElement},
-    px, rgb, size, AppContext as _, AsyncAppContext, Bounds, Context, Entity, InteractiveElement,
+    px, rgb, size, AppContext as _, AsyncApp, Bounds, Context, Entity, InteractiveElement,
     KeyBinding, Menu, MenuItem, ParentElement, Pixels, Render, ScreenCaptureStream, SharedString,
     StatefulInteractiveElement as _, Styled, Task, Window, WindowBounds, WindowHandle,
     WindowOptions,
@@ -127,7 +127,7 @@ impl LivekitWindow {
         url: &str,
         token: &str,
         bounds: Bounds<Pixels>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> WindowHandle<Self> {
         let (room, mut events) = Room::connect(url, token, RoomOptions::default())
             .await

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -6,7 +6,7 @@ pub use lsp_types::*;
 use anyhow::{anyhow, Context as _, Result};
 use collections::HashMap;
 use futures::{channel::oneshot, io::BufWriter, select, AsyncRead, AsyncWrite, Future, FutureExt};
-use gpui::{App, AsyncAppContext, BackgroundExecutor, SharedString, Task};
+use gpui::{App, AsyncApp, BackgroundExecutor, SharedString, Task};
 use parking_lot::{Mutex, RwLock};
 use postage::{barrier, prelude::Stream};
 use schemars::{
@@ -45,7 +45,7 @@ const CONTENT_LEN_HEADER: &str = "Content-Length: ";
 const LSP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60 * 2);
 const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
-type NotificationHandler = Box<dyn Send + FnMut(Option<RequestId>, Value, AsyncAppContext)>;
+type NotificationHandler = Box<dyn Send + FnMut(Option<RequestId>, Value, AsyncApp)>;
 type ResponseHandler = Box<dyn Send + FnOnce(Result<String, Error>)>;
 type IoHandler = Box<dyn Send + FnMut(IoKind, &str)>;
 
@@ -334,7 +334,7 @@ impl LanguageServer {
         binary: LanguageServerBinary,
         root_path: &Path,
         code_action_kinds: Option<Vec<CodeActionKind>>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Self> {
         let working_dir = if root_path.is_dir() {
             root_path
@@ -407,7 +407,7 @@ impl LanguageServer {
         working_dir: &Path,
         code_action_kinds: Option<Vec<CodeActionKind>>,
         binary: LanguageServerBinary,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
         on_unhandled_notification: F,
     ) -> Self
     where
@@ -505,7 +505,7 @@ impl LanguageServer {
         notification_handlers: Arc<Mutex<HashMap<&'static str, NotificationHandler>>>,
         response_handlers: Arc<Mutex<Option<HashMap<RequestId, ResponseHandler>>>>,
         io_handlers: Arc<Mutex<HashMap<i32, IoHandler>>>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> anyhow::Result<()>
     where
         Stdout: AsyncRead + Unpin + Send + 'static,
@@ -890,7 +890,7 @@ impl LanguageServer {
     pub fn on_notification<T, F>(&self, f: F) -> Subscription
     where
         T: notification::Notification,
-        F: 'static + Send + FnMut(T::Params, AsyncAppContext),
+        F: 'static + Send + FnMut(T::Params, AsyncApp),
     {
         self.on_custom_notification(T::METHOD, f)
     }
@@ -903,7 +903,7 @@ impl LanguageServer {
     where
         T: request::Request,
         T::Params: 'static + Send,
-        F: 'static + FnMut(T::Params, AsyncAppContext) -> Fut + Send,
+        F: 'static + FnMut(T::Params, AsyncApp) -> Fut + Send,
         Fut: 'static + Future<Output = Result<T::Result>>,
     {
         self.on_custom_request(T::METHOD, f)
@@ -941,7 +941,7 @@ impl LanguageServer {
     #[must_use]
     fn on_custom_notification<Params, F>(&self, method: &'static str, mut f: F) -> Subscription
     where
-        F: 'static + FnMut(Params, AsyncAppContext) + Send,
+        F: 'static + FnMut(Params, AsyncApp) + Send,
         Params: DeserializeOwned,
     {
         let prev_handler = self.notification_handlers.lock().insert(
@@ -965,7 +965,7 @@ impl LanguageServer {
     #[must_use]
     fn on_custom_request<Params, Res, Fut, F>(&self, method: &'static str, mut f: F) -> Subscription
     where
-        F: 'static + FnMut(Params, AsyncAppContext) -> Fut + Send,
+        F: 'static + FnMut(Params, AsyncApp) -> Fut + Send,
         Fut: 'static + Future<Output = Result<Res>>,
         Params: DeserializeOwned + Send + 'static,
         Res: Serialize,
@@ -1282,7 +1282,7 @@ impl FakeLanguageServer {
         binary: LanguageServerBinary,
         name: String,
         capabilities: ServerCapabilities,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> (LanguageServer, FakeLanguageServer) {
         let (stdin_writer, stdin_reader) = async_pipe::pipe();
         let (stdout_writer, stdout_reader) = async_pipe::pipe();
@@ -1430,7 +1430,7 @@ impl FakeLanguageServer {
     where
         T: 'static + request::Request,
         T::Params: 'static + Send,
-        F: 'static + Send + FnMut(T::Params, gpui::AsyncAppContext) -> Fut,
+        F: 'static + Send + FnMut(T::Params, gpui::AsyncApp) -> Fut,
         Fut: 'static + Send + Future<Output = Result<T::Result>>,
     {
         let (responded_tx, responded_rx) = futures::channel::mpsc::unbounded();
@@ -1459,7 +1459,7 @@ impl FakeLanguageServer {
     where
         T: 'static + notification::Notification,
         T::Params: 'static + Send,
-        F: 'static + Send + FnMut(T::Params, gpui::AsyncAppContext),
+        F: 'static + Send + FnMut(T::Params, gpui::AsyncApp),
     {
         let (handled_tx, handled_rx) = futures::channel::mpsc::unbounded();
         self.server.remove_notification_handler::<T>();

--- a/crates/notifications/src/notification_store.rs
+++ b/crates/notifications/src/notification_store.rs
@@ -3,7 +3,7 @@ use channel::{ChannelMessage, ChannelMessageId, ChannelStore};
 use client::{ChannelId, Client, UserStore};
 use collections::HashMap;
 use db::smol::stream::StreamExt;
-use gpui::{App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Global, Task};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Global, Task};
 use rpc::{proto, Notification, TypedEnvelope};
 use std::{ops::Range, sync::Arc};
 use sum_tree::{Bias, SumTree};
@@ -199,7 +199,7 @@ impl NotificationStore {
     async fn handle_new_notification(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::AddNotification>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<()> {
         Self::add_notifications(
             this,
@@ -217,7 +217,7 @@ impl NotificationStore {
     async fn handle_delete_notification(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::DeleteNotification>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             this.splice_notifications([(envelope.payload.notification_id, None)], false, cx);
@@ -228,7 +228,7 @@ impl NotificationStore {
     async fn handle_update_notification(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateNotification>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             if let Some(notification) = envelope.payload.notification {
@@ -259,7 +259,7 @@ impl NotificationStore {
         this: Entity<Self>,
         notifications: Vec<proto::Notification>,
         options: AddNotificationsOptions,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let mut user_ids = Vec::new();
         let mut message_ids = Vec::new();

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context as _};
 use collections::{HashMap, HashSet};
 use fs::Fs;
-use gpui::{AsyncAppContext, Entity};
+use gpui::{AsyncApp, Entity};
 use language::{language_settings::language_settings, Buffer, Diff};
 use lsp::{LanguageServer, LanguageServerId};
 use node_runtime::NodeRuntime;
@@ -235,7 +235,7 @@ impl Prettier {
         _: LanguageServerId,
         prettier_dir: PathBuf,
         _: NodeRuntime,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<Self> {
         Ok(Self::Test(TestPrettier {
             default: prettier_dir == default_prettier_dir().as_path(),
@@ -248,7 +248,7 @@ impl Prettier {
         server_id: LanguageServerId,
         prettier_dir: PathBuf,
         node: NodeRuntime,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> anyhow::Result<Self> {
         use lsp::{LanguageServerBinary, LanguageServerName};
 
@@ -305,7 +305,7 @@ impl Prettier {
         buffer: &Entity<Buffer>,
         buffer_path: Option<PathBuf>,
         ignore_dir: Option<PathBuf>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> anyhow::Result<Diff> {
         match self {
             Self::Real(local) => {

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -12,8 +12,7 @@ use fs::Fs;
 use futures::{channel::oneshot, future::Shared, Future, FutureExt as _, StreamExt};
 use git::{blame::Blame, diff::BufferDiff, repository::RepoPath};
 use gpui::{
-    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Subscription, Task,
-    WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Subscription, Task, WeakEntity,
 };
 use http_client::Url;
 use language::{

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -12,7 +12,7 @@ use fs::Fs;
 use futures::{channel::oneshot, future::Shared, Future, FutureExt as _, StreamExt};
 use git::{blame::Blame, diff::BufferDiff, repository::RepoPath};
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Subscription, Task,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Subscription, Task,
     WeakEntity,
 };
 use http_client::Url;
@@ -787,7 +787,7 @@ impl LocalBufferStore {
     ) -> Task<Result<Entity<Buffer>>> {
         let load_buffer = worktree.update(cx, |worktree, cx| {
             let load_file = worktree.load_file(path.as_ref(), cx);
-            let reservation = cx.reserve_model();
+            let reservation = cx.reserve_entity();
             let buffer_id = BufferId::from(reservation.entity_id().as_non_zero_u64());
             cx.spawn(move |_, mut cx| async move {
                 let loaded = load_file.await?;
@@ -795,7 +795,7 @@ impl LocalBufferStore {
                     .background_executor()
                     .spawn(async move { text::Buffer::new(0, buffer_id, loaded.text) })
                     .await;
-                cx.insert_model(reservation, |_| {
+                cx.insert_entity(reservation, |_| {
                     Buffer::build(text_buffer, Some(loaded.file), Capability::ReadWrite)
                 })
             })
@@ -1058,7 +1058,7 @@ impl BufferStore {
         this: WeakEntity<Self>,
         text: Result<Option<String>>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Entity<BufferChangeSet>> {
         let text = match text {
             Err(e) => {
@@ -1562,7 +1562,7 @@ impl BufferStore {
     pub async fn handle_update_buffer(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateBuffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let payload = envelope.payload.clone();
         let buffer_id = BufferId::new(payload.buffer_id)?;
@@ -1717,7 +1717,7 @@ impl BufferStore {
     pub async fn handle_update_buffer_file(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateBufferFile>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let buffer_id = envelope.payload.buffer_id;
         let buffer_id = BufferId::new(buffer_id)?;
@@ -1765,7 +1765,7 @@ impl BufferStore {
     pub async fn handle_save_buffer(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::SaveBuffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::BufferSaved> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
         let (buffer, project_id) = this.update(&mut cx, |this, _| {
@@ -1806,7 +1806,7 @@ impl BufferStore {
     pub async fn handle_close_buffer(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::CloseBuffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let peer_id = envelope.sender_id;
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
@@ -1830,7 +1830,7 @@ impl BufferStore {
     pub async fn handle_buffer_saved(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::BufferSaved>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
         let version = deserialize_version(&envelope.payload.version);
@@ -1858,7 +1858,7 @@ impl BufferStore {
     pub async fn handle_buffer_reloaded(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::BufferReloaded>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
         let version = deserialize_version(&envelope.payload.version);
@@ -1891,7 +1891,7 @@ impl BufferStore {
     pub async fn handle_blame_buffer(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::BlameBuffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::BlameBufferResponse> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
         let version = deserialize_version(&envelope.payload.version);
@@ -1912,7 +1912,7 @@ impl BufferStore {
     pub async fn handle_get_permalink_to_line(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::GetPermalinkToLine>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::GetPermalinkToLineResponse> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
         // let version = deserialize_version(&envelope.payload.version);
@@ -1937,7 +1937,7 @@ impl BufferStore {
     pub async fn handle_get_staged_text(
         this: Entity<Self>,
         request: TypedEnvelope<proto::GetStagedText>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::GetStagedTextResponse> {
         let buffer_id = BufferId::new(request.payload.buffer_id)?;
         let change_set = this
@@ -1966,7 +1966,7 @@ impl BufferStore {
     pub async fn handle_update_diff_base(
         this: Entity<Self>,
         request: TypedEnvelope<proto::UpdateDiffBase>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let buffer_id = BufferId::new(request.payload.buffer_id)?;
         let Some((buffer, change_set)) = this.update(&mut cx, |this, _| {
@@ -2011,7 +2011,7 @@ impl BufferStore {
     async fn handle_reload_buffers(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ReloadBuffers>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ReloadBuffersResponse> {
         let sender_id = envelope.original_sender_id().unwrap_or_default();
         let reload = this.update(&mut cx, |this, cx| {

--- a/crates/project/src/connection_manager.rs
+++ b/crates/project/src/connection_manager.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use client::Client;
 use collections::{HashMap, HashSet};
 use futures::{FutureExt, StreamExt};
-use gpui::{App, AppContext as _, AsyncAppContext, Context, Entity, Global, Task, WeakEntity};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, Global, Task, WeakEntity};
 use postage::stream::Stream;
 use rpc::proto;
 use std::{sync::Arc, time::Duration};
@@ -133,7 +133,7 @@ impl Manager {
     async fn maintain_connection(
         this: WeakEntity<Self>,
         client: Arc<Client>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let mut client_status = client.status();
         loop {

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -394,7 +394,7 @@ impl ImageStoreImpl for Entity<LocalImageStore> {
                 reload_task: None,
             })?;
 
-            let image_id = cx.read_model(&model, |model, _| model.id)?;
+            let image_id = cx.read_entity(&model, |model, _| model.id)?;
 
             this.update(&mut cx, |this, cx| {
                 image_store.update(cx, |image_store, cx| {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -12,7 +12,7 @@ use client::proto::{self, PeerId};
 use clock::Global;
 use collections::HashSet;
 use futures::future;
-use gpui::{App, AsyncAppContext, Entity};
+use gpui::{App, AsyncApp, Entity};
 use language::{
     language_settings::{language_settings, InlayHintKind, LanguageSettings},
     point_from_lsp, point_to_lsp,
@@ -122,7 +122,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Self::Response>;
 
     fn to_proto(&self, project_id: u64, buffer: &Buffer) -> Self::ProtoRequest;
@@ -131,7 +131,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
         message: Self::ProtoRequest,
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Self>;
 
     fn response_to_proto(
@@ -147,7 +147,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
         message: <Self::ProtoRequest as proto::RequestMessage>::Response,
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Self::Response>;
 
     fn buffer_id_from_proto(message: &Self::ProtoRequest) -> Result<BufferId>;
@@ -297,7 +297,7 @@ impl LspCommand for PrepareRename {
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
         _: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<PrepareRenameResponse> {
         buffer.update(&mut cx, |buffer, _| {
             match message {
@@ -339,7 +339,7 @@ impl LspCommand for PrepareRename {
         message: proto::PrepareRename,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -393,7 +393,7 @@ impl LspCommand for PrepareRename {
         message: proto::PrepareRenameResponse,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<PrepareRenameResponse> {
         if message.can_rename {
             buffer
@@ -453,7 +453,7 @@ impl LspCommand for PerformRename {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<ProjectTransaction> {
         if let Some(edit) = message {
             let (lsp_adapter, lsp_server) =
@@ -488,7 +488,7 @@ impl LspCommand for PerformRename {
         message: proto::PerformRename,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -526,7 +526,7 @@ impl LspCommand for PerformRename {
         message: proto::PerformRenameResponse,
         lsp_store: Entity<LspStore>,
         _: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<ProjectTransaction> {
         let message = message
             .transaction
@@ -582,7 +582,7 @@ impl LspCommand for GetDefinition {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_lsp(message, lsp_store, buffer, server_id, cx).await
     }
@@ -602,7 +602,7 @@ impl LspCommand for GetDefinition {
         message: proto::GetDefinition,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -634,7 +634,7 @@ impl LspCommand for GetDefinition {
         message: proto::GetDefinitionResponse,
         lsp_store: Entity<LspStore>,
         _: Entity<Buffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_proto(message.links, lsp_store, cx).await
     }
@@ -681,7 +681,7 @@ impl LspCommand for GetDeclaration {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_lsp(message, lsp_store, buffer, server_id, cx).await
     }
@@ -701,7 +701,7 @@ impl LspCommand for GetDeclaration {
         message: proto::GetDeclaration,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -733,7 +733,7 @@ impl LspCommand for GetDeclaration {
         message: proto::GetDeclarationResponse,
         lsp_store: Entity<LspStore>,
         _: Entity<Buffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_proto(message.links, lsp_store, cx).await
     }
@@ -773,7 +773,7 @@ impl LspCommand for GetImplementation {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_lsp(message, lsp_store, buffer, server_id, cx).await
     }
@@ -793,7 +793,7 @@ impl LspCommand for GetImplementation {
         message: proto::GetImplementation,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -825,7 +825,7 @@ impl LspCommand for GetImplementation {
         message: proto::GetImplementationResponse,
         project: Entity<LspStore>,
         _: Entity<Buffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_proto(message.links, project, cx).await
     }
@@ -872,7 +872,7 @@ impl LspCommand for GetTypeDefinition {
         project: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_lsp(message, project, buffer, server_id, cx).await
     }
@@ -892,7 +892,7 @@ impl LspCommand for GetTypeDefinition {
         message: proto::GetTypeDefinition,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -924,7 +924,7 @@ impl LspCommand for GetTypeDefinition {
         message: proto::GetTypeDefinitionResponse,
         project: Entity<LspStore>,
         _: Entity<Buffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<LocationLink>> {
         location_links_from_proto(message.links, project, cx).await
     }
@@ -938,7 +938,7 @@ fn language_server_for_buffer(
     lsp_store: &Entity<LspStore>,
     buffer: &Entity<Buffer>,
     server_id: LanguageServerId,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<(Arc<CachedLspAdapter>, Arc<LanguageServer>)> {
     lsp_store
         .update(cx, |lsp_store, cx| {
@@ -952,7 +952,7 @@ fn language_server_for_buffer(
 async fn location_links_from_proto(
     proto_links: Vec<proto::LocationLink>,
     lsp_store: Entity<LspStore>,
-    mut cx: AsyncAppContext,
+    mut cx: AsyncApp,
 ) -> Result<Vec<LocationLink>> {
     let mut links = Vec::new();
 
@@ -1018,7 +1018,7 @@ async fn location_links_from_lsp(
     lsp_store: Entity<LspStore>,
     buffer: Entity<Buffer>,
     server_id: LanguageServerId,
-    mut cx: AsyncAppContext,
+    mut cx: AsyncApp,
 ) -> Result<Vec<LocationLink>> {
     let message = match message {
         Some(message) => message,
@@ -1187,7 +1187,7 @@ impl LspCommand for GetReferences {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Vec<Location>> {
         let mut references = Vec::new();
         let (lsp_adapter, language_server) =
@@ -1240,7 +1240,7 @@ impl LspCommand for GetReferences {
         message: proto::GetReferences,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -1288,7 +1288,7 @@ impl LspCommand for GetReferences {
         message: proto::GetReferencesResponse,
         project: Entity<LspStore>,
         _: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Vec<Location>> {
         let mut locations = Vec::new();
         for location in message.locations {
@@ -1359,7 +1359,7 @@ impl LspCommand for GetDocumentHighlights {
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
         _: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Vec<DocumentHighlight>> {
         buffer.update(&mut cx, |buffer, _| {
             let mut lsp_highlights = lsp_highlights.unwrap_or_default();
@@ -1397,7 +1397,7 @@ impl LspCommand for GetDocumentHighlights {
         message: proto::GetDocumentHighlights,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -1441,7 +1441,7 @@ impl LspCommand for GetDocumentHighlights {
         message: proto::GetDocumentHighlightsResponse,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Vec<DocumentHighlight>> {
         let mut highlights = Vec::new();
         for highlight in message.highlights {
@@ -1512,7 +1512,7 @@ impl LspCommand for GetSignatureHelp {
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
         _: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self::Response> {
         let language = buffer.update(&mut cx, |buffer, _| buffer.language().cloned())?;
         Ok(message.and_then(|message| SignatureHelp::new(message, language)))
@@ -1532,7 +1532,7 @@ impl LspCommand for GetSignatureHelp {
         payload: Self::ProtoRequest,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         buffer
             .update(&mut cx, |buffer, _| {
@@ -1568,7 +1568,7 @@ impl LspCommand for GetSignatureHelp {
         response: proto::GetSignatureHelpResponse,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self::Response> {
         let language = buffer.update(&mut cx, |buffer, _| buffer.language().cloned())?;
         Ok(response
@@ -1619,7 +1619,7 @@ impl LspCommand for GetHover {
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
         _: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self::Response> {
         let Some(hover) = message else {
             return Ok(None);
@@ -1699,7 +1699,7 @@ impl LspCommand for GetHover {
         message: Self::ProtoRequest,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -1765,7 +1765,7 @@ impl LspCommand for GetHover {
         message: proto::GetHoverResponse,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self::Response> {
         let contents: Vec<_> = message
             .contents
@@ -1843,7 +1843,7 @@ impl LspCommand for GetCompletions {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self::Response> {
         let mut response_list = None;
         let mut completions = if let Some(completions) = completions {
@@ -2035,7 +2035,7 @@ impl LspCommand for GetCompletions {
         message: proto::GetCompletions,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let version = deserialize_version(&message.version);
         buffer
@@ -2080,7 +2080,7 @@ impl LspCommand for GetCompletions {
         message: proto::GetCompletionsResponse,
         _project: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self::Response> {
         buffer
             .update(&mut cx, |buffer, _| {
@@ -2224,7 +2224,7 @@ impl LspCommand for GetCodeActions {
         _: Entity<LspStore>,
         _: Entity<Buffer>,
         server_id: LanguageServerId,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> Result<Vec<CodeAction>> {
         let requested_kinds_set = if let Some(kinds) = self.kinds {
             Some(kinds.into_iter().collect::<HashSet<_>>())
@@ -2271,7 +2271,7 @@ impl LspCommand for GetCodeActions {
         message: proto::GetCodeActions,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let start = message
             .start
@@ -2314,7 +2314,7 @@ impl LspCommand for GetCodeActions {
         message: proto::GetCodeActionsResponse,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Vec<CodeAction>> {
         buffer
             .update(&mut cx, |buffer, _| {
@@ -2405,7 +2405,7 @@ impl LspCommand for OnTypeFormatting {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Option<Transaction>> {
         if let Some(edits) = message {
             let (lsp_adapter, lsp_server) =
@@ -2441,7 +2441,7 @@ impl LspCommand for OnTypeFormatting {
         message: proto::OnTypeFormatting,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -2485,7 +2485,7 @@ impl LspCommand for OnTypeFormatting {
         message: proto::OnTypeFormattingResponse,
         _: Entity<LspStore>,
         _: Entity<Buffer>,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> Result<Option<Transaction>> {
         let Some(transaction) = message.transaction else {
             return Ok(None);
@@ -2505,7 +2505,7 @@ impl InlayHints {
         server_id: LanguageServerId,
         resolve_state: ResolveState,
         force_no_type_left_padding: bool,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> anyhow::Result<InlayHint> {
         let kind = lsp_hint.kind.and_then(|kind| match kind {
             lsp::InlayHintKind::TYPE => Some(InlayHintKind::Type),
@@ -2914,7 +2914,7 @@ impl LspCommand for InlayHints {
         lsp_store: Entity<LspStore>,
         buffer: Entity<Buffer>,
         server_id: LanguageServerId,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> anyhow::Result<Vec<InlayHint>> {
         let (lsp_adapter, lsp_server) =
             language_server_for_buffer(&lsp_store, &buffer, server_id, &mut cx)?;
@@ -2969,7 +2969,7 @@ impl LspCommand for InlayHints {
         message: proto::InlayHints,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let start = message
             .start
@@ -3009,7 +3009,7 @@ impl LspCommand for InlayHints {
         message: proto::InlayHintsResponse,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> anyhow::Result<Vec<InlayHint>> {
         buffer
             .update(&mut cx, |buffer, _| {
@@ -3073,7 +3073,7 @@ impl LspCommand for LinkedEditingRange {
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
         _server_id: LanguageServerId,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Vec<Range<Anchor>>> {
         if let Some(lsp::LinkedEditingRanges { mut ranges, .. }) = message {
             ranges.sort_by_key(|range| range.start);
@@ -3107,7 +3107,7 @@ impl LspCommand for LinkedEditingRange {
         message: proto::LinkedEditingRange,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Self> {
         let position = message
             .position
@@ -3148,7 +3148,7 @@ impl LspCommand for LinkedEditingRange {
         message: proto::LinkedEditingRangeResponse,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Vec<Range<Anchor>>> {
         buffer
             .update(&mut cx, |buffer, _| {

--- a/crates/project/src/lsp_ext_command.rs
+++ b/crates/project/src/lsp_ext_command.rs
@@ -1,7 +1,7 @@
 use crate::{lsp_command::LspCommand, lsp_store::LspStore, make_text_document_identifier};
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
-use gpui::{App, AsyncAppContext, Entity};
+use gpui::{App, AsyncApp, Entity};
 use language::{point_to_lsp, proto::deserialize_anchor, Buffer};
 use lsp::{LanguageServer, LanguageServerId};
 use rpc::proto::{self, PeerId};
@@ -70,7 +70,7 @@ impl LspCommand for ExpandMacro {
         _: Entity<LspStore>,
         _: Entity<Buffer>,
         _: LanguageServerId,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<ExpandedMacro> {
         Ok(message
             .map(|message| ExpandedMacro {
@@ -94,7 +94,7 @@ impl LspCommand for ExpandMacro {
         message: Self::ProtoRequest,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> anyhow::Result<Self> {
         let position = message
             .position
@@ -123,7 +123,7 @@ impl LspCommand for ExpandMacro {
         message: proto::LspExtExpandMacroResponse,
         _: Entity<LspStore>,
         _: Entity<Buffer>,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<ExpandedMacro> {
         Ok(ExpandedMacro {
             name: message.name,
@@ -200,7 +200,7 @@ impl LspCommand for OpenDocs {
         _: Entity<LspStore>,
         _: Entity<Buffer>,
         _: LanguageServerId,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<DocsUrls> {
         Ok(message
             .map(|message| DocsUrls {
@@ -224,7 +224,7 @@ impl LspCommand for OpenDocs {
         message: Self::ProtoRequest,
         _: Entity<LspStore>,
         buffer: Entity<Buffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> anyhow::Result<Self> {
         let position = message
             .position
@@ -253,7 +253,7 @@ impl LspCommand for OpenDocs {
         message: proto::LspExtOpenDocsResponse,
         _: Entity<LspStore>,
         _: Entity<Buffer>,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<DocsUrls> {
         Ok(DocsUrls {
             web: message.web,
@@ -314,7 +314,7 @@ impl LspCommand for SwitchSourceHeader {
         _: Entity<LspStore>,
         _: Entity<Buffer>,
         _: LanguageServerId,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<SwitchSourceHeaderResult> {
         Ok(message
             .map(|message| SwitchSourceHeaderResult(message.0))
@@ -332,7 +332,7 @@ impl LspCommand for SwitchSourceHeader {
         _: Self::ProtoRequest,
         _: Entity<LspStore>,
         _: Entity<Buffer>,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<Self> {
         Ok(Self {})
     }
@@ -354,7 +354,7 @@ impl LspCommand for SwitchSourceHeader {
         message: proto::LspExtSwitchSourceHeaderResponse,
         _: Entity<LspStore>,
         _: Entity<Buffer>,
-        _: AsyncAppContext,
+        _: AsyncApp,
     ) -> anyhow::Result<SwitchSourceHeaderResult> {
         Ok(SwitchSourceHeaderResult(message.target_file))
     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -25,7 +25,7 @@ use futures::{
 };
 use globset::{Glob, GlobBuilder, GlobMatcher, GlobSet, GlobSetBuilder};
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, PromptLevel, Task,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, PromptLevel, Task,
     WeakEntity,
 };
 use http_client::HttpClient;
@@ -1089,7 +1089,7 @@ impl LocalLspStore {
         target: &LspFormatTarget,
         push_to_history: bool,
         trigger: FormatTrigger,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> anyhow::Result<ProjectTransaction> {
         // Do not allow multiple concurrent formatting requests for the
         // same buffer.
@@ -1437,7 +1437,7 @@ impl LocalLspStore {
         adapters_and_servers: &[(Arc<CachedLspAdapter>, Arc<LanguageServer>)],
         push_to_history: bool,
         transaction: &mut ProjectTransaction,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Option<FormatOperation>, anyhow::Error> {
         let result = match formatter {
             Formatter::LanguageServer { name } => {
@@ -1527,7 +1527,7 @@ impl LocalLspStore {
         abs_path: &Path,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Vec<(Range<Anchor>, String)>> {
         let capabilities = &language_server.capabilities();
         let range_formatting_provider = capabilities.document_range_formatting_provider.as_ref();
@@ -1598,7 +1598,7 @@ impl LocalLspStore {
         abs_path: &Path,
         language_server: &Arc<LanguageServer>,
         settings: &LanguageSettings,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Vec<(Range<Anchor>, String)>> {
         let uri = lsp::Url::from_file_path(abs_path)
             .map_err(|_| anyhow!("failed to convert abs path to uri"))?;
@@ -1651,7 +1651,7 @@ impl LocalLspStore {
         buffer: &FormattableBuffer,
         command: &str,
         arguments: Option<&[String]>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Option<Diff>> {
         let working_dir_path = buffer.handle.update(cx, |buffer, cx| {
             let file = File::from_dyn(buffer.file())?;
@@ -2029,7 +2029,7 @@ impl LocalLspStore {
         buffer: &Entity<Buffer>,
         push_to_history: bool,
         project_transaction: &mut ProjectTransaction,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<(), anyhow::Error> {
         for (lsp_adapter, language_server) in adapters_and_servers.iter() {
             let code_actions = code_actions.clone();
@@ -2107,7 +2107,7 @@ impl LocalLspStore {
         push_to_history: bool,
         _: Arc<CachedLspAdapter>,
         language_server: Arc<LanguageServer>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Option<Transaction>> {
         let edits = this
             .update(cx, |this, cx| {
@@ -2253,7 +2253,7 @@ impl LocalLspStore {
         push_to_history: bool,
         lsp_adapter: Arc<CachedLspAdapter>,
         language_server: Arc<LanguageServer>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<ProjectTransaction> {
         let fs = this.read_with(cx, |this, _| this.as_local().unwrap().fs.clone())?;
 
@@ -2478,7 +2478,7 @@ impl LocalLspStore {
         params: lsp::ApplyWorkspaceEditParams,
         server_id: LanguageServerId,
         adapter: Arc<CachedLspAdapter>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<lsp::ApplyWorkspaceEditResponse> {
         let this = this
             .upgrade()
@@ -5134,7 +5134,7 @@ impl LspStore {
     pub(crate) async fn refresh_workspace_configurations(
         this: &WeakEntity<Self>,
         fs: Arc<dyn Fs>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) {
         maybe!(async move {
             let servers = this
@@ -5679,7 +5679,7 @@ impl LspStore {
     async fn handle_lsp_command<T: LspCommand>(
         this: Entity<Self>,
         envelope: TypedEnvelope<T::ProtoRequest>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<<T::ProtoRequest as proto::RequestMessage>::Response>
     where
         <T::LspRequest as lsp::request::Request>::Params: Send,
@@ -5721,7 +5721,7 @@ impl LspStore {
     async fn handle_multi_lsp_query(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::MultiLspQuery>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::MultiLspQueryResponse> {
         let response_from_ssh = this.update(&mut cx, |this, _| {
             let (upstream_client, project_id) = this.upstream_client()?;
@@ -5872,7 +5872,7 @@ impl LspStore {
     async fn handle_apply_code_action(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ApplyCodeAction>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ApplyCodeActionResponse> {
         let sender_id = envelope.original_sender_id().unwrap_or_default();
         let action = Self::deserialize_code_action(
@@ -5905,7 +5905,7 @@ impl LspStore {
     async fn handle_register_buffer_with_language_servers(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::RegisterBufferWithLanguageServers>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
         let peer_id = envelope.original_sender_id.unwrap_or(envelope.sender_id);
@@ -5934,7 +5934,7 @@ impl LspStore {
     async fn handle_rename_project_entry(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::RenameProjectEntry>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
         let (worktree_id, worktree, old_path, is_dir) = this
@@ -5980,7 +5980,7 @@ impl LspStore {
     async fn handle_update_diagnostic_summary(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateDiagnosticSummary>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             let worktree_id = WorktreeId::from_proto(envelope.payload.worktree_id);
@@ -6041,7 +6041,7 @@ impl LspStore {
     async fn handle_start_language_server(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::StartLanguageServer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let server = envelope
             .payload
@@ -6072,7 +6072,7 @@ impl LspStore {
     async fn handle_update_language_server(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateLanguageServer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             let language_server_id = LanguageServerId(envelope.payload.language_server_id as usize);
@@ -6134,7 +6134,7 @@ impl LspStore {
     async fn handle_language_server_log(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::LanguageServerLog>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let language_server_id = LanguageServerId(envelope.payload.language_server_id as usize);
         let log_type = envelope
@@ -6298,7 +6298,7 @@ impl LspStore {
         old_path: &Path,
         new_path: &Path,
         is_dir: bool,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Task<()> {
         let old_uri = lsp::Url::from_file_path(old_path).ok().map(String::from);
         let new_uri = lsp::Url::from_file_path(new_path).ok().map(String::from);
@@ -6587,7 +6587,7 @@ impl LspStore {
     pub async fn handle_resolve_completion_documentation(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ResolveCompletionDocumentation>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ResolveCompletionDocumentationResponse> {
         let lsp_completion = serde_json::from_slice(&envelope.payload.lsp_completion)?;
 
@@ -6666,7 +6666,7 @@ impl LspStore {
     async fn handle_on_type_formatting(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::OnTypeFormatting>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::OnTypeFormattingResponse> {
         let on_type_formatting = this.update(&mut cx, |this, cx| {
             let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
@@ -6694,7 +6694,7 @@ impl LspStore {
     async fn handle_refresh_inlay_hints(
         this: Entity<Self>,
         _: TypedEnvelope<proto::RefreshInlayHints>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         this.update(&mut cx, |_, cx| {
             cx.emit(LspStoreEvent::RefreshInlayHints);
@@ -6705,7 +6705,7 @@ impl LspStore {
     async fn handle_inlay_hints(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::InlayHints>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::InlayHintsResponse> {
         let sender_id = envelope.original_sender_id().unwrap_or_default();
         let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
@@ -6750,7 +6750,7 @@ impl LspStore {
     async fn handle_resolve_inlay_hint(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ResolveInlayHint>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ResolveInlayHintResponse> {
         let proto_hint = envelope
             .payload
@@ -6781,7 +6781,7 @@ impl LspStore {
     async fn handle_open_buffer_for_symbol(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::OpenBufferForSymbol>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::OpenBufferForSymbolResponse> {
         let peer_id = envelope.original_sender_id().unwrap_or_default();
         let symbol = envelope
@@ -6850,7 +6850,7 @@ impl LspStore {
     pub async fn handle_get_project_symbols(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::GetProjectSymbols>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::GetProjectSymbolsResponse> {
         let symbols = this
             .update(&mut cx, |this, cx| {
@@ -6866,7 +6866,7 @@ impl LspStore {
     pub async fn handle_restart_language_servers(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::RestartLanguageServers>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         this.update(&mut cx, |this, cx| {
             let buffers = this.buffer_ids_to_buffers(envelope.payload.buffer_ids.into_iter(), cx);
@@ -6879,7 +6879,7 @@ impl LspStore {
     pub async fn handle_cancel_language_server_work(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::CancelLanguageServerWork>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         this.update(&mut cx, |this, cx| {
             if let Some(work) = envelope.payload.work {
@@ -6918,7 +6918,7 @@ impl LspStore {
     async fn handle_apply_additional_edits_for_completion(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ApplyCompletionAdditionalEdits>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ApplyCompletionAdditionalEditsResponse> {
         let (buffer, completion) = this.update(&mut cx, |this, cx| {
             let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
@@ -7094,7 +7094,7 @@ impl LspStore {
     async fn handle_format_buffers(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::FormatBuffers>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::FormatBuffersResponse> {
         let sender_id = envelope.original_sender_id().unwrap_or_default();
         let format = this.update(&mut cx, |this, cx| {
@@ -7125,7 +7125,7 @@ impl LspStore {
     async fn shutdown_language_server(
         server_state: Option<LanguageServerState>,
         name: LanguageServerName,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) {
         let server = match server_state {
             Some(LanguageServerState::Starting(task)) => {
@@ -8435,7 +8435,7 @@ impl LspAdapter for SshLspAdapter {
         &self,
         _: &dyn LspAdapterDelegate,
         _: Arc<dyn LanguageToolchainStore>,
-        _: &AsyncAppContext,
+        _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
         Some(self.binary.clone())
     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -25,8 +25,7 @@ use futures::{
 };
 use globset::{Glob, GlobBuilder, GlobMatcher, GlobSet, GlobSetBuilder};
 use gpui::{
-    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, PromptLevel, Task,
-    WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, PromptLevel, Task, WeakEntity,
 };
 use http_client::HttpClient;
 use itertools::Itertools as _;

--- a/crates/project/src/prettier_store.rs
+++ b/crates/project/src/prettier_store.rs
@@ -12,7 +12,7 @@ use futures::{
     stream::FuturesUnordered,
     FutureExt,
 };
-use gpui::{AsyncAppContext, Context, Entity, EventEmitter, Task, WeakEntity};
+use gpui::{AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use language::{
     language_settings::{Formatter, LanguageSettings, SelectedFormatter},
     Buffer, LanguageRegistry, LocalFile,
@@ -387,7 +387,7 @@ impl PrettierStore {
         prettier: &Prettier,
         worktree_id: Option<WorktreeId>,
         new_server_id: LanguageServerId,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) {
         let prettier_dir = prettier.prettier_dir();
         let is_default = prettier.is_default();
@@ -707,7 +707,7 @@ pub fn prettier_plugins_for_language(
 pub(super) async fn format_with_prettier(
     prettier_store: &WeakEntity<PrettierStore>,
     buffer: &Entity<Buffer>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Option<Result<crate::lsp_store::FormatOperation>> {
     let prettier_instance = prettier_store
         .update(cx, |prettier_store, cx| {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -48,8 +48,8 @@ use ::git::{
     status::FileStatus,
 };
 use gpui::{
-    AnyEntity, App, AppContext as _, AsyncApp, BorrowAppContext, Context, Entity,
-    EventEmitter, Hsla, SharedString, Task, WeakEntity, Window,
+    AnyEntity, App, AppContext as _, AsyncApp, BorrowAppContext, Context, Entity, EventEmitter,
+    Hsla, SharedString, Task, WeakEntity, Window,
 };
 use itertools::Itertools;
 use language::{

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -48,7 +48,7 @@ use ::git::{
     status::FileStatus,
 };
 use gpui::{
-    AnyEntity, App, AppContext as _, AsyncAppContext, BorrowAppContext, Context, Entity,
+    AnyEntity, App, AppContext as _, AsyncApp, BorrowAppContext, Context, Entity,
     EventEmitter, Hsla, SharedString, Task, WeakEntity, Window,
 };
 use itertools::Itertools;
@@ -898,7 +898,7 @@ impl Project {
         user_store: Entity<UserStore>,
         languages: Arc<LanguageRegistry>,
         fs: Arc<dyn Fs>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         let project =
             Self::in_room(remote_id, client, user_store, languages, fs, cx.clone()).await?;
@@ -916,7 +916,7 @@ impl Project {
         user_store: Entity<UserStore>,
         languages: Arc<LanguageRegistry>,
         fs: Arc<dyn Fs>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         client.authenticate_and_connect(true, &cx).await?;
 
@@ -958,7 +958,7 @@ impl Project {
         user_store: Entity<UserStore>,
         languages: Arc<LanguageRegistry>,
         fs: Arc<dyn Fs>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<Entity<Self>> {
         let remote_id = response.payload.project_id;
         let role = response.payload.role();
@@ -1156,7 +1156,7 @@ impl Project {
     #[cfg(any(test, feature = "test-support"))]
     pub async fn example(
         root_paths: impl IntoIterator<Item = &Path>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Entity<Project> {
         use clock::FakeSystemClock;
 
@@ -2018,7 +2018,7 @@ impl Project {
     async fn send_buffer_ordered_messages(
         this: WeakEntity<Self>,
         rx: UnboundedReceiver<BufferOrderedMessage>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         const MAX_BATCH_SIZE: usize = 128;
 
@@ -2028,7 +2028,7 @@ impl Project {
             operations_by_buffer_id: &mut HashMap<BufferId, Vec<proto::Operation>>,
             needs_resync_with_host: &mut bool,
             is_local: bool,
-            cx: &mut AsyncAppContext,
+            cx: &mut AsyncApp,
         ) -> Result<()> {
             for (buffer_id, operations) in operations_by_buffer_id.drain() {
                 let request = this.update(cx, |this, _| {
@@ -3541,7 +3541,7 @@ impl Project {
     async fn handle_unshare_project(
         this: Entity<Self>,
         _: TypedEnvelope<proto::UnshareProject>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             if this.is_local() || this.is_via_ssh() {
@@ -3556,7 +3556,7 @@ impl Project {
     async fn handle_add_collaborator(
         this: Entity<Self>,
         mut envelope: TypedEnvelope<proto::AddProjectCollaborator>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let collaborator = envelope
             .payload
@@ -3581,7 +3581,7 @@ impl Project {
     async fn handle_update_project_collaborator(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateProjectCollaborator>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let old_peer_id = envelope
             .payload
@@ -3624,7 +3624,7 @@ impl Project {
     async fn handle_remove_collaborator(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::RemoveProjectCollaborator>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             let peer_id = envelope
@@ -3652,7 +3652,7 @@ impl Project {
     async fn handle_update_project(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateProject>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             // Don't handle messages that were sent before the response to us joining the project
@@ -3666,7 +3666,7 @@ impl Project {
     async fn handle_toast(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::Toast>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |_, cx| {
             cx.emit(Event::Toast {
@@ -3680,7 +3680,7 @@ impl Project {
     async fn handle_language_server_prompt_request(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::LanguageServerPromptRequest>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::LanguageServerPromptResponse> {
         let (tx, mut rx) = smol::channel::bounded(1);
         let actions: Vec<_> = envelope
@@ -3727,7 +3727,7 @@ impl Project {
     async fn handle_hide_toast(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::HideToast>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |_, cx| {
             cx.emit(Event::HideToast {
@@ -3741,7 +3741,7 @@ impl Project {
     async fn handle_update_worktree(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateWorktree>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             let worktree_id = WorktreeId::from_proto(envelope.payload.worktree_id);
@@ -3758,7 +3758,7 @@ impl Project {
     async fn handle_update_buffer_from_ssh(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateBuffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let buffer_store = this.read_with(&cx, |this, cx| {
             if let Some(remote_id) = this.remote_id() {
@@ -3776,7 +3776,7 @@ impl Project {
     async fn handle_update_buffer(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateBuffer>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let buffer_store = this.read_with(&cx, |this, cx| {
             if let Some(ssh) = &this.ssh_client {
@@ -3812,7 +3812,7 @@ impl Project {
     async fn handle_create_buffer_for_peer(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::CreateBufferForPeer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         this.update(&mut cx, |this, cx| {
             this.buffer_store.update(cx, |buffer_store, cx| {
@@ -3829,7 +3829,7 @@ impl Project {
     async fn handle_synchronize_buffers(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::SynchronizeBuffers>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::SynchronizeBuffersResponse> {
         let response = this.update(&mut cx, |this, cx| {
             let client = this.client.clone();
@@ -3844,7 +3844,7 @@ impl Project {
     async fn handle_search_candidate_buffers(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::FindSearchCandidates>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::FindSearchCandidatesResponse> {
         let peer_id = envelope.original_sender_id()?;
         let message = envelope.payload;
@@ -3874,7 +3874,7 @@ impl Project {
     async fn handle_open_buffer_by_id(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::OpenBufferById>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::OpenBufferResponse> {
         let peer_id = envelope.original_sender_id()?;
         let buffer_id = BufferId::new(envelope.payload.id)?;
@@ -3887,7 +3887,7 @@ impl Project {
     async fn handle_open_buffer_by_path(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::OpenBufferByPath>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::OpenBufferResponse> {
         let peer_id = envelope.original_sender_id()?;
         let worktree_id = WorktreeId::from_proto(envelope.payload.worktree_id);
@@ -3908,7 +3908,7 @@ impl Project {
     async fn handle_open_new_buffer(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::OpenNewBuffer>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::OpenBufferResponse> {
         let buffer = this
             .update(&mut cx, |this, cx| this.create_buffer(cx))?
@@ -3922,7 +3922,7 @@ impl Project {
         this: Entity<Self>,
         buffer: Entity<Buffer>,
         peer_id: proto::PeerId,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<proto::OpenBufferResponse> {
         this.update(cx, |this, cx| {
             let is_private = buffer

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use collections::HashMap;
 use fs::Fs;
-use gpui::{App, AsyncAppContext, BorrowAppContext, Context, Entity, EventEmitter};
+use gpui::{App, AsyncApp, BorrowAppContext, Context, Entity, EventEmitter};
 use lsp::LanguageServerName;
 use paths::{
     local_settings_file_relative_path, local_tasks_file_relative_path,
@@ -323,7 +323,7 @@ impl SettingsObserver {
     async fn handle_update_worktree_settings(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateWorktreeSettings>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> anyhow::Result<()> {
         let kind = match envelope.payload.kind {
             Some(kind) => proto::LocalSettingsKind::from_i32(kind)

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use collections::HashMap;
 use fs::Fs;
 use futures::StreamExt as _;
-use gpui::{App, AsyncAppContext, Context, Entity, EventEmitter, Task, WeakEntity};
+use gpui::{App, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use language::{
     proto::{deserialize_anchor, serialize_anchor},
     ContextProvider as _, LanguageToolchainStore, Location,
@@ -58,7 +58,7 @@ impl TaskStore {
     async fn handle_task_context_for_location(
         store: Entity<Self>,
         envelope: TypedEnvelope<proto::TaskContextForLocation>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> anyhow::Result<proto::TaskContext> {
         let location = envelope
             .payload

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -5,7 +5,7 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 use collections::BTreeMap;
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, EventEmitter, Subscription, Task,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Subscription, Task,
     WeakEntity,
 };
 use language::{LanguageName, LanguageRegistry, LanguageToolchainStore, Toolchain, ToolchainList};
@@ -112,7 +112,7 @@ impl ToolchainStore {
     async fn handle_activate_toolchain(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ActivateToolchain>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         this.update(&mut cx, |this, cx| {
             let language_name = LanguageName::from_proto(envelope.payload.language_name);
@@ -134,7 +134,7 @@ impl ToolchainStore {
     async fn handle_active_toolchain(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ActiveToolchain>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ActiveToolchainResponse> {
         let toolchain = this
             .update(&mut cx, |this, cx| {
@@ -156,7 +156,7 @@ impl ToolchainStore {
     async fn handle_list_toolchains(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ListToolchains>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ListToolchainsResponse> {
         let toolchains = this
             .update(&mut cx, |this, cx| {
@@ -221,7 +221,7 @@ impl language::LanguageToolchainStore for LocalStore {
         self: Arc<Self>,
         worktree_id: WorktreeId,
         language_name: LanguageName,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Option<Toolchain> {
         self.0
             .update(cx, |this, cx| {
@@ -238,7 +238,7 @@ impl language::LanguageToolchainStore for RemoteStore {
         self: Arc<Self>,
         worktree_id: WorktreeId,
         language_name: LanguageName,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Option<Toolchain> {
         self.0
             .update(cx, |this, cx| {
@@ -256,7 +256,7 @@ impl language::LanguageToolchainStore for EmptyToolchainStore {
         self: Arc<Self>,
         _: WorktreeId,
         _: LanguageName,
-        _: &mut AsyncAppContext,
+        _: &mut AsyncApp,
     ) -> Option<Toolchain> {
         None
     }

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -5,8 +5,7 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 use collections::BTreeMap;
 use gpui::{
-    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Subscription, Task,
-    WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Subscription, Task, WeakEntity,
 };
 use language::{LanguageName, LanguageRegistry, LanguageToolchainStore, Toolchain, ToolchainList};
 use rpc::{proto, AnyProtoClient, TypedEnvelope};

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -12,7 +12,7 @@ use futures::{
     future::{BoxFuture, Shared},
     FutureExt, SinkExt,
 };
-use gpui::{App, AsyncAppContext, Context, Entity, EntityId, EventEmitter, Task, WeakEntity};
+use gpui::{App, AsyncApp, Context, Entity, EntityId, EventEmitter, Task, WeakEntity};
 use postage::oneshot;
 use rpc::{
     proto::{self, SSH_PROJECT_ID},
@@ -1041,7 +1041,7 @@ impl WorktreeStore {
     pub async fn handle_create_project_entry(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::CreateProjectEntry>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ProjectEntryResponse> {
         let worktree = this.update(&mut cx, |this, cx| {
             let worktree_id = WorktreeId::from_proto(envelope.payload.worktree_id);
@@ -1054,7 +1054,7 @@ impl WorktreeStore {
     pub async fn handle_copy_project_entry(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::CopyProjectEntry>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
         let worktree = this.update(&mut cx, |this, cx| {
@@ -1067,7 +1067,7 @@ impl WorktreeStore {
     pub async fn handle_delete_project_entry(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::DeleteProjectEntry>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
         let worktree = this.update(&mut cx, |this, cx| {
@@ -1080,7 +1080,7 @@ impl WorktreeStore {
     pub async fn handle_expand_project_entry(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ExpandProjectEntry>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::ExpandProjectEntryResponse> {
         let entry_id = ProjectEntryId::from_proto(envelope.payload.entry_id);
         let worktree = this
@@ -1092,7 +1092,7 @@ impl WorktreeStore {
     pub async fn handle_git_branches(
         this: Entity<Self>,
         branches: TypedEnvelope<proto::GitBranches>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<proto::GitBranchesResponse> {
         let project_path = branches
             .payload
@@ -1123,7 +1123,7 @@ impl WorktreeStore {
     pub async fn handle_update_branch(
         this: Entity<Self>,
         update_branch: TypedEnvelope<proto::UpdateGitBranch>,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Result<proto::Ack> {
         let project_path = update_branch
             .payload

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -350,7 +350,7 @@ mod tests {
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
         // Create the project symbols view.
-        let symbols = cx.new_window_model(|window, cx| {
+        let symbols = cx.new_window_entity(|window, cx| {
             Picker::uniform_list(
                 ProjectSymbolsDelegate::new(workspace.downgrade(), project.clone()),
                 window,

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -7,8 +7,8 @@ use editor::Editor;
 use extension_host::ExtensionStore;
 use futures::channel::oneshot;
 use gpui::{
-    percentage, Animation, AnimationExt, AnyWindowHandle, App, AsyncApp, DismissEvent,
-    Entity, EventEmitter, Focusable, FontFeatures, ParentElement as _, PromptLevel, Render,
+    percentage, Animation, AnimationExt, AnyWindowHandle, App, AsyncApp, DismissEvent, Entity,
+    EventEmitter, Focusable, FontFeatures, ParentElement as _, PromptLevel, Render,
     SemanticVersion, SharedString, Task, TextStyleRefinement, Transformation, WeakEntity,
 };
 
@@ -425,11 +425,7 @@ pub struct SshClientDelegate {
 }
 
 impl remote::SshClientDelegate for SshClientDelegate {
-    fn ask_password(
-        &self,
-        prompt: String,
-        cx: &mut AsyncApp,
-    ) -> oneshot::Receiver<Result<String>> {
+    fn ask_password(&self, prompt: String, cx: &mut AsyncApp) -> oneshot::Receiver<Result<String>> {
         let (tx, rx) = oneshot::channel();
         let mut known_password = self.known_password.clone();
         if let Some(password) = known_password.take() {

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -7,7 +7,7 @@ use editor::Editor;
 use extension_host::ExtensionStore;
 use futures::channel::oneshot;
 use gpui::{
-    percentage, Animation, AnimationExt, AnyWindowHandle, App, AsyncAppContext, DismissEvent,
+    percentage, Animation, AnimationExt, AnyWindowHandle, App, AsyncApp, DismissEvent,
     Entity, EventEmitter, Focusable, FontFeatures, ParentElement as _, PromptLevel, Render,
     SemanticVersion, SharedString, Task, TextStyleRefinement, Transformation, WeakEntity,
 };
@@ -428,7 +428,7 @@ impl remote::SshClientDelegate for SshClientDelegate {
     fn ask_password(
         &self,
         prompt: String,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> oneshot::Receiver<Result<String>> {
         let (tx, rx) = oneshot::channel();
         let mut known_password = self.known_password.clone();
@@ -446,7 +446,7 @@ impl remote::SshClientDelegate for SshClientDelegate {
         rx
     }
 
-    fn set_status(&self, status: Option<&str>, cx: &mut AsyncAppContext) {
+    fn set_status(&self, status: Option<&str>, cx: &mut AsyncApp) {
         self.update_status(status, cx)
     }
 
@@ -455,7 +455,7 @@ impl remote::SshClientDelegate for SshClientDelegate {
         platform: SshPlatform,
         release_channel: ReleaseChannel,
         version: Option<SemanticVersion>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Task<anyhow::Result<PathBuf>> {
         cx.spawn(|mut cx| async move {
             let binary_path = AutoUpdater::download_remote_server_release(
@@ -486,7 +486,7 @@ impl remote::SshClientDelegate for SshClientDelegate {
         platform: SshPlatform,
         release_channel: ReleaseChannel,
         version: Option<SemanticVersion>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Task<Result<Option<(String, String)>>> {
         cx.spawn(|mut cx| async move {
             AutoUpdater::get_remote_server_release_url(
@@ -502,7 +502,7 @@ impl remote::SshClientDelegate for SshClientDelegate {
 }
 
 impl SshClientDelegate {
-    fn update_status(&self, status: Option<&str>, cx: &mut AsyncAppContext) {
+    fn update_status(&self, status: Option<&str>, cx: &mut AsyncApp) {
         self.window
             .update(cx, |_, _, cx| {
                 self.ui.update(cx, |modal, cx| {
@@ -547,7 +547,7 @@ pub async fn open_ssh_project(
     paths: Vec<PathBuf>,
     app_state: Arc<AppState>,
     open_options: workspace::OpenOptions,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<()> {
     let window = if let Some(window) = open_options.replace_window {
         window

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -226,11 +226,7 @@ impl SshPlatform {
 }
 
 pub trait SshClientDelegate: Send + Sync {
-    fn ask_password(
-        &self,
-        prompt: String,
-        cx: &mut AsyncApp,
-    ) -> oneshot::Receiver<Result<String>>;
+    fn ask_password(&self, prompt: String, cx: &mut AsyncApp) -> oneshot::Receiver<Result<String>>;
     fn get_download_params(
         &self,
         platform: SshPlatform,
@@ -2474,11 +2470,7 @@ mod fake {
     pub(super) struct Delegate;
 
     impl SshClientDelegate for Delegate {
-        fn ask_password(
-            &self,
-            _: String,
-            _: &mut AsyncApp,
-        ) -> oneshot::Receiver<Result<String>> {
+        fn ask_password(&self, _: String, _: &mut AsyncApp) -> oneshot::Receiver<Result<String>> {
             unreachable!()
         }
 

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -17,7 +17,7 @@ use futures::{
     select, select_biased, AsyncReadExt as _, Future, FutureExt as _, StreamExt as _,
 };
 use gpui::{
-    App, AppContext, AsyncAppContext, BorrowAppContext, Context, Entity, EventEmitter, Global,
+    App, AppContext, AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Global,
     SemanticVersion, Task, WeakEntity,
 };
 use itertools::Itertools;
@@ -229,14 +229,14 @@ pub trait SshClientDelegate: Send + Sync {
     fn ask_password(
         &self,
         prompt: String,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> oneshot::Receiver<Result<String>>;
     fn get_download_params(
         &self,
         platform: SshPlatform,
         release_channel: ReleaseChannel,
         version: Option<SemanticVersion>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Task<Result<Option<(String, String)>>>;
 
     fn download_server_binary_locally(
@@ -244,9 +244,9 @@ pub trait SshClientDelegate: Send + Sync {
         platform: SshPlatform,
         release_channel: ReleaseChannel,
         version: Option<SemanticVersion>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Task<Result<PathBuf>>;
-    fn set_status(&self, status: Option<&str>, cx: &mut AsyncAppContext);
+    fn set_status(&self, status: Option<&str>, cx: &mut AsyncApp);
 }
 
 impl SshSocket {
@@ -813,7 +813,7 @@ impl SshRemoteClient {
     fn heartbeat(
         this: WeakEntity<Self>,
         mut connection_activity_rx: mpsc::Receiver<()>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Task<Result<()>> {
         let Ok(client) = this.update(cx, |this, _| this.client.clone()) else {
             return Task::ready(Err(anyhow!("SshRemoteClient lost")));
@@ -915,7 +915,7 @@ impl SshRemoteClient {
     fn monitor(
         this: WeakEntity<Self>,
         io_task: Task<Result<i32>>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Task<Result<()>> {
         cx.spawn(|mut cx| async move {
             let result = io_task.await;
@@ -1204,7 +1204,7 @@ trait RemoteConnection: Send + Sync {
         outgoing_rx: UnboundedReceiver<Envelope>,
         connection_activity_tx: Sender<()>,
         delegate: Arc<dyn SshClientDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Task<Result<i32>>;
     fn upload_directory(&self, src_path: PathBuf, dest_path: PathBuf, cx: &App)
         -> Task<Result<()>>;
@@ -1214,7 +1214,7 @@ trait RemoteConnection: Send + Sync {
     fn connection_options(&self) -> SshConnectionOptions;
 
     #[cfg(any(test, feature = "test-support"))]
-    fn simulate_disconnect(&self, _: &AsyncAppContext) {}
+    fn simulate_disconnect(&self, _: &AsyncApp) {}
 }
 
 struct SshRemoteConnection {
@@ -1298,7 +1298,7 @@ impl RemoteConnection for SshRemoteConnection {
         outgoing_rx: UnboundedReceiver<Envelope>,
         connection_activity_tx: Sender<()>,
         delegate: Arc<dyn SshClientDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Task<Result<i32>> {
         delegate.set_status(Some("Starting proxy"), cx);
 
@@ -1358,7 +1358,7 @@ impl SshRemoteConnection {
     async fn new(
         _connection_options: SshConnectionOptions,
         _delegate: Arc<dyn SshClientDelegate>,
-        _cx: &mut AsyncAppContext,
+        _cx: &mut AsyncApp,
     ) -> Result<Self> {
         Err(anyhow!("ssh is not supported on this platform"))
     }
@@ -1367,7 +1367,7 @@ impl SshRemoteConnection {
     async fn new(
         connection_options: SshConnectionOptions,
         delegate: Arc<dyn SshClientDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Self> {
         use futures::AsyncWriteExt as _;
         use futures::{io::BufReader, AsyncBufReadExt as _};
@@ -1584,7 +1584,7 @@ impl SshRemoteConnection {
         incoming_tx: UnboundedSender<Envelope>,
         mut outgoing_rx: UnboundedReceiver<Envelope>,
         mut connection_activity_tx: Sender<()>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Task<Result<i32>> {
         let mut child_stderr = ssh_proxy_process.stderr.take().unwrap();
         let mut child_stdout = ssh_proxy_process.stdout.take().unwrap();
@@ -1688,7 +1688,7 @@ impl SshRemoteConnection {
         release_channel: ReleaseChannel,
         version: SemanticVersion,
         commit: Option<AppCommitSha>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<PathBuf> {
         let version_str = match release_channel {
             ReleaseChannel::Nightly => {
@@ -1785,7 +1785,7 @@ impl SshRemoteConnection {
         body: &str,
         tmp_path_gz: &Path,
         delegate: &Arc<dyn SshClientDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         if let Some(parent) = tmp_path_gz.parent() {
             self.socket
@@ -1858,7 +1858,7 @@ impl SshRemoteConnection {
         src_path: &Path,
         tmp_path_gz: &Path,
         delegate: &Arc<dyn SshClientDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         if let Some(parent) = tmp_path_gz.parent() {
             self.socket
@@ -1888,7 +1888,7 @@ impl SshRemoteConnection {
         dst_path: &Path,
         tmp_path_gz: &Path,
         delegate: &Arc<dyn SshClientDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         delegate.set_status(Some("Extracting remote development server"), cx);
         let server_mode = 0o755;
@@ -1943,7 +1943,7 @@ impl SshRemoteConnection {
         &self,
         platform: SshPlatform,
         delegate: &Arc<dyn SshClientDelegate>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<PathBuf> {
         use smol::process::{Command, Stdio};
 
@@ -2085,7 +2085,7 @@ impl ChannelClient {
     fn start_handling_messages(
         this: Weak<Self>,
         mut incoming_rx: mpsc::UnboundedReceiver<Envelope>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Task<Result<()>> {
         cx.spawn(|cx| async move {
             let peer_id = PeerId { owner_id: 0, id: 0 };
@@ -2185,7 +2185,7 @@ impl ChannelClient {
         self: &Arc<Self>,
         incoming_rx: UnboundedReceiver<Envelope>,
         outgoing_tx: UnboundedSender<Envelope>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) {
         *self.outgoing_tx.lock() = outgoing_tx;
         *self.task.lock() = Self::start_handling_messages(Arc::downgrade(self), incoming_rx, cx);
@@ -2365,7 +2365,7 @@ mod fake {
         },
         select_biased, FutureExt, SinkExt, StreamExt,
     };
-    use gpui::{App, AsyncAppContext, SemanticVersion, Task, TestAppContext};
+    use gpui::{App, AsyncApp, SemanticVersion, Task, TestAppContext};
     use release_channel::ReleaseChannel;
     use rpc::proto::Envelope;
 
@@ -2379,7 +2379,7 @@ mod fake {
         pub(super) server_cx: SendableCx,
     }
 
-    pub(super) struct SendableCx(AsyncAppContext);
+    pub(super) struct SendableCx(AsyncApp);
     impl SendableCx {
         // SAFETY: When run in test mode, GPUI is always single threaded.
         pub(super) fn new(cx: &TestAppContext) -> Self {
@@ -2387,7 +2387,7 @@ mod fake {
         }
 
         // SAFETY: Enforce that we're on the main thread by requiring a valid AsyncAppContext
-        fn get(&self, _: &AsyncAppContext) -> AsyncAppContext {
+        fn get(&self, _: &AsyncApp) -> AsyncApp {
             self.0.clone()
         }
     }
@@ -2422,7 +2422,7 @@ mod fake {
             self.connection_options.clone()
         }
 
-        fn simulate_disconnect(&self, cx: &AsyncAppContext) {
+        fn simulate_disconnect(&self, cx: &AsyncApp) {
             let (outgoing_tx, _) = mpsc::unbounded::<Envelope>();
             let (_, incoming_rx) = mpsc::unbounded::<Envelope>();
             self.server_channel
@@ -2438,7 +2438,7 @@ mod fake {
             mut client_outgoing_rx: mpsc::UnboundedReceiver<Envelope>,
             mut connection_activity_tx: Sender<()>,
             _delegate: Arc<dyn SshClientDelegate>,
-            cx: &mut AsyncAppContext,
+            cx: &mut AsyncApp,
         ) -> Task<Result<i32>> {
             let (mut server_incoming_tx, server_incoming_rx) = mpsc::unbounded::<Envelope>();
             let (server_outgoing_tx, mut server_outgoing_rx) = mpsc::unbounded::<Envelope>();
@@ -2477,7 +2477,7 @@ mod fake {
         fn ask_password(
             &self,
             _: String,
-            _: &mut AsyncAppContext,
+            _: &mut AsyncApp,
         ) -> oneshot::Receiver<Result<String>> {
             unreachable!()
         }
@@ -2487,7 +2487,7 @@ mod fake {
             _: SshPlatform,
             _: ReleaseChannel,
             _: Option<SemanticVersion>,
-            _: &mut AsyncAppContext,
+            _: &mut AsyncApp,
         ) -> Task<Result<PathBuf>> {
             unreachable!()
         }
@@ -2497,11 +2497,11 @@ mod fake {
             _platform: SshPlatform,
             _release_channel: ReleaseChannel,
             _version: Option<SemanticVersion>,
-            _cx: &mut AsyncAppContext,
+            _cx: &mut AsyncApp,
         ) -> Task<Result<Option<(String, String)>>> {
             unreachable!()
         }
 
-        fn set_status(&self, _: Option<&str>, _: &mut AsyncAppContext) {}
+        fn set_status(&self, _: Option<&str>, _: &mut AsyncApp) {}
     }
 }

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -2382,7 +2382,7 @@ mod fake {
             Self(cx.to_async())
         }
 
-        // SAFETY: Enforce that we're on the main thread by requiring a valid AsyncAppContext
+        // SAFETY: Enforce that we're on the main thread by requiring a valid AsyncApp
         fn get(&self, _: &AsyncApp) -> AsyncApp {
             self.0.clone()
         }

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -401,7 +401,7 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
     )
     .await;
 
-    cx.update_model(&project, |project, _| {
+    cx.update_entity(&project, |project, _| {
         project.languages().register_test_language(LanguageConfig {
             name: "Rust".into(),
             matcher: LanguageMatcher {
@@ -578,7 +578,7 @@ async fn test_remote_cancel_language_server_work(
     )
     .await;
 
-    cx.update_model(&project, |project, _| {
+    cx.update_entity(&project, |project, _| {
         project.languages().register_test_language(LanguageConfig {
             name: "Rust".into(),
             matcher: LanguageMatcher {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -675,7 +675,7 @@ impl EventEmitter<()> for NotebookEditor {}
 // impl EventEmitter<ToolbarItemEvent> for NotebookControls {}
 
 // impl Render for NotebookControls {
-//     fn render(&mut self, window: &mut Window, cx: &mut ModelContext<Self>) -> impl IntoElement {
+//     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 //         div().child("notebook controls")
 //     }
 // }
@@ -684,7 +684,7 @@ impl EventEmitter<()> for NotebookEditor {}
 //     fn set_active_pane_item(
 //         &mut self,
 //         active_pane_item: Option<&dyn workspace::ItemHandle>,
-//         window: &mut Window, cx: &mut ModelContext<Self>,
+//         window: &mut Window, cx: &mut Context<Self>,
 //     ) -> workspace::ToolbarItemLocation {
 //         cx.notify();
 //         self.active_item = None;
@@ -696,7 +696,7 @@ impl EventEmitter<()> for NotebookEditor {}
 //         ToolbarItemLocation::PrimaryLeft
 //     }
 
-//     fn pane_focus_update(&mut self, pane_focused: bool, _window: &mut Window, _cx: &mut ModelContext<Self>) {
+//     fn pane_focus_update(&mut self, pane_focused: bool, _window: &mut Window, _cx: &mut Context<Self>) {
 //         self.pane_focused = pane_focused;
 //     }
 // }

--- a/crates/rpc/src/proto_client.rs
+++ b/crates/rpc/src/proto_client.rs
@@ -4,7 +4,7 @@ use futures::{
     future::{BoxFuture, LocalBoxFuture},
     Future, FutureExt as _,
 };
-use gpui::{AnyEntity, AnyWeakEntity, AsyncAppContext, Entity};
+use gpui::{AnyEntity, AnyWeakEntity, AsyncApp, Entity};
 use proto::{
     error::ErrorExt as _, AnyTypedEnvelope, EntityMessage, Envelope, EnvelopedMessage,
     RequestMessage, TypedEnvelope,
@@ -64,7 +64,7 @@ pub type ProtoMessageHandler = Arc<
             AnyEntity,
             Box<dyn AnyTypedEnvelope>,
             AnyProtoClient,
-            AsyncAppContext,
+            AsyncApp,
         ) -> LocalBoxFuture<'static, anyhow::Result<()>>,
 >;
 
@@ -111,7 +111,7 @@ impl ProtoMessageHandlerSet {
         this: &parking_lot::Mutex<Self>,
         message: Box<dyn AnyTypedEnvelope>,
         client: AnyProtoClient,
-        cx: AsyncAppContext,
+        cx: AsyncApp,
     ) -> Option<LocalBoxFuture<'static, anyhow::Result<()>>> {
         let payload_type_id = message.payload_type_id();
         let mut this = this.lock();
@@ -211,7 +211,7 @@ impl AnyProtoClient {
     where
         M: RequestMessage,
         E: 'static,
-        H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncAppContext) -> F + Send + Sync,
+        H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncApp) -> F + Send + Sync,
         F: 'static + Future<Output = anyhow::Result<M::Response>>,
     {
         self.0.message_handler_set().lock().add_message_handler(
@@ -243,7 +243,7 @@ impl AnyProtoClient {
     where
         M: EnvelopedMessage + RequestMessage + EntityMessage,
         E: 'static,
-        H: 'static + Sync + Send + Fn(gpui::Entity<E>, TypedEnvelope<M>, AsyncAppContext) -> F,
+        H: 'static + Sync + Send + Fn(gpui::Entity<E>, TypedEnvelope<M>, AsyncApp) -> F,
         F: 'static + Future<Output = anyhow::Result<M::Response>>,
     {
         let message_type_id = TypeId::of::<M>();
@@ -289,7 +289,7 @@ impl AnyProtoClient {
     where
         M: EnvelopedMessage + EntityMessage,
         E: 'static,
-        H: 'static + Sync + Send + Fn(gpui::Entity<E>, TypedEnvelope<M>, AsyncAppContext) -> F,
+        H: 'static + Sync + Send + Fn(gpui::Entity<E>, TypedEnvelope<M>, AsyncApp) -> F,
         F: 'static + Future<Output = anyhow::Result<()>>,
     {
         let message_type_id = TypeId::of::<M>();

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1431,9 +1431,9 @@ mod tests {
         });
         let cx = cx.add_empty_window();
         let editor =
-            cx.new_window_model(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
+            cx.new_window_entity(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
 
-        let search_bar = cx.new_window_model(|window, cx| {
+        let search_bar = cx.new_window_entity(|window, cx| {
             let mut search_bar = BufferSearchBar::new(window, cx);
             search_bar.set_active_pane_item(Some(&editor), window, cx);
             search_bar.show(window, cx);
@@ -2008,9 +2008,9 @@ mod tests {
         let cx = cx.add_empty_window();
 
         let editor =
-            cx.new_window_model(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
+            cx.new_window_entity(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
 
-        let search_bar = cx.new_window_model(|window, cx| {
+        let search_bar = cx.new_window_entity(|window, cx| {
             let mut search_bar = BufferSearchBar::new(window, cx);
             search_bar.set_active_pane_item(Some(&editor), window, cx);
             search_bar.show(window, cx);
@@ -2082,9 +2082,9 @@ mod tests {
         let cx = cx.add_empty_window();
 
         let editor =
-            cx.new_window_model(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
+            cx.new_window_entity(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
 
-        let search_bar = cx.new_window_model(|window, cx| {
+        let search_bar = cx.new_window_entity(|window, cx| {
             let mut search_bar = BufferSearchBar::new(window, cx);
             search_bar.set_active_pane_item(Some(&editor), window, cx);
             search_bar.show(window, cx);
@@ -2462,9 +2462,9 @@ mod tests {
         });
         let cx = cx.add_empty_window();
         let editor =
-            cx.new_window_model(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
+            cx.new_window_entity(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
 
-        let search_bar = cx.new_window_model(|window, cx| {
+        let search_bar = cx.new_window_entity(|window, cx| {
             let mut search_bar = BufferSearchBar::new(window, cx);
             search_bar.set_active_pane_item(Some(&editor), window, cx);
             search_bar.show(window, cx);
@@ -2530,7 +2530,7 @@ mod tests {
         .unindent();
 
         let cx = cx.add_empty_window();
-        let editor = cx.new_window_model(|window, cx| {
+        let editor = cx.new_window_entity(|window, cx| {
             let multibuffer = MultiBuffer::build_multi(
                 [
                     (
@@ -2547,7 +2547,7 @@ mod tests {
             Editor::for_multibuffer(multibuffer, None, false, window, cx)
         });
 
-        let search_bar = cx.new_window_model(|window, cx| {
+        let search_bar = cx.new_window_entity(|window, cx| {
             let mut search_bar = BufferSearchBar::new(window, cx);
             search_bar.set_active_pane_item(Some(&editor), window, cx);
             search_bar.show(window, cx);

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -3795,7 +3795,7 @@ pub mod tests {
         // Wait for the unstaged changes to be loaded
         cx.run_until_parked();
 
-        let buffer_search_bar = cx.new_window_model(|window, cx| {
+        let buffer_search_bar = cx.new_window_entity(|window, cx| {
             let mut search_bar = BufferSearchBar::new(window, cx);
             search_bar.set_active_pane_item(Some(&editor), window, cx);
             search_bar.show(window, cx);

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -11,9 +11,7 @@ mod worktree_index;
 use anyhow::{Context as _, Result};
 use collections::HashMap;
 use fs::Fs;
-use gpui::{
-    App, AppContext as _, AsyncAppContext, BorrowAppContext, Context, Entity, Global, WeakEntity,
-};
+use gpui::{App, AppContext as _, AsyncApp, BorrowAppContext, Context, Entity, Global, WeakEntity};
 use language::LineEnding;
 use project::{Project, Worktree};
 use std::{
@@ -41,7 +39,7 @@ impl SemanticDb {
     pub async fn new(
         db_path: PathBuf,
         embedding_provider: Arc<dyn EmbeddingProvider>,
-        cx: &mut AsyncAppContext,
+        cx: &mut AsyncApp,
     ) -> Result<Self> {
         let db_connection = cx
             .background_executor()
@@ -85,7 +83,7 @@ impl SemanticDb {
     pub async fn load_results(
         mut results: Vec<SearchResult>,
         fs: &Arc<dyn Fs>,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Result<Vec<LoadedSearchResult>> {
         let mut max_scores_by_path = HashMap::<_, (f32, usize)>::default();
         for result in &results {

--- a/crates/semantic_index/src/worktree_index.rs
+++ b/crates/semantic_index/src/worktree_index.rs
@@ -6,9 +6,7 @@ use anyhow::Result;
 use feature_flags::{AutoCommand, FeatureFlagAppExt};
 use fs::Fs;
 use futures::future::Shared;
-use gpui::{
-    App, AppContext as _, AsyncApp, Context, Entity, Subscription, Task, WeakEntity,
-};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, Subscription, Task, WeakEntity};
 use language::LanguageRegistry;
 use log;
 use project::{UpdatedEntriesSet, Worktree};

--- a/crates/semantic_index/src/worktree_index.rs
+++ b/crates/semantic_index/src/worktree_index.rs
@@ -7,7 +7,7 @@ use feature_flags::{AutoCommand, FeatureFlagAppExt};
 use fs::Fs;
 use futures::future::Shared;
 use gpui::{
-    App, AppContext as _, AsyncAppContext, Context, Entity, Subscription, Task, WeakEntity,
+    App, AppContext as _, AsyncApp, Context, Entity, Subscription, Task, WeakEntity,
 };
 use language::LanguageRegistry;
 use log;
@@ -170,7 +170,7 @@ impl WorktreeIndex {
     async fn index_entries(
         this: WeakEntity<Self>,
         updated_entries: channel::Receiver<UpdatedEntriesSet>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let is_auto_available = cx.update(|cx| cx.wait_for_flag::<AutoCommand>())?.await;
         let index = this.update(&mut cx, |this, cx| {

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -3,7 +3,7 @@ use collections::{btree_map, hash_map, BTreeMap, HashMap};
 use ec4rs::{ConfigParser, PropertiesSource, Section};
 use fs::Fs;
 use futures::{channel::mpsc, future::LocalBoxFuture, FutureExt, StreamExt};
-use gpui::{App, AsyncAppContext, BorrowAppContext, Global, Task, UpdateGlobal};
+use gpui::{App, AsyncApp, BorrowAppContext, Global, Task, UpdateGlobal};
 use paths::{local_settings_file_relative_path, EDITORCONFIG_NAME};
 use schemars::{gen::SchemaGenerator, schema::RootSchema, JsonSchema};
 use serde::{de::DeserializeOwned, Deserialize as _, Serialize};
@@ -88,7 +88,7 @@ pub trait Settings: 'static + Send + Sync {
     }
 
     #[track_caller]
-    fn try_read_global<R>(cx: &AsyncAppContext, f: impl FnOnce(&Self) -> R) -> Option<R>
+    fn try_read_global<R>(cx: &AsyncApp, f: impl FnOnce(&Self) -> R) -> Option<R>
     where
         Self: Sized,
     {
@@ -179,7 +179,7 @@ pub struct SettingsStore {
     )>,
     _setting_file_updates: Task<()>,
     setting_file_updates_tx: mpsc::UnboundedSender<
-        Box<dyn FnOnce(AsyncAppContext) -> LocalBoxFuture<'static, Result<()>>>,
+        Box<dyn FnOnce(AsyncApp) -> LocalBoxFuture<'static, Result<()>>>,
     >,
 }
 
@@ -406,7 +406,7 @@ impl SettingsStore {
         update: impl 'static + Send + FnOnce(&mut T::FileContent, &App),
     ) {
         self.setting_file_updates_tx
-            .unbounded_send(Box::new(move |cx: AsyncAppContext| {
+            .unbounded_send(Box::new(move |cx: AsyncApp| {
                 async move {
                     let old_text = Self::load_settings(&fs).await?;
                     let new_text = cx.read_global(|store: &SettingsStore, cx| {

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -178,9 +178,8 @@ pub struct SettingsStore {
         Box<dyn Fn(&dyn Any) -> Option<usize> + Send + Sync + 'static>,
     )>,
     _setting_file_updates: Task<()>,
-    setting_file_updates_tx: mpsc::UnboundedSender<
-        Box<dyn FnOnce(AsyncApp) -> LocalBoxFuture<'static, Result<()>>>,
-    >,
+    setting_file_updates_tx:
+        mpsc::UnboundedSender<Box<dyn FnOnce(AsyncApp) -> LocalBoxFuture<'static, Result<()>>>>,
 }
 
 #[derive(Clone)]

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -13,7 +13,7 @@ use collections::{BTreeMap, BTreeSet, HashMap};
 use format::VSSnippetsFile;
 use fs::Fs;
 use futures::stream::StreamExt;
-use gpui::{App, AppContext as _, AsyncAppContext, Context, Entity, Task, WeakEntity};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, Task, WeakEntity};
 pub use registry::*;
 use util::ResultExt;
 
@@ -64,7 +64,7 @@ pub struct Snippet {
 async fn process_updates(
     this: WeakEntity<SnippetProvider>,
     entries: Vec<PathBuf>,
-    mut cx: AsyncAppContext,
+    mut cx: AsyncApp,
 ) -> Result<()> {
     let fs = this.update(&mut cx, |this, _| this.fs.clone())?;
     for entry_path in entries {
@@ -114,7 +114,7 @@ async fn process_updates(
 async fn initial_scan(
     this: WeakEntity<SnippetProvider>,
     path: Arc<Path>,
-    mut cx: AsyncAppContext,
+    mut cx: AsyncApp,
 ) -> Result<()> {
     let fs = this.update(&mut cx, |this, _| this.fs.clone())?;
     let entries = fs.read_dir(&path).await;

--- a/crates/storybook/src/stories/indent_guides.rs
+++ b/crates/storybook/src/stories/indent_guides.rs
@@ -33,7 +33,7 @@ impl IndentGuidesStory {
 }
 
 impl Render for IndentGuidesStory {
-    fn render(&mut self, window: &mut Window, cx: &mut ModelContext<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         Story::container()
             .child(Story::title("Indent guides"))
             .child(

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -9,7 +9,7 @@ use client::{proto, Client};
 use collections::BTreeMap;
 
 use futures::{channel::mpsc, io::BufReader, AsyncBufReadExt, StreamExt};
-use gpui::{actions, App, AsyncAppContext, Context, Entity, EntityId, Global, Task, WeakEntity};
+use gpui::{actions, App, AsyncApp, Context, Entity, EntityId, Global, Task, WeakEntity};
 use language::{
     language_settings::all_language_settings, Anchor, Buffer, BufferSnapshot, ToOffset,
 };
@@ -342,7 +342,7 @@ impl SupermavenAgent {
     async fn handle_incoming_messages(
         this: WeakEntity<Supermaven>,
         stdout: ChildStdout,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         const MESSAGE_PREFIX: &str = "SM-MESSAGE ";
 

--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -349,7 +349,7 @@ mod tests {
         buffer1.update(cx, |this, cx| {
             this.set_language(Some(typescript_language), cx)
         });
-        let editor1 = cx.new_window_model(|window, cx| {
+        let editor1 = cx.new_window_entity(|window, cx| {
             Editor::for_buffer(buffer1, Some(project.clone()), window, cx)
         });
         let buffer2 = workspace
@@ -362,7 +362,7 @@ mod tests {
             .unwrap();
         buffer2.update(cx, |this, cx| this.set_language(Some(rust_language), cx));
         let editor2 = cx
-            .new_window_model(|window, cx| Editor::for_buffer(buffer2, Some(project), window, cx));
+            .new_window_entity(|window, cx| Editor::for_buffer(buffer2, Some(project), window, cx));
 
         let first_context = workspace
             .update_in(cx, |workspace, window, cx| {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -12,7 +12,7 @@ use collections::HashMap;
 use db::kvp::KEY_VALUE_STORE;
 use futures::future::join_all;
 use gpui::{
-    actions, Action, AnyView, App, AsyncAppContext, AsyncWindowContext, Context, Corner, Entity,
+    actions, Action, AnyView, App, AsyncApp, AsyncWindowContext, Context, Corner, Entity,
     EventEmitter, ExternalPaths, FocusHandle, Focusable, IntoElement, ParentElement, Pixels,
     Render, Styled, Task, WeakEntity, Window,
 };
@@ -1066,7 +1066,7 @@ pub fn new_terminal_pane(
 
 async fn wait_for_terminals_tasks(
     terminals_for_task: Vec<(usize, Entity<Pane>, Entity<TerminalView>)>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) {
     let pending_tasks = terminals_for_task.iter().filter_map(|(_, _, terminal)| {
         terminal

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context as _, Result};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use git::repository::Branch;
 use gpui::{
-    rems, AnyElement, App, AsyncAppContext, Context, DismissEvent, Entity, EventEmitter,
+    rems, AnyElement, App, AsyncApp, Context, DismissEvent, Entity, EventEmitter,
     FocusHandle, Focusable, InteractiveElement, IntoElement, ParentElement, Render, SharedString,
     Styled, Subscription, Task, WeakEntity, Window,
 };
@@ -117,7 +117,7 @@ impl BranchListDelegate {
     async fn new(
         workspace: Entity<Workspace>,
         branch_name_trailoff_after: usize,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Result<Self> {
         let all_branches_request = cx.update(|cx| {
             let project = workspace.read(cx).project().read(cx);

--- a/crates/vcs_menu/src/lib.rs
+++ b/crates/vcs_menu/src/lib.rs
@@ -2,9 +2,9 @@ use anyhow::{anyhow, Context as _, Result};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use git::repository::Branch;
 use gpui::{
-    rems, AnyElement, App, AsyncApp, Context, DismissEvent, Entity, EventEmitter,
-    FocusHandle, Focusable, InteractiveElement, IntoElement, ParentElement, Render, SharedString,
-    Styled, Subscription, Task, WeakEntity, Window,
+    rems, AnyElement, App, AsyncApp, Context, DismissEvent, Entity, EventEmitter, FocusHandle,
+    Focusable, InteractiveElement, IntoElement, ParentElement, Render, SharedString, Styled,
+    Subscription, Task, WeakEntity, Window,
 };
 use picker::{Picker, PickerDelegate};
 use project::ProjectPath;

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -349,7 +349,7 @@ mod test {
     use futures::StreamExt;
     use indoc::indoc;
 
-    use gpui::ViewInputHandler;
+    use gpui::EntityInputHandler;
 
     use crate::{
         state::Mode,

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -573,6 +573,7 @@ mod test {
     };
     use editor::EditorSettings;
     use editor::{display_map::DisplayRow, DisplayPoint};
+
     use indoc::indoc;
     use search::BufferSearchBar;
     use settings::SettingsStore;

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -669,7 +669,7 @@ mod test {
                 .expect("Buffer search bar should be deployed")
         });
 
-        cx.update_model(search_bar, |bar, _window, cx| {
+        cx.update_entity(search_bar, |bar, _window, cx| {
             assert_eq!(bar.query(cx), "cc");
         });
 

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -126,7 +126,7 @@ async fn test_buffer_search(cx: &mut gpui::TestAppContext) {
             .expect("Buffer search bar should be deployed")
     });
 
-    cx.update_model(search_bar, |bar, _, cx| {
+    cx.update_entity(search_bar, |bar, _, cx| {
         assert_eq!(bar.query(cx), "");
     })
 }
@@ -265,7 +265,7 @@ async fn test_selection_on_search(cx: &mut gpui::TestAppContext) {
             .expect("Buffer search bar should be deployed")
     });
 
-    cx.update_model(search_bar, |bar, _, cx| {
+    cx.update_entity(search_bar, |bar, _, cx| {
         assert_eq!(bar.query(cx), "cc");
     });
 

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -94,7 +94,7 @@ impl VimTestContext {
         Self { cx }
     }
 
-    pub fn update_model<F, T, R>(&mut self, model: Entity<T>, update: F) -> R
+    pub fn update_entity<F, T, R>(&mut self, model: Entity<T>, update: F) -> R
     where
         T: 'static,
         F: FnOnce(&mut T, &mut Window, &mut Context<T>) -> R + 'static,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -32,11 +32,11 @@ use futures::{
 };
 use gpui::{
     action_as, actions, canvas, impl_action_as, impl_actions, point, relative, size,
-    transparent_black, Action, AnyView, AnyWeakView, App, AsyncApp, AsyncWindowContext,
-    Bounds, Context, CursorStyle, Decorations, DragMoveEvent, Entity, EntityId, EventEmitter,
-    FocusHandle, Focusable, Global, Hsla, KeyContext, Keystroke, ManagedView, MouseButton,
-    PathPromptOptions, Point, PromptLevel, Render, ResizeEdge, Size, Stateful, Subscription, Task,
-    Tiling, WeakEntity, WindowBounds, WindowHandle, WindowId, WindowOptions,
+    transparent_black, Action, AnyView, AnyWeakView, App, AsyncApp, AsyncWindowContext, Bounds,
+    Context, CursorStyle, Decorations, DragMoveEvent, Entity, EntityId, EventEmitter, FocusHandle,
+    Focusable, Global, Hsla, KeyContext, Keystroke, ManagedView, MouseButton, PathPromptOptions,
+    Point, PromptLevel, Render, ResizeEdge, Size, Stateful, Subscription, Task, Tiling, WeakEntity,
+    WindowBounds, WindowHandle, WindowId, WindowOptions,
 };
 pub use item::{
     FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, PreviewTabsSettings,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -32,7 +32,7 @@ use futures::{
 };
 use gpui::{
     action_as, actions, canvas, impl_action_as, impl_actions, point, relative, size,
-    transparent_black, Action, AnyView, AnyWeakView, App, AsyncAppContext, AsyncWindowContext,
+    transparent_black, Action, AnyView, AnyWeakView, App, AsyncApp, AsyncWindowContext,
     Bounds, Context, CursorStyle, Decorations, DragMoveEvent, Entity, EntityId, EventEmitter,
     FocusHandle, Focusable, Global, Hsla, KeyContext, Keystroke, ManagedView, MouseButton,
     PathPromptOptions, Point, PromptLevel, Render, ResizeEdge, Size, Stateful, Subscription, Task,
@@ -5160,7 +5160,7 @@ enum ActivateInDirectionTarget {
     Dock(Entity<Dock>),
 }
 
-fn notify_if_database_failed(workspace: WindowHandle<Workspace>, cx: &mut AsyncAppContext) {
+fn notify_if_database_failed(workspace: WindowHandle<Workspace>, cx: &mut AsyncApp) {
     const REPORT_ISSUE_URL: &str = "https://github.com/zed-industries/zed/issues/new?assignees=&labels=admin+read%2Ctriage%2Cbug&projects=&template=1_bug_report.yml";
 
     workspace
@@ -5504,7 +5504,7 @@ impl WorkspaceStore {
     pub async fn handle_follow(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::Follow>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<proto::FollowResponse> {
         this.update(&mut cx, |this, cx| {
             let follower = Follower {
@@ -5534,7 +5534,7 @@ impl WorkspaceStore {
     async fn handle_update_followers(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::UpdateFollowers>,
-        mut cx: AsyncAppContext,
+        mut cx: AsyncApp,
     ) -> Result<()> {
         let leader_id = envelope.original_sender_id()?;
         let update = envelope.payload;
@@ -5657,7 +5657,7 @@ async fn join_channel_internal(
     app_state: &Arc<AppState>,
     requesting_window: Option<WindowHandle<Workspace>>,
     active_call: &Entity<ActiveCall>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<bool> {
     let (should_prompt, open_room) = active_call.update(cx, |active_call, cx| {
         let Some(room) = active_call.room().map(|room| room.read(cx)) else {
@@ -5877,7 +5877,7 @@ pub fn join_channel(
 
 pub async fn get_any_active_workspace(
     app_state: Arc<AppState>,
-    mut cx: AsyncAppContext,
+    mut cx: AsyncApp,
 ) -> anyhow::Result<WindowHandle<Workspace>> {
     // find an existing workspace to focus and show call controls
     let active_window = activate_any_workspace_window(&mut cx);
@@ -5888,7 +5888,7 @@ pub async fn get_any_active_workspace(
     activate_any_workspace_window(&mut cx).context("could not open zed")
 }
 
-fn activate_any_workspace_window(cx: &mut AsyncAppContext) -> Option<WindowHandle<Workspace>> {
+fn activate_any_workspace_window(cx: &mut AsyncApp) -> Option<WindowHandle<Workspace>> {
     cx.update(|cx| {
         if let Some(workspace_window) = cx
             .active_window()
@@ -6185,7 +6185,7 @@ pub fn open_ssh_project(
 fn serialize_ssh_project(
     connection_options: SshConnectionOptions,
     paths: Vec<PathBuf>,
-    cx: &AsyncAppContext,
+    cx: &AsyncApp,
 ) -> Task<
     Result<(
         SerializedSshProject,
@@ -6755,7 +6755,7 @@ mod tests {
 
         // Adding an item that creates ambiguity increases the level of detail on
         // both tabs.
-        let item2 = cx.new_window_model(|_window, cx| {
+        let item2 = cx.new_window_entity(|_window, cx| {
             let mut item = TestItem::new(cx);
             item.tab_descriptions = Some(vec!["c", "b2/c", "a/b2/c"]);
             item

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -18,9 +18,7 @@ use extension::ExtensionHostProxy;
 use fs::{Fs, RealFs};
 use futures::{future, StreamExt};
 use git::GitHostingProviderRegistry;
-use gpui::{
-    Action, App, AppContext as _, Application, AsyncApp, DismissEvent, UpdateGlobal as _,
-};
+use gpui::{Action, App, AppContext as _, Application, AsyncApp, DismissEvent, UpdateGlobal as _};
 
 use http_client::{read_proxy_from_env, Uri};
 use language::LanguageRegistry;
@@ -815,10 +813,7 @@ async fn installation_id() -> Result<IdType> {
     Ok(IdType::New(installation_id))
 }
 
-async fn restore_or_create_workspace(
-    app_state: Arc<AppState>,
-    cx: &mut AsyncApp,
-) -> Result<()> {
+async fn restore_or_create_workspace(app_state: Arc<AppState>, cx: &mut AsyncApp) -> Result<()> {
     if let Some(locations) = restorable_workspace_locations(cx, &app_state).await {
         for location in locations {
             match location {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -19,7 +19,7 @@ use fs::{Fs, RealFs};
 use futures::{future, StreamExt};
 use git::GitHostingProviderRegistry;
 use gpui::{
-    Action, App, AppContext as _, Application, AsyncAppContext, DismissEvent, UpdateGlobal as _,
+    Action, App, AppContext as _, Application, AsyncApp, DismissEvent, UpdateGlobal as _,
 };
 
 use http_client::{read_proxy_from_env, Uri};
@@ -129,7 +129,7 @@ fn files_not_created_on_launch(errors: HashMap<io::ErrorKind, Vec<&Path>>) {
     })
 }
 
-fn fail_to_open_window_async(e: anyhow::Error, cx: &mut AsyncAppContext) {
+fn fail_to_open_window_async(e: anyhow::Error, cx: &mut AsyncApp) {
     cx.update(|cx| fail_to_open_window(e, cx)).log_err();
 }
 
@@ -760,7 +760,7 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
     }
 }
 
-async fn authenticate(client: Arc<Client>, cx: &AsyncAppContext) -> Result<()> {
+async fn authenticate(client: Arc<Client>, cx: &AsyncApp) -> Result<()> {
     if stdout_is_a_pty() {
         if *client::ZED_DEVELOPMENT_AUTH {
             client.authenticate_and_connect(true, cx).await?;
@@ -817,7 +817,7 @@ async fn installation_id() -> Result<IdType> {
 
 async fn restore_or_create_workspace(
     app_state: Arc<AppState>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<()> {
     if let Some(locations) = restorable_workspace_locations(cx, &app_state).await {
         for location in locations {
@@ -874,7 +874,7 @@ async fn restore_or_create_workspace(
 }
 
 pub(crate) async fn restorable_workspace_locations(
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
     app_state: &Arc<AppState>,
 ) -> Option<Vec<SerializedWorkspaceLocation>> {
     let mut restore_behavior = cx

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -23,10 +23,9 @@ use feature_flags::FeatureFlagAppExt;
 use futures::FutureExt;
 use futures::{channel::mpsc, select_biased, StreamExt};
 use gpui::{
-    actions, point, px, Action, App, AppContext as _, AsyncAppContext, Context, DismissEvent,
-    Element, Entity, Focusable, KeyBinding, MenuItem, ParentElement, PathPromptOptions,
-    PromptLevel, ReadGlobal, SharedString, Styled, Task, TitlebarOptions, Window, WindowKind,
-    WindowOptions,
+    actions, point, px, Action, App, AppContext as _, AsyncApp, Context, DismissEvent, Element,
+    Entity, Focusable, KeyBinding, MenuItem, ParentElement, PathPromptOptions, PromptLevel,
+    ReadGlobal, SharedString, Styled, Task, TitlebarOptions, Window, WindowKind, WindowOptions,
 };
 pub use open_listener::*;
 use outline_panel::OutlinePanel;
@@ -1534,7 +1533,7 @@ fn open_settings_file(
     .detach_and_log_err(cx);
 }
 
-async fn register_zed_scheme(cx: &AsyncAppContext) -> anyhow::Result<()> {
+async fn register_zed_scheme(cx: &AsyncApp) -> anyhow::Result<()> {
     cx.update(|cx| cx.register_url_scheme(ZED_URL_SCHEME))?
         .await
 }

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -12,7 +12,7 @@ use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures::channel::{mpsc, oneshot};
 use futures::future::join_all;
 use futures::{FutureExt, SinkExt, StreamExt};
-use gpui::{App, AsyncAppContext, Global, WindowHandle};
+use gpui::{App, AsyncApp, Global, WindowHandle};
 use language::Point;
 use recent_projects::{open_ssh_project, SshSettings};
 use remote::SshConnectionOptions;
@@ -198,7 +198,7 @@ pub async fn open_paths_with_positions(
     path_positions: &[PathWithPosition],
     app_state: Arc<AppState>,
     open_options: workspace::OpenOptions,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<(
     WindowHandle<Workspace>,
     Vec<Option<Result<Box<dyn ItemHandle>>>>,
@@ -248,7 +248,7 @@ pub async fn open_paths_with_positions(
 pub async fn handle_cli_connection(
     (mut requests, responses): (mpsc::Receiver<CliRequest>, IpcSender<CliResponse>),
     app_state: Arc<AppState>,
-    mut cx: AsyncAppContext,
+    mut cx: AsyncApp,
 ) {
     if let Some(request) = requests.next().await {
         match request {
@@ -305,7 +305,7 @@ async fn open_workspaces(
     wait: bool,
     app_state: Arc<AppState>,
     env: Option<collections::HashMap<String, String>>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> Result<()> {
     let grouped_locations = if paths.is_empty() {
         // If no paths are provided, restore from previous workspaces unless a new workspace is requested with -n
@@ -412,7 +412,7 @@ async fn open_local_workspace(
     responses: &IpcSender<CliResponse>,
     env: Option<&HashMap<String, String>>,
     app_state: &Arc<AppState>,
-    cx: &mut AsyncAppContext,
+    cx: &mut AsyncApp,
 ) -> bool {
     let mut errored = false;
 

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -10,8 +10,7 @@ use client::{Client, UserStore};
 use collections::{HashMap, HashSet, VecDeque};
 use futures::AsyncReadExt;
 use gpui::{
-    actions, App, AppContext as _, AsyncAppContext, Context, Entity, EntityId, Global,
-    Subscription, Task,
+    actions, App, AppContext as _, AsyncApp, Context, Entity, EntityId, Global, Subscription, Task,
 };
 use http_client::{HttpClient, Method};
 use language::{
@@ -601,7 +600,7 @@ and then another
         input_events: String,
         input_excerpt: String,
         request_sent_at: Instant,
-        cx: &AsyncAppContext,
+        cx: &AsyncApp,
     ) -> Task<Result<InlineCompletion>> {
         let snapshot = snapshot.clone();
         cx.spawn(|cx| async move {


### PR DESCRIPTION
Fix a bug where a GPUI macro still used `ModelContext`
Rename `AsyncAppContext` -> `AsyncApp`
Rename update_model, read_model, insert_model, and reserve_model to update_entity, read_entity, insert_entity, and reserve_entity

Release Notes:

- N/A
