### PR TITLE
openai: Add back O1-Preview

### DIFF
--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -80,6 +80,7 @@ impl CloudModel {
                 | open_ai::Model::FourOmni
                 | open_ai::Model::FourOmniMini
                 | open_ai::Model::O1Mini
+                | open_ai::Model::O1Preview
                 | open_ai::Model::O1
                 | open_ai::Model::Custom { .. } => {
                     LanguageModelAvailability::RequiresPlan(Plan::ZedPro)

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -72,8 +72,10 @@ pub enum Model {
     FourOmni,
     #[serde(rename = "gpt-4o-mini", alias = "gpt-4o-mini")]
     FourOmniMini,
-    #[serde(rename = "o1", alias = "o1-preview")]
+    #[serde(rename = "o1", alias = "o1")]
     O1,
+    #[serde(rename = "o1-preview", alias = "o1-preview")]
+    O1Preview,
     #[serde(rename = "o1-mini", alias = "o1-mini")]
     O1Mini,
 
@@ -97,6 +99,7 @@ impl Model {
             "gpt-4o" => Ok(Self::FourOmni),
             "gpt-4o-mini" => Ok(Self::FourOmniMini),
             "o1" => Ok(Self::O1),
+            "o1-preview" => Ok(Self::O1Preview),
             "o1-mini" => Ok(Self::O1Mini),
             _ => Err(anyhow!("invalid model id")),
         }
@@ -110,6 +113,7 @@ impl Model {
             Self::FourOmni => "gpt-4o",
             Self::FourOmniMini => "gpt-4o-mini",
             Self::O1 => "o1",
+            Self::O1Preview => "o1-preview",
             Self::O1Mini => "o1-mini",
             Self::Custom { name, .. } => name,
         }
@@ -123,6 +127,7 @@ impl Model {
             Self::FourOmni => "gpt-4o",
             Self::FourOmniMini => "gpt-4o-mini",
             Self::O1 => "o1",
+            Self::O1Preview => "o1-preview",
             Self::O1Mini => "o1-mini",
             Self::Custom {
                 name, display_name, ..
@@ -137,7 +142,8 @@ impl Model {
             Self::FourTurbo => 128000,
             Self::FourOmni => 128000,
             Self::FourOmniMini => 128000,
-            Self::O1 => 128000,
+            Self::O1 => 200000,
+            Self::O1Preview => 128000,
             Self::O1Mini => 128000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/23425

Also corrects max_tokens for o1 (non-preview) to 200000, not 128000 as with o1-preview.

Release Notes:

- Restore o1-preview to OpenAI provider