### PR TITLE
Show settings file errors on startup

### DIFF
--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -3,7 +3,6 @@ use fs::Fs;
 use futures::{channel::mpsc, StreamExt};
 use gpui::{App, BackgroundExecutor, ReadGlobal, UpdateGlobal};
 use std::{path::PathBuf, sync::Arc, time::Duration};
-use util::ResultExt;
 
 pub const EMPTY_THEME_NAME: &str = "empty-theme";
 
@@ -73,18 +72,22 @@ pub fn handle_settings_file_changes(
         .block(user_settings_file_rx.next())
         .unwrap();
     SettingsStore::update_global(cx, |store, cx| {
-        store
-            .set_user_settings(&user_settings_content, cx)
-            .log_err();
+        let result = store.set_user_settings(&user_settings_content, cx);
+        if let Err(err) = &result {
+            log::error!("Failed to load user settings: {err}");
+        }
+        settings_changed(result.err(), cx);
     });
     cx.spawn(move |cx| async move {
         while let Some(user_settings_content) = user_settings_file_rx.next().await {
-            let result = cx.update_global(|store: &mut SettingsStore, cx| {
-                let result = store.set_user_settings(&user_settings_content, cx);
-                if let Err(err) = &result {
-                    log::error!("Failed to load user settings: {err}");
-                }
-                settings_changed(result.err(), cx);
+            let result = cx.update(|cx| {
+                SettingsStore::update_global(cx, |store, cx| {
+                    let result = store.set_user_settings(&user_settings_content, cx);
+                    if let Err(err) = &result {
+                        log::error!("Failed to load user settings: {err}");
+                    }
+                    settings_changed(result.err(), cx);
+                });
                 cx.refresh_windows();
             });
             if result.is_err() {

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -80,14 +80,12 @@ pub fn handle_settings_file_changes(
     });
     cx.spawn(move |cx| async move {
         while let Some(user_settings_content) = user_settings_file_rx.next().await {
-            let result = cx.update(|cx| {
-                SettingsStore::update_global(cx, |store, cx| {
-                    let result = store.set_user_settings(&user_settings_content, cx);
-                    if let Err(err) = &result {
-                        log::error!("Failed to load user settings: {err}");
-                    }
-                    settings_changed(result.err(), cx);
-                });
+            let result = cx.update_global(|store: &mut SettingsStore, cx| {
+                let result = store.set_user_settings(&user_settings_content, cx);
+                if let Err(err) = &result {
+                    log::error!("Failed to load user settings: {err}");
+                }
+                settings_changed(result.err(), cx);
                 cx.refresh_windows();
             });
             if result.is_err() {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -365,7 +365,6 @@ fn prompt_and_open_paths(app_state: Arc<AppState>, options: PathPromptOptions, c
 
 pub fn init(app_state: Arc<AppState>, cx: &mut App) {
     init_settings(cx);
-    notifications::init(cx);
     theme_preview::init(cx);
 
     cx.on_action(Workspace::close_global);

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -18,7 +18,7 @@ use extension::ExtensionHostProxy;
 use fs::{Fs, RealFs};
 use futures::{future, StreamExt};
 use git::GitHostingProviderRegistry;
-use gpui::{Action, App, AppContext as _, Application, AsyncApp, DismissEvent, UpdateGlobal as _};
+use gpui::{App, AppContext as _, Application, AsyncApp, UpdateGlobal as _};
 
 use http_client::{read_proxy_from_env, Uri};
 use language::LanguageRegistry;
@@ -33,9 +33,7 @@ use project::project_settings::ProjectSettings;
 use recent_projects::{open_ssh_project, SshSettings};
 use release_channel::{AppCommitSha, AppVersion, ReleaseChannel};
 use session::{AppSession, Session};
-use settings::{
-    handle_settings_file_changes, watch_config_file, InvalidSettingsError, Settings, SettingsStore,
-};
+use settings::{handle_settings_file_changes, watch_config_file, Settings, SettingsStore};
 use simplelog::ConfigBuilder;
 use std::{
     env,
@@ -50,17 +48,12 @@ use time::UtcOffset;
 use util::{maybe, ResultExt, TryFutureExt};
 use uuid::Uuid;
 use welcome::{show_welcome_view, BaseKeymap, FIRST_OPEN};
-use workspace::{
-    notifications::{simple_message_notification::MessageNotification, NotificationId},
-    AppState, SerializedWorkspaceLocation, WorkspaceSettings, WorkspaceStore,
-};
+use workspace::{AppState, SerializedWorkspaceLocation, WorkspaceSettings, WorkspaceStore};
 use zed::{
     app_menus, build_window_options, derive_paths_with_position, handle_cli_connection,
-    handle_keymap_file_changes, initialize_workspace, open_paths_with_positions, OpenListener,
-    OpenRequest,
+    handle_keymap_file_changes, handle_settings_changed, initialize_workspace,
+    inline_completion_registry, open_paths_with_positions, OpenListener, OpenRequest,
 };
-
-use crate::zed::inline_completion_registry;
 
 #[cfg(unix)]
 use util::{load_login_shell_environment, load_shell_from_passwd};
@@ -612,44 +605,6 @@ fn main() {
         })
         .detach();
     });
-}
-
-fn handle_settings_changed(error: Option<anyhow::Error>, cx: &mut App) {
-    struct SettingsParseErrorNotification;
-    let id = NotificationId::unique::<SettingsParseErrorNotification>();
-
-    for workspace in workspace::local_workspace_windows(cx) {
-        workspace
-            .update(cx, |workspace, _, cx| {
-                match error.as_ref() {
-                    Some(error) => {
-                        if let Some(InvalidSettingsError::LocalSettings { .. }) =
-                            error.downcast_ref::<InvalidSettingsError>()
-                        {
-                            // Local settings will be displayed by the projects
-                        } else {
-                            workspace.show_notification(id.clone(), cx, |cx| {
-                                cx.new(|_cx| {
-                                    MessageNotification::new(format!(
-                                        "Invalid user settings file\n{error}"
-                                    ))
-                                    .with_click_message("Open settings file")
-                                    .on_click(|window, cx| {
-                                        window.dispatch_action(
-                                            zed_actions::OpenSettings.boxed_clone(),
-                                            cx,
-                                        );
-                                        cx.emit(DismissEvent);
-                                    })
-                                })
-                            });
-                        }
-                    }
-                    None => workspace.dismiss_notification(&id, cx),
-                }
-            })
-            .log_err();
-    }
 }
 
 fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut App) {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -39,12 +39,12 @@ use release_channel::{AppCommitSha, ReleaseChannel};
 use rope::Rope;
 use search::project_search::ProjectSearchBar;
 use settings::{
-    initial_project_settings_content, initial_tasks_content, update_settings_file, KeymapFile,
-    KeymapFileLoadResult, Settings, SettingsStore, DEFAULT_KEYMAP_PATH, VIM_KEYMAP_PATH,
+    initial_project_settings_content, initial_tasks_content, update_settings_file,
+    InvalidSettingsError, KeymapFile, KeymapFileLoadResult, Settings, SettingsStore,
+    DEFAULT_KEYMAP_PATH, VIM_KEYMAP_PATH,
 };
 use std::any::TypeId;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
 use terminal_view::terminal_panel::{self, TerminalPanel};
 use theme::{ActiveTheme, ThemeSettings};
@@ -1220,7 +1220,7 @@ fn show_keymap_file_load_error(
     });
 
     cx.spawn(move |cx| async move {
-        let parsed_markdown = Rc::new(parsed_markdown.await);
+        let parsed_markdown = Arc::new(parsed_markdown.await);
         cx.update(|cx| {
             show_app_notification(notification_id, cx, move |cx| {
                 let workspace_handle = cx.entity().downgrade();
@@ -1271,6 +1271,33 @@ pub fn load_default_keymap(cx: &mut App) {
 
     if let Some(asset_path) = base_keymap.asset_path() {
         cx.bind_keys(KeymapFile::load_asset(asset_path, cx).unwrap());
+    }
+}
+
+pub fn handle_settings_changed(error: Option<anyhow::Error>, cx: &mut App) {
+    struct SettingsParseErrorNotification;
+    let id = NotificationId::unique::<SettingsParseErrorNotification>();
+
+    match error {
+        Some(error) => {
+            if let Some(InvalidSettingsError::LocalSettings { .. }) =
+                error.downcast_ref::<InvalidSettingsError>()
+            {
+                // Local settings errors are displayed by the projects
+                return;
+            }
+            show_app_notification(id, cx, move |cx| {
+                cx.new(|_cx| {
+                    MessageNotification::new(format!("Invalid user settings file\n{error}"))
+                        .with_click_message("Open settings file")
+                        .on_click(|window, cx| {
+                            window.dispatch_action(zed_actions::OpenSettings.boxed_clone(), cx);
+                            cx.emit(DismissEvent);
+                        })
+                })
+            });
+        }
+        None => dismiss_app_notification(&id, cx),
     }
 }
 


### PR DESCRIPTION
Required using a global `LazyLock<Mutex<AppNotifications>>` instead of a context global because settings errors first occur before initialization of the notifications global. 

Release Notes:

- Errors in settings file are now reported in UI on startup.