### PR TITLE
workspace: Prefer active window over other local non-collab windows for opening file

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5974,6 +5974,19 @@ pub fn open_paths(
                 .all(|file| !file.is_dir)
             {
                 cx.update(|cx| {
+                    if let Some(window) = cx
+                        .active_window()
+                        .and_then(|window| window.downcast::<Workspace>())
+                    {
+                        if let Ok(workspace) = window.read(cx) {
+                            let project = workspace.project().read(cx);
+                            if project.is_local() && !project.is_via_collab() {
+                                existing = Some(window);
+                                open_visible = OpenVisible::None;
+                                return;
+                            }
+                        }
+                    }
                     for window in local_workspace_windows(cx) {
                         if let Ok(workspace) = window.read(cx) {
                             let project = workspace.project().read(cx);


### PR DESCRIPTION
Closes #21625 #17401 #16426

This is how the opening of a file works currently:

1. We first check if the file is part of any existing worktree. If it is, we focus on that file in the worktree, and the window is activated.
2. If the file is not part of any worktree, we open it in the first local non-collab workspace we find and activate that window. This is the bug that the issues are based on.

This PR fixes it by modifying the second part of the above step, where the file is not part of any worktree. Now, we will first open the file in the active window, but only if the active window is local and non-collab. This resolves the issue. If the file can't be opened in the active window due to the local non-collab check, we will carry out the existing logic of opening the file in whichever window is local and non-collab.

I have tested this using the "workspace::OpenFiles" action, and "workspace::Open" also uses the same method. That is, it will work on all platforms.

Future: Some users also mentioned there should be a setting for whether we should open a non-workspace file in the existing window or in a separate new window. However, this seems out of scope, and a new issue should be created for this.

#9370 is related, but this likely doesn't fix it, as it deals with how macOS Finder's "Open with" handles files. I don't have macOS to test, but this PR won't resolve it if Finder always opens a new window.

Release Notes:

- Fixed the issue where a file outside of the workspace was opening in a random window instead of the last active window.