### PR TITLE
Add action `editor::InsertNumberSequence`

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -287,6 +287,7 @@ gpui::actions!(
         Indent,
         InsertUuidV4,
         InsertUuidV7,
+        InsertNumberSequence,
         JoinLines,
         KillRingCut,
         KillRingYank,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12660,6 +12660,24 @@ impl Editor {
         });
     }
 
+    fn insert_number_sequence(
+        &mut self,
+        _: &InsertNumberSequence,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.transact(window, cx, |this, window, cx| {
+            let edits = this
+                .selections
+                .all::<Point>(cx)
+                .into_iter()
+                .enumerate()
+                .map(|(idx, selection)| (selection.range(), (idx + 1).to_string()));
+            this.edit(edits, cx);
+            this.refresh_inline_completion(true, false, window, cx);
+        });
+    }
+
     pub fn open_selections_in_multibuffer(
         &mut self,
         _: &OpenSelectionsInMultibuffer,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -463,6 +463,7 @@ impl EditorElement {
         register_action(editor, window, Editor::spawn_nearest_task);
         register_action(editor, window, Editor::insert_uuid_v4);
         register_action(editor, window, Editor::insert_uuid_v7);
+        register_action(editor, window, Editor::insert_number_sequence);
         register_action(editor, window, Editor::open_selections_in_multibuffer);
     }
 


### PR DESCRIPTION
Closes #23005

Release Notes:

- Added `editor::InsertNumberSequence` action to insert numbers sequence in place of each cursor position.