### PR TITLE
assistant: Fix model selector label shift

### DIFF
--- a/crates/assistant2/src/assistant_model_selector.rs
+++ b/crates/assistant2/src/assistant_model_selector.rs
@@ -49,7 +49,7 @@ impl Render for AssistantModelSelector {
         let active_model = LanguageModelRegistry::read_global(cx).active_model();
         let focus_handle = self.focus_handle.clone();
         let model_name = match active_model {
-            Some(model) => SharedString::from(model.name().0),
+            Some(model) => model.name().0,
             _ => SharedString::from("No model selected"),
         };
 

--- a/crates/assistant2/src/assistant_model_selector.rs
+++ b/crates/assistant2/src/assistant_model_selector.rs
@@ -1,6 +1,6 @@
 use assistant_settings::AssistantSettings;
 use fs::Fs;
-use gpui::{Entity, FocusHandle};
+use gpui::{Entity, FocusHandle, SharedString};
 use language_model::LanguageModelRegistry;
 use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use settings::update_settings_file;
@@ -48,6 +48,10 @@ impl Render for AssistantModelSelector {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let active_model = LanguageModelRegistry::read_global(cx).active_model();
         let focus_handle = self.focus_handle.clone();
+        let model_name = match active_model {
+            Some(model) => SharedString::from(model.name().0),
+            _ => SharedString::from("No model selected"),
+        };
 
         LanguageModelSelectorPopoverMenu::new(
             self.selector.clone(),
@@ -57,23 +61,13 @@ impl Render for AssistantModelSelector {
                     h_flex()
                         .gap_0p5()
                         .child(
-                            div()
-                                .overflow_x_hidden()
-                                .flex_grow()
-                                .whitespace_nowrap()
-                                .child(match active_model {
-                                    Some(model) => h_flex()
-                                        .child(
-                                            Label::new(model.name().0)
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted),
-                                        )
-                                        .into_any_element(),
-                                    _ => Label::new("No model selected")
-                                        .size(LabelSize::Small)
-                                        .color(Color::Muted)
-                                        .into_any_element(),
-                                }),
+                            div().max_w_32().child(
+                                Label::new(model_name)
+                                    .size(LabelSize::Small)
+                                    .color(Color::Muted)
+                                    .text_ellipsis()
+                                    .into_any_element(),
+                            ),
                         )
                         .child(
                             Icon::new(IconName::ChevronDown)


### PR DESCRIPTION
This PR caps the width of the model label in the selector trigger to a certain size. This is fix the behavior of the popover dancing around, given its popover position is anchored to a certain edge of the trigger, and if the trigger size increases while you select different models with different name lengths, the popover dances around.

### Before

https://github.com/user-attachments/assets/0854fa2b-9eb2-45fb-886d-bde1cd644dcf

### After

Note how even though the second item has the largest label, the popover stays in place.

https://github.com/user-attachments/assets/06b60030-65dc-4f06-b486-3045042bbff0

Fixing that then means truncating the model name to keep it constrained into a max-width.

<img width="500" alt="Screenshot 2025-01-27 at 11 38 14 AM" src="https://github.com/user-attachments/assets/94ce9cc6-848c-4dac-86b8-321da75c3af3" />

Release Notes:

- N/A
