### PR TITLE
pane: Add settings to hide the tab bar buttons

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -593,7 +593,7 @@
     "show": true,
     // Whether or not to show the navigation history buttons.
     "show_nav_history_buttons": true,
-    /// Whether or not to show the pane-related buttons in the tab bar.
+    /// Whether or not to show the tab bar buttons.
     "show_tab_bar_buttons": true
   },
   // Settings related to the editor's tabs

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -592,7 +592,9 @@
     // Whether or not to show the tab bar in the editor
     "show": true,
     // Whether or not to show the navigation history buttons.
-    "show_nav_history_buttons": true
+    "show_nav_history_buttons": true,
+    /// Whether or not to show the pane-related buttons in the tab bar.
+    "show_tab_bar_buttons": true
   },
   // Settings related to the editor's tabs
   "tabs": {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -147,6 +147,7 @@ pub struct WorkspaceSettingsContent {
 pub struct TabBarSettings {
     pub show: bool,
     pub show_nav_history_buttons: bool,
+    pub show_tab_bar_buttons: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -159,6 +160,10 @@ pub struct TabBarSettingsContent {
     ///
     /// Default: true
     pub show_nav_history_buttons: Option<bool>,
+    /// Whether or not to show the pane-related buttons in the tab bar.
+    ///
+    /// Default: true
+    pub show_tab_bar_buttons: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -160,7 +160,7 @@ pub struct TabBarSettingsContent {
     ///
     /// Default: true
     pub show_nav_history_buttons: Option<bool>,
-    /// Whether or not to show the pane-related buttons in the tab bar.
+    /// Whether or not to show the tab bar buttons.
     ///
     /// Default: true
     pub show_tab_bar_buttons: Option<bool>,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -741,7 +741,7 @@ List of `string` values
 
 ### Tab Bar Buttons
 
-- Description: Whether or not to show the pane-related buttons in the tab bar.
+- Description: Whether or not to show the tab bar buttons.
 - Setting: `show_tab_bar_buttons`
 - Default: `true`
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -714,7 +714,8 @@ List of `string` values
 ```json
 "tab_bar": {
   "show": true,
-  "show_nav_history_buttons": true
+  "show_nav_history_buttons": true,
+  "show_tab_bar_buttons": true
 }
 ```
 
@@ -732,6 +733,16 @@ List of `string` values
 
 - Description: Whether or not to show the navigation history buttons.
 - Setting: `show_nav_history_buttons`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+### Tab Bar Buttons
+
+- Description: Whether or not to show the pane-related buttons in the tab bar.
+- Setting: `show_tab_bar_buttons`
 - Default: `true`
 
 **Options**


### PR DESCRIPTION
This PR adds the `show_tab_bar_buttons` under `tab_bar` that allows hiding the "New", "Split Pane", and "Zoom" buttons to the left of the pane tab bar.

Release Notes:

- Added a new `show_tab_bar_buttons` setting, under `tab_bar`, that enables hiding the pane tab bar buttons.
