### PR TITLE
assistant1: Add model selector back

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -3043,45 +3043,45 @@ impl Render for ContextEditor {
                                 .child(self.render_inject_context_menu(cx, window))
                                 .child(ui::Divider::vertical())
                                 .child(
-                                LanguageModelSelectorPopoverMenu::new(
-                                    self.model_selector.clone(),
-                                    ButtonLike::new("active-model")
-                                        .style(ButtonStyle::Subtle)
-                                        .child(
-                                        h_flex()
-                                            .gap_0p5()
+                                    LanguageModelSelectorPopoverMenu::new(
+                                        self.model_selector.clone(),
+                                        ButtonLike::new("active-model")
+                                            .style(ButtonStyle::Subtle)
                                             .child(
-                                                div()
-                                                    .overflow_x_hidden()
-                                                    .flex_grow()
-                                                    .whitespace_nowrap()
+                                                h_flex()
+                                                    .gap_0p5()
                                                     .child(
-                                                        match LanguageModelRegistry::read_global(cx)
-                                                            .active_model()
-                                                        {
-                                                            Some(model) => h_flex()
-                                                                .child(
-                                                                    Label::new(model.name().0)
+                                                        div()
+                                                            .overflow_x_hidden()
+                                                            .flex_grow()
+                                                            .whitespace_nowrap()
+                                                            .child(
+                                                                match LanguageModelRegistry::read_global(cx)
+                                                                    .active_model()
+                                                                {
+                                                                    Some(model) => h_flex()
+                                                                        .child(
+                                                                            Label::new(model.name().0)
+                                                                                .size(LabelSize::Small)
+                                                                                .color(Color::Muted),
+                                                                        )
+                                                                        .into_any_element(),
+                                                                    _ => Label::new("No model selected")
                                                                         .size(LabelSize::Small)
-                                                                        .color(Color::Muted),
-                                                                )
-                                                                .into_any_element(),
-                                                            _ => Label::new("No model selected")
-                                                                .size(LabelSize::Small)
-                                                                .color(Color::Muted)
-                                                                .into_any_element(),
-                                                        },
+                                                                        .color(Color::Muted)
+                                                                        .into_any_element(),
+                                                                },
+                                                            ),
+                                                    )
+                                                    .child(
+                                                        Icon::new(IconName::ChevronDown)
+                                                            .color(Color::Muted)
+                                                            .size(IconSize::XSmall),
                                                     ),
-                                            )
-                                            .child(
-                                                Icon::new(IconName::ChevronDown)
-                                                    .color(Color::Muted)
-                                                    .size(IconSize::XSmall),
                                             ),
-                                    ),
-                                )
-                                .with_handle(self.model_selector_menu_handle.clone()),
-                            ),
+                                    )
+                                    .with_handle(self.model_selector_menu_handle.clone()),
+                                ),
                         )
                         .child(
                             h_flex()


### PR DESCRIPTION
This PR adds the model selector back to the Assistant 1 (Prompt Editor) view—users shouldn't need to navigate to the thread view to change that.

<img width="800" alt="Screenshot 2025-01-27 at 10 35 01 AM" src="https://github.com/user-attachments/assets/15e67f8b-0dcd-4c28-8342-0d4a69c16d08" />

Release Notes:

- N/A
