### PR TITLE
Add comment explaining why AddSurrounds target is not deserializable

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -81,6 +81,7 @@ pub enum Operator {
         first_char: Option<char>,
     },
     AddSurrounds {
+        // Typically no need to configure this as `SendKeystrokes` can be used - see #23088.
         #[serde(skip)]
         target: Option<SurroundsType>,
     },


### PR DESCRIPTION
See #23088

Release Notes:

- N/A