### PR TITLE
assistant2: Fix model selector position

### DIFF
--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -146,12 +146,11 @@ impl<T: PopoverTrigger> RenderOnce for LanguageModelSelectorPopoverMenu<T> {
         PopoverMenu::new("model-switcher")
             .menu(move |_window, _cx| Some(language_model_selector.clone()))
             .trigger(self.trigger)
-            .anchor(gpui::Corner::BottomLeft)
-            .attach(gpui::Corner::TopLeft)
+            .anchor(gpui::Corner::BottomRight)
             .when_some(self.handle.clone(), |menu, handle| menu.with_handle(handle))
             .offset(gpui::Point {
                 x: px(0.0),
-                y: px(-4.0),
+                y: px(-2.0),
             })
     }
 }

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -146,8 +146,13 @@ impl<T: PopoverTrigger> RenderOnce for LanguageModelSelectorPopoverMenu<T> {
         PopoverMenu::new("model-switcher")
             .menu(move |_window, _cx| Some(language_model_selector.clone()))
             .trigger(self.trigger)
-            .attach(gpui::Corner::BottomLeft)
+            .anchor(gpui::Corner::BottomLeft)
+            .attach(gpui::Corner::TopLeft)
             .when_some(self.handle.clone(), |menu, handle| menu.with_handle(handle))
+            .offset(gpui::Point {
+                x: px(0.0),
+                y: px(-4.0),
+            })
     }
 }
 


### PR DESCRIPTION
This PR makes the model selector not render on top of its trigger.

<img width="800" alt="Screenshot 2025-01-27 at 12 02 01 PM" src="https://github.com/user-attachments/assets/76c5ac6f-ae27-4b3d-a80a-3027042c75f8" />

Release Notes:

- N/A 
