### PR TITLE
assistant2: Don't block `ThreadStore` initialization on reloading the threads

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -119,12 +119,10 @@ impl AssistantPanel {
         cx.spawn(|mut cx| async move {
             let tools = Arc::new(ToolWorkingSet::default());
             log::info!("[assistant2-debug] initializing ThreadStore");
-            let thread_store = workspace
-                .update(&mut cx, |workspace, cx| {
-                    let project = workspace.project().clone();
-                    ThreadStore::new(project, tools.clone(), cx)
-                })?
-                .await?;
+            let thread_store = workspace.update(&mut cx, |workspace, cx| {
+                let project = workspace.project().clone();
+                ThreadStore::new(project, tools.clone(), cx)
+            })??;
             log::info!("[assistant2-debug] finished initializing ThreadStore");
 
             let slash_commands = Arc::new(SlashCommandWorkingSet::default());


### PR DESCRIPTION
This PR changes the `ThreadStore` constructor to not block on reloading the threads before we finish initializing it.

This allows us to make the constructor synchronous instead of asynchronous.

Release Notes:

- N/A
