### PR TITLE
Flag issues as stale more aggressively

### DIFF
--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -19,11 +19,7 @@ jobs:
 
             Thanks for your help!
           close-issue-message: "This issue was closed due to inactivity. If you're still experiencing this problem, please open a new issue with a link to this issue."
-          # We will increase `days-before-stale` to 365 on or after Jan 24th,
-          # 2024. This date marks one year since migrating issues from
-          # 'community' to 'zed' repository. The migration added activity to all
-          # issues, preventing 365 days from working until then.
-          days-before-stale: 180
+          days-before-stale: 120
           days-before-close: 7
           any-of-issue-labels: "bug,panic / crash"
           operations-per-run: 1000


### PR DESCRIPTION
We used to wait 6 months to close stale issues. Jono suggested 1 month. I'm sort of splitting the difference and adding a bit of buffer. We can adjust again later on, if we want.

Release Notes:

- N/A
