### PR TITLE
Fix `project_panel::NewDirectory` in TextMate keymap

### DIFF
--- a/assets/keymaps/macos/textmate.json
+++ b/assets/keymaps/macos/textmate.json
@@ -13,7 +13,7 @@
       "cmd-b": "editor::GoToDefinition",
       "cmd-j": "editor::ScrollCursorCenter",
       "cmd-enter": "editor::NewlineBelow",
-      "cmd-alt-enter": "editor::NewLineAbove",
+      "cmd-alt-enter": "editor::NewlineAbove",
       "cmd-shift-l": "editor::SelectLine",
       "cmd-shift-t": "outline::Toggle",
       "alt-backspace": "editor::DeleteToPreviousWordStart",

--- a/assets/keymaps/macos/textmate.json
+++ b/assets/keymaps/macos/textmate.json
@@ -70,7 +70,7 @@
     "bindings": {
       "cmd-backspace": ["project_panel::Trash", { "skip_prompt": true }],
       "cmd-d": "project_panel::Duplicate",
-      "cmd-n": "project_panel::NewFolder",
+      "cmd-n": "project_panel::NewDirectory",
       "return": "project_panel::Rename",
       "cmd-c": "project_panel::Copy",
       "cmd-v": "project_panel::Paste",


### PR DESCRIPTION
Release Notes:

- Fixed `project_panel::NewDirectory`, `editor:: NewlineAbove` in TextMate keymap.
