### PR TITLE
Bind editor::OpenSelectionsInMultibuffer in `full` editors only

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -122,8 +122,7 @@
       "ctrl-i": "editor::ShowSignatureHelp",
       "alt-g b": "editor::ToggleGitBlame",
       "menu": "editor::OpenContextMenu",
-      "shift-f10": "editor::OpenContextMenu",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer"
+      "shift-f10": "editor::OpenContextMenu"
     }
   },
   {
@@ -141,7 +140,8 @@
       // "cmd-e": ["buffer_search::Deploy", { "focus": false }],
       "ctrl->": "assistant::QuoteSelection",
       "ctrl-<": "assistant::InsertIntoEditor",
-      "ctrl-alt-e": "editor::SelectEnclosingSymbol"
+      "ctrl-alt-e": "editor::SelectEnclosingSymbol",
+      "alt-enter": "editor::OpenSelectionsInMultibuffer"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -132,8 +132,7 @@
       "cmd-alt-g b": "editor::ToggleGitBlame",
       "cmd-i": "editor::ShowSignatureHelp",
       "ctrl-f12": "editor::GoToDeclaration",
-      "alt-ctrl-f12": "editor::GoToDeclarationSplit",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer"
+      "alt-ctrl-f12": "editor::GoToDeclarationSplit"
     }
   },
   {
@@ -151,7 +150,8 @@
       "cmd-e": ["buffer_search::Deploy", { "focus": false }],
       "cmd->": "assistant::QuoteSelection",
       "cmd-<": "assistant::InsertIntoEditor",
-      "cmd-alt-e": "editor::SelectEnclosingSymbol"
+      "cmd-alt-e": "editor::SelectEnclosingSymbol",
+      "alt-enter": "editor::OpenSelectionsInMultibuffer"
     }
   },
   {


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/23648

Binding `alt-enter` to all editors breaks https://github.com/zed-industries/zed/blob/46f45464be2d45def9ac51e29dea8690da051302/assets/keymaps/default-macos.json#L281 key binding for buffer search, and it's impossible to select all search matches anymore.

Release Notes:

- N/A
