### PR TITLE
gpui: Fix `pattern` example

### DIFF
--- a/crates/gpui/examples/pattern.rs
+++ b/crates/gpui/examples/pattern.rs
@@ -1,12 +1,12 @@
 use gpui::{
     div, linear_color_stop, linear_gradient, pattern_slash, prelude::*, px, rgb, size, App,
-    AppContext, Bounds, ViewContext, WindowBounds, WindowOptions,
+    AppContext, Application, Bounds, Context, Window, WindowBounds, WindowOptions,
 };
 
 struct PatternExample;
 
 impl Render for PatternExample {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .flex()
             .flex_col()
@@ -87,14 +87,14 @@ impl Render for PatternExample {
 }
 
 fn main() {
-    App::new().run(|cx: &mut AppContext| {
+    Application::new().run(|cx: &mut App| {
         let bounds = Bounds::centered(None, size(px(600.0), px(600.0)), cx);
         cx.open_window(
             WindowOptions {
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
-            |cx| cx.new_view(|_cx| PatternExample),
+            |_window, cx| cx.new(|_cx| PatternExample),
         )
         .unwrap();
 


### PR DESCRIPTION
This PR fixes the `pattern` example, which was merged in https://github.com/zed-industries/zed/pull/23576 without being updated with the new GPUI changes.

Release Notes:

- N/A
