### PR TITLE
assistant: Preserve selection focus in the model selector

### DIFF
--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -193,6 +193,7 @@ impl PickerDelegate for LanguageModelPickerDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Task<()> {
         let all_models = self.all_models.clone();
+        let current_index = self.selected_index;
 
         let llm_registry = LanguageModelRegistry::global(cx);
 
@@ -239,17 +240,26 @@ impl PickerDelegate for LanguageModelPickerDelegate {
 
             this.update_in(&mut cx, |this, window, cx| {
                 this.delegate.filtered_models = filtered_models;
-                this.delegate.set_selected_index(0, window, cx);
+                // Preserve selection focus
+                let new_index = if current_index >= this.delegate.filtered_models.len() {
+                    0
+                } else {
+                    current_index
+                };
+                this.delegate.set_selected_index(new_index, window, cx);
                 cx.notify();
             })
             .ok();
         })
     }
 
-    fn confirm(&mut self, _secondary: bool, _: &mut Window, cx: &mut Context<Picker<Self>>) {
+    fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
         if let Some(model_info) = self.filtered_models.get(self.selected_index) {
             let model = model_info.model.clone();
             (self.on_model_changed)(model.clone(), cx);
+
+            let current_index = self.selected_index;
+            self.set_selected_index(current_index, window, cx);
 
             cx.emit(DismissEvent);
         }


### PR DESCRIPTION
This PR fixes an incorrect behavior in the model selector where we were removing the focus from the selected item back to the very first item of the list. Now, if you click/hit return on an item, focus is preserved there. In other words, focus is always initially in the selected item.

### Before
https://github.com/user-attachments/assets/62b72b1f-4e32-4b4a-adff-dcf9a2c13a28

### After
https://github.com/user-attachments/assets/a8528933-da01-481a-96f3-0173a39a03c0

Release Notes:

- N/A
