### PR TITLE
Allow buffer search in project search

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -137,7 +137,7 @@
       "ctrl-k z": "editor::ToggleSoftWrap",
       "find": "buffer_search::Deploy",
       "ctrl-f": "buffer_search::Deploy",
-      "ctrl-h": ["buffer_search::Deploy", { "replace_enabled": true }],
+      "ctrl-h": ["buffer_search::DeployReplace"],
       // "cmd-e": ["buffer_search::Deploy", { "focus": false }],
       "ctrl->": "assistant::QuoteSelection",
       "ctrl-<": "assistant::InsertIntoEditor",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -137,7 +137,7 @@
       "ctrl-k z": "editor::ToggleSoftWrap",
       "find": "buffer_search::Deploy",
       "ctrl-f": "buffer_search::Deploy",
-      "ctrl-h": ["buffer_search::DeployReplace"],
+      "ctrl-h": "buffer_search::DeployReplace",
       // "cmd-e": ["buffer_search::Deploy", { "focus": false }],
       "ctrl->": "assistant::QuoteSelection",
       "ctrl-<": "assistant::InsertIntoEditor",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -146,7 +146,7 @@
       "cmd-shift-enter": "editor::NewlineAbove",
       "cmd-k z": "editor::ToggleSoftWrap",
       "cmd-f": "buffer_search::Deploy",
