### PR TITLE
menus: Add "Open File" action for Linux and Windows

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -53,7 +53,16 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("New", workspace::NewFile),
                 MenuItem::action("New Window", workspace::NewWindow),
                 MenuItem::separator(),
-                MenuItem::action("Open…", workspace::Open),
+                #[cfg(not(target_os = "macos"))]
+                MenuItem::action("Open File...", workspace::OpenFiles),
+                MenuItem::action(
+                    if cfg!(not(target_os = "macos")) {
+                        "Open Folder..."
+                    } else {
+                        "Open…"
+                    },
+                    workspace::Open,
+                ),
                 MenuItem::action(
                     "Open Recent...",
                     zed_actions::OpenRecent {


### PR DESCRIPTION
This PR adds menu item for `workspace::OpenFiles` in app menu on Linux and Windows.

Context:
When opening a file or folder on Linux and Windows via the native file picker, the picker can be either in file-only mode or folder-only mode. This means you have to open it already knowing whether you want to open a file or a folder, unlike macOS, which lets you choose either in the same picker.

For this reason, a new action, `workspace::OpenFiles`, was recently added for Linux and Windows. This is basically file-only mode, alongside the existing `workspace::Open` action, which is folder-only.  In macOS, the `workspace::Open` action is sufficient to open both file and folder.

Before:  
<img src="https://github.com/user-attachments/assets/67dc95d6-e98d-438a-9568-570e87617f85" alt="Before" width="200" />

After:  
<img src="https://github.com/user-attachments/assets/d0ffd02c-0f48-4edc-b426-4d430f2e0c86" alt="After" width="200" />

Release Notes:

- Added "Open File" action in file menu for Linux and Windows. 
