### PR TITLE
Fix highlights in edit predictions preview

### DIFF
--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -4,7 +4,7 @@ use gpui::{App, Context, Entity, EntityId, Task};
 use inline_completion::{Direction, InlineCompletion, InlineCompletionProvider};
 use language::{
     language_settings::{all_language_settings, AllLanguageSettings},
-    Buffer, OffsetRangeExt, ToOffset,
+    Buffer, EditWithInsertionHighlights, OffsetRangeExt, ToOffset,
 };
 use settings::Settings;
 use std::{path::Path, time::Duration};
@@ -255,8 +255,11 @@ impl InlineCompletionProvider for CopilotCompletionProvider {
             } else {
                 let position = cursor_position.bias_right(buffer);
                 Some(InlineCompletion {
-                    edits: vec![(position..position, completion_text.into())],
-                    edit_preview: None,
+                    edits: vec![EditWithInsertionHighlights {
+                        range: position..position,
+                        insertion: completion_text.into(),
+                        insertion_highlights: vec![],
+                    }],
                 })
             }
         } else {

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -4,7 +4,7 @@ use gpui::{App, Context, Entity, EntityId, Task};
 use inline_completion::{Direction, InlineCompletion, InlineCompletionProvider};
 use language::{
     language_settings::{all_language_settings, AllLanguageSettings},
-    Buffer, EditWithInsertionHighlights, OffsetRangeExt, ToOffset,
+    Buffer, OffsetRangeExt, PlainTextEdit, ToOffset,
 };
 use settings::Settings;
 use std::{path::Path, time::Duration};
@@ -255,11 +255,11 @@ impl InlineCompletionProvider for CopilotCompletionProvider {
             } else {
                 let position = cursor_position.bias_right(buffer);
                 Some(InlineCompletion {
-                    edits: vec![EditWithInsertionHighlights {
-                        range: position..position,
-                        insertion: completion_text.into(),
-                        insertion_highlights: vec![],
-                    }],
+                    edits: vec![PlainTextEdit {
+                        old_range: position..position,
+                        new_text: completion_text.into(),
+                    }
+                    .into()],
                 })
             }
         } else {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3432,7 +3432,6 @@ impl EditorElement {
             }
             InlineCompletion::Edit {
                 edits,
-                edit_preview,
                 display_mode,
                 snapshot,
             } => {
@@ -3443,13 +3442,13 @@ impl EditorElement {
                 let edit_start = edits
                     .first()
                     .unwrap()
-                    .0
+                    .range
                     .start
                     .to_display_point(editor_snapshot);
                 let edit_end = edits
                     .last()
                     .unwrap()
-                    .0
+                    .range
                     .end
                     .to_display_point(editor_snapshot);
 
@@ -3461,7 +3460,7 @@ impl EditorElement {
 
                 match display_mode {
                     EditDisplayMode::TabAccept => {
-                        let range = &edits.first()?.0;
+                        let range = &edits.first()?.range;
                         let target_display_point = range.end.to_display_point(editor_snapshot);
 
                         let target_line_end = DisplayPoint::new(
@@ -3487,9 +3486,8 @@ impl EditorElement {
                     EditDisplayMode::DiffPopover => {}
                 }
 
-                let highlighted_edits = edit_preview.as_ref().and_then(|edit_preview| {
-                    crate::inline_completion_edit_text(&snapshot, edits, edit_preview, false, cx)
-                })?;
+                let highlighted_edits =
+                    crate::inline_completion_edit_text(&snapshot, edits, false, cx)?;
 
                 let line_count = highlighted_edits.text.lines().count() + 1;
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -44,7 +44,7 @@ use language::{
         IndentGuideBackgroundColoring, IndentGuideColoring, IndentGuideSettings,
         ShowWhitespaceSetting,
     },
-    ChunkRendererContext,
+    ChunkRendererContext, TextEdit,
 };
 use lsp::DiagnosticSeverity;
 use multi_buffer::{
@@ -3442,13 +3442,13 @@ impl EditorElement {
                 let edit_start = edits
                     .first()
                     .unwrap()
-                    .range
+                    .old_range()
                     .start
                     .to_display_point(editor_snapshot);
                 let edit_end = edits
                     .last()
                     .unwrap()
-                    .range
+                    .old_range()
                     .end
                     .to_display_point(editor_snapshot);
 
@@ -3460,7 +3460,7 @@ impl EditorElement {
 
                 match display_mode {
                     EditDisplayMode::TabAccept => {
-                        let range = &edits.first()?.range;
+                        let range = &edits.first()?.old_range();
                         let target_display_point = range.end.to_display_point(editor_snapshot);
 
                         let target_line_end = DisplayPoint::new(

--- a/crates/inline_completion/src/inline_completion.rs
+++ b/crates/inline_completion/src/inline_completion.rs
@@ -1,6 +1,5 @@
 use gpui::{App, Context, Entity};
-use language::Buffer;
-use std::ops::Range;
+use language::{Buffer, EditWithInsertionHighlights};
 
 // TODO: Find a better home for `Direction`.
 //
@@ -14,8 +13,7 @@ pub enum Direction {
 
 #[derive(Clone)]
 pub struct InlineCompletion {
-    pub edits: Vec<(Range<language::Anchor>, String)>,
-    pub edit_preview: Option<language::EditPreview>,
+    pub edits: Vec<EditWithInsertionHighlights<language::Anchor>>,
 }
 
 pub trait InlineCompletionProvider: 'static + Sized {

--- a/crates/inline_completion/src/inline_completion.rs
+++ b/crates/inline_completion/src/inline_completion.rs
@@ -1,5 +1,5 @@
 use gpui::{App, Context, Entity};
-use language::{Buffer, EditWithInsertionHighlights};
+use language::{Buffer, TextEditWithNewHighlights};
 
 // TODO: Find a better home for `Direction`.
 //
@@ -13,7 +13,7 @@ pub enum Direction {
 
 #[derive(Clone)]
 pub struct InlineCompletion {
-    pub edits: Vec<EditWithInsertionHighlights<language::Anchor>>,
+    pub edits: Vec<TextEditWithNewHighlights<language::Anchor>>,
 }
 
 pub trait InlineCompletionProvider: 'static + Sized {

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2737,6 +2737,9 @@ async fn test_preview_edits_interpolate(cx: &mut TestAppContext) {
     });
 
     let edits = construct_edits(&buffer, [(Point::new(1, 5)..Point::new(1, 5), "irst")], cx);
+    let edit_preview = buffer
+        .read_with(cx, |buffer, cx| buffer.preview_edits(edits.clone(), cx))
+        .await;
     let highlighted_edits =
         cx.read(|cx| edit_preview.highlight_edits(&buffer.read(cx).snapshot(), &edits, false, cx));
 

--- a/crates/zeta/src/completion_diff_element.rs
+++ b/crates/zeta/src/completion_diff_element.rs
@@ -26,8 +26,9 @@ impl CompletionDiffElement {
         let mut cursor_offset_in_diff = None;
         let mut delta = 0;
         let mut diff_highlights = Vec::new();
-        for (old_range, new_text) in completion.edits.iter() {
-            let old_range = old_range.to_offset(&completion.snapshot);
+        for edit in completion.edits.iter() {
+            let old_range = edit.range.to_offset(&completion.snapshot);
+            let new_text = &edit.insertion;
 
             if cursor_offset_in_diff.is_none() && completion.cursor_offset <= old_range.end {
                 cursor_offset_in_diff =
@@ -51,7 +52,8 @@ impl CompletionDiffElement {
             }
 
             if !new_text.is_empty() {
-                diff.insert_str(old_end_in_diff, new_text);
+                // todo! use insertion_highlights
+                diff.insert_str(old_end_in_diff, new_text.as_str());
                 diff_highlights.push((
                     old_end_in_diff..old_end_in_diff + new_text.len(),
                     HighlightStyle {

--- a/crates/zeta/src/completion_diff_element.rs
+++ b/crates/zeta/src/completion_diff_element.rs
@@ -5,7 +5,7 @@ use gpui::{
     point, prelude::*, quad, size, AnyElement, App, Bounds, Corners, Edges, HighlightStyle, Hsla,
     StyledText, TextLayout, TextStyle,
 };
-use language::OffsetRangeExt;
+use language::{OffsetRangeExt, TextEdit};
 use settings::Settings;
 use theme::ThemeSettings;
 use ui::prelude::*;
@@ -27,8 +27,8 @@ impl CompletionDiffElement {
         let mut delta = 0;
         let mut diff_highlights = Vec::new();
         for edit in completion.edits.iter() {
-            let old_range = edit.range.to_offset(&completion.snapshot);
-            let new_text = &edit.insertion;
+            let old_range = edit.old_range().to_offset(&completion.snapshot);
+            let new_text = &edit.new_text();
 
             if cursor_offset_in_diff.is_none() && completion.cursor_offset <= old_range.end {
                 cursor_offset_in_diff =
@@ -52,7 +52,6 @@ impl CompletionDiffElement {
             }
 
             if !new_text.is_empty() {
-                // todo! use insertion_highlights
                 diff.insert_str(old_end_in_diff, new_text.as_str());
                 diff_highlights.push((
                     old_end_in_diff..old_end_in_diff + new_text.len(),

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -14,8 +14,8 @@ use gpui::{
 };
 use http_client::{HttpClient, Method};
 use language::{
-    language_settings::all_language_settings, Anchor, Buffer, BufferSnapshot,
-    EditWithInsertionHighlights, OffsetRangeExt, Point, ToOffset, ToPoint,
+    language_settings::all_language_settings, Anchor, Buffer, BufferSnapshot, OffsetRangeExt,
+    PlainTextEdit, Point, TextEdit, TextEditWithNewHighlights, ToOffset, ToPoint,
 };
 use language_models::LlmApiToken;
 use rpc::{PredictEditsParams, PredictEditsResponse, EXPIRED_LLM_TOKEN_HEADER_NAME};
@@ -74,7 +74,7 @@ pub struct InlineCompletion {
     path: Arc<Path>,
     excerpt_range: Range<usize>,
     cursor_offset: usize,
-    edits: Arc<[EditWithInsertionHighlights<Anchor>]>,
+    edits: Arc<[TextEditWithNewHighlights<Anchor>]>,
     snapshot: BufferSnapshot,
     input_outline: Arc<str>,
     input_events: Arc<str>,
@@ -93,60 +93,8 @@ impl InlineCompletion {
     fn interpolate(
         &self,
         new_snapshot: &BufferSnapshot,
-    ) -> Option<Vec<EditWithInsertionHighlights<Anchor>>> {
+    ) -> Option<Vec<TextEditWithNewHighlights<Anchor>>> {
         interpolate(&self.snapshot, new_snapshot, &self.edits)
-    }
-}
-
-trait Edit {
-    fn range(&self) -> &Range<Anchor>;
-    fn insertion(&self) -> &String;
-    fn set_range_and_drop_prefix(&self, range: Range<Anchor>, prefix_len: usize) -> Self;
-}
-
-impl Edit for EditWithInsertionHighlights<Anchor> {
-    fn range(&self) -> &Range<Anchor> {
-        &self.range
-    }
-
-    fn insertion(&self) -> &String {
-        &self.insertion
-    }
-
-    fn set_range_and_drop_prefix(&self, range: Range<Anchor>, prefix_length: usize) -> Self {
-        let insertion_highlights = self
-            .insertion_highlights
-            .iter()
-            .flat_map(|(range, highlight_id)| {
-                if range.end <= prefix_length {
-                    None
-                } else {
-                    Some((
-                        range.start.saturating_sub(prefix_length)..range.end - prefix_length,
-                        *highlight_id,
-                    ))
-                }
-            })
-            .collect::<Vec<_>>();
-        EditWithInsertionHighlights {
-            range,
-            insertion: self.insertion[prefix_length..].to_string(),
-            insertion_highlights,
-        }
-    }
-}
-
-impl Edit for (Range<Anchor>, String) {
-    fn range(&self) -> &Range<Anchor> {
-        &self.0
-    }
-
-    fn insertion(&self) -> &String {
-        &self.1
-    }
-
-    fn set_range_and_drop_prefix(&self, range: Range<Anchor>, prefix_length: usize) -> Self {
-        (range, self.1[prefix_length..].to_string())
     }
 }
 
@@ -156,7 +104,7 @@ fn interpolate<E>(
     current_edits: &[E],
 ) -> Option<Vec<E>>
 where
-    E: Clone + Edit,
+    E: Clone + TextEdit<Anchor>,
 {
     let mut edits = Vec::new();
 
@@ -164,8 +112,8 @@ where
         .edits_since::<usize>(&old_snapshot.version)
         .peekable();
     for model_edit in current_edits.iter() {
-        let model_old_range = model_edit.range();
-        let model_new_text = model_edit.insertion();
+        let model_old_range = model_edit.old_range();
+        let model_new_text = model_edit.new_text();
         let model_offset_range = model_old_range.to_offset(old_snapshot);
         while let Some(next_user_edit) = user_edits.peek() {
             if next_user_edit.old.end < model_offset_range.start {
@@ -185,10 +133,11 @@ where
 
                 if model_new_text.starts_with(&user_new_text) {
                     if user_new_text.len() < model_new_text.len() {
-                        let range = new_snapshot.anchor_after(user_edit.new.end)
+                        let mut modified_edit = model_edit.with_prefix_dropped(user_new_text.len());
+                        *modified_edit.mut_old_range() = new_snapshot
+                            .anchor_after(user_edit.new.end)
                             ..new_snapshot.anchor_before(user_edit.new.end);
-                        let prefix_length = user_new_text.len();
-                        edits.push(model_edit.set_range_and_drop_prefix(range, prefix_length));
+                        edits.push(modified_edit);
                     }
 
                     user_edits.next();
@@ -664,7 +613,7 @@ and then another
         cx.spawn(|cx| async move {
             let output_excerpt: Arc<str> = output_excerpt.into();
 
-            let edits: Vec<(Range<Anchor>, String)> = cx
+            let edits: Vec<PlainTextEdit<Anchor>> = cx
                 .background_executor()
                 .spawn({
                     let output_excerpt = output_excerpt.clone();
@@ -677,7 +626,7 @@ and then another
             let (edits, snapshot) = buffer.read_with(&cx, {
                 move |buffer, cx| {
                     let new_snapshot = buffer.snapshot();
-                    let edits: Vec<(Range<Anchor>, String)> =
+                    let edits: Vec<PlainTextEdit<Anchor>> =
                         interpolate(&snapshot, &new_snapshot, &edits)
                             .context("Interpolated edits are empty")?;
 
@@ -711,7 +660,7 @@ and then another
         output_excerpt: Arc<str>,
         excerpt_range: Range<usize>,
         snapshot: &BufferSnapshot,
-    ) -> Result<Vec<(Range<Anchor>, String)>> {
+    ) -> Result<Vec<PlainTextEdit<Anchor>>> {
         let content = output_excerpt.replace(CURSOR_MARKER, "");
 
         let start_markers = content
@@ -769,7 +718,7 @@ and then another
         new_text: &str,
         offset: usize,
         snapshot: &BufferSnapshot,
-    ) -> Vec<(Range<Anchor>, String)> {
+    ) -> Vec<PlainTextEdit<Anchor>> {
         let diff = similar::TextDiff::from_words(old_text.as_str(), new_text);
 
         let mut edits: Vec<(Range<usize>, String)> = Vec::new();
@@ -822,10 +771,11 @@ and then another
                 old_range.end = old_range.end.saturating_sub(suffix_len);
 
                 let new_text = new_text[prefix_len..new_text.len() - suffix_len].to_string();
-                (
-                    snapshot.anchor_after(old_range.start)..snapshot.anchor_before(old_range.end),
+                PlainTextEdit {
+                    old_range: snapshot.anchor_after(old_range.start)
+                        ..snapshot.anchor_before(old_range.end),
                     new_text,
-                )
+                }
             })
             .collect()
     }
@@ -1083,7 +1033,7 @@ impl CurrentInlineCompletion {
         if old_edits.len() == 1 && new_edits.len() == 1 {
             let old = &old_edits[0];
             let new = &new_edits[0];
-            new.range == old.range && new.insertion.starts_with(&old.insertion)
+            new.old_range() == old.old_range() && new.new_text().starts_with(old.new_text())
         } else {
             true
         }
@@ -1286,16 +1236,17 @@ impl inline_completion::InlineCompletionProvider for ZetaInlineCompletionProvide
         let (closest_edit_ix, closest_edit) =
             edits.iter().enumerate().min_by_key(|(_, edit)| {
                 let distance_from_start =
-                    cursor_row.abs_diff(edit.range.start.to_point(buffer).row);
-                let distance_from_end = cursor_row.abs_diff(edit.range.end.to_point(buffer).row);
+                    cursor_row.abs_diff(edit.old_range().start.to_point(buffer).row);
+                let distance_from_end =
+                    cursor_row.abs_diff(edit.old_range().end.to_point(buffer).row);
                 cmp::min(distance_from_start, distance_from_end)
             })?;
-        let closest_edit_range = &closest_edit.range;
+        let closest_edit_range = &closest_edit.old_range();
 
         let mut edit_start_ix = closest_edit_ix;
         for edit in edits[..edit_start_ix].iter().rev() {
-            let distance_from_closest_edit =
-                closest_edit_range.start.to_point(buffer).row - edit.range.end.to_point(buffer).row;
+            let distance_from_closest_edit = closest_edit_range.start.to_point(buffer).row
+                - edit.old_range().end.to_point(buffer).row;
             if distance_from_closest_edit <= 1 {
                 edit_start_ix -= 1;
             } else {
@@ -1305,8 +1256,8 @@ impl inline_completion::InlineCompletionProvider for ZetaInlineCompletionProvide
 
         let mut edit_end_ix = closest_edit_ix + 1;
         for edit in &edits[edit_end_ix..] {
-            let distance_from_closest_edit =
-                edit.range.start.to_point(buffer).row - closest_edit_range.end.to_point(buffer).row;
+            let distance_from_closest_edit = edit.old_range().start.to_point(buffer).row
+                - closest_edit_range.end.to_point(buffer).row;
             if distance_from_closest_edit <= 1 {
                 edit_end_ix += 1;
             } else {
@@ -1336,7 +1287,7 @@ mod tests {
     #[gpui::test]
     async fn test_inline_completion_basic_interpolation(cx: &mut TestAppContext) {
         let buffer = cx.new(|cx| Buffer::local("Lorem ipsum dolor", cx));
-        let edits: Vec<(Range<Anchor>, String)> = cx.update(|cx| {
+        let edits: Vec<PlainTextEdit<Anchor>> = cx.update(|cx| {
             to_completion_edits(
                 [(2..5, "REM".to_string()), (9..11, "".to_string())],
                 &buffer,
@@ -1505,7 +1456,11 @@ mod tests {
 
         let completion = completion_task.await.unwrap();
         buffer.update(cx, |buffer, cx| {
-            buffer.edit(completion.edits.iter().map(|edit| edit.plain()), None, cx)
+            buffer.edit(
+                completion.edits.iter().map(|edit| edit.to_tuple()),
+                None,
+                cx,
+            )
         });
         assert_eq!(
             buffer.read_with(cx, |buffer, _| buffer.text()),
@@ -1517,21 +1472,19 @@ mod tests {
         iterator: impl IntoIterator<Item = (Range<usize>, String)>,
         buffer: &Entity<Buffer>,
         cx: &App,
-    ) -> Vec<(Range<Anchor>, String)> {
+    ) -> Vec<PlainTextEdit<Anchor>> {
         let buffer = buffer.read(cx);
         iterator
             .into_iter()
-            .map(|(range, text)| {
-                (
-                    buffer.anchor_after(range.start)..buffer.anchor_before(range.end),
-                    text,
-                )
+            .map(|(range, text)| PlainTextEdit {
+                old_range: buffer.anchor_after(range.start)..buffer.anchor_before(range.end),
+                new_text: text,
             })
             .collect()
     }
 
     fn from_completion_edits(
-        editor_edits: &[EditWithInsertionHighlights<Anchor>],
+        editor_edits: &[TextEditWithNewHighlights<Anchor>],
         buffer: &Entity<Buffer>,
         cx: &App,
     ) -> Vec<(Range<usize>, String)> {
@@ -1539,10 +1492,9 @@ mod tests {
         editor_edits
             .iter()
             .map(|edit| {
-                (
-                    edit.range.start.to_offset(buffer)..edit.range.end.to_offset(buffer),
-                    edit.insertion.clone(),
-                )
+                edit.clone()
+                    .map_position(|position| position.to_offset(buffer))
+                    .to_tuple()
             })
             .collect()
     }


### PR DESCRIPTION
* Computes highlights for the inserted text when generating the edit prediction.

* For edit previews, uses the current buffer highlights for unchanged and deleted regions.

* Adds `PlainTextEdit` and `EditWithNewHighlights` structs.  Both implement the `TextEdit` trait.

Release Notes:

- N/A