### PR TITLE
Fix terminal drag and drop

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -35,10 +35,10 @@ use workspace::{
     item::SerializableItem,
     move_active_item, move_item, pane,
     ui::IconName,
-    ActivateNextPane, ActivatePane, ActivatePaneInDirection, ActivatePreviousPane, DraggedTab,
-    ItemId, MoveItemToPane, MoveItemToPaneInDirection, NewTerminal, Pane, PaneGroup,
-    SplitDirection, SplitDown, SplitLeft, SplitRight, SplitUp, SwapPaneInDirection, ToggleZoom,
-    Workspace,
+    ActivateNextPane, ActivatePane, ActivatePaneInDirection, ActivatePreviousPane,
+    DraggedSelection, DraggedTab, ItemId, MoveItemToPane, MoveItemToPaneInDirection, NewTerminal,
+    Pane, PaneGroup, SplitDirection, SplitDown, SplitLeft, SplitRight, SplitUp,
+    SwapPaneInDirection, ToggleZoom, Workspace,
 };
 
 use anyhow::{anyhow, Context as _, Result};
@@ -1036,6 +1036,17 @@ pub fn new_terminal_pane(
                             add_paths_to_terminal(pane, &[entry_path], window, cx);
                         }
                     }
+                }
+            } else if let Some(selection) = dropped_item.downcast_ref::<DraggedSelection>() {
+                let project = project.read(cx);
+                let paths_to_add = selection
+                    .items()
+                    .map(|selected_entry| selected_entry.entry_id)
+                    .filter_map(|entry_id| project.path_for_entry(entry_id, cx))
+                    .filter_map(|project_path| project.absolute_path(&project_path, cx))
+                    .collect::<Vec<_>>();
+                if !paths_to_add.is_empty() {
+                    add_paths_to_terminal(pane, &paths_to_add, window, cx);
                 }
             } else if let Some(&entry_id) = dropped_item.downcast_ref::<ProjectEntryId>() {
                 if let Some(entry_path) = project

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1130,7 +1130,6 @@ impl Render for TerminalView {
         let focused = self.focus_handle.is_focused(window);
 
         div()
-            .occlude()
             .id("terminal-view")
             .size_full()
             .relative()


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/23823

* Fixes terminal drag and drop not working after https://github.com/zed-industries/zed/pull/23256
* Fixes project panel items drag and drop not working after selection overhaul even earlier: now, all marked items are added to terminal on drag and drop

Release Notes:

- Fixed terminal drag and drop, including project panel items
