### PR TITLE
collab: Fix error message when missing Kinesis region

### DIFF
--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -407,7 +407,7 @@ async fn build_kinesis_client(config: &Config) -> anyhow::Result<aws_sdk_kinesis
             config
                 .kinesis_region
                 .clone()
-                .ok_or_else(|| anyhow!("missing blob_store_region"))?,
+                .ok_or_else(|| anyhow!("missing kinesis_region"))?,
         ))
         .credentials_provider(keys)
         .load()


### PR DESCRIPTION
This PR fixes a typo in the error that occurs when trying to construct an AWS Kinesis client and the `kinesis_region` value is missing.

Release Notes:

- N/A
