### PR TITLE
ci: Restrict more jobs to only run in the `zed-industries` organization

### DIFF
--- a/.github/workflows/bump_patch_version.yml
+++ b/.github/workflows/bump_patch_version.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   bump_patch_version:
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
     steps:

--- a/.github/workflows/community_delete_comments.yml
+++ b/.github/workflows/community_delete_comments.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   delete_comment:
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Check for specific strings in comment

--- a/.github/workflows/community_release_actions.yml
+++ b/.github/workflows/community_release_actions.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   discord_release:
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
     steps:
       - name: Get release URL

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   danger:
+    if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   style:
     name: Check formatting and Clippy lints
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
       - test

--- a/.github/workflows/publish_extension_cli.yml
+++ b/.github/workflows/publish_extension_cli.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   publish:
     name: Publish zed-extension CLI
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - ubuntu-latest
     steps:

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   tests:
     name: Run randomized tests
+    if: github.repository_owner == 'zed-industries'
     runs-on:
       - buildjet-16vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
This PR updates the GitHub Action definitions to restrict more CI jobs to only run in the `zed-industries` organization (and thus, not on forks).

Release Notes:

- N/A
