### PR TITLE
Omit gitignored files from context file picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "ui",
  "util",
  "workspace",
+ "worktree",
 ]
 
 [[package]]

--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -124,7 +124,7 @@ impl FileContextPickerDelegate {
             let file_matches = project.worktrees(cx).flat_map(|worktree| {
                 let worktree = worktree.read(cx);
                 let path_prefix: Arc<str> = worktree.root_name().into();
-                worktree.files(true, 0).map(move |entry| PathMatch {
+                worktree.files(false, 0).map(move |entry| PathMatch {
                     score: 0.,
                     positions: Vec::new(),
                     worktree_id: worktree.id().to_usize(),

--- a/crates/assistant_slash_commands/Cargo.toml
+++ b/crates/assistant_slash_commands/Cargo.toml
@@ -45,6 +45,7 @@ toml.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+worktree.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/assistant_slash_commands/src/file_command.rs
+++ b/crates/assistant_slash_commands/src/file_command.rs
@@ -20,6 +20,7 @@ use std::{
 use ui::prelude::*;
 use util::ResultExt;
 use workspace::Workspace;
+use worktree::ChildEntriesOptions;
 
 pub struct FileSlashCommand;
 
@@ -42,8 +43,12 @@ impl FileSlashCommand {
                 .chain(project.worktrees(cx).flat_map(|worktree| {
                     let worktree = worktree.read(cx);
                     let id = worktree.id();
-                    let entries =
-                        worktree.child_entries_with_options(Path::new(""), true, true, false);
+                    let options = ChildEntriesOptions {
+                        include_files: true,
+                        include_dirs: true,
+                        include_ignored: false,
+                    };
+                    let entries = worktree.child_entries_with_options(Path::new(""), options);
                     entries.map(move |entry| {
                         (
                             project::ProjectPath {

--- a/crates/assistant_slash_commands/src/file_command.rs
+++ b/crates/assistant_slash_commands/src/file_command.rs
@@ -42,7 +42,9 @@ impl FileSlashCommand {
                 .chain(project.worktrees(cx).flat_map(|worktree| {
                     let worktree = worktree.read(cx);
                     let id = worktree.id();
-                    worktree.child_entries(Path::new("")).map(move |entry| {
+                    let entries =
+                        worktree.child_entries_with_options(Path::new(""), true, true, false);
+                    entries.map(move |entry| {
                         (
                             project::ProjectPath {
                                 worktree_id: id,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2658,14 +2658,24 @@ impl Snapshot {
     }
 
     pub fn child_entries<'a>(&'a self, parent_path: &'a Path) -> ChildEntriesIter<'a> {
+        self.child_entries_with_options(parent_path, true, true, true)
+    }
+
+    pub fn child_entries_with_options<'a>(
+        &'a self,
+        parent_path: &'a Path,
+        include_files: bool,
+        include_dirs: bool,
+        include_ignored: bool,
+    ) -> ChildEntriesIter<'a> {
         let mut cursor = self.entries_by_path.cursor(&());
         cursor.seek(&TraversalTarget::path(parent_path), Bias::Right, &());
         let traversal = Traversal {
             snapshot: self,
             cursor,
-            include_files: true,
-            include_dirs: true,
-            include_ignored: true,
+            include_files,
+            include_dirs,
+            include_ignored,
         };
         ChildEntriesIter {
             traversal,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2658,24 +2658,27 @@ impl Snapshot {
     }
 
     pub fn child_entries<'a>(&'a self, parent_path: &'a Path) -> ChildEntriesIter<'a> {
-        self.child_entries_with_options(parent_path, true, true, true)
+        let options = ChildEntriesOptions {
+            include_files: true,
+            include_dirs: true,
+            include_ignored: true,
+        };
+        self.child_entries_with_options(parent_path, options)
     }
 
     pub fn child_entries_with_options<'a>(
         &'a self,
         parent_path: &'a Path,
-        include_files: bool,
-        include_dirs: bool,
-        include_ignored: bool,
+        options: ChildEntriesOptions,
     ) -> ChildEntriesIter<'a> {
         let mut cursor = self.entries_by_path.cursor(&());
         cursor.seek(&TraversalTarget::path(parent_path), Bias::Right, &());
         let traversal = Traversal {
             snapshot: self,
             cursor,
-            include_files,
-            include_dirs,
-            include_ignored,
+            include_files: options.include_files,
+            include_dirs: options.include_dirs,
+            include_ignored: options.include_ignored,
         };
         ChildEntriesIter {
             traversal,
@@ -5995,6 +5998,12 @@ impl<'a, 'b> SeekTarget<'a, PathSummary<Unit>, TraversalProgress<'a>> for Traver
     fn cmp(&self, cursor_location: &TraversalProgress<'a>, _: &()) -> Ordering {
         self.cmp_progress(cursor_location)
     }
+}
+
+pub struct ChildEntriesOptions {
+    pub include_files: bool,
+    pub include_dirs: bool,
+    pub include_ignored: bool,
 }
 
 pub struct ChildEntriesIter<'a> {


### PR DESCRIPTION
In both `thread` and `prompt editor` the context file picker, gitignored files are hidden (as expected) when searching files by path, but they are still shown initially as you create the file picker.

Plus, selecting gitignored files in the `prompt editor` is bugged and collapses everything.

This PR settles on not showing gitignored files to solve these inconsistencies.

Release Notes:

- Fix gitignored files filter occasionally not working in context file picker.
