### PR TITLE
assistant1: Adjust tab and button labels

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -198,7 +198,7 @@ pub struct ContextEditor {
     dragged_file_worktrees: Vec<Entity<Worktree>>,
 }
 
-pub const DEFAULT_TAB_TITLE: &str = "New Chat";
+pub const DEFAULT_TAB_TITLE: &str = "New Prompt Editor";
 const MAX_TAB_TITLE_LEN: usize = 16;
 
 impl ContextEditor {
@@ -2437,13 +2437,7 @@ impl ContextEditor {
                 button.tooltip(move |_, _| tooltip.clone())
             })
             .layer(ElevationIndex::ModalSurface)
-            .child(Label::new(
-                if AssistantSettings::get_global(cx).are_live_diffs_enabled(cx) {
-                    "Chat"
-                } else {
-                    "Send"
-                },
-            ))
+            .child(Label::new("Send"))
             .children(
                 KeyBinding::for_action_in(&Assist, &focus_handle, window)
                     .map(|binding| binding.into_any_element()),


### PR DESCRIPTION
This PR removes the "chat" terminology from the tab and main send button of the Prompt Editor. I feel like we should focus on "chat"/"thread" as concepts/terminologies in the Assistant 2 moving forward.

Release Notes:

- N/A
