### PR TITLE
assistant2: Add debug logging for initialization issues

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -118,14 +118,17 @@ impl AssistantPanel {
     ) -> Task<Result<Entity<Self>>> {
         cx.spawn(|mut cx| async move {
             let tools = Arc::new(ToolWorkingSet::default());
+            log::info!("[assistant2-debug] initializing ThreadStore");
             let thread_store = workspace
                 .update(&mut cx, |workspace, cx| {
                     let project = workspace.project().clone();
                     ThreadStore::new(project, tools.clone(), cx)
                 })?
                 .await?;
+            log::info!("[assistant2-debug] finished initializing ThreadStore");
 
             let slash_commands = Arc::new(SlashCommandWorkingSet::default());
+            log::info!("[assistant2-debug] initializing ContextStore");
             let context_store = workspace
                 .update(&mut cx, |workspace, cx| {
                     let project = workspace.project().clone();
@@ -138,6 +141,7 @@ impl AssistantPanel {
                     )
                 })?
                 .await?;
+            log::info!("[assistant2-debug] finished initializing ContextStore");
 
             workspace.update_in(&mut cx, |workspace, window, cx| {
                 cx.new(|cx| Self::new(workspace, thread_store, context_store, tools, window, cx))
@@ -153,6 +157,7 @@ impl AssistantPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        log::info!("[assistant2-debug] AssistantPanel::new");
         let thread = thread_store.update(cx, |this, cx| this.create_thread(cx));
         let fs = workspace.app_state().fs.clone();
         let project = workspace.project().clone();

--- a/crates/assistant2/src/thread_store.rs
+++ b/crates/assistant2/src/thread_store.rs
@@ -67,7 +67,9 @@ impl ThreadStore {
                 this
             })?;
 
+            log::info!("[assistant2-debug] reloading threads");
             this.update(&mut cx, |this, cx| this.reload(cx))?.await?;
+            log::info!("[assistant2-debug] finished reloading threads");
 
             Ok(this)
         })

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -440,12 +440,14 @@ fn initialize_panels(
         };
 
         let (assistant_panel, assistant2_panel) = if is_assistant2_enabled {
+            log::info!("[assistant2-debug] initializing Assistant2");
             let assistant2_panel = assistant2::AssistantPanel::load(
                 workspace_handle.clone(),
                 prompt_builder,
                 cx.clone(),
             )
             .await?;
+            log::info!("[assistant2-debug] finished initializing Assistant2");
 
             (None, Some(assistant2_panel))
         } else {
@@ -461,6 +463,7 @@ fn initialize_panels(
 
         workspace_handle.update_in(&mut cx, |workspace, window, cx| {
             if let Some(assistant2_panel) = assistant2_panel {
+                log::info!("[assistant2-debug] adding Assistant2 panel");
                 workspace.add_panel(assistant2_panel, window, cx);
             }
 


### PR DESCRIPTION
This PR adds some logging so we can debug the issues some folks have been having with Assistant2 not getting initialized properly.

All the logs are prefixed with `[assistant2-debug]` so they're easier to pick out of the logs, as well as find them later to clean up once we've diagnosed the issue.

Release Notes:

- N/A