-      "cmd-alt-f": ["buffer_search::Deploy", { "replace_enabled": true }],
+      "cmd-alt-f": "buffer_search::DeployReplace",
       "cmd-alt-l": ["buffer_search::Deploy", { "selection_search_enabled": true }],
       "cmd-e": ["buffer_search::Deploy", { "focus": false }],
       "cmd->": "assistant::QuoteSelection",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -727,6 +727,7 @@ pub struct Editor {
     expect_bounds_change: Option<Bounds<Pixels>>,
     tasks: BTreeMap<(BufferId, BufferRow), RunnableTasks>,
     tasks_update_task: Option<Task<()>>,
+    in_project_search: bool,
     previous_search_ranges: Option<Arc<[Range<Anchor>]>>,
     breadcrumb_header: Option<String>,
     focused_block: Option<FocusedBlock>,
@@ -1424,6 +1425,7 @@ impl Editor {
             ],
             tasks_update_task: None,
             linked_edit_ranges: Default::default(),
+            in_project_search: false,
             previous_search_ranges: None,
             breadcrumb_header: None,
             focused_block: None,
@@ -1699,6 +1701,10 @@ impl Editor {
 
     pub fn set_collaboration_hub(&mut self, hub: Box<dyn CollaborationHub>) {
         self.collaboration_hub = Some(hub);
+    }
+
+    pub fn set_in_project_search(&mut self, in_project_search: bool) {
+        self.in_project_search = in_project_search;
     }
 
     pub fn set_custom_context_menu(

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1341,9 +1341,9 @@ impl SearchableItem for Editor {
                 case: true,
                 word: true,
                 regex: true,
-                replacement: false,
-                selection: false,
-                next_prev: false,
+                replacement: true,
+                selection: true,
+                next_prev: true,
             }
         }
     }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -38,8 +38,11 @@ use text::{BufferId, Selection};
 use theme::{Theme, ThemeSettings};
 use ui::{h_flex, prelude::*, IconDecorationKind, Label};
 use util::{paths::PathExt, ResultExt, TryFutureExt};
-use workspace::item::{BreadcrumbText, FollowEvent};
 use workspace::item::{Dedup, ItemSettings, SerializableItem, TabContentParams};
+use workspace::{
+    item::{BreadcrumbText, FollowEvent},
+    searchable::SearchOptions,
+};
 use workspace::{
     item::{FollowableItem, Item, ItemEvent, ProjectItem},
     searchable::{Direction, SearchEvent, SearchableItem, SearchableItemHandle},
@@ -1320,6 +1323,28 @@ impl SearchableItem for Editor {
             self.set_search_within_ranges(&ranges, cx);
         } else if let Some(previous_search_ranges) = self.previous_search_ranges.take() {
             self.set_search_within_ranges(&previous_search_ranges, cx)
+        }
+    }
+
+    fn supported_options(&self) -> SearchOptions {
+        if self.in_project_search {
+            SearchOptions {
+                case: true,
+                word: true,
+                regex: true,
+                replacement: false,
+                selection: false,
+                next_prev: false,
+            }
+        } else {
+            SearchOptions {
+                case: true,
+                word: true,
+                regex: true,
+                replacement: false,
+                selection: false,
+                next_prev: false,
+            }
         }
     }
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1334,7 +1334,7 @@ impl SearchableItem for Editor {
                 regex: true,
                 replacement: false,
                 selection: false,
-                next_prev: false,
+                find_in_results: true,
             }
         } else {
             SearchOptions {
@@ -1343,7 +1343,7 @@ impl SearchableItem for Editor {
                 regex: true,
                 replacement: true,
                 selection: true,
-                next_prev: true,
+                find_in_results: false,
             }
         }
     }

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -1153,7 +1153,7 @@ impl SearchableItem for LspLogView {
             case: true,
             word: true,
             regex: true,
-            next_prev: true,
+            find_in_results: false,
             // LSP log is read-only.
             replacement: false,
             selection: false,

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -1148,11 +1148,12 @@ impl SearchableItem for LspLogView {
     ) {
         // Since LSP Log is read-only, it doesn't make sense to support replace operation.
     }
-    fn supported_options() -> workspace::searchable::SearchOptions {
+    fn supported_options(&self) -> workspace::searchable::SearchOptions {
         workspace::searchable::SearchOptions {
             case: true,
             word: true,
             regex: true,
+            next_prev: true,
             // LSP log is read-only.
             replacement: false,
             selection: false,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -55,13 +55,21 @@ pub struct Deploy {
 
 impl_actions!(buffer_search, [Deploy]);
 
-actions!(buffer_search, [Dismiss, FocusEditor]);
+actions!(buffer_search, [DeployReplace, Dismiss, FocusEditor]);
 
 impl Deploy {
     pub fn find() -> Self {
         Self {
             focus: true,
             replace_enabled: false,
+            selection_search_enabled: false,
+        }
+    }
+
+    pub fn replace() -> Self {
+        Self {
+            focus: true,
+            replace_enabled: true,
             selection_search_enabled: false,
         }
     }
@@ -630,6 +638,13 @@ impl BufferSearchBar {
         // when the deploy action is triggered in the buffer.
         registrar.register_handler(ForDeployed(|this, deploy, window, cx| {
             this.deploy(deploy, window, cx);
+        }));
+        registrar.register_handler(ForDismissed(|this, _: &DeployReplace, window, cx| {
+            if this.supported_options(cx).find_in_results {
+                cx.propagate();
+            } else {
+                this.deploy(&Deploy::replace(), window, cx);
+            }
         }));
         registrar.register_handler(ForDismissed(|this, deploy, window, cx| {
             this.deploy(deploy, window, cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -223,7 +223,7 @@ impl Render for BufferSearchBar {
 
         let search_line = h_flex()
             .gap_2()
-            .when(!supported_options.next_prev, |el| {
+            .when(supported_options.find_in_results, |el| {
                 el.child(Label::new("Find in results").color(Color::Hint))
             })
             .child(
@@ -331,7 +331,7 @@ impl Render for BufferSearchBar {
                             }),
                         )
                     })
-                    .when(supported_options.next_prev, |el| {
+                    .when(!supported_options.find_in_results, |el| {
                         el.child(
                             IconButton::new("select-all", ui::IconName::SelectAll)
                                 .on_click(|_, window, cx| {
@@ -384,7 +384,7 @@ impl Render for BufferSearchBar {
                             ))
                         })
                     })
-                    .when(!supported_options.next_prev, |el| {
+                    .when(supported_options.find_in_results, |el| {
                         el.child(
                             IconButton::new(SharedString::from("Close"), IconName::Close)
                                 .shape(IconButtonShape::Square)
@@ -484,7 +484,7 @@ impl Render for BufferSearchBar {
                 this.on_action(cx.listener(Self::toggle_selection))
             })
             .child(h_flex().relative().child(search_line.w_full()).when(
-                !narrow_mode && supported_options.next_prev,
+                !narrow_mode && !supported_options.find_in_results,
                 |div| {
                     div.child(
                         h_flex().absolute().right_0().child(
@@ -542,7 +542,7 @@ impl ToolbarItemView for BufferSearchBar {
                     }),
                 ));
 
-            let is_project_search = !searchable_item_handle.supported_options(cx).next_prev;
+            let is_project_search = searchable_item_handle.supported_options(cx).find_in_results;
             self.active_searchable_item = Some(searchable_item_handle);
             drop(self.update_matches(true, window, cx));
             if !self.dismissed {
@@ -595,25 +595,25 @@ impl BufferSearchBar {
             }
         }));
         registrar.register_handler(WithResults(|this, action: &SelectNextMatch, window, cx| {
-            if this.supported_options(cx).next_prev {
-                this.select_next_match(action, window, cx);
-            } else {
+            if this.supported_options(cx).find_in_results {
                 cx.propagate();
+            } else {
+                this.select_next_match(action, window, cx);
             }
         }));
         registrar.register_handler(WithResults(|this, action: &SelectPrevMatch, window, cx| {
-            if this.supported_options(cx).next_prev {
-                this.select_prev_match(action, window, cx);
-            } else {
+            if this.supported_options(cx).find_in_results {
                 cx.propagate();
+            } else {
+                this.select_prev_match(action, window, cx);
             }
         }));
         registrar.register_handler(WithResults(
             |this, action: &SelectAllMatches, window, cx| {
-                if this.supported_options(cx).next_prev {
-                    this.select_all_matches(action, window, cx);
-                } else {
+                if this.supported_options(cx).find_in_results {
                     cx.propagate();
+                } else {
+                    this.select_all_matches(action, window, cx);
                 }
             },
         ));

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -421,6 +421,9 @@ impl Item for ProjectSearchView {
             None
         }
     }
+    fn as_searchable(&self, _: &Entity<Self>) -> Option<Box<dyn SearchableItemHandle>> {
+        Some(Box::new(self.results_editor.clone()))
+    }
 
     fn deactivated(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.results_editor
@@ -736,6 +739,7 @@ impl ProjectSearchView {
             let mut editor =
                 Editor::for_multibuffer(excerpts, Some(project.clone()), true, window, cx);
             editor.set_searchable(false);
+            editor.set_in_project_search(true);
             editor
         });
         subscriptions.push(cx.observe(&results_editor, |_, _, cx| cx.emit(ViewEvent::UpdateTab)));

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1487,7 +1487,7 @@ impl SearchableItem for TerminalView {
             regex: true,
             replacement: false,
             selection: false,
-            next_prev: true,
+            find_in_results: false,
         }
     }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1480,13 +1480,14 @@ impl SerializableItem for TerminalView {
 impl SearchableItem for TerminalView {
     type Match = RangeInclusive<Point>;
 
-    fn supported_options() -> SearchOptions {
+    fn supported_options(&self) -> SearchOptions {
         SearchOptions {
             case: false,
             word: false,
             regex: true,
             replacement: false,
             selection: false,
+            next_prev: true,
         }
     }
 

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -42,18 +42,20 @@ pub struct SearchOptions {
     /// Specifies whether the  supports search & replace.
     pub replacement: bool,
     pub selection: bool,
+    pub next_prev: bool,
 }
 
 pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
     type Match: Any + Sync + Send + Clone;
 
-    fn supported_options() -> SearchOptions {
+    fn supported_options(&self) -> SearchOptions {
         SearchOptions {
             case: true,
             word: true,
             regex: true,
             replacement: true,
             selection: true,
+            next_prev: true,
         }
     }
 
@@ -66,7 +68,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
     }
 
     fn has_filtered_search_ranges(&mut self) -> bool {
-        Self::supported_options().selection
+        self.supported_options().selection
     }
 
     fn toggle_filtered_search_ranges(
@@ -157,7 +159,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
 pub trait SearchableItemHandle: ItemHandle {
     fn downgrade(&self) -> Box<dyn WeakSearchableItemHandle>;
     fn boxed_clone(&self) -> Box<dyn SearchableItemHandle>;
-    fn supported_options(&self) -> SearchOptions;
+    fn supported_options(&self, cx: &App) -> SearchOptions;
     fn subscribe_to_search_events(
         &self,
         window: &mut Window,
@@ -224,8 +226,8 @@ impl<T: SearchableItem> SearchableItemHandle for Entity<T> {
         Box::new(self.clone())
     }
 
-    fn supported_options(&self) -> SearchOptions {
-        T::supported_options()
+    fn supported_options(&self, cx: &App) -> SearchOptions {
+        self.read(cx).supported_options()
     }
 
     fn subscribe_to_search_events(

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -42,7 +42,7 @@ pub struct SearchOptions {
     /// Specifies whether the  supports search & replace.
     pub replacement: bool,
     pub selection: bool,
-    pub next_prev: bool,
+    pub find_in_results: bool,
 }
 
 pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
@@ -55,7 +55,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
             regex: true,
             replacement: true,
             selection: true,
-            next_prev: true,
+            find_in_results: false,
         }
     }
 

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -98,7 +98,7 @@ impl Render for Toolbar {
             return div();
         }
 
-        let secondary_item = self.secondary_items().next().map(|item| item.to_any());
+        let secondary_items = self.secondary_items().map(|item| item.to_any());
 
         let has_left_items = self.left_items().count() > 0;
         let has_right_items = self.right_items().count() > 0;
@@ -145,7 +145,7 @@ impl Render for Toolbar {
                         }),
                 )
             })
-            .children(secondary_item)
+            .children(secondary_items)
     }
 }
 

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -82,7 +82,7 @@ impl Toolbar {
     }
 
     fn secondary_items(&self) -> impl Iterator<Item = &dyn ToolbarItemViewHandle> {
-        self.items.iter().filter_map(|(item, location)| {
+        self.items.iter().rev().filter_map(|(item, location)| {
             if *location == ToolbarItemLocation::Secondary {
                 Some(item.as_ref())
             } else {


### PR DESCRIPTION
Closes #13437
Closes #19993

Release Notes:

- Allow searching within the results of a project search
- vim: Fix `/`/`?`, `n`/`N`, `gn`/`gN`,`*`/`#` in project search results
