### PR TITLE
assistant2: Fix opening the configuration via the button

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -679,8 +679,8 @@ impl AssistantPanel {
                             .icon_size(IconSize::Small)
                             .style(ButtonStyle::Subtle)
                             .tooltip(Tooltip::text("Configure Assistant"))
-                            .on_click(move |_event, _window, cx| {
-                                cx.dispatch_action(&OpenConfiguration);
+                            .on_click(move |_event, window, cx| {
+                                window.dispatch_action(OpenConfiguration.boxed_clone(), cx);
                             }),
                     ),
             )


### PR DESCRIPTION
This PR fixes an issues where clicking the "Open Configuration" button wasn't opening the configuration.

We needed to change how the action was dispatched after #22632.

Release Notes:

- N/A
